### PR TITLE
DPS calculator: charge manipulation

### DIFF
--- a/docs/superpowers/plans/2026-05-31-charge-manipulation.md
+++ b/docs/superpowers/plans/2026-05-31-charge-manipulation.md
@@ -1,0 +1,824 @@
+# Charge Manipulation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Model charge-manipulation effects (self charge gains parsed from skill text + a flat ally/supporter charge contribution) so the DPS calculator's charged skill fires on a realistic cadence.
+
+**Architecture:** Feed extra charges into the existing per-round charge accumulator in `runSinglePass`. A new `parseChargeGain` parser auto-fills a `selfChargeGain` (amount + condition, reusing the conditional-condition machinery) from the attacker's own skill text; a flat manual `allyChargePerRound` represents supporters. Both accumulate every round; charged round resets to 0. A new global enemy-type input feeds the Thresh-style "if Defender" condition. No new damage slice — cadence changes redistribute existing damage.
+
+**Tech Stack:** React 18, TypeScript, Vite, Vitest. Follows the established skill-parsed-mechanic pipeline (secondary damage, conditional scaling).
+
+**Spec:** `docs/superpowers/specs/2026-05-31-charge-manipulation-design.md`
+
+---
+
+## File Structure
+
+- `src/types/calculator.ts` — `EnemyBaseClass`, `ChargeGain`, extend `ConditionalCondition` + labels, extend `DPSShipConfig` + `autoFilledFields` union.
+- `src/utils/skillTextParser.ts` — new `parseChargeGain` + a charge-specific condition classifier.
+- `src/utils/__tests__/skillTextParser.test.ts` — parser tests.
+- `src/utils/calculators/dpsSimulator.ts` — extend `DPSSimulationInput`, thread fields through `runSinglePass`, add the per-round charge-gain block.
+- `src/utils/calculators/__tests__/dpsSimulator.test.ts` — cadence tests.
+- `src/pages/calculators/DPSCalculatorPage.tsx` — auto-fill, seeding, `simulateDPS` call, updaters, global `enemyType` state.
+- `src/components/calculator/CombatSettingsPanel.tsx` — enemy-type `Select`.
+- `src/components/calculator/ShipConfigCard.tsx` — "Charge Manipulation" collapsible section + re-sync `useEffect`.
+- `src/components/calculator/ShipConfigSummary.tsx` — charged-skill cadence line.
+- `src/pages/DocumentationPage.tsx` + `src/constants/changelog.ts` — docs + changelog.
+
+---
+
+## Task 1: Types
+
+**Files:**
+- Modify: `src/types/calculator.ts`
+
+- [ ] **Step 1: Extend `ConditionalCondition` and its labels**
+
+In `src/types/calculator.ts`, change the `ConditionalCondition` union (currently lines 12-18) to add three variants, and add labels:
+
+```ts
+export type ConditionalCondition =
+    | 'self-buff' // derivable
+    | 'enemy-debuff' // derivable
+    | 'enemy-buff' // manual
+    | 'adjacent-ally' // manual
+    | 'enemy-adjacent' // manual
+    | 'enemy-destroyed' // manual
+    | 'always' // unconditional / always-true under sim assumptions (charge gains)
+    | 'self-crit' // derivable from crit rate (charge gains)
+    | 'enemy-type'; // derivable from the global enemy-type input (charge gains)
+```
+
+Add to `CONDITIONAL_CONDITION_LABELS` (currently lines 28-35):
+
+```ts
+    always: 'every round',
+    'self-crit': 'on critical hit',
+    'enemy-type': 'when enemy matches type',
+```
+
+- [ ] **Step 2: Add `EnemyBaseClass` and `ChargeGain` types**
+
+After the `ConditionalDamage` interface (around line 26), add:
+
+```ts
+export type EnemyBaseClass = 'Attacker' | 'Defender' | 'Debuffer' | 'Supporter';
+
+export interface ChargeGain {
+    amount: number; // charges per trigger (e.g. 1, 2)
+    condition: ConditionalCondition;
+    derivable: boolean; // true → read sim state; false → use manualCount
+    manualCount?: number; // used when !derivable (default 1)
+    requiredEnemyType?: EnemyBaseClass; // only for condition 'enemy-type'
+}
+```
+
+- [ ] **Step 3: Extend `DPSShipConfig` and `autoFilledFields`**
+
+In `DPSShipConfig` (around lines 120-130), after `startCharged: boolean;` add:
+
+```ts
+    selfChargeGain?: ChargeGain;
+    allyChargePerRound?: number;
+```
+
+And extend the `autoFilledFields` Set union (lines 122-130) by adding `| 'selfChargeGain'`.
+
+- [ ] **Step 4: Verify compile**
+
+Run: `npm run lint`
+Expected: PASS (no new errors). Type-only change; downstream `simulateDPS` call already omits these (optional fields).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/calculator.ts
+git commit -m "feat: add ChargeGain types for charge manipulation"
+```
+
+---
+
+## Task 2: Parser — `parseChargeGain`
+
+**Files:**
+- Modify: `src/utils/skillTextParser.ts`
+- Test: `src/utils/__tests__/skillTextParser.test.ts`
+
+Reference siblings already in the file: `parseConditionalDamage` (~line 211), `mapConditionPhrase` (~line 180). Charge phrases in `docs/ship-skills.csv` are wrapped in `<unit-aid>…</unit-aid>` tags; conditions are plain text around them. Do NOT reuse `mapConditionPhrase` (it only handles "for each …" grammar).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/utils/__tests__/skillTextParser.test.ts` (import `parseChargeGain` from `../skillTextParser`):
+
+```ts
+describe('parseChargeGain', () => {
+    it('parses always-true (speed) self gain — Chakara', () => {
+        const text =
+            'This Unit deals <unit-damage>180% damage</unit-damage>. If all damaged enemies have more Speed than this Unit, it <unit-aid>adds 1 charge</unit-aid> to its Charged Skill.';
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'always',
+            derivable: true,
+        });
+    });
+
+    it('parses full-HP self gain as always-true — Cobalt', () => {
+        const text =
+            "This Unit <unit-aid>adds 1 charge</unit-aid> to its charged skill at the start of the turn if it is at full HP.";
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'always',
+            derivable: true,
+        });
+    });
+
+    it('parses enemy-buff threshold gain (manual) — Nuqtu', () => {
+        const text =
+            'If the target has 3 or more buffs, the Unit <unit-aid>gains 2 charges</unit-aid> to its Charged Skill.';
+        expect(parseChargeGain(text)).toEqual({
+            amount: 2,
+            condition: 'enemy-buff',
+            derivable: false,
+        });
+    });
+
+    it('parses "equal to the number of buffs" per-buff gain — Rhodium', () => {
+        const text =
+            'Unit adds charges to the <unit-aid>Charged Skill</unit-aid> equal to the number of <unit-aid>Buffs</unit-aid> on the target.';
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'enemy-buff',
+            derivable: false,
+        });
+    });
+
+    it('parses enemy-type (Defender) gain and ignores the removal clause — Thresh', () => {
+        const text =
+            "If the target is a Defender, this Unit <unit-aid>removes 1 charge</unit-aid> from the enemy and <unit-aid>adds 1 charge</unit-aid> to this Unit's Charged Skill.";
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'enemy-type',
+            derivable: true,
+            requiredEnemyType: 'Defender',
+        });
+    });
+
+    it('parses stealth condition as enemy-buff (manual) — Selenite', () => {
+        const text =
+            "If any target is <unit-aid>Stealthed</unit-aid>, it <unit-aid>adds 1 charge</unit-aid> to this Unit's Charged Skill.";
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'enemy-buff',
+            derivable: false,
+        });
+    });
+
+    it('parses "2 or more enemies" as enemy-adjacent (manual) — Tygr', () => {
+        const text =
+            'If it damages 2 or more enemies, it adds <unit-aid>adds 1 charge</unit-aid> to its Charged Skill.';
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'enemy-adjacent',
+            derivable: false,
+        });
+    });
+
+    it('parses debuff-infliction as enemy-debuff (derivable) — Hemlock', () => {
+        const text =
+            'This Unit <unit-aid>gains 1 charge</unit-aid> to its charged skill after it inflicts a <unit-aid>debuff</unit-aid>.';
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'enemy-debuff',
+            derivable: true,
+        });
+    });
+
+    it('parses crit-based self gain as self-crit (derivable) — Asphodel', () => {
+        const text =
+            "This Unit's attacks are always critical and <unit-aid>adds 1 charge</unit-aid> to its Charged Skill after critically damaging an enemy.";
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'self-crit',
+            derivable: true,
+        });
+    });
+
+    it('returns null for enemy charge removal — Demolisher', () => {
+        const text =
+            "When a bomb explodes on an enemy, this unit removes 2 charges from the enemy's charged skill.";
+        expect(parseChargeGain(text)).toBeNull();
+    });
+
+    it('returns null for on-kill gain — Valiant', () => {
+        const text =
+            'This Unit <unit-aid>gains 1 charge</unit-aid> for its Charged Skill upon killing an enemy.';
+        expect(parseChargeGain(text)).toBeNull();
+    });
+
+    it('returns null for ally-grant — Liberator', () => {
+        const text =
+            'When an enemy dies, all allies <unit-aid>add 1 charge</unit-aid> to their Charged Skills.';
+        expect(parseChargeGain(text)).toBeNull();
+    });
+
+    it('returns null when there is no charge phrase', () => {
+        expect(parseChargeGain('This Unit deals <unit-damage>140% damage</unit-damage>.')).toBeNull();
+        expect(parseChargeGain('')).toBeNull();
+        expect(parseChargeGain(null)).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- skillTextParser`
+Expected: FAIL with "parseChargeGain is not a function" (or import error).
+
+- [ ] **Step 3: Implement `parseChargeGain`**
+
+Add to `src/utils/skillTextParser.ts` (import `ChargeGain`, `EnemyBaseClass` from `../types/calculator` alongside the existing `ConditionalDamage`, `ConditionalCondition` imports). Place after `parseConditionalDamage`:
+
+```ts
+// Phrases that disqualify a charge phrase from being a self-gain we model:
+// ally-grant to others, on-kill (enemy never dies), enemy-repair (never repairs).
+const CHARGE_DISQUALIFY_RE =
+    /all allies|their charged skill|charged skill of all allies|upon killing|killing an enemy|when an enemy dies|when an enemy repairs|enemy performs a repair|enemy repairs/i;
+
+// "adds/gains N charge(s)" inside a <unit-aid> tag (self-add; "removes" is excluded
+// because the verb is constrained to adds/gains).
+const SELF_CHARGE_ADD_RE =
+    /<unit-aid>\s*(?:adds?|gains?)\s+(\d+|a|an)\s+charges?\s*<\/unit-aid>/i;
+
+// Rhodium-style untagged form: "adds charges to the Charged Skill equal to the
+// number of buffs on the target".
+const PER_BUFF_CHARGE_RE = /adds?\s+charges?\s+to\s+the\s+<?[^>]*charged skill[^.]*equal to the number of/i;
+
+function classifyChargeCondition(
+    text: string
+): { condition: ConditionalCondition; derivable: boolean; requiredEnemyType?: EnemyBaseClass } {
+    const p = text.toLowerCase();
+    if (p.includes('is a defender'))
+        return { condition: 'enemy-type', derivable: true, requiredEnemyType: 'Defender' };
+    if (p.includes('critically damag') || p.includes('critically hit') || p.includes('critical'))
+        return { condition: 'self-crit', derivable: true };
+    if (p.includes('inflict') && p.includes('debuff'))
+        return { condition: 'enemy-debuff', derivable: true };
+    if (p.includes('stealth')) return { condition: 'enemy-buff', derivable: false };
+    if (p.includes('buffs on the target') || p.includes('buff on the target') ||
+        p.includes('or more buffs') || p.includes('buffs on the enemy') ||
+        p.includes('number of buffs'))
+        return { condition: 'enemy-buff', derivable: false };
+    if (p.includes('2 or more enemies') || p.includes('two or more enemies') ||
+        p.includes('damages 2'))
+        return { condition: 'enemy-adjacent', derivable: false };
+    // speed / full-HP / lowest-speed and anything else → always-true under sim assumptions
+    return { condition: 'always', derivable: true };
+}
+
+/**
+ * Parses a self-targeted Charged-Skill charge gain from skill text. Returns null
+ * for ally-grant, enemy-removal, on-kill, and enemy-repair phrasings (out of
+ * scope or never-fire under the sim assumptions). Conditions are classified into
+ * the (shared) ConditionalCondition set; `derivable` follows the same meaning as
+ * ConditionalDamage. Reference data: docs/ship-skills.csv.
+ */
+export function parseChargeGain(text: string | null | undefined): ChargeGain | null {
+    if (!text) return null;
+    if (CHARGE_DISQUALIFY_RE.test(text)) return null;
+
+    // Rhodium "equal to the number of buffs" form (amount is per-buff = 1).
+    if (PER_BUFF_CHARGE_RE.test(text)) {
+        return { amount: 1, condition: 'enemy-buff', derivable: false };
+    }
+
+    const m = SELF_CHARGE_ADD_RE.exec(text);
+    if (!m) return null;
+    const raw = m[1].toLowerCase();
+    const amount = raw === 'a' || raw === 'an' ? 1 : parseInt(raw, 10);
+    if (!amount || isNaN(amount)) return null;
+
+    const { condition, derivable, requiredEnemyType } = classifyChargeCondition(text);
+    return {
+        amount,
+        condition,
+        derivable,
+        ...(requiredEnemyType ? { requiredEnemyType } : {}),
+    };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- skillTextParser`
+Expected: PASS (all `parseChargeGain` cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/skillTextParser.ts src/utils/__tests__/skillTextParser.test.ts
+git commit -m "feat: parse charge-gain effects from skill text"
+```
+
+---
+
+## Task 3: Simulator — charge-gain accumulation
+
+**Files:**
+- Modify: `src/utils/calculators/dpsSimulator.ts`
+- Test: `src/utils/calculators/__tests__/dpsSimulator.test.ts`
+
+- [ ] **Step 1: Extend `DPSSimulationInput`**
+
+In `src/utils/calculators/dpsSimulator.ts`, import `ChargeGain` and `EnemyBaseClass` from `../../types/calculator` (alongside existing imports). Add to `DPSSimulationInput` (after `chargedConditional?`, ~line 55):
+
+```ts
+    /** Per-round self charge gain parsed from the attacker's skill text. */
+    selfChargeGain?: ChargeGain;
+    /** Flat extra charges per round contributed by allies/supporters. */
+    allyChargePerRound?: number;
+    /** Enemy base class, for the 'enemy-type' charge-gain condition. */
+    enemyType?: EnemyBaseClass;
+```
+
+- [ ] **Step 2: Write the failing cadence tests**
+
+Add to `src/utils/calculators/__tests__/dpsSimulator.test.ts`. Use the existing test convention (`crit: 100, critDamage: 0` → critMultiplier 1; `enemyDefense: 0`). Build a minimal input via the existing helper/pattern in that file (mirror an existing `simulateDPS({...})` test for required fields). The key field under test is the round `action` sequence.
+
+```ts
+describe('charge manipulation', () => {
+    // Helper: indices (1-based round numbers) where the charged skill fired.
+    const chargedRounds = (result: ReturnType<typeof simulateDPS>) =>
+        result.rounds.filter((r) => r.action === 'charged').map((r) => r.round);
+
+    const base = {
+        attack: 1000,
+        crit: 100,
+        critDamage: 0,
+        defensePenetration: 0,
+        activeMultiplier: 100,
+        chargedMultiplier: 200,
+        chargeCount: 3,
+        activeDoTs: [],
+        chargedDoTs: [],
+        enemyDefense: 0,
+        enemyHp: 500000,
+        rounds: 12,
+        selfBuffs: [],
+        enemyDebuffs: [],
+    };
+
+    it('baseline: charged fires once charges reach chargeCount (every 4th round for 3 charges)', () => {
+        // R1..R3 bank +1 each → charges 1,2,3; R4 sees 3 → charged. Then repeats.
+        const result = simulateDPS({ ...base });
+        expect(chargedRounds(result)).toEqual([4, 8, 12]);
+    });
+
+    it('allyChargePerRound speeds up cadence', () => {
+        // Per active round banks 1+1=2; charged round banks 0+1=1.
+        // R1: 0<3 active → 2. R2: 2<3 active → 4. R3: 4>=3 charged → 0, +1 → 1.
+        // R4: 1<3 active → 3. R5: 3>=3 charged → 0,+1 → 1. R6: active → 3. R7: charged...
+        const result = simulateDPS({ ...base, allyChargePerRound: 1 });
+        expect(chargedRounds(result)).toEqual([3, 5, 7, 9, 11]);
+    });
+
+    it('always-true self gain speeds up cadence', () => {
+        const result = simulateDPS({
+            ...base,
+            selfChargeGain: { amount: 1, condition: 'always', derivable: true },
+        });
+        // Same accumulation as allyChargePerRound: 1 (active banks 1+1, charged banks 1).
+        expect(chargedRounds(result)).toEqual([3, 5, 7, 9, 11]);
+    });
+
+    it('self-crit at 100% crit contributes +1/round', () => {
+        const result = simulateDPS({
+            ...base,
+            selfChargeGain: { amount: 1, condition: 'self-crit', derivable: true },
+        });
+        expect(chargedRounds(result)).toEqual([3, 5, 7, 9, 11]);
+    });
+
+    it('enemy-type gain only applies when enemy type matches', () => {
+        const gain = {
+            amount: 1,
+            condition: 'enemy-type' as const,
+            derivable: true,
+            requiredEnemyType: 'Defender' as const,
+        };
+        const matched = simulateDPS({ ...base, selfChargeGain: gain, enemyType: 'Defender' });
+        const unmatched = simulateDPS({ ...base, selfChargeGain: gain, enemyType: 'Attacker' });
+        expect(chargedRounds(matched)).toEqual([3, 5, 7, 9, 11]);
+        expect(chargedRounds(unmatched)).toEqual([4, 8, 12]); // same as baseline
+    });
+
+    it('does nothing when there is no charged skill', () => {
+        const result = simulateDPS({
+            ...base,
+            chargedMultiplier: 0,
+            allyChargePerRound: 5,
+        });
+        expect(chargedRounds(result)).toEqual([]);
+    });
+});
+```
+
+> Note: confirm `base` includes every required `DPSSimulationInput` field by checking an existing test in the same file; add any missing required fields (e.g. it may already default optional ones). Re-derive the expected arrays by hand if the file's existing baseline test shows a different reset/increment timing than assumed here, then make the assertions match the actual semantics (do not loosen to "~every N").
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npm test -- dpsSimulator`
+Expected: FAIL — charge-manipulation cases fail (cadence unchanged / fields ignored). The baseline test should PASS already (documents current behavior).
+
+- [ ] **Step 4: Thread the fields into `runSinglePass`**
+
+In `simulateDPS` (~line 483), destructure the three new fields from `input` and pass them into the `runSinglePass` call (mirror how `chargedConditional` is threaded ~lines 502-571). Add to `runSinglePass`'s params interface/destructure: `selfChargeGain?: ChargeGain`, `allyChargePerRound?: number`, `enemyType?: EnemyBaseClass`.
+
+- [ ] **Step 5: Add the per-round charge-gain block**
+
+In the round loop, immediately **after** the conditional-bonus block (the `conditionalBonusPct` computation, ~lines 332-352) and before Step 1 damage — so `effectiveCrit` (~line 294) and `landedEnemyDebuffs`/DoT arrays (~line 341) are in scope — add:
+
+```ts
+        // Charge manipulation: bonus charges accumulate every round (active and
+        // charged). Charged round already reset charges to 0 at the top, so
+        // post-fire rounds still bank bonus/ally charges. Gated on hasChargedSkill.
+        if (hasChargedSkill) {
+            let chargeGainCount = 0;
+            if (selfChargeGain) {
+                switch (selfChargeGain.condition) {
+                    case 'always':
+                        chargeGainCount = 1;
+                        break;
+                    case 'self-crit':
+                        chargeGainCount = effectiveCrit / 100;
+                        break;
+                    case 'self-buff':
+                        chargeGainCount = entry.activeSelfBuffs.filter(
+                            (ab) => ab.stacks === undefined || ab.stacks > 0
+                        ).length;
+                        break;
+                    case 'enemy-debuff':
+                        chargeGainCount =
+                            landedEnemyDebuffs.length +
+                            corrosionEntries.length +
+                            infernoEntries.length +
+                            pendingBombs.length;
+                        break;
+                    case 'enemy-type':
+                        chargeGainCount =
+                            enemyType !== undefined &&
+                            enemyType === selfChargeGain.requiredEnemyType
+                                ? 1
+                                : 0;
+                        break;
+                    default:
+                        // enemy-buff, enemy-adjacent, adjacent-ally, enemy-destroyed
+                        chargeGainCount = selfChargeGain.manualCount ?? 1;
+                        break;
+                }
+            }
+            const bonusCharges = selfChargeGain ? chargeGainCount * selfChargeGain.amount : 0;
+            charges += bonusCharges + (allyChargePerRound ?? 0);
+        }
+```
+
+- [ ] **Step 6: Round charges for display**
+
+Charges can now be fractional. In the `roundData.push({...})` (~line 428), change `charges,` to `charges: Math.round(charges),` so the timeline shows whole numbers.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `npm test -- dpsSimulator`
+Expected: PASS (baseline + all charge-manipulation cases). If a hand-derived array is off by the reset/increment timing, re-derive against the actual loop and correct the test — do not change the production semantics to match a guess.
+
+- [ ] **Step 8: Run the full suite + lint**
+
+Run: `npm test && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/utils/calculators/dpsSimulator.ts src/utils/calculators/__tests__/dpsSimulator.test.ts
+git commit -m "feat: accumulate manipulated charges in DPS sim"
+```
+
+---
+
+## Task 4: Page wiring
+
+**Files:**
+- Modify: `src/pages/calculators/DPSCalculatorPage.tsx`
+
+- [ ] **Step 1: Parse `selfChargeGain` in `buildSkillAutoFill`**
+
+In `buildSkillAutoFill` (~line 43): import `parseChargeGain` and the `ChargeGain` / `EnemyBaseClass` types. Scan active + all passive skill texts (the gain is often on a passive, e.g. Hemlock/Asphodel/Cobalt) and take the first match. Seed `manualCount: 1` for non-derivable, mirroring `seedManual`:
+
+```ts
+    const seedChargeManual = (c: ChargeGain | null): ChargeGain | undefined => {
+        if (!c) return undefined;
+        return !c.derivable && c.manualCount === undefined ? { ...c, manualCount: 1 } : c;
+    };
+    const selfChargeGain = seedChargeManual(
+        parseChargeGain(ship.activeSkillText) ??
+            parseChargeGain(ship.firstPassiveSkillText) ??
+            parseChargeGain(ship.secondPassiveSkillText) ??
+            parseChargeGain(ship.thirdPassiveSkillText)
+    );
+```
+
+Add `'selfChargeGain'` to the local `autoFilledFields` Set type union (lines 54-62), add `if (selfChargeGain) autoFilledFields.add('selfChargeGain');`, and add `selfChargeGain` to the returned object (lines 69-77).
+
+- [ ] **Step 2: Seed in `getInitialConfig` (ship branch + default branch)**
+
+In the ship branch (~lines 107-149): destructure `selfChargeGain` from `buildSkillAutoFill`, and add to the returned config object: `selfChargeGain,` and `allyChargePerRound: 0,`.
+
+In the default (no-ship) branch (~lines 155-178): add `allyChargePerRound: 0,` to the config (leave `selfChargeGain` undefined).
+
+- [ ] **Step 3: Add global `enemyType` state**
+
+Near the other enemy state (`enemyDefense`/`enemyHp`/`enemySecurity`, ~lines 184-194), add:
+
+```ts
+    const [enemyType, setEnemyType] = useState<EnemyBaseClass | undefined>(undefined);
+```
+
+- [ ] **Step 4: Pass new fields into `simulateDPS`**
+
+In the `simulateDPS({...})` call (~lines 271-298) add:
+
+```ts
+                    selfChargeGain: config.selfChargeGain,
+                    allyChargePerRound: config.allyChargePerRound,
+                    enemyType,
+```
+
+Add `enemyType` to the `simResults` `useMemo` dependency array (~lines 302-313).
+
+- [ ] **Step 5: Seed in `selectShipForConfig`**
+
+In `selectShipForConfig` (~lines 406-454): destructure `selfChargeGain` from `buildSkillAutoFill`, and in the returned merged config add `selfChargeGain,` (next to `activeConditional`). Leave `allyChargePerRound` as `c.allyChargePerRound ?? 0` to preserve any user value.
+
+- [ ] **Step 6: Add updaters**
+
+After `updateConfigConditional` (~line 550) add:
+
+```ts
+    const updateConfigChargeGain = (id: string, value: ChargeGain | undefined) => {
+        setConfigs((prev) =>
+            prev.map((c) => {
+                if (c.id !== id) return c;
+                const next = new Set(c.autoFilledFields);
+                next.delete('selfChargeGain');
+                return { ...c, selfChargeGain: value, autoFilledFields: next };
+            })
+        );
+    };
+
+    const updateConfigAllyCharge = (id: string, value: number) => {
+        setConfigs((prev) => prev.map((c) => (c.id === id ? { ...c, allyChargePerRound: value } : c)));
+    };
+```
+
+- [ ] **Step 7: Wire props into `<ShipConfigCard>` and `<CombatSettingsPanel>`**
+
+On `<ShipConfigCard>` (~lines 663-702) add:
+
+```tsx
+                                onChargeGainChange={(value) =>
+                                    updateConfigChargeGain(config.id, value)
+                                }
+                                onAllyChargeChange={(value) =>
+                                    updateConfigAllyCharge(config.id, value)
+                                }
+```
+
+On `<CombatSettingsPanel>` (~lines 629-657) add:
+
+```tsx
+                        enemyType={enemyType}
+                        onEnemyTypeChange={setEnemyType}
+```
+
+- [ ] **Step 8: Verify build**
+
+Run: `npm run lint`
+Expected: errors only about the not-yet-added `ShipConfigCard` / `CombatSettingsPanel` props (resolved in Task 5). If other errors appear, fix them.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/pages/calculators/DPSCalculatorPage.tsx
+git commit -m "feat: wire charge manipulation into DPS calculator page"
+```
+
+---
+
+## Task 5: UI — config card, combat panel, summary
+
+**Files:**
+- Modify: `src/components/calculator/CombatSettingsPanel.tsx`
+- Modify: `src/components/calculator/ShipConfigCard.tsx`
+- Modify: `src/components/calculator/ShipConfigSummary.tsx`
+
+- [ ] **Step 1: Enemy-type selector in CombatSettingsPanel**
+
+In `src/components/calculator/CombatSettingsPanel.tsx`: import `EnemyBaseClass` from `../../types/calculator`. Add to `CombatSettingsPanelProps`:
+
+```ts
+    enemyType?: EnemyBaseClass;
+    onEnemyTypeChange: (v: EnemyBaseClass | undefined) => void;
+```
+
+Destructure them in the component. Near the enemy-affinity `Select` (~line 108), add a new `Select` (mirror the affinity one):
+
+```tsx
+                    <Select
+                        label="Enemy Type"
+                        value={enemyType ?? ''}
+                        options={[
+                            { value: '', label: 'Any / Unknown' },
+                            { value: 'Attacker', label: 'Attacker' },
+                            { value: 'Defender', label: 'Defender' },
+                            { value: 'Debuffer', label: 'Debuffer' },
+                            { value: 'Supporter', label: 'Supporter' },
+                        ]}
+                        onChange={(v) =>
+                            onEnemyTypeChange(v === '' ? undefined : (v as EnemyBaseClass))
+                        }
+                    />
+```
+
+> Check the exact `Select` API used by the affinity selector in this file (options array vs children `<option>`) and match it.
+
+- [ ] **Step 2: Charge Manipulation section in ShipConfigCard — props**
+
+In `src/components/calculator/ShipConfigCard.tsx`: import `ChargeGain`, `EnemyBaseClass`, and `CONDITIONAL_CONDITION_LABELS` (already imported). Add to the props interface (near `onConditionalChange`, ~line 55):
+
+```ts
+    onChargeGainChange: (value: ChargeGain | undefined) => void;
+    onAllyChargeChange: (value: number) => void;
+```
+
+Destructure both in the component signature.
+
+- [ ] **Step 3: Re-sync open-state**
+
+Add an `openCharge` state next to `openConditional` (~line 91):
+
+```ts
+    const [openCharge, setOpenCharge] = useState(
+        Boolean(config.selfChargeGain || config.allyChargePerRound)
+    );
+```
+
+Extend the existing re-sync `useEffect` (~lines 97-104) to also set it and add the deps:
+
+```ts
+        setOpenCharge(Boolean(config.selfChargeGain || config.allyChargePerRound));
+```
+deps add: `config.selfChargeGain, config.allyChargePerRound`.
+
+- [ ] **Step 4: Charge Manipulation section markup**
+
+After the Conditional Damage `CollapsibleForm` (closes ~line 448), add a sibling section mirroring it:
+
+```tsx
+                    <Button
+                        variant="link"
+                        onClick={() => setOpenCharge((v) => !v)}
+                        className="w-full flex justify-between items-center mt-4"
+                    >
+                        <span className="flex items-center gap-2">
+                            <ChevronDownIcon
+                                className={`text-sm text-theme-text-secondary h-8 w-8 p-2 transition-transform duration-300 ${openCharge ? 'rotate-180' : ''}`}
+                            />
+                            Charge Manipulation
+                        </span>
+                    </Button>
+                    <CollapsibleForm isVisible={openCharge}>
+                        {config.selfChargeGain ? (
+                            <div className="mb-4">
+                                <div className="text-sm font-semibold mb-1">
+                                    Self: +{config.selfChargeGain.amount} charge
+                                    {config.selfChargeGain.amount !== 1 ? 's' : ''}/round{' '}
+                                    {CONDITIONAL_CONDITION_LABELS[config.selfChargeGain.condition]}
+                                </div>
+                                {config.selfChargeGain.derivable ? (
+                                    <p className="text-xs text-theme-text-secondary">
+                                        Auto-counted each round from sim state.
+                                    </p>
+                                ) : (
+                                    <Input
+                                        label="Trigger count / round"
+                                        type="number"
+                                        min="0"
+                                        value={config.selfChargeGain.manualCount ?? 1}
+                                        helpLabel={
+                                            config.autoFilledFields?.has('selfChargeGain')
+                                                ? 'auto-filled'
+                                                : undefined
+                                        }
+                                        onChange={(e) =>
+                                            onChargeGainChange({
+                                                ...config.selfChargeGain!,
+                                                manualCount: parseInt(e.target.value) || 0,
+                                            })
+                                        }
+                                    />
+                                )}
+                            </div>
+                        ) : (
+                            <p className="text-xs text-theme-text-secondary mb-2">
+                                No self charge gain detected.
+                            </p>
+                        )}
+                        <Input
+                            label="Ally charges / round"
+                            type="number"
+                            min="0"
+                            step="0.5"
+                            value={config.allyChargePerRound ?? 0}
+                            helpLabel="from supporters (e.g. Castor, Liberator)"
+                            onChange={(e) =>
+                                onAllyChargeChange(parseFloat(e.target.value) || 0)
+                            }
+                        />
+                    </CollapsibleForm>
+```
+
+- [ ] **Step 5: Cadence line in ShipConfigSummary**
+
+In `src/components/calculator/ShipConfigSummary.tsx`, after the Total Damage block (~line 66), add a charged-skill cadence line shown when a charged skill exists:
+
+```tsx
+            {config.chargedMultiplier > 0 && config.chargeCount > 0 && (
+                <div className="flex justify-between mb-2">
+                    <span className="text-theme-text-secondary">Charged skill fires:</span>
+                    <span>
+                        {(() => {
+                            const fires = simResult.rounds.filter(
+                                (r) => r.action === 'charged'
+                            ).length;
+                            return fires > 0
+                                ? `every ${(simResult.rounds.length / fires).toFixed(1)} rounds`
+                                : '—';
+                        })()}
+                    </span>
+                </div>
+            )}
+```
+
+- [ ] **Step 6: Build + lint**
+
+Run: `npm run lint && npm test`
+Expected: PASS.
+
+- [ ] **Step 7: Manual smoke test**
+
+Run: `npm start`. Open the DPS calculator. Select a ship with a charge gain (e.g. Chakara, Cobalt, Thresh). Confirm: the "Charge Manipulation" section auto-opens and shows the parsed self gain; setting "Ally charges / round" or "Enemy Type" (for Thresh) changes the "Charged skill fires: every X rounds" line and the damage totals.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/calculator/CombatSettingsPanel.tsx src/components/calculator/ShipConfigCard.tsx src/components/calculator/ShipConfigSummary.tsx
+git commit -m "feat: charge manipulation UI section + enemy-type selector"
+```
+
+---
+
+## Task 6: Docs + changelog
+
+**Files:**
+- Modify: `src/pages/DocumentationPage.tsx`
+- Modify: `src/constants/changelog.ts`
+
+- [ ] **Step 1: Update in-app docs**
+
+In `src/pages/DocumentationPage.tsx`, find the DPS calculator section and the "About the Simulation" prose (search "Conditional" / "Secondary" added in prior features). Add a short paragraph describing charge manipulation: self charge gains parsed from skill text (conditions auto-counted from sim state, or a manual trigger count), the flat "Ally charges / round" supporter input, the enemy-type selector, and that these change how often the charged skill fires.
+
+- [ ] **Step 2: Add changelog entry**
+
+In `src/constants/changelog.ts`, add to `UNRELEASED_CHANGES` a plain-English entry, e.g.:
+
+> "DPS calculator now models charge manipulation: ships that add charges to their Charged Skill (and supporter ships that feed charges to allies) make the charged skill fire sooner. Includes a new enemy-type selector for type-conditional charge gains."
+
+- [ ] **Step 3: Build + lint**
+
+Run: `npm run lint && npm test`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/DocumentationPage.tsx src/constants/changelog.ts
+git commit -m "docs: document charge manipulation in DPS calculator"
+```
+
+---
+
+## Final verification
+
+- [ ] Run `npm test` — all pass.
+- [ ] Run `npm run lint` — zero warnings (max-warnings: 0).
+- [ ] Manual: charge gain auto-fills for Chakara/Cobalt/Thresh/Nuqtu; ally-charge + enemy-type inputs shift cadence and totals; ships without a charged skill ignore the inputs.
+- [ ] Update memory: mark charge manipulation shipped in `project_dps_skill_mechanic_pipeline.md` and pick the next target.

--- a/docs/superpowers/plans/2026-05-31-charge-manipulation.md
+++ b/docs/superpowers/plans/2026-05-31-charge-manipulation.md
@@ -236,40 +236,55 @@ Expected: FAIL with "parseChargeGain is not a function" (or import error).
 
 - [ ] **Step 3: Implement `parseChargeGain`**
 
-Add to `src/utils/skillTextParser.ts` (import `ChargeGain`, `EnemyBaseClass` from `../types/calculator` alongside the existing `ConditionalDamage`, `ConditionalCondition` imports). Place after `parseConditionalDamage`:
+Add to `src/utils/skillTextParser.ts` (import `ChargeGain`, `EnemyBaseClass` from `../types/calculator` alongside the existing `ConditionalDamage`, `ConditionalCondition` imports). Place after `parseConditionalDamage`.
+
+**Key approach:** strip the `<unit-aid>` / `<unit-skill>` / `<unit-damage>` tags first, then match plain text. The tags wrap the amount in some skills (Chakara: `<unit-aid>adds 1 charge</unit-aid>`) but wrap the *nouns* in others (Rhodium: `<unit-aid>Charged Skill</unit-aid>` … `<unit-aid>Buffs</unit-aid>`), so tag-spanning regexes are brittle. Stripping tags makes both forms plain. Self-vs-removal is distinguished by the verb (`adds`/`gains` vs `removes`), not the tag.
+
+> First check whether the file already has a tag-stripping helper near line 40 (there is a tag-matching comment there). If one exists, reuse it; otherwise add `stripUnitTags` below.
 
 ```ts
+function stripUnitTags(text: string): string {
+    return text.replace(/<\/?unit-(?:aid|skill|damage)>/gi, '');
+}
+
 // Phrases that disqualify a charge phrase from being a self-gain we model:
 // ally-grant to others, on-kill (enemy never dies), enemy-repair (never repairs).
 const CHARGE_DISQUALIFY_RE =
     /all allies|their charged skill|charged skill of all allies|upon killing|killing an enemy|when an enemy dies|when an enemy repairs|enemy performs a repair|enemy repairs/i;
 
-// "adds/gains N charge(s)" inside a <unit-aid> tag (self-add; "removes" is excluded
-// because the verb is constrained to adds/gains).
-const SELF_CHARGE_ADD_RE =
-    /<unit-aid>\s*(?:adds?|gains?)\s+(\d+|a|an)\s+charges?\s*<\/unit-aid>/i;
+// "adds/gains N charge(s)" (self-add). "removes" is excluded by the verb set, so
+// Thresh's "removes 1 charge ... and adds 1 charge" matches only the add.
+const SELF_CHARGE_ADD_RE = /\b(?:adds?|gains?)\s+(\d+|a|an)\s+charges?\b/i;
 
-// Rhodium-style untagged form: "adds charges to the Charged Skill equal to the
-// number of buffs on the target".
-const PER_BUFF_CHARGE_RE = /adds?\s+charges?\s+to\s+the\s+<?[^>]*charged skill[^.]*equal to the number of/i;
+// Rhodium-style form: "adds charges to the Charged Skill equal to the number of
+// buffs on the target" (amount is per-buff = 1). Runs on tag-stripped text.
+const PER_BUFF_CHARGE_RE =
+    /adds?\s+charges?\s+to\s+the\s+charged skill[^.]*equal to the number of/i;
 
 function classifyChargeCondition(
-    text: string
+    text: string // already tag-stripped, any case
 ): { condition: ConditionalCondition; derivable: boolean; requiredEnemyType?: EnemyBaseClass } {
     const p = text.toLowerCase();
     if (p.includes('is a defender'))
         return { condition: 'enemy-type', derivable: true, requiredEnemyType: 'Defender' };
-    if (p.includes('critically damag') || p.includes('critically hit') || p.includes('critical'))
+    if (p.includes('critically damag') || p.includes('critically hit'))
         return { condition: 'self-crit', derivable: true };
     if (p.includes('inflict') && p.includes('debuff'))
         return { condition: 'enemy-debuff', derivable: true };
     if (p.includes('stealth')) return { condition: 'enemy-buff', derivable: false };
-    if (p.includes('buffs on the target') || p.includes('buff on the target') ||
-        p.includes('or more buffs') || p.includes('buffs on the enemy') ||
-        p.includes('number of buffs'))
+    if (
+        p.includes('buffs on the target') ||
+        p.includes('buff on the target') ||
+        p.includes('or more buffs') ||
+        p.includes('buffs on the enemy') ||
+        p.includes('number of buffs')
+    )
         return { condition: 'enemy-buff', derivable: false };
-    if (p.includes('2 or more enemies') || p.includes('two or more enemies') ||
-        p.includes('damages 2'))
+    if (
+        p.includes('2 or more enemies') ||
+        p.includes('two or more enemies') ||
+        p.includes('damages 2')
+    )
         return { condition: 'enemy-adjacent', derivable: false };
     // speed / full-HP / lowest-speed and anything else → always-true under sim assumptions
     return { condition: 'always', derivable: true };
@@ -284,20 +299,21 @@ function classifyChargeCondition(
  */
 export function parseChargeGain(text: string | null | undefined): ChargeGain | null {
     if (!text) return null;
-    if (CHARGE_DISQUALIFY_RE.test(text)) return null;
+    const plain = stripUnitTags(text);
+    if (CHARGE_DISQUALIFY_RE.test(plain)) return null;
 
     // Rhodium "equal to the number of buffs" form (amount is per-buff = 1).
-    if (PER_BUFF_CHARGE_RE.test(text)) {
+    if (PER_BUFF_CHARGE_RE.test(plain)) {
         return { amount: 1, condition: 'enemy-buff', derivable: false };
     }
 
-    const m = SELF_CHARGE_ADD_RE.exec(text);
+    const m = SELF_CHARGE_ADD_RE.exec(plain);
     if (!m) return null;
     const raw = m[1].toLowerCase();
     const amount = raw === 'a' || raw === 'an' ? 1 : parseInt(raw, 10);
     if (!amount || isNaN(amount)) return null;
 
-    const { condition, derivable, requiredEnemyType } = classifyChargeCondition(text);
+    const { condition, derivable, requiredEnemyType } = classifyChargeCondition(plain);
     return {
         amount,
         condition,
@@ -306,6 +322,8 @@ export function parseChargeGain(text: string | null | undefined): ChargeGain | n
     };
 }
 ```
+
+> Note for the test in Step 1: the Rhodium fixture's `<unit-aid>` tags around "Charged Skill"/"Buffs" are stripped before matching, so `PER_BUFF_CHARGE_RE` and the `number of buffs` classifier both hit. Verify mentally: stripped Rhodium = "Unit adds charges to the Charged Skill equal to the number of Buffs on the target." → matches `PER_BUFF_CHARGE_RE` → returns `{ amount: 1, condition: 'enemy-buff', derivable: false }`. ✓
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -465,10 +483,7 @@ In the round loop, immediately **after** the conditional-bonus block (the `condi
                         break;
                     case 'enemy-type':
                         chargeGainCount =
-                            enemyType !== undefined &&
-                            enemyType === selfChargeGain.requiredEnemyType
-                                ? 1
-                                : 0;
+                            enemyType === selfChargeGain.requiredEnemyType ? 1 : 0;
                         break;
                     default:
                         // enemy-buff, enemy-adjacent, adjacent-ally, enemy-destroyed

--- a/docs/superpowers/specs/2026-05-31-charge-manipulation-design.md
+++ b/docs/superpowers/specs/2026-05-31-charge-manipulation-design.md
@@ -45,16 +45,26 @@ These bound which triggers are modelable and how:
 | Trigger phrasing | Ships | Model |
 |---|---|---|
 | enemies faster / lowest speed / at full HP | Chakara, Cobalt | `always` → count 1 |
-| after critically damaging | Asphodel, Hermes | `self-crit` → count = effectiveCrit/100 |
+| after critically damaging (own crit) | Asphodel | `self-crit` → count = effectiveCrit/100 |
 | target has N buffs / per buff on target | Nuqtu, Rhodium | `enemy-buff` (manual count) |
 | after inflicting a debuff | Hemlock | `enemy-debuff` (derivable) |
 | hits 2+ enemies | Tygr | `enemy-adjacent` (manual count) |
 | target is a Defender | Thresh | `enemy-type` (new global input) |
 | target is Stealthed | Selenite | `enemy-buff` "Stealth" present (manual count) |
 | on kill / when enemy repairs | Valiant, Obsidian, Zosimos | **excluded** (never fire) |
-| ally crits / enemy dies → allies gain | Hermes, Liberator, Castor | **external** → `allyChargePerRound` (manual) |
+| **ally** crits / enemy dies → allies gain | Hermes (gains on *ally* crit), Liberator | **external** → `allyChargePerRound` (manual) |
 | removes N charges from enemy | Demolisher, Thresh, Zosimos | **out of scope** (no enemy charged skill in single-ship sim) |
 | starts combat fully Charged | Sansi, Valkyrie, … | already handled via `startCharged` |
+
+Notes:
+- **Thresh has two charge clauses in one skill**: "removes 1 charge from the enemy
+  **and** adds 1 charge to this Unit's Charged Skill". `parseChargeGain` must
+  extract the *self-add* ("adds 1 charge to this Unit's Charged Skill" + the
+  "If the target is a Defender" condition → `enemy-type`) and ignore the
+  enemy-removal clause in the same sentence.
+- Castor (cited earlier as an ally-charge supporter) is **not** in
+  `docs/ship-skills.csv`, so it is not a parser fixture — ally charges are
+  manual (`allyChargePerRound`) regardless.
 
 ## Data model (`src/types/calculator.ts`)
 
@@ -66,6 +76,7 @@ interface ChargeGain {
   condition: ConditionalCondition; // reused enum + 3 new variants
   derivable: boolean;              // true → read sim state; false → use manualCount
   manualCount?: number;            // used when !derivable (default 1)
+  requiredEnemyType?: EnemyBaseClass; // only for condition 'enemy-type' (Thresh → 'Defender')
 }
 ```
 
@@ -74,52 +85,88 @@ conditionals):
 
 - `'always'` — unconditional, or a condition that is always-true under the sim
   assumptions (Chakara speed, Cobalt full-HP). Count = 1.
-- `'self-crit'` — derivable. Count = effectiveCrit / 100 (Asphodel, Hermes).
-- `'enemy-type'` — derivable from the new global enemy-type input (Thresh
+- `'self-crit'` — derivable. Count = effectiveCrit / 100 (Asphodel only). Note
+  Hermes is *not* self-crit — it gains on **ally** crits → external/manual.
+- `'enemy-type'` — derivable from the new **global** enemy-type input (Thresh
   "if Defender"). Count = 1 when the enemy type matches, else 0.
 
 Existing reused conditions: `self-buff`, `enemy-debuff` (derivable, linear);
 `enemy-buff`, `enemy-adjacent` (manual count). Add labels for the new variants to
 `CONDITIONAL_CONDITION_LABELS`.
 
-Add to `DPSShipConfig`:
+Define a small enemy-class enum (deliberately **not** `ShipTypeName` from
+`src/constants/shipTypes.ts`, whose role list has variants like
+`Defender(Security)`):
+
+```ts
+type EnemyBaseClass = 'Attacker' | 'Defender' | 'Debuffer' | 'Supporter';
+```
+
+Add to **`DPSShipConfig`** (per-attacker, auto-filled / user-tuned):
 
 - `selfChargeGain?: ChargeGain`
 - `allyChargePerRound?: number`
-- `enemyType?: EnemyBaseClass` — `'Attacker' | 'Defender' | 'Debuffer' | 'Supporter'`
-  (a small enum, not the full role list)
+
+Enemy type is a property of the **enemy, not each attacker**, so it is **global
+page state** (alongside `enemyDefense` / `enemyHp` / `enemySecurity` /
+`enemyAffinity` in `DPSCalculatorPage`), **not** on `DPSShipConfig`. The required
+type for the `enemy-type` condition is stored on the parsed `ChargeGain` (e.g. a
+`requiredEnemyType?: EnemyBaseClass` field, or implied as "Defender" for the only
+known case) and compared against the global value in the sim.
 
 Extend the `autoFilledFields` Set union with `'selfChargeGain'`.
 
-Add to `DPSSimulationInput`: `selfChargeGain?`, `allyChargePerRound?`,
-`enemyType?` (same types as above).
+Add to `DPSSimulationInput`: `selfChargeGain?: ChargeGain`,
+`allyChargePerRound?: number`, `enemyType?: EnemyBaseClass`.
 
 ## Simulator (`src/utils/calculators/dpsSimulator.ts`)
 
 Thread `selfChargeGain`, `allyChargePerRound`, and `enemyType` through
 `runSinglePass` params/destructure and the `simulateDPS` call site.
 
-In the round loop, after the action/charge-reset block, compute the bonus
-charges and add them **every round**:
+**Placement (important):** the bonus-charge block must go **after** the existing
+conditional-bonus evaluation (currently ~dpsSimulator.ts:332-352), *not* after
+the action/charge-reset block at ~244-256. It depends on values that only exist
+later in the round: `effectiveCrit` (computed ~line 294, needed for `self-crit`)
+and `landedEnemyDebuffs` + DoT arrays (computed ~line 341, needed for the
+`enemy-debuff` derivable count). Adding it at the reset block would reference
+undefined locals. The block reuses the same counting expressions as
+`conditionalBonusPct` (self-buff count, enemy-debuff count).
+
+The bonus is computed every round, then applied to `charges`. Because the
+threshold check happens at the **top** of the round (line 244) reading the value
+carried from the previous round, adding the bonus at the bottom of the round body
+means it counts toward the *next* round's check — matching the existing `+1`
+active-round semantics:
 
 ```ts
-// Count derived exactly like conditionalBonusPct.
+// Count derived exactly like conditionalBonusPct above.
 let chargeGainCount = 0;
 if (selfChargeGain) {
   switch (selfChargeGain.condition) {
     case 'always':       chargeGainCount = 1; break;
     case 'self-crit':    chargeGainCount = effectiveCrit / 100; break;
-    case 'self-buff':    chargeGainCount = /* count self buffs */; break;
-    case 'enemy-debuff': chargeGainCount = /* count enemy debuffs */; break;
-    case 'enemy-type':   chargeGainCount = enemyType === requiredType ? 1 : 0; break;
+    case 'self-buff':    chargeGainCount = entry.activeSelfBuffs.filter(
+                           (ab) => ab.stacks === undefined || ab.stacks > 0).length; break;
+    case 'enemy-debuff': chargeGainCount = landedEnemyDebuffs.length +
+                           corrosionEntries.length + infernoEntries.length +
+                           pendingBombs.length; break;
+    case 'enemy-type':   chargeGainCount =
+                           enemyType === selfChargeGain.requiredEnemyType ? 1 : 0; break;
     default:             chargeGainCount = selfChargeGain.manualCount ?? 1; // enemy-buff, enemy-adjacent
   }
 }
-const bonusCharges = selfChargeGain
-  ? chargeGainCount * selfChargeGain.amount
-  : 0;
-charges += bonusCharges + (allyChargePerRound ?? 0);
+const bonusCharges = selfChargeGain ? chargeGainCount * selfChargeGain.amount : 0;
+if (hasChargedSkill) {
+  charges += bonusCharges + (allyChargePerRound ?? 0);
+}
 ```
+
+Note the existing `+1` is added inside the active branch at the top (line 254)
+and the charged round resets to 0 (line 248). So net accumulation toward the next
+fire is: active round = `1 + bonus + ally`; charged round = `bonus + ally` (the
+reset happens before this block runs, so post-fire rounds still bank bonus/ally
+charges — consistent with the "every round" decision).
 
 Charges accumulate **fractionally** for a precise average cadence (e.g. a
 self-crit gain at 70% crit contributes 0.7/round). `roundData.charges` is
@@ -130,22 +177,43 @@ the existing direct/charged damage.
 `hasChargedSkill` gating is unchanged: bonus charges only matter when a charged
 skill exists (`chargedMultiplier > 0 && chargeCount >= 1`).
 
-Ordering note: derivable `self-crit` reads `effectiveCrit`, which is computed
-mid-round; place the charge-gain block after `effectiveCrit` is available.
-
 ## Parser (`src/utils/skillTextParser.ts`)
 
 New `parseChargeGain(text): ChargeGain | null`, a sibling of
-`parseConditionalDamage`. Matches self-targeted charge gains:
+`parseConditionalDamage`.
 
-- "adds N charge(s) to its Charged Skill" / "gains N charge(s) to its Charged
-  Skill" / "gains a charge" → `amount`.
+**Tag-awareness:** in `docs/ship-skills.csv` every charge amount is wrapped in a
+tag — `<unit-aid>adds 1 charge</unit-aid>`, `<unit-aid>gains 2 charges</unit-aid>`,
+`<unit-aid>add 1 charge</unit-aid>` — while the condition clause is plain text
+*outside* the tag, before or after it ("If the target is a Defender, …",
+"… if it is at full HP", "after critically damaging an enemy"). Like
+`parseSecondaryDamage`/`parseSkillDamage`, the regex must tolerate the tag
+wrapping: match the amount inside `<unit-aid>…</unit-aid>` (also handle the
+`<unit-skill>` wrapping used by Castor-style ally lines for the negative case),
+and read the condition from the surrounding plain text. Match the number word too
+("gains a charge" → 1).
+
+Match self-targeted charge gains:
+
+- "adds N charge(s) to its/this Unit's Charged Skill" / "gains N charge(s) to its
+  Charged Skill" / "gains a charge" → `amount`.
 - "adds charges ... equal to the number of buffs on the target" (Rhodium) →
   `amount: 1`, condition `enemy-buff`, derivable false (manual count).
-- Classify the surrounding condition clause into a `ConditionalCondition`
-  (speed/full-HP → `always`; crit → `self-crit`; Defender → `enemy-type`;
-  buffs on target → `enemy-buff`; debuff inflict → `enemy-debuff`; 2+ enemies →
-  `enemy-adjacent`). Default to `always` when no recognizable condition.
+
+**New condition classifier (do not reuse `mapConditionPhrase`):** the existing
+`mapConditionPhrase` (skillTextParser.ts ~180-195) only recognizes the
+conditional-damage "for each …" grammar (buff/debuff on unit/enemy, adjacent
+ally, destroyed enemy) — *none* of the charge triggers use that phrasing. Write a
+dedicated classifier mapping the charge-trigger clauses:
+
+- speed ("more Speed than this Unit", "lowest Speed") / full-HP ("at full HP") → `always`
+- "critically damaging" / "critically hits" (self) → `self-crit`
+- "is a Defender" → `enemy-type` (set `requiredEnemyType: 'Defender'`)
+- "buffs on the target" / "3 or more buffs" → `enemy-buff`
+- "Stealthed" / "has Stealth" → `enemy-buff` (Stealth)
+- "inflicts a debuff" / "after it inflicts a debuff" → `enemy-debuff`
+- "damages 2 or more enemies" → `enemy-adjacent`
+- default → `always` (unconditional self-add)
 
 Returns `null` for:
 
@@ -153,18 +221,30 @@ Returns `null` for:
 - ally-grant-to-others ("all allies add 1 charge", "charged skill of all allies")
 - on-kill / enemy-repair triggers (never fire under sim assumptions)
 
+**Clause precedence:** check the negative/ignore patterns (enemy-removal,
+ally-grant, on-kill, enemy-repair) *before* extracting a self-add, because a
+single skill can contain both (Thresh: "removes 1 charge from the enemy and adds
+1 charge to this Unit's Charged Skill"). Strip/ignore the enemy-removal clause,
+then extract the self-add ("adds 1 charge to this Unit's Charged Skill" +
+"If the target is a Defender" → `enemy-type`). Conversely, a line whose only
+charge phrase is ally-grant/removal returns `null`.
+
 Reference data: `docs/ship-skills.csv`.
 
 ## Page wiring (`src/pages/calculators/DPSCalculatorPage.tsx`)
 
 - Parse `selfChargeGain` in `buildSkillAutoFill` (scan active + passive skill
   texts, like other auto-fills).
-- Seed `selfChargeGain` and defaults for `allyChargePerRound` / `enemyType` in
-  **both** `getInitialConfig` and `selectShipForConfig`.
-- Pass `selfChargeGain`, `allyChargePerRound`, `enemyType` into the
-  `simulateDPS({...})` call.
+- Seed `selfChargeGain` and a default `allyChargePerRound` in **both**
+  `getInitialConfig` and `selectShipForConfig` (per-attacker config).
+- Add `enemyType` as **global page state** (`useState`), alongside the existing
+  `enemyDefense` / `enemyHp` / `enemySecurity` / `enemyAffinity` — *not* on
+  `DPSShipConfig`.
+- Pass per-attacker `selfChargeGain` + `allyChargePerRound` and the global
+  `enemyType` into each `simulateDPS({...})` call.
 - Add an `updateConfigChargeGain` updater mirroring `updateConfigConditional`,
-  plus simple updaters for the flat `allyChargePerRound` and `enemyType`.
+  plus a simple updater for the flat `allyChargePerRound`; `enemyType` uses its
+  own page-level setter.
 - Wire the new props into `<ShipConfigCard>`.
 
 ## UI
@@ -203,8 +283,13 @@ pattern, `card`) per project conventions.
   (enemy-removal → null), Valiant (on-kill → null), Liberator (ally-grant → null).
 - **Simulator** (`src/utils/calculators/__tests__/dpsSimulator.test.ts`):
   cadence-shift assertions using the test convention (`crit:100, critDamage:0` →
-  critMultiplier 1, `enemyDefense:0`). E.g. `chargeCount:3` + `allyChargePerRound:1`
-  → charged fires ~every 2 rounds; `selfChargeGain` with `always` → faster
-  cadence than baseline; `self-crit` at 100% crit → +1/round.
+  critMultiplier 1, `enemyDefense:0`). **Derive expected fire-rounds by hand from
+  the exact accumulation** (active round banks `1 + bonus + ally`; charged round
+  resets to 0 then banks `bonus + ally`; threshold checked at round start), then
+  assert the specific rounds where `action === 'charged'` — do not assert a vague
+  "~every 2 rounds". Cases: baseline (no manipulation) unchanged vs. current
+  behavior; `allyChargePerRound:1` at `chargeCount:3` fires sooner; `selfChargeGain`
+  `always` faster than baseline; `self-crit` at 100% crit contributes +1/round;
+  `enemy-type` gives the bonus only when `enemyType` matches `requiredEnemyType`.
 - **Docs + changelog**: `DocumentationPage.tsx` (DPS section + "About the
   Simulation" prose) and `UNRELEASED_CHANGES` in `src/constants/changelog.ts`.

--- a/docs/superpowers/specs/2026-05-31-charge-manipulation-design.md
+++ b/docs/superpowers/specs/2026-05-31-charge-manipulation-design.md
@@ -191,7 +191,10 @@ tag — `<unit-aid>adds 1 charge</unit-aid>`, `<unit-aid>gains 2 charges</unit-a
 wrapping: match the amount inside `<unit-aid>…</unit-aid>` (also handle the
 `<unit-skill>` wrapping used by Castor-style ally lines for the negative case),
 and read the condition from the surrounding plain text. Match the number word too
-("gains a charge" → 1).
+("gains a charge" → amount 1). (Note: the only CSV instance of "gains a charge"
+is Zosimos, whose enemy-repair condition makes it an excluded → null case via the
+clause precedence below; the number-word handling is illustrative for
+amount extraction.)
 
 Match self-targeted charge gains:
 

--- a/docs/superpowers/specs/2026-05-31-charge-manipulation-design.md
+++ b/docs/superpowers/specs/2026-05-31-charge-manipulation-design.md
@@ -1,0 +1,210 @@
+# Charge Manipulation — DPS Calculator Design
+
+**Date:** 2026-05-31
+**Status:** Approved
+
+## Overview
+
+Skill text frequently changes *when* a ship's Charged Skill fires by adding or
+removing charges ("adds 1 charge to its Charged Skill", "gains 2 charges",
+"when an enemy dies, all allies add 1 charge"). The DPS calculator already
+tracks charges in `runSinglePass` — each active round adds +1 charge, and when
+`charges >= chargeCount` the charged skill fires and charges reset to 0.
+
+This feature feeds two additional charge sources into that accumulator so the
+charged skill fires on a realistic cadence:
+
+1. **Self charge gain** — auto-filled from the attacker's own skill text,
+   evaluated per-round against sim state using the existing conditional-condition
+   machinery.
+2. **Ally charge per round** — a flat, manually-entered number representing
+   supporters (Castor / Liberator / Hermes) that feed charges to the attacker.
+   These live on *other* ships, so they cannot be parsed from the attacker's own
+   skill text.
+
+Both sources accumulate **every round** (active and charged). When the charged
+skill fires, charges **reset to 0** — matching the simulator's current overflow
+behavior. This only shifts cadence; it introduces no new damage slice.
+
+## Sim assumptions (provided by user)
+
+These bound which triggers are modelable and how:
+
+- Enemy never dies → on-kill triggers never fire → **excluded**.
+- Enemy never attacks → attacker always full HP → "if full HP" → **always true**.
+- Speed conditionals → **always true**.
+- Enemy never repairs → "when enemy repairs" triggers → **excluded**.
+- All allies adjacent.
+- Enemy not Stealthed unless that buff is explicitly added.
+- On-crit / N-buffs / N-debuffs / debuff-infliction conditions are already
+  modeled by the existing sim and condition framework.
+- Enemy ship type is added as a new UI input and modeled.
+
+## CSV trigger → model mapping
+
+| Trigger phrasing | Ships | Model |
+|---|---|---|
+| enemies faster / lowest speed / at full HP | Chakara, Cobalt | `always` → count 1 |
+| after critically damaging | Asphodel, Hermes | `self-crit` → count = effectiveCrit/100 |
+| target has N buffs / per buff on target | Nuqtu, Rhodium | `enemy-buff` (manual count) |
+| after inflicting a debuff | Hemlock | `enemy-debuff` (derivable) |
+| hits 2+ enemies | Tygr | `enemy-adjacent` (manual count) |
+| target is a Defender | Thresh | `enemy-type` (new global input) |
+| target is Stealthed | Selenite | `enemy-buff` "Stealth" present (manual count) |
+| on kill / when enemy repairs | Valiant, Obsidian, Zosimos | **excluded** (never fire) |
+| ally crits / enemy dies → allies gain | Hermes, Liberator, Castor | **external** → `allyChargePerRound` (manual) |
+| removes N charges from enemy | Demolisher, Thresh, Zosimos | **out of scope** (no enemy charged skill in single-ship sim) |
+| starts combat fully Charged | Sansi, Valkyrie, … | already handled via `startCharged` |
+
+## Data model (`src/types/calculator.ts`)
+
+New `ChargeGain`, mirroring `ConditionalDamage`:
+
+```ts
+interface ChargeGain {
+  amount: number;                  // charges per trigger (e.g. 1, 2)
+  condition: ConditionalCondition; // reused enum + 3 new variants
+  derivable: boolean;              // true → read sim state; false → use manualCount
+  manualCount?: number;            // used when !derivable (default 1)
+}
+```
+
+Extend `ConditionalCondition` with three variants (also future-proofs damage
+conditionals):
+
+- `'always'` — unconditional, or a condition that is always-true under the sim
+  assumptions (Chakara speed, Cobalt full-HP). Count = 1.
+- `'self-crit'` — derivable. Count = effectiveCrit / 100 (Asphodel, Hermes).
+- `'enemy-type'` — derivable from the new global enemy-type input (Thresh
+  "if Defender"). Count = 1 when the enemy type matches, else 0.
+
+Existing reused conditions: `self-buff`, `enemy-debuff` (derivable, linear);
+`enemy-buff`, `enemy-adjacent` (manual count). Add labels for the new variants to
+`CONDITIONAL_CONDITION_LABELS`.
+
+Add to `DPSShipConfig`:
+
+- `selfChargeGain?: ChargeGain`
+- `allyChargePerRound?: number`
+- `enemyType?: EnemyBaseClass` — `'Attacker' | 'Defender' | 'Debuffer' | 'Supporter'`
+  (a small enum, not the full role list)
+
+Extend the `autoFilledFields` Set union with `'selfChargeGain'`.
+
+Add to `DPSSimulationInput`: `selfChargeGain?`, `allyChargePerRound?`,
+`enemyType?` (same types as above).
+
+## Simulator (`src/utils/calculators/dpsSimulator.ts`)
+
+Thread `selfChargeGain`, `allyChargePerRound`, and `enemyType` through
+`runSinglePass` params/destructure and the `simulateDPS` call site.
+
+In the round loop, after the action/charge-reset block, compute the bonus
+charges and add them **every round**:
+
+```ts
+// Count derived exactly like conditionalBonusPct.
+let chargeGainCount = 0;
+if (selfChargeGain) {
+  switch (selfChargeGain.condition) {
+    case 'always':       chargeGainCount = 1; break;
+    case 'self-crit':    chargeGainCount = effectiveCrit / 100; break;
+    case 'self-buff':    chargeGainCount = /* count self buffs */; break;
+    case 'enemy-debuff': chargeGainCount = /* count enemy debuffs */; break;
+    case 'enemy-type':   chargeGainCount = enemyType === requiredType ? 1 : 0; break;
+    default:             chargeGainCount = selfChargeGain.manualCount ?? 1; // enemy-buff, enemy-adjacent
+  }
+}
+const bonusCharges = selfChargeGain
+  ? chargeGainCount * selfChargeGain.amount
+  : 0;
+charges += bonusCharges + (allyChargePerRound ?? 0);
+```
+
+Charges accumulate **fractionally** for a precise average cadence (e.g. a
+self-crit gain at 70% crit contributes 0.7/round). `roundData.charges` is
+rounded only for display. The `charges >= chargeCount` threshold check is
+unchanged. No new total/summary slice — cadence change naturally redistributes
+the existing direct/charged damage.
+
+`hasChargedSkill` gating is unchanged: bonus charges only matter when a charged
+skill exists (`chargedMultiplier > 0 && chargeCount >= 1`).
+
+Ordering note: derivable `self-crit` reads `effectiveCrit`, which is computed
+mid-round; place the charge-gain block after `effectiveCrit` is available.
+
+## Parser (`src/utils/skillTextParser.ts`)
+
+New `parseChargeGain(text): ChargeGain | null`, a sibling of
+`parseConditionalDamage`. Matches self-targeted charge gains:
+
+- "adds N charge(s) to its Charged Skill" / "gains N charge(s) to its Charged
+  Skill" / "gains a charge" → `amount`.
+- "adds charges ... equal to the number of buffs on the target" (Rhodium) →
+  `amount: 1`, condition `enemy-buff`, derivable false (manual count).
+- Classify the surrounding condition clause into a `ConditionalCondition`
+  (speed/full-HP → `always`; crit → `self-crit`; Defender → `enemy-type`;
+  buffs on target → `enemy-buff`; debuff inflict → `enemy-debuff`; 2+ enemies →
+  `enemy-adjacent`). Default to `always` when no recognizable condition.
+
+Returns `null` for:
+
+- enemy-removal phrasings ("removes N charges from the enemy")
+- ally-grant-to-others ("all allies add 1 charge", "charged skill of all allies")
+- on-kill / enemy-repair triggers (never fire under sim assumptions)
+
+Reference data: `docs/ship-skills.csv`.
+
+## Page wiring (`src/pages/calculators/DPSCalculatorPage.tsx`)
+
+- Parse `selfChargeGain` in `buildSkillAutoFill` (scan active + passive skill
+  texts, like other auto-fills).
+- Seed `selfChargeGain` and defaults for `allyChargePerRound` / `enemyType` in
+  **both** `getInitialConfig` and `selectShipForConfig`.
+- Pass `selfChargeGain`, `allyChargePerRound`, `enemyType` into the
+  `simulateDPS({...})` call.
+- Add an `updateConfigChargeGain` updater mirroring `updateConfigConditional`,
+  plus simple updaters for the flat `allyChargePerRound` and `enemyType`.
+- Wire the new props into `<ShipConfigCard>`.
+
+## UI
+
+- **`ShipConfigCard.tsx`** — new collapsible "Charge Manipulation" section,
+  mirroring the "Conditional Damage" section: self-gain amount + condition
+  select + manual count (shown only for non-derivable conditions) + an
+  "Ally charges / round" numeric field. Re-sync the collapsible open-state with a
+  `useEffect` keyed on the parsed `selfChargeGain` / `allyChargePerRound` values.
+- **`ShipConfigSummary.tsx`** — a breakdown line showing the effective cadence
+  (average rounds between charged skills) and the active charge sources.
+- **Enemy-type selector** — a `Select` (None / Attacker / Defender / Debuffer /
+  Supporter) placed near the enemy stat inputs, feeding the `enemy-type`
+  condition.
+
+All UI uses existing primitives (`Select`, `Input`, `CollapsibleForm`/section
+pattern, `card`) per project conventions.
+
+## Out of scope (flagged)
+
+- Enemy charge removal and ally-grant-to-others as *modeled* effects — there is
+  no enemy/ally charged skill in a single-ship sim. Parsed-skipped.
+- On-kill / enemy-repair triggers — excluded (enemy never dies/repairs).
+- Threshold conditions like Nuqtu "if target has 3+ buffs" auto-fill as
+  `enemy-buff` with a manual count; the user tunes the exact count. The parser
+  does not encode the threshold arithmetic.
+- Per-supporter rows for ally charges — a single flat number covers the common
+  case (YAGNI).
+
+## Testing
+
+- **Parser** (`src/utils/__tests__/skillTextParser.test.ts`): positive cases
+  Chakara (`always`), Nuqtu/Rhodium (`enemy-buff`), Thresh (`enemy-type`),
+  Selenite (`enemy-buff` Stealth), Tygr (`enemy-adjacent`), Hemlock
+  (`enemy-debuff`), Asphodel (`self-crit`); negative cases Demolisher
+  (enemy-removal → null), Valiant (on-kill → null), Liberator (ally-grant → null).
+- **Simulator** (`src/utils/calculators/__tests__/dpsSimulator.test.ts`):
+  cadence-shift assertions using the test convention (`crit:100, critDamage:0` →
+  critMultiplier 1, `enemyDefense:0`). E.g. `chargeCount:3` + `allyChargePerRound:1`
+  → charged fires ~every 2 rounds; `selfChargeGain` with `always` → faster
+  cadence than baseline; `self-crit` at 100% crit → +1/round.
+- **Docs + changelog**: `DocumentationPage.tsx` (DPS section + "About the
+  Simulation" prose) and `UNRELEASED_CHANGES` in `src/constants/changelog.ts`.

--- a/src/components/calculator/CombatSettingsPanel.tsx
+++ b/src/components/calculator/CombatSettingsPanel.tsx
@@ -4,7 +4,7 @@ import { ChevronDownIcon } from '../ui/icons/ChevronIcons';
 import { Button } from '../ui/Button';
 import { Input } from '../ui/Input';
 import { Select } from '../ui/Select';
-import { SelectedGameBuff, TeamShipConfig } from '../../types/calculator';
+import { SelectedGameBuff, TeamShipConfig, EnemyBaseClass } from '../../types/calculator';
 import { AffinityName, Ship } from '../../types/ship';
 import { GameBuffPicker } from './GameBuffPicker';
 import { TeamShipRow } from './TeamShipRow';
@@ -33,6 +33,8 @@ interface CombatSettingsPanelProps {
     onTeamShipStartChargedChange: (id: string, checked: boolean) => void;
     onTeamShipBuffsChange: (id: string, buffs: SelectedGameBuff[]) => void;
     onTeamShipEnemyDebuffsChange: (id: string, debuffs: SelectedGameBuff[]) => void;
+    enemyType?: EnemyBaseClass;
+    onEnemyTypeChange: (v: EnemyBaseClass | undefined) => void;
 }
 
 export const CombatSettingsPanel: React.FC<CombatSettingsPanelProps> = ({
@@ -59,6 +61,8 @@ export const CombatSettingsPanel: React.FC<CombatSettingsPanelProps> = ({
     onTeamShipStartChargedChange,
     onTeamShipBuffsChange,
     onTeamShipEnemyDebuffsChange,
+    enemyType,
+    onEnemyTypeChange,
 }) => (
     <div className="card space-y-2">
         <Button
@@ -75,7 +79,7 @@ export const CombatSettingsPanel: React.FC<CombatSettingsPanelProps> = ({
         </Button>
         <CollapsibleForm isVisible={isOpen}>
             <div className="space-y-4 pt-2">
-                <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4">
+                <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-6 gap-4">
                     <Input
                         label="Enemy Defense"
                         type="number"
@@ -115,6 +119,20 @@ export const CombatSettingsPanel: React.FC<CombatSettingsPanelProps> = ({
                             { value: 'chemical', label: 'Chemical' },
                             { value: 'electric', label: 'Electric' },
                         ]}
+                    />
+                    <Select
+                        label="Enemy Type"
+                        value={enemyType ?? ''}
+                        options={[
+                            { value: '', label: 'Any / Unknown' },
+                            { value: 'Attacker', label: 'Attacker' },
+                            { value: 'Defender', label: 'Defender' },
+                            { value: 'Debuffer', label: 'Debuffer' },
+                            { value: 'Supporter', label: 'Supporter' },
+                        ]}
+                        onChange={(v) =>
+                            onEnemyTypeChange(v === '' ? undefined : (v as EnemyBaseClass))
+                        }
                     />
                 </div>
                 <p className="text-sm text-theme-text-secondary">

--- a/src/components/calculator/ShipConfigCard.tsx
+++ b/src/components/calculator/ShipConfigCard.tsx
@@ -10,6 +10,7 @@ import {
     SelectedGameBuff,
     SecondaryDamage,
     ConditionalDamage,
+    ChargeGain,
     CONDITIONAL_CONDITION_LABELS,
 } from '../../types/calculator';
 import { DPSSimulationResult } from '../../utils/calculators/dpsSimulator';
@@ -56,6 +57,8 @@ interface ShipConfigCardProps {
         field: 'activeConditional' | 'chargedConditional',
         value: ConditionalDamage | undefined
     ) => void;
+    onChargeGainChange: (value: ChargeGain | undefined) => void;
+    onAllyChargeChange: (value: number) => void;
     enemyAffinity: AffinityName;
     enemySecurity: number;
 }
@@ -80,6 +83,8 @@ export const ShipConfigCard: React.FC<ShipConfigCardProps> = ({
     onEnemyDebuffsChange,
     onSecondaryChange,
     onConditionalChange,
+    onChargeGainChange,
+    onAllyChargeChange,
     enemyAffinity,
     enemySecurity,
 }) => {
@@ -91,17 +96,23 @@ export const ShipConfigCard: React.FC<ShipConfigCardProps> = ({
     const [openConditional, setOpenConditional] = useState(
         Boolean(config.activeConditional || config.chargedConditional)
     );
+    const [openCharge, setOpenCharge] = useState(
+        Boolean(config.selfChargeGain || config.allyChargePerRound)
+    );
     // Re-sync the collapsible sections when parsed values change (e.g. after
     // selectShipForConfig auto-fills a newly selected ship) so freshly detected
     // secondary/conditional data is revealed rather than hidden in a closed section.
     useEffect(() => {
         setOpenSecondary(Boolean(config.activeSecondary || config.chargedSecondary));
         setOpenConditional(Boolean(config.activeConditional || config.chargedConditional));
+        setOpenCharge(Boolean(config.selfChargeGain || config.allyChargePerRound));
     }, [
         config.activeSecondary,
         config.chargedSecondary,
         config.activeConditional,
         config.chargedConditional,
+        config.selfChargeGain,
+        config.allyChargePerRound,
     ]);
     const { getShipById } = useShips();
     const selectedShip = config.shipId ? getShipById(config.shipId) : undefined;
@@ -445,6 +456,69 @@ export const ShipConfigCard: React.FC<ShipConfigCardProps> = ({
                                 </div>
                             );
                         })}
+                    </CollapsibleForm>
+
+                    <Button
+                        variant="link"
+                        onClick={() => setOpenCharge((v) => !v)}
+                        className="w-full flex justify-between items-center mt-4"
+                    >
+                        <span className="flex items-center gap-2">
+                            <ChevronDownIcon
+                                className={`text-sm text-theme-text-secondary h-8 w-8 p-2 transition-transform duration-300 ${openCharge ? 'rotate-180' : ''}`}
+                            />
+                            Charge Manipulation
+                        </span>
+                    </Button>
+                    <CollapsibleForm isVisible={openCharge}>
+                        {config.selfChargeGain ? (
+                            <div className="mb-4">
+                                <div className="text-sm font-semibold mb-1">
+                                    Self: +{config.selfChargeGain.amount} charge
+                                    {config.selfChargeGain.amount !== 1 ? 's' : ''}/round{' '}
+                                    {CONDITIONAL_CONDITION_LABELS[config.selfChargeGain.condition]}
+                                </div>
+                                {config.selfChargeGain.derivable ? (
+                                    <p className="text-xs text-theme-text-secondary">
+                                        Auto-counted each round from sim state.
+                                    </p>
+                                ) : (
+                                    <Input
+                                        label="Trigger count / round"
+                                        type="number"
+                                        min="0"
+                                        value={config.selfChargeGain.manualCount ?? 1}
+                                        helpLabel={
+                                            config.autoFilledFields?.has('selfChargeGain')
+                                                ? 'auto-filled'
+                                                : undefined
+                                        }
+                                        onChange={(e) => {
+                                            const gain = config.selfChargeGain;
+                                            if (gain) {
+                                                onChargeGainChange({
+                                                    ...gain,
+                                                    manualCount: parseInt(e.target.value) || 0,
+                                                });
+                                            }
+                                        }}
+                                    />
+                                )}
+                            </div>
+                        ) : (
+                            <p className="text-xs text-theme-text-secondary mb-2">
+                                No self charge gain detected.
+                            </p>
+                        )}
+                        <Input
+                            label="Ally charges / round"
+                            type="number"
+                            min="0"
+                            step="0.5"
+                            value={config.allyChargePerRound ?? 0}
+                            helpLabel="from supporters (e.g. Castor, Liberator)"
+                            onChange={(e) => onAllyChargeChange(parseFloat(e.target.value) || 0)}
+                        />
                     </CollapsibleForm>
 
                     {selectedShip && (

--- a/src/components/calculator/ShipConfigCard.tsx
+++ b/src/components/calculator/ShipConfigCard.tsx
@@ -473,11 +473,19 @@ export const ShipConfigCard: React.FC<ShipConfigCardProps> = ({
                     <CollapsibleForm isVisible={openCharge}>
                         {config.selfChargeGain ? (
                             <div className="mb-4">
-                                <div className="text-sm font-semibold mb-1">
-                                    Self: +{config.selfChargeGain.amount} charge
-                                    {config.selfChargeGain.amount !== 1 ? 's' : ''}/round{' '}
-                                    {CONDITIONAL_CONDITION_LABELS[config.selfChargeGain.condition]}
-                                </div>
+                                {(() => {
+                                    const cg = config.selfChargeGain;
+                                    const conditionLabel =
+                                        cg.condition === 'enemy-type' && cg.requiredEnemyType
+                                            ? `when enemy is a ${cg.requiredEnemyType}`
+                                            : CONDITIONAL_CONDITION_LABELS[cg.condition];
+                                    return (
+                                        <div className="text-sm font-semibold mb-1">
+                                            Self: +{cg.amount} charge
+                                            {cg.amount !== 1 ? 's' : ''}/round {conditionLabel}
+                                        </div>
+                                    );
+                                })()}
                                 {config.selfChargeGain.derivable ? (
                                     <p className="text-xs text-theme-text-secondary">
                                         Auto-counted each round from sim state.

--- a/src/components/calculator/ShipConfigSummary.tsx
+++ b/src/components/calculator/ShipConfigSummary.tsx
@@ -64,6 +64,21 @@ export const ShipConfigSummary: React.FC<ShipConfigSummaryProps> = ({
                     {simResult.summary.totalDamage.toLocaleString()}
                 </span>
             </div>
+            {config.chargedMultiplier > 0 && config.chargeCount > 0 && (
+                <div className="flex justify-between mb-2">
+                    <span className="text-theme-text-secondary">Charged skill fires:</span>
+                    <span>
+                        {(() => {
+                            const fires = simResult.rounds.filter(
+                                (r) => r.action === 'charged'
+                            ).length;
+                            return fires > 0
+                                ? `every ${(simResult.rounds.length / fires).toFixed(1)} rounds`
+                                : '—';
+                        })()}
+                    </span>
+                </div>
+            )}
             {simResult.summary.totalSecondaryDamage > 0 && (
                 <div className="flex justify-between mb-2">
                     <span className="text-theme-text-secondary">

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -10,6 +10,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Recruitment calculator: faction event weighting now stacks on top of the affinity weighting, and you can choose a 10x or 20x faction multiplier.',
     'DPS Calculator now models secondary damage that scales off Defense or max HP (e.g. Chakara, Lodolite) — auto-detected from skill text, editable, and scaling with Defense Up / HP buffs.',
     "DPS Calculator now models conditional damage bonuses that scale with a count (e.g. +20% per adjacent ally, +15% per debuff on the enemy). Counts derived from your buffs or the enemy's debuffs are tallied automatically each round; other conditions take a manual count. Auto-detected from skill text and editable per skill.",
+    'DPS Calculator now models charge manipulation: ships that add charges to their Charged Skill (and supporter ships that feed charges to allies) make the charged skill fire sooner. Added an enemy-type selector for type-conditional charge gains.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -2167,6 +2167,24 @@ const DocumentationPage: React.FC = () => {
                                         row.
                                     </p>
                                     <p className="text-theme-text mb-2">
+                                        <span className="text-primary">Charge Manipulation:</span>{' '}
+                                        Ships that add charges to their own Charged Skill each round
+                                        (e.g. &quot;+1 charge if you crit&quot;) make the charged
+                                        skill fire sooner. These self-gain conditions are
+                                        auto-detected from skill text and tallied automatically each
+                                        round from sim state (crits, enemy debuffs, active self
+                                        buffs); you can also set a manual trigger count per
+                                        condition. The{' '}
+                                        <span className="text-primary">Ally charges / round</span>{' '}
+                                        field models supporter ships that feed charges to the
+                                        attacker. The{' '}
+                                        <span className="text-primary">Enemy Type</span> selector
+                                        enables type-conditional charge gains (e.g. gains that only
+                                        trigger against a Defender). The simulation summary shows a
+                                        &quot;Charged skill fires: every N rounds&quot; line
+                                        reflecting the effective cadence.
+                                    </p>
+                                    <p className="text-theme-text mb-2">
                                         <span className="text-primary">Start Charged:</span> Some
                                         ships have skills that begin combat already charged. When
                                         detected from your ship&apos;s skill data, this checkbox

--- a/src/pages/calculators/DPSCalculatorPage.tsx
+++ b/src/pages/calculators/DPSCalculatorPage.tsx
@@ -12,12 +12,15 @@ import {
     TeamShipConfig,
     SecondaryDamage,
     ConditionalDamage,
+    ChargeGain,
+    EnemyBaseClass,
 } from '../../types/calculator';
 import {
     parseSkillDamage,
     parseSecondaryDamage,
     parseConditionalDamage,
     detectFullyCharged,
+    parseChargeGain,
 } from '../../utils/skillTextParser';
 import {
     buildSkillBuffAutoFill,
@@ -51,6 +54,16 @@ function buildSkillAutoFill(ship: Ship) {
     };
     const activeConditional = seedManual(parseConditionalDamage(ship.activeSkillText));
     const chargedConditional = seedManual(parseConditionalDamage(ship.chargeSkillText));
+    const seedChargeManual = (c: ChargeGain | null): ChargeGain | undefined => {
+        if (!c) return undefined;
+        return !c.derivable && c.manualCount === undefined ? { ...c, manualCount: 1 } : c;
+    };
+    const selfChargeGain = seedChargeManual(
+        parseChargeGain(ship.activeSkillText) ??
+            parseChargeGain(ship.firstPassiveSkillText) ??
+            parseChargeGain(ship.secondPassiveSkillText) ??
+            parseChargeGain(ship.thirdPassiveSkillText)
+    );
     const autoFilledFields = new Set<
         | 'activeMultiplier'
         | 'chargedMultiplier'
@@ -59,6 +72,7 @@ function buildSkillAutoFill(ship: Ship) {
         | 'chargedSecondary'
         | 'activeConditional'
         | 'chargedConditional'
+        | 'selfChargeGain'
     >();
     if (activeParsed > 0) autoFilledFields.add('activeMultiplier');
     if (chargedParsed > 0) autoFilledFields.add('chargedMultiplier');
@@ -66,6 +80,7 @@ function buildSkillAutoFill(ship: Ship) {
     if (chargedSecondary) autoFilledFields.add('chargedSecondary');
     if (activeConditional) autoFilledFields.add('activeConditional');
     if (chargedConditional) autoFilledFields.add('chargedConditional');
+    if (selfChargeGain) autoFilledFields.add('selfChargeGain');
     return {
         activeParsed,
         chargedParsed,
@@ -73,6 +88,7 @@ function buildSkillAutoFill(ship: Ship) {
         chargedSecondary,
         activeConditional,
         chargedConditional,
+        selfChargeGain,
         autoFilledFields,
     };
 }
@@ -111,6 +127,7 @@ const DPSCalculatorPage: React.FC = () => {
                     chargedSecondary,
                     activeConditional,
                     chargedConditional,
+                    selfChargeGain,
                     autoFilledFields,
                 } = buildSkillAutoFill(ship);
                 autoFilledFields.add('hacking');
@@ -131,6 +148,8 @@ const DPSCalculatorPage: React.FC = () => {
                             chargedSecondary,
                             activeConditional,
                             chargedConditional,
+                            selfChargeGain,
+                            allyChargePerRound: 0,
                             activeMultiplier: activeParsed > 0 ? activeParsed : 100,
                             chargedMultiplier: chargedParsed > 0 ? chargedParsed : 0,
                             chargeCount: ship.chargeSkillCharge ?? 0,
@@ -168,6 +187,7 @@ const DPSCalculatorPage: React.FC = () => {
                     chargedMultiplier: 0,
                     chargeCount: 0,
                     startCharged: false,
+                    allyChargePerRound: 0,
                     activeDoTs: [...DEFAULT_DOT_CONFIG],
                     chargedDoTs: [...DEFAULT_DOT_CONFIG],
                     buffs: [],
@@ -184,6 +204,7 @@ const DPSCalculatorPage: React.FC = () => {
     const [enemyDefense, setEnemyDefense] = useState(10000);
     const [enemyHp, setEnemyHp] = useState(500000);
     const [enemySecurity, setEnemySecurity] = useState(100);
+    const [enemyType, setEnemyType] = useState<EnemyBaseClass | undefined>(undefined);
     const [rounds, setRounds] = useState(20);
     const [viewMode, setViewMode] = useState<'table' | 'heatmap'>('heatmap');
     const [attackerBuffs, setAttackerBuffs] = useState<SelectedGameBuff[]>([]);
@@ -295,6 +316,9 @@ const DPSCalculatorPage: React.FC = () => {
                     affinityDamageModifier: damageModifier,
                     affinityCritCap: critCap,
                     affinityCritPenalty: critPenalty,
+                    selfChargeGain: config.selfChargeGain,
+                    allyChargePerRound: config.allyChargePerRound,
+                    enemyType,
                 })
             );
         });
@@ -304,6 +328,7 @@ const DPSCalculatorPage: React.FC = () => {
         enemyDefense,
         enemyHp,
         enemySecurity,
+        enemyType,
         rounds,
         attackerBuffs,
         enemyBuffs,
@@ -410,6 +435,7 @@ const DPSCalculatorPage: React.FC = () => {
             chargedSecondary,
             activeConditional,
             chargedConditional,
+            selfChargeGain,
             autoFilledFields,
         } = buildSkillAutoFill(ship);
         autoFilledFields.add('hacking');
@@ -436,6 +462,8 @@ const DPSCalculatorPage: React.FC = () => {
                     chargedSecondary,
                     activeConditional,
                     chargedConditional,
+                    selfChargeGain,
+                    allyChargePerRound: c.allyChargePerRound ?? 0,
                     activeMultiplier: activeParsed > 0 ? activeParsed : c.activeMultiplier,
                     chargedMultiplier: chargedParsed > 0 ? chargedParsed : c.chargedMultiplier,
                     chargeCount: ship.chargeSkillCharge ?? c.chargeCount,
@@ -549,6 +577,23 @@ const DPSCalculatorPage: React.FC = () => {
         );
     };
 
+    const updateConfigChargeGain = (id: string, value: ChargeGain | undefined) => {
+        setConfigs((prev) =>
+            prev.map((c) => {
+                if (c.id !== id) return c;
+                const next = new Set(c.autoFilledFields);
+                next.delete('selfChargeGain');
+                return { ...c, selfChargeGain: value, autoFilledFields: next };
+            })
+        );
+    };
+
+    const updateConfigAllyCharge = (id: string, value: number) => {
+        setConfigs((prev) =>
+            prev.map((c) => (c.id === id ? { ...c, allyChargePerRound: value } : c))
+        );
+    };
+
     const updateConfigEnemyDebuffs = (id: string, enemyDebuffs: SelectedGameBuff[]) => {
         setConfigs((prev) => prev.map((c) => (c.id === id ? { ...c, enemyDebuffs } : c)));
     };
@@ -654,6 +699,8 @@ const DPSCalculatorPage: React.FC = () => {
                         onTeamShipEnemyDebuffsChange={(id, debuffs) =>
                             updateTeamShip(id, { enemyDebuffs: debuffs })
                         }
+                        enemyType={enemyType}
+                        onEnemyTypeChange={setEnemyType}
                     />
 
                     <div
@@ -698,6 +745,12 @@ const DPSCalculatorPage: React.FC = () => {
                                 }
                                 onConditionalChange={(field, value) =>
                                     updateConfigConditional(config.id, field, value)
+                                }
+                                onChargeGainChange={(value) =>
+                                    updateConfigChargeGain(config.id, value)
+                                }
+                                onAllyChargeChange={(value) =>
+                                    updateConfigAllyCharge(config.id, value)
                                 }
                             />
                         ))}

--- a/src/types/calculator.ts
+++ b/src/types/calculator.ts
@@ -15,7 +15,10 @@ export type ConditionalCondition =
     | 'enemy-buff' // manual
     | 'adjacent-ally' // manual
     | 'enemy-adjacent' // manual
-    | 'enemy-destroyed'; // manual
+    | 'enemy-destroyed' // manual
+    | 'always' // unconditional / always-true under sim assumptions (charge gains)
+    | 'self-crit' // derivable from crit rate (charge gains)
+    | 'enemy-type'; // derivable from the global enemy-type input (charge gains)
 
 export interface ConditionalDamage {
     pct: number; // per-unit bonus % added to the skill multiplier
@@ -25,6 +28,16 @@ export interface ConditionalDamage {
     cap?: number; // optional total-bonus ceiling ("up to 100%")
 }
 
+export type EnemyBaseClass = 'Attacker' | 'Defender' | 'Debuffer' | 'Supporter';
+
+export interface ChargeGain {
+    amount: number; // charges per trigger (e.g. 1, 2)
+    condition: ConditionalCondition;
+    derivable: boolean; // true → read sim state; false → use manualCount
+    manualCount?: number; // used when !derivable (default 1)
+    requiredEnemyType?: EnemyBaseClass; // only for condition 'enemy-type'
+}
+
 export const CONDITIONAL_CONDITION_LABELS: Record<ConditionalCondition, string> = {
     'self-buff': 'per buff on this unit',
     'enemy-debuff': 'per debuff on the enemy',
@@ -32,6 +45,9 @@ export const CONDITIONAL_CONDITION_LABELS: Record<ConditionalCondition, string> 
     'adjacent-ally': 'per adjacent ally',
     'enemy-adjacent': 'per unit adjacent to the enemy',
     'enemy-destroyed': 'per destroyed enemy',
+    always: 'every round',
+    'self-crit': 'on critical hit',
+    'enemy-type': 'when enemy matches type',
 };
 
 export interface Buff {
@@ -119,6 +135,8 @@ export interface DPSShipConfig {
     chargedConditional?: ConditionalDamage;
     chargeCount: number;
     startCharged: boolean;
+    selfChargeGain?: ChargeGain;
+    allyChargePerRound?: number;
     autoFilledFields?: Set<
         | 'activeMultiplier'
         | 'chargedMultiplier'
@@ -127,6 +145,7 @@ export interface DPSShipConfig {
         | 'chargedSecondary'
         | 'activeConditional'
         | 'chargedConditional'
+        | 'selfChargeGain'
     >;
     activeDoTs: DoTApplicationConfig;
     chargedDoTs: DoTApplicationConfig;

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -7,6 +7,7 @@ import {
     parseAllSkillEffects,
     parseSecondaryDamage,
     parseConditionalDamage,
+    parseChargeGain,
 } from '../skillTextParser';
 import type { Ship } from '../../types/ship';
 
@@ -463,6 +464,125 @@ describe('parseConditionalDamage', () => {
     it('returns null for empty input', () => {
         expect(parseConditionalDamage('')).toBeNull();
         expect(parseConditionalDamage(null)).toBeNull();
+    });
+});
+
+describe('parseChargeGain', () => {
+    it('parses always-true (speed) self gain — Chakara', () => {
+        const text =
+            'This Unit deals <unit-damage>180% damage</unit-damage>. If all damaged enemies have more Speed than this Unit, it <unit-aid>adds 1 charge</unit-aid> to its Charged Skill.';
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'always',
+            derivable: true,
+        });
+    });
+
+    it('parses full-HP self gain as always-true — Cobalt', () => {
+        const text =
+            'This Unit <unit-aid>adds 1 charge</unit-aid> to its charged skill at the start of the turn if it is at full HP.';
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'always',
+            derivable: true,
+        });
+    });
+
+    it('parses enemy-buff threshold gain (manual) — Nuqtu', () => {
+        const text =
+            'If the target has 3 or more buffs, the Unit <unit-aid>gains 2 charges</unit-aid> to its Charged Skill.';
+        expect(parseChargeGain(text)).toEqual({
+            amount: 2,
+            condition: 'enemy-buff',
+            derivable: false,
+        });
+    });
+
+    it('parses "equal to the number of buffs" per-buff gain — Rhodium', () => {
+        const text =
+            'Unit adds charges to the <unit-aid>Charged Skill</unit-aid> equal to the number of <unit-aid>Buffs</unit-aid> on the target.';
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'enemy-buff',
+            derivable: false,
+        });
+    });
+
+    it('parses enemy-type (Defender) gain and ignores the removal clause — Thresh', () => {
+        const text =
+            "If the target is a Defender, this Unit <unit-aid>removes 1 charge</unit-aid> from the enemy and <unit-aid>adds 1 charge</unit-aid> to this Unit's Charged Skill.";
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'enemy-type',
+            derivable: true,
+            requiredEnemyType: 'Defender',
+        });
+    });
+
+    it('parses stealth condition as enemy-buff (manual) — Selenite', () => {
+        const text =
+            "If any target is <unit-aid>Stealthed</unit-aid>, it <unit-aid>adds 1 charge</unit-aid> to this Unit's Charged Skill.";
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'enemy-buff',
+            derivable: false,
+        });
+    });
+
+    it('parses "2 or more enemies" as enemy-adjacent (manual) — Tygr', () => {
+        const text =
+            'If it damages 2 or more enemies, it adds <unit-aid>adds 1 charge</unit-aid> to its Charged Skill.';
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'enemy-adjacent',
+            derivable: false,
+        });
+    });
+
+    it('parses debuff-infliction as enemy-debuff (derivable) — Hemlock', () => {
+        const text =
+            'This Unit <unit-aid>gains 1 charge</unit-aid> to its charged skill after it inflicts a <unit-aid>debuff</unit-aid>.';
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'enemy-debuff',
+            derivable: true,
+        });
+    });
+
+    it('parses crit-based self gain as self-crit (derivable) — Asphodel', () => {
+        const text =
+            "This Unit's attacks are always critical and <unit-aid>adds 1 charge</unit-aid> to its Charged Skill after critically damaging an enemy.";
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'self-crit',
+            derivable: true,
+        });
+    });
+
+    it('returns null for enemy charge removal — Demolisher', () => {
+        const text =
+            "When a bomb explodes on an enemy, this unit removes 2 charges from the enemy's charged skill.";
+        expect(parseChargeGain(text)).toBeNull();
+    });
+
+    it('returns null for on-kill gain — Valiant', () => {
+        const text =
+            'This Unit <unit-aid>gains 1 charge</unit-aid> for its Charged Skill upon killing an enemy.';
+        expect(parseChargeGain(text)).toBeNull();
+    });
+
+    it('returns null for ally-grant — Liberator', () => {
+        const text =
+            'When an enemy dies, all allies <unit-aid>add 1 charge</unit-aid> to their Charged Skills.';
+        expect(parseChargeGain(text)).toBeNull();
+    });
+
+    it('returns null when there is no charge phrase', () => {
+        expect(
+            parseChargeGain('This Unit deals <unit-damage>140% damage</unit-damage>.')
+        ).toBeNull();
+        expect(parseChargeGain('')).toBeNull();
+        expect(parseChargeGain(null)).toBeNull();
     });
 });
 

--- a/src/utils/calculators/__tests__/dpsSimulator.test.ts
+++ b/src/utils/calculators/__tests__/dpsSimulator.test.ts
@@ -907,4 +907,75 @@ describe('simulateDPS', () => {
             expect(result.summary.totalConditionalDamage).toBe(600);
         });
     });
+
+    describe('charge manipulation', () => {
+        // Helper: 1-based round numbers where the charged skill fired.
+        const chargedRounds = (result: ReturnType<typeof simulateDPS>) =>
+            result.rounds.filter((r) => r.action === 'charged').map((r) => r.round);
+
+        const base = {
+            attack: 1000,
+            crit: 100,
+            critDamage: 0,
+            defensePenetration: 0,
+            activeMultiplier: 100,
+            chargedMultiplier: 200,
+            chargeCount: 3,
+            activeDoTs: [],
+            chargedDoTs: [],
+            enemyDefense: 0,
+            enemyHp: 500000,
+            rounds: 12,
+            selfBuffs: [],
+            enemyDebuffs: [],
+        };
+
+        it('baseline: charged fires once charges reach chargeCount (every 4th round for 3 charges)', () => {
+            const result = simulateDPS({ ...base });
+            expect(chargedRounds(result)).toEqual([4, 8, 12]);
+        });
+
+        it('allyChargePerRound speeds up cadence', () => {
+            const result = simulateDPS({ ...base, allyChargePerRound: 1 });
+            expect(chargedRounds(result)).toEqual([3, 5, 7, 9, 11]);
+        });
+
+        it('always-true self gain speeds up cadence', () => {
+            const result = simulateDPS({
+                ...base,
+                selfChargeGain: { amount: 1, condition: 'always', derivable: true },
+            });
+            expect(chargedRounds(result)).toEqual([3, 5, 7, 9, 11]);
+        });
+
+        it('self-crit at 100% crit contributes +1/round', () => {
+            const result = simulateDPS({
+                ...base,
+                selfChargeGain: { amount: 1, condition: 'self-crit', derivable: true },
+            });
+            expect(chargedRounds(result)).toEqual([3, 5, 7, 9, 11]);
+        });
+
+        it('enemy-type gain only applies when enemy type matches', () => {
+            const gain = {
+                amount: 1,
+                condition: 'enemy-type' as const,
+                derivable: true,
+                requiredEnemyType: 'Defender' as const,
+            };
+            const matched = simulateDPS({ ...base, selfChargeGain: gain, enemyType: 'Defender' });
+            const unmatched = simulateDPS({ ...base, selfChargeGain: gain, enemyType: 'Attacker' });
+            expect(chargedRounds(matched)).toEqual([3, 5, 7, 9, 11]);
+            expect(chargedRounds(unmatched)).toEqual([4, 8, 12]);
+        });
+
+        it('does nothing when there is no charged skill', () => {
+            const result = simulateDPS({
+                ...base,
+                chargedMultiplier: 0,
+                allyChargePerRound: 5,
+            });
+            expect(chargedRounds(result)).toEqual([]);
+        });
+    });
 });

--- a/src/utils/calculators/dpsSimulator.ts
+++ b/src/utils/calculators/dpsSimulator.ts
@@ -1,9 +1,11 @@
 import { calculateCritMultiplier, calculateDamageReduction } from '../autogear/priorityScore';
 import {
     Buff,
+    ChargeGain,
     ConditionalDamage,
     DoTApplicationConfig,
     DoTApplicationEntry,
+    EnemyBaseClass,
     SecondaryDamage,
     SelectedGameBuff,
 } from '../../types/calculator';
@@ -53,6 +55,12 @@ export interface DPSSimulationInput {
     activeConditional?: ConditionalDamage;
     /** Conditional scaling bonus applied on charged-skill rounds. */
     chargedConditional?: ConditionalDamage;
+    /** Per-round self charge gain parsed from the attacker's skill text. */
+    selfChargeGain?: ChargeGain;
+    /** Flat extra charges per round contributed by allies/supporters. */
+    allyChargePerRound?: number;
+    /** Enemy base class, for the 'enemy-type' charge-gain condition. */
+    enemyType?: EnemyBaseClass;
 }
 
 export interface RoundData {
@@ -177,6 +185,9 @@ function runSinglePass(params: {
     chargedSecondary?: SecondaryDamage;
     activeConditional?: ConditionalDamage;
     chargedConditional?: ConditionalDamage;
+    selfChargeGain?: ChargeGain;
+    allyChargePerRound?: number;
+    enemyType?: EnemyBaseClass;
 }): {
     rounds: RoundData[];
     rawTotals: {
@@ -219,6 +230,9 @@ function runSinglePass(params: {
         chargedSecondary,
         activeConditional,
         chargedConditional,
+        selfChargeGain,
+        allyChargePerRound,
+        enemyType,
     } = params;
 
     // All mutable state declared fresh on every call
@@ -351,6 +365,44 @@ function runSinglePass(params: {
             }
         }
 
+        // Charge manipulation: bonus charges accumulate every round (active and
+        // charged). Charged round already reset charges to 0 at the top, so
+        // post-fire rounds still bank bonus/ally charges. Gated on hasChargedSkill.
+        if (hasChargedSkill) {
+            let chargeGainCount = 0;
+            if (selfChargeGain) {
+                switch (selfChargeGain.condition) {
+                    case 'always':
+                        chargeGainCount = 1;
+                        break;
+                    case 'self-crit':
+                        chargeGainCount = effectiveCrit / 100;
+                        break;
+                    case 'self-buff':
+                        chargeGainCount = entry.activeSelfBuffs.filter(
+                            (ab) => ab.stacks === undefined || ab.stacks > 0
+                        ).length;
+                        break;
+                    case 'enemy-debuff':
+                        chargeGainCount =
+                            landedEnemyDebuffs.length +
+                            corrosionEntries.length +
+                            infernoEntries.length +
+                            pendingBombs.length;
+                        break;
+                    case 'enemy-type':
+                        chargeGainCount = enemyType === selfChargeGain.requiredEnemyType ? 1 : 0;
+                        break;
+                    default:
+                        // enemy-buff, enemy-adjacent, adjacent-ally, enemy-destroyed
+                        chargeGainCount = selfChargeGain.manualCount ?? 1;
+                        break;
+                }
+            }
+            const bonusCharges = selfChargeGain ? chargeGainCount * selfChargeGain.amount : 0;
+            charges += bonusCharges + (allyChargePerRound ?? 0);
+        }
+
         const preCritDamage =
             effectiveAttack * ((multiplier + conditionalBonusPct) / 100) + secondaryStatValue;
         const postDefenseFactor =
@@ -428,7 +480,7 @@ function runSinglePass(params: {
         roundData.push({
             round: r,
             action,
-            charges,
+            charges: Math.round(charges),
             directDamage: Math.round(directDamage),
             corrosionDamage: Math.round(corrosionDamage),
             infernoDamage: Math.round(infernoDamage),
@@ -502,6 +554,9 @@ export function simulateDPS(input: DPSSimulationInput): DPSSimulationResult {
         chargedSecondary,
         activeConditional,
         chargedConditional,
+        selfChargeGain,
+        allyChargePerRound,
+        enemyType,
     } = input;
     const { affinityDamageModifier = 0, affinityCritCap = 100, affinityCritPenalty = 0 } = input;
 
@@ -569,6 +624,9 @@ export function simulateDPS(input: DPSSimulationInput): DPSSimulationResult {
         chargedSecondary,
         activeConditional,
         chargedConditional,
+        selfChargeGain,
+        allyChargePerRound,
+        enemyType,
     });
 
     const totalDamage = Math.round(rawTotals.cumulative);

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -6,6 +6,8 @@ import {
     StackTrigger,
     ConditionalDamage,
     ConditionalCondition,
+    ChargeGain,
+    EnemyBaseClass,
 } from '../types/calculator';
 
 /**
@@ -230,6 +232,85 @@ export function parseConditionalDamage(text: string | null | undefined): Conditi
         };
     }
     return null;
+}
+
+function stripUnitTags(text: string): string {
+    return text.replace(/<\/?unit-(?:aid|skill|damage)>/gi, '');
+}
+
+// Phrases that disqualify a charge phrase from being a self-gain we model:
+// ally-grant to others, on-kill (enemy never dies), enemy-repair (never repairs).
+const CHARGE_DISQUALIFY_RE =
+    /all allies|their charged skill|charged skill of all allies|upon killing|killing an enemy|when an enemy dies|when an enemy repairs|enemy performs a repair|enemy repairs/i;
+
+// "adds/gains N charge(s)" (self-add). "removes" is excluded by the verb set, so
+// Thresh's "removes 1 charge ... and adds 1 charge" matches only the add.
+const SELF_CHARGE_ADD_RE = /\b(?:adds?|gains?)\s+(\d+|a|an)\s+charges?\b/i;
+
+// Rhodium-style form: "adds charges to the Charged Skill equal to the number of
+// buffs on the target" (amount is per-buff = 1). Runs on tag-stripped text.
+const PER_BUFF_CHARGE_RE =
+    /adds?\s+charges?\s+to\s+the\s+charged skill[^.]*equal to the number of/i;
+
+function classifyChargeCondition(
+    text: string // already tag-stripped, any case
+): { condition: ConditionalCondition; derivable: boolean; requiredEnemyType?: EnemyBaseClass } {
+    const p = text.toLowerCase();
+    if (p.includes('is a defender'))
+        return { condition: 'enemy-type', derivable: true, requiredEnemyType: 'Defender' };
+    if (p.includes('critically damag') || p.includes('critically hit'))
+        return { condition: 'self-crit', derivable: true };
+    if (p.includes('inflict') && p.includes('debuff'))
+        return { condition: 'enemy-debuff', derivable: true };
+    if (p.includes('stealth')) return { condition: 'enemy-buff', derivable: false };
+    if (
+        p.includes('buffs on the target') ||
+        p.includes('buff on the target') ||
+        p.includes('or more buffs') ||
+        p.includes('buffs on the enemy') ||
+        p.includes('number of buffs')
+    )
+        return { condition: 'enemy-buff', derivable: false };
+    if (
+        p.includes('2 or more enemies') ||
+        p.includes('two or more enemies') ||
+        p.includes('damages 2')
+    )
+        return { condition: 'enemy-adjacent', derivable: false };
+    // speed / full-HP / lowest-speed and anything else → always-true under sim assumptions
+    return { condition: 'always', derivable: true };
+}
+
+/**
+ * Parses a self-targeted Charged-Skill charge gain from skill text. Returns null
+ * for ally-grant, enemy-removal, on-kill, and enemy-repair phrasings (out of
+ * scope or never-fire under the sim assumptions). Conditions are classified into
+ * the (shared) ConditionalCondition set; `derivable` follows the same meaning as
+ * ConditionalDamage. Reference data: docs/ship-skills.csv.
+ */
+export function parseChargeGain(text: string | null | undefined): ChargeGain | null {
+    if (!text) return null;
+    const plain = stripUnitTags(text);
+    if (CHARGE_DISQUALIFY_RE.test(plain)) return null;
+
+    // Rhodium "equal to the number of buffs" form (amount is per-buff = 1).
+    if (PER_BUFF_CHARGE_RE.test(plain)) {
+        return { amount: 1, condition: 'enemy-buff', derivable: false };
+    }
+
+    const m = SELF_CHARGE_ADD_RE.exec(plain);
+    if (!m) return null;
+    const raw = m[1].toLowerCase();
+    const amount = raw === 'a' || raw === 'an' ? 1 : parseInt(raw, 10);
+    if (!amount || isNaN(amount)) return null;
+
+    const { condition, derivable, requiredEnemyType } = classifyChargeCondition(plain);
+    return {
+        amount,
+        condition,
+        derivable,
+        ...(requiredEnemyType ? { requiredEnemyType } : {}),
+    };
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds charge-manipulation modeling to the DPS calculator so the Charged Skill fires on a realistic cadence:

- **Self charge gains** parsed from a ship's skill text (`parseChargeGain`) accelerate how often the Charged Skill fires. Conditions reuse the existing `ConditionalCondition` machinery and are auto-counted each round from sim state (`always`, `self-crit`, `self-buff`, `enemy-debuff`) or take a manual trigger count (`enemy-buff`, `enemy-adjacent`).
- **Ally charges / round** — a flat manual input modeling supporter ships (Castor/Liberator) feeding charges to the attacker.
- **Enemy Type** selector (global) drives type-conditional gains (e.g. Thresh "if the target is a Defender").
- Summary shows a **"Charged skill fires: every N rounds"** cadence line.

Out of scope (parsed → null): enemy charge removal, ally-grant-to-others, on-kill / enemy-repair triggers (never fire under the sim's assumptions).

Spec: `docs/superpowers/specs/2026-05-31-charge-manipulation-design.md`
Plan: `docs/superpowers/plans/2026-05-31-charge-manipulation.md`

## Implementation notes

- Charges accumulate every round; the charged round resets to 0 (matches existing overflow behavior). Charges accumulate fractionally internally (e.g. self-crit at 70% → 0.7/round); only the displayed value is rounded.
- The per-round charge block is placed after the conditional-bonus computation so `effectiveCrit` and the landed-debuff/DoT arrays are in scope.
- New parser strips `<unit-*>` tags before matching and uses a dedicated condition classifier (not `mapConditionPhrase`).

## Test Plan

- [x] `npm test` — 713 passing (12 new parser cases, 6 new sim cadence cases)
- [x] `npm run lint` — clean (max-warnings 0)
- [x] Manual verification in the running app:
  - [x] Ally charges/round 0→1 shifts cadence (4.0 → 2.2 rounds)
  - [x] Chakara auto-fills "Self: +1 charge/round every round" (always)
  - [x] Thresh auto-fills "Self: +1 charge/round when enemy is a Defender" (enemy-type)
  - [x] Enemy Type = Defender enables the gain (→1.1); = Attacker gates it off (→2.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)