### PR TITLE
feat: add Classified Archive hidden ARG page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,7 @@ const ChronoReaverCalculatorPage = lazy(
     () => import('./pages/calculators/ChronoReaverCalculatorPage')
 );
 const AdminPanel = lazy(() => import('./pages/admin/AdminPanel'));
+const ClassifiedPage = lazy(() => import('./pages/ClassifiedPage'));
 const NotFoundPage = lazy(() => import('./pages/NotFoundPage'));
 
 const App: React.FC = () => {
@@ -297,6 +298,12 @@ const App: React.FC = () => {
                                                                                         path="/admin"
                                                                                         element={
                                                                                             <AdminPanel />
+                                                                                        }
+                                                                                    />
+                                                                                    <Route
+                                                                                        path="/classified"
+                                                                                        element={
+                                                                                            <ClassifiedPage />
                                                                                         }
                                                                                     />
                                                                                     <Route

--- a/src/__tests__/utils/classifiedArchive.test.ts
+++ b/src/__tests__/utils/classifiedArchive.test.ts
@@ -27,8 +27,24 @@ describe('readUnlocked', () => {
     it('filters out non-string entries', () => {
         localStorage.setItem(
             'classified_unlocked',
-            JSON.stringify(['valid', 42, null, 'also-valid'])
+            JSON.stringify(['the-mechanisms', 42, null, 'the-bludgeon'])
         );
-        expect(readUnlocked()).toEqual(['valid', 'also-valid']);
+        expect(readUnlocked()).toEqual(['the-mechanisms', 'the-bludgeon']);
+    });
+
+    it('filters out unknown fragment IDs', () => {
+        localStorage.setItem(
+            'classified_unlocked',
+            JSON.stringify(['the-mechanisms', 'unknown-id', 'the-bludgeon'])
+        );
+        expect(readUnlocked()).toEqual(['the-mechanisms', 'the-bludgeon']);
+    });
+
+    it('deduplicates repeated fragment IDs', () => {
+        localStorage.setItem(
+            'classified_unlocked',
+            JSON.stringify(['the-mechanisms', 'the-mechanisms', 'the-bludgeon'])
+        );
+        expect(readUnlocked()).toEqual(['the-mechanisms', 'the-bludgeon']);
     });
 });

--- a/src/__tests__/utils/classifiedArchive.test.ts
+++ b/src/__tests__/utils/classifiedArchive.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readUnlocked, writeUnlocked } from '../../constants/classifiedArchive';
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe('readUnlocked', () => {
+    it('returns empty array when key is absent', () => {
+        expect(readUnlocked()).toEqual([]);
+    });
+
+    it('returns stored fragment IDs', () => {
+        writeUnlocked(['the-mechanisms', 'the-bludgeon']);
+        expect(readUnlocked()).toEqual(['the-mechanisms', 'the-bludgeon']);
+    });
+
+    it('returns empty array when stored value is malformed JSON', () => {
+        localStorage.setItem('classified_unlocked', 'not-json{{{');
+        expect(readUnlocked()).toEqual([]);
+    });
+
+    it('returns empty array when stored value is not an array', () => {
+        localStorage.setItem('classified_unlocked', JSON.stringify({ id: 'x' }));
+        expect(readUnlocked()).toEqual([]);
+    });
+
+    it('filters out non-string entries', () => {
+        localStorage.setItem(
+            'classified_unlocked',
+            JSON.stringify(['valid', 42, null, 'also-valid'])
+        );
+        expect(readUnlocked()).toEqual(['valid', 'also-valid']);
+    });
+});

--- a/src/components/seo/Seo.tsx
+++ b/src/components/seo/Seo.tsx
@@ -6,9 +6,10 @@ interface SeoProps {
     title?: string;
     keywords?: string;
     ogImage?: string;
+    noIndex?: boolean;
 }
 
-const Seo: React.FC<SeoProps> = ({ title, description, keywords, ogImage }) => {
+const Seo: React.FC<SeoProps> = ({ title, description, keywords, ogImage, noIndex }) => {
     const siteTitle = 'Starborne Planner';
     const fullTitle = title ? `${title} | ${siteTitle}` : siteTitle;
     const siteUrl = 'https://starborneplanner.com';
@@ -21,6 +22,7 @@ const Seo: React.FC<SeoProps> = ({ title, description, keywords, ogImage }) => {
             <meta name="description" content={description} />
             {keywords && <meta name="keywords" content={keywords} />}
             <link rel="canonical" href={canonicalUrl} />
+            {noIndex && <meta name="robots" content="noindex,nofollow" />}
 
             {/* Open Graph / Facebook */}
             <meta property="og:type" content="website" />

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -5,7 +5,9 @@ export const CURRENT_VERSION = '1.63.0';
 // RELEASE CHECKLIST: move these strings into a new ChangelogEntry at the top of
 // CHANGELOG (with the new version + today's date), clear this array back to [],
 // and bump CURRENT_VERSION. All three steps must happen together.
-export const UNRELEASED_CHANGES: string[] = [];
+export const UNRELEASED_CHANGES: string[] = [
+    'Classified terminal: two-screen layout with index and detail views, keyboard navigation (↑↓/Enter/Esc), animated decode transitions, and a final transmission revealed when all 4 fragments are decrypted.',
+];
 
 export const CHANGELOG: ChangelogEntry[] = [
     {

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -5,9 +5,7 @@ export const CURRENT_VERSION = '1.63.0';
 // RELEASE CHECKLIST: move these strings into a new ChangelogEntry at the top of
 // CHANGELOG (with the new version + today's date), clear this array back to [],
 // and bump CURRENT_VERSION. All three steps must happen together.
-export const UNRELEASED_CHANGES: string[] = [
-    'Classified terminal: two-screen layout with index and detail views, keyboard navigation (↑↓/Enter/Esc), animated decode transitions, and a final transmission revealed when all 4 fragments are decrypted.',
-];
+export const UNRELEASED_CHANGES: string[] = [];
 
 export const CHANGELOG: ChangelogEntry[] = [
     {

--- a/src/constants/classifiedArchive.ts
+++ b/src/constants/classifiedArchive.ts
@@ -51,7 +51,14 @@ export function readUnlocked(): string[] {
     try {
         const raw = localStorage.getItem('classified_unlocked');
         const parsed = raw ? JSON.parse(raw) : [];
-        return Array.isArray(parsed) ? parsed.filter((x) => typeof x === 'string') : [];
+        if (!Array.isArray(parsed)) return [];
+        const validIds = new Set(CLASSIFIED_FRAGMENTS.map((f) => f.id));
+        const seen = new Set<string>();
+        return parsed.filter((x) => {
+            if (typeof x !== 'string' || !validIds.has(x) || seen.has(x)) return false;
+            seen.add(x);
+            return true;
+        });
     } catch {
         return [];
     }

--- a/src/constants/classifiedArchive.ts
+++ b/src/constants/classifiedArchive.ts
@@ -1,0 +1,62 @@
+export interface ClassifiedFragment {
+    id: string;
+    title: string;
+    hintLine: string;
+    authCode: string;
+    body: string;
+    barColorClass: string;
+    sourceEggSlug: string;
+}
+
+export const CLASSIFIED_FRAGMENTS: ClassifiedFragment[] = [
+    {
+        id: 'the-mechanisms',
+        title: 'The Doors Were Always There',
+        hintLine: 'GRAVIMETRIC SURVEY — TAU SCORPII REGION — BINDERBURG INTERNAL',
+        authCode: 'DOOR-7A',
+        barColorClass: 'text-indigo-400',
+        sourceEggSlug: 'the-mechanisms',
+        body: `[PLACEHOLDER — awaiting dev lore]\n\nThe mechanisms predate every recorded civilisation. Gelecek derived the Translocation Drive from them. Binderburg has been quietly fortifying stations in their vicinity for decades.\n\nNeither faction understands what they actually are.\n\nThey are not artifacts. They are not ruins.\n\nThey are doors.`,
+    },
+    {
+        id: 'the-bludgeon',
+        title: 'First Contact — Field Report',
+        hintLine: 'ANOMALY DESIGNATION: THE_BLUDGEON — GELECEK FIELD INTELLIGENCE',
+        authCode: 'HIVE-3X',
+        barColorClass: 'text-yellow-400',
+        sourceEggSlug: 'the-bludgeon',
+        body: `[PLACEHOLDER — awaiting dev lore]\n\nFirst contact was not recognised as contact.\n\nArmored plating that reforms around damage. Communications no scanner has ever detected. Swarming offshoots responding to a signal that cannot be found.\n\nThe researchers thought they were observing a weapon.\n\nThey were being observed.`,
+    },
+    {
+        id: 'the-abyss',
+        title: 'Internal Memo — Blockade Command',
+        hintLine: 'SPIRAL EXPANSE BLOCKADE — JOINT FACTION COMMUNIQUÉ — EYES ONLY',
+        authCode: 'KEEP-OUT',
+        barColorClass: 'text-purple-400',
+        sourceEggSlug: 'the-abyss',
+        body: `[PLACEHOLDER — awaiting dev lore]\n\nAll six factions agreed to the blockade.\n\nThis has never happened before. It has never happened since.\n\nThe official statement says the anomaly is a navigational hazard. The classified addendum says the blockade is not to keep ships out.\n\nIt is to keep something in.\n\nIt is no longer working.`,
+    },
+    {
+        id: 'furnace-of-heaven',
+        title: 'Furnace Signal — Decrypted Packet',
+        hintLine: 'ENCRYPTED SIGNAL — ORIGIN: FURNACE OF HEAVEN NEBULA — UNATTRIBUTED',
+        authCode: 'ALREADY',
+        barColorClass: 'text-orange-400',
+        sourceEggSlug: 'furnace-of-heaven',
+        body: `[PLACEHOLDER — awaiting dev lore]\n\nThe signal has been broadcasting for longer than the blockade has existed.\n\nThree probes and one unarmed scout were dispatched to triangulate. None returned.\n\nThe signal is not a warning.\n\nIt is not a distress call.\n\nDecryption analysis suggests it is a census.`,
+    },
+];
+
+export function readUnlocked(): string[] {
+    try {
+        const raw = localStorage.getItem('classified_unlocked');
+        const parsed = raw ? JSON.parse(raw) : [];
+        return Array.isArray(parsed) ? parsed.filter((x) => typeof x === 'string') : [];
+    } catch {
+        return [];
+    }
+}
+
+export function writeUnlocked(ids: string[]): void {
+    localStorage.setItem('classified_unlocked', JSON.stringify(ids));
+}

--- a/src/constants/classifiedArchive.ts
+++ b/src/constants/classifiedArchive.ts
@@ -12,7 +12,7 @@ export const CLASSIFIED_FRAGMENTS: ClassifiedFragment[] = [
     {
         id: 'the-mechanisms',
         title: 'The Doors Were Always There',
-        hintLine: 'GRAVIMETRIC SURVEY — TAU SCORPII REGION — BINDERBURG INTERNAL',
+        hintLine: 'BINDERBURG SURVEY LOG — TAU SCORPII — STRUCTURE CLASS: UNDEFINED',
         authCode: 'DOOR-7A',
         barColorClass: 'text-indigo-400',
         sourceEggSlug: 'the-mechanisms',
@@ -21,7 +21,7 @@ export const CLASSIFIED_FRAGMENTS: ClassifiedFragment[] = [
     {
         id: 'the-bludgeon',
         title: 'First Contact — Field Report',
-        hintLine: 'ANOMALY DESIGNATION: THE_BLUDGEON — GELECEK FIELD INTELLIGENCE',
+        hintLine: 'GELECEK FIELD INTEL — BLUNT-ALPHA CONTACT LOG — PLASMA SHELL',
         authCode: 'HIVE-3X',
         barColorClass: 'text-yellow-400',
         sourceEggSlug: 'the-bludgeon',
@@ -30,7 +30,7 @@ export const CLASSIFIED_FRAGMENTS: ClassifiedFragment[] = [
     {
         id: 'the-abyss',
         title: 'Internal Memo — Blockade Command',
-        hintLine: 'SPIRAL EXPANSE BLOCKADE — JOINT FACTION COMMUNIQUÉ — EYES ONLY',
+        hintLine: 'JOINT FACTION INCIDENT — EXPANSE PERIMETER — DEPTH CLASS: OMEGA',
         authCode: 'KEEP-OUT',
         barColorClass: 'text-purple-400',
         sourceEggSlug: 'the-abyss',
@@ -39,7 +39,7 @@ export const CLASSIFIED_FRAGMENTS: ClassifiedFragment[] = [
     {
         id: 'furnace-of-heaven',
         title: 'Furnace Signal — Decrypted Packet',
-        hintLine: 'ENCRYPTED SIGNAL — ORIGIN: FURNACE OF HEAVEN NEBULA — UNATTRIBUTED',
+        hintLine: 'SIGNAL INTERCEPT — NEBULAR STELLAR FORGE — HEAT SIG: CELESTIAL',
         authCode: 'ALREADY',
         barColorClass: 'text-orange-400',
         sourceEggSlug: 'furnace-of-heaven',

--- a/src/index.css
+++ b/src/index.css
@@ -890,6 +890,117 @@
         }
     }
 
+    /* ── Classified Archive page ──────────────────────────── */
+
+    .classified-static {
+        background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.4'/%3E%3C/svg%3E");
+        background-size: 150px 150px;
+        animation: classified-static-scroll 0.4s steps(4) infinite;
+        transition-property: opacity;
+        transition-duration: 700ms;
+        transition-timing-function: ease-out;
+        pointer-events: none;
+    }
+
+    @keyframes classified-static-scroll {
+        0% {
+            background-position: 0 0;
+        }
+        25% {
+            background-position: 50px 25px;
+        }
+        50% {
+            background-position: 25px 50px;
+        }
+        75% {
+            background-position: 75px 0;
+        }
+        100% {
+            background-position: 0 75px;
+        }
+    }
+
+    .classified-title-glitch {
+        animation: classified-title-glitch 8s steps(1) infinite;
+    }
+
+    @keyframes classified-title-glitch {
+        0%,
+        92%,
+        100% {
+            text-shadow: none;
+            clip-path: none;
+            transform: none;
+        }
+        93% {
+            text-shadow:
+                2px 0 #f0f,
+                -2px 0 #0ff;
+            clip-path: inset(20% 0 60% 0);
+            transform: translateX(3px);
+        }
+        94% {
+            text-shadow:
+                -2px 0 #f0f,
+                2px 0 #0ff;
+            clip-path: inset(60% 0 10% 0);
+            transform: translateX(-3px);
+        }
+        95% {
+            text-shadow: none;
+            clip-path: none;
+            transform: none;
+        }
+        96% {
+            text-shadow: 1px 0 #f0f;
+            clip-path: inset(40% 0 40% 0);
+            transform: translateX(1px);
+        }
+        97% {
+            text-shadow: none;
+            clip-path: none;
+            transform: none;
+        }
+    }
+
+    .classified-fragment-noise::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.35'/%3E%3C/svg%3E");
+        background-size: 100px 100px;
+        animation: classified-static-scroll 0.5s steps(3) infinite;
+        pointer-events: none;
+        border-radius: inherit;
+    }
+
+    .classified-decode {
+        animation: classified-decode 0.6s ease-out forwards;
+    }
+
+    @keyframes classified-decode {
+        from {
+            opacity: 0;
+            filter: blur(4px);
+            letter-spacing: 0.4em;
+        }
+        to {
+            opacity: 1;
+            filter: none;
+            letter-spacing: normal;
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .classified-static,
+        .classified-title-glitch,
+        .classified-fragment-noise::before,
+        .classified-decode {
+            animation: none !important;
+            transition: none !important;
+        }
+    }
+
     /* Synthwave: Background color on body (image moved to fixed div for mobile compat) */
     [data-theme='synthwave'] body {
         background-color: rgb(var(--color-bg));

--- a/src/pages/ClassifiedPage.tsx
+++ b/src/pages/ClassifiedPage.tsx
@@ -5,6 +5,12 @@ import { CLASSIFIED_FRAGMENTS, readUnlocked, writeUnlocked } from '../constants/
 
 const BAR_TOTAL = 22;
 
+const BOOT_LINES: [string, string, string] = [
+    '> ROUTING THROUGH ANSIBLE RELAY — ORIGIN MASKED...',
+    '> BYPASSING SOVA WATCHDOG PROTOCOL...',
+    '> PULLING CLASSIFIED FILE: ABYSS INCIDENT...',
+];
+
 const OPACITY_BY_UNLOCKED: Record<number, string> = {
     0: 'opacity-60',
     1: 'opacity-40',
@@ -35,6 +41,10 @@ export default function ClassifiedPage() {
     const [decrypting, setDecrypting] = useState<Record<string, boolean>>({});
     const [barProgress, setBarProgress] = useState<Record<string, number>>({});
 
+    const [bootComplete, setBootComplete] = useState(false);
+    const [bootBarProgress, setBootBarProgress] = useState<number | null>(null);
+    const [bootBarFilled, setBootBarFilled] = useState(false);
+
     const intervalsRef = useRef<Record<string, ReturnType<typeof setInterval>>>({});
     const flickerRef = useRef<HTMLDivElement>(null);
 
@@ -47,6 +57,36 @@ export default function ClassifiedPage() {
         const intervals = intervalsRef.current;
         return () => {
             Object.values(intervals).forEach(clearInterval);
+        };
+    }, []);
+
+    useEffect(() => {
+        const timers: ReturnType<typeof setTimeout>[] = [];
+        let fillInterval: ReturnType<typeof setInterval> | null = null;
+
+        timers.push(
+            setTimeout(() => {
+                setBootBarProgress(0);
+                let count = 0;
+                fillInterval = setInterval(() => {
+                    count++;
+                    setBootBarProgress(count);
+                    if (count >= BAR_TOTAL) {
+                        if (fillInterval) clearInterval(fillInterval);
+                        timers.push(
+                            setTimeout(() => {
+                                setBootBarFilled(true);
+                                timers.push(setTimeout(() => setBootComplete(true), 500));
+                            }, 200)
+                        );
+                    }
+                }, 40);
+            }, 1800)
+        );
+
+        return () => {
+            timers.forEach(clearTimeout);
+            if (fillInterval) clearInterval(fillInterval);
         };
     }, []);
 
@@ -182,12 +222,6 @@ export default function ClassifiedPage() {
                 <div className="absolute inset-0 bg-[url('/images/BG2.png')] bg-cover opacity-[0.15] mix-blend-screen" />
                 <div className="absolute inset-0 bg-black/60" />
 
-                {/* VHS glitch burst */}
-                <div
-                    ref={flickerRef}
-                    className="not-found-burst absolute inset-0 pointer-events-none bg-[url('/images/transition.webp')] bg-cover mix-blend-darken"
-                />
-
                 {/* Corruption static overlay */}
                 <div
                     className={`classified-static absolute inset-0 mix-blend-overlay ${staticOpacity}`}
@@ -195,12 +229,46 @@ export default function ClassifiedPage() {
 
                 {/* Content */}
                 <div className="relative z-10 flex items-center justify-center min-h-full p-4">
-                    <div className="max-w-2xl w-full card backdrop-blur-sm">
+                    <div className="relative overflow-hidden max-w-2xl w-full card backdrop-blur-sm">
+                        {/* VHS glitch burst — card-scoped */}
+                        <div
+                            ref={flickerRef}
+                            className="not-found-burst absolute inset-0 pointer-events-none bg-[url('/images/transition.webp')] bg-cover mix-blend-darken z-10"
+                        />
+                        {/* BOOT SEQUENCE */}
+                        {!bootComplete && (
+                            <div className="space-y-1 font-mono text-sm">
+                                {BOOT_LINES.map((line, i) => (
+                                    <div
+                                        key={i}
+                                        className="not-found-line text-green-400"
+                                        style={{ animationDelay: `${0.2 + i * 0.35}s` }}
+                                    >
+                                        {line}
+                                    </div>
+                                ))}
+                                <div
+                                    className="not-found-line"
+                                    style={{ animationDelay: `${0.2 + 3 * 0.35}s` }}
+                                >
+                                    <span
+                                        className={
+                                            bootBarFilled ? 'text-red-400' : 'text-green-400'
+                                        }
+                                    >
+                                        {bootBarFilled
+                                            ? `> ${'█'.repeat(BAR_TOTAL)} [BREACH CONFIRMED]`
+                                            : `> ${'█'.repeat(bootBarProgress ?? 0)}${'░'.repeat(BAR_TOTAL - (bootBarProgress ?? 0))}`}
+                                    </span>
+                                </div>
+                            </div>
+                        )}
+
                         {/* INDEX SCREEN */}
-                        {mode === 'index' && (
-                            <div key="index" className="classified-decode">
+                        {bootComplete && mode === 'index' && (
+                            <div key="index" className="not-found-reveal classified-decode">
                                 {/* Header */}
-                                <div className="text-[0.65rem] text-gray-500 uppercase tracking-[0.3em]">
+                                <div className="text-[0.65rem] text-primary uppercase tracking-[0.3em]">
                                     {'// STARBORNE PLANNER'}
                                 </div>
                                 <p className="classified-title-glitch font-mono text-sm font-bold tracking-[0.3em] uppercase text-primary mt-1">
@@ -291,12 +359,24 @@ export default function ClassifiedPage() {
                                     </span>
                                     base
                                 </p>
+
+                                {/* Warning — presence detected */}
+                                <div className="mt-3 space-y-0.5">
+                                    <p className="font-mono text-[0.65rem] text-red-400 tracking-widest">
+                                        {
+                                            'UNAUTHORIZED ACCESS DETECTED — COUNTER MEASURES ACTIVATED'
+                                        }
+                                    </p>
+                                </div>
                             </div>
                         )}
 
                         {/* DETAIL SCREEN */}
-                        {mode === 'detail' && activeFragment && (
-                            <div key={activeFragmentId} className="classified-decode">
+                        {bootComplete && mode === 'detail' && activeFragment && (
+                            <div
+                                key={activeFragmentId}
+                                className="not-found-reveal classified-decode"
+                            >
                                 <div className="text-[0.65rem] text-gray-500 uppercase tracking-[0.3em]">
                                     {'// FRAGMENT ACCESS'}
                                 </div>

--- a/src/pages/ClassifiedPage.tsx
+++ b/src/pages/ClassifiedPage.tsx
@@ -1,0 +1,215 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Seo from '../components/seo/Seo';
+import { Button } from '../components/ui';
+import { CLASSIFIED_FRAGMENTS, readUnlocked, writeUnlocked } from '../constants/classifiedArchive';
+
+const BAR_TOTAL = 22;
+
+const OPACITY_BY_UNLOCKED: Record<number, string> = {
+    0: 'opacity-60',
+    1: 'opacity-40',
+    2: 'opacity-25',
+    3: 'opacity-10',
+    4: 'opacity-0',
+};
+
+const FINAL_TRANSMISSION = `[PLACEHOLDER — awaiting dev lore]\n\nThe mechanisms. The Bludgeon. The blockade. The signal.\n\nFour pieces. One answer.\n\nIt came through before the blockade was established.\n\nIt has been here the whole time.\n\nIt is patient.`;
+
+export default function ClassifiedPage() {
+    const navigate = useNavigate();
+    const [unlocked, setUnlocked] = useState<string[]>(() => readUnlocked());
+    const [inputs, setInputs] = useState<Record<string, string>>({});
+    const [errors, setErrors] = useState<Record<string, boolean>>({});
+    const [decrypting, setDecrypting] = useState<Record<string, boolean>>({});
+    const [barProgress, setBarProgress] = useState<Record<string, number>>({});
+
+    const unlockedCount = unlocked.length;
+    const allUnlocked = unlockedCount === CLASSIFIED_FRAGMENTS.length;
+    const staticOpacity = OPACITY_BY_UNLOCKED[Math.min(unlockedCount, 4)];
+
+    function handleSubmit(fragmentId: string, authCode: string) {
+        const input = (inputs[fragmentId] ?? '').trim().toUpperCase();
+        if (input !== authCode.trim().toUpperCase()) {
+            setErrors((e) => ({ ...e, [fragmentId]: true }));
+            setTimeout(() => setErrors((e) => ({ ...e, [fragmentId]: false })), 800);
+            return;
+        }
+
+        // Start decrypt bar animation
+        setDecrypting((d) => ({ ...d, [fragmentId]: true }));
+        let count = 0;
+        const interval = setInterval(() => {
+            count++;
+            setBarProgress((p) => ({ ...p, [fragmentId]: count }));
+            if (count >= BAR_TOTAL) {
+                clearInterval(interval);
+                const next = [...unlocked, fragmentId];
+                setUnlocked(next);
+                writeUnlocked(next);
+                setDecrypting((d) => ({ ...d, [fragmentId]: false }));
+            }
+        }, 40);
+    }
+
+    return (
+        <>
+            <Seo
+                title="CLASSIFIED — STARBORNE PLANNER"
+                description="Abyss Incident — Classified Archive"
+                noIndex
+            />
+            <div className="not-found-scanlines fixed inset-0 z-[110] font-secondary overflow-y-auto">
+                {/* Background layers */}
+                <div className="absolute inset-0 bg-[url('/images/Deep_crevasse_01_extended.webp')] bg-cover bg-top" />
+                <div className="absolute inset-0 bg-[url('/images/BG2.png')] bg-cover opacity-[0.15] mix-blend-screen" />
+                <div className="absolute inset-0 bg-black/60" />
+
+                {/* Corruption static overlay */}
+                <div
+                    className={`classified-static absolute inset-0 mix-blend-overlay ${staticOpacity}`}
+                />
+
+                {/* Content */}
+                <div className="relative z-10 flex flex-col items-center min-h-full p-4 py-12 gap-6">
+                    {/* Header */}
+                    <div className="max-w-2xl w-full card backdrop-blur-sm space-y-3">
+                        <div className="text-[0.65rem] text-primary uppercase tracking-[0.3em]">
+                            {'// STARBORNE PLANNER'}
+                        </div>
+                        <p className="classified-title-glitch font-mono text-sm font-bold tracking-[0.3em] uppercase text-primary">
+                            {'> ABYSS INCIDENT — CLASSIFIED ARCHIVE'}
+                        </p>
+                        <p className="font-mono text-xs text-gray-500 tracking-widest">
+                            {`[${unlockedCount}/${CLASSIFIED_FRAGMENTS.length} FRAGMENTS DECRYPTED]`}
+                        </p>
+                    </div>
+
+                    {/* Fragment slots */}
+                    {CLASSIFIED_FRAGMENTS.map((fragment) => {
+                        const isUnlocked = unlocked.includes(fragment.id);
+                        const isDecrypting = decrypting[fragment.id] ?? false;
+                        const progress = barProgress[fragment.id] ?? 0;
+                        const hasError = errors[fragment.id] ?? false;
+
+                        return (
+                            <div
+                                key={fragment.id}
+                                className="max-w-2xl w-full card backdrop-blur-sm relative overflow-hidden"
+                            >
+                                {/* Noise overlay on locked fragments */}
+                                {!isUnlocked && !isDecrypting && (
+                                    <div className="classified-fragment-noise absolute inset-0 z-0" />
+                                )}
+
+                                <div className="relative z-10 space-y-4">
+                                    {isDecrypting ? (
+                                        <div className="space-y-2 font-mono text-sm">
+                                            <p className="text-green-400">{'> DECRYPTING...'}</p>
+                                            <p className={fragment.barColorClass}>
+                                                {`> ${'█'.repeat(progress)}${'░'.repeat(BAR_TOTAL - progress)}`}
+                                            </p>
+                                        </div>
+                                    ) : isUnlocked ? (
+                                        <div className="classified-decode space-y-4">
+                                            <div className="flex items-center justify-between">
+                                                <p
+                                                    className={`font-mono text-xs font-bold tracking-widest uppercase ${fragment.barColorClass}`}
+                                                >
+                                                    {`> ${'█'.repeat(BAR_TOTAL)} [DECRYPTED]`}
+                                                </p>
+                                            </div>
+                                            <div className="space-y-1">
+                                                <p className="text-base font-bold tracking-widest uppercase text-primary">
+                                                    {fragment.title}
+                                                </p>
+                                            </div>
+                                            <div className="text-sm text-gray-400 space-y-3 font-mono">
+                                                {fragment.body.split('\n\n').map((para, i) => (
+                                                    <p key={i}>{para}</p>
+                                                ))}
+                                            </div>
+                                        </div>
+                                    ) : (
+                                        <div className="space-y-4">
+                                            <p className="font-mono text-xs text-gray-600 tracking-widest uppercase">
+                                                {`> ORIGIN FILE: ${fragment.hintLine} — FIELD AGENTS ONLY`}
+                                            </p>
+                                            <p
+                                                className={`font-mono text-xs ${hasError ? 'text-red-400' : 'text-gray-600'} tracking-widest`}
+                                            >
+                                                {hasError
+                                                    ? '> [AUTHORIZATION FAILED]'
+                                                    : '> ENTER AUTH CODE TO DECRYPT'}
+                                            </p>
+                                            <div className="flex gap-2 items-center font-mono text-sm">
+                                                <span className="text-green-400 shrink-0">
+                                                    {'>'}
+                                                </span>
+                                                <input
+                                                    type="text"
+                                                    maxLength={12}
+                                                    placeholder="_ _ _ _ _ _"
+                                                    value={inputs[fragment.id] ?? ''}
+                                                    onChange={(e) =>
+                                                        setInputs((i) => ({
+                                                            ...i,
+                                                            [fragment.id]: e.target.value,
+                                                        }))
+                                                    }
+                                                    onKeyDown={(e) => {
+                                                        if (e.key === 'Enter')
+                                                            handleSubmit(
+                                                                fragment.id,
+                                                                fragment.authCode
+                                                            );
+                                                    }}
+                                                    className={`bg-transparent border-b ${hasError ? 'border-red-500 text-red-400' : 'border-gray-600 text-green-400'} outline-none uppercase tracking-widest w-40 placeholder-gray-700 text-sm`}
+                                                    autoComplete="off"
+                                                    spellCheck={false}
+                                                />
+                                                <Button
+                                                    variant="secondary"
+                                                    size="xs"
+                                                    onClick={() =>
+                                                        handleSubmit(fragment.id, fragment.authCode)
+                                                    }
+                                                >
+                                                    SUBMIT
+                                                </Button>
+                                            </div>
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+                        );
+                    })}
+
+                    {/* Final transmission — 4/4 only */}
+                    {allUnlocked && (
+                        <div className="max-w-2xl w-full card backdrop-blur-sm classified-decode space-y-4">
+                            <p className="font-mono text-xs text-red-500 tracking-widest uppercase font-bold">
+                                {'> FINAL TRANSMISSION — DECRYPTED'}
+                            </p>
+                            <p className="text-base font-bold tracking-widest uppercase text-primary">
+                                ARCHIVE COMPLETE
+                            </p>
+                            <div className="text-sm text-gray-400 space-y-3 font-mono">
+                                {FINAL_TRANSMISSION.split('\n\n').map((para, i) => (
+                                    <p key={i}>{para}</p>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Footer nav */}
+                    <div className="max-w-2xl w-full flex justify-center">
+                        <Button variant="secondary" onClick={() => void navigate('/')}>
+                            Return to Base
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+}

--- a/src/pages/ClassifiedPage.tsx
+++ b/src/pages/ClassifiedPage.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Seo from '../components/seo/Seo';
-import { Button } from '../components/ui';
 import { CLASSIFIED_FRAGMENTS, readUnlocked, writeUnlocked } from '../constants/classifiedArchive';
 
 const BAR_TOTAL = 22;
@@ -19,8 +18,10 @@ const FINAL_TRANSMISSION = `[PLACEHOLDER — awaiting dev lore]\n\nThe mechanism
 type Mode = 'index' | 'detail';
 
 export default function ClassifiedPage() {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const navigate = useNavigate();
     const [unlocked, setUnlocked] = useState<string[]>(() => readUnlocked());
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [inputs, setInputs] = useState<Record<string, string>>({});
     const [errors, setErrors] = useState<Record<string, boolean>>({});
     const [decrypting, setDecrypting] = useState<Record<string, boolean>>({});
@@ -28,10 +29,8 @@ export default function ClassifiedPage() {
 
     const intervalsRef = useRef<Record<string, ReturnType<typeof setInterval>>>({});
 
-    // New state — two-screen model (used in Tasks 2–4; suppress until then)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    // New state — two-screen model
     const [mode, setMode] = useState<Mode>('index');
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [cursorIndex, setCursorIndex] = useState(0);
     const [activeFragmentId, setActiveFragmentId] = useState<string | null>(null);
 
@@ -46,6 +45,7 @@ export default function ClassifiedPage() {
     const allUnlocked = unlockedCount === CLASSIFIED_FRAGMENTS.length;
     const staticOpacity = OPACITY_BY_UNLOCKED[Math.min(unlockedCount, 4)];
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const handleSubmit = useCallback(
         (fragmentId: string, authCode: string) => {
             const input = (inputs[fragmentId] ?? '').trim().toUpperCase();
@@ -74,7 +74,6 @@ export default function ClassifiedPage() {
         [inputs]
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const navigateToFragment = useCallback((index: number) => {
         const fragment = CLASSIFIED_FRAGMENTS[index];
         setCursorIndex(index);
@@ -88,7 +87,6 @@ export default function ClassifiedPage() {
         setActiveFragmentId(null);
     }, []);
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const activeFragment = activeFragmentId
         ? (CLASSIFIED_FRAGMENTS.find((f) => f.id === activeFragmentId) ?? null)
         : null;
@@ -121,142 +119,116 @@ export default function ClassifiedPage() {
                 />
 
                 {/* Content */}
-                <div className="relative z-10 flex flex-col items-center min-h-full p-4 py-12 gap-6">
-                    {/* Header */}
-                    <div className="max-w-2xl w-full card backdrop-blur-sm space-y-3">
-                        <div className="text-[0.65rem] text-primary uppercase tracking-[0.3em]">
-                            {'// STARBORNE PLANNER'}
-                        </div>
-                        <p className="classified-title-glitch font-mono text-sm font-bold tracking-[0.3em] uppercase text-primary">
-                            {'> ABYSS INCIDENT — CLASSIFIED ARCHIVE'}
-                        </p>
-                        <p className="font-mono text-xs text-gray-500 tracking-widest">
-                            {`[${unlockedCount}/${CLASSIFIED_FRAGMENTS.length} FRAGMENTS DECRYPTED]`}
-                        </p>
-                    </div>
+                <div className="relative z-10 flex flex-col items-center min-h-full p-4 py-12">
+                    <div className="max-w-2xl w-full card backdrop-blur-sm">
+                        {/* INDEX SCREEN */}
+                        {mode === 'index' && (
+                            <div key="index" className="classified-decode">
+                                {/* Header */}
+                                <div className="text-[0.65rem] text-gray-500 uppercase tracking-[0.3em]">
+                                    {'// STARBORNE PLANNER'}
+                                </div>
+                                <p className="classified-title-glitch font-mono text-sm font-bold tracking-[0.3em] uppercase text-primary mt-1">
+                                    {'> ABYSS INCIDENT — CLASSIFIED ARCHIVE'}
+                                </p>
+                                <p className="font-mono text-xs text-gray-500 tracking-widest mt-1 mb-3">
+                                    {`[${unlockedCount}/${CLASSIFIED_FRAGMENTS.length} FRAGMENTS DECRYPTED]`}
+                                </p>
 
-                    {/* Fragment slots */}
-                    {CLASSIFIED_FRAGMENTS.map((fragment) => {
-                        const isUnlocked = unlocked.includes(fragment.id);
-                        const isDecrypting = decrypting[fragment.id] ?? false;
-                        const progress = barProgress[fragment.id] ?? 0;
-                        const hasError = errors[fragment.id] ?? false;
+                                <hr className="border-gray-800 mb-3" />
 
-                        return (
-                            <div
-                                key={fragment.id}
-                                className="max-w-2xl w-full card backdrop-blur-sm relative overflow-hidden"
-                            >
-                                {/* Noise overlay on locked fragments */}
-                                {!isUnlocked && !isDecrypting && (
-                                    <div className="classified-fragment-noise absolute inset-0 z-0" />
+                                {/* Instruction hint */}
+                                <p className="font-mono text-[0.65rem] text-gray-600 tracking-widest mb-3">
+                                    {'USE ↑↓ TO NAVIGATE · ENTER OR CLICK TO ACCESS'}
+                                </p>
+
+                                {/* Fragment rows */}
+                                <div>
+                                    {CLASSIFIED_FRAGMENTS.map((fragment, i) => {
+                                        const isFocused = cursorIndex === i;
+                                        const isRowUnlocked = unlocked.includes(fragment.id);
+                                        return (
+                                            <div
+                                                key={fragment.id}
+                                                className={`flex items-center justify-between py-0.5 cursor-pointer ${
+                                                    isFocused
+                                                        ? 'bg-green-950/30 border-l-2 border-green-400 -mx-4 px-[14px]'
+                                                        : 'pl-5'
+                                                }`}
+                                                onMouseEnter={() => setCursorIndex(i)}
+                                                onClick={() => navigateToFragment(i)}
+                                            >
+                                                <span className="font-mono text-xs tracking-widest flex items-center gap-2">
+                                                    <span
+                                                        className={`w-3 shrink-0 text-green-400 ${isFocused ? '' : 'invisible'}`}
+                                                    >
+                                                        ▶
+                                                    </span>
+                                                    <span className={fragment.barColorClass}>
+                                                        {fragment.title.toUpperCase()}
+                                                    </span>
+                                                </span>
+                                                <span
+                                                    className={`font-mono text-[0.6rem] font-bold tracking-widest px-1 border ml-2 shrink-0 ${
+                                                        isRowUnlocked
+                                                            ? 'text-green-400 border-green-900 bg-green-950/50'
+                                                            : 'text-red-400 border-red-900 bg-red-950/30'
+                                                    }`}
+                                                >
+                                                    {isRowUnlocked ? 'DECRYPTED' : 'LOCKED'}
+                                                </span>
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+
+                                {/* Final transmission — 4/4 only, index mode only */}
+                                {allUnlocked && (
+                                    <div className="classified-decode mt-4 space-y-3">
+                                        <hr className="border-gray-800" />
+                                        <p className="font-mono text-xs text-red-500 tracking-widest uppercase font-bold">
+                                            {'> FINAL TRANSMISSION — DECRYPTED'}
+                                        </p>
+                                        <p className="text-base font-bold tracking-widest uppercase text-primary">
+                                            ARCHIVE COMPLETE
+                                        </p>
+                                        <div className="text-sm text-gray-400 space-y-3 font-mono">
+                                            {FINAL_TRANSMISSION.split('\n\n').map((para, i) => (
+                                                <p key={i}>{para}</p>
+                                            ))}
+                                        </div>
+                                    </div>
                                 )}
 
-                                <div className="relative z-10 space-y-4">
-                                    {isDecrypting ? (
-                                        <div className="space-y-2 font-mono text-sm">
-                                            <p className="text-green-400">{'> DECRYPTING...'}</p>
-                                            <p className={fragment.barColorClass}>
-                                                {`> ${'█'.repeat(progress)}${'░'.repeat(BAR_TOTAL - progress)}`}
-                                            </p>
-                                        </div>
-                                    ) : isUnlocked ? (
-                                        <div className="classified-decode space-y-4">
-                                            <div className="flex items-center justify-between">
-                                                <p
-                                                    className={`font-mono text-xs font-bold tracking-widest uppercase ${fragment.barColorClass}`}
-                                                >
-                                                    {`> ${'█'.repeat(BAR_TOTAL)} [DECRYPTED]`}
-                                                </p>
-                                            </div>
-                                            <div className="space-y-1">
-                                                <p className="text-base font-bold tracking-widest uppercase text-primary">
-                                                    {fragment.title}
-                                                </p>
-                                            </div>
-                                            <div className="text-sm text-gray-400 space-y-3 font-mono">
-                                                {fragment.body.split('\n\n').map((para, i) => (
-                                                    <p key={i}>{para}</p>
-                                                ))}
-                                            </div>
-                                        </div>
-                                    ) : (
-                                        <div className="space-y-4">
-                                            <p className="font-mono text-xs text-gray-600 tracking-widest uppercase">
-                                                {`> ORIGIN FILE: ${fragment.hintLine} — FIELD AGENTS ONLY`}
-                                            </p>
-                                            <p
-                                                className={`font-mono text-xs ${hasError ? 'text-red-400' : 'text-gray-600'} tracking-widest`}
-                                            >
-                                                {hasError
-                                                    ? '> [AUTHORIZATION FAILED]'
-                                                    : '> ENTER AUTH CODE TO DECRYPT'}
-                                            </p>
-                                            <div className="flex gap-2 items-center font-mono text-sm">
-                                                <span className="text-green-400 shrink-0">
-                                                    {'>'}
-                                                </span>
-                                                <input
-                                                    type="text"
-                                                    maxLength={12}
-                                                    placeholder="_ _ _ _ _ _"
-                                                    value={inputs[fragment.id] ?? ''}
-                                                    onChange={(e) =>
-                                                        setInputs((i) => ({
-                                                            ...i,
-                                                            [fragment.id]: e.target.value,
-                                                        }))
-                                                    }
-                                                    onKeyDown={(e) => {
-                                                        if (e.key === 'Enter')
-                                                            handleSubmit(
-                                                                fragment.id,
-                                                                fragment.authCode
-                                                            );
-                                                    }}
-                                                    className={`bg-transparent border-b ${hasError ? 'border-red-500 text-red-400' : 'border-gray-600 text-green-400'} outline-none uppercase tracking-widest w-40 placeholder-gray-700 text-sm`}
-                                                    autoComplete="off"
-                                                    spellCheck={false}
-                                                />
-                                                <Button
-                                                    variant="secondary"
-                                                    size="xs"
-                                                    onClick={() =>
-                                                        handleSubmit(fragment.id, fragment.authCode)
-                                                    }
-                                                >
-                                                    SUBMIT
-                                                </Button>
-                                            </div>
-                                        </div>
-                                    )}
-                                </div>
-                            </div>
-                        );
-                    })}
+                                <hr className="border-gray-800 mt-4 mb-2" />
 
-                    {/* Final transmission — 4/4 only */}
-                    {allUnlocked && (
-                        <div className="max-w-2xl w-full card backdrop-blur-sm classified-decode space-y-4">
-                            <p className="font-mono text-xs text-red-500 tracking-widest uppercase font-bold">
-                                {'> FINAL TRANSMISSION — DECRYPTED'}
-                            </p>
-                            <p className="text-base font-bold tracking-widest uppercase text-primary">
-                                ARCHIVE COMPLETE
-                            </p>
-                            <div className="text-sm text-gray-400 space-y-3 font-mono">
-                                {FINAL_TRANSMISSION.split('\n\n').map((para, i) => (
-                                    <p key={i}>{para}</p>
-                                ))}
+                                {/* Footer key legend */}
+                                <p className="font-mono text-[0.65rem] text-gray-600 tracking-widest">
+                                    <span className="inline-block bg-black border border-gray-700 text-gray-500 text-[0.6rem] px-1 mr-0.5">
+                                        ↑
+                                    </span>
+                                    <span className="inline-block bg-black border border-gray-700 text-gray-500 text-[0.6rem] px-1 mr-2">
+                                        ↓
+                                    </span>
+                                    {'move · '}
+                                    <span className="inline-block bg-black border border-gray-700 text-gray-500 text-[0.6rem] px-1 mx-1">
+                                        ↵
+                                    </span>
+                                    {'open · '}
+                                    <span className="inline-block bg-black border border-gray-700 text-gray-500 text-[0.6rem] px-1 mx-1">
+                                        ESC
+                                    </span>
+                                    base
+                                </p>
                             </div>
-                        </div>
-                    )}
+                        )}
 
-                    {/* Footer nav */}
-                    <div className="max-w-2xl w-full flex justify-center">
-                        <Button variant="secondary" onClick={() => void navigate('/')}>
-                            Return to Base
-                        </Button>
+                        {/* DETAIL SCREEN — implemented in Task 4 */}
+                        {mode === 'detail' && activeFragment && (
+                            <div key={activeFragmentId} className="classified-decode">
+                                <p className="font-mono text-xs text-gray-500">Loading fragment…</p>
+                            </div>
+                        )}
                     </div>
                 </div>
             </div>

--- a/src/pages/ClassifiedPage.tsx
+++ b/src/pages/ClassifiedPage.tsx
@@ -20,7 +20,6 @@ type Mode = 'index' | 'detail';
 export default function ClassifiedPage() {
     const navigate = useNavigate();
     const [unlocked, setUnlocked] = useState<string[]>(() => readUnlocked());
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [inputs, setInputs] = useState<Record<string, string>>({});
     const [errors, setErrors] = useState<Record<string, boolean>>({});
     const [decrypting, setDecrypting] = useState<Record<string, boolean>>({});
@@ -134,13 +133,9 @@ export default function ClassifiedPage() {
         ? (CLASSIFIED_FRAGMENTS.find((f) => f.id === activeFragmentId) ?? null)
         : null;
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const detailIsUnlocked = activeFragmentId ? unlocked.includes(activeFragmentId) : false;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const detailIsDecrypting = activeFragmentId ? (decrypting[activeFragmentId] ?? false) : false;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const detailProgress = activeFragmentId ? (barProgress[activeFragmentId] ?? 0) : 0;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const detailHasError = activeFragmentId ? (errors[activeFragmentId] ?? false) : false;
 
     return (
@@ -266,10 +261,123 @@ export default function ClassifiedPage() {
                             </div>
                         )}
 
-                        {/* DETAIL SCREEN — implemented in Task 4 */}
+                        {/* DETAIL SCREEN */}
                         {mode === 'detail' && activeFragment && (
                             <div key={activeFragmentId} className="classified-decode">
-                                <p className="font-mono text-xs text-gray-500">Loading fragment…</p>
+                                <div className="text-[0.65rem] text-gray-500 uppercase tracking-[0.3em]">
+                                    {'// FRAGMENT ACCESS'}
+                                </div>
+                                <p
+                                    className={`font-mono text-sm font-bold tracking-[0.3em] uppercase ${activeFragment.barColorClass} mt-1 mb-3`}
+                                >
+                                    {activeFragment.title.toUpperCase()}
+                                </p>
+
+                                {/* DECRYPTING STATE */}
+                                {detailIsDecrypting && (
+                                    <div className="space-y-1 font-mono text-xs">
+                                        <p className="text-gray-500 tracking-widest">
+                                            {'> STATUS: '}
+                                            <span className="text-green-400">DECRYPTING...</span>
+                                        </p>
+                                        <hr className="border-gray-800 my-2" />
+                                        <p className={activeFragment.barColorClass}>
+                                            {`> ${'█'.repeat(detailProgress)}${'░'.repeat(BAR_TOTAL - detailProgress)} ${Math.round((detailProgress / BAR_TOTAL) * 100)}%`}
+                                        </p>
+                                        <hr className="border-gray-800 mt-3 mb-2" />
+                                        <p className="text-gray-600 tracking-widest">{'— — —'}</p>
+                                    </div>
+                                )}
+
+                                {/* UNLOCKED STATE */}
+                                {!detailIsDecrypting && detailIsUnlocked && (
+                                    <div>
+                                        <p
+                                            className={`font-mono text-xs tracking-widest ${activeFragment.barColorClass} mb-3`}
+                                        >
+                                            {`> ${'█'.repeat(BAR_TOTAL)} [DECRYPTED]`}
+                                        </p>
+                                        <hr className="border-gray-800 mb-3" />
+                                        <div className="classified-decode text-sm text-gray-400 space-y-3 font-mono">
+                                            {activeFragment.body.split('\n\n').map((para, i) => (
+                                                <p key={i}>{para}</p>
+                                            ))}
+                                        </div>
+                                        <hr className="border-gray-800 mt-3 mb-2" />
+                                        <p className="font-mono text-[0.65rem] text-gray-600 tracking-widest">
+                                            <span className="inline-block bg-black border border-gray-700 text-gray-500 text-[0.6rem] px-1 mr-1">
+                                                ESC
+                                            </span>
+                                            back to index
+                                        </p>
+                                    </div>
+                                )}
+
+                                {/* LOCKED STATE */}
+                                {!detailIsDecrypting && !detailIsUnlocked && (
+                                    <div>
+                                        <p className="font-mono text-xs text-gray-600 tracking-widest">
+                                            {`> ORIGIN FILE: ${activeFragment.hintLine} — FIELD AGENTS ONLY`}
+                                        </p>
+                                        <p className="font-mono text-xs text-gray-600 tracking-widest mt-1">
+                                            {'> STATUS: '}
+                                            <span className="text-red-400">
+                                                LOCKED — AUTH REQUIRED
+                                            </span>
+                                        </p>
+                                        <hr className="border-gray-800 my-3" />
+                                        <p
+                                            className={`font-mono text-xs tracking-widest ${
+                                                detailHasError ? 'text-red-400' : 'text-gray-500'
+                                            }`}
+                                        >
+                                            {detailHasError
+                                                ? '> [AUTHORIZATION FAILED]'
+                                                : '> ENTER AUTH CODE TO DECRYPT'}
+                                        </p>
+                                        <div className="flex items-center gap-2 font-mono text-sm mt-2">
+                                            <span className="text-green-400">{'>'}</span>
+                                            <input
+                                                type="text"
+                                                maxLength={12}
+                                                placeholder="_ _ _ _ _ _"
+                                                value={inputs[activeFragment.id] ?? ''}
+                                                onChange={(e) =>
+                                                    setInputs((p) => ({
+                                                        ...p,
+                                                        [activeFragment.id]: e.target.value,
+                                                    }))
+                                                }
+                                                onKeyDown={(e) => {
+                                                    if (e.key === 'Enter')
+                                                        handleSubmit(
+                                                            activeFragment.id,
+                                                            activeFragment.authCode
+                                                        );
+                                                }}
+                                                className={`bg-transparent border-b ${
+                                                    detailHasError
+                                                        ? 'border-red-500 text-red-400'
+                                                        : 'border-gray-600 text-green-400'
+                                                } outline-none uppercase tracking-widest w-40 placeholder-gray-700 text-sm`}
+                                                autoComplete="off"
+                                                spellCheck={false}
+                                                autoFocus
+                                            />
+                                        </div>
+                                        <hr className="border-gray-800 mt-3 mb-2" />
+                                        <p className="font-mono text-[0.65rem] text-gray-600 tracking-widest">
+                                            <span className="inline-block bg-black border border-gray-700 text-gray-500 text-[0.6rem] px-1 mr-0.5">
+                                                ↵
+                                            </span>
+                                            {'submit · '}
+                                            <span className="inline-block bg-black border border-gray-700 text-gray-500 text-[0.6rem] px-1 mx-1">
+                                                ESC
+                                            </span>
+                                            back to index
+                                        </p>
+                                    </div>
+                                )}
                             </div>
                         )}
                     </div>

--- a/src/pages/ClassifiedPage.tsx
+++ b/src/pages/ClassifiedPage.tsx
@@ -120,6 +120,7 @@ export default function ClassifiedPage() {
 
     const handleSubmit = useCallback(
         (fragmentId: string, authCode: string) => {
+            if (decrypting[fragmentId] || unlocked.includes(fragmentId)) return;
             const input = (inputs[fragmentId] ?? '').trim().toUpperCase();
             if (input !== authCode.trim().toUpperCase()) {
                 setErrors((e) => ({ ...e, [fragmentId]: true }));
@@ -134,16 +135,17 @@ export default function ClassifiedPage() {
                 if (count >= BAR_TOTAL) {
                     clearInterval(interval);
                     setUnlocked((prev) => {
-                        const next = [...prev, fragmentId];
+                        const next = prev.includes(fragmentId) ? prev : [...prev, fragmentId];
                         writeUnlocked(next);
                         return next;
                     });
                     setDecrypting((d) => ({ ...d, [fragmentId]: false }));
+                    delete intervalsRef.current[fragmentId];
                 }
             }, 40);
             intervalsRef.current[fragmentId] = interval;
         },
-        [inputs]
+        [inputs, decrypting, unlocked]
     );
 
     const navigateToFragment = useCallback((index: number) => {

--- a/src/pages/ClassifiedPage.tsx
+++ b/src/pages/ClassifiedPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Seo from '../components/seo/Seo';
 import { Button } from '../components/ui';
@@ -23,6 +23,15 @@ export default function ClassifiedPage() {
     const [errors, setErrors] = useState<Record<string, boolean>>({});
     const [decrypting, setDecrypting] = useState<Record<string, boolean>>({});
     const [barProgress, setBarProgress] = useState<Record<string, number>>({});
+
+    const intervalsRef = useRef<Record<string, ReturnType<typeof setInterval>>>({});
+
+    useEffect(() => {
+        const intervals = intervalsRef.current;
+        return () => {
+            Object.values(intervals).forEach(clearInterval);
+        };
+    }, []);
 
     const unlockedCount = unlocked.length;
     const allUnlocked = unlockedCount === CLASSIFIED_FRAGMENTS.length;
@@ -50,6 +59,7 @@ export default function ClassifiedPage() {
                 setDecrypting((d) => ({ ...d, [fragmentId]: false }));
             }
         }, 40);
+        intervalsRef.current[fragmentId] = interval;
     }
 
     return (

--- a/src/pages/ClassifiedPage.tsx
+++ b/src/pages/ClassifiedPage.tsx
@@ -18,7 +18,6 @@ const FINAL_TRANSMISSION = `[PLACEHOLDER — awaiting dev lore]\n\nThe mechanism
 type Mode = 'index' | 'detail';
 
 export default function ClassifiedPage() {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const navigate = useNavigate();
     const [unlocked, setUnlocked] = useState<string[]>(() => readUnlocked());
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -45,7 +44,6 @@ export default function ClassifiedPage() {
     const allUnlocked = unlockedCount === CLASSIFIED_FRAGMENTS.length;
     const staticOpacity = OPACITY_BY_UNLOCKED[Math.min(unlockedCount, 4)];
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const handleSubmit = useCallback(
         (fragmentId: string, authCode: string) => {
             const input = (inputs[fragmentId] ?? '').trim().toUpperCase();
@@ -81,11 +79,56 @@ export default function ClassifiedPage() {
         setMode('detail');
     }, []);
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const navigateToIndex = useCallback(() => {
         setMode('index');
         setActiveFragmentId(null);
     }, []);
+
+    useEffect(() => {
+        function onKeyDown(e: KeyboardEvent) {
+            if (mode === 'index') {
+                if (e.key === 'ArrowUp') {
+                    e.preventDefault();
+                    setCursorIndex(
+                        (i) => (i - 1 + CLASSIFIED_FRAGMENTS.length) % CLASSIFIED_FRAGMENTS.length
+                    );
+                } else if (e.key === 'ArrowDown') {
+                    e.preventDefault();
+                    setCursorIndex((i) => (i + 1) % CLASSIFIED_FRAGMENTS.length);
+                } else if (e.key === 'Enter') {
+                    navigateToFragment(cursorIndex);
+                } else if (e.key === 'Escape') {
+                    void navigate('/');
+                }
+            } else if (mode === 'detail' && activeFragmentId) {
+                if (e.key === 'Escape') {
+                    if (decrypting[activeFragmentId]) return;
+                    navigateToIndex();
+                } else if (e.key === 'Enter' && document.activeElement?.tagName !== 'INPUT') {
+                    const fragment = CLASSIFIED_FRAGMENTS.find((f) => f.id === activeFragmentId);
+                    if (
+                        fragment &&
+                        !unlocked.includes(activeFragmentId) &&
+                        !decrypting[activeFragmentId]
+                    ) {
+                        handleSubmit(activeFragmentId, fragment.authCode);
+                    }
+                }
+            }
+        }
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, [
+        mode,
+        cursorIndex,
+        activeFragmentId,
+        decrypting,
+        unlocked,
+        navigate,
+        navigateToFragment,
+        navigateToIndex,
+        handleSubmit,
+    ]);
 
     const activeFragment = activeFragmentId
         ? (CLASSIFIED_FRAGMENTS.find((f) => f.id === activeFragmentId) ?? null)

--- a/src/pages/ClassifiedPage.tsx
+++ b/src/pages/ClassifiedPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Seo from '../components/seo/Seo';
 import { Button } from '../components/ui';
@@ -16,6 +16,8 @@ const OPACITY_BY_UNLOCKED: Record<number, string> = {
 
 const FINAL_TRANSMISSION = `[PLACEHOLDER — awaiting dev lore]\n\nThe mechanisms. The Bludgeon. The blockade. The signal.\n\nFour pieces. One answer.\n\nIt came through before the blockade was established.\n\nIt has been here the whole time.\n\nIt is patient.`;
 
+type Mode = 'index' | 'detail';
+
 export default function ClassifiedPage() {
     const navigate = useNavigate();
     const [unlocked, setUnlocked] = useState<string[]>(() => readUnlocked());
@@ -25,6 +27,13 @@ export default function ClassifiedPage() {
     const [barProgress, setBarProgress] = useState<Record<string, number>>({});
 
     const intervalsRef = useRef<Record<string, ReturnType<typeof setInterval>>>({});
+
+    // New state — two-screen model (used in Tasks 2–4; suppress until then)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [mode, setMode] = useState<Mode>('index');
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [cursorIndex, setCursorIndex] = useState(0);
+    const [activeFragmentId, setActiveFragmentId] = useState<string | null>(null);
 
     useEffect(() => {
         const intervals = intervalsRef.current;
@@ -37,30 +46,61 @@ export default function ClassifiedPage() {
     const allUnlocked = unlockedCount === CLASSIFIED_FRAGMENTS.length;
     const staticOpacity = OPACITY_BY_UNLOCKED[Math.min(unlockedCount, 4)];
 
-    function handleSubmit(fragmentId: string, authCode: string) {
-        const input = (inputs[fragmentId] ?? '').trim().toUpperCase();
-        if (input !== authCode.trim().toUpperCase()) {
-            setErrors((e) => ({ ...e, [fragmentId]: true }));
-            setTimeout(() => setErrors((e) => ({ ...e, [fragmentId]: false })), 800);
-            return;
-        }
-
-        // Start decrypt bar animation
-        setDecrypting((d) => ({ ...d, [fragmentId]: true }));
-        let count = 0;
-        const interval = setInterval(() => {
-            count++;
-            setBarProgress((p) => ({ ...p, [fragmentId]: count }));
-            if (count >= BAR_TOTAL) {
-                clearInterval(interval);
-                const next = [...unlocked, fragmentId];
-                setUnlocked(next);
-                writeUnlocked(next);
-                setDecrypting((d) => ({ ...d, [fragmentId]: false }));
+    const handleSubmit = useCallback(
+        (fragmentId: string, authCode: string) => {
+            const input = (inputs[fragmentId] ?? '').trim().toUpperCase();
+            if (input !== authCode.trim().toUpperCase()) {
+                setErrors((e) => ({ ...e, [fragmentId]: true }));
+                setTimeout(() => setErrors((e) => ({ ...e, [fragmentId]: false })), 800);
+                return;
             }
-        }, 40);
-        intervalsRef.current[fragmentId] = interval;
-    }
+            setDecrypting((d) => ({ ...d, [fragmentId]: true }));
+            let count = 0;
+            const interval = setInterval(() => {
+                count++;
+                setBarProgress((p) => ({ ...p, [fragmentId]: count }));
+                if (count >= BAR_TOTAL) {
+                    clearInterval(interval);
+                    setUnlocked((prev) => {
+                        const next = [...prev, fragmentId];
+                        writeUnlocked(next);
+                        return next;
+                    });
+                    setDecrypting((d) => ({ ...d, [fragmentId]: false }));
+                }
+            }, 40);
+            intervalsRef.current[fragmentId] = interval;
+        },
+        [inputs]
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const navigateToFragment = useCallback((index: number) => {
+        const fragment = CLASSIFIED_FRAGMENTS[index];
+        setCursorIndex(index);
+        setActiveFragmentId(fragment.id);
+        setMode('detail');
+    }, []);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const navigateToIndex = useCallback(() => {
+        setMode('index');
+        setActiveFragmentId(null);
+    }, []);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const activeFragment = activeFragmentId
+        ? (CLASSIFIED_FRAGMENTS.find((f) => f.id === activeFragmentId) ?? null)
+        : null;
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const detailIsUnlocked = activeFragmentId ? unlocked.includes(activeFragmentId) : false;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const detailIsDecrypting = activeFragmentId ? (decrypting[activeFragmentId] ?? false) : false;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const detailProgress = activeFragmentId ? (barProgress[activeFragmentId] ?? 0) : 0;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const detailHasError = activeFragmentId ? (errors[activeFragmentId] ?? false) : false;
 
     return (
         <>

--- a/src/pages/ClassifiedPage.tsx
+++ b/src/pages/ClassifiedPage.tsx
@@ -13,7 +13,17 @@ const OPACITY_BY_UNLOCKED: Record<number, string> = {
     4: 'opacity-0',
 };
 
-const FINAL_TRANSMISSION = `[PLACEHOLDER — awaiting dev lore]\n\nThe mechanisms. The Bludgeon. The blockade. The signal.\n\nFour pieces. One answer.\n\nIt came through before the blockade was established.\n\nIt has been here the whole time.\n\nIt is patient.`;
+// Stored as +1 Caesar shift — each letter incremented by one
+const FINAL_TRANSMISSION_ENCODED = `[QMBDFIPMEFS — bxbjujoh efw mpsf]\n\nUif nfdibojtnt. Uif Cmvehfpo. Uif cmpdlbef. Uif tjhobm.\n\nGpvs qjfdft. Pof botxfs.\n\nJu dbnf uispvhi cfgpsf uif cmpdlbef xbt ftubcmjtife.\n\nJu ibt cffo ifsf uif xipmf ujnf.\n\nJu jt qbujfou.`;
+
+function decipherTransmission(text: string): string {
+    return text.replace(/[a-zA-Z]/g, (c) => {
+        const base = c >= 'a' ? 97 : 65;
+        return String.fromCharCode(((c.charCodeAt(0) - base - 1 + 26) % 26) + base);
+    });
+}
+
+const FINAL_TRANSMISSION = decipherTransmission(FINAL_TRANSMISSION_ENCODED);
 
 type Mode = 'index' | 'detail';
 
@@ -26,6 +36,7 @@ export default function ClassifiedPage() {
     const [barProgress, setBarProgress] = useState<Record<string, number>>({});
 
     const intervalsRef = useRef<Record<string, ReturnType<typeof setInterval>>>({});
+    const flickerRef = useRef<HTMLDivElement>(null);
 
     // New state — two-screen model
     const [mode, setMode] = useState<Mode>('index');
@@ -36,6 +47,30 @@ export default function ClassifiedPage() {
         const intervals = intervalsRef.current;
         return () => {
             Object.values(intervals).forEach(clearInterval);
+        };
+    }, []);
+
+    useEffect(() => {
+        const flicker = flickerRef.current;
+        const triggerBurst = () => {
+            if (!flicker) return;
+            flicker.classList.remove('not-found-burst-active');
+            void flicker.offsetWidth;
+            flicker.classList.add('not-found-burst-active');
+        };
+        const schedule = (): ReturnType<typeof setTimeout> =>
+            setTimeout(
+                () => {
+                    triggerBurst();
+                    timeoutRef = schedule();
+                },
+                3000 + Math.random() * 3000
+            );
+        const initialTimer = setTimeout(triggerBurst, 600);
+        let timeoutRef = schedule();
+        return () => {
+            clearTimeout(initialTimer);
+            clearTimeout(timeoutRef);
         };
     }, []);
 
@@ -140,16 +175,18 @@ export default function ClassifiedPage() {
 
     return (
         <>
-            <Seo
-                title="CLASSIFIED — STARBORNE PLANNER"
-                description="Abyss Incident — Classified Archive"
-                noIndex
-            />
+            <Seo title="CLASSIFIED" description="Abyss Incident — Classified Archive" noIndex />
             <div className="not-found-scanlines fixed inset-0 z-[110] font-secondary overflow-y-auto">
                 {/* Background layers */}
                 <div className="absolute inset-0 bg-[url('/images/Deep_crevasse_01_extended.webp')] bg-cover bg-top" />
                 <div className="absolute inset-0 bg-[url('/images/BG2.png')] bg-cover opacity-[0.15] mix-blend-screen" />
                 <div className="absolute inset-0 bg-black/60" />
+
+                {/* VHS glitch burst */}
+                <div
+                    ref={flickerRef}
+                    className="not-found-burst absolute inset-0 pointer-events-none bg-[url('/images/transition.webp')] bg-cover mix-blend-darken"
+                />
 
                 {/* Corruption static overlay */}
                 <div
@@ -157,7 +194,7 @@ export default function ClassifiedPage() {
                 />
 
                 {/* Content */}
-                <div className="relative z-10 flex flex-col items-center min-h-full p-4 py-12">
+                <div className="relative z-10 flex items-center justify-center min-h-full p-4">
                     <div className="max-w-2xl w-full card backdrop-blur-sm">
                         {/* INDEX SCREEN */}
                         {mode === 'index' && (
@@ -188,11 +225,7 @@ export default function ClassifiedPage() {
                                         return (
                                             <div
                                                 key={fragment.id}
-                                                className={`flex items-center justify-between py-0.5 cursor-pointer ${
-                                                    isFocused
-                                                        ? 'bg-green-950/30 border-l-2 border-green-400 -mx-4 px-[14px]'
-                                                        : 'pl-5'
-                                                }`}
+                                                className={`flex items-center justify-between py-0.5 cursor-pointer ${isFocused ? 'bg-green-950/30' : ''}`}
                                                 onMouseEnter={() => setCursorIndex(i)}
                                                 onClick={() => navigateToFragment(i)}
                                             >
@@ -200,7 +233,7 @@ export default function ClassifiedPage() {
                                                     <span
                                                         className={`w-3 shrink-0 text-green-400 ${isFocused ? '' : 'invisible'}`}
                                                     >
-                                                        ▶
+                                                        {'>'}
                                                     </span>
                                                     <span className={fragment.barColorClass}>
                                                         {fragment.title.toUpperCase()}

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -275,7 +275,7 @@ const DocumentationPage: React.FC = () => {
                                         <li>The Steam client</li>
                                     </ul>
 
-                                    <div className="p-4 bg-dark-lighter">
+                                    <div className="card">
                                         <h4 className="font-semibold text-primary mb-2">
                                             Steps to Export Data:
                                         </h4>
@@ -323,7 +323,7 @@ const DocumentationPage: React.FC = () => {
                                         </div>
                                     </div>
 
-                                    <div className="p-4 bg-dark-lighter">
+                                    <div className="card">
                                         <h4 className="font-semibold text-primary mb-2">
                                             Importing into the Calculator:
                                         </h4>
@@ -1109,7 +1109,7 @@ const DocumentationPage: React.FC = () => {
                                     </p>
                                     <h4 className="text-lg font-semibold">Attacker Roles</h4>
                                     <div className="flex flex-wrap gap-4">
-                                        <div className="p-4 bg-dark-lighter">
+                                        <div className="card">
                                             <h4 className="font-semibold text-primary">Attacker</h4>
                                             <p className="text-theme-text">
                                                 Focuses on maximizing damage output through:
@@ -1123,7 +1123,7 @@ const DocumentationPage: React.FC = () => {
                                     </div>
                                     <h4 className="text-lg font-semibold">Defender Roles</h4>
                                     <div className="flex flex-wrap gap-4">
-                                        <div className="p-4 bg-dark-lighter">
+                                        <div className="card">
                                             <h4 className="font-semibold text-primary">Defender</h4>
                                             <p className="text-theme-text">
                                                 Optimizes for survival through:
@@ -1135,7 +1135,7 @@ const DocumentationPage: React.FC = () => {
                                             </ul>
                                         </div>
 
-                                        <div className="p-4 bg-dark-lighter">
+                                        <div className="card">
                                             <h4 className="font-semibold text-primary">
                                                 Defender (Security)
                                             </h4>
@@ -1151,7 +1151,7 @@ const DocumentationPage: React.FC = () => {
                                     </div>
                                     <h4 className="text-lg font-semibold">Debuffer Roles</h4>
                                     <div className="flex flex-wrap gap-4">
-                                        <div className="p-4 bg-dark-lighter">
+                                        <div className="card">
                                             <h4 className="font-semibold text-primary">Debuffer</h4>
                                             <p className="text-theme-text">
                                                 Specializes in hacking and damage:
@@ -1161,7 +1161,7 @@ const DocumentationPage: React.FC = () => {
                                             </ul>
                                         </div>
 
-                                        <div className="p-4 bg-dark-lighter">
+                                        <div className="card">
                                             <h4 className="font-semibold text-primary">
                                                 Debuffer (Defensive)
                                             </h4>
@@ -1173,7 +1173,7 @@ const DocumentationPage: React.FC = () => {
                                             </ul>
                                         </div>
 
-                                        <div className="p-4 bg-dark-lighter">
+                                        <div className="card">
                                             <h4 className="font-semibold text-primary">
                                                 Debuffer (Defensive, Security)
                                             </h4>
@@ -1185,7 +1185,7 @@ const DocumentationPage: React.FC = () => {
                                             </ul>
                                         </div>
 
-                                        <div className="p-4 bg-dark-lighter">
+                                        <div className="card">
                                             <h4 className="font-semibold text-primary">
                                                 Debuffer (Bomber)
                                             </h4>
@@ -1197,7 +1197,7 @@ const DocumentationPage: React.FC = () => {
                                             </ul>
                                         </div>
 
-                                        <div className="p-4 bg-dark-lighter">
+                                        <div className="card">
                                             <h4 className="font-semibold text-primary">
                                                 Debuffer (Corrosion)
                                             </h4>
@@ -1212,7 +1212,7 @@ const DocumentationPage: React.FC = () => {
                                     </div>
                                     <h4 className="text-lg font-semibold">Supporter Roles</h4>
                                     <div className="flex flex-wrap gap-4">
-                                        <div className="p-4 bg-dark-lighter">
+                                        <div className="card">
                                             <h4 className="font-semibold text-primary">
                                                 Supporter
                                             </h4>
@@ -1226,7 +1226,7 @@ const DocumentationPage: React.FC = () => {
                                             </ul>
                                         </div>
 
-                                        <div className="p-4 bg-dark-lighter">
+                                        <div className="card">
                                             <h4 className="font-semibold text-primary">
                                                 Supporter (Buffer)
                                             </h4>
@@ -1242,7 +1242,7 @@ const DocumentationPage: React.FC = () => {
                                             </ul>
                                         </div>
 
-                                        <div className="p-4 bg-dark-lighter">
+                                        <div className="card">
                                             <h4 className="font-semibold text-primary">
                                                 Supporter (Offensive)
                                             </h4>
@@ -1258,7 +1258,7 @@ const DocumentationPage: React.FC = () => {
                                             </ul>
                                         </div>
 
-                                        <div className="p-4 bg-dark-lighter">
+                                        <div className="card">
                                             <h4 className="font-semibold text-primary">
                                                 Supporter (Shield)
                                             </h4>
@@ -1308,7 +1308,7 @@ const DocumentationPage: React.FC = () => {
                                     list — order matters, higher tweaks weigh more in scoring.
                                 </p>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold">Stat Priorities</h4>
                                     <p className="text-theme-text">
                                         Define minimum and maximum values for specific stats. The
@@ -1322,7 +1322,7 @@ const DocumentationPage: React.FC = () => {
                                     </p>
                                 </div>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold">Hard Requirements</h4>
                                     <p className="text-theme-text mb-2">
                                         Any min/max limit on a stat priority can be flagged as a{' '}
@@ -1345,7 +1345,7 @@ const DocumentationPage: React.FC = () => {
                                     </p>
                                 </div>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold">Set Priorities</h4>
                                     <p className="text-theme-text">
                                         Specify which gear sets you want to complete and how many
@@ -1361,7 +1361,7 @@ const DocumentationPage: React.FC = () => {
                                     </p>
                                 </div>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold">Stat Bonuses</h4>
                                     <p className="text-theme-text">
                                         Add bonus effects that contribute to the role score. For
@@ -1375,7 +1375,7 @@ const DocumentationPage: React.FC = () => {
                                     </p>
                                 </div>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold">Buffs</h4>
                                     <p className="text-theme-text">
                                         Add external buffs as tweaks (e.g. Volk&apos;s +30% crit
@@ -1388,7 +1388,7 @@ const DocumentationPage: React.FC = () => {
                                     </p>
                                 </div>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold">Equipment Constraints</h4>
                                     <ul className="text-theme-text list-disc pl-4 space-y-1">
                                         <li>
@@ -1418,7 +1418,7 @@ const DocumentationPage: React.FC = () => {
                                     </ul>
                                 </div>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold">Arena Season Modifiers</h4>
                                     <p className="text-theme-text">
                                         PVP arena seasons apply temporary stat modifiers to ships
@@ -1454,7 +1454,7 @@ const DocumentationPage: React.FC = () => {
                                 Available Algorithms
                             </h3>
                             <div className="space-y-4">
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold text-primary">
                                         Genetic Algorithm (Recommended)
                                     </h4>
@@ -1467,7 +1467,7 @@ const DocumentationPage: React.FC = () => {
                                     </p>
                                 </div>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold text-primary">
                                         Two-Pass Algorithm
                                     </h4>
@@ -1478,7 +1478,7 @@ const DocumentationPage: React.FC = () => {
                                     </p>
                                 </div>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold text-primary">
                                         Set-First Approach
                                     </h4>
@@ -1489,7 +1489,7 @@ const DocumentationPage: React.FC = () => {
                                     </p>
                                 </div>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold text-primary">Beam Search</h4>
                                     <p className="text-theme-text">
                                         A balanced approach that keeps multiple possible
@@ -2067,7 +2067,7 @@ const DocumentationPage: React.FC = () => {
                             </p>
 
                             <div className="space-y-4">
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold text-primary mb-2">Navigation</h4>
                                     <ul className="text-theme-text space-y-1 list-disc list-inside">
                                         <li>
@@ -2089,7 +2089,7 @@ const DocumentationPage: React.FC = () => {
                                     </ul>
                                 </div>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold text-primary mb-2">Decryption</h4>
                                     <p className="text-theme-text">
                                         Each fragment requires an authorisation code. Enter the
@@ -2119,7 +2119,7 @@ const DocumentationPage: React.FC = () => {
                             </p>
 
                             <div className="space-y-4">
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold text-primary mb-2">
                                         DPS Calculator
                                     </h4>
@@ -2181,7 +2181,7 @@ const DocumentationPage: React.FC = () => {
                                     </p>
                                 </div>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold text-primary mb-2">
                                         Defense Calculator
                                     </h4>
@@ -2191,7 +2191,7 @@ const DocumentationPage: React.FC = () => {
                                     </p>
                                 </div>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold text-primary mb-2">
                                         Healing Calculator
                                     </h4>
@@ -2203,7 +2203,7 @@ const DocumentationPage: React.FC = () => {
                                     </p>
                                 </div>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold text-primary mb-2">
                                         Damage Deconstruction
                                     </h4>
@@ -2213,7 +2213,7 @@ const DocumentationPage: React.FC = () => {
                                     </p>
                                 </div>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold text-primary mb-2">
                                         JSON Diff Calculator
                                     </h4>
@@ -2224,7 +2224,7 @@ const DocumentationPage: React.FC = () => {
                                     </p>
                                 </div>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold text-primary mb-2">
                                         Speed Calculator
                                     </h4>
@@ -2277,7 +2277,7 @@ const DocumentationPage: React.FC = () => {
                             </p>
 
                             <div className="space-y-4">
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold text-primary mb-2">
                                         Beacon Types
                                     </h4>
@@ -2288,7 +2288,7 @@ const DocumentationPage: React.FC = () => {
                                     </p>
                                 </div>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold text-primary mb-2">
                                         Faction Events
                                     </h4>
@@ -2300,7 +2300,7 @@ const DocumentationPage: React.FC = () => {
                                     </p>
                                 </div>
 
-                                <div className="p-4 bg-dark-lighter">
+                                <div className="card">
                                     <h4 className="font-semibold text-primary mb-2">
                                         Individual Event Ships
                                     </h4>

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -2053,6 +2053,57 @@ const DocumentationPage: React.FC = () => {
                         </div>
                     </section>
 
+                    {/* Classified Archive Section */}
+                    <section id="classified" className="space-y-4 [counter-increment:section]">
+                        <h2 className="text-2xl font-bold before:content-[counter(section)'.'] before:mr-2">
+                            Classified Archive
+                        </h2>
+                        <div className="card space-y-4">
+                            <h3 className="text-xl font-semibold mb-2">Terminal Interface</h3>
+                            <p className="text-theme-text">
+                                The Classified Archive (<code>/classified</code>) is a hidden
+                                terminal interface containing encrypted lore fragments. Navigate and
+                                decrypt them to uncover backstory and hidden transmissions.
+                            </p>
+
+                            <div className="space-y-4">
+                                <div className="p-4 bg-dark-lighter">
+                                    <h4 className="font-semibold text-primary mb-2">Navigation</h4>
+                                    <ul className="text-theme-text space-y-1 list-disc list-inside">
+                                        <li>
+                                            <strong>↑ / ↓ arrow keys</strong> — move the cursor
+                                            between fragments on the index screen
+                                        </li>
+                                        <li>
+                                            <strong>Enter or click</strong> — open the selected
+                                            fragment
+                                        </li>
+                                        <li>
+                                            <strong>ESC</strong> — return to the index from a
+                                            fragment detail; from the index, ESC navigates home
+                                        </li>
+                                        <li>
+                                            <strong>Mouse hover</strong> — moves the cursor to the
+                                            hovered row
+                                        </li>
+                                    </ul>
+                                </div>
+
+                                <div className="p-4 bg-dark-lighter">
+                                    <h4 className="font-semibold text-primary mb-2">Decryption</h4>
+                                    <p className="text-theme-text">
+                                        Each fragment requires an authorisation code. Enter the
+                                        correct code to start the decrypt sequence — a progress bar
+                                        counts to 100% and the lore text fades in. Once decrypted, a
+                                        fragment can be re-read at any time without re-entering the
+                                        code. Decrypt all 4 fragments to reveal a final
+                                        transmission.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+
                     {/* Calculators Section */}
                     <section id="calculators" className="space-y-4 [counter-increment:section]">
                         <h2 className="text-2xl font-bold before:content-[counter(section)'.'] before:mr-2">

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -564,7 +564,10 @@ const NotFoundPage: React.FC = () => {
                                             <p className="text-xs text-gray-600 font-mono mt-2">
                                                 {'> SIGNAL ID: '}
                                                 <span className="group inline-block cursor-pointer">
-                                                    <span className="blur-sm group-hover:blur-none transition-[filter] duration-300 select-all text-gray-400">
+                                                    <span
+                                                        tabIndex={0}
+                                                        className="blur-sm group-hover:blur-none focus:blur-none transition-[filter] duration-300 select-all text-gray-400 outline-none"
+                                                    >
                                                         {easterEgg.authCode}
                                                     </span>
                                                 </span>

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -8,12 +8,6 @@ import { CLASSIFIED_FRAGMENTS } from '../constants/classifiedArchive';
 const BAR_TOTAL = 22;
 const BAR_FINAL_FILLED_DEFAULT = 13;
 
-const DEFAULT_TERMINAL_LINES = [
-    '> INITIALIZING NAV SYSTEMS... [OK]',
-    '> SCANNING SECTOR_404...',
-    '> ERROR: NULL_SECTOR_REFERENCE',
-];
-
 interface EasterEggConfig {
     terminalLines: [string, string, string];
     barLabel: string;
@@ -406,7 +400,13 @@ const NotFoundPage: React.FC = () => {
     const [hintCipher] = useState(
         () => SLUG_CIPHERS[Math.floor(Math.random() * SLUG_CIPHERS.length)]
     );
-    const terminalLines = easterEgg?.terminalLines ?? DEFAULT_TERMINAL_LINES;
+    const slugLabel = slug ? slug.toUpperCase().replace(/-/g, '_') : 'UNKNOWN';
+    const defaultTerminalLines: [string, string, string] = [
+        '> INITIALIZING NAV SYSTEMS... [OK]',
+        `> SCANNING SECTOR: ${slugLabel}...`,
+        '> ERROR: NULL_SECTOR_REFERENCE',
+    ];
+    const terminalLines = easterEgg?.terminalLines ?? defaultTerminalLines;
     const barFinalFilled = easterEgg ? BAR_TOTAL : BAR_FINAL_FILLED_DEFAULT;
 
     // Sequence: wait for terminal lines → fill bar → resolve/corrupt → reveal content
@@ -518,7 +518,7 @@ const NotFoundPage: React.FC = () => {
                 <div className="relative z-10 flex items-start justify-center h-full overflow-y-auto p-4">
                     <div className="card max-w-lg w-full space-y-6 backdrop-blur-sm my-auto">
                         {/* // label */}
-                        <div className="text-[0.65rem] text-primary uppercase tracking-[0.3em] [text-shadow:0_1px_4px_rgba(0,0,0,0.8)]">
+                        <div className="text-[0.65rem] text-primary uppercase tracking-[0.3em]">
                             {'// STARBORNE PLANNER'}
                         </div>
 
@@ -581,24 +581,20 @@ const NotFoundPage: React.FC = () => {
                                     </>
                                 ) : (
                                     <>
-                                        <div
-                                            ref={glitchRef}
-                                            className="text-center text-8xl font-bold text-primary tracking-widest"
-                                        >
-                                            404
-                                        </div>
-
-                                        <div className="text-center space-y-2">
-                                            <p className="text-base font-bold tracking-widest uppercase text-primary">
+                                        <div className="space-y-2">
+                                            <p
+                                                ref={glitchRef}
+                                                className="text-base font-bold tracking-widest uppercase text-primary"
+                                            >
                                                 SECTOR_404: SIGNAL LOST
                                             </p>
-                                            <p className="text-sm text-gray-400">
+                                            <p className="text-sm text-gray-400 space-y-3 font-mono">
                                                 The route you&apos;re looking for has been redacted
                                                 from our navigation charts.
                                             </p>
                                         </div>
 
-                                        <p className="text-center text-[0.6rem] text-gray-700 font-mono tracking-widest mt-2">
+                                        <p className="text-xs text-gray-700 font-mono tracking-widest mt-2">
                                             {`> TRANSMISSION REF: ${hintCipher(hintSlug)}`}
                                         </p>
                                         <div className="flex justify-center gap-3">

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { Button } from '../components/ui';
 import Seo from '../components/seo/Seo';
 import { SEO_CONFIG } from '../constants/seo';
+import { CLASSIFIED_FRAGMENTS } from '../constants/classifiedArchive';
 
 const BAR_TOTAL = 22;
 const BAR_FINAL_FILLED_DEFAULT = 13;
@@ -20,7 +21,10 @@ interface EasterEggConfig {
     title: string;
     subtitle: string;
     body: string;
+    authCode?: string;
 }
+
+const _codes = Object.fromEntries(CLASSIFIED_FRAGMENTS.map((f) => [f.sourceEggSlug, f.authCode]));
 
 const EASTER_EGGS: Record<string, EasterEggConfig> = {
     'the-bludgeon': {
@@ -34,6 +38,7 @@ const EASTER_EGGS: Record<string, EasterEggConfig> = {
         title: 'TARGET LOST FROM ALL SCANNERS',
         subtitle: 'Drive data wiped. No record found.',
         body: `You were close. The Bludgeon — designation unofficial, nature unknown — was spotted here moments ago.\n\nArmored plating that reforms around damage. Plasma-encased missiles. A communications method no scanner has ever detected.\n\nThe running theory: it sensed your approach and actively counteracted it in real time.\n\nYour drive data has been wiped. There are no records.`,
+        authCode: _codes['the-bludgeon'],
     },
     'binderburg-rd': {
         terminalLines: [
@@ -190,6 +195,7 @@ const EASTER_EGGS: Record<string, EasterEggConfig> = {
         title: 'MECHANISM — CLASS UNKNOWN',
         subtitle: 'Both Gelecek and Binderburg R&D deny knowledge of this location.',
         body: `You have found something you were not meant to find.\n\nThe mechanisms — gravimetric anomalies clustered near black holes and the Tau Scorpii star — predate every known civilization. Binderburg has been quietly fortifying research stations in their vicinity for decades. Gelecek believes they are evidence of alien intelligence.\n\nBoth are wrong. Both are right. Neither will share their data.\n\nThis finding has been logged. Undocumented facilities in this sector have been placed on alert.\n\nStep away from the mechanism.`,
+        authCode: _codes['the-mechanisms'],
     },
     'the-apostate': {
         terminalLines: [
@@ -214,6 +220,7 @@ const EASTER_EGGS: Record<string, EasterEggConfig> = {
         title: 'THE ABYSS — BLOCKADE ACTIVE',
         subtitle: 'Time-space anomaly. Class: unknown. Origin: unknown.',
         body: `You have reached the blockade perimeter established around the anomaly known as The Abyss.\n\nAll six sovereign factions have agreed — for once — that no ship should pass.\n\nWhat lies beyond has not been documented. What has been documented has not been shared. Everliving ships have been observed moving through the region. MPL Chair Gwayne Erebus has taken a personal interest.\n\nTurn back.\n\nOr don't. The Abyss doesn't care either way.`,
+        authCode: _codes['the-abyss'],
     },
     'furnace-of-heaven': {
         terminalLines: [
@@ -226,6 +233,7 @@ const EASTER_EGGS: Record<string, EasterEggConfig> = {
         title: 'FURNACE OF HEAVEN',
         subtitle: 'Uninhabitable nebula. Edge of the Abyss. Do not approach.',
         body: `The encrypted data dumps trace back here. A nebula near the infamous Furnace of Heaven, on the edge of the Abyss and generally considered uninhabitable.\n\nSomething is in there.\n\nWhen confronted, Tsar Rasputin only smiled. "A new star is forming, Commander. Your fleet is cute. Stay clear of the flames."\n\nThe source of the signal has not been identified. Three probes and one unarmed scout were dispatched to triangulate. None returned.\n\nStep back from the telescope.`,
+        authCode: _codes['furnace-of-heaven'],
     },
     'gamish-waypoint': {
         terminalLines: [
@@ -360,6 +368,10 @@ const NotFoundPage: React.FC = () => {
 
     const slug = pathname.replace(/^\//, '');
     const easterEgg = EASTER_EGGS[slug] ?? null;
+    const EASTER_EGG_SLUGS = Object.keys(EASTER_EGGS);
+    const [hintSlug] = useState(
+        () => EASTER_EGG_SLUGS[Math.floor(Math.random() * EASTER_EGG_SLUGS.length)]
+    );
     const terminalLines = easterEgg?.terminalLines ?? DEFAULT_TERMINAL_LINES;
     const barFinalFilled = easterEgg ? BAR_TOTAL : BAR_FINAL_FILLED_DEFAULT;
 
@@ -514,6 +526,16 @@ const NotFoundPage: React.FC = () => {
                                                 <p key={i}>{para}</p>
                                             ))}
                                         </div>
+                                        {easterEgg.authCode && (
+                                            <p className="text-xs text-gray-600 font-mono mt-2">
+                                                {'> SIGNAL ID: '}
+                                                <span className="group inline-block cursor-pointer">
+                                                    <span className="blur-sm group-hover:blur-none transition-[filter] duration-300 select-all text-gray-400">
+                                                        {easterEgg.authCode}
+                                                    </span>
+                                                </span>
+                                            </p>
+                                        )}
                                         <div className="flex justify-center">
                                             <Button
                                                 variant="secondary"
@@ -542,6 +564,9 @@ const NotFoundPage: React.FC = () => {
                                             </p>
                                         </div>
 
+                                        <p className="text-center text-[0.6rem] text-gray-700 font-mono tracking-widest mt-2">
+                                            {`> TRANSMISSION REF: ${hintSlug}`}
+                                        </p>
                                         <div className="flex justify-center gap-3">
                                             <Button
                                                 variant="primary"

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -26,6 +26,37 @@ interface EasterEggConfig {
 
 const _codes = Object.fromEntries(CLASSIFIED_FRAGMENTS.map((f) => [f.sourceEggSlug, f.authCode]));
 
+const SLUG_CIPHERS: Array<(text: string) => string> = [
+    // +1 Caesar
+    (t) =>
+        t.replace(/[a-zA-Z]/g, (c) => {
+            const b = c >= 'a' ? 97 : 65;
+            return String.fromCharCode(((c.charCodeAt(0) - b + 1) % 26) + b);
+        }),
+    // +2 Caesar
+    (t) =>
+        t.replace(/[a-zA-Z]/g, (c) => {
+            const b = c >= 'a' ? 97 : 65;
+            return String.fromCharCode(((c.charCodeAt(0) - b + 2) % 26) + b);
+        }),
+    // Reverse
+    (t) => t.split('').reverse().join(''),
+    // Letters → 1-based position numbers, dot-separated, hyphens preserved
+    (t) =>
+        t
+            .split('-')
+            .map((w) =>
+                w
+                    .split('')
+                    .map((c) => {
+                        const n = c.toLowerCase().charCodeAt(0) - 96;
+                        return n >= 1 && n <= 26 ? String(n) : c;
+                    })
+                    .join('.')
+            )
+            .join('-'),
+];
+
 const EASTER_EGGS: Record<string, EasterEggConfig> = {
     'the-bludgeon': {
         terminalLines: [
@@ -372,6 +403,9 @@ const NotFoundPage: React.FC = () => {
     const [hintSlug] = useState(
         () => EASTER_EGG_SLUGS[Math.floor(Math.random() * EASTER_EGG_SLUGS.length)]
     );
+    const [hintCipher] = useState(
+        () => SLUG_CIPHERS[Math.floor(Math.random() * SLUG_CIPHERS.length)]
+    );
     const terminalLines = easterEgg?.terminalLines ?? DEFAULT_TERMINAL_LINES;
     const barFinalFilled = easterEgg ? BAR_TOTAL : BAR_FINAL_FILLED_DEFAULT;
 
@@ -565,7 +599,7 @@ const NotFoundPage: React.FC = () => {
                                         </div>
 
                                         <p className="text-center text-[0.6rem] text-gray-700 font-mono tracking-widest mt-2">
-                                            {`> TRANSMISSION REF: ${hintSlug}`}
+                                            {`> TRANSMISSION REF: ${hintCipher(hintSlug)}`}
                                         </p>
                                         <div className="flex justify-center gap-3">
                                             <Button


### PR DESCRIPTION
## Summary
- Adds \`/classified\` — a hidden terminal page with 4 locked lore fragments about the Abyss hivemind. No nav link; discovered by exploration.
- Four code-bearing Easter egg pages (\`/the-mechanisms\`, \`/the-bludgeon\`, \`/the-abyss\`, \`/furnace-of-heaven\`) each get a \`> SIGNAL ID: [REDACTED]\` line; hovering the blurred span reveals the auth code.
- Default 404 page gets a subtle \`> TRANSMISSION REF: [random-slug]\` hint drawn from all ~25 Easter egg slugs on each mount.
- Auth codes and unlock state persist in \`localStorage\` (\`classified_unlocked\` key). Input normalised (\`.trim().toUpperCase()\`) before comparison.
- Static SVG noise overlay decreases opacity as fragments unlock (60→40→25→10→0%); final transmission block appears at 4/4.

## Test Plan
- [ ] Visit \`/classified\` — page loads with \`[0/4 FRAGMENTS DECRYPTED]\` and 4 locked slots
- [ ] Enter a wrong code → brief red flash on input
- [ ] Enter \`door-7a\` (lowercase) in fragment 1 → accepts, decrypt animation plays, lore reveals, header updates to \`[1/4 FRAGMENTS DECRYPTED]\`
- [ ] Reload \`/classified\` — fragment 1 still unlocked (localStorage persisted)
- [ ] Unlock all 4 → \`[4/4 FRAGMENTS DECRYPTED]\`, static overlay clears, final transmission appears
- [ ] Visit \`/the-mechanisms\` — \`> SIGNAL ID:\` line present, hover reveals \`DOOR-7A\`
- [ ] Visit \`/tenebris\` (non-code egg) — no \`> SIGNAL ID:\` line
- [ ] Visit any unknown URL — \`> TRANSMISSION REF: [slug]\` visible in subtle gray below the bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)