### PR TITLE
feat: conditional scaling damage in DPS calculator

### DIFF
--- a/src/components/calculator/ShipConfigCard.tsx
+++ b/src/components/calculator/ShipConfigCard.tsx
@@ -9,6 +9,8 @@ import {
     AttackerBuffTotals,
     SelectedGameBuff,
     SecondaryDamage,
+    ConditionalDamage,
+    CONDITIONAL_CONDITION_LABELS,
 } from '../../types/calculator';
 import { DPSSimulationResult } from '../../utils/calculators/dpsSimulator';
 import { ShipSelector } from '../ship/ShipSelector';
@@ -50,6 +52,10 @@ interface ShipConfigCardProps {
         field: 'activeSecondary' | 'chargedSecondary',
         value: SecondaryDamage | undefined
     ) => void;
+    onConditionalChange: (
+        field: 'activeConditional' | 'chargedConditional',
+        value: ConditionalDamage | undefined
+    ) => void;
     enemyAffinity: AffinityName;
     enemySecurity: number;
 }
@@ -73,6 +79,7 @@ export const ShipConfigCard: React.FC<ShipConfigCardProps> = ({
     onBuffsChange,
     onEnemyDebuffsChange,
     onSecondaryChange,
+    onConditionalChange,
     enemyAffinity,
     enemySecurity,
 }) => {
@@ -80,6 +87,9 @@ export const ShipConfigCard: React.FC<ShipConfigCardProps> = ({
     const [skillRefOpen, setSkillRefOpen] = useState(false);
     const [openSecondary, setOpenSecondary] = useState(
         Boolean(config.activeSecondary || config.chargedSecondary)
+    );
+    const [openConditional, setOpenConditional] = useState(
+        Boolean(config.activeConditional || config.chargedConditional)
     );
     const { getShipById } = useShips();
     const selectedShip = config.shipId ? getShipById(config.shipId) : undefined;
@@ -355,6 +365,74 @@ export const ShipConfigCard: React.FC<ShipConfigCardProps> = ({
                                 }
                             />
                         </div>
+                    </CollapsibleForm>
+
+                    <Button
+                        variant="link"
+                        onClick={() => setOpenConditional((v) => !v)}
+                        className="w-full flex justify-between items-center mt-4"
+                    >
+                        <span className="flex items-center gap-2">
+                            <ChevronDownIcon
+                                className={`text-sm text-theme-text-secondary h-8 w-8 p-2 transition-transform duration-300 ${openConditional ? 'rotate-180' : ''}`}
+                            />
+                            Conditional Damage
+                        </span>
+                    </Button>
+                    <CollapsibleForm isVisible={openConditional}>
+                        {(
+                            [
+                                ['activeConditional', 'Active', config.activeConditional],
+                                ['chargedConditional', 'Charged', config.chargedConditional],
+                            ] as const
+                        ).map(([field, label, cond]) => {
+                            if (!cond) {
+                                return (
+                                    <p
+                                        key={field}
+                                        className="text-xs text-theme-text-secondary mb-2"
+                                    >
+                                        {label}: no conditional bonus detected.
+                                    </p>
+                                );
+                            }
+                            return (
+                                <div key={field} className="mb-4">
+                                    <div className="text-sm font-semibold mb-1">
+                                        {label}: +{cond.pct}%{' '}
+                                        {CONDITIONAL_CONDITION_LABELS[cond.condition]}
+                                        {cond.cap !== undefined ? ` (max +${cond.cap}%)` : ''}
+                                    </div>
+                                    {cond.derivable ? (
+                                        <p className="text-xs text-theme-text-secondary">
+                                            Auto-counted each round from your active{' '}
+                                            {cond.condition === 'self-buff'
+                                                ? 'buffs'
+                                                : 'enemy debuffs'}
+                                            .
+                                        </p>
+                                    ) : (
+                                        <Input
+                                            label="Count"
+                                            type="number"
+                                            min="0"
+                                            value={cond.manualCount ?? 1}
+                                            helpLabel={
+                                                config.autoFilledFields?.has(field)
+                                                    ? 'auto-filled'
+                                                    : undefined
+                                            }
+                                            onChange={(e) =>
+                                                onConditionalChange(field, {
+                                                    ...cond,
+                                                    manualCount: parseInt(e.target.value) || 0,
+                                                })
+                                            }
+                                        />
+                                    )}
+                                </div>
+                            );
+                        })}
                     </CollapsibleForm>
 
                     {selectedShip && (

--- a/src/components/calculator/ShipConfigSummary.tsx
+++ b/src/components/calculator/ShipConfigSummary.tsx
@@ -72,6 +72,14 @@ export const ShipConfigSummary: React.FC<ShipConfigSummaryProps> = ({
                     <span>{simResult.summary.totalSecondaryDamage.toLocaleString()}</span>
                 </div>
             )}
+            {simResult.summary.totalConditionalDamage > 0 && (
+                <div className="flex justify-between mb-2">
+                    <span className="text-theme-text-secondary">
+                        Conditional (scaling, incl. in Direct):
+                    </span>
+                    <span>{simResult.summary.totalConditionalDamage.toLocaleString()}</span>
+                </div>
+            )}
             {hasDoTs && (
                 <div className="grid grid-cols-4 gap-1 mt-2">
                     <div className="text-center p-1 bg-dark-lighter rounded">

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -9,6 +9,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Recruitment calculator: corrected the affinity weighting to match the game — Thermal/Chemical/Electric are now a single combined pool where each ship has 10x the pull weight of an antimatter ship (instead of a fixed per-affinity split).',
     'Recruitment calculator: faction event weighting now stacks on top of the affinity weighting, and you can choose a 10x or 20x faction multiplier.',
     'DPS Calculator now models secondary damage that scales off Defense or max HP (e.g. Chakara, Lodolite) — auto-detected from skill text, editable, and scaling with Defense Up / HP buffs.',
+    "DPS Calculator now models conditional damage bonuses that scale with a count (e.g. +20% per adjacent ally, +15% per debuff on the enemy). Counts derived from your buffs or the enemy's debuffs are tallied automatically each round; other conditions take a manual count. Auto-detected from skill text and editable per skill.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -2155,6 +2155,18 @@ const DocumentationPage: React.FC = () => {
                                         scales with Defense Up / HP buffs.
                                     </p>
                                     <p className="text-theme-text mb-2">
+                                        <span className="text-primary">
+                                            Conditional Scaling Damage:
+                                        </span>{' '}
+                                        Some attackers gain bonus damage that scales with a count,
+                                        such as &quot;+20% per adjacent ally&quot; or &quot;+15% per
+                                        debuff on the enemy&quot;. When the count derives from your
+                                        buffs or the enemy&apos;s debuffs, it is tallied
+                                        automatically each round; other conditions take a manual
+                                        count. Auto-detected from skill text and editable per skill
+                                        row.
+                                    </p>
+                                    <p className="text-theme-text mb-2">
                                         <span className="text-primary">Start Charged:</span> Some
                                         ships have skills that begin combat already charged. When
                                         detected from your ship&apos;s skill data, this checkbox

--- a/src/pages/calculators/DPSCalculatorPage.tsx
+++ b/src/pages/calculators/DPSCalculatorPage.tsx
@@ -783,6 +783,14 @@ const DPSCalculatorPage: React.FC = () => {
                             editable in each skill row.
                         </p>
                         <p className="mb-2">
+                            Some attackers gain bonus damage that scales with a count — e.g. +20%
+                            per adjacent ally, or +15% per debuff on the enemy. This bonus is added
+                            to the skill multiplier. When the count is something the simulator
+                            tracks (your own buffs, or debuffs on the enemy) it is counted
+                            automatically each round; otherwise you set the count manually. It is
+                            auto-detected from skill text and editable per skill row.
+                        </p>
+                        <p className="mb-2">
                             DoT effects (corrosion, inferno, bombs) bypass enemy defense entirely.
                             Corrosion deals a percentage of the target&apos;s HP per stack. Inferno
                             and bombs deal a percentage of the attacker&apos;s attack stat. Bombs

--- a/src/pages/calculators/DPSCalculatorPage.tsx
+++ b/src/pages/calculators/DPSCalculatorPage.tsx
@@ -771,9 +771,9 @@ const DPSCalculatorPage: React.FC = () => {
                             as:
                         </p>
                         <p className="mb-2 font-mono bg-dark-lighter p-2 text-sm">
-                            Direct = (Attack × SkillMultiplier% + SourceStat × Secondary%) ×
-                            CritMultiplier × (1 - DamageReduction%) × (1 + OutgoingDmg%) × (1 +
-                            IncomingDmg%)
+                            Direct = (Attack × (SkillMultiplier% + ConditionalBonus%) + SourceStat ×
+                            Secondary%) × CritMultiplier × (1 - DamageReduction%) × (1 +
+                            OutgoingDmg%) × (1 + IncomingDmg%)
                         </p>
                         <p className="mb-2">
                             Some ships deal additional damage equal to a percentage of their Defense

--- a/src/pages/calculators/DPSCalculatorPage.tsx
+++ b/src/pages/calculators/DPSCalculatorPage.tsx
@@ -11,10 +11,12 @@ import {
     SelectedGameBuff,
     TeamShipConfig,
     SecondaryDamage,
+    ConditionalDamage,
 } from '../../types/calculator';
 import {
     parseSkillDamage,
     parseSecondaryDamage,
+    parseConditionalDamage,
     detectFullyCharged,
 } from '../../utils/skillTextParser';
 import {
@@ -43,18 +45,36 @@ function buildSkillAutoFill(ship: Ship) {
     const chargedParsed = parseSkillDamage(ship.chargeSkillText ?? '');
     const activeSecondary = parseSecondaryDamage(ship.activeSkillText) ?? undefined;
     const chargedSecondary = parseSecondaryDamage(ship.chargeSkillText) ?? undefined;
+    const seedManual = (c: ConditionalDamage | null): ConditionalDamage | undefined => {
+        if (!c) return undefined;
+        return !c.derivable && c.manualCount === undefined ? { ...c, manualCount: 1 } : c;
+    };
+    const activeConditional = seedManual(parseConditionalDamage(ship.activeSkillText));
+    const chargedConditional = seedManual(parseConditionalDamage(ship.chargeSkillText));
     const autoFilledFields = new Set<
         | 'activeMultiplier'
         | 'chargedMultiplier'
         | 'hacking'
         | 'activeSecondary'
         | 'chargedSecondary'
+        | 'activeConditional'
+        | 'chargedConditional'
     >();
     if (activeParsed > 0) autoFilledFields.add('activeMultiplier');
     if (chargedParsed > 0) autoFilledFields.add('chargedMultiplier');
     if (activeSecondary) autoFilledFields.add('activeSecondary');
     if (chargedSecondary) autoFilledFields.add('chargedSecondary');
-    return { activeParsed, chargedParsed, activeSecondary, chargedSecondary, autoFilledFields };
+    if (activeConditional) autoFilledFields.add('activeConditional');
+    if (chargedConditional) autoFilledFields.add('chargedConditional');
+    return {
+        activeParsed,
+        chargedParsed,
+        activeSecondary,
+        chargedSecondary,
+        activeConditional,
+        chargedConditional,
+        autoFilledFields,
+    };
 }
 
 const DPSCalculatorPage: React.FC = () => {
@@ -89,6 +109,8 @@ const DPSCalculatorPage: React.FC = () => {
                     chargedParsed,
                     activeSecondary,
                     chargedSecondary,
+                    activeConditional,
+                    chargedConditional,
                     autoFilledFields,
                 } = buildSkillAutoFill(ship);
                 autoFilledFields.add('hacking');
@@ -107,6 +129,8 @@ const DPSCalculatorPage: React.FC = () => {
                             hp: Math.round(final.hp ?? 0),
                             activeSecondary,
                             chargedSecondary,
+                            activeConditional,
+                            chargedConditional,
                             activeMultiplier: activeParsed > 0 ? activeParsed : 100,
                             chargedMultiplier: chargedParsed > 0 ? chargedParsed : 0,
                             chargeCount: ship.chargeSkillCharge ?? 0,
@@ -254,6 +278,8 @@ const DPSCalculatorPage: React.FC = () => {
                     hp: config.hp,
                     activeSecondary: config.activeSecondary,
                     chargedSecondary: config.chargedSecondary,
+                    activeConditional: config.activeConditional,
+                    chargedConditional: config.chargedConditional,
                     activeMultiplier: config.activeMultiplier,
                     chargedMultiplier: config.chargedMultiplier,
                     chargeCount: config.chargeCount,
@@ -377,8 +403,15 @@ const DPSCalculatorPage: React.FC = () => {
             ship.id
         );
         const final = statsBreakdown.final;
-        const { activeParsed, chargedParsed, activeSecondary, chargedSecondary, autoFilledFields } =
-            buildSkillAutoFill(ship);
+        const {
+            activeParsed,
+            chargedParsed,
+            activeSecondary,
+            chargedSecondary,
+            activeConditional,
+            chargedConditional,
+            autoFilledFields,
+        } = buildSkillAutoFill(ship);
         autoFilledFields.add('hacking');
         const { selfBuffs, enemyDebuffs: newEnemyDebuffs } = buildSkillBuffAutoFill(ship);
         const { activeDoTs: newActiveDoTs, chargedDoTs: newChargedDoTs } = buildDoTAutoFill(ship);
@@ -401,6 +434,8 @@ const DPSCalculatorPage: React.FC = () => {
                     hp: Math.round(final.hp ?? 0),
                     activeSecondary,
                     chargedSecondary,
+                    activeConditional,
+                    chargedConditional,
                     activeMultiplier: activeParsed > 0 ? activeParsed : c.activeMultiplier,
                     chargedMultiplier: chargedParsed > 0 ? chargedParsed : c.chargedMultiplier,
                     chargeCount: ship.chargeSkillCharge ?? c.chargeCount,
@@ -488,6 +523,21 @@ const DPSCalculatorPage: React.FC = () => {
         id: string,
         field: 'activeSecondary' | 'chargedSecondary',
         value: SecondaryDamage | undefined
+    ) => {
+        setConfigs((prev) =>
+            prev.map((c) => {
+                if (c.id !== id) return c;
+                const next = new Set(c.autoFilledFields);
+                next.delete(field);
+                return { ...c, [field]: value, autoFilledFields: next };
+            })
+        );
+    };
+
+    const updateConfigConditional = (
+        id: string,
+        field: 'activeConditional' | 'chargedConditional',
+        value: ConditionalDamage | undefined
     ) => {
         setConfigs((prev) =>
             prev.map((c) => {
@@ -645,6 +695,9 @@ const DPSCalculatorPage: React.FC = () => {
                                 }
                                 onSecondaryChange={(field, value) =>
                                     updateConfigSecondary(config.id, field, value)
+                                }
+                                onConditionalChange={(field, value) =>
+                                    updateConfigConditional(config.id, field, value)
                                 }
                             />
                         ))}

--- a/src/types/calculator.ts
+++ b/src/types/calculator.ts
@@ -9,6 +9,31 @@ export interface SecondaryDamage {
     pct: number; // e.g. 80 for "80% of Defense"
 }
 
+export type ConditionalCondition =
+    | 'self-buff' // derivable
+    | 'enemy-debuff' // derivable
+    | 'enemy-buff' // manual
+    | 'adjacent-ally' // manual
+    | 'enemy-adjacent' // manual
+    | 'enemy-destroyed'; // manual
+
+export interface ConditionalDamage {
+    pct: number; // per-unit bonus % added to the skill multiplier
+    condition: ConditionalCondition;
+    derivable: boolean; // true → count from sim state; false → manual
+    manualCount?: number; // used when !derivable (default 1)
+    cap?: number; // optional total-bonus ceiling ("up to 100%")
+}
+
+export const CONDITIONAL_CONDITION_LABELS: Record<ConditionalCondition, string> = {
+    'self-buff': 'per buff on this unit',
+    'enemy-debuff': 'per debuff on the enemy',
+    'enemy-buff': 'per buff on the enemy',
+    'adjacent-ally': 'per adjacent ally',
+    'enemy-adjacent': 'per unit adjacent to the enemy',
+    'enemy-destroyed': 'per destroyed enemy',
+};
+
 export interface Buff {
     id: string;
     stat: 'attack' | 'crit' | 'critDamage' | 'outgoingDamage' | 'defence' | 'hp';
@@ -90,6 +115,8 @@ export interface DPSShipConfig {
     hp: number; // source stat for HP-based secondary damage
     activeSecondary?: SecondaryDamage;
     chargedSecondary?: SecondaryDamage;
+    activeConditional?: ConditionalDamage;
+    chargedConditional?: ConditionalDamage;
     chargeCount: number;
     startCharged: boolean;
     autoFilledFields?: Set<
@@ -98,6 +125,8 @@ export interface DPSShipConfig {
         | 'hacking'
         | 'activeSecondary'
         | 'chargedSecondary'
+        | 'activeConditional'
+        | 'chargedConditional'
     >;
     activeDoTs: DoTApplicationConfig;
     chargedDoTs: DoTApplicationConfig;

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -6,6 +6,7 @@ import {
     parseSkillEffects,
     parseAllSkillEffects,
     parseSecondaryDamage,
+    parseConditionalDamage,
 } from '../skillTextParser';
 import type { Ship } from '../../types/ship';
 
@@ -381,6 +382,86 @@ describe('parseSecondaryDamage', () => {
     it('parseSkillDamage still returns the primary multiplier for a secondary-damage skill', () => {
         expect(parseSkillDamage(chakara)).toBe(180);
         expect(parseSkillDamage(lodolite)).toBe(240);
+    });
+});
+
+describe('parseConditionalDamage', () => {
+    it('parses a tagged "additional X% ... for each adjacent ally" (Centurion)', () => {
+        const text =
+            'This Unit deals <unit-damage>100% damage</unit-damage> with an additional <unit-damage>20%</unit-damage> for each adjacent ally.';
+        expect(parseConditionalDamage(text)).toEqual({
+            pct: 20,
+            condition: 'adjacent-ally',
+            derivable: false,
+        });
+    });
+
+    it('parses an untagged "plus an extra X% for each buff on the enemy" (Nuqtu)', () => {
+        const text =
+            'This Unit Deals <unit-damage>140% damage</unit-damage>, with additional damage equal to <unit-damage>80%</unit-damage> of its Defense plus an extra 30% for each buff on the enemy.';
+        expect(parseConditionalDamage(text)).toEqual({
+            pct: 30,
+            condition: 'enemy-buff',
+            derivable: false,
+        });
+    });
+
+    it('marks "for each debuff on the enemy" as derivable', () => {
+        const text =
+            'This Unit deals <unit-damage>180% damage</unit-damage> with an additional <unit-damage>15%</unit-damage> for each debuff on the enemy.';
+        expect(parseConditionalDamage(text)).toEqual({
+            pct: 15,
+            condition: 'enemy-debuff',
+            derivable: true,
+        });
+    });
+
+    it('marks "for each buff on this Unit" as derivable', () => {
+        const text =
+            'This Unit deals <unit-damage>100% damage</unit-damage>, increasing by an additional <unit-damage>25%</unit-damage> for each buff on this Unit.';
+        expect(parseConditionalDamage(text)).toEqual({
+            pct: 25,
+            condition: 'self-buff',
+            derivable: true,
+        });
+    });
+
+    it('maps "Unit adjacent to the enemy" to enemy-adjacent', () => {
+        const text =
+            'This Unit deals <unit-damage>145% damage</unit-damage>, increasing by <unit-damage>30%</unit-damage> for each Unit adjacent to the enemy.';
+        expect(parseConditionalDamage(text)).toEqual({
+            pct: 30,
+            condition: 'enemy-adjacent',
+            derivable: false,
+        });
+    });
+
+    it('captures a cap from "up to max of N%"', () => {
+        const text =
+            'This Unit deals <unit-damage>20% more direct damage</unit-damage> for each destroyed enemy, up to max of 100%.';
+        expect(parseConditionalDamage(text)).toEqual({
+            pct: 20,
+            condition: 'enemy-destroyed',
+            derivable: false,
+            cap: 100,
+        });
+    });
+
+    it('ignores repair/heal scaling ("repairs X% ... for each enemy destroyed")', () => {
+        const text =
+            'This Unit <unit-damage>repairs 60%</unit-damage> of its Max HP for each enemy Unit destroyed by the attack upon killing them.';
+        expect(parseConditionalDamage(text)).toBeNull();
+    });
+
+    it('returns null when there is no "for each" conditional', () => {
+        expect(
+            parseConditionalDamage('This Unit deals <unit-damage>180% damage</unit-damage>.')
+        ).toBeNull();
+    });
+
+    it('returns null for empty input', () => {
+        expect(parseConditionalDamage('')).toBeNull();
+        expect(parseConditionalDamage(null)).toBeNull();
     });
 });
 

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -404,6 +404,7 @@ describe('parseConditionalDamage', () => {
             condition: 'enemy-buff',
             derivable: false,
         });
+        expect(parseSecondaryDamage(text)).toEqual({ stat: 'defense', pct: 80 });
     });
 
     it('marks "for each debuff on the enemy" as derivable', () => {

--- a/src/utils/calculators/__tests__/dpsSimulator.test.ts
+++ b/src/utils/calculators/__tests__/dpsSimulator.test.ts
@@ -888,5 +888,23 @@ describe('simulateDPS', () => {
             expect(result.summary.totalConditionalDamage).toBe(0);
             expect(result.rounds[0].directDamage).toBe(1000);
         });
+
+        it('derives the enemy-debuff count from prior-round DoT entries (ramps over rounds)', () => {
+            // A corrosion DoT is applied each active round, but this round's DoT is pushed
+            // AFTER damage is computed — so the enemy-debuff count is the number of PRIOR-round
+            // DoT entries: 0, then 1, then 2. bonus = 20% * count.
+            const result = simulateDPS({
+                ...exactInput,
+                rounds: 3,
+                activeDoTs: [{ id: 'c', type: 'corrosion', tier: 3, stacks: 1, duration: 10 }],
+                activeConditional: { pct: 20, condition: 'enemy-debuff', derivable: true },
+            });
+            // round 1: count 0 → preCrit 1000; round 2: count 1 → 1200; round 3: count 2 → 1400
+            expect(result.rounds[0].directDamage).toBe(1000);
+            expect(result.rounds[1].directDamage).toBe(1200);
+            expect(result.rounds[2].directDamage).toBe(1400);
+            // conditional slice: 0 + 200 + 400 = 600
+            expect(result.summary.totalConditionalDamage).toBe(600);
+        });
     });
 });

--- a/src/utils/calculators/__tests__/dpsSimulator.test.ts
+++ b/src/utils/calculators/__tests__/dpsSimulator.test.ts
@@ -795,4 +795,98 @@ describe('simulateDPS', () => {
             expect(result.summary.totalSecondaryDamage).toBe(500);
         });
     });
+
+    describe('conditional scaling damage', () => {
+        const exactInput = {
+            ...baseInput,
+            attack: 1000,
+            crit: 100,
+            critDamage: 0, // critMultiplier = 1
+            enemyDefense: 0, // no reduction
+            activeMultiplier: 100,
+            rounds: 1,
+        };
+
+        it('applies a manual count to a non-derivable condition', () => {
+            // bonus = 30 * 3 = 90 → preCrit = 1000 * (100 + 90)/100 = 1900
+            const result = simulateDPS({
+                ...exactInput,
+                activeConditional: {
+                    pct: 30,
+                    condition: 'enemy-buff',
+                    derivable: false,
+                    manualCount: 3,
+                },
+            });
+            expect(result.rounds[0].directDamage).toBe(1900);
+            expect(result.summary.totalConditionalDamage).toBe(900);
+        });
+
+        it('defaults manual count to 1 when omitted', () => {
+            // bonus = 30 * 1 = 30 → preCrit = 1300
+            const result = simulateDPS({
+                ...exactInput,
+                activeConditional: { pct: 30, condition: 'enemy-buff', derivable: false },
+            });
+            expect(result.rounds[0].directDamage).toBe(1300);
+            expect(result.summary.totalConditionalDamage).toBe(300);
+        });
+
+        it('derives the count from active self buffs', () => {
+            // 2 self buffs → count 2 → bonus = 25*2 = 50 → preCrit = 1500
+            const result = simulateDPS({
+                ...exactInput,
+                selfBuffs: [makeAlwaysBuff('b1', {}), makeAlwaysBuff('b2', {})],
+                activeConditional: { pct: 25, condition: 'self-buff', derivable: true },
+            });
+            expect(result.rounds[0].directDamage).toBe(1500);
+            expect(result.summary.totalConditionalDamage).toBe(500);
+        });
+
+        it('respects the cap', () => {
+            // raw bonus = 20*10 = 200, capped at 100 → preCrit = 2000
+            const result = simulateDPS({
+                ...exactInput,
+                activeConditional: {
+                    pct: 20,
+                    condition: 'enemy-destroyed',
+                    derivable: false,
+                    manualCount: 10,
+                    cap: 100,
+                },
+            });
+            expect(result.rounds[0].directDamage).toBe(2000);
+        });
+
+        it('uses chargedConditional (not activeConditional) on a charged round', () => {
+            const result = simulateDPS({
+                ...exactInput,
+                chargedMultiplier: 100,
+                chargeCount: 1,
+                startCharged: true,
+                activeConditional: {
+                    pct: 30,
+                    condition: 'enemy-buff',
+                    derivable: false,
+                    manualCount: 3,
+                },
+                chargedConditional: {
+                    pct: 10,
+                    condition: 'enemy-buff',
+                    derivable: false,
+                    manualCount: 2,
+                },
+            });
+            // charged round: bonus = 10*2 = 20 → preCrit = 1200
+            expect(result.rounds[0].action).toBe('charged');
+            expect(result.rounds[0].directDamage).toBe(1200);
+            expect(result.summary.totalConditionalDamage).toBe(200);
+        });
+
+        it('reports zero conditional damage when none configured', () => {
+            const result = simulateDPS({ ...exactInput });
+            expect(result.summary.totalConditionalDamage).toBe(0);
+            expect(result.rounds[0].directDamage).toBe(1000);
+        });
+    });
 });

--- a/src/utils/calculators/dpsSimulator.ts
+++ b/src/utils/calculators/dpsSimulator.ts
@@ -1,6 +1,7 @@
 import { calculateCritMultiplier, calculateDamageReduction } from '../autogear/priorityScore';
 import {
     Buff,
+    ConditionalDamage,
     DoTApplicationConfig,
     DoTApplicationEntry,
     SecondaryDamage,
@@ -48,6 +49,10 @@ export interface DPSSimulationInput {
     activeSecondary?: SecondaryDamage;
     /** Secondary damage applied on charged-skill rounds. */
     chargedSecondary?: SecondaryDamage;
+    /** Conditional scaling bonus applied on active-skill rounds. */
+    activeConditional?: ConditionalDamage;
+    /** Conditional scaling bonus applied on charged-skill rounds. */
+    chargedConditional?: ConditionalDamage;
 }
 
 export interface RoundData {
@@ -79,6 +84,7 @@ export interface DPSSimulationSummary {
     totalInfernoDamage: number;
     totalBombDamage: number;
     totalSecondaryDamage: number;
+    totalConditionalDamage: number;
 }
 
 export interface DPSSimulationResult {
@@ -169,6 +175,8 @@ function runSinglePass(params: {
     hp: number;
     activeSecondary?: SecondaryDamage;
     chargedSecondary?: SecondaryDamage;
+    activeConditional?: ConditionalDamage;
+    chargedConditional?: ConditionalDamage;
 }): {
     rounds: RoundData[];
     rawTotals: {
@@ -178,6 +186,7 @@ function runSinglePass(params: {
         bomb: number;
         cumulative: number;
         totalSecondary: number;
+        totalConditional: number;
     };
 } {
     const {
@@ -208,6 +217,8 @@ function runSinglePass(params: {
         hp,
         activeSecondary,
         chargedSecondary,
+        activeConditional,
+        chargedConditional,
     } = params;
 
     // All mutable state declared fresh on every call
@@ -218,6 +229,7 @@ function runSinglePass(params: {
     let totalInfernoRaw = 0;
     let totalBombRaw = 0;
     let totalSecondaryRaw = 0;
+    let totalConditionalRaw = 0;
     const corrosionEntries: ActiveDoTStack[] = [];
     const infernoEntries: ActiveDoTStack[] = [];
     const pendingBombs: PendingBomb[] = [];
@@ -244,6 +256,7 @@ function runSinglePass(params: {
         }
 
         const secondary = action === 'charged' ? chargedSecondary : activeSecondary;
+        const conditional = action === 'charged' ? chargedConditional : activeConditional;
 
         // Per-round buff totals from timeline
         const entry = timeline[r - 1];
@@ -312,7 +325,34 @@ function runSinglePass(params: {
             secondaryStatValue = source * (secondary.pct / 100);
         }
 
-        const preCritDamage = effectiveAttack * (multiplier / 100) + secondaryStatValue;
+        // Conditional scaling bonus, folded additively into the skill multiplier.
+        // Derivable conditions read this round's sim state (pre-Step-3 DoT arrays,
+        // so this round's freshly-applied DoTs are not yet counted); manual
+        // conditions use a static count.
+        let conditionalBonusPct = 0;
+        if (conditional) {
+            let count: number;
+            if (conditional.condition === 'self-buff') {
+                count = entry.activeSelfBuffs.filter(
+                    (ab) => ab.stacks === undefined || ab.stacks > 0
+                ).length;
+            } else if (conditional.condition === 'enemy-debuff') {
+                count =
+                    landedEnemyDebuffs.length +
+                    corrosionEntries.length +
+                    infernoEntries.length +
+                    pendingBombs.length;
+            } else {
+                count = conditional.manualCount ?? 1;
+            }
+            conditionalBonusPct = conditional.pct * count;
+            if (conditional.cap !== undefined) {
+                conditionalBonusPct = Math.min(conditionalBonusPct, conditional.cap);
+            }
+        }
+
+        const preCritDamage =
+            effectiveAttack * ((multiplier + conditionalBonusPct) / 100) + secondaryStatValue;
         const postDefenseFactor =
             critMultiplier *
             (1 - damageReduction / 100) *
@@ -321,6 +361,7 @@ function runSinglePass(params: {
             affinityMult;
         const directDamage = preCritDamage * postDefenseFactor;
         const secondaryDamage = secondaryStatValue * postDefenseFactor;
+        const conditionalDamage = effectiveAttack * (conditionalBonusPct / 100) * postDefenseFactor;
 
         // Step 3: Apply new DoT stacks from this round's skill (subject to landing roll)
         const dotsLanded = roundDebuffLanded;
@@ -378,6 +419,7 @@ function runSinglePass(params: {
         cumulativeDamage += totalRoundDamage;
         totalDirectRaw += directDamage;
         totalSecondaryRaw += secondaryDamage;
+        totalConditionalRaw += conditionalDamage;
         totalCorrosionRaw += corrosionDamage;
         totalInfernoRaw += infernoDamage;
         totalBombRaw += bombDamage;
@@ -433,6 +475,7 @@ function runSinglePass(params: {
             bomb: totalBombRaw,
             cumulative: cumulativeDamage,
             totalSecondary: totalSecondaryRaw,
+            totalConditional: totalConditionalRaw,
         },
     };
 }
@@ -457,6 +500,8 @@ export function simulateDPS(input: DPSSimulationInput): DPSSimulationResult {
         hp = 0,
         activeSecondary,
         chargedSecondary,
+        activeConditional,
+        chargedConditional,
     } = input;
     const { affinityDamageModifier = 0, affinityCritCap = 100, affinityCritPenalty = 0 } = input;
 
@@ -522,6 +567,8 @@ export function simulateDPS(input: DPSSimulationInput): DPSSimulationResult {
         hp,
         activeSecondary,
         chargedSecondary,
+        activeConditional,
+        chargedConditional,
     });
 
     const totalDamage = Math.round(rawTotals.cumulative);
@@ -536,6 +583,7 @@ export function simulateDPS(input: DPSSimulationInput): DPSSimulationResult {
             totalInfernoDamage: Math.round(rawTotals.inferno),
             totalBombDamage: Math.round(rawTotals.bomb),
             totalSecondaryDamage: Math.round(rawTotals.totalSecondary),
+            totalConditionalDamage: Math.round(rawTotals.totalConditional),
         },
     };
 }

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1,6 +1,12 @@
 import { BUFFS } from '../constants/buffs';
 import { Ship } from '../types/ship';
-import { SecondaryDamage, SecondaryDamageStat, StackTrigger } from '../types/calculator';
+import {
+    SecondaryDamage,
+    SecondaryDamageStat,
+    StackTrigger,
+    ConditionalDamage,
+    ConditionalCondition,
+} from '../types/calculator';
 
 /**
  * Represents a parsed segment of skill text
@@ -165,6 +171,63 @@ export function parseSecondaryDamage(text: string | null | undefined): Secondary
     if (isNaN(pct)) return null;
     const stat: SecondaryDamageStat = match[2].toLowerCase().includes('hp') ? 'hp' : 'defense';
     return { stat, pct };
+}
+
+// Matches "X% ... for each <phrase>" where no other % sits between the number and
+// "for each". Global so we can skip repair/heal contexts and unknown phrases.
+const CONDITIONAL_RE = /(\d+(?:\.\d+)?)\s*%[^%]*?for each\s+([^.,;<]+)/gi;
+
+function mapConditionPhrase(
+    raw: string
+): { condition: ConditionalCondition; derivable: boolean } | null {
+    const p = raw.trim().toLowerCase();
+    // Order matters: "debuff" contains "buff"; "buff on this unit" before "buff on the enemy".
+    if (p.includes('debuff on the enemy') || p.includes('debuff on enemy'))
+        return { condition: 'enemy-debuff', derivable: true };
+    if (p.includes('buff on this unit')) return { condition: 'self-buff', derivable: true };
+    if (p.includes('buff on the enemy') || p.includes('buff on enemy'))
+        return { condition: 'enemy-buff', derivable: false };
+    if (p.includes('adjacent to the enemy'))
+        return { condition: 'enemy-adjacent', derivable: false };
+    if (p.includes('adjacent all')) return { condition: 'adjacent-ally', derivable: false };
+    if (p.includes('destroyed enem')) return { condition: 'enemy-destroyed', derivable: false };
+    return null;
+}
+
+function parseConditionalCap(text: string): number | null {
+    const m = /up to[^%]*?(\d+(?:\.\d+)?)\s*%/i.exec(text);
+    return m ? parseFloat(m[1]) : null;
+}
+
+/**
+ * Returns the conditional scaling bonus from a skill, e.g.
+ * "an additional <unit-damage>20%</unit-damage> for each adjacent ally" or the
+ * untagged "plus an extra 30% for each buff on the enemy" (Nuqtu). The bonus is
+ * a per-unit % added to the skill multiplier; `derivable` is true when the sim
+ * can count the condition itself (self buffs / enemy debuffs). Repair/heal
+ * scaling ("repairs X% ... for each enemy destroyed") is ignored. Returns null
+ * when no recognized "for each" conditional is present.
+ */
+export function parseConditionalDamage(text: string | null | undefined): ConditionalDamage | null {
+    if (!text) return null;
+    for (const m of text.matchAll(CONDITIONAL_RE)) {
+        const pct = parseFloat(m[1]);
+        if (isNaN(pct)) continue;
+        // Skip repair/heal scaling — look just before the matched number.
+        const idx = m.index ?? 0;
+        const before = text.slice(Math.max(0, idx - 20), idx).toLowerCase();
+        if (before.includes('repair')) continue;
+        const mapped = mapConditionPhrase(m[2]);
+        if (!mapped) continue;
+        const cap = parseConditionalCap(text);
+        return {
+            pct,
+            condition: mapped.condition,
+            derivable: mapped.derivable,
+            ...(cap !== null ? { cap } : {}),
+        };
+    }
+    return null;
 }
 
 /**

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -219,7 +219,9 @@ export function parseConditionalDamage(text: string | null | undefined): Conditi
         if (before.includes('repair')) continue;
         const mapped = mapConditionPhrase(m[2]);
         if (!mapped) continue;
-        const cap = parseConditionalCap(text);
+        // Scope the cap search to the conditional clause onward so an earlier,
+        // unrelated "up to X%" elsewhere in the skill text isn't picked up.
+        const cap = parseConditionalCap(text.slice(idx));
         return {
             pct,
             condition: mapped.condition,


### PR DESCRIPTION
## Summary

Adds **conditional scaling multipliers** to the DPS calculator — attacker skills whose damage multiplier scales with a count (e.g. `+20% per adjacent ally`, `+15% per debuff on the enemy`, `+30% per buff on the enemy`).

- **Parser** (`parseConditionalDamage`): auto-detects `+X% for each …` bonuses from skill text — tagged, `increasing by`, and untagged (`plus an extra 30% …`, Nuqtu) forms; repair-scaling guard; optional cap (`up to … N%`).
- **Simulator**: folds the bonus into the attack multiplier (`(multiplier + pct×count)/100`), leaving the secondary stat term untouched; reports a new `totalConditionalDamage` bucket.
- **Hybrid counts**: `self-buff` and `enemy-debuff` are auto-counted per round from sim state (prior-round buff/DoT state, so they ramp); other conditions take a manual count (default 1).
- **UI**: a "Conditional Damage" block in the ship config card (auto-counted note for derivable conditions, count input for manual), plus a breakdown line in the summary and an updated formula.
- Docs + changelog updated.

Mirrors the existing secondary-damage feature end-to-end. Each task went through fresh-implementer + independent spec/quality review; a final review surfaced 3 gaps (summary display, enemy-debuff test, Nuqtu co-occurrence assertion) which were all fixed.

> **Base:** targets `feat/dps-secondary-stat-damage` (not `main`) — this work builds on the unmerged secondary-stat-damage code. Merge after that branch lands.

## Test Plan

- [x] `npm run lint` clean (max-warnings 0)
- [x] `npm test` — 694/694 pass (15 new: 9 parser, 6 simulator incl. enemy-debuff ramp + cap)
- [x] Manual verification in the running app: selected Nuqtu → auto-filled Active 140%, secondary 80% Defense, conditional +30%/+40% per enemy buff; editing the manual count moved Total Damage (count 0→1→5 = 116k→129k→180k); summary shows "Conditional (scaling, incl. in Direct)"; active/charged conditionals independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)