### PR TITLE
feat: forced implant types in autogear

### DIFF
--- a/src/__tests__/components/autogear/SetPriorityRow.test.tsx
+++ b/src/__tests__/components/autogear/SetPriorityRow.test.tsx
@@ -1,10 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
+import { SetPriorityRow } from '../../../components/autogear/SetPriorityRow';
 
 // Sidebar imports /favicon.ico?url which is not available in test environment
 vi.mock('../../../components/ui/layout/Sidebar', () => ({ Sidebar: () => null }));
-
-import { SetPriorityRow } from '../../../components/autogear/SetPriorityRow';
 
 const noop = vi.fn();
 const baseProps = {

--- a/src/__tests__/components/autogear/SetPriorityRow.test.tsx
+++ b/src/__tests__/components/autogear/SetPriorityRow.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+// Sidebar imports /favicon.ico?url which is not available in test environment
+vi.mock('../../../components/ui/layout/Sidebar', () => ({ Sidebar: () => null }));
+
+import { SetPriorityRow } from '../../../components/autogear/SetPriorityRow';
+
+const noop = vi.fn();
+const baseProps = {
+    isEditing: false,
+    canMoveUp: false,
+    canMoveDown: false,
+    onUpdate: noop,
+    onEdit: noop,
+    onMoveUp: noop,
+    onMoveDown: noop,
+    onRemove: noop,
+};
+
+describe('SetPriorityRow', () => {
+    it('renders gear-set row with count editor', () => {
+        render(<SetPriorityRow {...baseProps} priority={{ setName: 'SHIELD', count: 2 }} />);
+        expect(screen.getByText(/shield/i)).toBeInTheDocument();
+        expect(screen.getByText('2')).toBeInTheDocument();
+        expect(screen.getByText(/pieces/i)).toBeInTheDocument();
+    });
+
+    it('does NOT crash for implant-type key and hides count editor', () => {
+        const availableImplantTypes = [{ key: 'HASTE', name: 'Haste', label: 'Haste' }];
+        render(
+            <SetPriorityRow
+                {...baseProps}
+                priority={{ setName: 'HASTE', count: 1, kind: 'implant' }}
+                availableImplantTypes={availableImplantTypes}
+            />
+        );
+        expect(screen.getByText('Haste')).toBeInTheDocument();
+        expect(screen.queryByText(/pieces/i)).not.toBeInTheDocument();
+    });
+
+    it('falls back to setName when implant type not in availableImplantTypes', () => {
+        render(
+            <SetPriorityRow
+                {...baseProps}
+                priority={{ setName: 'UNKNOWN_TYPE', count: 1, kind: 'implant' }}
+            />
+        );
+        expect(screen.getByText('UNKNOWN_TYPE')).toBeInTheDocument();
+    });
+});

--- a/src/components/autogear/AutogearConfigList.tsx
+++ b/src/components/autogear/AutogearConfigList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StatPriority, SetPriority, StatBonus, FleetBuff } from '../../types/autogear';
 import { GEAR_SETS, ShipTypeName } from '../../constants';
+import { IMPLANTS } from '../../constants/implants';
 import { SHIP_TYPES } from '../../constants/shipTypes';
 import { STATS } from '../../constants/stats';
 import { StatName } from '../../types/stats';
