### PR TITLE
feat: editor guardrails for not-simulated ability types

### DIFF
--- a/src/components/skills/AbilityCard.tsx
+++ b/src/components/skills/AbilityCard.tsx
@@ -5,6 +5,7 @@ import {
     AbilityTarget,
     Condition,
     ModifierChannel,
+    SkillSlot,
 } from '../../types/abilities';
 import { DoTType, ParsedBuffEffects, SelectedGameBuff } from '../../types/calculator';
 import { Select } from '../ui/Select';
@@ -13,6 +14,12 @@ import { Checkbox } from '../ui/Checkbox';
 import { Button } from '../ui/Button';
 import { ChevronUpIcon, ChevronDownIcon } from '../ui/icons/ChevronIcons';
 import { GameBuffPicker } from '../calculator/GameBuffPicker';
+import {
+    NOT_SIMULATED_TYPES,
+    PASSIVE_NOOP_TYPES,
+    NOT_SIMULATED_NOTE,
+    PASSIVE_NOOP_WARNING,
+} from './simCoverage';
 import { ConditionRow } from './ConditionRow';
 
 interface Props {
@@ -22,6 +29,8 @@ interface Props {
     /** Move this ability up/down in the skill's execution order; undefined at the ends. */
     onMoveUp?: () => void;
     onMoveDown?: () => void;
+    /** Slot this ability lives in; enables slot-specific sim-coverage warnings. */
+    slot?: SkillSlot;
 }
 
 const ABILITY_TYPE_LABELS: Record<Ability['type'], string> = {
@@ -113,6 +122,7 @@ export const AbilityCard: React.FC<Props> = ({
     onRemove,
     onMoveUp,
     onMoveDown,
+    slot,
 }) => {
     const updateConfig = (config: AbilityConfig) => onChange({ ...ability, config });
 
@@ -477,7 +487,9 @@ export const AbilityCard: React.FC<Props> = ({
             default:
                 return (
                     <p className="text-xs text-theme-text-secondary">
-                        No editable fields for this ability type.
+                        {NOT_SIMULATED_TYPES.has(ability.type)
+                            ? NOT_SIMULATED_NOTE
+                            : 'No editable fields for this ability type.'}
                     </p>
                 );
         }
@@ -534,6 +546,10 @@ export const AbilityCard: React.FC<Props> = ({
                     </Button>
                 </div>
             </div>
+
+            {slot === 'passive' && PASSIVE_NOOP_TYPES.has(ability.type) && (
+                <p className="text-xs text-yellow-400">{PASSIVE_NOOP_WARNING}</p>
+            )}
 
             <Select
                 label="Target"

--- a/src/components/skills/AbilityTypePicker.tsx
+++ b/src/components/skills/AbilityTypePicker.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { AbilityType } from '../../types/abilities';
 import { Button } from '../ui/Button';
+import { NOT_SIMULATED_NOTE } from './simCoverage';
 
 interface Props {
     onPick: (type: AbilityType) => void;
@@ -24,7 +25,7 @@ const TYPE_LABELS: Record<AbilityType, string> = {
     control: 'Control',
 };
 
-const CATEGORIES: { label: string; types: AbilityType[] }[] = [
+const CATEGORIES: { label: string; types: AbilityType[]; note?: string }[] = [
     { label: 'Damage', types: ['damage', 'additional-damage'] },
     {
         label: 'Modify',
@@ -39,7 +40,11 @@ const CATEGORIES: { label: string; types: AbilityType[] }[] = [
         ],
     },
     { label: 'Charge', types: ['charge'] },
-    { label: 'Utility', types: ['heal', 'shield', 'cleanse', 'purge', 'control'] },
+    {
+        label: 'Utility',
+        types: ['heal', 'shield', 'cleanse', 'purge', 'control'],
+        note: NOT_SIMULATED_NOTE,
+    },
 ];
 
 export const AbilityTypePicker: React.FC<Props> = ({ onPick }) => (
@@ -49,6 +54,9 @@ export const AbilityTypePicker: React.FC<Props> = ({ onPick }) => (
                 <span className="text-xs font-semibold uppercase text-theme-text-secondary">
                     {category.label}
                 </span>
+                {category.note && (
+                    <p className="text-xs text-theme-text-secondary">{category.note}</p>
+                )}
                 <div className="flex flex-wrap gap-2">
                     {category.types.map((type) => (
                         <Button

--- a/src/components/skills/SkillEditorModal.tsx
+++ b/src/components/skills/SkillEditorModal.tsx
@@ -135,6 +135,7 @@ export const SkillEditorModal: React.FC<Props> = ({
                     <AbilityCard
                         key={ability.id}
                         ability={ability}
+                        slot={slot}
                         onChange={(updated) => handleAbilityChange(index, updated)}
                         onRemove={() => handleAbilityRemove(index)}
                         onMoveUp={index > 0 ? () => handleAbilityMove(index, -1) : undefined}

--- a/src/components/skills/__tests__/AbilityCard.test.tsx
+++ b/src/components/skills/__tests__/AbilityCard.test.tsx
@@ -64,6 +64,46 @@ describe('AbilityCard', () => {
         expect(onRemove).toHaveBeenCalled();
     });
 
+    describe('sim-coverage notices', () => {
+        const heal: Ability = {
+            id: 'a1',
+            type: 'heal',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'heal', pct: 20, basis: 'hp' },
+        };
+        const dot: Ability = {
+            id: 'a2',
+            type: 'dot',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'dot', dotType: 'corrosion', tier: 5, stacks: 1, duration: 2 },
+        };
+
+        it('shows a not-simulated note for utility types', () => {
+            render(<AbilityCard ability={heal} onChange={() => {}} onRemove={() => {}} />);
+            expect(screen.getByText(/not simulated in the dps calculator/i)).toBeInTheDocument();
+        });
+
+        it('warns when a firing-only type sits on the passive slot', () => {
+            render(
+                <AbilityCard ability={dot} slot="passive" onChange={() => {}} onRemove={() => {}} />
+            );
+            expect(screen.getByText(/not simulated on the passive slot/i)).toBeInTheDocument();
+        });
+
+        it('does not warn for the same type on the active slot', () => {
+            render(
+                <AbilityCard ability={dot} slot="active" onChange={() => {}} onRemove={() => {}} />
+            );
+            expect(
+                screen.queryByText(/not simulated on the passive slot/i)
+            ).not.toBeInTheDocument();
+        });
+    });
+
     it('reconstructs picker value from config.buffName and shows selected buff', () => {
         const buffAbilityWithName: Ability = {
             ...buffAbility,

--- a/src/components/skills/__tests__/AbilityTypePicker.test.tsx
+++ b/src/components/skills/__tests__/AbilityTypePicker.test.tsx
@@ -29,4 +29,9 @@ describe('AbilityTypePicker', () => {
         expect(screen.getByText('Damage', { selector: 'span' })).toBeInTheDocument();
         expect(screen.getByText('Utility')).toBeInTheDocument();
     });
+
+    it('marks the Utility category as not simulated in DPS', () => {
+        render(<AbilityTypePicker onPick={() => {}} />);
+        expect(screen.getByText(/not simulated in the dps calculator/i)).toBeInTheDocument();
+    });
 });

--- a/src/components/skills/__tests__/SkillEditorModal.test.tsx
+++ b/src/components/skills/__tests__/SkillEditorModal.test.tsx
@@ -202,4 +202,25 @@ describe('SkillEditorModal', () => {
         );
         expect(screen.queryByText('Active Skill')).not.toBeInTheDocument();
     });
+
+    it('shows passive-slot warning when a firing-only ability is on the passive slot', () => {
+        const dotAbility: Ability = {
+            id: 'a2',
+            type: 'dot',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'dot', dotType: 'corrosion', tier: 5, stacks: 1, duration: 2 },
+        };
+        render(
+            <SkillEditorModal
+                isOpen
+                slot="passive"
+                skill={{ slot: 'passive', abilities: [dotAbility] }}
+                onChange={vi.fn()}
+                onClose={vi.fn()}
+            />
+        );
+        expect(screen.getByText(/not simulated on the passive slot/i)).toBeInTheDocument();
+    });
 });

--- a/src/components/skills/simCoverage.ts
+++ b/src/components/skills/simCoverage.ts
@@ -1,0 +1,32 @@
+import { AbilityType } from '../../types/abilities';
+
+/**
+ * Ability types the DPS sim does not consume at all. They stay pickable in the
+ * editor (annotations for the future Healing-calc / combat-sim phases) but must
+ * be visibly marked so a configured ability isn't mistaken for a simulated one.
+ */
+export const NOT_SIMULATED_TYPES: ReadonlySet<AbilityType> = new Set([
+    'heal',
+    'shield',
+    'cleanse',
+    'purge',
+    'control',
+]);
+
+/**
+ * Ability types the DPS sim sources from the FIRING skill only (active/charged).
+ * Placed on the passive slot they are silent no-ops today — warn, don't block,
+ * so real ship passives can still be documented ahead of sim support.
+ * See docs/skill-model-coverage.md section 4 (slot sourcing).
+ */
+export const PASSIVE_NOOP_TYPES: ReadonlySet<AbilityType> = new Set([
+    'dot',
+    'charge',
+    'detonate-dot',
+    'accumulate-detonate',
+    'additional-damage',
+]);
+
+export const NOT_SIMULATED_NOTE = 'Not simulated in the DPS calculator yet.';
+export const PASSIVE_NOOP_WARNING =
+    'Not simulated on the passive slot - the DPS calculator only reads this ability type from the active and charged skills.';

--- a/src/components/skills/simCoverage.ts
+++ b/src/components/skills/simCoverage.ts
@@ -29,4 +29,4 @@ export const PASSIVE_NOOP_TYPES: ReadonlySet<AbilityType> = new Set([
 
 export const NOT_SIMULATED_NOTE = 'Not simulated in the DPS calculator yet.';
 export const PASSIVE_NOOP_WARNING =
-    'Not simulated on the passive slot - the DPS calculator only reads this ability type from the active and charged skills.';
+    'Not simulated on the passive slot — the DPS calculator only reads this ability type from the active and charged skills.';

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -15,6 +15,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'DPS enemy HP now declines as damage accumulates: "below X% HP" execute-style effects kick in mid-fight, HP-proportional bonuses track the live value (Akula\'s "up to 30% based on current HP" decays; Tithonus\' missing-HP bonus ramps up), the chart tooltip shows the enemy\'s remaining HP% and charge progress per round, and each ship\'s line is marked where its damage empties the enemy HP pool.',
     'Many DPS skill auto-fill fixes: conditions are scoped to their own sentence (no more leaking across abbreviation periods like "Inc.", onto recurring per-turn grants, or onto the wrong ability), Judge\'s HP-gated damage and Nayra\'s end-of-tag Defense damage parse correctly, Shield-gain text is no longer read as bonus damage, and threshold-gated charge gains no longer fire early.',
     'Autogear: you can now set a minimum (or maximum) Effective HP as a stat limit — handy when you care about overall survivability rather than tuning HP and Defense separately. Works as a soft limit or a hard requirement like any other stat.',
+    'Skill editor: ability types the DPS calculator does not simulate (heal, shield, cleanse, purge, control) are now labelled, and abilities that only work on the active/charged skill warn when placed on the passive skill.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [


### PR DESCRIPTION
Phase 0 of the combat-engine spec (docs/superpowers/specs/2026-06-03-combat-engine-phase1-design.md).

- Utility ability types (heal/shield/cleanse/purge/control) are marked "not simulated in the DPS calculator" in the type picker and on ability cards
- dot/charge/detonate-dot/accumulate-detonate/additional-damage abilities warn when placed on the passive slot (firing-skill-only in the sim)
- Warn, don't block: configs stay saveable for documentation ahead of sim support

🤖 Generated with [Claude Code](https://claude.com/claude-code)