### PR TITLE
fix: address PR feedback on DPS calculator stochastic run

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -12,7 +12,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Added audio reader to the Lore page — play individual ship bios and world lore articles via text-to-speech, or use Play All to listen through the entire list hands-free.',
     'Calculators now auto-fill buff and debuff pickers based on the selected ship\'s skill text — buffs granted by the ship appear pre-populated with a "skill" badge and can be removed manually.',
     'DPS Calculator: buffs and debuffs now only apply during the rounds they are actually active. Hover any round on the damage chart to see which buffs and debuffs are active and how many turns remain.',
-    "Hacking and security stats added to the DPS calculator. Set your ship's hacking (auto-filled from ship data) and the enemy's security (Combat Settings) to model the probability of debuffs landing. Defaults keep current behaviour (always land). Damage numbers with partial landing rates are averaged over 200 simulated combats.",
+    "Hacking and security stats added to the DPS calculator. Set your ship's hacking (auto-filled from ship data) and the enemy's security (Combat Settings) to model the probability of debuffs landing. Defaults keep current behaviour (always land). Damage numbers with partial landing rates reflect a single stochastic combat run.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/contexts/ShipsContext.tsx
+++ b/src/contexts/ShipsContext.tsx
@@ -295,6 +295,8 @@ export const ShipsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     useEffect(() => {
         if (!storageShips) return;
 
+        let cancelled = false;
+
         // Authenticated path: loadShips() handles enrichment via the ship_templates join
         if (activeProfileId) {
             setLocalShips(storageShips);
@@ -316,6 +318,7 @@ export const ShipsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
             )
             .in('name', uniqueNames)
             .then(({ data }) => {
+                if (cancelled) return;
                 if (!data) {
                     setLocalShips(storageShips);
                     return;
@@ -338,6 +341,10 @@ export const ShipsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
                     })
                 );
             });
