### PR TITLE
ci(netlify): add build plugin that dispatches e2e workflow on prod su…

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,13 @@
   command = "npx puppeteer browsers install chrome && npm run build"
   publish = "dist"
 
+# Fires a repository_dispatch on GitHub after a successful production deploy
+# so the e2e-post-deploy smoke workflow can run against the new build.
+# Requires env vars GH_DISPATCH_TOKEN and GH_DISPATCH_REPO to be set in
+# Netlify site settings.
+[[plugins]]
+  package = "./plugins/github-dispatch"
+
 # Security headers
 [[headers]]
   for = "/*"

--- a/plugins/github-dispatch/index.js
+++ b/plugins/github-dispatch/index.js
@@ -1,0 +1,60 @@
+// Netlify build plugin: fires a repository_dispatch on GitHub after a
+// successful production deploy so the e2e-post-deploy workflow can kick off.
+//
+// Env vars (set in Netlify site settings → environment variables):
+//   GH_DISPATCH_TOKEN  — fine-grained PAT with Contents: write on the repo
+//   GH_DISPATCH_REPO   — e.g. "TheSusort/starborne-frontiers-calculator"
+//
+// Runs only when CONTEXT === "production" so preview/branch deploys don't
+// trigger the smoke suite.
+
+const EVENT_TYPE = 'netlify-deploy-succeeded';
+
+export const onSuccess = async function ({ utils }) {
+    const context = process.env.CONTEXT;
+    if (context !== 'production') {
+        console.log(`[github-dispatch] skipping: context="${context}" (only fires on production)`);
+        return;
+    }
+
+    const token = process.env.GH_DISPATCH_TOKEN;
+    const repo = process.env.GH_DISPATCH_REPO;
+    const deployUrl = process.env.DEPLOY_PRIME_URL || process.env.URL || process.env.DEPLOY_URL;
+
+    if (!token) {
+        return utils.build.failPlugin('GH_DISPATCH_TOKEN is not set — add it in Netlify env vars');
+    }
+    if (!repo) {
+        return utils.build.failPlugin('GH_DISPATCH_REPO is not set — add it in Netlify env vars (e.g. "TheSusort/starborne-frontiers-calculator")');
+    }
+
+    const endpoint = `https://api.github.com/repos/${repo}/dispatches`;
+    const body = {
+        event_type: EVENT_TYPE,
+        client_payload: {
+            deploy_url: deployUrl,
+            commit_ref: process.env.COMMIT_REF,
+            deploy_id: process.env.DEPLOY_ID,
+        },
+    };
+
+    const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+        const text = await res.text().catch(() => '<no body>');
+        return utils.build.failPlugin(
+            `GitHub dispatch failed: ${res.status} ${res.statusText} — ${text}`
+        );
+    }
+
+    console.log(`[github-dispatch] posted ${EVENT_TYPE} for ${deployUrl}`);
+};

--- a/plugins/github-dispatch/manifest.yml
+++ b/plugins/github-dispatch/manifest.yml
@@ -1,0 +1,2 @@
+name: github-dispatch
+inputs: []

--- a/plugins/github-dispatch/package.json
+++ b/plugins/github-dispatch/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "netlify-plugin-github-dispatch",
+    "version": "1.0.0",
+    "description": "Netlify build plugin that fires a repository_dispatch on GitHub after a successful production deploy.",
+    "type": "module",
+    "main": "index.js",
+    "private": true
+}


### PR DESCRIPTION
…ccess

Netlify's HTTP POST notification only supports a URL field — no custom headers or body — so it can't POST to GitHub's /dispatches endpoint directly (needs Authorization). A small in-repo build plugin fires from Netlify's onSuccess hook with proper auth and payload. Scoped to CONTEXT=production so preview/branch deploys don't trigger the smoke.

Env vars required in Netlify:
  GH_DISPATCH_TOKEN — fine-grained PAT, Contents: write on the repo
  GH_DISPATCH_REPO  — TheSusort/starborne-frontiers-calculator