### PR TITLE
ci(e2e): trigger post-deploy smoke via Netlify outgoing webhook

### DIFF
--- a/.github/workflows/e2e-post-deploy.yml
+++ b/.github/workflows/e2e-post-deploy.yml
@@ -32,11 +32,20 @@
 #   - Spec: docs/plans/2026-04-21-e2e-post-deploy-testing-design.md
 #   - Known adjacent issue: signup UI has no "check your email" confirmation
 #     state (tracked separately; this suite bypasses via admin API).
+#
+# Netlify wiring:
+#   Netlify's built-in GitHub App does NOT post deployment_status events for
+#   this repo (the /deployments page is empty), so we rely on an outgoing
+#   webhook from Netlify that POSTs to this repo's /dispatches endpoint with
+#   event_type "netlify-deploy-succeeded". The deployment_status trigger is
+#   kept as a fallback in case the GitHub App starts posting events later.
 
 name: E2E — post-deploy smoke
 
 on:
     deployment_status:
+    repository_dispatch:
+        types: [netlify-deploy-succeeded]
     workflow_dispatch:
         inputs:
             base_url:
@@ -50,9 +59,11 @@ concurrency:
 jobs:
     smoke:
         # deployment_status: only prod successes
+        # repository_dispatch: always run (Netlify webhook only fires on prod success)
         # workflow_dispatch: always run
         if: >-
             github.event_name == 'workflow_dispatch' ||
+            github.event_name == 'repository_dispatch' ||
             (github.event.deployment_status.state == 'success' &&
              github.event.deployment.environment == 'production')
         runs-on: ubuntu-latest
@@ -77,7 +88,7 @@ jobs:
             - name: Run playwright
               working-directory: e2e
               env:
-                  E2E_BASE_URL: ${{ github.event.deployment_status.environment_url || github.event.inputs.base_url || 'https://starborneplanner.com' }}
+                  E2E_BASE_URL: ${{ github.event.deployment_status.environment_url || github.event.client_payload.deploy_url || github.event.inputs.base_url || 'https://starborneplanner.com' }}
                   SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
                   SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
                   E2E_TEST_EMAIL_PREFIX: ${{ secrets.E2E_TEST_EMAIL_PREFIX }}


### PR DESCRIPTION
Netlify's built-in GitHub App is not posting deployment_status events for this repo (the /deployments page is empty), so the workflow never fired after the first prod deploy. Add a repository_dispatch trigger that Netlify will POST to via an outgoing webhook on "Deploy succeeded", and accept the deploy_url from the client_payload. The deployment_status trigger is retained as a fallback.