### PR TITLE
fix(e2e): wait for inventory IndexedDB write; log page errors

### DIFF
--- a/e2e/helpers/capture-page-errors.ts
+++ b/e2e/helpers/capture-page-errors.ts
@@ -1,0 +1,29 @@
+import { Page, TestInfo } from '@playwright/test';
+
+/**
+ * Attach listeners that surface browser-side errors in the test log so
+ * failures aren't silent. Logs:
+ *   - console.error / console.warn messages
+ *   - uncaught page exceptions (pageerror)
+ *   - failed network requests
+ *
+ * Call once per test (typically from beforeEach) BEFORE the first page.goto.
+ */
+export function capturePageErrors(page: Page, testInfo: TestInfo): void {
+    const tag = `[page ${testInfo.title}]`;
+
+    page.on('console', (msg) => {
+        const type = msg.type();
+        if (type === 'error' || type === 'warning') {
+            console.log(`${tag} console.${type}: ${msg.text()}`);
+        }
+    });
+
+    page.on('pageerror', (err) => {
+        console.log(`${tag} pageerror: ${err.message}\n${err.stack ?? ''}`);
+    });
+
+    page.on('requestfailed', (req) => {
+        console.log(`${tag} requestfailed: ${req.method()} ${req.url()} — ${req.failure()?.errorText ?? 'unknown'}`);
+    });
+}

--- a/e2e/helpers/page-actions.ts
+++ b/e2e/helpers/page-actions.ts
@@ -13,12 +13,9 @@ const FIXTURE_PATH = resolve(__dirname, '..', 'fixtures', 'gameData.json');
 export async function importGameData(page: Page): Promise<void> {
     const input = page.getByTestId('import-game-data-input');
     await input.setInputFiles(FIXTURE_PATH);
-    // Wait for the import pipeline to finish writing to localStorage.
-    // The ImportButton handler calls setShips after parsing, which persists
-    // the collection under the 'ships' key (see src/constants/storage.ts,
-    // StorageKey.SHIPS). A non-empty array is a reliable completion signal —
-    // the hidden input is never disabled during import, so checking
-    // toBeEnabled on it resolves immediately and is not a real wait.
+
+    // Wait for localStorage `ships` (set via useStorage, non-IDB) to populate.
+    // This confirms the import pipeline ran and `setShips` was called.
     await page.waitForFunction(
         () => {
             const raw = window.localStorage.getItem('ships');
@@ -30,6 +27,42 @@ export async function importGameData(page: Page): Promise<void> {
                 return false;
             }
         },
+        null,
+        { timeout: 30_000 }
+    );
+
+    // Inventory is written to IndexedDB (InventoryProvider passes
+    // `useIndexedDB: true` to useStorage), not localStorage, and completes
+    // asynchronously *after* setShips. Without waiting on IDB, the test can
+    // navigate to /gear before the write lands and see an empty inventory.
+    // DB_NAME='starborneFrontiers', STORE_NAME='data', key='inventory_items'
+    // (see src/hooks/useStorage.ts and src/constants/storage.ts).
+    await page.waitForFunction(
+        () =>
+            new Promise<boolean>((resolve) => {
+                const open = window.indexedDB.open('starborneFrontiers', 1);
+                open.onerror = () => resolve(false);
+                open.onsuccess = () => {
+                    const db = open.result;
+                    if (!db.objectStoreNames.contains('data')) {
+                        db.close();
+                        resolve(false);
+                        return;
+                    }
+                    const tx = db.transaction('data', 'readonly');
+                    const store = tx.objectStore('data');
+                    const get = store.get('inventory_items');
+                    get.onerror = () => {
+                        db.close();
+                        resolve(false);
+                    };
+                    get.onsuccess = () => {
+                        db.close();
+                        const value = get.result;
+                        resolve(Array.isArray(value) && value.length > 0);
+                    };
+                };
+            }),
         null,
         { timeout: 30_000 }
     );

--- a/e2e/tests/anon-import.spec.ts
+++ b/e2e/tests/anon-import.spec.ts
@@ -1,9 +1,11 @@
 import { test, expect } from '@playwright/test';
 import { importGameData } from '../helpers/page-actions';
 import { silenceFirstVisitOverlays } from '../helpers/silence-overlays';
+import { capturePageErrors } from '../helpers/capture-page-errors';
 
 test.describe('anonymous user imports game data', () => {
-    test.beforeEach(async ({ page }) => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        capturePageErrors(page, testInfo);
         await silenceFirstVisitOverlays(page);
     });
 

--- a/e2e/tests/new-account-signup-migrate.spec.ts
+++ b/e2e/tests/new-account-signup-migrate.spec.ts
@@ -8,6 +8,7 @@ import {
 import { generateTestCredentials } from '../helpers/disposableEmail';
 import { installMigrationSentinel, waitForMigration } from '../helpers/wait-for-migration';
 import { silenceFirstVisitOverlays } from '../helpers/silence-overlays';
+import { capturePageErrors } from '../helpers/capture-page-errors';
 import {
     confirmUserEmail,
     deleteTestUser,
@@ -22,13 +23,14 @@ if (!DOMAIN) throw new Error('E2E_TEST_EMAIL_DOMAIN is required');
 test.describe('new account: signup → confirm → signin → migrate', () => {
     const created: string[] = [];
 
-    test.beforeEach(async ({ page }) => {
+    test.beforeEach(async ({ page }, testInfo) => {
         // Both init-script helpers must run BEFORE the first page.goto so
         // the scripts are registered on the browser context for every
         // document load. The migration sentinel in particular must be in
         // place before any auth state change can dispatch
         // `app:migration:end` — otherwise a race with fast sign-in paths
         // (e.g. email confirmation OFF) could miss the event.
+        capturePageErrors(page, testInfo);
         await silenceFirstVisitOverlays(page);
         await installMigrationSentinel(page);
     });

--- a/e2e/tests/oauth-sanity.spec.ts
+++ b/e2e/tests/oauth-sanity.spec.ts
@@ -1,8 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { silenceFirstVisitOverlays } from '../helpers/silence-overlays';
+import { capturePageErrors } from '../helpers/capture-page-errors';
 
 test.describe('google oauth redirect sanity', () => {
-    test.beforeEach(async ({ page }) => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        capturePageErrors(page, testInfo);
         await silenceFirstVisitOverlays(page);
     });
 


### PR DESCRIPTION
Two linked improvements after a first real prod run surfaced a silent failure (gear-count not found — the page showed "No gear created yet").

1. importGameData now waits for the 'inventory_items' key in IndexedDB after the 'ships' localStorage write. InventoryProvider passes useIndexedDB: true to useStorage, so gear and implants land in IDB rather than localStorage; the previous wait was blind to that path and let the test race past an in-flight write.

2. capturePageErrors attaches console/pageerror/requestfailed listeners in each spec's beforeEach so future browser-side failures surface in the CI log rather than needing trace forensics.