### PR TITLE
fix(netlify): dispatch the canonical URL, not the branch preview

### DIFF
--- a/plugins/github-dispatch/index.js
+++ b/plugins/github-dispatch/index.js
@@ -19,7 +19,11 @@ export const onSuccess = async function ({ utils }) {
 
     const token = process.env.GH_DISPATCH_TOKEN;
     const repo = process.env.GH_DISPATCH_REPO;
-    const deployUrl = process.env.DEPLOY_PRIME_URL || process.env.URL || process.env.DEPLOY_URL;
+    // Prefer the canonical production URL (URL) over the branch permalink
+    // (DEPLOY_PRIME_URL). The preview domain (`main--<site>.netlify.app`)
+    // isn't in Supabase's allowed origins, so CORS-gated fetches from the
+    // browser would fail there even though the same bundle works on prod.
+    const deployUrl = process.env.URL || process.env.DEPLOY_PRIME_URL || process.env.DEPLOY_URL;
 
     if (!token) {
         return utils.build.failPlugin('GH_DISPATCH_TOKEN is not set — add it in Netlify env vars');


### PR DESCRIPTION
Run 2 surfaced that tests were hitting main--starborne-planner.netlify.app (Netlify's branch permalink for main), not starborneplanner.com. Supabase CORS is configured for the canonical production origin only, so the import pipeline's tracking fetch failed with TypeError: Failed to fetch from the preview domain and the full post-import flow never completed. Reorder the env fallbacks so URL (canonical prod) wins over DEPLOY_PRIME_URL (permalink).