### PR TITLE
feat: Effective HP as an autogear stat limit

### DIFF
--- a/docs/superpowers/plans/2026-05-31-charge-manipulation.md
+++ b/docs/superpowers/plans/2026-05-31-charge-manipulation.md
@@ -1,0 +1,824 @@
+# Charge Manipulation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Model charge-manipulation effects (self charge gains parsed from skill text + a flat ally/supporter charge contribution) so the DPS calculator's charged skill fires on a realistic cadence.
+
+**Architecture:** Feed extra charges into the existing per-round charge accumulator in `runSinglePass`. A new `parseChargeGain` parser auto-fills a `selfChargeGain` (amount + condition, reusing the conditional-condition machinery) from the attacker's own skill text; a flat manual `allyChargePerRound` represents supporters. Both accumulate every round; charged round resets to 0. A new global enemy-type input feeds the Thresh-style "if Defender" condition. No new damage slice — cadence changes redistribute existing damage.
+
+**Tech Stack:** React 18, TypeScript, Vite, Vitest. Follows the established skill-parsed-mechanic pipeline (secondary damage, conditional scaling).
+
+**Spec:** `docs/superpowers/specs/2026-05-31-charge-manipulation-design.md`
+
+---
+
+## File Structure
+
+- `src/types/calculator.ts` — `EnemyBaseClass`, `ChargeGain`, extend `ConditionalCondition` + labels, extend `DPSShipConfig` + `autoFilledFields` union.
+- `src/utils/skillTextParser.ts` — new `parseChargeGain` + a charge-specific condition classifier.
+- `src/utils/__tests__/skillTextParser.test.ts` — parser tests.
+- `src/utils/calculators/dpsSimulator.ts` — extend `DPSSimulationInput`, thread fields through `runSinglePass`, add the per-round charge-gain block.
+- `src/utils/calculators/__tests__/dpsSimulator.test.ts` — cadence tests.
+- `src/pages/calculators/DPSCalculatorPage.tsx` — auto-fill, seeding, `simulateDPS` call, updaters, global `enemyType` state.
+- `src/components/calculator/CombatSettingsPanel.tsx` — enemy-type `Select`.
+- `src/components/calculator/ShipConfigCard.tsx` — "Charge Manipulation" collapsible section + re-sync `useEffect`.
+- `src/components/calculator/ShipConfigSummary.tsx` — charged-skill cadence line.
+- `src/pages/DocumentationPage.tsx` + `src/constants/changelog.ts` — docs + changelog.
+
+---
+
+## Task 1: Types
+
+**Files:**
+- Modify: `src/types/calculator.ts`
+
+- [ ] **Step 1: Extend `ConditionalCondition` and its labels**
+
+In `src/types/calculator.ts`, change the `ConditionalCondition` union (currently lines 12-18) to add three variants, and add labels:
+
+```ts
+export type ConditionalCondition =
+    | 'self-buff' // derivable
+    | 'enemy-debuff' // derivable
+    | 'enemy-buff' // manual
+    | 'adjacent-ally' // manual
+    | 'enemy-adjacent' // manual
+    | 'enemy-destroyed' // manual
+    | 'always' // unconditional / always-true under sim assumptions (charge gains)
+    | 'self-crit' // derivable from crit rate (charge gains)
+    | 'enemy-type'; // derivable from the global enemy-type input (charge gains)
+```
+
+Add to `CONDITIONAL_CONDITION_LABELS` (currently lines 28-35):
+
+```ts
+    always: 'every round',
+    'self-crit': 'on critical hit',
+    'enemy-type': 'when enemy matches type',
+```
+
+- [ ] **Step 2: Add `EnemyBaseClass` and `ChargeGain` types**
+
+After the `ConditionalDamage` interface (around line 26), add:
+
+```ts
+export type EnemyBaseClass = 'Attacker' | 'Defender' | 'Debuffer' | 'Supporter';
+
+export interface ChargeGain {
+    amount: number; // charges per trigger (e.g. 1, 2)
+    condition: ConditionalCondition;
+    derivable: boolean; // true → read sim state; false → use manualCount
+    manualCount?: number; // used when !derivable (default 1)
+    requiredEnemyType?: EnemyBaseClass; // only for condition 'enemy-type'
+}
+```
+
+- [ ] **Step 3: Extend `DPSShipConfig` and `autoFilledFields`**
+
+In `DPSShipConfig` (around lines 120-130), after `startCharged: boolean;` add:
+
+```ts
+    selfChargeGain?: ChargeGain;
+    allyChargePerRound?: number;
+```
+
+And extend the `autoFilledFields` Set union (lines 122-130) by adding `| 'selfChargeGain'`.
+
+- [ ] **Step 4: Verify compile**
+
+Run: `npm run lint`
+Expected: PASS (no new errors). Type-only change; downstream `simulateDPS` call already omits these (optional fields).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/calculator.ts
+git commit -m "feat: add ChargeGain types for charge manipulation"
+```
+
+---
+
+## Task 2: Parser — `parseChargeGain`
+
+**Files:**
+- Modify: `src/utils/skillTextParser.ts`
+- Test: `src/utils/__tests__/skillTextParser.test.ts`
+
+Reference siblings already in the file: `parseConditionalDamage` (~line 211), `mapConditionPhrase` (~line 180). Charge phrases in `docs/ship-skills.csv` are wrapped in `<unit-aid>…</unit-aid>` tags; conditions are plain text around them. Do NOT reuse `mapConditionPhrase` (it only handles "for each …" grammar).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/utils/__tests__/skillTextParser.test.ts` (import `parseChargeGain` from `../skillTextParser`):
+
+```ts
+describe('parseChargeGain', () => {
+    it('parses always-true (speed) self gain — Chakara', () => {
+        const text =
+            'This Unit deals <unit-damage>180% damage</unit-damage>. If all damaged enemies have more Speed than this Unit, it <unit-aid>adds 1 charge</unit-aid> to its Charged Skill.';
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'always',
+            derivable: true,
+        });
+    });
+
+    it('parses full-HP self gain as always-true — Cobalt', () => {
+        const text =
+            "This Unit <unit-aid>adds 1 charge</unit-aid> to its charged skill at the start of the turn if it is at full HP.";
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'always',
+            derivable: true,
+        });
+    });
+
+    it('parses enemy-buff threshold gain (manual) — Nuqtu', () => {
+        const text =
+            'If the target has 3 or more buffs, the Unit <unit-aid>gains 2 charges</unit-aid> to its Charged Skill.';
+        expect(parseChargeGain(text)).toEqual({
+            amount: 2,
+            condition: 'enemy-buff',
+            derivable: false,
+        });
+    });
+
+    it('parses "equal to the number of buffs" per-buff gain — Rhodium', () => {
+        const text =
+            'Unit adds charges to the <unit-aid>Charged Skill</unit-aid> equal to the number of <unit-aid>Buffs</unit-aid> on the target.';
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'enemy-buff',
+            derivable: false,
+        });
+    });
+
+    it('parses enemy-type (Defender) gain and ignores the removal clause — Thresh', () => {
+        const text =
+            "If the target is a Defender, this Unit <unit-aid>removes 1 charge</unit-aid> from the enemy and <unit-aid>adds 1 charge</unit-aid> to this Unit's Charged Skill.";
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'enemy-type',
+            derivable: true,
+            requiredEnemyType: 'Defender',
+        });
+    });
+
+    it('parses stealth condition as enemy-buff (manual) — Selenite', () => {
+        const text =
+            "If any target is <unit-aid>Stealthed</unit-aid>, it <unit-aid>adds 1 charge</unit-aid> to this Unit's Charged Skill.";
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'enemy-buff',
+            derivable: false,
+        });
+    });
+
+    it('parses "2 or more enemies" as enemy-adjacent (manual) — Tygr', () => {
+        const text =
+            'If it damages 2 or more enemies, it adds <unit-aid>adds 1 charge</unit-aid> to its Charged Skill.';
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'enemy-adjacent',
+            derivable: false,
+        });
+    });
+
+    it('parses debuff-infliction as enemy-debuff (derivable) — Hemlock', () => {
+        const text =
+            'This Unit <unit-aid>gains 1 charge</unit-aid> to its charged skill after it inflicts a <unit-aid>debuff</unit-aid>.';
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'enemy-debuff',
+            derivable: true,
+        });
+    });
+
+    it('parses crit-based self gain as self-crit (derivable) — Asphodel', () => {
+        const text =
+            "This Unit's attacks are always critical and <unit-aid>adds 1 charge</unit-aid> to its Charged Skill after critically damaging an enemy.";
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'self-crit',
+            derivable: true,
+        });
+    });
+
+    it('returns null for enemy charge removal — Demolisher', () => {
+        const text =
+            "When a bomb explodes on an enemy, this unit removes 2 charges from the enemy's charged skill.";
+        expect(parseChargeGain(text)).toBeNull();
+    });
+
+    it('returns null for on-kill gain — Valiant', () => {
+        const text =
+            'This Unit <unit-aid>gains 1 charge</unit-aid> for its Charged Skill upon killing an enemy.';
+        expect(parseChargeGain(text)).toBeNull();
+    });
+
+    it('returns null for ally-grant — Liberator', () => {
+        const text =
+            'When an enemy dies, all allies <unit-aid>add 1 charge</unit-aid> to their Charged Skills.';
+        expect(parseChargeGain(text)).toBeNull();
+    });
+
+    it('returns null when there is no charge phrase', () => {
+        expect(parseChargeGain('This Unit deals <unit-damage>140% damage</unit-damage>.')).toBeNull();
+        expect(parseChargeGain('')).toBeNull();
+        expect(parseChargeGain(null)).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- skillTextParser`
+Expected: FAIL with "parseChargeGain is not a function" (or import error).
+
+- [ ] **Step 3: Implement `parseChargeGain`**
+
+Add to `src/utils/skillTextParser.ts` (import `ChargeGain`, `EnemyBaseClass` from `../types/calculator` alongside the existing `ConditionalDamage`, `ConditionalCondition` imports). Place after `parseConditionalDamage`:
+
+```ts
+// Phrases that disqualify a charge phrase from being a self-gain we model:
+// ally-grant to others, on-kill (enemy never dies), enemy-repair (never repairs).
+const CHARGE_DISQUALIFY_RE =
+    /all allies|their charged skill|charged skill of all allies|upon killing|killing an enemy|when an enemy dies|when an enemy repairs|enemy performs a repair|enemy repairs/i;
+
+// "adds/gains N charge(s)" inside a <unit-aid> tag (self-add; "removes" is excluded
+// because the verb is constrained to adds/gains).
+const SELF_CHARGE_ADD_RE =
+    /<unit-aid>\s*(?:adds?|gains?)\s+(\d+|a|an)\s+charges?\s*<\/unit-aid>/i;
+
+// Rhodium-style untagged form: "adds charges to the Charged Skill equal to the
+// number of buffs on the target".
+const PER_BUFF_CHARGE_RE = /adds?\s+charges?\s+to\s+the\s+<?[^>]*charged skill[^.]*equal to the number of/i;
+
+function classifyChargeCondition(
+    text: string
+): { condition: ConditionalCondition; derivable: boolean; requiredEnemyType?: EnemyBaseClass } {
+    const p = text.toLowerCase();
+    if (p.includes('is a defender'))
+        return { condition: 'enemy-type', derivable: true, requiredEnemyType: 'Defender' };
+    if (p.includes('critically damag') || p.includes('critically hit') || p.includes('critical'))
+        return { condition: 'self-crit', derivable: true };
+    if (p.includes('inflict') && p.includes('debuff'))
+        return { condition: 'enemy-debuff', derivable: true };
+    if (p.includes('stealth')) return { condition: 'enemy-buff', derivable: false };
+    if (p.includes('buffs on the target') || p.includes('buff on the target') ||
+        p.includes('or more buffs') || p.includes('buffs on the enemy') ||
+        p.includes('number of buffs'))
+        return { condition: 'enemy-buff', derivable: false };
+    if (p.includes('2 or more enemies') || p.includes('two or more enemies') ||
+        p.includes('damages 2'))
+        return { condition: 'enemy-adjacent', derivable: false };
+    // speed / full-HP / lowest-speed and anything else → always-true under sim assumptions
+    return { condition: 'always', derivable: true };
+}
+
+/**
+ * Parses a self-targeted Charged-Skill charge gain from skill text. Returns null
+ * for ally-grant, enemy-removal, on-kill, and enemy-repair phrasings (out of
+ * scope or never-fire under the sim assumptions). Conditions are classified into
+ * the (shared) ConditionalCondition set; `derivable` follows the same meaning as
+ * ConditionalDamage. Reference data: docs/ship-skills.csv.
+ */
+export function parseChargeGain(text: string | null | undefined): ChargeGain | null {
+    if (!text) return null;
+    if (CHARGE_DISQUALIFY_RE.test(text)) return null;
+
+    // Rhodium "equal to the number of buffs" form (amount is per-buff = 1).
+    if (PER_BUFF_CHARGE_RE.test(text)) {
+        return { amount: 1, condition: 'enemy-buff', derivable: false };
+    }
+
+    const m = SELF_CHARGE_ADD_RE.exec(text);
+    if (!m) return null;
+    const raw = m[1].toLowerCase();
+    const amount = raw === 'a' || raw === 'an' ? 1 : parseInt(raw, 10);
+    if (!amount || isNaN(amount)) return null;
+
+    const { condition, derivable, requiredEnemyType } = classifyChargeCondition(text);
+    return {
+        amount,
+        condition,
+        derivable,
+        ...(requiredEnemyType ? { requiredEnemyType } : {}),
+    };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- skillTextParser`
+Expected: PASS (all `parseChargeGain` cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/skillTextParser.ts src/utils/__tests__/skillTextParser.test.ts
+git commit -m "feat: parse charge-gain effects from skill text"
+```
+
+---
+
+## Task 3: Simulator — charge-gain accumulation
+
+**Files:**
+- Modify: `src/utils/calculators/dpsSimulator.ts`
+- Test: `src/utils/calculators/__tests__/dpsSimulator.test.ts`
+
+- [ ] **Step 1: Extend `DPSSimulationInput`**
+
+In `src/utils/calculators/dpsSimulator.ts`, import `ChargeGain` and `EnemyBaseClass` from `../../types/calculator` (alongside existing imports). Add to `DPSSimulationInput` (after `chargedConditional?`, ~line 55):
+
+```ts
+    /** Per-round self charge gain parsed from the attacker's skill text. */
+    selfChargeGain?: ChargeGain;
+    /** Flat extra charges per round contributed by allies/supporters. */
+    allyChargePerRound?: number;
+    /** Enemy base class, for the 'enemy-type' charge-gain condition. */
+    enemyType?: EnemyBaseClass;
+```
+
+- [ ] **Step 2: Write the failing cadence tests**
+
+Add to `src/utils/calculators/__tests__/dpsSimulator.test.ts`. Use the existing test convention (`crit: 100, critDamage: 0` → critMultiplier 1; `enemyDefense: 0`). Build a minimal input via the existing helper/pattern in that file (mirror an existing `simulateDPS({...})` test for required fields). The key field under test is the round `action` sequence.
+
+```ts
+describe('charge manipulation', () => {
+    // Helper: indices (1-based round numbers) where the charged skill fired.
+    const chargedRounds = (result: ReturnType<typeof simulateDPS>) =>
+        result.rounds.filter((r) => r.action === 'charged').map((r) => r.round);
+
+    const base = {
+        attack: 1000,
+        crit: 100,
+        critDamage: 0,
+        defensePenetration: 0,
+        activeMultiplier: 100,
+        chargedMultiplier: 200,
+        chargeCount: 3,
+        activeDoTs: [],
+        chargedDoTs: [],
+        enemyDefense: 0,
+        enemyHp: 500000,
+        rounds: 12,
+        selfBuffs: [],
+        enemyDebuffs: [],
+    };
+
+    it('baseline: charged fires once charges reach chargeCount (every 4th round for 3 charges)', () => {
+        // R1..R3 bank +1 each → charges 1,2,3; R4 sees 3 → charged. Then repeats.
+        const result = simulateDPS({ ...base });
+        expect(chargedRounds(result)).toEqual([4, 8, 12]);
+    });
+
+    it('allyChargePerRound speeds up cadence', () => {
+        // Per active round banks 1+1=2; charged round banks 0+1=1.
+        // R1: 0<3 active → 2. R2: 2<3 active → 4. R3: 4>=3 charged → 0, +1 → 1.
+        // R4: 1<3 active → 3. R5: 3>=3 charged → 0,+1 → 1. R6: active → 3. R7: charged...
+        const result = simulateDPS({ ...base, allyChargePerRound: 1 });
+        expect(chargedRounds(result)).toEqual([3, 5, 7, 9, 11]);
+    });
+
+    it('always-true self gain speeds up cadence', () => {
+        const result = simulateDPS({
+            ...base,
+            selfChargeGain: { amount: 1, condition: 'always', derivable: true },
+        });
+        // Same accumulation as allyChargePerRound: 1 (active banks 1+1, charged banks 1).
+        expect(chargedRounds(result)).toEqual([3, 5, 7, 9, 11]);
+    });
+
+    it('self-crit at 100% crit contributes +1/round', () => {
+        const result = simulateDPS({
+            ...base,
+            selfChargeGain: { amount: 1, condition: 'self-crit', derivable: true },
+        });
+        expect(chargedRounds(result)).toEqual([3, 5, 7, 9, 11]);
+    });
+
+    it('enemy-type gain only applies when enemy type matches', () => {
+        const gain = {
+            amount: 1,
+            condition: 'enemy-type' as const,
+            derivable: true,
+            requiredEnemyType: 'Defender' as const,
+        };
+        const matched = simulateDPS({ ...base, selfChargeGain: gain, enemyType: 'Defender' });
+        const unmatched = simulateDPS({ ...base, selfChargeGain: gain, enemyType: 'Attacker' });
+        expect(chargedRounds(matched)).toEqual([3, 5, 7, 9, 11]);
+        expect(chargedRounds(unmatched)).toEqual([4, 8, 12]); // same as baseline
+    });
+
+    it('does nothing when there is no charged skill', () => {
+        const result = simulateDPS({
+            ...base,
+            chargedMultiplier: 0,
+            allyChargePerRound: 5,
+        });
+        expect(chargedRounds(result)).toEqual([]);
+    });
+});
+```
+
+> Note: confirm `base` includes every required `DPSSimulationInput` field by checking an existing test in the same file; add any missing required fields (e.g. it may already default optional ones). Re-derive the expected arrays by hand if the file's existing baseline test shows a different reset/increment timing than assumed here, then make the assertions match the actual semantics (do not loosen to "~every N").
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npm test -- dpsSimulator`
+Expected: FAIL — charge-manipulation cases fail (cadence unchanged / fields ignored). The baseline test should PASS already (documents current behavior).
+
+- [ ] **Step 4: Thread the fields into `runSinglePass`**
+
+In `simulateDPS` (~line 483), destructure the three new fields from `input` and pass them into the `runSinglePass` call (mirror how `chargedConditional` is threaded ~lines 502-571). Add to `runSinglePass`'s params interface/destructure: `selfChargeGain?: ChargeGain`, `allyChargePerRound?: number`, `enemyType?: EnemyBaseClass`.
+
+- [ ] **Step 5: Add the per-round charge-gain block**
+
+In the round loop, immediately **after** the conditional-bonus block (the `conditionalBonusPct` computation, ~lines 332-352) and before Step 1 damage — so `effectiveCrit` (~line 294) and `landedEnemyDebuffs`/DoT arrays (~line 341) are in scope — add:
+
+```ts
+        // Charge manipulation: bonus charges accumulate every round (active and
+        // charged). Charged round already reset charges to 0 at the top, so
+        // post-fire rounds still bank bonus/ally charges. Gated on hasChargedSkill.
+        if (hasChargedSkill) {
+            let chargeGainCount = 0;
+            if (selfChargeGain) {
+                switch (selfChargeGain.condition) {
+                    case 'always':
+                        chargeGainCount = 1;
+                        break;
+                    case 'self-crit':
+                        chargeGainCount = effectiveCrit / 100;
+                        break;
+                    case 'self-buff':
+                        chargeGainCount = entry.activeSelfBuffs.filter(
+                            (ab) => ab.stacks === undefined || ab.stacks > 0
+                        ).length;
+                        break;
+                    case 'enemy-debuff':
+                        chargeGainCount =
+                            landedEnemyDebuffs.length +
+                            corrosionEntries.length +
+                            infernoEntries.length +
+                            pendingBombs.length;
+                        break;
+                    case 'enemy-type':
+                        chargeGainCount =
+                            enemyType !== undefined &&
+                            enemyType === selfChargeGain.requiredEnemyType
+                                ? 1
+                                : 0;
+                        break;
+                    default:
+                        // enemy-buff, enemy-adjacent, adjacent-ally, enemy-destroyed
+                        chargeGainCount = selfChargeGain.manualCount ?? 1;
+                        break;
+                }
+            }
+            const bonusCharges = selfChargeGain ? chargeGainCount * selfChargeGain.amount : 0;
+            charges += bonusCharges + (allyChargePerRound ?? 0);
+        }
+```
+
+- [ ] **Step 6: Round charges for display**
+
+Charges can now be fractional. In the `roundData.push({...})` (~line 428), change `charges,` to `charges: Math.round(charges),` so the timeline shows whole numbers.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `npm test -- dpsSimulator`
+Expected: PASS (baseline + all charge-manipulation cases). If a hand-derived array is off by the reset/increment timing, re-derive against the actual loop and correct the test — do not change the production semantics to match a guess.
+
+- [ ] **Step 8: Run the full suite + lint**
+
+Run: `npm test && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/utils/calculators/dpsSimulator.ts src/utils/calculators/__tests__/dpsSimulator.test.ts
+git commit -m "feat: accumulate manipulated charges in DPS sim"
+```
+
+---
+
+## Task 4: Page wiring
+
+**Files:**
+- Modify: `src/pages/calculators/DPSCalculatorPage.tsx`
+
+- [ ] **Step 1: Parse `selfChargeGain` in `buildSkillAutoFill`**
+
+In `buildSkillAutoFill` (~line 43): import `parseChargeGain` and the `ChargeGain` / `EnemyBaseClass` types. Scan active + all passive skill texts (the gain is often on a passive, e.g. Hemlock/Asphodel/Cobalt) and take the first match. Seed `manualCount: 1` for non-derivable, mirroring `seedManual`:
+
+```ts
+    const seedChargeManual = (c: ChargeGain | null): ChargeGain | undefined => {
+        if (!c) return undefined;
+        return !c.derivable && c.manualCount === undefined ? { ...c, manualCount: 1 } : c;
+    };
+    const selfChargeGain = seedChargeManual(
+        parseChargeGain(ship.activeSkillText) ??
+            parseChargeGain(ship.firstPassiveSkillText) ??
+            parseChargeGain(ship.secondPassiveSkillText) ??
+            parseChargeGain(ship.thirdPassiveSkillText)
+    );
+```
+
+Add `'selfChargeGain'` to the local `autoFilledFields` Set type union (lines 54-62), add `if (selfChargeGain) autoFilledFields.add('selfChargeGain');`, and add `selfChargeGain` to the returned object (lines 69-77).
+
+- [ ] **Step 2: Seed in `getInitialConfig` (ship branch + default branch)**
+
+In the ship branch (~lines 107-149): destructure `selfChargeGain` from `buildSkillAutoFill`, and add to the returned config object: `selfChargeGain,` and `allyChargePerRound: 0,`.
+
+In the default (no-ship) branch (~lines 155-178): add `allyChargePerRound: 0,` to the config (leave `selfChargeGain` undefined).
+
+- [ ] **Step 3: Add global `enemyType` state**
+
+Near the other enemy state (`enemyDefense`/`enemyHp`/`enemySecurity`, ~lines 184-194), add:
+
+```ts
+    const [enemyType, setEnemyType] = useState<EnemyBaseClass | undefined>(undefined);
+```
+
+- [ ] **Step 4: Pass new fields into `simulateDPS`**
+
+In the `simulateDPS({...})` call (~lines 271-298) add:
+
+```ts
+                    selfChargeGain: config.selfChargeGain,
+                    allyChargePerRound: config.allyChargePerRound,
+                    enemyType,
+```
+
+Add `enemyType` to the `simResults` `useMemo` dependency array (~lines 302-313).
+
+- [ ] **Step 5: Seed in `selectShipForConfig`**
+
+In `selectShipForConfig` (~lines 406-454): destructure `selfChargeGain` from `buildSkillAutoFill`, and in the returned merged config add `selfChargeGain,` (next to `activeConditional`). Leave `allyChargePerRound` as `c.allyChargePerRound ?? 0` to preserve any user value.
+
+- [ ] **Step 6: Add updaters**
+
+After `updateConfigConditional` (~line 550) add:
+
+```ts
+    const updateConfigChargeGain = (id: string, value: ChargeGain | undefined) => {
+        setConfigs((prev) =>
+            prev.map((c) => {
+                if (c.id !== id) return c;
+                const next = new Set(c.autoFilledFields);
+                next.delete('selfChargeGain');
+                return { ...c, selfChargeGain: value, autoFilledFields: next };
+            })
+        );
+    };
+
+    const updateConfigAllyCharge = (id: string, value: number) => {
+        setConfigs((prev) => prev.map((c) => (c.id === id ? { ...c, allyChargePerRound: value } : c)));
+    };
+```
+
+- [ ] **Step 7: Wire props into `<ShipConfigCard>` and `<CombatSettingsPanel>`**
+
+On `<ShipConfigCard>` (~lines 663-702) add:
+
+```tsx
+                                onChargeGainChange={(value) =>
+                                    updateConfigChargeGain(config.id, value)
+                                }
+                                onAllyChargeChange={(value) =>
+                                    updateConfigAllyCharge(config.id, value)
+                                }
+```
+
+On `<CombatSettingsPanel>` (~lines 629-657) add:
+
+```tsx
+                        enemyType={enemyType}
+                        onEnemyTypeChange={setEnemyType}
+```
+
+- [ ] **Step 8: Verify build**
+
+Run: `npm run lint`
+Expected: errors only about the not-yet-added `ShipConfigCard` / `CombatSettingsPanel` props (resolved in Task 5). If other errors appear, fix them.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/pages/calculators/DPSCalculatorPage.tsx
+git commit -m "feat: wire charge manipulation into DPS calculator page"
+```
+
+---
+
+## Task 5: UI — config card, combat panel, summary
+
+**Files:**
+- Modify: `src/components/calculator/CombatSettingsPanel.tsx`
+- Modify: `src/components/calculator/ShipConfigCard.tsx`
+- Modify: `src/components/calculator/ShipConfigSummary.tsx`
+
+- [ ] **Step 1: Enemy-type selector in CombatSettingsPanel**
+
+In `src/components/calculator/CombatSettingsPanel.tsx`: import `EnemyBaseClass` from `../../types/calculator`. Add to `CombatSettingsPanelProps`:
+
+```ts
+    enemyType?: EnemyBaseClass;
+    onEnemyTypeChange: (v: EnemyBaseClass | undefined) => void;
+```
+
+Destructure them in the component. Near the enemy-affinity `Select` (~line 108), add a new `Select` (mirror the affinity one):
+
+```tsx
+                    <Select
+                        label="Enemy Type"
+                        value={enemyType ?? ''}
+                        options={[
+                            { value: '', label: 'Any / Unknown' },
+                            { value: 'Attacker', label: 'Attacker' },
+                            { value: 'Defender', label: 'Defender' },
+                            { value: 'Debuffer', label: 'Debuffer' },
+                            { value: 'Supporter', label: 'Supporter' },
+                        ]}
+                        onChange={(v) =>
+                            onEnemyTypeChange(v === '' ? undefined : (v as EnemyBaseClass))
+                        }
+                    />
+```
+
+> Check the exact `Select` API used by the affinity selector in this file (options array vs children `<option>`) and match it.
+
+- [ ] **Step 2: Charge Manipulation section in ShipConfigCard — props**
+
+In `src/components/calculator/ShipConfigCard.tsx`: import `ChargeGain`, `EnemyBaseClass`, and `CONDITIONAL_CONDITION_LABELS` (already imported). Add to the props interface (near `onConditionalChange`, ~line 55):
+
+```ts
+    onChargeGainChange: (value: ChargeGain | undefined) => void;
+    onAllyChargeChange: (value: number) => void;
+```
+
+Destructure both in the component signature.
+
+- [ ] **Step 3: Re-sync open-state**
+
+Add an `openCharge` state next to `openConditional` (~line 91):
+
+```ts
+    const [openCharge, setOpenCharge] = useState(
+        Boolean(config.selfChargeGain || config.allyChargePerRound)
+    );
+```
+
+Extend the existing re-sync `useEffect` (~lines 97-104) to also set it and add the deps:
+
+```ts
+        setOpenCharge(Boolean(config.selfChargeGain || config.allyChargePerRound));
+```
+deps add: `config.selfChargeGain, config.allyChargePerRound`.
+
+- [ ] **Step 4: Charge Manipulation section markup**
+
+After the Conditional Damage `CollapsibleForm` (closes ~line 448), add a sibling section mirroring it:
+
+```tsx
+                    <Button
+                        variant="link"
+                        onClick={() => setOpenCharge((v) => !v)}
+                        className="w-full flex justify-between items-center mt-4"
+                    >
+                        <span className="flex items-center gap-2">
+                            <ChevronDownIcon
+                                className={`text-sm text-theme-text-secondary h-8 w-8 p-2 transition-transform duration-300 ${openCharge ? 'rotate-180' : ''}`}
+                            />
+                            Charge Manipulation
+                        </span>
+                    </Button>
+                    <CollapsibleForm isVisible={openCharge}>
+                        {config.selfChargeGain ? (
+                            <div className="mb-4">
+                                <div className="text-sm font-semibold mb-1">
+                                    Self: +{config.selfChargeGain.amount} charge
+                                    {config.selfChargeGain.amount !== 1 ? 's' : ''}/round{' '}
+                                    {CONDITIONAL_CONDITION_LABELS[config.selfChargeGain.condition]}
+                                </div>
+                                {config.selfChargeGain.derivable ? (
+                                    <p className="text-xs text-theme-text-secondary">
+                                        Auto-counted each round from sim state.
+                                    </p>
+                                ) : (
+                                    <Input
+                                        label="Trigger count / round"
+                                        type="number"
+                                        min="0"
+                                        value={config.selfChargeGain.manualCount ?? 1}
+                                        helpLabel={
+                                            config.autoFilledFields?.has('selfChargeGain')
+                                                ? 'auto-filled'
+                                                : undefined
+                                        }
+                                        onChange={(e) =>
+                                            onChargeGainChange({
+                                                ...config.selfChargeGain!,
+                                                manualCount: parseInt(e.target.value) || 0,
+                                            })
+                                        }
+                                    />
+                                )}
+                            </div>
+                        ) : (
+                            <p className="text-xs text-theme-text-secondary mb-2">
+                                No self charge gain detected.
+                            </p>
+                        )}
+                        <Input
+                            label="Ally charges / round"
+                            type="number"
+                            min="0"
+                            step="0.5"
+                            value={config.allyChargePerRound ?? 0}
+                            helpLabel="from supporters (e.g. Castor, Liberator)"
+                            onChange={(e) =>
+                                onAllyChargeChange(parseFloat(e.target.value) || 0)
+                            }
+                        />
+                    </CollapsibleForm>
+```
+
+- [ ] **Step 5: Cadence line in ShipConfigSummary**
+
+In `src/components/calculator/ShipConfigSummary.tsx`, after the Total Damage block (~line 66), add a charged-skill cadence line shown when a charged skill exists:
+
+```tsx
+            {config.chargedMultiplier > 0 && config.chargeCount > 0 && (
+                <div className="flex justify-between mb-2">
+                    <span className="text-theme-text-secondary">Charged skill fires:</span>
+                    <span>
+                        {(() => {
+                            const fires = simResult.rounds.filter(
+                                (r) => r.action === 'charged'
+                            ).length;
+                            return fires > 0
+                                ? `every ${(simResult.rounds.length / fires).toFixed(1)} rounds`
+                                : '—';
+                        })()}
+                    </span>
+                </div>
+            )}
+```
+
+- [ ] **Step 6: Build + lint**
+
+Run: `npm run lint && npm test`
+Expected: PASS.
+
+- [ ] **Step 7: Manual smoke test**
+
+Run: `npm start`. Open the DPS calculator. Select a ship with a charge gain (e.g. Chakara, Cobalt, Thresh). Confirm: the "Charge Manipulation" section auto-opens and shows the parsed self gain; setting "Ally charges / round" or "Enemy Type" (for Thresh) changes the "Charged skill fires: every X rounds" line and the damage totals.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/calculator/CombatSettingsPanel.tsx src/components/calculator/ShipConfigCard.tsx src/components/calculator/ShipConfigSummary.tsx
+git commit -m "feat: charge manipulation UI section + enemy-type selector"
+```
+
+---
+
+## Task 6: Docs + changelog
+
+**Files:**
+- Modify: `src/pages/DocumentationPage.tsx`
+- Modify: `src/constants/changelog.ts`
+
+- [ ] **Step 1: Update in-app docs**
+
+In `src/pages/DocumentationPage.tsx`, find the DPS calculator section and the "About the Simulation" prose (search "Conditional" / "Secondary" added in prior features). Add a short paragraph describing charge manipulation: self charge gains parsed from skill text (conditions auto-counted from sim state, or a manual trigger count), the flat "Ally charges / round" supporter input, the enemy-type selector, and that these change how often the charged skill fires.
+
+- [ ] **Step 2: Add changelog entry**
+
+In `src/constants/changelog.ts`, add to `UNRELEASED_CHANGES` a plain-English entry, e.g.:
+
+> "DPS calculator now models charge manipulation: ships that add charges to their Charged Skill (and supporter ships that feed charges to allies) make the charged skill fire sooner. Includes a new enemy-type selector for type-conditional charge gains."
+
+- [ ] **Step 3: Build + lint**
+
+Run: `npm run lint && npm test`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/DocumentationPage.tsx src/constants/changelog.ts
+git commit -m "docs: document charge manipulation in DPS calculator"
+```
+
+---
+
+## Final verification
+
+- [ ] Run `npm test` — all pass.
+- [ ] Run `npm run lint` — zero warnings (max-warnings: 0).
+- [ ] Manual: charge gain auto-fills for Chakara/Cobalt/Thresh/Nuqtu; ally-charge + enemy-type inputs shift cadence and totals; ships without a charged skill ignore the inputs.
+- [ ] Update memory: mark charge manipulation shipped in `project_dps_skill_mechanic_pipeline.md` and pick the next target.

--- a/docs/superpowers/plans/2026-05-31-charge-manipulation.md
+++ b/docs/superpowers/plans/2026-05-31-charge-manipulation.md
@@ -236,40 +236,55 @@ Expected: FAIL with "parseChargeGain is not a function" (or import error).
 
 - [ ] **Step 3: Implement `parseChargeGain`**
 
-Add to `src/utils/skillTextParser.ts` (import `ChargeGain`, `EnemyBaseClass` from `../types/calculator` alongside the existing `ConditionalDamage`, `ConditionalCondition` imports). Place after `parseConditionalDamage`:
+Add to `src/utils/skillTextParser.ts` (import `ChargeGain`, `EnemyBaseClass` from `../types/calculator` alongside the existing `ConditionalDamage`, `ConditionalCondition` imports). Place after `parseConditionalDamage`.
+
+**Key approach:** strip the `<unit-aid>` / `<unit-skill>` / `<unit-damage>` tags first, then match plain text. The tags wrap the amount in some skills (Chakara: `<unit-aid>adds 1 charge</unit-aid>`) but wrap the *nouns* in others (Rhodium: `<unit-aid>Charged Skill</unit-aid>` … `<unit-aid>Buffs</unit-aid>`), so tag-spanning regexes are brittle. Stripping tags makes both forms plain. Self-vs-removal is distinguished by the verb (`adds`/`gains` vs `removes`), not the tag.
+
+> First check whether the file already has a tag-stripping helper near line 40 (there is a tag-matching comment there). If one exists, reuse it; otherwise add `stripUnitTags` below.
 
 ```ts
+function stripUnitTags(text: string): string {
+    return text.replace(/<\/?unit-(?:aid|skill|damage)>/gi, '');
+}
+
 // Phrases that disqualify a charge phrase from being a self-gain we model:
 // ally-grant to others, on-kill (enemy never dies), enemy-repair (never repairs).
 const CHARGE_DISQUALIFY_RE =
     /all allies|their charged skill|charged skill of all allies|upon killing|killing an enemy|when an enemy dies|when an enemy repairs|enemy performs a repair|enemy repairs/i;
 
-// "adds/gains N charge(s)" inside a <unit-aid> tag (self-add; "removes" is excluded
-// because the verb is constrained to adds/gains).
-const SELF_CHARGE_ADD_RE =
-    /<unit-aid>\s*(?:adds?|gains?)\s+(\d+|a|an)\s+charges?\s*<\/unit-aid>/i;
+// "adds/gains N charge(s)" (self-add). "removes" is excluded by the verb set, so
+// Thresh's "removes 1 charge ... and adds 1 charge" matches only the add.
+const SELF_CHARGE_ADD_RE = /\b(?:adds?|gains?)\s+(\d+|a|an)\s+charges?\b/i;
 
-// Rhodium-style untagged form: "adds charges to the Charged Skill equal to the
-// number of buffs on the target".
-const PER_BUFF_CHARGE_RE = /adds?\s+charges?\s+to\s+the\s+<?[^>]*charged skill[^.]*equal to the number of/i;
+// Rhodium-style form: "adds charges to the Charged Skill equal to the number of
+// buffs on the target" (amount is per-buff = 1). Runs on tag-stripped text.
+const PER_BUFF_CHARGE_RE =
+    /adds?\s+charges?\s+to\s+the\s+charged skill[^.]*equal to the number of/i;
 
 function classifyChargeCondition(
-    text: string
+    text: string // already tag-stripped, any case
 ): { condition: ConditionalCondition; derivable: boolean; requiredEnemyType?: EnemyBaseClass } {
     const p = text.toLowerCase();
     if (p.includes('is a defender'))
         return { condition: 'enemy-type', derivable: true, requiredEnemyType: 'Defender' };
-    if (p.includes('critically damag') || p.includes('critically hit') || p.includes('critical'))
+    if (p.includes('critically damag') || p.includes('critically hit'))
         return { condition: 'self-crit', derivable: true };
     if (p.includes('inflict') && p.includes('debuff'))
         return { condition: 'enemy-debuff', derivable: true };
     if (p.includes('stealth')) return { condition: 'enemy-buff', derivable: false };
-    if (p.includes('buffs on the target') || p.includes('buff on the target') ||
-        p.includes('or more buffs') || p.includes('buffs on the enemy') ||
-        p.includes('number of buffs'))
+    if (
+        p.includes('buffs on the target') ||
+        p.includes('buff on the target') ||
+        p.includes('or more buffs') ||
+        p.includes('buffs on the enemy') ||
+        p.includes('number of buffs')
+    )
         return { condition: 'enemy-buff', derivable: false };
-    if (p.includes('2 or more enemies') || p.includes('two or more enemies') ||
-        p.includes('damages 2'))
+    if (
+        p.includes('2 or more enemies') ||
+        p.includes('two or more enemies') ||
+        p.includes('damages 2')
+    )
         return { condition: 'enemy-adjacent', derivable: false };
     // speed / full-HP / lowest-speed and anything else → always-true under sim assumptions
     return { condition: 'always', derivable: true };
@@ -284,20 +299,21 @@ function classifyChargeCondition(
  */
 export function parseChargeGain(text: string | null | undefined): ChargeGain | null {
     if (!text) return null;
-    if (CHARGE_DISQUALIFY_RE.test(text)) return null;
+    const plain = stripUnitTags(text);
+    if (CHARGE_DISQUALIFY_RE.test(plain)) return null;
 
     // Rhodium "equal to the number of buffs" form (amount is per-buff = 1).
-    if (PER_BUFF_CHARGE_RE.test(text)) {
+    if (PER_BUFF_CHARGE_RE.test(plain)) {
         return { amount: 1, condition: 'enemy-buff', derivable: false };
     }
 
-    const m = SELF_CHARGE_ADD_RE.exec(text);
+    const m = SELF_CHARGE_ADD_RE.exec(plain);
     if (!m) return null;
     const raw = m[1].toLowerCase();
     const amount = raw === 'a' || raw === 'an' ? 1 : parseInt(raw, 10);
     if (!amount || isNaN(amount)) return null;
 
-    const { condition, derivable, requiredEnemyType } = classifyChargeCondition(text);
+    const { condition, derivable, requiredEnemyType } = classifyChargeCondition(plain);
     return {
         amount,
         condition,
@@ -306,6 +322,8 @@ export function parseChargeGain(text: string | null | undefined): ChargeGain | n
     };
 }
 ```
+
+> Note for the test in Step 1: the Rhodium fixture's `<unit-aid>` tags around "Charged Skill"/"Buffs" are stripped before matching, so `PER_BUFF_CHARGE_RE` and the `number of buffs` classifier both hit. Verify mentally: stripped Rhodium = "Unit adds charges to the Charged Skill equal to the number of Buffs on the target." → matches `PER_BUFF_CHARGE_RE` → returns `{ amount: 1, condition: 'enemy-buff', derivable: false }`. ✓
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -465,10 +483,7 @@ In the round loop, immediately **after** the conditional-bonus block (the `condi
                         break;
                     case 'enemy-type':
                         chargeGainCount =
-                            enemyType !== undefined &&
-                            enemyType === selfChargeGain.requiredEnemyType
-                                ? 1
-                                : 0;
+                            enemyType === selfChargeGain.requiredEnemyType ? 1 : 0;
                         break;
                     default:
                         // enemy-buff, enemy-adjacent, adjacent-ally, enemy-destroyed

--- a/docs/superpowers/plans/2026-06-03-effective-hp-stat-limit.md
+++ b/docs/superpowers/plans/2026-06-03-effective-hp-stat-limit.md
@@ -1,0 +1,479 @@
+# Effective HP Stat Limit — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add "Effective HP" as a selectable stat limit in autogear config that behaves exactly like existing limits (min/max + hard requirement).
+
+**Architecture:** Effective HP is a *derived* value (from `hp` + `defence` + `damageReduction`), not a base stat. Keep `StatName` clean for gear/import/display; introduce a `LimitableStat = StatName | 'effectiveHp'` type used only by limits. A single resolver (`resolveLimitStatValue`) computes the value at every limit read-site via the existing `calculateEffectiveHP`. Labels resolve through `getLimitStatLabel` since `STATS` is keyed by `StatName`.
+
+**Tech Stack:** React 18, TypeScript, Vite, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-effective-hp-stat-limit-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `src/types/stats.ts` | Stat type vocabulary | Add `DerivedStatName`, `LimitableStat` |
+| `src/types/autogear.ts` | `StatPriority` | Widen `.stat` to `LimitableStat` |
+| `src/utils/autogear/AutogearStrategy.ts` | `HardRequirementViolation` | Widen `.stat` to `LimitableStat` |
+| `src/utils/autogear/priorityScore.ts` | Scoring + limit checks | Add `resolveLimitStatValue`; route read-sites |
+| `src/utils/autogear/scoring.ts` | Re-export barrel | Re-export `resolveLimitStatValue` |
+| `src/utils/autogear/strategies/GeneticStrategy.ts` | Hard-violation builder | Route read-site through resolver |
+| `src/pages/manager/AutogearPage.tsx` | Unmet-priorities display | Route read-site through resolver |
+| `src/constants/stats.ts` | Labels + normalizers | Add `effectiveHp` normalizer, `getLimitStatLabel`, `DERIVED_STAT_LABELS` |
+| `src/components/stats/StatPriorityForm.tsx` | Limit picker form | Add `effectiveHp` to options; type as `LimitableStat` |
+| `src/components/autogear/StatPriorityRow.tsx` | Limit row label | Use `getLimitStatLabel` |
+| `src/components/autogear/GearSuggestions.tsx` | Violation banner label | Use `getLimitStatLabel` |
+| `src/components/autogear/AutogearConfigList.tsx` | Config list label | Use `getLimitStatLabel` |
+| `src/constants/changelog.ts` | Changelog | Add `UNRELEASED_CHANGES` entry |
+| `src/pages/DocumentationPage.tsx` | In-app docs | Mention effective-HP limit |
+| `src/utils/autogear/__tests__/priorityScore.test.ts` | Tests | Add `effectiveHp` resolution + limit tests |
+
+---
+
+## Task 1: Types + `resolveLimitStatValue` + route read-sites
+
+This is the functional core. The type widening and the resolver MUST land together — widening `StatPriority.stat` to `LimitableStat` makes the bare `stats[priority.stat]` indexing fail to type-check, so the resolver replaces those sites in the same task.
+
+**Files:**
+- Modify: `src/types/stats.ts`
+- Modify: `src/types/autogear.ts`
+- Modify: `src/utils/autogear/AutogearStrategy.ts`
+- Modify: `src/utils/autogear/priorityScore.ts`
+- Modify: `src/utils/autogear/strategies/GeneticStrategy.ts`
+- Modify: `src/pages/manager/AutogearPage.tsx`
+- Modify: `src/constants/stats.ts` (normalizer only)
+- Test: `src/utils/autogear/__tests__/priorityScore.test.ts`
+
+- [ ] **Step 1: Add the derived-stat types** in `src/types/stats.ts`, immediately after the `StatName` definition (after line 21):
+
+```ts
+// Derived (computed) stats that can be used as autogear *limits* but are not
+// real gear/base stats. Kept out of StatName so gear rolls, imports, and stat
+// display are unaffected.
+export type DerivedStatName = 'effectiveHp';
+
+// Stat identifiers usable as autogear limit targets: every base StatName plus
+// derived stats resolved on the fly (see resolveLimitStatValue).
+export type LimitableStat = StatName | DerivedStatName;
+```
+
+- [ ] **Step 2: Widen `StatPriority.stat`** in `src/types/autogear.ts`. Change the import and the field:
+
+```ts
+// import line (was: import { StatName } from './stats';)
+import { StatName, LimitableStat } from './stats';
+```
+
+```ts
+export interface StatPriority {
+    stat: LimitableStat;
+    weight?: number;
+    minLimit?: number;
+    maxLimit?: number;
+    hardRequirement?: boolean;
+}
+```
+
+(Leave other uses of `StatName` in this file — e.g. `FleetBuff.stat` — unchanged.)
+
+- [ ] **Step 3: Widen `HardRequirementViolation.stat`** in `src/utils/autogear/AutogearStrategy.ts`:
+
+```ts
+// ensure LimitableStat is imported from '../../types/stats'
+export interface HardRequirementViolation {
+    stat: LimitableStat;
+    kind: 'min' | 'max';
+    limit: number;
+    actual: number;
+}
+```
+
+Check the existing import line at the top of the file; add `LimitableStat` to the `../../types/stats` import (or create one if absent).
+
+- [ ] **Step 4: Write the failing test** in `src/utils/autogear/__tests__/priorityScore.test.ts`. Add to the imports at the top:
+
+```ts
+import {
+    calculatePriorityScore,
+    resolveLimitStatValue,
+    calculateHardViolation,
+    calculateEffectiveHP,
+} from '../priorityScore';
+import { StatPriority } from '../../../types/autogear';
+```
+
+(Adjust the existing `calculatePriorityScore` import line rather than duplicating it.) Then append:
+
+```ts
+describe('resolveLimitStatValue', () => {
+    it('passes base stats through unchanged', () => {
+        expect(resolveLimitStatValue(stats, 'hp')).toBe(stats.hp);
+        expect(resolveLimitStatValue(stats, 'defence')).toBe(stats.defence);
+    });
+
+    it('resolves effectiveHp via calculateEffectiveHP', () => {
+        expect(resolveLimitStatValue(stats, 'effectiveHp')).toBeCloseTo(
+            calculateEffectiveHP(stats.hp, stats.defence, stats.damageReduction ?? 0),
+            5
+        );
+    });
+
+    it('does not produce NaN/Infinity when defence is 0', () => {
+        const zeroDef: typeof stats = { ...stats, defence: 0 };
+        const ehp = resolveLimitStatValue(zeroDef, 'effectiveHp');
+        expect(Number.isFinite(ehp)).toBe(true);
+        expect(ehp).toBeGreaterThan(0);
+    });
+});
+
+describe('effectiveHp as a limit', () => {
+    it('reports a hard violation when effectiveHp is below an unreachable min', () => {
+        const priorities: StatPriority[] = [
+            { stat: 'effectiveHp', minLimit: 100_000_000, hardRequirement: true, weight: 1 },
+        ];
+        expect(calculateHardViolation(stats, priorities)).toBeGreaterThan(0);
+    });
+
+    it('reports no hard violation when effectiveHp min is met', () => {
+        const priorities: StatPriority[] = [
+            { stat: 'effectiveHp', minLimit: 1, hardRequirement: true, weight: 1 },
+        ];
+        expect(calculateHardViolation(stats, priorities)).toBe(0);
+    });
+
+    it('applies a soft penalty when an effectiveHp min limit is missed', () => {
+        const unmet: StatPriority[] = [
+            { stat: 'effectiveHp', minLimit: 100_000_000, weight: 1 },
+        ];
+        const met: StatPriority[] = [{ stat: 'effectiveHp', minLimit: 1, weight: 1 }];
+        const scoreUnmet = calculatePriorityScore(stats, unmet, 'DEFENDER');
+        const scoreMet = calculatePriorityScore(stats, met, 'DEFENDER');
+        expect(scoreUnmet).toBeLessThan(scoreMet);
+    });
+});
+```
+
+- [ ] **Step 5: Run the test, verify it fails** (resolver not exported yet):
+
+Run: `npm test -- src/utils/autogear/__tests__/priorityScore.test.ts`
+Expected: FAIL — `resolveLimitStatValue is not a function` / import error.
+
+- [ ] **Step 6: Implement `resolveLimitStatValue`** in `src/utils/autogear/priorityScore.ts`, immediately after `calculateEffectiveHP` (after line 25). Also add the `LimitableStat` import:
+
+```ts
+// top of file — extend the stats import
+import { BaseStats, LimitableStat } from '../../types/stats';
+```
+
+```ts
+/**
+ * Resolve the value to compare against a stat limit. Base stats pass through;
+ * derived stats (effectiveHp) are computed from the build's stats on the fly.
+ */
+export function resolveLimitStatValue(stats: BaseStats, stat: LimitableStat): number {
+    if (stat === 'effectiveHp') {
+        return calculateEffectiveHP(stats.hp, stats.defence, stats.damageReduction ?? 0);
+    }
+    return stats[stat] || 0;
+}
+```
+
+- [ ] **Step 7: Route the three `priorityScore.ts` read-sites** through the resolver.
+
+`calculateDefaultScore` (~line 340):
+```ts
+        const statValue = resolveLimitStatValue(stats, priority.stat);
+        const normalizer = STAT_NORMALIZERS[priority.stat] || 1;
+```
+
+`calculateHardViolation` (~line 358):
+```ts
+        const value = resolveLimitStatValue(stats, p.stat);
+```
+
+`calculatePriorityScore` soft-penalty loop (~line 384):
+```ts
+        const statValue = resolveLimitStatValue(stats, priority.stat);
+```
+
+- [ ] **Step 8: Add the `effectiveHp` normalizer** in `src/constants/stats.ts` inside `STAT_NORMALIZERS` (after line 136, before the closing brace):
+
+```ts
+    effectiveHp: 30000, // effectiveHP runs ~1.3-5x raw hp; normalize above hp's 10k
+```
+
+- [ ] **Step 9a: Re-export `resolveLimitStatValue` from the scoring barrel.** `src/utils/autogear/scoring.ts` is a re-export barrel for every `priorityScore` helper, and `GeneticStrategy` imports from it (not directly from `priorityScore`). Add `resolveLimitStatValue` to BOTH the import-from-`./priorityScore` block (~lines 12-21) and the `export { ... }` re-export block (~lines 24-33) in `scoring.ts`:
+
+```ts
+import {
+    calculatePriorityScore,
+    // ...existing...
+    calculateHardViolation,
+    resolveLimitStatValue,
+} from './priorityScore';
+
+// Re-export ... so existing imports from this module continue to work
+export {
+    calculatePriorityScore,
+    // ...existing...
+    calculateHardViolation,
+    resolveLimitStatValue,
+};
+```
+
+- [ ] **Step 9b: Route `GeneticStrategy.ts` read-site** (~line 364). Add `resolveLimitStatValue` to the existing import from `'../scoring'` (line 8: `import { calculateTotalScore, calculateHardViolation, clearScoreCache } from '../scoring';`), then replace the read:
+
+```ts
+import { calculateTotalScore, calculateHardViolation, clearScoreCache, resolveLimitStatValue } from '../scoring';
+```
+```ts
+            const value = resolveLimitStatValue(stats, p.stat);
+```
+
+- [ ] **Step 10: Route `AutogearPage.tsx` read-site** (~line 900). Add `resolveLimitStatValue` to the existing import from `../../utils/autogear/priorityScore` (or add an import), then:
+
+```ts
+            const currentValue = resolveLimitStatValue(stats, priority.stat);
+```
+
+- [ ] **Step 11: Run the tests, verify they pass:**
+
+Run: `npm test -- src/utils/autogear/__tests__/priorityScore.test.ts`
+Expected: PASS (all new + existing cases).
+
+- [ ] **Step 12: Type-check the whole project:**
+
+Run: `npx tsc --noEmit`
+Expected: no errors. (If a `stats[stat]` site outside the routed five still fails, route it through `resolveLimitStatValue` too.)
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/types/stats.ts src/types/autogear.ts src/utils/autogear/AutogearStrategy.ts src/utils/autogear/priorityScore.ts src/utils/autogear/scoring.ts src/utils/autogear/strategies/GeneticStrategy.ts src/pages/manager/AutogearPage.tsx src/constants/stats.ts src/utils/autogear/__tests__/priorityScore.test.ts
+git commit -m "feat: resolve effective HP as an autogear limit stat"
+```
+
+---
+
+## Task 2: Labels (`getLimitStatLabel`)
+
+`STATS` is `Record<StatName, ...>` and will not contain `effectiveHp`, so `STATS[stat].label` is `undefined` for the derived stat (and two render sites access it unsafely). Add a resolver and use it everywhere a limit stat is labelled.
+
+**Files:**
+- Modify: `src/constants/stats.ts`
+- Modify: `src/components/stats/StatPriorityForm.tsx`
+- Modify: `src/components/autogear/StatPriorityRow.tsx`
+- Modify: `src/components/autogear/GearSuggestions.tsx`
+- Modify: `src/components/autogear/AutogearConfigList.tsx`
+- Test: `src/constants/__tests__/stats.test.ts` (create if absent — check first)
+
+- [ ] **Step 1: Write the failing test.** Check for an existing stats test file first:
+
+Run: `ls src/constants/__tests__/ 2>/dev/null`
+
+Create `src/constants/__tests__/stats.test.ts` (or append if it exists):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { getLimitStatLabel } from '../stats';
+
+describe('getLimitStatLabel', () => {
+    it('returns the STATS label for a base stat', () => {
+        expect(getLimitStatLabel('hp')).toBe('HP');
+    });
+    it('returns a human label for the derived effectiveHp stat', () => {
+        expect(getLimitStatLabel('effectiveHp')).toBe('Effective HP');
+    });
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails:**
+
+Run: `npm test -- src/constants/__tests__/stats.test.ts`
+Expected: FAIL — `getLimitStatLabel is not a function`.
+
+- [ ] **Step 3: Implement labels** in `src/constants/stats.ts`. Update the type import and add the map + resolver near the bottom of the file (after `STAT_NORMALIZERS`):
+
+```ts
+// top: was `import type { StatName, StatType } from '../types/stats';`
+import type { StatName, StatType, LimitableStat, DerivedStatName } from '../types/stats';
+```
+
+```ts
+// Labels for derived limit stats (not present in STATS, which is keyed by StatName).
+export const DERIVED_STAT_LABELS: Record<DerivedStatName, { label: string; shortLabel: string }> =
+    {
+        effectiveHp: { label: 'Effective HP', shortLabel: 'EHP' },
+    };
+
+/** Display label for any limitable stat, including derived ones. */
+export function getLimitStatLabel(stat: LimitableStat): string {
+    return (
+        STATS[stat as StatName]?.label ??
+        DERIVED_STAT_LABELS[stat as DerivedStatName]?.label ??
+        stat
+    );
+}
+```
+
+- [ ] **Step 4: Run it, verify it passes:**
+
+Run: `npm test -- src/constants/__tests__/stats.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Use `getLimitStatLabel` at the render sites.**
+
+`src/components/autogear/StatPriorityRow.tsx` (~line 73) — was `{STATS[priority.stat].label}`:
+```tsx
+{getLimitStatLabel(priority.stat)}
+```
+
+`src/components/autogear/GearSuggestions.tsx` (~line 86) — was `{STATS[v.stat].label}`:
+```tsx
+{getLimitStatLabel(v.stat)}
+```
+
+`src/components/autogear/AutogearConfigList.tsx` (~line 83) — was `{STATS[priority.stat]?.label || priority.stat}`:
+```tsx
+{getLimitStatLabel(priority.stat)}
+```
+
+In each file, add `getLimitStatLabel` to the existing `../../constants/stats` (or `../../constants`) import. Remove the now-unused `STATS` import only if nothing else in the file uses it.
+
+- [ ] **Step 6: Type-check:**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/constants/stats.ts src/constants/__tests__/stats.test.ts src/components/autogear/StatPriorityRow.tsx src/components/autogear/GearSuggestions.tsx src/components/autogear/AutogearConfigList.tsx
+git commit -m "feat: label derived effective-HP limit stat safely"
+```
+
+---
+
+## Task 3: UI — add to the Limits dropdown
+
+**Files:**
+- Modify: `src/components/stats/StatPriorityForm.tsx`
+
+- [ ] **Step 1: Widen the available-stats list and state.** In `src/components/stats/StatPriorityForm.tsx`:
+
+Imports:
+```tsx
+import { StatName, LimitableStat } from '../../types/stats';
+import { StatPriority } from '../../types/autogear';
+import { STATS, getLimitStatLabel } from '../../constants/stats';
+```
+
+Available stats (line 7) — type as `LimitableStat[]` and append `effectiveHp`:
+```tsx
+const AVAILABLE_STATS: LimitableStat[] = [
+    'attack',
+    'defence',
+    'hp',
+    'effectiveHp',
+    'speed',
+    'crit',
+    'critDamage',
+    'hacking',
+    'security',
+    'healModifier',
+    'shield',
+];
+```
+
+State (line 37):
+```tsx
+    const [selectedStat, setSelectedStat] = useState<LimitableStat>(AVAILABLE_STATS[0]);
+```
+
+`onChange` cast (line 94):
+```tsx
+                    onChange={(value) => setSelectedStat(value as LimitableStat)}
+```
+
+Option labels (lines 95-98) — use the resolver:
+```tsx
+                    options={AVAILABLE_STATS.map((stat) => ({
+                        value: stat,
+                        label: getLimitStatLabel(stat),
+                    }))}
+```
+
+`STATS` may now be unused in this file — if ESLint flags it, drop it from the import.
+
+- [ ] **Step 2: Type-check and lint:**
+
+Run: `npx tsc --noEmit && npm run lint`
+Expected: no errors, 0 warnings.
+
+- [ ] **Step 3: Manual smoke check** (optional, if dev server available): open Autogear → add a Limit → confirm "Effective HP" appears in the dropdown, accepts a min, and a row renders with the "Effective HP" label.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/stats/StatPriorityForm.tsx
+git commit -m "feat: offer Effective HP in the autogear limit picker"
+```
+
+---
+
+## Task 4: Docs + changelog
+
+**Files:**
+- Modify: `src/constants/changelog.ts`
+- Modify: `src/pages/DocumentationPage.tsx`
+
+- [ ] **Step 1: Add a changelog entry.** In `src/constants/changelog.ts`, append to the `UNRELEASED_CHANGES` array:
+
+```ts
+    'Autogear: you can now set a minimum (or maximum) Effective HP as a stat limit — handy when you care about overall survivability rather than tuning HP and Defense separately. Works as a soft limit or a hard requirement like any other stat.',
+```
+
+- [ ] **Step 2: Mention it in the docs.** In `src/pages/DocumentationPage.tsx`, in the "Stat Priorities" card (~line 1313), extend the description paragraph to note the derived stat. Append a sentence to the existing first `<p>`:
+
+```tsx
+                                        optimizing the overall build. You can also limit{' '}
+                                        <strong>Effective HP</strong> — a derived survivability
+                                        value combining HP, Defense, and damage reduction.
+```
+
+(Keep the surrounding JSX intact; only extend the sentence inside the existing paragraph.)
+
+- [ ] **Step 3: Type-check and lint:**
+
+Run: `npx tsc --noEmit && npm run lint`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/constants/changelog.ts src/pages/DocumentationPage.tsx
+git commit -m "docs: note Effective HP autogear limit"
+```
+
+---
+
+## Task 5: Full verification
+
+- [ ] **Step 1: Run the full test suite:**
+
+Run: `npm test`
+Expected: all pass.
+
+- [ ] **Step 2: Lint + type-check:**
+
+Run: `npm run lint && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Final review** — confirm every `stats[priority.stat]` / `stats[p.stat]` limit read-site goes through `resolveLimitStatValue`, and every limit-stat label goes through `getLimitStatLabel`:
+
+Run: `grep -rn "stats\[priority.stat\]\|stats\[p.stat\]\|STATS\[priority.stat\]\|STATS\[v.stat\]" src/`
+Expected: no remaining limit read/label sites (matches in unrelated code that legitimately uses base `StatName` are fine).

--- a/docs/superpowers/specs/2026-05-31-charge-manipulation-design.md
+++ b/docs/superpowers/specs/2026-05-31-charge-manipulation-design.md
@@ -45,16 +45,26 @@ These bound which triggers are modelable and how:
 | Trigger phrasing | Ships | Model |
 |---|---|---|
 | enemies faster / lowest speed / at full HP | Chakara, Cobalt | `always` → count 1 |
-| after critically damaging | Asphodel, Hermes | `self-crit` → count = effectiveCrit/100 |
+| after critically damaging (own crit) | Asphodel | `self-crit` → count = effectiveCrit/100 |
 | target has N buffs / per buff on target | Nuqtu, Rhodium | `enemy-buff` (manual count) |
 | after inflicting a debuff | Hemlock | `enemy-debuff` (derivable) |
 | hits 2+ enemies | Tygr | `enemy-adjacent` (manual count) |
 | target is a Defender | Thresh | `enemy-type` (new global input) |
 | target is Stealthed | Selenite | `enemy-buff` "Stealth" present (manual count) |
 | on kill / when enemy repairs | Valiant, Obsidian, Zosimos | **excluded** (never fire) |
-| ally crits / enemy dies → allies gain | Hermes, Liberator, Castor | **external** → `allyChargePerRound` (manual) |
+| **ally** crits / enemy dies → allies gain | Hermes (gains on *ally* crit), Liberator | **external** → `allyChargePerRound` (manual) |
 | removes N charges from enemy | Demolisher, Thresh, Zosimos | **out of scope** (no enemy charged skill in single-ship sim) |
 | starts combat fully Charged | Sansi, Valkyrie, … | already handled via `startCharged` |
+
+Notes:
+- **Thresh has two charge clauses in one skill**: "removes 1 charge from the enemy
+  **and** adds 1 charge to this Unit's Charged Skill". `parseChargeGain` must
+  extract the *self-add* ("adds 1 charge to this Unit's Charged Skill" + the
+  "If the target is a Defender" condition → `enemy-type`) and ignore the
+  enemy-removal clause in the same sentence.
+- Castor (cited earlier as an ally-charge supporter) is **not** in
+  `docs/ship-skills.csv`, so it is not a parser fixture — ally charges are
+  manual (`allyChargePerRound`) regardless.
 
 ## Data model (`src/types/calculator.ts`)
 
@@ -66,6 +76,7 @@ interface ChargeGain {
   condition: ConditionalCondition; // reused enum + 3 new variants
   derivable: boolean;              // true → read sim state; false → use manualCount
   manualCount?: number;            // used when !derivable (default 1)
+  requiredEnemyType?: EnemyBaseClass; // only for condition 'enemy-type' (Thresh → 'Defender')
 }
 ```
 
@@ -74,52 +85,88 @@ conditionals):
 
 - `'always'` — unconditional, or a condition that is always-true under the sim
   assumptions (Chakara speed, Cobalt full-HP). Count = 1.
-- `'self-crit'` — derivable. Count = effectiveCrit / 100 (Asphodel, Hermes).
-- `'enemy-type'` — derivable from the new global enemy-type input (Thresh
+- `'self-crit'` — derivable. Count = effectiveCrit / 100 (Asphodel only). Note
+  Hermes is *not* self-crit — it gains on **ally** crits → external/manual.
+- `'enemy-type'` — derivable from the new **global** enemy-type input (Thresh
   "if Defender"). Count = 1 when the enemy type matches, else 0.
 
 Existing reused conditions: `self-buff`, `enemy-debuff` (derivable, linear);
 `enemy-buff`, `enemy-adjacent` (manual count). Add labels for the new variants to
 `CONDITIONAL_CONDITION_LABELS`.
 
-Add to `DPSShipConfig`:
+Define a small enemy-class enum (deliberately **not** `ShipTypeName` from
+`src/constants/shipTypes.ts`, whose role list has variants like
+`Defender(Security)`):
+
+```ts
+type EnemyBaseClass = 'Attacker' | 'Defender' | 'Debuffer' | 'Supporter';
+```
+
+Add to **`DPSShipConfig`** (per-attacker, auto-filled / user-tuned):
 
 - `selfChargeGain?: ChargeGain`
 - `allyChargePerRound?: number`
-- `enemyType?: EnemyBaseClass` — `'Attacker' | 'Defender' | 'Debuffer' | 'Supporter'`
-  (a small enum, not the full role list)
+
+Enemy type is a property of the **enemy, not each attacker**, so it is **global
+page state** (alongside `enemyDefense` / `enemyHp` / `enemySecurity` /
+`enemyAffinity` in `DPSCalculatorPage`), **not** on `DPSShipConfig`. The required
+type for the `enemy-type` condition is stored on the parsed `ChargeGain` (e.g. a
+`requiredEnemyType?: EnemyBaseClass` field, or implied as "Defender" for the only
+known case) and compared against the global value in the sim.
 
 Extend the `autoFilledFields` Set union with `'selfChargeGain'`.
 
-Add to `DPSSimulationInput`: `selfChargeGain?`, `allyChargePerRound?`,
-`enemyType?` (same types as above).
+Add to `DPSSimulationInput`: `selfChargeGain?: ChargeGain`,
+`allyChargePerRound?: number`, `enemyType?: EnemyBaseClass`.
 
 ## Simulator (`src/utils/calculators/dpsSimulator.ts`)
 
 Thread `selfChargeGain`, `allyChargePerRound`, and `enemyType` through
 `runSinglePass` params/destructure and the `simulateDPS` call site.
 
-In the round loop, after the action/charge-reset block, compute the bonus
-charges and add them **every round**:
+**Placement (important):** the bonus-charge block must go **after** the existing
+conditional-bonus evaluation (currently ~dpsSimulator.ts:332-352), *not* after
+the action/charge-reset block at ~244-256. It depends on values that only exist
+later in the round: `effectiveCrit` (computed ~line 294, needed for `self-crit`)
+and `landedEnemyDebuffs` + DoT arrays (computed ~line 341, needed for the
+`enemy-debuff` derivable count). Adding it at the reset block would reference
+undefined locals. The block reuses the same counting expressions as
+`conditionalBonusPct` (self-buff count, enemy-debuff count).
+
+The bonus is computed every round, then applied to `charges`. Because the
+threshold check happens at the **top** of the round (line 244) reading the value
+carried from the previous round, adding the bonus at the bottom of the round body
+means it counts toward the *next* round's check — matching the existing `+1`
+active-round semantics:
 
 ```ts
-// Count derived exactly like conditionalBonusPct.
+// Count derived exactly like conditionalBonusPct above.
 let chargeGainCount = 0;
 if (selfChargeGain) {
   switch (selfChargeGain.condition) {
     case 'always':       chargeGainCount = 1; break;
     case 'self-crit':    chargeGainCount = effectiveCrit / 100; break;
-    case 'self-buff':    chargeGainCount = /* count self buffs */; break;
-    case 'enemy-debuff': chargeGainCount = /* count enemy debuffs */; break;
-    case 'enemy-type':   chargeGainCount = enemyType === requiredType ? 1 : 0; break;
+    case 'self-buff':    chargeGainCount = entry.activeSelfBuffs.filter(
+                           (ab) => ab.stacks === undefined || ab.stacks > 0).length; break;
+    case 'enemy-debuff': chargeGainCount = landedEnemyDebuffs.length +
+                           corrosionEntries.length + infernoEntries.length +
+                           pendingBombs.length; break;
+    case 'enemy-type':   chargeGainCount =
+                           enemyType === selfChargeGain.requiredEnemyType ? 1 : 0; break;
     default:             chargeGainCount = selfChargeGain.manualCount ?? 1; // enemy-buff, enemy-adjacent
   }
 }
-const bonusCharges = selfChargeGain
-  ? chargeGainCount * selfChargeGain.amount
-  : 0;
-charges += bonusCharges + (allyChargePerRound ?? 0);
+const bonusCharges = selfChargeGain ? chargeGainCount * selfChargeGain.amount : 0;
+if (hasChargedSkill) {
+  charges += bonusCharges + (allyChargePerRound ?? 0);
+}
 ```
+
+Note the existing `+1` is added inside the active branch at the top (line 254)
+and the charged round resets to 0 (line 248). So net accumulation toward the next
+fire is: active round = `1 + bonus + ally`; charged round = `bonus + ally` (the
+reset happens before this block runs, so post-fire rounds still bank bonus/ally
+charges — consistent with the "every round" decision).
 
 Charges accumulate **fractionally** for a precise average cadence (e.g. a
 self-crit gain at 70% crit contributes 0.7/round). `roundData.charges` is
@@ -130,22 +177,43 @@ the existing direct/charged damage.
 `hasChargedSkill` gating is unchanged: bonus charges only matter when a charged
 skill exists (`chargedMultiplier > 0 && chargeCount >= 1`).
 
-Ordering note: derivable `self-crit` reads `effectiveCrit`, which is computed
-mid-round; place the charge-gain block after `effectiveCrit` is available.
-
 ## Parser (`src/utils/skillTextParser.ts`)
 
 New `parseChargeGain(text): ChargeGain | null`, a sibling of
-`parseConditionalDamage`. Matches self-targeted charge gains:
+`parseConditionalDamage`.
 
-- "adds N charge(s) to its Charged Skill" / "gains N charge(s) to its Charged
-  Skill" / "gains a charge" → `amount`.
+**Tag-awareness:** in `docs/ship-skills.csv` every charge amount is wrapped in a
+tag — `<unit-aid>adds 1 charge</unit-aid>`, `<unit-aid>gains 2 charges</unit-aid>`,
+`<unit-aid>add 1 charge</unit-aid>` — while the condition clause is plain text
+*outside* the tag, before or after it ("If the target is a Defender, …",
+"… if it is at full HP", "after critically damaging an enemy"). Like
+`parseSecondaryDamage`/`parseSkillDamage`, the regex must tolerate the tag
+wrapping: match the amount inside `<unit-aid>…</unit-aid>` (also handle the
+`<unit-skill>` wrapping used by Castor-style ally lines for the negative case),
+and read the condition from the surrounding plain text. Match the number word too
+("gains a charge" → 1).
+
+Match self-targeted charge gains:
+
+- "adds N charge(s) to its/this Unit's Charged Skill" / "gains N charge(s) to its
+  Charged Skill" / "gains a charge" → `amount`.
 - "adds charges ... equal to the number of buffs on the target" (Rhodium) →
   `amount: 1`, condition `enemy-buff`, derivable false (manual count).
-- Classify the surrounding condition clause into a `ConditionalCondition`
-  (speed/full-HP → `always`; crit → `self-crit`; Defender → `enemy-type`;
-  buffs on target → `enemy-buff`; debuff inflict → `enemy-debuff`; 2+ enemies →
-  `enemy-adjacent`). Default to `always` when no recognizable condition.
+
+**New condition classifier (do not reuse `mapConditionPhrase`):** the existing
+`mapConditionPhrase` (skillTextParser.ts ~180-195) only recognizes the
+conditional-damage "for each …" grammar (buff/debuff on unit/enemy, adjacent
+ally, destroyed enemy) — *none* of the charge triggers use that phrasing. Write a
+dedicated classifier mapping the charge-trigger clauses:
+
+- speed ("more Speed than this Unit", "lowest Speed") / full-HP ("at full HP") → `always`
+- "critically damaging" / "critically hits" (self) → `self-crit`
+- "is a Defender" → `enemy-type` (set `requiredEnemyType: 'Defender'`)
+- "buffs on the target" / "3 or more buffs" → `enemy-buff`
+- "Stealthed" / "has Stealth" → `enemy-buff` (Stealth)
+- "inflicts a debuff" / "after it inflicts a debuff" → `enemy-debuff`
+- "damages 2 or more enemies" → `enemy-adjacent`
+- default → `always` (unconditional self-add)
 
 Returns `null` for:
 
@@ -153,18 +221,30 @@ Returns `null` for:
 - ally-grant-to-others ("all allies add 1 charge", "charged skill of all allies")
 - on-kill / enemy-repair triggers (never fire under sim assumptions)
 
+**Clause precedence:** check the negative/ignore patterns (enemy-removal,
+ally-grant, on-kill, enemy-repair) *before* extracting a self-add, because a
+single skill can contain both (Thresh: "removes 1 charge from the enemy and adds
+1 charge to this Unit's Charged Skill"). Strip/ignore the enemy-removal clause,
+then extract the self-add ("adds 1 charge to this Unit's Charged Skill" +
+"If the target is a Defender" → `enemy-type`). Conversely, a line whose only
+charge phrase is ally-grant/removal returns `null`.
+
 Reference data: `docs/ship-skills.csv`.
 
 ## Page wiring (`src/pages/calculators/DPSCalculatorPage.tsx`)
 
 - Parse `selfChargeGain` in `buildSkillAutoFill` (scan active + passive skill
   texts, like other auto-fills).
-- Seed `selfChargeGain` and defaults for `allyChargePerRound` / `enemyType` in
-  **both** `getInitialConfig` and `selectShipForConfig`.
-- Pass `selfChargeGain`, `allyChargePerRound`, `enemyType` into the
-  `simulateDPS({...})` call.
+- Seed `selfChargeGain` and a default `allyChargePerRound` in **both**
+  `getInitialConfig` and `selectShipForConfig` (per-attacker config).
+- Add `enemyType` as **global page state** (`useState`), alongside the existing
+  `enemyDefense` / `enemyHp` / `enemySecurity` / `enemyAffinity` — *not* on
+  `DPSShipConfig`.
+- Pass per-attacker `selfChargeGain` + `allyChargePerRound` and the global
+  `enemyType` into each `simulateDPS({...})` call.
 - Add an `updateConfigChargeGain` updater mirroring `updateConfigConditional`,
-  plus simple updaters for the flat `allyChargePerRound` and `enemyType`.
+  plus a simple updater for the flat `allyChargePerRound`; `enemyType` uses its
+  own page-level setter.
 - Wire the new props into `<ShipConfigCard>`.
 
 ## UI
@@ -203,8 +283,13 @@ pattern, `card`) per project conventions.
   (enemy-removal → null), Valiant (on-kill → null), Liberator (ally-grant → null).
 - **Simulator** (`src/utils/calculators/__tests__/dpsSimulator.test.ts`):
   cadence-shift assertions using the test convention (`crit:100, critDamage:0` →
-  critMultiplier 1, `enemyDefense:0`). E.g. `chargeCount:3` + `allyChargePerRound:1`
-  → charged fires ~every 2 rounds; `selfChargeGain` with `always` → faster
-  cadence than baseline; `self-crit` at 100% crit → +1/round.
+  critMultiplier 1, `enemyDefense:0`). **Derive expected fire-rounds by hand from
+  the exact accumulation** (active round banks `1 + bonus + ally`; charged round
+  resets to 0 then banks `bonus + ally`; threshold checked at round start), then
+  assert the specific rounds where `action === 'charged'` — do not assert a vague
+  "~every 2 rounds". Cases: baseline (no manipulation) unchanged vs. current
+  behavior; `allyChargePerRound:1` at `chargeCount:3` fires sooner; `selfChargeGain`
+  `always` faster than baseline; `self-crit` at 100% crit contributes +1/round;
+  `enemy-type` gives the bonus only when `enemyType` matches `requiredEnemyType`.
 - **Docs + changelog**: `DocumentationPage.tsx` (DPS section + "About the
   Simulation" prose) and `UNRELEASED_CHANGES` in `src/constants/changelog.ts`.

--- a/docs/superpowers/specs/2026-05-31-charge-manipulation-design.md
+++ b/docs/superpowers/specs/2026-05-31-charge-manipulation-design.md
@@ -191,7 +191,10 @@ tag — `<unit-aid>adds 1 charge</unit-aid>`, `<unit-aid>gains 2 charges</unit-a
 wrapping: match the amount inside `<unit-aid>…</unit-aid>` (also handle the
 `<unit-skill>` wrapping used by Castor-style ally lines for the negative case),
 and read the condition from the surrounding plain text. Match the number word too
-("gains a charge" → 1).
+("gains a charge" → amount 1). (Note: the only CSV instance of "gains a charge"
+is Zosimos, whose enemy-repair condition makes it an excluded → null case via the
+clause precedence below; the number-word handling is illustrative for
+amount extraction.)
 
 Match self-targeted charge gains:
 

--- a/docs/superpowers/specs/2026-05-31-charge-manipulation-design.md
+++ b/docs/superpowers/specs/2026-05-31-charge-manipulation-design.md
@@ -1,0 +1,210 @@
+# Charge Manipulation — DPS Calculator Design
+
+**Date:** 2026-05-31
+**Status:** Approved
+
+## Overview
+
+Skill text frequently changes *when* a ship's Charged Skill fires by adding or
+removing charges ("adds 1 charge to its Charged Skill", "gains 2 charges",
+"when an enemy dies, all allies add 1 charge"). The DPS calculator already
+tracks charges in `runSinglePass` — each active round adds +1 charge, and when
+`charges >= chargeCount` the charged skill fires and charges reset to 0.
+
+This feature feeds two additional charge sources into that accumulator so the
+charged skill fires on a realistic cadence:
+
+1. **Self charge gain** — auto-filled from the attacker's own skill text,
+   evaluated per-round against sim state using the existing conditional-condition
+   machinery.
+2. **Ally charge per round** — a flat, manually-entered number representing
+   supporters (Castor / Liberator / Hermes) that feed charges to the attacker.
+   These live on *other* ships, so they cannot be parsed from the attacker's own
+   skill text.
+
+Both sources accumulate **every round** (active and charged). When the charged
+skill fires, charges **reset to 0** — matching the simulator's current overflow
+behavior. This only shifts cadence; it introduces no new damage slice.
+
+## Sim assumptions (provided by user)
+
+These bound which triggers are modelable and how:
+
+- Enemy never dies → on-kill triggers never fire → **excluded**.
+- Enemy never attacks → attacker always full HP → "if full HP" → **always true**.
+- Speed conditionals → **always true**.
+- Enemy never repairs → "when enemy repairs" triggers → **excluded**.
+- All allies adjacent.
+- Enemy not Stealthed unless that buff is explicitly added.
+- On-crit / N-buffs / N-debuffs / debuff-infliction conditions are already
+  modeled by the existing sim and condition framework.
+- Enemy ship type is added as a new UI input and modeled.
+
+## CSV trigger → model mapping
+
+| Trigger phrasing | Ships | Model |
+|---|---|---|
+| enemies faster / lowest speed / at full HP | Chakara, Cobalt | `always` → count 1 |
+| after critically damaging | Asphodel, Hermes | `self-crit` → count = effectiveCrit/100 |
+| target has N buffs / per buff on target | Nuqtu, Rhodium | `enemy-buff` (manual count) |
+| after inflicting a debuff | Hemlock | `enemy-debuff` (derivable) |
+| hits 2+ enemies | Tygr | `enemy-adjacent` (manual count) |
+| target is a Defender | Thresh | `enemy-type` (new global input) |
+| target is Stealthed | Selenite | `enemy-buff` "Stealth" present (manual count) |
+| on kill / when enemy repairs | Valiant, Obsidian, Zosimos | **excluded** (never fire) |
+| ally crits / enemy dies → allies gain | Hermes, Liberator, Castor | **external** → `allyChargePerRound` (manual) |
+| removes N charges from enemy | Demolisher, Thresh, Zosimos | **out of scope** (no enemy charged skill in single-ship sim) |
+| starts combat fully Charged | Sansi, Valkyrie, … | already handled via `startCharged` |
+
+## Data model (`src/types/calculator.ts`)
+
+New `ChargeGain`, mirroring `ConditionalDamage`:
+
+```ts
+interface ChargeGain {
+  amount: number;                  // charges per trigger (e.g. 1, 2)
+  condition: ConditionalCondition; // reused enum + 3 new variants
+  derivable: boolean;              // true → read sim state; false → use manualCount
+  manualCount?: number;            // used when !derivable (default 1)
+}
+```
+
+Extend `ConditionalCondition` with three variants (also future-proofs damage
+conditionals):
+
+- `'always'` — unconditional, or a condition that is always-true under the sim
+  assumptions (Chakara speed, Cobalt full-HP). Count = 1.
+- `'self-crit'` — derivable. Count = effectiveCrit / 100 (Asphodel, Hermes).
+- `'enemy-type'` — derivable from the new global enemy-type input (Thresh
+  "if Defender"). Count = 1 when the enemy type matches, else 0.
+
+Existing reused conditions: `self-buff`, `enemy-debuff` (derivable, linear);
+`enemy-buff`, `enemy-adjacent` (manual count). Add labels for the new variants to
+`CONDITIONAL_CONDITION_LABELS`.
+
+Add to `DPSShipConfig`:
+
+- `selfChargeGain?: ChargeGain`
+- `allyChargePerRound?: number`
+- `enemyType?: EnemyBaseClass` — `'Attacker' | 'Defender' | 'Debuffer' | 'Supporter'`
+  (a small enum, not the full role list)
+
+Extend the `autoFilledFields` Set union with `'selfChargeGain'`.
+
+Add to `DPSSimulationInput`: `selfChargeGain?`, `allyChargePerRound?`,
+`enemyType?` (same types as above).
+
+## Simulator (`src/utils/calculators/dpsSimulator.ts`)
+
+Thread `selfChargeGain`, `allyChargePerRound`, and `enemyType` through
+`runSinglePass` params/destructure and the `simulateDPS` call site.
+
+In the round loop, after the action/charge-reset block, compute the bonus
+charges and add them **every round**:
+
+```ts
+// Count derived exactly like conditionalBonusPct.
+let chargeGainCount = 0;
+if (selfChargeGain) {
+  switch (selfChargeGain.condition) {
+    case 'always':       chargeGainCount = 1; break;
+    case 'self-crit':    chargeGainCount = effectiveCrit / 100; break;
+    case 'self-buff':    chargeGainCount = /* count self buffs */; break;
+    case 'enemy-debuff': chargeGainCount = /* count enemy debuffs */; break;
+    case 'enemy-type':   chargeGainCount = enemyType === requiredType ? 1 : 0; break;
+    default:             chargeGainCount = selfChargeGain.manualCount ?? 1; // enemy-buff, enemy-adjacent
+  }
+}
+const bonusCharges = selfChargeGain
+  ? chargeGainCount * selfChargeGain.amount
+  : 0;
+charges += bonusCharges + (allyChargePerRound ?? 0);
+```
+
+Charges accumulate **fractionally** for a precise average cadence (e.g. a
+self-crit gain at 70% crit contributes 0.7/round). `roundData.charges` is
+rounded only for display. The `charges >= chargeCount` threshold check is
+unchanged. No new total/summary slice — cadence change naturally redistributes
+the existing direct/charged damage.
+
+`hasChargedSkill` gating is unchanged: bonus charges only matter when a charged
+skill exists (`chargedMultiplier > 0 && chargeCount >= 1`).
+
+Ordering note: derivable `self-crit` reads `effectiveCrit`, which is computed
+mid-round; place the charge-gain block after `effectiveCrit` is available.
+
+## Parser (`src/utils/skillTextParser.ts`)
+
+New `parseChargeGain(text): ChargeGain | null`, a sibling of
+`parseConditionalDamage`. Matches self-targeted charge gains:
+
+- "adds N charge(s) to its Charged Skill" / "gains N charge(s) to its Charged
+  Skill" / "gains a charge" → `amount`.
+- "adds charges ... equal to the number of buffs on the target" (Rhodium) →
+  `amount: 1`, condition `enemy-buff`, derivable false (manual count).
+- Classify the surrounding condition clause into a `ConditionalCondition`
+  (speed/full-HP → `always`; crit → `self-crit`; Defender → `enemy-type`;
+  buffs on target → `enemy-buff`; debuff inflict → `enemy-debuff`; 2+ enemies →
+  `enemy-adjacent`). Default to `always` when no recognizable condition.
+
+Returns `null` for:
+
+- enemy-removal phrasings ("removes N charges from the enemy")
+- ally-grant-to-others ("all allies add 1 charge", "charged skill of all allies")
+- on-kill / enemy-repair triggers (never fire under sim assumptions)
+
+Reference data: `docs/ship-skills.csv`.
+
+## Page wiring (`src/pages/calculators/DPSCalculatorPage.tsx`)
+
+- Parse `selfChargeGain` in `buildSkillAutoFill` (scan active + passive skill
+  texts, like other auto-fills).
+- Seed `selfChargeGain` and defaults for `allyChargePerRound` / `enemyType` in
+  **both** `getInitialConfig` and `selectShipForConfig`.
+- Pass `selfChargeGain`, `allyChargePerRound`, `enemyType` into the
+  `simulateDPS({...})` call.
+- Add an `updateConfigChargeGain` updater mirroring `updateConfigConditional`,
+  plus simple updaters for the flat `allyChargePerRound` and `enemyType`.
+- Wire the new props into `<ShipConfigCard>`.
+
+## UI
+
+- **`ShipConfigCard.tsx`** — new collapsible "Charge Manipulation" section,
+  mirroring the "Conditional Damage" section: self-gain amount + condition
+  select + manual count (shown only for non-derivable conditions) + an
+  "Ally charges / round" numeric field. Re-sync the collapsible open-state with a
+  `useEffect` keyed on the parsed `selfChargeGain` / `allyChargePerRound` values.
+- **`ShipConfigSummary.tsx`** — a breakdown line showing the effective cadence
+  (average rounds between charged skills) and the active charge sources.
+- **Enemy-type selector** — a `Select` (None / Attacker / Defender / Debuffer /
+  Supporter) placed near the enemy stat inputs, feeding the `enemy-type`
+  condition.
+
+All UI uses existing primitives (`Select`, `Input`, `CollapsibleForm`/section
+pattern, `card`) per project conventions.
+
+## Out of scope (flagged)
+
+- Enemy charge removal and ally-grant-to-others as *modeled* effects — there is
+  no enemy/ally charged skill in a single-ship sim. Parsed-skipped.
+- On-kill / enemy-repair triggers — excluded (enemy never dies/repairs).
+- Threshold conditions like Nuqtu "if target has 3+ buffs" auto-fill as
+  `enemy-buff` with a manual count; the user tunes the exact count. The parser
+  does not encode the threshold arithmetic.
+- Per-supporter rows for ally charges — a single flat number covers the common
+  case (YAGNI).
+
+## Testing
+
+- **Parser** (`src/utils/__tests__/skillTextParser.test.ts`): positive cases
+  Chakara (`always`), Nuqtu/Rhodium (`enemy-buff`), Thresh (`enemy-type`),
+  Selenite (`enemy-buff` Stealth), Tygr (`enemy-adjacent`), Hemlock
+  (`enemy-debuff`), Asphodel (`self-crit`); negative cases Demolisher
+  (enemy-removal → null), Valiant (on-kill → null), Liberator (ally-grant → null).
+- **Simulator** (`src/utils/calculators/__tests__/dpsSimulator.test.ts`):
+  cadence-shift assertions using the test convention (`crit:100, critDamage:0` →
+  critMultiplier 1, `enemyDefense:0`). E.g. `chargeCount:3` + `allyChargePerRound:1`
+  → charged fires ~every 2 rounds; `selfChargeGain` with `always` → faster
+  cadence than baseline; `self-crit` at 100% crit → +1/round.
+- **Docs + changelog**: `DocumentationPage.tsx` (DPS section + "About the
+  Simulation" prose) and `UNRELEASED_CHANGES` in `src/constants/changelog.ts`.

--- a/docs/superpowers/specs/2026-06-03-effective-hp-stat-limit-design.md
+++ b/docs/superpowers/specs/2026-06-03-effective-hp-stat-limit-design.md
@@ -1,0 +1,197 @@
+# Effective HP as an Autogear Stat Limit — Design
+
+**Date:** 2026-06-03
+**Status:** Approved (design)
+**Branch:** `feat/effective-hp-limit`
+
+## Problem
+
+Autogear lets users set per-stat min/max limits (`StatPriority`) for stats like
+`hp`, `defence`, and `speed`. When a build needs to meet a **survivability**
+target, neither an `hp` limit nor a `defence` limit expresses it well —
+survivability is the combination of both (plus the `damageReduction` stat).
+Users want to set a minimum **effective HP** directly instead of guessing hp/def
+values that approximate it.
+
+Effective HP is already computed in the codebase via `calculateEffectiveHP(hp,
+defence, damageReductionPercent)` in `src/utils/autogear/priorityScore.ts`, and
+surfaced in simulation results. It is a *derived* value, not a base stat.
+
+## Goal
+
+Add **Effective HP** as a selectable entry in the existing autogear "Limits"
+dropdown, behaving exactly like other limits:
+
+- Supports `minLimit`, `maxLimit`, and the **Hard Requirement** toggle.
+- Participates in soft-penalty scoring and the hard-requirement retry/violation
+  flow identically to `hp`/`defence`/`speed`.
+- Shows up in the "Unmet Stat Priorities" and hard-requirement violation UI with
+  a proper label.
+
+## Non-Goals (YAGNI)
+
+- Other derived limits (DPS, survival rounds, etc.). The type design below makes
+  adding more derived limits trivial later, but only `effectiveHp` is added now.
+- Influencing implant filtering. `effectiveHp` does not correspond to any gear
+  stat name, so implant filtering (`implantFilter.ts`, which matches
+  `priority.stat` against gear stat names) simply ignores it. Acceptable —
+  effective HP limits are still enforced through scoring penalties and the hard
+  requirement path.
+
+## Core Design Decision: keep `StatName` clean
+
+`StatPriority.stat` is currently typed `StatName`. But `StatName` is also the
+type for **gear stat rolls**, the import attribute mapping, and stat display
+across the app. Adding `'effectiveHp'` to `StatName` would leak a non-gear,
+derived value into all those places.
+
+Instead, introduce a wider type used **only for limits**:
+
+```ts
+// src/types/stats.ts
+export type DerivedStatName = 'effectiveHp';
+export type LimitableStat = StatName | DerivedStatName;
+```
+
+`StatName` stays exactly as-is (gear, imports, display unaffected).
+
+## Components & Changes
+
+### 1. Types
+
+| File | Change |
+|------|--------|
+| `src/types/stats.ts` | Add `DerivedStatName` and `LimitableStat`. |
+| `src/types/autogear.ts` | `StatPriority.stat: StatName` → `LimitableStat`. |
+| `src/utils/autogear/AutogearStrategy.ts` | `HardRequirementViolation.stat: StatName` → `LimitableStat`. |
+
+`UnmetPriority.stat` (in `AutogearPage.tsx`) is already typed `string` — no change.
+
+### 2. Value resolution (`src/utils/autogear/priorityScore.ts`)
+
+New exported pure helper:
+
+```ts
+export function resolveLimitStatValue(stats: BaseStats, stat: LimitableStat): number {
+    if (stat === 'effectiveHp') {
+        return calculateEffectiveHP(stats.hp, stats.defence, stats.damageReduction ?? 0);
+    }
+    return stats[stat] || 0;
+}
+```
+
+Route every site that currently reads `stats[priority.stat]` for a limit through
+this helper:
+
+| Site | Function |
+|------|----------|
+| `priorityScore.ts` ~:340 | `calculateDefaultScore` (weighted manual-mode score) |
+| `priorityScore.ts` ~:358 | `calculateHardViolation` |
+| `priorityScore.ts` ~:384 | `calculatePriorityScore` (soft min/max penalties) |
+| `strategies/GeneticStrategy.ts` ~:364 | hard-requirement violation builder |
+| `pages/manager/AutogearPage.tsx` ~:900 | `getUnmetPriorities` |
+
+Behaviour is unchanged for every existing stat (the helper returns
+`stats[stat] || 0` for them); only `'effectiveHp'` gains derived resolution.
+
+### 3. Scoring normalizer (`src/constants/stats.ts`)
+
+`STAT_NORMALIZERS` (a `Record<string, number>`) is used by `calculateDefaultScore`
+in manual mode. Add:
+
+```ts
+effectiveHp: 30000, // effectiveHP runs ~1.3-5x raw hp; normalize above hp's 10k
+```
+
+Without this it would default to `1` and dominate the weighted sum. This only
+affects manual-mode (no-role) weighted scoring; the limit-penalty and
+hard-requirement paths are normalizer-independent.
+
+### 4. Labels (`src/constants/stats.ts` + render sites)
+
+`STATS` is keyed by `StatName` and will not contain `effectiveHp`. Add a small
+derived-label map plus a resolver:
+
+```ts
+const DERIVED_STAT_LABELS: Record<DerivedStatName, { label: string; shortLabel: string }> = {
+    effectiveHp: { label: 'Effective HP', shortLabel: 'EHP' },
+};
+
+export function getLimitStatLabel(stat: LimitableStat): string {
+    return STATS[stat as StatName]?.label ?? DERIVED_STAT_LABELS[stat as DerivedStatName]?.label ?? stat;
+}
+```
+
+Use `getLimitStatLabel` at the label render sites so a derived stat renders
+correctly (and never crashes on `STATS[stat].label` being undefined):
+
+| File | Site |
+|------|------|
+| `components/stats/StatPriorityForm.tsx` | dropdown option labels |
+| `components/autogear/StatPriorityRow.tsx` ~:73 | `STATS[priority.stat].label` (currently unsafe) |
+| `components/autogear/GearSuggestions.tsx` ~:86 | `STATS[v.stat].label` (currently unsafe) |
+| `components/autogear/AutogearConfigList.tsx` ~:83 | `STATS[priority.stat]?.label \|\| priority.stat` (works, but show clean label) |
+
+### 5. UI (`components/stats/StatPriorityForm.tsx`)
+
+- `AVAILABLE_STATS: LimitableStat[]`, append `'effectiveHp'`.
+- `selectedStat` state typed `LimitableStat`.
+- Option label via `getLimitStatLabel`.
+- Min/max inputs and the Hard Requirement checkbox already work generically — no
+  other changes.
+
+## Data Flow
+
+```
+User picks "Effective HP" + min in StatPriorityForm
+  → StatPriority { stat: 'effectiveHp', minLimit, hardRequirement? } saved to config
+  → autogear scoring:
+      resolveLimitStatValue(stats, 'effectiveHp') = calculateEffectiveHP(hp, def, dmgReduction)
+      → soft penalty (calculatePriorityScore) and/or
+      → hard violation (calculateHardViolation → GeneticStrategy retry)
+  → unmet/violation UI renders via getLimitStatLabel('effectiveHp') = "Effective HP"
+```
+
+## Error Handling / Edge Cases
+
+- `damageReduction` may be `undefined` on `BaseStats` → coalesce to `0` (matches
+  existing `calculateEffectiveHP` default param).
+- `defence` of `0` → `calculateDamageReduction(0)` uses `Math.log10(0) = -Infinity`,
+  producing reduction ≈ 0, so effective HP ≈ hp. No divide-by-zero
+  (`100 - reduction` stays near 100). Confirm in tests.
+- Existing stats are unaffected: helper returns `stats[stat] || 0` for them.
+
+## Testing
+
+Add unit tests (Vitest) in the autogear test area:
+
+1. `resolveLimitStatValue(stats, 'effectiveHp')` equals
+   `calculateEffectiveHP(stats.hp, stats.defence, stats.damageReduction)`.
+2. `resolveLimitStatValue(stats, 'hp')` equals `stats.hp` (passthrough).
+3. `calculateHardViolation` reports a violation when effectiveHp is below an
+   `effectiveHp` minLimit hard requirement, and 0 when met.
+4. `calculatePriorityScore` applies a soft penalty for an unmet `effectiveHp`
+   minLimit and none when met.
+5. Edge: `defence: 0` does not produce `NaN`/`Infinity`.
+
+## Documentation & Changelog
+
+- Add an `UNRELEASED_CHANGES` entry in `src/constants/changelog.ts` (user-facing:
+  "Autogear can now target a minimum Effective HP directly as a stat limit").
+- Update `src/pages/DocumentationPage.tsx` if it enumerates autogear limit stats.
+
+## Files Touched (summary)
+
+- `src/types/stats.ts`
+- `src/types/autogear.ts`
+- `src/utils/autogear/AutogearStrategy.ts`
+- `src/utils/autogear/priorityScore.ts`
+- `src/constants/stats.ts`
+- `src/components/stats/StatPriorityForm.tsx`
+- `src/components/autogear/StatPriorityRow.tsx`
+- `src/components/autogear/GearSuggestions.tsx`
+- `src/components/autogear/AutogearConfigList.tsx`
+- `src/pages/manager/AutogearPage.tsx`
+- `src/constants/changelog.ts`
+- `src/pages/DocumentationPage.tsx` (if applicable)
+- Test file(s) for `priorityScore` / limit resolution

--- a/src/components/autogear/AutogearConfigList.tsx
+++ b/src/components/autogear/AutogearConfigList.tsx
@@ -80,7 +80,7 @@ export const AutogearConfigList: React.FC<AutogearConfigListProps> = ({
                                 {priority.maxLimit && (
                                     <span>{'max ' + priority.maxLimit}</span>
                                 )}{' '}
-                                {STATS[priority.stat]?.label || priority.stat}
+                                {STATS[priority.stat as StatName]?.label || priority.stat}
                                 {priority.hardRequirement && <span> (strict)</span>}
                             </span>
                         ))}

--- a/src/components/autogear/AutogearConfigList.tsx
+++ b/src/components/autogear/AutogearConfigList.tsx
@@ -3,7 +3,7 @@ import { StatPriority, SetPriority, StatBonus, FleetBuff } from '../../types/aut
 import { GEAR_SETS, ShipTypeName } from '../../constants';
 import { IMPLANTS } from '../../constants/implants';
 import { SHIP_TYPES } from '../../constants/shipTypes';
-import { STATS } from '../../constants/stats';
+import { STATS, getLimitStatLabel } from '../../constants/stats';
 import { StatName } from '../../types/stats';
 
 interface AutogearConfigListProps {
@@ -80,7 +80,7 @@ export const AutogearConfigList: React.FC<AutogearConfigListProps> = ({
                                 {priority.maxLimit && (
                                     <span>{'max ' + priority.maxLimit}</span>
                                 )}{' '}
-                                {STATS[priority.stat as StatName]?.label || priority.stat}
+                                {getLimitStatLabel(priority.stat)}
                                 {priority.hardRequirement && <span> (strict)</span>}
                             </span>
                         ))}

--- a/src/components/autogear/GearSuggestions.tsx
+++ b/src/components/autogear/GearSuggestions.tsx
@@ -10,6 +10,7 @@ import { useGearUpgrades } from '../../hooks/useGearUpgrades';
 import { StarToggleButton } from '../starred/StarToggleButton';
 import { HardRequirementViolation } from '../../utils/autogear/AutogearStrategy';
 import { STATS } from '../../constants/stats';
+import { StatName } from '../../types/stats';
 
 interface GearSuggestionsProps {
     suggestions: GearSuggestion[];
@@ -83,8 +84,8 @@ export const GearSuggestions: React.FC<GearSuggestionsProps> = ({
                     <ul className="list-disc pl-4 space-y-1">
                         {hardViolations.map((v, i) => (
                             <li key={i} className="text-red-100 text-sm">
-                                {STATS[v.stat].label}: needed {v.kind} {v.limit.toLocaleString()},
-                                got {v.actual.toFixed(1)}
+                                {STATS[v.stat as StatName]?.label ?? v.stat}: needed {v.kind}{' '}
+                                {v.limit.toLocaleString()}, got {v.actual.toFixed(1)}
                             </li>
                         ))}
                     </ul>

--- a/src/components/autogear/GearSuggestions.tsx
+++ b/src/components/autogear/GearSuggestions.tsx
@@ -9,8 +9,7 @@ import { Ship } from '../../types/ship';
 import { useGearUpgrades } from '../../hooks/useGearUpgrades';
 import { StarToggleButton } from '../starred/StarToggleButton';
 import { HardRequirementViolation } from '../../utils/autogear/AutogearStrategy';
-import { STATS } from '../../constants/stats';
-import { StatName } from '../../types/stats';
+import { getLimitStatLabel } from '../../constants/stats';
 
 interface GearSuggestionsProps {
     suggestions: GearSuggestion[];
@@ -84,7 +83,7 @@ export const GearSuggestions: React.FC<GearSuggestionsProps> = ({
                     <ul className="list-disc pl-4 space-y-1">
                         {hardViolations.map((v, i) => (
                             <li key={i} className="text-red-100 text-sm">
-                                {STATS[v.stat as StatName]?.label ?? v.stat}: needed {v.kind}{' '}
+                                {getLimitStatLabel(v.stat)}: needed {v.kind}{' '}
                                 {v.limit.toLocaleString()}, got {v.actual.toFixed(1)}
                             </li>
                         ))}

--- a/src/components/autogear/StatPriorityRow.tsx
+++ b/src/components/autogear/StatPriorityRow.tsx
@@ -9,6 +9,7 @@ import {
     Tooltip,
 } from '../ui';
 import { StatPriority } from '../../types/autogear';
+import { StatName } from '../../types/stats';
 import { STATS } from '../../constants';
 
 interface StatPriorityRowProps {
@@ -70,7 +71,7 @@ export const StatPriorityRow: React.FC<StatPriorityRowProps> = ({
                 )}
             </div>
             <span>
-                {STATS[priority.stat].label}
+                {STATS[priority.stat as StatName]?.label ?? priority.stat}
                 {priority.minLimit !== undefined && (
                     <>
                         {' ('}

--- a/src/components/autogear/StatPriorityRow.tsx
+++ b/src/components/autogear/StatPriorityRow.tsx
@@ -9,8 +9,7 @@ import {
     Tooltip,
 } from '../ui';
 import { StatPriority } from '../../types/autogear';
-import { StatName } from '../../types/stats';
-import { STATS } from '../../constants';
+import { getLimitStatLabel } from '../../constants';
 
 interface StatPriorityRowProps {
     priority: StatPriority;
@@ -71,7 +70,7 @@ export const StatPriorityRow: React.FC<StatPriorityRowProps> = ({
                 )}
             </div>
             <span>
-                {STATS[priority.stat as StatName]?.label ?? priority.stat}
+                {getLimitStatLabel(priority.stat)}
                 {priority.minLimit !== undefined && (
                     <>
                         {' ('}

--- a/src/components/stats/StatPriorityForm.tsx
+++ b/src/components/stats/StatPriorityForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Button, Checkbox, Input, Select, Tooltip } from '../ui';
-import { StatName } from '../../types/stats';
+import { StatName, LimitableStat } from '../../types/stats';
 import { StatPriority } from '../../types/autogear';
 import { STATS } from '../../constants/stats';
 
@@ -34,7 +34,7 @@ export const StatPriorityForm: React.FC<Props> = ({
     onSave,
     onCancel,
 }) => {
-    const [selectedStat, setSelectedStat] = useState<StatName>(AVAILABLE_STATS[0]);
+    const [selectedStat, setSelectedStat] = useState<LimitableStat>(AVAILABLE_STATS[0]);
     const [maxLimit, setMaxLimit] = useState<string>('');
     const [minLimit, setMinLimit] = useState<string>('');
     const [hardRequirement, setHardRequirement] = useState<boolean>(false);
@@ -91,7 +91,7 @@ export const StatPriorityForm: React.FC<Props> = ({
                     label="Stat"
                     className="flex-1 min-w-[8rem]"
                     value={selectedStat}
-                    onChange={(value) => setSelectedStat(value as StatName)}
+                    onChange={(value) => setSelectedStat(value as LimitableStat)}
                     options={AVAILABLE_STATS.map((stat) => ({
                         value: stat,
                         label: STATS[stat].label,

--- a/src/components/stats/StatPriorityForm.tsx
+++ b/src/components/stats/StatPriorityForm.tsx
@@ -1,13 +1,14 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Button, Checkbox, Input, Select, Tooltip } from '../ui';
-import { StatName, LimitableStat } from '../../types/stats';
+import { LimitableStat } from '../../types/stats';
 import { StatPriority } from '../../types/autogear';
-import { STATS } from '../../constants/stats';
+import { getLimitStatLabel } from '../../constants/stats';
 
-const AVAILABLE_STATS: StatName[] = [
+const AVAILABLE_STATS: LimitableStat[] = [
     'attack',
     'defence',
     'hp',
+    'effectiveHp',
     'speed',
     'crit',
     'critDamage',
@@ -94,7 +95,7 @@ export const StatPriorityForm: React.FC<Props> = ({
                     onChange={(value) => setSelectedStat(value as LimitableStat)}
                     options={AVAILABLE_STATS.map((stat) => ({
                         value: stat,
-                        label: STATS[stat].label,
+                        label: getLimitStatLabel(stat),
                     }))}
                     helpLabel="Set a stat priority to be met by the gear you equip. A min or max value is required."
                 />

--- a/src/constants/__tests__/stats.test.ts
+++ b/src/constants/__tests__/stats.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { getLimitStatLabel } from '../stats';
+
+describe('getLimitStatLabel', () => {
+    it('returns the STATS label for a base stat', () => {
+        expect(getLimitStatLabel('hp')).toBe('HP');
+    });
+    it('returns a human label for the derived effectiveHp stat', () => {
+        expect(getLimitStatLabel('effectiveHp')).toBe('Effective HP');
+    });
+});

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -10,6 +10,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Recruitment calculator: faction event weighting now stacks on top of the affinity weighting, and you can choose a 10x or 20x faction multiplier.',
     'DPS Calculator now models secondary damage that scales off Defense or max HP (e.g. Chakara, Lodolite) — auto-detected from skill text, editable, and scaling with Defense Up / HP buffs.',
     "DPS Calculator now models conditional damage bonuses that scale with a count (e.g. +20% per adjacent ally, +15% per debuff on the enemy). Counts derived from your buffs or the enemy's debuffs are tallied automatically each round; other conditions take a manual count. Auto-detected from skill text and editable per skill.",
+    'Autogear: you can now set a minimum (or maximum) Effective HP as a stat limit — handy when you care about overall survivability rather than tuning HP and Defense separately. Works as a soft limit or a hard requirement like any other stat.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/stats.ts
+++ b/src/constants/stats.ts
@@ -134,5 +134,6 @@ export const STAT_NORMALIZERS: Record<string, number> = {
     critChance: 25, // Normalize around 25%
     critDamage: 50, // Normalize around 50%
     speed: 100, // Normalize around 100
+    effectiveHp: 30000, // effectiveHP runs ~1.3-5x raw hp; normalize above hp's 10k
     // Add other stats as needed
 };

--- a/src/constants/stats.ts
+++ b/src/constants/stats.ts
@@ -1,4 +1,4 @@
-import type { StatName, StatType } from '../types/stats';
+import type { StatName, StatType, LimitableStat, DerivedStatName } from '../types/stats';
 import { GearSlotName } from './gearTypes';
 
 const MAX_FLAT_VALUE = 5000;
@@ -137,3 +137,17 @@ export const STAT_NORMALIZERS: Record<string, number> = {
     effectiveHp: 30000, // effectiveHP runs ~1.3-5x raw hp; normalize above hp's 10k
     // Add other stats as needed
 };
+
+// Labels for derived limit stats (not present in STATS, which is keyed by StatName).
+export const DERIVED_STAT_LABELS: Record<DerivedStatName, { label: string; shortLabel: string }> = {
+    effectiveHp: { label: 'Effective HP', shortLabel: 'EHP' },
+};
+
+/** Display label for any limitable stat, including derived ones. */
+export function getLimitStatLabel(stat: LimitableStat): string {
+    return (
+        STATS[stat as StatName]?.label ??
+        DERIVED_STAT_LABELS[stat as DerivedStatName]?.label ??
+        stat
+    );
+}

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -1313,7 +1313,9 @@ const DocumentationPage: React.FC = () => {
                                     <p className="text-theme-text">
                                         Define minimum and maximum values for specific stats. The
                                         algorithm will try to keep stats within these ranges while
-                                        optimizing the overall build.
+                                        optimizing the overall build. You can also limit{' '}
+                                        <strong>Effective HP</strong> — a derived survivability
+                                        value combining HP, Defense, and damage reduction.
                                     </p>
                                     <p className="text-theme-text mt-2">
                                         Each row has an <strong>Edit</strong> button (opens the form

--- a/src/pages/manager/AutogearPage.tsx
+++ b/src/pages/manager/AutogearPage.tsx
@@ -21,6 +21,7 @@ import {
     HardRequirementViolation,
 } from '../../utils/autogear/AutogearStrategy';
 import { getAutogearStrategy } from '../../utils/autogear/getStrategy';
+import { resolveLimitStatValue } from '../../utils/autogear/priorityScore';
 import { runSimulation, SimulationSummary } from '../../utils/simulation/simulationCalculator';
 import { StatList } from '../../components/stats/StatList';
 import { GEAR_SETS, SHIP_TYPES, ShipTypeName } from '../../constants';
@@ -897,7 +898,7 @@ export const AutogearPage: React.FC = () => {
             // Hard-flagged priorities are surfaced in the GearSuggestions banner, not here.
             if (priority.hardRequirement) return;
 
-            const currentValue = stats[priority.stat] || 0;
+            const currentValue = resolveLimitStatValue(stats, priority.stat);
 
             if (priority.minLimit && currentValue < priority.minLimit) {
                 unmet.push({

--- a/src/types/autogear.ts
+++ b/src/types/autogear.ts
@@ -1,9 +1,9 @@
 import type { ShipTypeName } from '../constants/shipTypes';
 import { AutogearAlgorithm } from '../utils/autogear/AutogearStrategy';
-import { StatName } from './stats';
+import { StatName, LimitableStat } from './stats';
 
 export interface StatPriority {
-    stat: StatName;
+    stat: LimitableStat;
     weight?: number;
     minLimit?: number;
     maxLimit?: number;

--- a/src/types/stats.ts
+++ b/src/types/stats.ts
@@ -20,6 +20,15 @@ export type FlexibleStats = 'hp' | 'attack' | 'defence' | 'speed' | 'hacking' | 
 // Combined type for all stat names
 export type StatName = PercentageOnlyStats | FlexibleStats;
 
+// Derived (computed) stats that can be used as autogear *limits* but are not
+// real gear/base stats. Kept out of StatName so gear rolls, imports, and stat
+// display are unaffected.
+export type DerivedStatName = 'effectiveHp';
+
+// Stat identifiers usable as autogear limit targets: every base StatName plus
+// derived stats resolved on the fly (see resolveLimitStatValue).
+export type LimitableStat = StatName | DerivedStatName;
+
 export type StatType = 'flat' | 'percentage';
 
 export interface PercentageStat {

--- a/src/utils/autogear/AutogearStrategy.ts
+++ b/src/utils/autogear/AutogearStrategy.ts
@@ -8,10 +8,10 @@ import type {
     FleetBuff,
 } from '../../types/autogear';
 import type { ShipTypeName } from '../../constants/shipTypes';
-import type { EngineeringStat, StatName } from '../../types/stats';
+import type { EngineeringStat, LimitableStat } from '../../types/stats';
 
 export interface HardRequirementViolation {
-    stat: StatName;
+    stat: LimitableStat;
     kind: 'min' | 'max';
     limit: number;
     actual: number;

--- a/src/utils/autogear/__tests__/priorityScore.test.ts
+++ b/src/utils/autogear/__tests__/priorityScore.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { calculatePriorityScore } from '../priorityScore';
+import {
+    calculatePriorityScore,
+    resolveLimitStatValue,
+    calculateHardViolation,
+    calculateEffectiveHP,
+} from '../priorityScore';
 import { BaseStats } from '../../../types/stats';
-import { SetPriority } from '../../../types/autogear';
+import { SetPriority, StatPriority } from '../../../types/autogear';
 
 const stats: BaseStats = {
     hp: 50000,
@@ -108,5 +113,50 @@ describe('calculatePriorityScore — implant set requirements', () => {
         const clean = calculatePriorityScore(stats, [], 'ATTACKER', {}, [], [], false, 0);
         // Gear requirement is unsatisfied — penalty should fire even though implant count is present
         expect(penalised).toBeLessThan(clean);
+    });
+});
+
+describe('resolveLimitStatValue', () => {
+    it('passes base stats through unchanged', () => {
+        expect(resolveLimitStatValue(stats, 'hp')).toBe(stats.hp);
+        expect(resolveLimitStatValue(stats, 'defence')).toBe(stats.defence);
+    });
+
+    it('resolves effectiveHp via calculateEffectiveHP', () => {
+        expect(resolveLimitStatValue(stats, 'effectiveHp')).toBeCloseTo(
+            calculateEffectiveHP(stats.hp, stats.defence, stats.damageReduction ?? 0),
+            5
+        );
+    });
+
+    it('does not produce NaN/Infinity when defence is 0', () => {
+        const zeroDef: typeof stats = { ...stats, defence: 0 };
+        const ehp = resolveLimitStatValue(zeroDef, 'effectiveHp');
+        expect(Number.isFinite(ehp)).toBe(true);
+        expect(ehp).toBeGreaterThan(0);
+    });
+});
+
+describe('effectiveHp as a limit', () => {
+    it('reports a hard violation when effectiveHp is below an unreachable min', () => {
+        const priorities: StatPriority[] = [
+            { stat: 'effectiveHp', minLimit: 100_000_000, hardRequirement: true, weight: 1 },
+        ];
+        expect(calculateHardViolation(stats, priorities)).toBeGreaterThan(0);
+    });
+
+    it('reports no hard violation when effectiveHp min is met', () => {
+        const priorities: StatPriority[] = [
+            { stat: 'effectiveHp', minLimit: 1, hardRequirement: true, weight: 1 },
+        ];
+        expect(calculateHardViolation(stats, priorities)).toBe(0);
+    });
+
+    it('applies a soft penalty when an effectiveHp min limit is missed', () => {
+        const unmet: StatPriority[] = [{ stat: 'effectiveHp', minLimit: 100_000_000, weight: 1 }];
+        const met: StatPriority[] = [{ stat: 'effectiveHp', minLimit: 1, weight: 1 }];
+        const scoreUnmet = calculatePriorityScore(stats, unmet, 'DEFENDER');
+        const scoreMet = calculatePriorityScore(stats, met, 'DEFENDER');
+        expect(scoreUnmet).toBeLessThan(scoreMet);
     });
 });

--- a/src/utils/autogear/priorityScore.ts
+++ b/src/utils/autogear/priorityScore.ts
@@ -1,4 +1,4 @@
-import { BaseStats } from '../../types/stats';
+import { BaseStats, LimitableStat } from '../../types/stats';
 import { StatPriority, SetPriority, StatBonus } from '../../types/autogear';
 import { STAT_NORMALIZERS, ShipTypeName, GEAR_SETS } from '../../constants';
 import { ENEMY_ATTACK, ENEMY_COUNT, BASE_HEAL_PERCENT } from '../../constants/simulation';
@@ -22,6 +22,17 @@ export function calculateEffectiveHP(
     const effectiveHpFromDefense = hp * (100 / (100 - defenseReduction));
     // Apply damageReduction stat (from gear/refits) as a separate multiplier
     return effectiveHpFromDefense * (1 + damageReductionPercent / 100);
+}
+
+/**
+ * Resolve the value to compare against a stat limit. Base stats pass through;
+ * derived stats (effectiveHp) are computed from the build's stats on the fly.
+ */
+export function resolveLimitStatValue(stats: BaseStats, stat: LimitableStat): number {
+    if (stat === 'effectiveHp') {
+        return calculateEffectiveHP(stats.hp, stats.defence, stats.damageReduction ?? 0);
+    }
+    return stats[stat] || 0;
 }
 
 // Defense penetration lookup table with known values at 15k defense
@@ -337,7 +348,7 @@ function calculateDefaultScore(stats: BaseStats, priorities: StatPriority[]): nu
     let totalScore = 0;
     const orderMultipliers = getOrderMultipliers(priorities.length);
     priorities.forEach((priority, index) => {
-        const statValue = stats[priority.stat] || 0;
+        const statValue = resolveLimitStatValue(stats, priority.stat);
         const normalizer = STAT_NORMALIZERS[priority.stat] || 1;
         const normalizedValue = statValue / normalizer;
         const orderMultiplier = orderMultipliers[index];
@@ -355,7 +366,7 @@ export function calculateHardViolation(stats: BaseStats, priorities: StatPriorit
     let violation = 0;
     for (const p of priorities) {
         if (!p.hardRequirement) continue;
-        const value = stats[p.stat] || 0;
+        const value = resolveLimitStatValue(stats, p.stat);
         if (p.minLimit && value < p.minLimit) {
             violation += (p.minLimit - value) / p.minLimit;
         }
@@ -381,7 +392,7 @@ export function calculatePriorityScore(
 
     // Calculate penalties based on min/max limits
     for (const priority of priorities) {
-        const statValue = stats[priority.stat] || 0;
+        const statValue = resolveLimitStatValue(stats, priority.stat);
 
         if (priority.minLimit) {
             if (statValue < priority.minLimit) {

--- a/src/utils/autogear/scoring.ts
+++ b/src/utils/autogear/scoring.ts
@@ -18,6 +18,7 @@ import {
     applyAdditiveBonuses,
     calculateMultiplierFactor,
     calculateHardViolation,
+    resolveLimitStatValue,
 } from './priorityScore';
 
 // Re-export calculatePriorityScore so existing imports from this module continue to work
@@ -30,6 +31,7 @@ export {
     applyAdditiveBonuses,
     calculateMultiplierFactor,
     calculateHardViolation,
+    resolveLimitStatValue,
 };
 
 // Exported for testing only.

--- a/src/utils/autogear/strategies/GeneticStrategy.ts
+++ b/src/utils/autogear/strategies/GeneticStrategy.ts
@@ -5,7 +5,12 @@ import { StatPriority, SetPriority, StatBonus } from '../../../types/autogear';
 import type { FleetBuff } from '../../../types/autogear';
 import { GEAR_SLOTS, GearSlotName, ShipTypeName } from '../../../constants';
 import { EngineeringStat } from '../../../types/stats';
-import { calculateTotalScore, calculateHardViolation, clearScoreCache } from '../scoring';
+import {
+    calculateTotalScore,
+    calculateHardViolation,
+    clearScoreCache,
+    resolveLimitStatValue,
+} from '../scoring';
 import { calculateTotalStats } from '../../ship/statsCalculator';
 import { compareIndividuals } from '../individualComparator';
 import { BaseStrategy } from '../BaseStrategy';
@@ -361,7 +366,7 @@ export class GeneticStrategy extends BaseStrategy implements AutogearStrategy {
         const violations: HardRequirementViolation[] = [];
         for (const p of priorities) {
             if (!p.hardRequirement) continue;
-            const value = stats[p.stat] || 0;
+            const value = resolveLimitStatValue(stats, p.stat);
             if (p.minLimit && value < p.minLimit) {
                 violations.push({ stat: p.stat, kind: 'min', limit: p.minLimit, actual: value });
             }


### PR DESCRIPTION
## Summary
- Adds **Effective HP** as a selectable stat limit in the autogear config, behaving exactly like existing limits (min/max + hard-requirement toggle, soft-penalty scoring + hard-requirement retry/violation display).
- Effective HP is a *derived* value (HP + Defense + damage reduction) computed via the existing `calculateEffectiveHP`. To avoid polluting `StatName` (used for gear rolls/imports/display), a new `LimitableStat = StatName | 'effectiveHp'` type is used only for limits, and a single `resolveLimitStatValue` helper resolves the value at every limit read-site (routed via the `scoring.ts` barrel).
- Derived-stat labels render safely through a new `getLimitStatLabel`; `effectiveHp: 30000` added to `STAT_NORMALIZERS` for sane manual-mode weighting.
- In-app docs (Stat Priorities section) and changelog updated.

## Test Plan
- [x] Unit tests: `resolveLimitStatValue` passthrough + effectiveHp resolution + defence=0 finiteness; `calculateHardViolation` and `calculatePriorityScore` penalize an effectiveHp min limit correctly; `getLimitStatLabel` resolves base and derived labels.
- [x] Full suite green (702 tests, 55 files), `tsc --noEmit` clean, ESLint 0 warnings.
- [ ] Manual: Autogear → add a Limit → select **Effective HP** → set a min → confirm the row labels correctly and the optimizer respects it (soft + hard requirement).

Spec & plan: `docs/superpowers/specs/2026-06-03-effective-hp-stat-limit-design.md`, `docs/superpowers/plans/2026-06-03-effective-hp-stat-limit.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)