@@ -88,7 +89,11 @@ export const AutogearConfigList: React.FC<AutogearConfigListProps> = ({
                     <>
                         {setPriorities.map((setPriority, index) => (
                             <span key={index}>
-                                {setPriority.count} x {GEAR_SETS[setPriority.setName]?.name}
+                                {setPriority.kind === 'implant'
+                                    ? (GEAR_SETS[setPriority.setName]?.name ??
+                                      IMPLANTS[setPriority.setName]?.name ??
+                                      setPriority.setName)
+                                    : `${setPriority.count} x ${GEAR_SETS[setPriority.setName]?.name ?? setPriority.setName}`}
                             </span>
                         ))}
                     </>

--- a/src/components/autogear/AutogearSettings.tsx
+++ b/src/components/autogear/AutogearSettings.tsx
@@ -520,12 +520,16 @@ export const AutogearSettings: React.FC<AutogearSettingsProps> = ({
                                                                             )
                                                                         }
                                                                         onMoveUp={() =>
+                                                                            prevKindIdx !==
+                                                                                undefined &&
                                                                             onMoveSetPriority(
                                                                                 absoluteIndex,
                                                                                 prevKindIdx
                                                                             )
                                                                         }
                                                                         onMoveDown={() =>
+                                                                            nextKindIdx !==
+                                                                                undefined &&
                                                                             onMoveSetPriority(
                                                                                 absoluteIndex,
                                                                                 nextKindIdx
@@ -599,12 +603,16 @@ export const AutogearSettings: React.FC<AutogearSettingsProps> = ({
                                                                             )
                                                                         }
                                                                         onMoveUp={() =>
+                                                                            prevKindIdx !==
+                                                                                undefined &&
                                                                             onMoveSetPriority(
                                                                                 absoluteIndex,
                                                                                 prevKindIdx
                                                                             )
                                                                         }
                                                                         onMoveDown={() =>
+                                                                            nextKindIdx !==
+                                                                                undefined &&
                                                                             onMoveSetPriority(
                                                                                 absoluteIndex,
                                                                                 nextKindIdx

--- a/src/components/autogear/AutogearSettings.tsx
+++ b/src/components/autogear/AutogearSettings.tsx
@@ -179,7 +179,10 @@ const SetPriorityForm: React.FC<{
                             min="0"
                             max="6"
                             value={count}
-                            onChange={(e) => setCount(parseInt(e.target.value))}
+                            onChange={(e) => {
+                                const next = Number.parseInt(e.target.value, 10);
+                                setCount(Number.isNaN(next) ? 0 : next);
+                            }}
                         />
                     </div>
                 )}

--- a/src/components/autogear/AutogearSettings.tsx
+++ b/src/components/autogear/AutogearSettings.tsx
@@ -34,7 +34,13 @@ type TweakView =
     | { mode: 'picker' }
     | {
           mode: 'form';
-          type: 'priority' | 'setPriority' | 'statBonus' | 'fleetBuff' | 'excludedImplant';
+          type:
+              | 'priority'
+              | 'setPriority'
+              | 'implantPriority'
+              | 'statBonus'
+              | 'fleetBuff'
+              | 'excludedImplant';
           editIndex: number | null;
       };
 
@@ -309,7 +315,13 @@ export const AutogearSettings: React.FC<AutogearSettingsProps> = ({
 
     const openPicker = () => setTweakView({ mode: 'picker' });
     const openForm = (
-        type: 'priority' | 'setPriority' | 'statBonus' | 'fleetBuff' | 'excludedImplant',
+        type:
+            | 'priority'
+            | 'setPriority'
+            | 'implantPriority'
+            | 'statBonus'
+            | 'fleetBuff'
+            | 'excludedImplant',
         editIndex: number | null = null
     ) => setTweakView({ mode: 'form', type, editIndex });
     const backToList = () => setTweakView({ mode: 'list' });
@@ -319,6 +331,10 @@ export const AutogearSettings: React.FC<AutogearSettingsProps> = ({
     const isEditingSetPriority = (index: number) =>
         tweakView.mode === 'form' &&
         tweakView.type === 'setPriority' &&
+        tweakView.editIndex === index;
+    const isEditingImplantPriority = (index: number) =>
+        tweakView.mode === 'form' &&
+        tweakView.type === 'implantPriority' &&
         tweakView.editIndex === index;
     const isEditingStatBonus = (index: number) =>
         tweakView.mode === 'form' &&
@@ -439,33 +455,177 @@ export const AutogearSettings: React.FC<AutogearSettingsProps> = ({
                                             ))}
                                         </div>
                                     )}
-                                    {setPriorities.length > 0 && (
-                                        <div className="space-y-1">
-                                            <h4 className="text-xs uppercase tracking-wide text-theme-text-secondary">
-                                                Gear set
-                                            </h4>
-                                            {setPriorities.map((priority, index) => (
-                                                <SetPriorityRow
-                                                    key={`set-${index}`}
-                                                    priority={priority}
-                                                    isEditing={isEditingSetPriority(index)}
-                                                    canMoveUp={index > 0}
-                                                    canMoveDown={index < setPriorities.length - 1}
-                                                    onUpdate={(updated) =>
-                                                        onUpdateSetPriority(index, updated)
-                                                    }
-                                                    onEdit={() => openForm('setPriority', index)}
-                                                    onMoveUp={() =>
-                                                        onMoveSetPriority(index, index - 1)
-                                                    }
-                                                    onMoveDown={() =>
-                                                        onMoveSetPriority(index, index + 1)
-                                                    }
-                                                    onRemove={() => onRemoveSetPriority(index)}
-                                                />
-                                            ))}
-                                        </div>
-                                    )}
+                                    {(() => {
+                                        const gearSetAbsoluteIndices = setPriorities
+                                            .map((_, i) => i)
+                                            .filter((i) => setPriorities[i].kind !== 'implant');
+                                        const implantAbsoluteIndices = setPriorities
+                                            .map((_, i) => i)
+                                            .filter((i) => setPriorities[i].kind === 'implant');
+
+                                        return (
+                                            <>
+                                                {gearSetAbsoluteIndices.length > 0 && (
+                                                    <div className="space-y-1">
+                                                        <h4 className="text-xs uppercase tracking-wide text-theme-text-secondary">
+                                                            Gear set
+                                                        </h4>
+                                                        {setPriorities
+                                                            .map((priority, absoluteIndex) => ({
+                                                                priority,
+                                                                absoluteIndex,
+                                                            }))
+                                                            .filter(
+                                                                ({ priority }) =>
+                                                                    priority.kind !== 'implant'
+                                                            )
+                                                            .map(({ priority, absoluteIndex }) => {
+                                                                const kindIdx =
+                                                                    gearSetAbsoluteIndices.indexOf(
+                                                                        absoluteIndex
+                                                                    );
+                                                                const prevKindIdx =
+                                                                    gearSetAbsoluteIndices[
+                                                                        kindIdx - 1
+                                                                    ];
+                                                                const nextKindIdx =
+                                                                    gearSetAbsoluteIndices[
+                                                                        kindIdx + 1
+                                                                    ];
+                                                                return (
+                                                                    <SetPriorityRow
+                                                                        key={`set-${absoluteIndex}`}
+                                                                        priority={priority}
+                                                                        isEditing={isEditingSetPriority(
+                                                                            absoluteIndex
+                                                                        )}
+                                                                        canMoveUp={
+                                                                            prevKindIdx !==
+                                                                            undefined
+                                                                        }
+                                                                        canMoveDown={
+                                                                            nextKindIdx !==
+                                                                            undefined
+                                                                        }
+                                                                        onUpdate={(updated) =>
+                                                                            onUpdateSetPriority(
+                                                                                absoluteIndex,
+                                                                                updated
+                                                                            )
+                                                                        }
+                                                                        onEdit={() =>
+                                                                            openForm(
+                                                                                'setPriority',
+                                                                                absoluteIndex
+                                                                            )
+                                                                        }
+                                                                        onMoveUp={() =>
+                                                                            onMoveSetPriority(
+                                                                                absoluteIndex,
+                                                                                prevKindIdx
+                                                                            )
+                                                                        }
+                                                                        onMoveDown={() =>
+                                                                            onMoveSetPriority(
+                                                                                absoluteIndex,
+                                                                                nextKindIdx
+                                                                            )
+                                                                        }
+                                                                        onRemove={() =>
+                                                                            onRemoveSetPriority(
+                                                                                absoluteIndex
+                                                                            )
+                                                                        }
+                                                                        availableImplantTypes={
+                                                                            availableImplantTypes
+                                                                        }
+                                                                    />
+                                                                );
+                                                            })}
+                                                    </div>
+                                                )}
+                                                {implantAbsoluteIndices.length > 0 && (
+                                                    <div className="space-y-1">
+                                                        <h4 className="text-xs uppercase tracking-wide text-theme-text-secondary">
+                                                            Required implants
+                                                        </h4>
+                                                        {setPriorities
+                                                            .map((priority, absoluteIndex) => ({
+                                                                priority,
+                                                                absoluteIndex,
+                                                            }))
+                                                            .filter(
+                                                                ({ priority }) =>
+                                                                    priority.kind === 'implant'
+                                                            )
+                                                            .map(({ priority, absoluteIndex }) => {
+                                                                const kindIdx =
+                                                                    implantAbsoluteIndices.indexOf(
+                                                                        absoluteIndex
+                                                                    );
+                                                                const prevKindIdx =
+                                                                    implantAbsoluteIndices[
+                                                                        kindIdx - 1
+                                                                    ];
+                                                                const nextKindIdx =
+                                                                    implantAbsoluteIndices[
+                                                                        kindIdx + 1
+                                                                    ];
+                                                                return (
+                                                                    <SetPriorityRow
+                                                                        key={`implant-${absoluteIndex}`}
+                                                                        priority={priority}
+                                                                        isEditing={isEditingImplantPriority(
+                                                                            absoluteIndex
+                                                                        )}
+                                                                        canMoveUp={
+                                                                            prevKindIdx !==
+                                                                            undefined
+                                                                        }
+                                                                        canMoveDown={
+                                                                            nextKindIdx !==
+                                                                            undefined
+                                                                        }
+                                                                        onUpdate={(updated) =>
+                                                                            onUpdateSetPriority(
+                                                                                absoluteIndex,
+                                                                                updated
+                                                                            )
+                                                                        }
+                                                                        onEdit={() =>
+                                                                            openForm(
+                                                                                'implantPriority',
+                                                                                absoluteIndex
+                                                                            )
+                                                                        }
+                                                                        onMoveUp={() =>
+                                                                            onMoveSetPriority(
+                                                                                absoluteIndex,
+                                                                                prevKindIdx
+                                                                            )
+                                                                        }
+                                                                        onMoveDown={() =>
+                                                                            onMoveSetPriority(
+                                                                                absoluteIndex,
+                                                                                nextKindIdx
+                                                                            )
+                                                                        }
+                                                                        onRemove={() =>
+                                                                            onRemoveSetPriority(
+                                                                                absoluteIndex
+                                                                            )
+                                                                        }
+                                                                        availableImplantTypes={
+                                                                            availableImplantTypes
+                                                                        }
+                                                                    />
+                                                                );
+                                                            })}
+                                                    </div>
+                                                )}
+                                            </>
+                                        );
+                                    })()}
                                     {statBonuses.length > 0 && (
                                         <div className="space-y-1">
                                             <h4 className="text-xs uppercase tracking-wide text-theme-text-secondary">
@@ -649,6 +809,19 @@ export const AutogearSettings: React.FC<AutogearSettingsProps> = ({
                                         </div>
                                     </button>
                                 )}
+                                {optimizeImplants && availableImplantTypes.length > 0 && (
+                                    <button
+                                        type="button"
+                                        className="w-full text-left p-3 bg-dark border border-dark-border hover:border-primary hover:bg-dark-lighter rounded transition-colors"
+                                        onClick={() => openForm('implantPriority')}
+                                    >
+                                        <div className="font-semibold">Forced implant type</div>
+                                        <div className="text-xs text-theme-text-secondary">
+                                            Require a specific implant type to appear in the
+                                            autogear result (e.g. Bulwark).
+                                        </div>
+                                    </button>
+                                )}
                             </div>
                         </div>
                     )}
@@ -679,7 +852,9 @@ export const AutogearSettings: React.FC<AutogearSettingsProps> = ({
                                             ? 'scale'
                                             : tweakView.type === 'fleetBuff'
                                               ? 'buff'
-                                              : 'excluded implant type'}
+                                              : tweakView.type === 'implantPriority'
+                                                ? 'forced implant type'
+                                                : 'excluded implant type'}
                                 </span>
                             </div>
                             {tweakView.type === 'priority' && (
@@ -707,6 +882,31 @@ export const AutogearSettings: React.FC<AutogearSettingsProps> = ({
                             )}
                             {tweakView.type === 'setPriority' && (
                                 <SetPriorityForm
+                                    onAdd={(p) => {
+                                        onAddSetPriority(p);
+                                        backToList();
+                                    }}
+                                    editingValue={
+                                        tweakView.editIndex !== null
+                                            ? setPriorities[tweakView.editIndex]
+                                            : undefined
+                                    }
+                                    onSave={(p) => {
+                                        if (
+                                            tweakView.mode === 'form' &&
+                                            tweakView.editIndex !== null
+                                        ) {
+                                            onUpdateSetPriority(tweakView.editIndex, p);
+                                            backToList();
+                                        }
+                                    }}
+                                    onCancel={backToList}
+                                />
+                            )}
+                            {tweakView.type === 'implantPriority' && (
+                                <SetPriorityForm
+                                    mode="implantType"
+                                    availableImplantTypes={availableImplantTypes}
                                     onAdd={(p) => {
                                         onAddSetPriority(p);
                                         backToList();

--- a/src/components/autogear/AutogearSettings.tsx
+++ b/src/components/autogear/AutogearSettings.tsx
@@ -108,7 +108,9 @@ const SetPriorityForm: React.FC<{
     editingValue?: SetPriority;
     onSave?: (priority: SetPriority) => void;
     onCancel?: () => void;
-}> = ({ onAdd, editingValue, onSave, onCancel }) => {
+    mode?: 'gearSet' | 'implantType';
+    availableImplantTypes?: { key: string; name: string; label: string }[];
+}> = ({ onAdd, editingValue, onSave, onCancel, mode = 'gearSet', availableImplantTypes }) => {
     const [selectedSet, setSelectedSet] = useState<string>('');
     const [count, setCount] = useState<number>(2);
 
@@ -118,47 +120,63 @@ const SetPriorityForm: React.FC<{
             setCount(editingValue.count);
         } else {
             setSelectedSet('');
-            setCount(2);
+            setCount(mode === 'implantType' ? 1 : 2);
         }
-    }, [editingValue]);
+    }, [editingValue, mode]);
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         if (!selectedSet) return;
-        const value = { setName: selectedSet, count };
+        const value: SetPriority =
+            mode === 'implantType'
+                ? { setName: selectedSet, count: 1, kind: 'implant' }
+                : { setName: selectedSet, count };
         if (editingValue && onSave) {
             onSave(value);
             return;
         }
         onAdd(value);
         setSelectedSet('');
-        setCount(2);
+        setCount(mode === 'implantType' ? 1 : 2);
     };
+
+    const selectOptions =
+        mode === 'implantType'
+            ? (availableImplantTypes ?? [])
+                  .map((t) => ({ value: t.key, label: t.label }))
+                  .sort((a, b) => a.label.localeCompare(b.label))
+            : Object.entries(GEAR_SETS)
+                  .map(([key, set]) => ({ value: key, label: set.name }))
+                  .sort((a, b) => a.label.localeCompare(b.label));
 
     return (
         <form onSubmit={handleSubmit} className="space-y-3">
             <div className="flex gap-3 items-end flex-wrap">
                 <Select
-                    label="Gear set"
+                    label={mode === 'implantType' ? 'Implant type' : 'Gear set'}
                     className="flex-1 min-w-[8rem]"
-                    options={Object.entries(GEAR_SETS)
-                        .map(([key, set]) => ({ value: key, label: set.name }))
-                        .sort((a, b) => a.label.localeCompare(b.label))}
+                    options={selectOptions}
                     value={selectedSet}
                     onChange={(value) => setSelectedSet(value)}
                     noDefaultSelection
-                    helpLabel="Select a gear set to be met by the gear you equip."
+                    helpLabel={
+                        mode === 'implantType'
+                            ? 'Select an implant type to be required in the autogear result.'
+                            : 'Select a gear set to be met by the gear you equip.'
+                    }
                 />
-                <div className="w-24">
-                    <Input
-                        label="No. of pieces"
-                        type="number"
-                        min="0"
-                        max="6"
-                        value={count}
-                        onChange={(e) => setCount(parseInt(e.target.value))}
-                    />
-                </div>
+                {mode === 'gearSet' && (
+                    <div className="w-24">
+                        <Input
+                            label="No. of pieces"
+                            type="number"
+                            min="0"
+                            max="6"
+                            value={count}
+                            onChange={(e) => setCount(parseInt(e.target.value))}
+                        />
+                    </div>
+                )}
             </div>
 
             <div className="flex justify-end gap-2 flex-wrap">

--- a/src/components/autogear/SetPriorityRow.tsx
+++ b/src/components/autogear/SetPriorityRow.tsx
@@ -20,6 +20,7 @@ interface SetPriorityRowProps {
     onMoveUp: () => void;
     onMoveDown: () => void;
     onRemove: () => void;
+    availableImplantTypes?: { key: string; name: string; label: string }[];
 }
 
 export const SetPriorityRow: React.FC<SetPriorityRowProps> = ({
@@ -32,7 +33,13 @@ export const SetPriorityRow: React.FC<SetPriorityRowProps> = ({
     onMoveUp,
     onMoveDown,
     onRemove,
+    availableImplantTypes,
 }) => {
+    const label =
+        GEAR_SETS[priority.setName]?.name ??
+        availableImplantTypes?.find((t) => t.key === priority.setName)?.label ??
+        priority.setName;
+
     return (
         <div className={`flex items-center text-sm gap-2 ${isEditing ? 'opacity-60' : ''}`}>
             <div className="flex flex-col">
@@ -62,17 +69,23 @@ export const SetPriorityRow: React.FC<SetPriorityRowProps> = ({
                 )}
             </div>
             <span>
-                {GEAR_SETS[priority.setName].name} ({' '}
-                <InlineNumberEdit
-                    value={priority.count}
-                    onSave={(v) => v !== undefined && onUpdate({ ...priority, count: v })}
-                    min={0}
-                    max={6}
-                    disabled={isEditing}
-                >
-                    {priority.count}
-                </InlineNumberEdit>
-                {' pieces)'}
+                {priority.kind === 'implant' ? (
+                    label
+                ) : (
+                    <>
+                        {label} ({' '}
+                        <InlineNumberEdit
+                            value={priority.count}
+                            onSave={(v) => v !== undefined && onUpdate({ ...priority, count: v })}
+                            min={0}
+                            max={6}
+                            disabled={isEditing}
+                        >
+                            {priority.count}
+                        </InlineNumberEdit>
+                        {' pieces)'}
+                    </>
+                )}
                 {isEditing && (
                     <span className="ml-2 text-xs text-theme-text-secondary">(editing)</span>
                 )}

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -6,6 +6,7 @@ export const CURRENT_VERSION = '1.62.0';
 // CHANGELOG (with the new version + today's date), clear this array back to [],
 // and bump CURRENT_VERSION. All three steps must happen together.
 export const UNRELEASED_CHANGES: string[] = [
+    'Autogear: force a specific implant type to always appear in optimized loadouts (requires Optimize implants to be enabled)',
     'Added audio reader to the Lore page — play individual ship bios and world lore articles via text-to-speech, or use Play All to listen through the entire list hands-free.',
     'Calculators now auto-fill buff and debuff pickers based on the selected ship\'s skill text — buffs granted by the ship appear pre-populated with a "skill" badge and can be removed manually.',
     'DPS Calculator: buffs and debuffs now only apply during the rounds they are actually active. Hover any round on the damage chart to see which buffs and debuffs are active and how many turns remain.',

--- a/src/pages/manager/AutogearPage.tsx
+++ b/src/pages/manager/AutogearPage.tsx
@@ -1385,8 +1385,11 @@ export const AutogearPage: React.FC = () => {
                     onAddSetPriority={(priority) => {
                         if (shipSettings) {
                             const config = getShipConfig(shipSettings.id);
+                            const isImplantEntry = priority.kind === 'implant';
                             const existingIndex = config.setPriorities.findIndex(
-                                (p) => p.setName === priority.setName
+                                (p) =>
+                                    p.setName === priority.setName &&
+                                    (p.kind === 'implant') === isImplantEntry
                             );
                             const updatedPriorities =
                                 existingIndex >= 0
@@ -1394,18 +1397,32 @@ export const AutogearPage: React.FC = () => {
                                           i === existingIndex ? priority : p
                                       )
                                     : [...config.setPriorities, priority];
+                            const updatedExcluded = isImplantEntry
+                                ? (config.excludedImplantTypes ?? []).filter(
+                                      (k) => k !== priority.setName
+                                  )
+                                : config.excludedImplantTypes;
                             updateShipConfig(shipSettings.id, {
                                 setPriorities: updatedPriorities,
+                                excludedImplantTypes: updatedExcluded,
                             });
                         }
                     }}
                     onUpdateSetPriority={(index, priority) => {
                         if (shipSettings) {
                             const config = getShipConfig(shipSettings.id);
+                            const updatedPriorities = config.setPriorities.map((p, i) =>
+                                i === index ? priority : p
+                            );
+                            const updatedExcluded =
+                                priority.kind === 'implant'
+                                    ? (config.excludedImplantTypes ?? []).filter(
+                                          (k) => k !== priority.setName
+                                      )
+                                    : config.excludedImplantTypes;
                             updateShipConfig(shipSettings.id, {
-                                setPriorities: config.setPriorities.map((p, i) =>
-                                    i === index ? priority : p
-                                ),
+                                setPriorities: updatedPriorities,
+                                excludedImplantTypes: updatedExcluded,
                             });
                         }
                     }}
@@ -1475,8 +1492,13 @@ export const AutogearPage: React.FC = () => {
                     }
                     onSetExcludedImplantTypes={(keys) => {
                         if (shipSettings) {
+                            const config = getShipConfig(shipSettings.id);
+                            const filteredPriorities = config.setPriorities.filter(
+                                (p) => !(p.kind === 'implant' && keys.includes(p.setName))
+                            );
                             updateShipConfig(shipSettings.id, {
                                 excludedImplantTypes: keys,
+                                setPriorities: filteredPriorities,
                             });
                         }
                     }}

--- a/src/types/autogear.ts
+++ b/src/types/autogear.ts
@@ -13,6 +13,7 @@ export interface StatPriority {
 export interface SetPriority {
     setName: string;
     count: number;
+    kind?: 'implant';
 }
 
 export interface GearSuggestion {

--- a/src/utils/autogear/__tests__/priorityScore.test.ts
+++ b/src/utils/autogear/__tests__/priorityScore.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { calculatePriorityScore } from '../priorityScore';
+import { BaseStats } from '../../../types/stats';
+import { SetPriority } from '../../../types/autogear';
+
+const stats: BaseStats = {
+    hp: 50000,
+    attack: 10000,
+    defence: 8000,
+    speed: 300,
+    hacking: 5000,
+    security: 3000,
+    crit: 50,
+    critDamage: 150,
+    healModifier: 0,
+    hpRegen: 0,
+    shield: 0,
+    damageReduction: 0,
+    defensePenetration: 0,
+};
+
+describe('calculatePriorityScore — implant set requirements', () => {
+    it('applies no penalty when implant type is present', () => {
+        const setPriorities: SetPriority[] = [{ setName: 'HASTE', count: 1, kind: 'implant' }];
+        const implantSetCount = { HASTE: 1 };
+        const setCount = {};
+        const scoreWith = calculatePriorityScore(
+            stats,
+            [],
+            'ATTACKER',
+            setCount,
+            setPriorities,
+            [],
+            false,
+            0,
+            implantSetCount
+        );
+        const scoreWithout = calculatePriorityScore(stats, [], 'ATTACKER', {}, [], [], false, 0);
+        // With implant satisfied, no penalty — score should equal unconstrained score
+        expect(scoreWith).toBeCloseTo(scoreWithout, 5);
+    });
+
+    it('applies penalty when required implant type is absent', () => {
+        const setPriorities: SetPriority[] = [{ setName: 'HASTE', count: 1, kind: 'implant' }];
+        const setCount = {};
+        const implantSetCount = {};
+        const penalised = calculatePriorityScore(
+            stats,
+            [],
+            'ATTACKER',
+            setCount,
+            setPriorities,
+            [],
+            false,
+            0,
+            implantSetCount
+        );
+        const clean = calculatePriorityScore(stats, [], 'ATTACKER', {}, [], [], false, 0);
+        expect(penalised).toBeLessThan(clean);
+    });
+
+    it('AMBUSH implant does NOT inflate gear orphan penalty', () => {
+        // AMBUSH is in both GEAR_SETS and IMPLANTS
+        const setPriorities: SetPriority[] = [{ setName: 'AMBUSH', count: 1, kind: 'implant' }];
+        const setCount = {}; // no AMBUSH gear
+        const implantSetCount = { AMBUSH: 1 };
+        const scoreWithImplant = calculatePriorityScore(
+            stats,
+            [],
+            'ATTACKER',
+            setCount,
+            setPriorities,
+            [],
+            true,
+            0,
+            implantSetCount
+        );
+        const scoreNoImplant = calculatePriorityScore(
+            stats,
+            [],
+            'ATTACKER',
+            setCount,
+            [],
+            [],
+            true,
+            0
+        );
+        // Having an AMBUSH implant (satisfied requirement) should not reduce score vs no requirement
+        expect(scoreWithImplant).toBeCloseTo(scoreNoImplant, 5);
+    });
+});

--- a/src/utils/autogear/__tests__/priorityScore.test.ts
+++ b/src/utils/autogear/__tests__/priorityScore.test.ts
@@ -88,4 +88,25 @@ describe('calculatePriorityScore — implant set requirements', () => {
         // Having an AMBUSH implant (satisfied requirement) should not reduce score vs no requirement
         expect(scoreWithImplant).toBeCloseTo(scoreNoImplant, 5);
     });
+
+    it('implant count does NOT satisfy a gear-set requirement of the same name', () => {
+        // AMBUSH exists in both GEAR_SETS and IMPLANTS — gear requirement must not be satisfied by implant
+        const gearSetPriority: SetPriority[] = [{ setName: 'AMBUSH', count: 1 }];
+        const implantSetCount = { AMBUSH: 1 };
+        const noGearCount = {};
+        const penalised = calculatePriorityScore(
+            stats,
+            [],
+            'ATTACKER',
+            noGearCount,
+            gearSetPriority,
+            [],
+            false,
+            0,
+            implantSetCount
+        );
+        const clean = calculatePriorityScore(stats, [], 'ATTACKER', {}, [], [], false, 0);
+        // Gear requirement is unsatisfied — penalty should fire even though implant count is present
+        expect(penalised).toBeLessThan(clean);
+    });
 });

--- a/src/utils/autogear/fastScoring/fastScore.ts
+++ b/src/utils/autogear/fastScoring/fastScore.ts
@@ -90,6 +90,18 @@ export function fastScore(
         if (c > 0) setCount[context.gearRegistry.setIdToName[setId]] = c;
     }
 
+    // Build implantSetCount separately — do NOT add to setCount (workspace.setCount is gear-only)
+    const implantSetCount: Record<string, number> = {};
+    for (let i = 0; i < effectiveImplantIds.length; i++) {
+        const id = effectiveImplantIds[i];
+        if (id < 0) continue;
+        const setId = context.implantRegistry.setIds[id];
+        if (setId !== 0) {
+            const name = context.implantRegistry.setIdToName[setId];
+            if (name) implantSetCount[name] = (implantSetCount[name] || 0) + 1;
+        }
+    }
+
     // Arcane siege — check effectiveImplantIds for ARCANE_SIEGE
     let arcaneSiegeMultiplier = 0;
     const shieldCount = setCount['SHIELD'] || 0;
@@ -113,7 +125,8 @@ export function fastScore(
         context.setPriorities as SetPriority[],
         context.statBonuses as StatBonus[],
         context.tryToCompleteSets,
-        arcaneSiegeMultiplier
+        arcaneSiegeMultiplier,
+        implantSetCount
     );
 
     if (!hasHardRequirements) {

--- a/src/utils/autogear/priorityScore.ts
+++ b/src/utils/autogear/priorityScore.ts
@@ -374,7 +374,8 @@ export function calculatePriorityScore(
     setPriorities?: SetPriority[],
     statBonuses?: StatBonus[],
     tryToCompleteSets?: boolean,
-    arcaneSiegeMultiplier: number = 0
+    arcaneSiegeMultiplier: number = 0,
+    implantSetCount?: Record<string, number>
 ): number {
     let penalties = 0;
 
@@ -402,7 +403,9 @@ export function calculatePriorityScore(
     // Calculate set requirement penalties
     if (setPriorities && setPriorities.length > 0 && setCount) {
         for (const setPriority of setPriorities) {
-            const currentCount = setCount[setPriority.setName] || 0;
+            const currentCount =
+                (setCount[setPriority.setName] || 0) +
+                (implantSetCount?.[setPriority.setName] || 0);
             if (currentCount < setPriority.count) {
                 // Calculate penalty as percentage below required count
                 // Multiply by 2 to make set requirements more important

--- a/src/utils/autogear/priorityScore.ts
+++ b/src/utils/autogear/priorityScore.ts
@@ -401,11 +401,11 @@ export function calculatePriorityScore(
     }
 
     // Calculate set requirement penalties
-    if (setPriorities && setPriorities.length > 0 && setCount) {
+    if (setPriorities && setPriorities.length > 0) {
         for (const setPriority of setPriorities) {
-            const currentCount =
-                (setCount[setPriority.setName] || 0) +
-                (implantSetCount?.[setPriority.setName] || 0);
+            const gearCount = setCount?.[setPriority.setName] || 0;
+            const implantCount = implantSetCount?.[setPriority.setName] || 0;
+            const currentCount = setPriority.kind === 'implant' ? implantCount : gearCount;
             if (currentCount < setPriority.count) {
                 // Calculate penalty as percentage below required count
                 // Multiply by 2 to make set requirements more important

--- a/src/utils/autogear/scoring.ts
+++ b/src/utils/autogear/scoring.ts
@@ -241,6 +241,17 @@ export function calculateTotalScore(
     }
     performanceTracker.endTimer('CalculateSetCount');
 
+    // Build implantSetCount separately — keeps setCount gear-only for the orphan penalty loop
+    const implantSetCount: Record<string, number> = {};
+    if (ship.implants) {
+        for (const gearId of Object.values(ship.implants)) {
+            if (!gearId) continue;
+            const gear = getGearPiece(gearId);
+            if (!gear?.setBonus) continue;
+            implantSetCount[gear.setBonus] = (implantSetCount[gear.setBonus] || 0) + 1;
+        }
+    }
+
     // Calculate Arcane Siege multiplier if applicable (reuses setCount, caches implant lookup)
     performanceTracker.startTimer('CalculateArcaneSiege');
     const arcaneSiegeMultiplier = calculateArcaneSiegeMultiplier(ship, setCount, getGearPiece);
@@ -265,7 +276,8 @@ export function calculateTotalScore(
         setPriorities,
         statBonuses,
         tryToCompleteSets,
-        arcaneSiegeMultiplier
+        arcaneSiegeMultiplier,
+        implantSetCount
     );
     performanceTracker.endTimer('CalculatePriorityScore');
 


### PR DESCRIPTION
## Summary

- Allows users to force a specific implant type (family) to always appear in autogear results when "Optimize implants" is enabled
- Reuses the existing `setPriorities` array with a new `kind?: 'implant'` discriminant on `SetPriority`
- Bidirectional mutual exclusion with "Excluded implant types" — forcing removes from exclusions, excluding removes from forced entries

## Changes

**Scoring**
- `SetPriority` extended with `kind?: 'implant'` (AMBUSH-safe — exists in both `GEAR_SETS` and `IMPLANTS`)
- `calculatePriorityScore` gets optional `implantSetCount?` param — feeds requirement penalty only; orphan-penalty loop stays gear-only
- Both slow path (`scoring.ts`) and fast path (`fastScore.ts`) build `implantSetCount` separately from gear `setCount`

**UI**
- `SetPriorityRow`: crash fix for implant keys + hides count editor for implant rows
- `AutogearConfigList`: correct label fallback for implant entries
- `SetPriorityForm`: new `mode="implantType"` for implant-type selection (no count, always produces `count: 1, kind: 'implant'`)
- `AutogearSettings`: new "Forced implant type" picker button, breadcrumb fix, two sub-groups in tweaks list (Gear set / Required implants) with absolute-index callbacks and within-kind-only movement
- `AutogearPage`: kind-scoped dedup + bidirectional mutual exclusion with `excludedImplantTypes`

## Test plan

- [ ] Enable "Optimize implants", open Add tweak → "Forced implant type" appears
- [ ] Add a forced implant type (e.g. Haste) → appears in "Required implants" sub-group
- [ ] Run autogear → a Haste implant is in the result
- [ ] Exclude Haste → forced Haste entry is removed from setPriorities automatically
- [ ] Force Haste → Haste is removed from excludedImplantTypes automatically
- [ ] Add AMBUSH gear set requirement (2 pieces) + AMBUSH forced implant → both coexist, no crash
- [ ] Edit a forced implant row → form shows implant type selector (not gear sets)
- [ ] With no implants in inventory → "Forced implant type" picker button does not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)