+
+        return () => {
+            cancelled = true;
+        };
     }, [storageShips, activeProfileId]);
 
     const loadShips = useCallback(async () => {

--- a/src/contexts/ShipsContext.tsx
+++ b/src/contexts/ShipsContext.tsx
@@ -295,8 +295,6 @@ export const ShipsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     useEffect(() => {
         if (!storageShips) return;
 
-        let cancelled = false;
-
         // Authenticated path: loadShips() handles enrichment via the ship_templates join
         if (activeProfileId) {
             setLocalShips(storageShips);
@@ -310,6 +308,7 @@ export const ShipsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
             return;
         }
 
+        const controller = new AbortController();
         const uniqueNames = [...new Set(shipsNeedingText.map((s) => s.name))];
         void supabase
             .from('ship_templates')
@@ -317,8 +316,9 @@ export const ShipsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
                 'name, active_skill_text, charge_skill_text, charge_skill_charge, first_passive_skill_text, second_passive_skill_text, third_passive_skill_text'
             )
             .in('name', uniqueNames)
+            .abortSignal(controller.signal)
             .then(({ data }) => {
-                if (cancelled) return;
+                if (controller.signal.aborted) return;
                 if (!data) {
                     setLocalShips(storageShips);
                     return;
@@ -343,7 +343,7 @@ export const ShipsProvider: React.FC<{ children: React.ReactNode }> = ({ childre
             });
 
         return () => {
-            cancelled = true;
+            controller.abort();
         };
     }, [storageShips, activeProfileId]);
 

--- a/src/utils/calculators/__tests__/dpsSimulator.test.ts
+++ b/src/utils/calculators/__tests__/dpsSimulator.test.ts
@@ -629,9 +629,26 @@ describe('simulateDPS', () => {
         });
 
         it('50% landing gives damage between 0% and 100% landing', () => {
-            const full = simulateDPS({ ...baseWithDebuff, hacking: 200, enemySecurity: 100 });
-            const none = simulateDPS({ ...baseWithDebuff, hacking: 0, enemySecurity: 100 });
-            const partial = simulateDPS({ ...baseWithDebuff, hacking: 150, enemySecurity: 100 });
+            // Use a large round count so the stochastic mid-landing case reliably falls
+            // between the deterministic 0% and 100% landing results.
+            const full = simulateDPS({
+                ...baseWithDebuff,
+                rounds: 1000,
+                hacking: 200,
+                enemySecurity: 100,
+            });
+            const none = simulateDPS({
+                ...baseWithDebuff,
+                rounds: 1000,
+                hacking: 0,
+                enemySecurity: 100,
+            });
+            const partial = simulateDPS({
+                ...baseWithDebuff,
+                rounds: 1000,
+                hacking: 150,
+                enemySecurity: 100,
+            });
             expect(partial.summary.totalDamage).toBeGreaterThan(none.summary.totalDamage);
             expect(partial.summary.totalDamage).toBeLessThan(full.summary.totalDamage);
         });

--- a/src/utils/calculators/dpsSimulator.ts
+++ b/src/utils/calculators/dpsSimulator.ts
@@ -151,7 +151,16 @@ function runSinglePass(params: {
     affinityDamageModifier: number;
     affinityCritCap: number;
     affinityCritPenalty: number;
-}): RoundData[] {
+}): {
+    rounds: RoundData[];
+    rawTotals: {
+        direct: number;
+        corrosion: number;
+        inferno: number;
+        bomb: number;
+        cumulative: number;
+    };
+} {
     const {
         attack,
         crit,
@@ -181,6 +190,10 @@ function runSinglePass(params: {
     // All mutable state declared fresh on every call
     let charges = startCharged ? chargeCount : 0;
     let cumulativeDamage = 0;
+    let totalDirectRaw = 0;
+    let totalCorrosionRaw = 0;
+    let totalInfernoRaw = 0;
+    let totalBombRaw = 0;
     const corrosionEntries: ActiveDoTStack[] = [];
     const infernoEntries: ActiveDoTStack[] = [];
     const pendingBombs: PendingBomb[] = [];
@@ -221,10 +234,11 @@ function runSinglePass(params: {
             toSimBuffs(roundSelfBuffs)
         );
 
+        const roundDebuffLanded = Math.random() < debuffLandingChance;
         const landedEnemyDebuffs: ActiveBuff[] = [];
         const resistedEnemyDebuffs: ActiveBuff[] = [];
         const roundEnemyDebuffs = entry.activeEnemyDebuffs.flatMap((ab) => {
-            if (Math.random() >= debuffLandingChance) {
+            if (!roundDebuffLanded) {
                 resistedEnemyDebuffs.push(ab);
                 return [];
             }
@@ -274,7 +288,7 @@ function runSinglePass(params: {
             affinityMult;
 
         // Step 3: Apply new DoT stacks from this round's skill (subject to landing roll)
-        const dotsLanded = Math.random() < debuffLandingChance;
+        const dotsLanded = roundDebuffLanded;
         if (dotsLanded) {
             for (const dot of dotsConfig) {
                 if (dot.stacks <= 0 || dot.tier <= 0) continue;
@@ -325,6 +339,10 @@ function runSinglePass(params: {
 
         const totalRoundDamage = directDamage + corrosionDamage + infernoDamage + bombDamage;
         cumulativeDamage += totalRoundDamage;
+        totalDirectRaw += directDamage;
+        totalCorrosionRaw += corrosionDamage;
+        totalInfernoRaw += infernoDamage;
+        totalBombRaw += bombDamage;
 
         // Report stacks after expiry (state going into next round)
         roundData.push({
@@ -368,7 +386,16 @@ function runSinglePass(params: {
         });
     }
 
-    return roundData;
+    return {
+        rounds: roundData,
+        rawTotals: {
+            direct: totalDirectRaw,
+            corrosion: totalCorrosionRaw,
+            inferno: totalInfernoRaw,
+            bomb: totalBombRaw,
+            cumulative: cumulativeDamage,
+        },
+    };
 }
 
 export function simulateDPS(input: DPSSimulationInput): DPSSimulationResult {
@@ -423,7 +450,7 @@ export function simulateDPS(input: DPSSimulationInput): DPSSimulationResult {
         enemyDebuffLookup.set(b.buffName, [...existing, b]);
     }
 
-    const rounds = runSinglePass({
+    const { rounds, rawTotals } = runSinglePass({
         attack,
         crit,
         critDamage,
@@ -449,27 +476,17 @@ export function simulateDPS(input: DPSSimulationInput): DPSSimulationResult {
         affinityCritPenalty,
     });
 
-    let totalDirectDamage = 0;
-    let totalCorrosionDamage = 0;
-    let totalInfernoDamage = 0;
-    let totalBombDamage = 0;
-    for (const rd of rounds) {
-        totalDirectDamage += rd.directDamage;
-        totalCorrosionDamage += rd.corrosionDamage;
-        totalInfernoDamage += rd.infernoDamage;
-        totalBombDamage += rd.bombDamage;
-    }
-    const totalDamage = rounds[rounds.length - 1]?.cumulativeDamage ?? 0;
+    const totalDamage = Math.round(rawTotals.cumulative);
 
     return {
         rounds,
         summary: {
             totalDamage,
-            avgDamagePerRound: Math.round(totalDamage / numRounds),
-            totalDirectDamage,
-            totalCorrosionDamage,
-            totalInfernoDamage,
-            totalBombDamage,
+            avgDamagePerRound: Math.round(rawTotals.cumulative / numRounds),
+            totalDirectDamage: Math.round(rawTotals.direct),
+            totalCorrosionDamage: Math.round(rawTotals.corrosion),
+            totalInfernoDamage: Math.round(rawTotals.inferno),
+            totalBombDamage: Math.round(rawTotals.bomb),
         },
     };
 }


### PR DESCRIPTION
- changelog: describe partial-landing damage as a single stochastic run
  instead of an average over 200 combats.
- ShipsContext: add a cancellation flag to the unauthenticated template
  fetch so stale supabase responses can't overwrite newer state.
- dpsSimulator: use a single per-round landing roll for both enemy
  debuffs and DoT application; accumulate raw damage values inside the
  simulation loop and round only at the summary boundary so summary
  totals match cumulativeDamage without rounding drift.
- dpsSimulator tests: increase rounds in the 50%-landing test to
  eliminate flakiness from small-sample all-land/all-fail outcomes.