### PR TITLE
feat(targeting): ship target/pattern data foundation

### DIFF
--- a/docs/superpowers/plans/2026-06-13-targeting-data-foundation.md
+++ b/docs/superpowers/plans/2026-06-13-targeting-data-foundation.md
@@ -1,0 +1,896 @@
+# Targeting Data Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ingest the gathered ship target/pattern data into `ship_templates`, expose it as raw strings on the frontend `Ship` model, and build a tested parser that tokenizes the raw game strings into a structured model — no combat-engine changes.
+
+**Architecture:** Raw game strings stored in four new nullable `ship_templates` columns (mirroring `*_skill_text`); a server-side populate script loads them from `docs/ship-targeting.csv`; a pure, dependency-free `targetingParser.ts` derives the structured model at runtime; empty charged columns mean "charged targets the same as active" and that inheritance is resolved in the parser, not the DB.
+
+**Tech Stack:** TypeScript, Supabase (Postgres), Vitest, tsx scripts.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-targeting-data-foundation-design.md`
+
+**Conventions to honor (from CLAUDE.md / project memory):**
+- ESM project (`"type": "module"`). Scripts and tests run from the repo root, so relative paths like `'docs/ship-targeting.csv'` resolve correctly (same convention as `scripts/auditSkills.ts`).
+- `docs/` is **gitignored** — the plan/spec are the only docs touched and were committed with `git add -f`. Source/test/migration/script files are NOT gitignored and commit normally.
+- Service-role key (`SUPABASE_SERVICE_ROLE_KEY`) is **server-only** — only in `scripts/`. Never a `VITE_` var.
+- Pre-commit hook runs the **full** vitest suite. Let it run for code commits (it's the safety net). Only docs-only commits use `--no-verify`.
+- `gh auth switch --hostname github.com --user TheSusort` before any PR/merge op.
+
+---
+
+## Branch setup (do first)
+
+This is one PR's worth of work. Do NOT work on `main`.
+
+- [ ] **Create the feature branch**
+
+```bash
+cd /Users/kennethsusort/PersonalProjects/starborne-frontiers-calculator
+git checkout main && git pull --ff-only
+git checkout -b feat/targeting-data-foundation
+```
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `supabase/migrations/20260613000001_add_targeting_to_ship_templates.sql` | NEW — add 4 nullable text columns to `ship_templates` |
+| `src/utils/targetingParser.ts` | NEW — types + pure tokenizing parser (target axis, pattern axis, per-skill, per-ship with charged inheritance) |
+| `src/utils/__tests__/targetingParser.test.ts` | NEW — per-token unit tests, charged-inheritance tests, corpus coverage test |
+| `src/types/ship.ts` | MODIFY — add 4 optional raw-string fields to `Ship` and `ShipData` |
+| `src/hooks/useShipsData.ts` | MODIFY — extend local `ShipTemplate` interface + `transformShipTemplate` |
+| `src/services/shipTemplateProposalService.ts` | MODIFY — extend its `ShipTemplate` interface (keep table shape accurate) |
+| `scripts/populate-ship-targeting.ts` | NEW — CSV → `ship_templates` (service role), dry-run + unmatched report |
+| `package.json` | MODIFY — add `populate-targeting` script |
+
+---
+
+## Task 1: Database migration
+
+**Files:**
+- Create: `supabase/migrations/20260613000001_add_targeting_to_ship_templates.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Add ship targeting/pattern data to ship_templates.
+-- Verbatim game strings (parsed at runtime by src/utils/targetingParser.ts).
+-- Charged columns are an OVERRIDE: empty means "charged targets the same as active".
+ALTER TABLE public.ship_templates
+  ADD COLUMN IF NOT EXISTS active_target   text,
+  ADD COLUMN IF NOT EXISTS active_pattern  text,
+  ADD COLUMN IF NOT EXISTS charged_target  text,
+  ADD COLUMN IF NOT EXISTS charged_pattern text;
+```
+
+- [ ] **Step 2: Sanity-check the SQL**
+
+No RLS change needed (existing, already-policied table). Confirm column names use the
+`charged_` prefix for targeting (matches the gathered CSV) even though the existing
+skill column uses `charge_` — this divergence is intentional and documented in the spec.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/20260613000001_add_targeting_to_ship_templates.sql
+git commit -m "feat(db): add targeting/pattern columns to ship_templates"
+```
+
+> **Note:** the migration is applied to Supabase by the maintainer via the Supabase
+> CLI/dashboard (per CLAUDE.md "Database Migrations"). The frontend `select('*')`
+> automatically picks up the new columns once applied; no code depends on them being
+> populated to compile or pass tests.
+
+---
+
+## Task 2: Parser — types + target axis (TDD)
+
+**Files:**
+- Create: `src/utils/targetingParser.ts`
+- Test: `src/utils/__tests__/targetingParser.test.ts`
+
+- [ ] **Step 1: Write the failing test for `parseTarget`**
+
+Create `src/utils/__tests__/targetingParser.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { parseTarget } from '../targetingParser';
+
+describe('parseTarget', () => {
+    it('maps enemy-side selections', () => {
+        expect(parseTarget('front')).toEqual({ raw: 'front', side: 'enemy', selection: 'front' });
+        expect(parseTarget('back')).toEqual({ raw: 'back', side: 'enemy', selection: 'back' });
+        expect(parseTarget('skip')).toEqual({ raw: 'skip', side: 'enemy', selection: 'skip' });
+        expect(parseTarget('all')).toEqual({ raw: 'all', side: 'enemy', selection: 'all' });
+    });
+
+    it('maps ally-side selections', () => {
+        expect(parseTarget('allies')).toEqual({ raw: 'allies', side: 'ally', selection: 'team' });
+        expect(parseTarget('all-allies')).toEqual({ raw: 'all-allies', side: 'ally', selection: 'all' });
+        expect(parseTarget('other-allies')).toEqual({ raw: 'other-allies', side: 'ally', selection: 'others' });
+        expect(parseTarget('self')).toEqual({ raw: 'self', side: 'ally', selection: 'self' });
+    });
+
+    it('is case/whitespace tolerant', () => {
+        expect(parseTarget('  Front ')).toMatchObject({ side: 'enemy', selection: 'front' });
+    });
+
+    it('throws on unknown target', () => {
+        expect(() => parseTarget('sideways')).toThrow(/unknown target/i);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `npx vitest run src/utils/__tests__/targetingParser.test.ts`
+Expected: FAIL — cannot import `parseTarget` (module/file does not exist).
+
+- [ ] **Step 3: Implement types + `parseTarget`**
+
+Create `src/utils/targetingParser.ts`:
+
+```ts
+import { Ship } from '../types/ship';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TargetSide = 'enemy' | 'ally';
+export type TargetSelection =
+    | 'front'
+    | 'back'
+    | 'skip'
+    | 'all'
+    | 'team'
+    | 'others'
+    | 'self';
+
+export interface ParsedTarget {
+    raw: string;
+    side: TargetSide;
+    selection: TargetSelection;
+}
+
+export type PatternShape =
+    | 'base'
+    | 'cone'
+    | 'line'
+    | 'cross'
+    | 'curve'
+    | 'circle'
+    | 'backline'
+    | 'root'
+    | 'split'
+    | 'burst'
+    | 'scattershot'
+    | 'wings'
+    | 'range'
+    | 'pickaxe'
+    | 'all';
+
+export interface PatternModifiers {
+    support?: boolean;
+    prolonged?: boolean;
+    reverse?: boolean;
+    notSelf?: boolean;
+    fromCentre?: boolean;
+    anchorMod?: 'back' | 'center' | 'forward';
+}
+
+export interface ParsedPattern {
+    raw: string;
+    shape: PatternShape;
+    range: number | 'all' | 'lane';
+    modifiers: PatternModifiers;
+}
+
+export interface SkillTargeting {
+    target: ParsedTarget;
+    pattern: ParsedPattern;
+}
+
+export interface ShipTargeting {
+    active?: SkillTargeting;
+    charged?: SkillTargeting;
+}
+
+// ---------------------------------------------------------------------------
+// Target axis
+// ---------------------------------------------------------------------------
+
+const TARGET_MAP: Record<string, { side: TargetSide; selection: TargetSelection }> = {
+    front: { side: 'enemy', selection: 'front' },
+    back: { side: 'enemy', selection: 'back' },
+    skip: { side: 'enemy', selection: 'skip' },
+    all: { side: 'enemy', selection: 'all' },
+    allies: { side: 'ally', selection: 'team' },
+    'all-allies': { side: 'ally', selection: 'all' },
+    'other-allies': { side: 'ally', selection: 'others' },
+    self: { side: 'ally', selection: 'self' },
+};
+
+export function parseTarget(raw: string): ParsedTarget {
+    const key = raw.trim().toLowerCase();
+    const mapped = TARGET_MAP[key];
+    if (!mapped) {
+        throw new Error(`Unknown target value: "${raw}"`);
+    }
+    return { raw, side: mapped.side, selection: mapped.selection };
+}
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `npx vitest run src/utils/__tests__/targetingParser.test.ts`
+Expected: PASS (the `parseTarget` describe block).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/targetingParser.ts src/utils/__tests__/targetingParser.test.ts
+git commit -m "feat(targeting): parser types + target-axis tokenizer"
+```
+
+---
+
+## Task 3: Parser — pattern axis (TDD)
+
+**Files:**
+- Modify: `src/utils/targetingParser.ts`
+- Test: `src/utils/__tests__/targetingParser.test.ts`
+
+- [ ] **Step 1: Add the failing `parsePattern` tests**
+
+Append to the test file (and add `parsePattern` to the import):
+
+```ts
+import { parsePattern } from '../targetingParser';
+
+describe('parsePattern', () => {
+    it('parses Pattern-Base as base / range 0', () => {
+        expect(parsePattern('Pattern-Base')).toEqual({
+            raw: 'Pattern-Base', shape: 'base', range: 0, modifiers: {},
+        });
+    });
+
+    it('parses a numeric range', () => {
+        expect(parsePattern('Pattern-Cone-Range-1')).toMatchObject({ shape: 'cone', range: 1, modifiers: {} });
+        expect(parsePattern('Pattern-Line-Range-2')).toMatchObject({ shape: 'line', range: 2, modifiers: {} });
+        expect(parsePattern('Pattern-Range-3')).toMatchObject({ shape: 'range', range: 3, modifiers: {} });
+        expect(parsePattern('Pattern-Support-Double-Pickaxe-Range-0')).toMatchObject({ shape: 'pickaxe', range: 0 });
+    });
+
+    it('detects the support modifier (before or after the shape token)', () => {
+        expect(parsePattern('Pattern-Circle-Support-Range-1').modifiers.support).toBe(true);
+        expect(parsePattern('Pattern-Base-Support')).toMatchObject({ shape: 'base', range: 0, modifiers: { support: true } });
+        expect(parsePattern('Pattern-Support-All')).toMatchObject({ shape: 'all', range: 'all', modifiers: { support: true } });
+        expect(parsePattern('Pattern-All')).toMatchObject({ shape: 'all', range: 'all', modifiers: {} });
+    });
+
+    it('detects whole-lane range', () => {
+        expect(parsePattern('Pattern-Line-Support-whole-lane')).toMatchObject({
+            shape: 'line', range: 'lane', modifiers: { support: true },
+        });
+    });
+
+    it('detects prolonged + anchor modifiers', () => {
+        expect(parsePattern('Pattern-Prolonged_Cone-Support-Range-2')).toMatchObject({
+            shape: 'cone', range: 2, modifiers: { prolonged: true, support: true },
+        });
+        expect(parsePattern('Pattern-Prolonged_Cone-Support-Center-Range-2').modifiers).toMatchObject({
+            prolonged: true, support: true, anchorMod: 'center',
+        });
+        expect(parsePattern('Pattern-Cone-Back-Range-1').modifiers).toMatchObject({ anchorMod: 'back' });
+        expect(parsePattern('Pattern-Support-Forward-Circle-Range-1')).toMatchObject({
+            shape: 'circle', modifiers: { support: true, anchorMod: 'forward' },
+        });
+    });
+
+    it('does NOT treat backline as an anchor "back"', () => {
+        const p = parsePattern('Pattern-Backline-Range-1');
+        expect(p.shape).toBe('backline');
+        expect(p.modifiers.anchorMod).toBeUndefined();
+    });
+
+    it('detects reverse / notSelf / fromCentre', () => {
+        expect(parsePattern('Pattern-Reverse-Curve-Range-1')).toMatchObject({ shape: 'curve', modifiers: { reverse: true } });
+        expect(parsePattern('Pattern-Reverse-Cone-Range-1')).toMatchObject({ shape: 'cone', modifiers: { reverse: true } });
+        expect(parsePattern('Pattern-Line-Support-Not-Self-Range-2').modifiers).toMatchObject({ support: true, notSelf: true });
+        expect(parsePattern('Pattern-Wings-Support-Not-Self-Range-2')).toMatchObject({ shape: 'wings', modifiers: { support: true, notSelf: true } });
+        expect(parsePattern('Pattern-Line-from-centre-Range-1').modifiers).toMatchObject({ fromCentre: true });
+    });
+
+    it('normalizes the "Patern" typo', () => {
+        expect(parsePattern('Patern-Support-All')).toMatchObject({ shape: 'all', range: 'all', modifiers: { support: true } });
+    });
+
+    it('throws on an unrecognizable shape', () => {
+        expect(() => parsePattern('Pattern-Nonsense-Range-1')).toThrow(/unknown pattern shape/i);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `npx vitest run src/utils/__tests__/targetingParser.test.ts -t parsePattern`
+Expected: FAIL — `parsePattern` not exported.
+
+- [ ] **Step 3: Implement `parsePattern`**
+
+Append to `src/utils/targetingParser.ts`:
+
+```ts
+// ---------------------------------------------------------------------------
+// Pattern axis
+// ---------------------------------------------------------------------------
+
+// Shape detection is presence-based (not positional) and ORDER-SENSITIVE:
+// check 'backline' before any 'line'/'back' rule so it isn't mis-split.
+function detectShape(lower: string): PatternShape {
+    if (/backline/.test(lower)) return 'backline';
+    if (/scattershot/.test(lower)) return 'scattershot';
+    if (/pickaxe/.test(lower)) return 'pickaxe';
+    if (/cone/.test(lower)) return 'cone';
+    if (/cross/.test(lower)) return 'cross';
+    if (/curve/.test(lower)) return 'curve';
+    if (/circle/.test(lower)) return 'circle';
+    if (/wings/.test(lower)) return 'wings';
+    if (/root/.test(lower)) return 'root';
+    if (/split/.test(lower)) return 'split';
+    if (/burst/.test(lower)) return 'burst';
+    if (/line/.test(lower)) return 'line';
+    if (/base/.test(lower)) return 'base';
+    // standalone "all" shape (Pattern-All, Pattern-Support-All) with no other shape token
+    if (/(^|-)all($|-)/.test(lower)) return 'all';
+    // pure range shape (Pattern-Range-N) with no other shape token
+    if (/range-\d+/.test(lower)) return 'range';
+    throw new Error(`Unknown pattern shape in: "${lower}"`);
+}
+
+export function parsePattern(raw: string): ParsedPattern {
+    // Normalize: fix the "Patern" typo, turn "Prolonged_Cone" into "Prolonged-Cone".
+    const normalized = raw
+        .trim()
+        .replace(/^Patern-/i, 'Pattern-')
+        .replace(/_/g, '-');
+    const body = normalized.replace(/^Pattern-/i, '');
+    const lower = body.toLowerCase();
+
+    const modifiers: PatternModifiers = {};
+    if (/(^|-)support(-|$)/.test(lower)) modifiers.support = true;
+    if (/(^|-)prolonged(-|$)/.test(lower)) modifiers.prolonged = true;
+    if (/(^|-)reverse(-|$)/.test(lower)) modifiers.reverse = true;
+    if (/not-self/.test(lower)) modifiers.notSelf = true;
+    if (/from-centre/.test(lower)) modifiers.fromCentre = true;
+    // anchor modifier (mutually exclusive); 'back' must not fire on 'backline'
+    if (/(^|-)back(-|$)/.test(lower)) modifiers.anchorMod = 'back';
+    else if (/(^|-)center(-|$)/.test(lower)) modifiers.anchorMod = 'center';
+    else if (/(^|-)forward(-|$)/.test(lower)) modifiers.anchorMod = 'forward';
+
+    let range: number | 'all' | 'lane';
+    const rangeMatch = lower.match(/range-(\d+)/);
+    if (rangeMatch) {
+        range = parseInt(rangeMatch[1], 10);
+    } else if (/whole-lane/.test(lower)) {
+        range = 'lane';
+    } else if (/(^|-)all($|-)/.test(lower)) {
+        range = 'all';
+    } else {
+        // Pattern-Base / Pattern-Base-Support — no range token, point-blank.
+        range = 0;
+    }
+
+    return { raw, shape: detectShape(lower), range, modifiers };
+}
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `npx vitest run src/utils/__tests__/targetingParser.test.ts`
+Expected: PASS (parseTarget + parsePattern blocks).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/targetingParser.ts src/utils/__tests__/targetingParser.test.ts
+git commit -m "feat(targeting): pattern-axis tokenizer"
+```
+
+---
+
+## Task 4: Parser — per-skill + per-ship with charged inheritance (TDD)
+
+**Files:**
+- Modify: `src/utils/targetingParser.ts`
+- Modify: `src/types/ship.ts` (needed for the `parseShipTargeting` Pick type to compile — add the fields here)
+- Test: `src/utils/__tests__/targetingParser.test.ts`
+
+> The `Ship` type fields are added in this task because `parseShipTargeting` references
+> them via `Pick<Ship, ...>`. The plumbing that *populates* those fields is Task 6.
+
+- [ ] **Step 1: Add the raw-string fields to the `Ship` and `ShipData` interfaces**
+
+In `src/types/ship.ts`, after `thirdPassiveSkillText?: string;` in BOTH the `Ship`
+interface (around line 28) and the `ShipData` interface (around line 78), add:
+
+```ts
+    activeTarget?: string;
+    activePattern?: string;
+    chargedTarget?: string;
+    chargedPattern?: string;
+```
+
+- [ ] **Step 2: Write the failing tests for the per-skill + per-ship functions**
+
+Append to the test file (add the imports):
+
+```ts
+import { parseSkillTargeting, parseShipTargeting } from '../targetingParser';
+
+describe('parseSkillTargeting', () => {
+    it('combines target + pattern', () => {
+        expect(parseSkillTargeting('front', 'Pattern-Cone-Range-1')).toEqual({
+            target: { raw: 'front', side: 'enemy', selection: 'front' },
+            pattern: { raw: 'Pattern-Cone-Range-1', shape: 'cone', range: 1, modifiers: {} },
+        });
+    });
+});
+
+describe('parseShipTargeting — charged inheritance', () => {
+    const base = {
+        activeTarget: 'front',
+        activePattern: 'Pattern-Line-Range-1',
+        chargedTarget: undefined,
+        chargedPattern: undefined,
+        chargeSkillCharge: undefined,
+    };
+
+    it('parses active when present', () => {
+        const r = parseShipTargeting({ ...base });
+        expect(r.active).toMatchObject({ target: { selection: 'front' }, pattern: { shape: 'line' } });
+    });
+
+    it('inherits active when charged is empty AND the ship has a charged skill', () => {
+        const r = parseShipTargeting({ ...base, chargeSkillCharge: 4 });
+        expect(r.charged).toEqual(r.active);
+    });
+
+    it('uses the explicit charged override when present', () => {
+        const r = parseShipTargeting({
+            ...base,
+            chargeSkillCharge: 4,
+            chargedTarget: 'front',
+            chargedPattern: 'Pattern-Cone-Range-1',
+        });
+        expect(r.charged?.pattern.shape).toBe('cone');
+        expect(r.charged).not.toEqual(r.active);
+    });
+
+    it('leaves charged undefined when there is no charged skill', () => {
+        const r = parseShipTargeting({ ...base, chargeSkillCharge: undefined });
+        expect(r.charged).toBeUndefined();
+    });
+
+    it('returns empty object when there is no active targeting', () => {
+        const r = parseShipTargeting({
+            activeTarget: undefined,
+            activePattern: undefined,
+            chargedTarget: undefined,
+            chargedPattern: undefined,
+            chargeSkillCharge: 4,
+        });
+        expect(r.active).toBeUndefined();
+        expect(r.charged).toBeUndefined();
+    });
+});
+```
+
+- [ ] **Step 3: Run the test, verify it fails**
+
+Run: `npx vitest run src/utils/__tests__/targetingParser.test.ts -t inheritance`
+Expected: FAIL — `parseSkillTargeting` / `parseShipTargeting` not exported.
+
+- [ ] **Step 4: Implement the two functions**
+
+Append to `src/utils/targetingParser.ts`:
+
+```ts
+// ---------------------------------------------------------------------------
+// Per-skill and per-ship
+// ---------------------------------------------------------------------------
+
+export function parseSkillTargeting(target: string, pattern: string): SkillTargeting {
+    return { target: parseTarget(target), pattern: parsePattern(pattern) };
+}
+
+export function parseShipTargeting(
+    ship: Pick<
+        Ship,
+        'activeTarget' | 'activePattern' | 'chargedTarget' | 'chargedPattern' | 'chargeSkillCharge'
+    >
+): ShipTargeting {
+    const result: ShipTargeting = {};
+
+    if (ship.activeTarget && ship.activePattern) {
+        result.active = parseSkillTargeting(ship.activeTarget, ship.activePattern);
+    }
+
+    if (ship.chargedTarget && ship.chargedPattern) {
+        // Explicit override (charged differs from active).
+        result.charged = parseSkillTargeting(ship.chargedTarget, ship.chargedPattern);
+    } else if (result.active && ship.chargeSkillCharge != null) {
+        // Empty charged columns mean "charged targets the same as active"; only
+        // inherit when the ship actually has a charged skill.
+        result.charged = result.active;
+    }
+
+    return result;
+}
+```
+
+- [ ] **Step 5: Run the test, verify it passes**
+
+Run: `npx vitest run src/utils/__tests__/targetingParser.test.ts`
+Expected: PASS (all four describe blocks).
+
+- [ ] **Step 6: Type-check (the new `Ship` fields + Pick must compile)**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/utils/targetingParser.ts src/utils/__tests__/targetingParser.test.ts src/types/ship.ts
+git commit -m "feat(targeting): per-skill + per-ship parse with charged inheritance"
+```
+
+---
+
+## Task 5: Corpus coverage test
+
+Proves the whole gathered vocabulary tokenizes with no `unknown` and no throw.
+
+**Files:**
+- Test: `src/utils/__tests__/targetingParser.test.ts`
+
+- [ ] **Step 1: Add the corpus test**
+
+Append to the test file (add `existsSync`/`readFileSync` imports at the top):
+
+```ts
+import { existsSync, readFileSync } from 'fs';
+
+// docs/ is gitignored (dev-machine-local reference data). Skip cleanly if absent.
+const CSV_PATH = 'docs/ship-targeting.csv';
+const csvAvailable = existsSync(CSV_PATH);
+
+describe.skipIf(!csvAvailable)('ship-targeting.csv corpus coverage', () => {
+    const rows = readFileSync(CSV_PATH, 'utf8')
+        .split(/\r?\n/)
+        .filter((l) => l.trim().length > 0)
+        .slice(1) // drop header
+        .map((line) => {
+            const [name, activeTarget, activePattern, chargedTarget, chargedPattern] =
+                line.split(',');
+            return {
+                name: name.trim(),
+                activeTarget: (activeTarget ?? '').trim(),
+                activePattern: (activePattern ?? '').trim(),
+                chargedTarget: (chargedTarget ?? '').trim(),
+                chargedPattern: (chargedPattern ?? '').trim(),
+            };
+        });
+
+    it('has rows to test', () => {
+        expect(rows.length).toBeGreaterThan(100);
+    });
+
+    it('every active target+pattern tokenizes with no unknown / no throw', () => {
+        for (const row of rows) {
+            expect(
+                () => parseSkillTargeting(row.activeTarget, row.activePattern),
+                `active for ${row.name}: "${row.activeTarget}" / "${row.activePattern}"`
+            ).not.toThrow();
+        }
+    });
+
+    it('every explicit charged target+pattern tokenizes with no unknown / no throw', () => {
+        for (const row of rows) {
+            if (row.chargedTarget && row.chargedPattern) {
+                expect(
+                    () => parseSkillTargeting(row.chargedTarget, row.chargedPattern),
+                    `charged for ${row.name}: "${row.chargedTarget}" / "${row.chargedPattern}"`
+                ).not.toThrow();
+            }
+        }
+    });
+});
+```
+
+- [ ] **Step 2: Run the corpus test, verify it passes**
+
+Run: `npx vitest run src/utils/__tests__/targetingParser.test.ts -t corpus`
+Expected: PASS. If any row throws, the failure message names the ship and the raw
+values — fix `targetingParser.ts` (a missing shape/modifier) until green. This is the
+coverage gate from the spec.
+
+- [ ] **Step 3: Run the full parser test file once more**
+
+Run: `npx vitest run src/utils/__tests__/targetingParser.test.ts`
+Expected: ALL PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/__tests__/targetingParser.test.ts
+git commit -m "test(targeting): corpus coverage gate over ship-targeting.csv"
+```
+
+---
+
+## Task 6: Frontend plumbing (template → Ship)
+
+Thread the raw strings from `ship_templates` onto the `Ship` model. `Ship`/`ShipData`
+fields were already added in Task 4; this task wires the template fetch + transform.
+
+**Files:**
+- Modify: `src/hooks/useShipsData.ts` (`ShipTemplate` interface ~lines 5–35, `transformShipTemplate` ~lines 37–72)
+- Modify: `src/services/shipTemplateProposalService.ts` (`ShipTemplate` interface ~lines 22–55)
+
+- [ ] **Step 1: Extend the `ShipTemplate` interface in `useShipsData.ts`**
+
+After `third_passive_skill_text?: string;` (around line 18) add:
+
+```ts
+    active_target?: string;
+    active_pattern?: string;
+    charged_target?: string;
+    charged_pattern?: string;
+```
+
+- [ ] **Step 2: Map the columns in `transformShipTemplate`**
+
+After `thirdPassiveSkillText: template.third_passive_skill_text,` (around line 68) add:
+
+```ts
+    activeTarget: template.active_target,
+    activePattern: template.active_pattern,
+    chargedTarget: template.charged_target,
+    chargedPattern: template.charged_pattern,
+```
+
+- [ ] **Step 3: Extend the `ShipTemplate` interface in `shipTemplateProposalService.ts`**
+
+After `third_passive_skill_text: string | null;` (around line 35) add:
+
+```ts
+    active_target?: string | null;
+    active_pattern?: string | null;
+    charged_target?: string | null;
+    charged_pattern?: string | null;
+```
+
+(No change to the proposal insert/upsert paths — targeting is not proposal-driven; this
+just keeps the interface accurate to the table shape.)
+
+- [ ] **Step 4: Type-check + lint**
+
+Run: `npx tsc --noEmit && npm run lint`
+Expected: no errors, 0 warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useShipsData.ts src/services/shipTemplateProposalService.ts
+git commit -m "feat(targeting): plumb targeting columns onto the Ship model"
+```
+
+---
+
+## Task 7: Populate script
+
+Loads the CSV into `ship_templates` using the service role; dry-run + unmatched report.
+
+**Files:**
+- Create: `scripts/populate-ship-targeting.ts`
+- Modify: `package.json` (add the npm script)
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/populate-ship-targeting.ts`:
+
+```ts
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync } from 'fs';
+
+const DRY_RUN = process.env.DRY_RUN === 'true' || process.argv.includes('--dry-run');
+const CSV_PATH = 'docs/ship-targeting.csv';
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !serviceRoleKey) {
+    console.error('Missing VITE_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in .env');
+    process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+interface Row {
+    name: string;
+    active_target: string | null;
+    active_pattern: string | null;
+    charged_target: string | null;
+    charged_pattern: string | null;
+}
+
+const parseCsv = (): Row[] => {
+    const lines = readFileSync(CSV_PATH, 'utf8')
+        .split(/\r?\n/)
+        .filter((l) => l.trim().length > 0);
+    const rows: Row[] = [];
+    for (let i = 1; i < lines.length; i++) {
+        const [name, at, ap, ct, cp] = lines[i].split(',');
+        const norm = (v?: string) => {
+            const t = (v ?? '').trim();
+            return t.length ? t : null;
+        };
+        rows.push({
+            name: (name ?? '').trim(),
+            active_target: norm(at),
+            active_pattern: norm(ap),
+            charged_target: norm(ct),
+            charged_pattern: norm(cp),
+        });
+    }
+    return rows;
+};
+
+const main = async () => {
+    const rows = parseCsv();
+
+    const { data: templates, error } = await supabase
+        .from('ship_templates')
+        .select('id, name');
+    if (error || !templates) {
+        console.error('Failed to fetch ship_templates:', error?.message);
+        process.exit(1);
+    }
+
+    const byName = new Map<string, { id: string; name: string }>();
+    for (const t of templates) byName.set(t.name.toLowerCase(), t);
+
+    const unmatchedCsv: string[] = [];
+    const matched = new Set<string>();
+    let updated = 0;
+
+    for (const row of rows) {
+        const tmpl = byName.get(row.name.toLowerCase());
+        if (!tmpl) {
+            unmatchedCsv.push(row.name);
+            continue;
+        }
+        matched.add(tmpl.name.toLowerCase());
+
+        const payload = {
+            active_target: row.active_target,
+            active_pattern: row.active_pattern,
+            charged_target: row.charged_target,
+            charged_pattern: row.charged_pattern,
+        };
+
+        if (DRY_RUN) {
+            console.log(`[dry-run] ${tmpl.name}:`, JSON.stringify(payload));
+            updated++;
+            continue;
+        }
+
+        const { error: upErr } = await supabase
+            .from('ship_templates')
+            .update(payload)
+            .eq('id', tmpl.id);
+        if (upErr) {
+            console.error(`Failed to update ${tmpl.name}:`, upErr.message);
+            continue;
+        }
+        updated++;
+    }
+
+    const unmatchedTemplates = templates
+        .filter((t) => !matched.has(t.name.toLowerCase()))
+        .map((t) => t.name)
+        .sort();
+
+    console.log(`\n${DRY_RUN ? '[DRY RUN] ' : ''}Processed ${updated}/${rows.length} CSV rows.`);
+    if (unmatchedCsv.length) {
+        console.warn(
+            `\nCSV names with NO matching template (${unmatchedCsv.length}):\n  ${unmatchedCsv.join('\n  ')}`
+        );
+    }
+    if (unmatchedTemplates.length) {
+        console.warn(
+            `\nTemplates with NO CSV targeting row (${unmatchedTemplates.length}):\n  ${unmatchedTemplates.join('\n  ')}`
+        );
+    }
+};
+
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});
+```
+
+- [ ] **Step 2: Add the npm script**
+
+In `package.json` `scripts`, next to `"admin:import"`, add:
+
+```json
+        "populate-targeting": "tsx scripts/populate-ship-targeting.ts",
+```
+
+- [ ] **Step 3: Type-check the script**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Dry-run (maintainer, needs `.env` with service role key)**
+
+Run: `npm run populate-targeting -- --dry-run`
+Expected: prints per-ship payloads, ends with `Processed N/147 CSV rows.` and ideally
+`0` unmatched in both directions. Investigate any unmatched names before the real run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/populate-ship-targeting.ts package.json
+git commit -m "feat(targeting): populate script for ship_templates targeting columns"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full suite + lint + types**
+
+```bash
+npx vitest run && npm run lint && npx tsc --noEmit
+```
+Expected: all tests pass (existing suite unchanged + new parser tests), 0 lint warnings, no type errors.
+
+- [ ] **Apply the migration** (maintainer, Supabase CLI/dashboard) and **run the real populate**:
+
+```bash
+# after migration is applied:
+npm run populate-targeting -- --dry-run   # confirm 0 unmatched
+npm run populate-targeting                 # write
+```
+
+- [ ] **Changelog** — this is a data/infrastructure foundation with no user-visible
+  behaviour change, so **no** `UNRELEASED_CHANGES` entry is needed (per the changelog
+  rule: skip internal tooling / non-user-facing changes). If the maintainer disagrees,
+  add a one-liner under `src/constants/changelog.ts`.
+
+- [ ] **Open the PR** (`gh auth switch --hostname github.com --user TheSusort` first).
+
+---
+
+## Success criteria (from spec)
+
+- Migration adds the 4 nullable columns.
+- Populate dry-run reports 0 unmatched (or the few are resolved).
+- Corpus test green across all 147 ships (every active + explicit charged value
+  tokenizes with no `unknown` and no throw).
+- Raw targeting strings reach the frontend `Ship` model.
+- Existing test suite unchanged; `lint` + `tsc` clean.
+
+## Out of scope (later phases)
+
+Cell geometry (`resolveCells`), engine target-resolution, AoE application, UI/visualizer.

--- a/docs/superpowers/specs/2026-06-13-targeting-data-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-13-targeting-data-foundation-design.md
@@ -66,7 +66,13 @@ ALTER TABLE public.ship_templates
 ```
 
 - No RLS changes — `ship_templates` is an existing, already-policied table.
-- Charged columns are sparse (only 9 ships have charged targeting in the corpus).
+- **Charged columns are an OVERRIDE, not a full value.** The gathered data only
+  fills `charged_target` / `charged_pattern` when the charged skill's targeting
+  **differs** from the active skill's. An empty charged column therefore means
+  "the charged skill targets the same as the active skill" (inheritance) — **not**
+  "no charged targeting." We store the data verbatim (empty = inherit); the
+  inheritance is resolved at parse time (see §4), so the DB stays minimal and
+  matches the maintainer's intent. The populate script does **not** back-fill.
 - Naming follows the existing `active_skill_text` / `charge_skill_text` convention.
 
 ### 2. Populate script
@@ -163,8 +169,28 @@ export function parseTarget(raw: string): ParsedTarget;
 export function parsePattern(raw: string): ParsedPattern;
 export function parseSkillTargeting(target: string, pattern: string): SkillTargeting;
 export function parseShipTargeting(ship: Pick<Ship,
-  'activeTarget' | 'activePattern' | 'chargedTarget' | 'chargedPattern'>): ShipTargeting;
+  'activeTarget' | 'activePattern' | 'chargedTarget' | 'chargedPattern' | 'chargeSkillCharge'>): ShipTargeting;
 ```
+
+**Charged-targeting inheritance (resolved here, not in the DB).** Because empty
+charged columns mean "same as active", `parseShipTargeting` resolves charged as
+follows:
+
+- `active` = `parseSkillTargeting(activeTarget, activePattern)` when both are
+  present, else `undefined`.
+- `charged`:
+  - If **both** `chargedTarget` and `chargedPattern` are present → parse them
+    (an explicit override).
+  - Else if the ship **has a charged skill** (`chargeSkillCharge != null`) and
+    `active` is defined → `charged` **inherits** `active` (a structural copy of the
+    active `SkillTargeting`).
+  - Else → `undefined` (no charged skill, or no active to inherit from).
+
+This means a consumer never has to special-case "empty = same as active"; the
+model already carries the resolved charged targeting. The gate on
+`chargeSkillCharge` prevents fabricating charged targeting for ships that have no
+charged skill at all. `parseSkillTargeting` itself stays pure (one skill, no
+inheritance) so it is independently testable.
 
 **Grammar handled** (loosely — modifiers are order-flexible, so the parser should
 detect tokens by presence, **not** by fixed position):
@@ -215,6 +241,10 @@ shape. Also do not assume `Prolonged_Cone` always carries an anchor (AEGIS's
 - **Per-token unit tests** — each of the 8 target values; each shape; each
   modifier (support, prolonged, reverse, notSelf, fromCentre, anchorMod variants);
   range numeric / `all` / `lane`.
+- **Charged-inheritance tests** for `parseShipTargeting`: (a) empty charged +
+  `chargeSkillCharge != null` → `charged` deep-equals `active`; (b) explicit
+  charged override → `charged` reflects the override, not active; (c) empty
+  charged + `chargeSkillCharge == null` → `charged` is `undefined`.
 - **Corpus test** — reads `docs/ship-targeting.csv` and asserts every `active`
   and (non-empty) `charged` value parses with **no `'unknown'` shape or selection
   and no unconsumed tokens**. This is the coverage gate that the entire vocabulary

--- a/docs/superpowers/specs/2026-06-13-targeting-data-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-13-targeting-data-foundation-design.md
@@ -1,0 +1,259 @@
+# Targeting Data Foundation — Design
+
+**Date:** 2026-06-13
+**Status:** Approved (design), pending spec review
+**Phase:** Combat engine — targeting prerequisite (data layer only)
+
+## Context
+
+The combat engine's targeting is deliberately degenerate today (single-target
+focus-fire vs the configured heal target). The full positional model — 3×4 hex
+board, front/back/skip target anchoring, AoE/pattern spread — was the deferred
+"4d" work, blocked on two missing pieces of game data:
+
+1. **Who each skill targets** (`front` / `back` / `skip` / `allies` / `self` / `all` / …)
+2. **The spread pattern** (`Cone-Range-1`, `Line-Range-2`, `Backline-Range-1`, …)
+
+Both have now been hand-gathered into `docs/ship-targeting.csv` (147 ships,
+columns: `name, active_target, active_pattern, charged_target, charged_pattern`).
+The 3×4 hex board already exists in the encounter-notes feature
+(`src/types/encounters.ts` `Position` = `T1–T4` / `M1–M4` / `B1–B4`,
+rendered by `src/components/encounters/FormationGrid.tsx`).
+
+This phase is **scoped to the data foundation only**: ingest the data, expose it
+on the frontend `Ship` model, and build a tested parser that tokenizes the raw
+game strings into a structured model. **No combat-engine changes.** The positional
+engine that consumes this model is a later phase.
+
+## Goal
+
+Make the targeting/pattern data available as a clean, validated, structured model
+so the later positional-engine phase has a ready contract to build on — without
+guessing at board geometry now.
+
+## Non-goals (explicitly later phases)
+
+- Cell geometry: `resolveCells(model, anchor) → Position[]` (which exact hexes a
+  shape covers). This is the genuinely hard part that needs exact game-truth and
+  is the engine phase's concern.
+- Engine target-resolution / replacing single-target focus-fire.
+- AoE / pattern application during combat.
+- Any UI, board visualizer, or simulator-page work.
+
+## Approach
+
+Decisions locked during brainstorming:
+
+- **Storage = raw strings, parse at runtime.** Mirrors how `*_skill_text` is
+  stored and `skillTextParser` derives abilities. DB stays simple; the parser can
+  evolve with no migration; data-quality fixes live in the parser, not the data.
+- **Model depth = tokenize only.** The parser decomposes each string into a typed
+  model and validates the whole corpus parses; it does not compute board cells.
+
+## Design
+
+### 1. Database (Supabase)
+
+Migration `supabase/migrations/YYYYMMDD_add_targeting_to_ship_templates.sql` adds
+four **nullable text columns** to `ship_templates`, holding verbatim game strings:
+
+```sql
+ALTER TABLE public.ship_templates
+  ADD COLUMN IF NOT EXISTS active_target   text,
+  ADD COLUMN IF NOT EXISTS active_pattern  text,
+  ADD COLUMN IF NOT EXISTS charged_target  text,
+  ADD COLUMN IF NOT EXISTS charged_pattern text;
+```
+
+- No RLS changes — `ship_templates` is an existing, already-policied table.
+- Charged columns are sparse (only 9 ships have charged targeting in the corpus).
+- Naming follows the existing `active_skill_text` / `charge_skill_text` convention.
+
+### 2. Populate script
+
+`scripts/populate-ship-targeting.ts` — server-side, uses
+`SUPABASE_SERVICE_ROLE_KEY` (never a `VITE_` var, per the security rules; same key
+pattern as `scripts/admin-import.ts` and `scripts/update-ship-skills.ts`).
+
+Behaviour:
+
+- Reads `docs/ship-targeting.csv`.
+- Matches each row to a `ship_templates` row by **case-insensitive `name`**.
+- Updates the four columns for matched rows.
+- `--dry-run` flag: report what would change without writing.
+- **Reports unmatched names in both directions** (CSV rows with no template,
+  templates with no CSV row) so drift is caught before writing.
+
+The maintainer (Kenneth) runs this; it needs the service-role key, exactly like
+`npm run admin:import`. Name-match has been pre-verified: all 147 CSV names match
+the canonical template names (the generated `docs/ship-skills.csv` derives from
+`ship_templates.name`, and the targeting names are a subset of it with zero
+mismatches).
+
+### 3. Frontend plumbing
+
+`supabase.from('ship_templates').select('*')` already pulls the new columns, so
+the only code changes thread them into the typed model:
+
+- `src/types/ship.ts` — add four optional raw-string fields to `Ship` (and the
+  sibling interface in the same file): `activeTarget`, `activePattern`,
+  `chargedTarget`, `chargedPattern`.
+- `src/hooks/useShipsData.ts` — extend the local `ShipTemplate` interface with the
+  four snake_case columns and map them in `transformShipTemplate`.
+- `src/services/shipTemplateProposalService.ts` — extend its `ShipTemplate`
+  interface with the four columns (kept in sync with the table shape).
+
+These are raw strings only — no parsing in the plumbing layer.
+
+### 4. The parser — `src/utils/targetingParser.ts` (new)
+
+Pure, dependency-free, alongside `src/utils/skillTextParser.ts`. Tokenizes the two
+axes into a structured model.
+
+```ts
+// ---- TARGET axis ----
+export type TargetSide = 'enemy' | 'ally';
+export type TargetSelection =
+  | 'front' | 'back' | 'skip' | 'all'   // enemy-side selections
+  | 'team' | 'others' | 'self';         // ally-side selections
+
+export interface ParsedTarget {
+  raw: string;
+  side: TargetSide;
+  selection: TargetSelection;
+}
+
+// Mapping (raw → side/selection):
+//   front        → enemy / front
+//   back         → enemy / back
+//   skip         → enemy / skip
+//   all          → enemy / all
+//   allies       → ally  / team      (pattern-scoped allies)
+//   all-allies   → ally  / all       (entire friendly team)
+//   other-allies → ally  / others    (team minus self)
+//   self         → ally  / self
+
+// ---- PATTERN axis ----
+export type PatternShape =
+  | 'base' | 'cone' | 'line' | 'cross' | 'curve' | 'circle' | 'backline'
+  | 'root' | 'split' | 'burst' | 'scattershot' | 'wings' | 'range'
+  | 'pickaxe' | 'all';
+
+export interface PatternModifiers {
+  support?: boolean;     // "-Support-" / "Support-All" / "Base-Support"
+  prolonged?: boolean;   // "Prolonged_Cone"
+  reverse?: boolean;     // "Reverse-Curve" / "Reverse-Cone"
+  notSelf?: boolean;     // "Not-Self"
+  fromCentre?: boolean;  // "Line-from-centre"
+  anchorMod?: 'back' | 'center' | 'forward'; // Cone-Back / …-Center / Support-Forward-Circle
+}
+
+export interface ParsedPattern {
+  raw: string;
+  shape: PatternShape;
+  range: number | 'all' | 'lane'; // numeric 0–3; 'all' (Pattern-All/Support-All); 'lane' (whole-lane)
+  modifiers: PatternModifiers;
+}
+
+// ---- combined ----
+export interface SkillTargeting { target: ParsedTarget; pattern: ParsedPattern; }
+export interface ShipTargeting { active?: SkillTargeting; charged?: SkillTargeting; }
+
+export function parseTarget(raw: string): ParsedTarget;
+export function parsePattern(raw: string): ParsedPattern;
+export function parseSkillTargeting(target: string, pattern: string): SkillTargeting;
+export function parseShipTargeting(ship: Pick<Ship,
+  'activeTarget' | 'activePattern' | 'chargedTarget' | 'chargedPattern'>): ShipTargeting;
+```
+
+**Grammar handled** (loosely — modifiers are order-flexible, so the parser should
+detect tokens by presence, **not** by fixed position):
+`Pattern-[Prolonged_]<Shape>[-Support][-Back|-Center|-Forward|-Not-Self|-from-centre|-Double-Pickaxe]-Range-<N|whole-lane>`,
+plus the standalone forms `Pattern-All`, `Pattern-Support-All`, `Pattern-Base-Support`.
+
+**Important:** `Support` and the anchor token can appear *before* the shape, not
+just after it — e.g. `Pattern-Support-Double-Pickaxe-Range-0`,
+`Pattern-Support-Forward-Circle-Range-1`, `Pattern-Support-All`. The parser must
+**not** assume `<Shape>` precedes `-Support`. Implement it as: normalize → strip
+the `Pattern-` prefix → pull out the `Range-N` / `whole-lane` suffix → detect each
+modifier token by presence anywhere in the remainder → the surviving token is the
+shape. Also do not assume `Prolonged_Cone` always carries an anchor (AEGIS's
+`Pattern-Prolonged_Cone-Support-Range-2` has none; Sentinel's `…-Center-…` does).
+
+**Token → model mapping for the irregular cases:**
+
+| Raw pattern (example)                          | shape        | range  | modifiers                         |
+|------------------------------------------------|--------------|--------|-----------------------------------|
+| `Pattern-Base`                                 | `base`       | `0`    | —                                 |
+| `Pattern-Base-Support` (Meatshield)            | `base`       | `0`    | `support`                         |
+| `Pattern-Cone-Range-1`                         | `cone`       | `1`    | —                                 |
+| `Pattern-Cone-Back-Range-1` (APEX)             | `cone`       | `1`    | `anchorMod:'back'`                |
+| `Pattern-Prolonged_Cone-Support-Center-Range-2`| `cone`       | `2`    | `prolonged, support, anchorMod:'center'` |
+| `Pattern-Reverse-Cone-Range-1` (Pestilence chg)| `cone`       | `1`    | `reverse`                         |
+| `Pattern-Line-from-centre-Range-1`             | `line`       | `1`    | `fromCentre`                      |
+| `Pattern-Line-Support-whole-lane`              | `line`       | `lane` | `support`                         |
+| `Pattern-Line-Support-Not-Self-Range-2` (Mender)| `line`      | `2`    | `support, notSelf`                |
+| `Pattern-Reverse-Curve-Range-1` (Sansi)        | `curve`      | `1`    | `reverse`                         |
+| `Pattern-Range-3` (Incinerator/Ripper)         | `range`      | `3`    | —                                 |
+| `Pattern-Support-Forward-Circle-Range-1` (Howler)| `circle`   | `1`    | `support, anchorMod:'forward'`    |
+| `Pattern-Support-Double-Pickaxe-Range-0` (Graphite)| `pickaxe`| `0`    | `support`                         |
+| `Pattern-Wings-Support-Not-Self-Range-2` (Purifier)| `wings`  | `2`    | `support, notSelf`                |
+| `Pattern-All` (Curator)                        | `all`        | `all`  | —                                 |
+| `Pattern-Support-All` (Chimei/Hayyan)          | `all`        | `all`  | `support`                         |
+
+**Data-quality normalization (in the parser, before tokenizing):**
+
+- `Patern` → `Pattern` (Grif's `Patern-Support-All` typo).
+- `Prolonged_Cone` underscore handled by the `Prolonged_` prefix rule.
+- `Range-0` is valid (numeric 0).
+- `whole-lane` → `range:'lane'`.
+
+### 5. Tests (TDD)
+
+`src/utils/__tests__/targetingParser.test.ts`:
+
+- **Per-token unit tests** — each of the 8 target values; each shape; each
+  modifier (support, prolonged, reverse, notSelf, fromCentre, anchorMod variants);
+  range numeric / `all` / `lane`.
+- **Corpus test** — reads `docs/ship-targeting.csv` and asserts every `active`
+  and (non-empty) `charged` value parses with **no `'unknown'` shape or selection
+  and no unconsumed tokens**. This is the coverage gate that the entire vocabulary
+  is handled. (Note: `docs/` is gitignored; the test reads the local file via a
+  relative path, consistent with other reference-data-backed tooling. If the file
+  is absent the test should skip with a clear message rather than fail, since the
+  reference data is dev-machine-local.)
+
+## File touch list
+
+| File | Change |
+|------|--------|
+| `supabase/migrations/YYYYMMDD_add_targeting_to_ship_templates.sql` | new — 4 nullable columns |
+| `scripts/populate-ship-targeting.ts` | new — CSV → ship_templates (service role), dry-run + unmatched report |
+| `src/utils/targetingParser.ts` | new — types + parser |
+| `src/utils/__tests__/targetingParser.test.ts` | new — token + corpus tests |
+| `src/types/ship.ts` | add 4 optional raw-string fields |
+| `src/hooks/useShipsData.ts` | extend `ShipTemplate` + `transformShipTemplate` |
+| `src/services/shipTemplateProposalService.ts` | extend `ShipTemplate` interface |
+
+## Success criteria
+
+- Migration adds the 4 nullable columns (applied via Supabase CLI/dashboard).
+- Populate script runs, reports **0 unmatched** (or the few are resolved).
+- Corpus test green across all 147 ships (every active + charged value tokenizes
+  with no `unknown` and no leftover tokens).
+- Raw targeting strings reach the frontend `Ship` model.
+- Existing test suite unchanged (no engine behaviour touched); `lint` + `tsc` clean.
+
+## Risks / notes
+
+- **Name drift** between CSV and `ship_templates` — mitigated by the dry-run
+  unmatched report; pre-verified zero mismatches at design time.
+- **Vocabulary completeness** — the corpus test is the backstop; any future ship
+  with a novel shape/modifier fails the test loudly rather than silently producing
+  `unknown`.
+- **`charge_skill_text` vs `charged_pattern` naming** — the existing skill column
+  uses `charge_` while the targeting CSV uses `charged_`. We keep `charged_` for
+  the targeting columns to match the gathered data verbatim; documented here to
+  avoid confusion.
+- The structured model intentionally stops at tokens. The later engine phase adds
+  geometry; keeping the model token-only now avoids encoding board-cell guesses.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "fetch-buffs": "tsx src/utils/dataUpdate/updateBuffsData.ts",
         "fetch:gear-icons": "tsx scripts/fetch-gear-icons.ts",
         "admin:import": "tsx scripts/admin-import.ts",
+        "populate-targeting": "tsx scripts/populate-ship-targeting.ts",
         "e2e": "cd e2e && npm test",
         "e2e:headed": "cd e2e && npm run test:headed",
         "e2e:ui": "cd e2e && npm run test:ui",

--- a/scripts/populate-ship-targeting.ts
+++ b/scripts/populate-ship-targeting.ts
@@ -1,0 +1,119 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync } from 'fs';
+
+const DRY_RUN = process.env.DRY_RUN === 'true' || process.argv.includes('--dry-run');
+const CSV_PATH = 'docs/ship-targeting.csv';
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !serviceRoleKey) {
+    console.error('Missing VITE_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in .env');
+    process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+interface Row {
+    name: string;
+    active_target: string | null;
+    active_pattern: string | null;
+    charged_target: string | null;
+    charged_pattern: string | null;
+}
+
+const parseCsv = (): Row[] => {
+    const lines = readFileSync(CSV_PATH, 'utf8')
+        .split(/\r?\n/)
+        .filter((l) => l.trim().length > 0);
+    const rows: Row[] = [];
+    for (let i = 1; i < lines.length; i++) {
+        const [name, at, ap, ct, cp] = lines[i].split(',');
+        const norm = (v?: string) => {
+            const t = (v ?? '').trim();
+            return t.length ? t : null;
+        };
+        rows.push({
+            name: (name ?? '').trim(),
+            active_target: norm(at),
+            active_pattern: norm(ap),
+            charged_target: norm(ct),
+            charged_pattern: norm(cp),
+        });
+    }
+    return rows;
+};
+
+const main = async () => {
+    const rows = parseCsv();
+
+    const { data: templates, error } = await supabase
+        .from('ship_templates')
+        .select('id, name');
+    if (error || !templates) {
+        console.error('Failed to fetch ship_templates:', error?.message);
+        process.exit(1);
+    }
+
+    const byName = new Map<string, { id: string; name: string }>();
+    for (const t of templates) byName.set(t.name.toLowerCase(), t);
+
+    const unmatchedCsv: string[] = [];
+    const matched = new Set<string>();
+    let updated = 0;
+
+    for (const row of rows) {
+        const tmpl = byName.get(row.name.toLowerCase());
+        if (!tmpl) {
+            unmatchedCsv.push(row.name);
+            continue;
+        }
+        matched.add(tmpl.name.toLowerCase());
+
+        const payload = {
+            active_target: row.active_target,
+            active_pattern: row.active_pattern,
+            charged_target: row.charged_target,
+            charged_pattern: row.charged_pattern,
+        };
+
+        if (DRY_RUN) {
+            console.log(`[dry-run] ${tmpl.name}:`, JSON.stringify(payload));
+            updated++;
+            continue;
+        }
+
+        const { error: upErr } = await supabase
+            .from('ship_templates')
+            .update(payload)
+            .eq('id', tmpl.id);
+        if (upErr) {
+            console.error(`Failed to update ${tmpl.name}:`, upErr.message);
+            continue;
+        }
+        updated++;
+    }
+
+    const unmatchedTemplates = templates
+        .filter((t) => !matched.has(t.name.toLowerCase()))
+        .map((t) => t.name)
+        .sort();
+
+    console.log(`\n${DRY_RUN ? '[DRY RUN] ' : ''}Processed ${updated}/${rows.length} CSV rows.`);
+    if (unmatchedCsv.length) {
+        console.warn(
+            `\nCSV names with NO matching template (${unmatchedCsv.length}):\n  ${unmatchedCsv.join('\n  ')}`
+        );
+    }
+    if (unmatchedTemplates.length) {
+        console.warn(
+            `\nTemplates with NO CSV targeting row (${unmatchedTemplates.length}):\n  ${unmatchedTemplates.join('\n  ')}`
+        );
+    }
+};
+
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});

--- a/scripts/populate-ship-targeting.ts
+++ b/scripts/populate-ship-targeting.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import { readFileSync } from 'fs';
+import { parseTargetingCsv } from '../src/utils/targetingParser';
 
 const DRY_RUN = process.env.DRY_RUN === 'true' || process.argv.includes('--dry-run');
 const CSV_PATH = 'docs/ship-targeting.csv';
@@ -15,38 +16,9 @@ if (!supabaseUrl || !serviceRoleKey) {
 
 const supabase = createClient(supabaseUrl, serviceRoleKey);
 
-interface Row {
-    name: string;
-    active_target: string | null;
-    active_pattern: string | null;
-    charged_target: string | null;
-    charged_pattern: string | null;
-}
-
-const parseCsv = (): Row[] => {
-    const lines = readFileSync(CSV_PATH, 'utf8')
-        .split(/\r?\n/)
-        .filter((l) => l.trim().length > 0);
-    const rows: Row[] = [];
-    for (let i = 1; i < lines.length; i++) {
-        const [name, at, ap, ct, cp] = lines[i].split(',');
-        const norm = (v?: string) => {
-            const t = (v ?? '').trim();
-            return t.length ? t : null;
-        };
-        rows.push({
-            name: (name ?? '').trim(),
-            active_target: norm(at),
-            active_pattern: norm(ap),
-            charged_target: norm(ct),
-            charged_pattern: norm(cp),
-        });
-    }
-    return rows;
-};
-
 const main = async () => {
-    const rows = parseCsv();
+    const rows = parseTargetingCsv(readFileSync(CSV_PATH, 'utf8'));
+    const orNull = (v: string) => (v.length ? v : null);
 
     const { data: templates, error } = await supabase
         .from('ship_templates')
@@ -72,10 +44,10 @@ const main = async () => {
         matched.add(tmpl.name.toLowerCase());
 
         const payload = {
-            active_target: row.active_target,
-            active_pattern: row.active_pattern,
-            charged_target: row.charged_target,
-            charged_pattern: row.charged_pattern,
+            active_target: orNull(row.activeTarget),
+            active_pattern: orNull(row.activePattern),
+            charged_target: orNull(row.chargedTarget),
+            charged_pattern: orNull(row.chargedPattern),
         };
 
         if (DRY_RUN) {
@@ -100,7 +72,8 @@ const main = async () => {
         .map((t) => t.name)
         .sort();
 
-    console.log(`\n${DRY_RUN ? '[DRY RUN] ' : ''}Processed ${updated}/${rows.length} CSV rows.`);
+    const verb = DRY_RUN ? 'Would update' : 'Updated';
+    console.log(`\n${verb} ${updated}/${rows.length} matched CSV rows.`);
     if (unmatchedCsv.length) {
         console.warn(
             `\nCSV names with NO matching template (${unmatchedCsv.length}):\n  ${unmatchedCsv.join('\n  ')}`

--- a/src/hooks/useShipsData.ts
+++ b/src/hooks/useShipsData.ts
@@ -16,6 +16,10 @@ interface ShipTemplate {
     first_passive_skill_text?: string;
     second_passive_skill_text?: string;
     third_passive_skill_text?: string;
+    active_target?: string;
+    active_pattern?: string;
+    charged_target?: string;
+    charged_pattern?: string;
     bio?: string;
     quote?: string;
     quote_author?: string;
@@ -66,6 +70,10 @@ const transformShipTemplate = (template: ShipTemplate): Ship => ({
     firstPassiveSkillText: template.first_passive_skill_text,
     secondPassiveSkillText: template.second_passive_skill_text,
     thirdPassiveSkillText: template.third_passive_skill_text,
+    activeTarget: template.active_target,
+    activePattern: template.active_pattern,
+    chargedTarget: template.charged_target,
+    chargedPattern: template.charged_pattern,
     bio: template.bio,
     quote: template.quote,
     quoteAuthor: template.quote_author,

--- a/src/hooks/useShipsData.ts
+++ b/src/hooks/useShipsData.ts
@@ -16,10 +16,10 @@ interface ShipTemplate {
     first_passive_skill_text?: string;
     second_passive_skill_text?: string;
     third_passive_skill_text?: string;
-    active_target?: string;
-    active_pattern?: string;
-    charged_target?: string;
-    charged_pattern?: string;
+    active_target?: string | null;
+    active_pattern?: string | null;
+    charged_target?: string | null;
+    charged_pattern?: string | null;
     bio?: string;
     quote?: string;
     quote_author?: string;
@@ -70,10 +70,10 @@ const transformShipTemplate = (template: ShipTemplate): Ship => ({
     firstPassiveSkillText: template.first_passive_skill_text,
     secondPassiveSkillText: template.second_passive_skill_text,
     thirdPassiveSkillText: template.third_passive_skill_text,
-    activeTarget: template.active_target,
-    activePattern: template.active_pattern,
-    chargedTarget: template.charged_target,
-    chargedPattern: template.charged_pattern,
+    activeTarget: template.active_target ?? undefined,
+    activePattern: template.active_pattern ?? undefined,
+    chargedTarget: template.charged_target ?? undefined,
+    chargedPattern: template.charged_pattern ?? undefined,
     bio: template.bio,
     quote: template.quote,
     quoteAuthor: template.quote_author,

--- a/src/services/shipTemplateProposalService.ts
+++ b/src/services/shipTemplateProposalService.ts
@@ -33,6 +33,10 @@ export interface ShipTemplate {
     first_passive_skill_text: string | null;
     second_passive_skill_text: string | null;
     third_passive_skill_text: string | null;
+    active_target?: string | null;
+    active_pattern?: string | null;
+    charged_target?: string | null;
+    charged_pattern?: string | null;
     definition_id: string | null;
     base_stats: {
         hp: number;

--- a/src/types/ship.ts
+++ b/src/types/ship.ts
@@ -26,6 +26,10 @@ export interface Ship {
     firstPassiveSkillText?: string;
     secondPassiveSkillText?: string;
     thirdPassiveSkillText?: string;
+    activeTarget?: string;
+    activePattern?: string;
+    chargedTarget?: string;
+    chargedPattern?: string;
     bio?: string;
     quote?: string;
     quoteAuthor?: string;
@@ -76,6 +80,10 @@ export interface ShipData {
     firstPassiveSkillText?: string;
     secondPassiveSkillText?: string;
     thirdPassiveSkillText?: string;
+    activeTarget?: string;
+    activePattern?: string;
+    chargedTarget?: string;
+    chargedPattern?: string;
     bio?: string;
     quote?: string;
     quoteAuthor?: string;

--- a/src/utils/__tests__/targetingParser.test.ts
+++ b/src/utils/__tests__/targetingParser.test.ts
@@ -159,6 +159,14 @@ describe('parsePattern', () => {
     it('throws on an unrecognizable shape', () => {
         expect(() => parsePattern('Pattern-Nonsense-Range-1')).toThrow(/unknown pattern shape/i);
     });
+
+    it('captures the double modifier (Double-Pickaxe)', () => {
+        expect(parsePattern('Pattern-Support-Double-Pickaxe-Range-0')).toMatchObject({
+            shape: 'pickaxe',
+            range: 0,
+            modifiers: { support: true, double: true },
+        });
+    });
 });
 
 describe('parseSkillTargeting', () => {
@@ -230,6 +238,7 @@ describe.skipIf(!csvAvailable)('ship-targeting.csv corpus coverage', () => {
         .split(/\r?\n/)
         .filter((l) => l.trim().length > 0)
         .slice(1) // drop header
+        // Naive split is safe: ship-targeting.csv has no quoted fields or embedded commas.
         .map((line) => {
             const [name, activeTarget, activePattern, chargedTarget, chargedPattern] =
                 line.split(',');

--- a/src/utils/__tests__/targetingParser.test.ts
+++ b/src/utils/__tests__/targetingParser.test.ts
@@ -5,6 +5,7 @@ import {
     parsePattern,
     parseSkillTargeting,
     parseShipTargeting,
+    parseTargetingCsv,
 } from '../targetingParser';
 
 describe('parseTarget', () => {
@@ -234,22 +235,7 @@ const CSV_PATH = 'docs/ship-targeting.csv';
 const csvAvailable = existsSync(CSV_PATH);
 
 describe.skipIf(!csvAvailable)('ship-targeting.csv corpus coverage', () => {
-    const rows = readFileSync(CSV_PATH, 'utf8')
-        .split(/\r?\n/)
-        .filter((l) => l.trim().length > 0)
-        .slice(1) // drop header
-        // Naive split is safe: ship-targeting.csv has no quoted fields or embedded commas.
-        .map((line) => {
-            const [name, activeTarget, activePattern, chargedTarget, chargedPattern] =
-                line.split(',');
-            return {
-                name: name.trim(),
-                activeTarget: (activeTarget ?? '').trim(),
-                activePattern: (activePattern ?? '').trim(),
-                chargedTarget: (chargedTarget ?? '').trim(),
-                chargedPattern: (chargedPattern ?? '').trim(),
-            };
-        });
+    const rows = parseTargetingCsv(readFileSync(CSV_PATH, 'utf8'));
 
     it('has rows to test', () => {
         expect(rows.length).toBeGreaterThan(100);

--- a/src/utils/__tests__/targetingParser.test.ts
+++ b/src/utils/__tests__/targetingParser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseTarget } from '../targetingParser';
+import { parseTarget, parsePattern } from '../targetingParser';
 
 describe('parseTarget', () => {
     it('maps enemy-side selections', () => {
@@ -30,5 +30,127 @@ describe('parseTarget', () => {
 
     it('throws on unknown target', () => {
         expect(() => parseTarget('sideways')).toThrow(/unknown target/i);
+    });
+});
+
+describe('parsePattern', () => {
+    it('parses Pattern-Base as base / range 0', () => {
+        expect(parsePattern('Pattern-Base')).toEqual({
+            raw: 'Pattern-Base',
+            shape: 'base',
+            range: 0,
+            modifiers: {},
+        });
+    });
+
+    it('parses a numeric range', () => {
+        expect(parsePattern('Pattern-Cone-Range-1')).toMatchObject({
+            shape: 'cone',
+            range: 1,
+            modifiers: {},
+        });
+        expect(parsePattern('Pattern-Line-Range-2')).toMatchObject({
+            shape: 'line',
+            range: 2,
+            modifiers: {},
+        });
+        expect(parsePattern('Pattern-Range-3')).toMatchObject({
+            shape: 'range',
+            range: 3,
+            modifiers: {},
+        });
+        expect(parsePattern('Pattern-Support-Double-Pickaxe-Range-0')).toMatchObject({
+            shape: 'pickaxe',
+            range: 0,
+        });
+    });
+
+    it('detects the support modifier (before or after the shape token)', () => {
+        expect(parsePattern('Pattern-Circle-Support-Range-1').modifiers.support).toBe(true);
+        expect(parsePattern('Pattern-Base-Support')).toMatchObject({
+            shape: 'base',
+            range: 0,
+            modifiers: { support: true },
+        });
+        expect(parsePattern('Pattern-Support-All')).toMatchObject({
+            shape: 'all',
+            range: 'all',
+            modifiers: { support: true },
+        });
+        expect(parsePattern('Pattern-All')).toMatchObject({
+            shape: 'all',
+            range: 'all',
+            modifiers: {},
+        });
+    });
+
+    it('detects whole-lane range', () => {
+        expect(parsePattern('Pattern-Line-Support-whole-lane')).toMatchObject({
+            shape: 'line',
+            range: 'lane',
+            modifiers: { support: true },
+        });
+    });
+
+    it('detects prolonged + anchor modifiers', () => {
+        expect(parsePattern('Pattern-Prolonged_Cone-Support-Range-2')).toMatchObject({
+            shape: 'cone',
+            range: 2,
+            modifiers: { prolonged: true, support: true },
+        });
+        expect(
+            parsePattern('Pattern-Prolonged_Cone-Support-Center-Range-2').modifiers
+        ).toMatchObject({
+            prolonged: true,
+            support: true,
+            anchorMod: 'center',
+        });
+        expect(parsePattern('Pattern-Cone-Back-Range-1').modifiers).toMatchObject({
+            anchorMod: 'back',
+        });
+        expect(parsePattern('Pattern-Support-Forward-Circle-Range-1')).toMatchObject({
+            shape: 'circle',
+            modifiers: { support: true, anchorMod: 'forward' },
+        });
+    });
+
+    it('does NOT treat backline as an anchor "back"', () => {
+        const p = parsePattern('Pattern-Backline-Range-1');
+        expect(p.shape).toBe('backline');
+        expect(p.modifiers.anchorMod).toBeUndefined();
+    });
+
+    it('detects reverse / notSelf / fromCentre', () => {
+        expect(parsePattern('Pattern-Reverse-Curve-Range-1')).toMatchObject({
+            shape: 'curve',
+            modifiers: { reverse: true },
+        });
+        expect(parsePattern('Pattern-Reverse-Cone-Range-1')).toMatchObject({
+            shape: 'cone',
+            modifiers: { reverse: true },
+        });
+        expect(parsePattern('Pattern-Line-Support-Not-Self-Range-2').modifiers).toMatchObject({
+            support: true,
+            notSelf: true,
+        });
+        expect(parsePattern('Pattern-Wings-Support-Not-Self-Range-2')).toMatchObject({
+            shape: 'wings',
+            modifiers: { support: true, notSelf: true },
+        });
+        expect(parsePattern('Pattern-Line-from-centre-Range-1').modifiers).toMatchObject({
+            fromCentre: true,
+        });
+    });
+
+    it('normalizes the "Patern" typo', () => {
+        expect(parsePattern('Patern-Support-All')).toMatchObject({
+            shape: 'all',
+            range: 'all',
+            modifiers: { support: true },
+        });
+    });
+
+    it('throws on an unrecognizable shape', () => {
+        expect(() => parsePattern('Pattern-Nonsense-Range-1')).toThrow(/unknown pattern shape/i);
     });
 });

--- a/src/utils/__tests__/targetingParser.test.ts
+++ b/src/utils/__tests__/targetingParser.test.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from 'fs';
 import { describe, it, expect } from 'vitest';
 import {
     parseTarget,
@@ -217,5 +218,51 @@ describe('parseShipTargeting — charged inheritance', () => {
         });
         expect(r.active).toBeUndefined();
         expect(r.charged).toBeUndefined();
+    });
+});
+
+// docs/ is gitignored (dev-machine-local reference data). Skip cleanly if absent.
+const CSV_PATH = 'docs/ship-targeting.csv';
+const csvAvailable = existsSync(CSV_PATH);
+
+describe.skipIf(!csvAvailable)('ship-targeting.csv corpus coverage', () => {
+    const rows = readFileSync(CSV_PATH, 'utf8')
+        .split(/\r?\n/)
+        .filter((l) => l.trim().length > 0)
+        .slice(1) // drop header
+        .map((line) => {
+            const [name, activeTarget, activePattern, chargedTarget, chargedPattern] =
+                line.split(',');
+            return {
+                name: name.trim(),
+                activeTarget: (activeTarget ?? '').trim(),
+                activePattern: (activePattern ?? '').trim(),
+                chargedTarget: (chargedTarget ?? '').trim(),
+                chargedPattern: (chargedPattern ?? '').trim(),
+            };
+        });
+
+    it('has rows to test', () => {
+        expect(rows.length).toBeGreaterThan(100);
+    });
+
+    it('every active target+pattern tokenizes with no unknown / no throw', () => {
+        for (const row of rows) {
+            expect(
+                () => parseSkillTargeting(row.activeTarget, row.activePattern),
+                `active for ${row.name}: "${row.activeTarget}" / "${row.activePattern}"`
+            ).not.toThrow();
+        }
+    });
+
+    it('every explicit charged target+pattern tokenizes with no unknown / no throw', () => {
+        for (const row of rows) {
+            if (row.chargedTarget && row.chargedPattern) {
+                expect(
+                    () => parseSkillTargeting(row.chargedTarget, row.chargedPattern),
+                    `charged for ${row.name}: "${row.chargedTarget}" / "${row.chargedPattern}"`
+                ).not.toThrow();
+            }
+        }
     });
 });

--- a/src/utils/__tests__/targetingParser.test.ts
+++ b/src/utils/__tests__/targetingParser.test.ts
@@ -212,6 +212,26 @@ describe('parseShipTargeting — charged inheritance', () => {
         expect(r.charged).not.toEqual(r.active);
     });
 
+    it('merges a one-sided charged TARGET override with the active pattern', () => {
+        const r = parseShipTargeting({
+            ...base,
+            chargeSkillCharge: 4,
+            chargedTarget: 'back', // differs from active target only
+        });
+        expect(r.charged?.target.selection).toBe('back');
+        expect(r.charged?.pattern.shape).toBe('line'); // inherited from active
+    });
+
+    it('merges a one-sided charged PATTERN override with the active target', () => {
+        const r = parseShipTargeting({
+            ...base,
+            chargeSkillCharge: 4,
+            chargedPattern: 'Pattern-Cone-Range-1', // differs from active pattern only
+        });
+        expect(r.charged?.target.selection).toBe('front'); // inherited from active
+        expect(r.charged?.pattern.shape).toBe('cone');
+    });
+
     it('leaves charged undefined when there is no charged skill', () => {
         const r = parseShipTargeting({ ...base, chargeSkillCharge: undefined });
         expect(r.charged).toBeUndefined();
@@ -227,6 +247,27 @@ describe('parseShipTargeting — charged inheritance', () => {
         });
         expect(r.active).toBeUndefined();
         expect(r.charged).toBeUndefined();
+    });
+});
+
+describe('parseTargetingCsv', () => {
+    it('parses well-formed rows (incl. empty trailing charged columns)', () => {
+        const rows = parseTargetingCsv('name,at,ap,ct,cp\nAEGIS,allies,Pattern-Base,,');
+        expect(rows).toEqual([
+            {
+                name: 'AEGIS',
+                activeTarget: 'allies',
+                activePattern: 'Pattern-Base',
+                chargedTarget: '',
+                chargedPattern: '',
+            },
+        ]);
+    });
+
+    it('throws on a row with the wrong number of columns', () => {
+        expect(() => parseTargetingCsv('name,at,ap,ct,cp\nAEGIS,allies,Pattern-Base')).toThrow(
+            /Malformed ship-targeting\.csv row 2: expected 5 columns, got 3/
+        );
     });
 });
 

--- a/src/utils/__tests__/targetingParser.test.ts
+++ b/src/utils/__tests__/targetingParser.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { parseTarget } from '../targetingParser';
+
+describe('parseTarget', () => {
+    it('maps enemy-side selections', () => {
+        expect(parseTarget('front')).toEqual({ raw: 'front', side: 'enemy', selection: 'front' });
+        expect(parseTarget('back')).toEqual({ raw: 'back', side: 'enemy', selection: 'back' });
+        expect(parseTarget('skip')).toEqual({ raw: 'skip', side: 'enemy', selection: 'skip' });
+        expect(parseTarget('all')).toEqual({ raw: 'all', side: 'enemy', selection: 'all' });
+    });
+
+    it('maps ally-side selections', () => {
+        expect(parseTarget('allies')).toEqual({ raw: 'allies', side: 'ally', selection: 'team' });
+        expect(parseTarget('all-allies')).toEqual({
+            raw: 'all-allies',
+            side: 'ally',
+            selection: 'all',
+        });
+        expect(parseTarget('other-allies')).toEqual({
+            raw: 'other-allies',
+            side: 'ally',
+            selection: 'others',
+        });
+        expect(parseTarget('self')).toEqual({ raw: 'self', side: 'ally', selection: 'self' });
+    });
+
+    it('is case/whitespace tolerant', () => {
+        expect(parseTarget('  Front ')).toMatchObject({ side: 'enemy', selection: 'front' });
+    });
+
+    it('throws on unknown target', () => {
+        expect(() => parseTarget('sideways')).toThrow(/unknown target/i);
+    });
+});

--- a/src/utils/__tests__/targetingParser.test.ts
+++ b/src/utils/__tests__/targetingParser.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { parseTarget, parsePattern } from '../targetingParser';
+import {
+    parseTarget,
+    parsePattern,
+    parseSkillTargeting,
+    parseShipTargeting,
+} from '../targetingParser';
 
 describe('parseTarget', () => {
     it('maps enemy-side selections', () => {
@@ -152,5 +157,65 @@ describe('parsePattern', () => {
 
     it('throws on an unrecognizable shape', () => {
         expect(() => parsePattern('Pattern-Nonsense-Range-1')).toThrow(/unknown pattern shape/i);
+    });
+});
+
+describe('parseSkillTargeting', () => {
+    it('combines target + pattern', () => {
+        expect(parseSkillTargeting('front', 'Pattern-Cone-Range-1')).toEqual({
+            target: { raw: 'front', side: 'enemy', selection: 'front' },
+            pattern: { raw: 'Pattern-Cone-Range-1', shape: 'cone', range: 1, modifiers: {} },
+        });
+    });
+});
+
+describe('parseShipTargeting — charged inheritance', () => {
+    const base = {
+        activeTarget: 'front',
+        activePattern: 'Pattern-Line-Range-1',
+        chargedTarget: undefined,
+        chargedPattern: undefined,
+        chargeSkillCharge: undefined,
+    };
+
+    it('parses active when present', () => {
+        const r = parseShipTargeting({ ...base });
+        expect(r.active).toMatchObject({
+            target: { selection: 'front' },
+            pattern: { shape: 'line' },
+        });
+    });
+
+    it('inherits active when charged is empty AND the ship has a charged skill', () => {
+        const r = parseShipTargeting({ ...base, chargeSkillCharge: 4 });
+        expect(r.charged).toEqual(r.active);
+    });
+
+    it('uses the explicit charged override when present', () => {
+        const r = parseShipTargeting({
+            ...base,
+            chargeSkillCharge: 4,
+            chargedTarget: 'front',
+            chargedPattern: 'Pattern-Cone-Range-1',
+        });
+        expect(r.charged?.pattern.shape).toBe('cone');
+        expect(r.charged).not.toEqual(r.active);
+    });
+
+    it('leaves charged undefined when there is no charged skill', () => {
+        const r = parseShipTargeting({ ...base, chargeSkillCharge: undefined });
+        expect(r.charged).toBeUndefined();
+    });
+
+    it('returns empty object when there is no active targeting', () => {
+        const r = parseShipTargeting({
+            activeTarget: undefined,
+            activePattern: undefined,
+            chargedTarget: undefined,
+            chargedPattern: undefined,
+            chargeSkillCharge: 4,
+        });
+        expect(r.active).toBeUndefined();
+        expect(r.charged).toBeUndefined();
     });
 });

--- a/src/utils/targetingParser.ts
+++ b/src/utils/targetingParser.ts
@@ -35,6 +35,7 @@ export interface PatternModifiers {
     prolonged?: boolean;
     reverse?: boolean;
     notSelf?: boolean;
+    double?: boolean;
     fromCentre?: boolean;
     anchorMod?: 'back' | 'center' | 'forward';
 }
@@ -145,6 +146,8 @@ export function parsePattern(raw: string): ParsedPattern {
     if (/(^|-)prolonged(-|$)/.test(lower)) modifiers.prolonged = true;
     if (/(^|-)reverse(-|$)/.test(lower)) modifiers.reverse = true;
     if (/not-self/.test(lower)) modifiers.notSelf = true;
+    if (/(^|-)double(-|$)/.test(lower)) modifiers.double = true;
+    // British spelling only — the corpus uses "from-centre"; a future "from-center" would need adding here.
     if (/from-centre/.test(lower)) modifiers.fromCentre = true;
     // anchor modifier (mutually exclusive); 'back' must not fire on 'backline'
     if (/(^|-)back(-|$)/.test(lower)) modifiers.anchorMod = 'back';

--- a/src/utils/targetingParser.ts
+++ b/src/utils/targetingParser.ts
@@ -1,3 +1,5 @@
+import { Ship } from '../types/ship';
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -163,4 +165,36 @@ export function parsePattern(raw: string): ParsedPattern {
     }
 
     return { raw, shape: detectShape(lower), range, modifiers };
+}
+
+// ---------------------------------------------------------------------------
+// Per-skill and per-ship
+// ---------------------------------------------------------------------------
+
+export function parseSkillTargeting(target: string, pattern: string): SkillTargeting {
+    return { target: parseTarget(target), pattern: parsePattern(pattern) };
+}
+
+export function parseShipTargeting(
+    ship: Pick<
+        Ship,
+        'activeTarget' | 'activePattern' | 'chargedTarget' | 'chargedPattern' | 'chargeSkillCharge'
+    >
+): ShipTargeting {
+    const result: ShipTargeting = {};
+
+    if (ship.activeTarget && ship.activePattern) {
+        result.active = parseSkillTargeting(ship.activeTarget, ship.activePattern);
+    }
+
+    if (ship.chargedTarget && ship.chargedPattern) {
+        // Explicit override (charged differs from active).
+        result.charged = parseSkillTargeting(ship.chargedTarget, ship.chargedPattern);
+    } else if (result.active && ship.chargeSkillCharge != null) {
+        // Empty charged columns mean "charged targets the same as active"; only
+        // inherit when the ship actually has a charged skill.
+        result.charged = result.active;
+    }
+
+    return result;
 }

--- a/src/utils/targetingParser.ts
+++ b/src/utils/targetingParser.ts
@@ -77,3 +77,90 @@ export function parseTarget(raw: string): ParsedTarget {
     }
     return { raw, side: mapped.side, selection: mapped.selection };
 }
+
+// ---------------------------------------------------------------------------
+// Pattern axis
+// ---------------------------------------------------------------------------
+
+// Known modifier/meta tokens that can appear in the body without being a shape.
+const KNOWN_NON_SHAPE_TOKENS = new Set([
+    'support',
+    'prolonged',
+    'reverse',
+    'not',
+    'self',
+    'from',
+    'centre',
+    'center',
+    'back',
+    'forward',
+    'double',
+    'whole',
+    'lane',
+]);
+
+// Shape detection is presence-based (not positional) and ORDER-SENSITIVE:
+// check 'backline' before any 'line'/'back' rule so it isn't mis-split.
+function detectShape(lower: string): PatternShape {
+    if (/backline/.test(lower)) return 'backline';
+    if (/scattershot/.test(lower)) return 'scattershot';
+    if (/pickaxe/.test(lower)) return 'pickaxe';
+    if (/cone/.test(lower)) return 'cone';
+    if (/cross/.test(lower)) return 'cross';
+    if (/curve/.test(lower)) return 'curve';
+    if (/circle/.test(lower)) return 'circle';
+    if (/wings/.test(lower)) return 'wings';
+    if (/root/.test(lower)) return 'root';
+    if (/split/.test(lower)) return 'split';
+    if (/burst/.test(lower)) return 'burst';
+    if (/line/.test(lower)) return 'line';
+    if (/base/.test(lower)) return 'base';
+    // standalone "all" shape (Pattern-All, Pattern-Support-All) with no other shape token
+    if (/(^|-)all($|-)/.test(lower)) return 'all';
+    // pure range shape (Pattern-Range-N): only when all remaining tokens are known
+    if (/range-\d+/.test(lower)) {
+        // Strip the range-N segment and split remaining tokens
+        const withoutRange = lower.replace(/range-\d+/, '').replace(/^-|-$/, '');
+        const unknownTokens = withoutRange
+            .split('-')
+            .filter((t) => t.length > 0 && !KNOWN_NON_SHAPE_TOKENS.has(t));
+        if (unknownTokens.length === 0) return 'range';
+    }
+    throw new Error(`Unknown pattern shape in: "${lower}"`);
+}
+
+export function parsePattern(raw: string): ParsedPattern {
+    // Normalize: fix the "Patern" typo, turn "Prolonged_Cone" into "Prolonged-Cone".
+    const normalized = raw
+        .trim()
+        .replace(/^Patern-/i, 'Pattern-')
+        .replace(/_/g, '-');
+    const body = normalized.replace(/^Pattern-/i, '');
+    const lower = body.toLowerCase();
+
+    const modifiers: PatternModifiers = {};
+    if (/(^|-)support(-|$)/.test(lower)) modifiers.support = true;
+    if (/(^|-)prolonged(-|$)/.test(lower)) modifiers.prolonged = true;
+    if (/(^|-)reverse(-|$)/.test(lower)) modifiers.reverse = true;
+    if (/not-self/.test(lower)) modifiers.notSelf = true;
+    if (/from-centre/.test(lower)) modifiers.fromCentre = true;
+    // anchor modifier (mutually exclusive); 'back' must not fire on 'backline'
+    if (/(^|-)back(-|$)/.test(lower)) modifiers.anchorMod = 'back';
+    else if (/(^|-)center(-|$)/.test(lower)) modifiers.anchorMod = 'center';
+    else if (/(^|-)forward(-|$)/.test(lower)) modifiers.anchorMod = 'forward';
+
+    let range: number | 'all' | 'lane';
+    const rangeMatch = lower.match(/range-(\d+)/);
+    if (rangeMatch) {
+        range = parseInt(rangeMatch[1], 10);
+    } else if (/whole-lane/.test(lower)) {
+        range = 'lane';
+    } else if (/(^|-)all($|-)/.test(lower)) {
+        range = 'all';
+    } else {
+        // Pattern-Base / Pattern-Base-Support — no range token, point-blank.
+        range = 0;
+    }
+
+    return { raw, shape: detectShape(lower), range, modifiers };
+}

--- a/src/utils/targetingParser.ts
+++ b/src/utils/targetingParser.ts
@@ -57,6 +57,37 @@ export interface ShipTargeting {
     charged?: SkillTargeting;
 }
 
+export interface TargetingCsvRow {
+    name: string;
+    activeTarget: string;
+    activePattern: string;
+    chargedTarget: string;
+    chargedPattern: string;
+}
+
+/**
+ * Parses the raw text of docs/ship-targeting.csv into rows.
+ * NOTE: ship-targeting.csv has no quoted fields or embedded commas, so a naive
+ * comma split is safe. Keep this the single source of truth for that assumption.
+ */
+export function parseTargetingCsv(csvText: string): TargetingCsvRow[] {
+    return csvText
+        .split(/\r?\n/)
+        .filter((l) => l.trim().length > 0)
+        .slice(1) // drop header
+        .map((line) => {
+            const [name, activeTarget, activePattern, chargedTarget, chargedPattern] =
+                line.split(',');
+            return {
+                name: (name ?? '').trim(),
+                activeTarget: (activeTarget ?? '').trim(),
+                activePattern: (activePattern ?? '').trim(),
+                chargedTarget: (chargedTarget ?? '').trim(),
+                chargedPattern: (chargedPattern ?? '').trim(),
+            };
+        });
+}
+
 // ---------------------------------------------------------------------------
 // Target axis
 // ---------------------------------------------------------------------------

--- a/src/utils/targetingParser.ts
+++ b/src/utils/targetingParser.ts
@@ -75,9 +75,14 @@ export function parseTargetingCsv(csvText: string): TargetingCsvRow[] {
         .split(/\r?\n/)
         .filter((l) => l.trim().length > 0)
         .slice(1) // drop header
-        .map((line) => {
-            const [name, activeTarget, activePattern, chargedTarget, chargedPattern] =
-                line.split(',');
+        .map((line, i) => {
+            const parts = line.split(',');
+            if (parts.length !== 5) {
+                throw new Error(
+                    `Malformed ship-targeting.csv row ${i + 2}: expected 5 columns, got ${parts.length}: "${line}"`
+                );
+            }
+            const [name, activeTarget, activePattern, chargedTarget, chargedPattern] = parts;
             return {
                 name: (name ?? '').trim(),
                 activeTarget: (activeTarget ?? '').trim(),
@@ -221,11 +226,16 @@ export function parseShipTargeting(
         result.active = parseSkillTargeting(ship.activeTarget, ship.activePattern);
     }
 
-    if (ship.chargedTarget && ship.chargedPattern) {
-        // Explicit override (charged differs from active).
-        result.charged = parseSkillTargeting(ship.chargedTarget, ship.chargedPattern);
+    // Charged columns are a per-column override: the data only fills a charged
+    // field when it differs from active, so a charged skill that differs in only
+    // ONE axis (e.g. a different target but the same pattern) fills just that
+    // column. Merge per-column, falling back to active for the unfilled axis.
+    const chargedTarget = ship.chargedTarget || ship.activeTarget;
+    const chargedPattern = ship.chargedPattern || ship.activePattern;
+    if ((ship.chargedTarget || ship.chargedPattern) && chargedTarget && chargedPattern) {
+        result.charged = parseSkillTargeting(chargedTarget, chargedPattern);
     } else if (result.active && ship.chargeSkillCharge != null) {
-        // Empty charged columns mean "charged targets the same as active"; only
+        // Both charged columns empty = "charged targets the same as active"; only
         // inherit when the ship actually has a charged skill.
         result.charged = result.active;
     }

--- a/src/utils/targetingParser.ts
+++ b/src/utils/targetingParser.ts
@@ -1,0 +1,79 @@
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TargetSide = 'enemy' | 'ally';
+export type TargetSelection = 'front' | 'back' | 'skip' | 'all' | 'team' | 'others' | 'self';
+
+export interface ParsedTarget {
+    raw: string;
+    side: TargetSide;
+    selection: TargetSelection;
+}
+
+export type PatternShape =
+    | 'base'
+    | 'cone'
+    | 'line'
+    | 'cross'
+    | 'curve'
+    | 'circle'
+    | 'backline'
+    | 'root'
+    | 'split'
+    | 'burst'
+    | 'scattershot'
+    | 'wings'
+    | 'range'
+    | 'pickaxe'
+    | 'all';
+
+export interface PatternModifiers {
+    support?: boolean;
+    prolonged?: boolean;
+    reverse?: boolean;
+    notSelf?: boolean;
+    fromCentre?: boolean;
+    anchorMod?: 'back' | 'center' | 'forward';
+}
+
+export interface ParsedPattern {
+    raw: string;
+    shape: PatternShape;
+    range: number | 'all' | 'lane';
+    modifiers: PatternModifiers;
+}
+
+export interface SkillTargeting {
+    target: ParsedTarget;
+    pattern: ParsedPattern;
+}
+
+export interface ShipTargeting {
+    active?: SkillTargeting;
+    charged?: SkillTargeting;
+}
+
+// ---------------------------------------------------------------------------
+// Target axis
+// ---------------------------------------------------------------------------
+
+const TARGET_MAP: Record<string, { side: TargetSide; selection: TargetSelection }> = {
+    front: { side: 'enemy', selection: 'front' },
+    back: { side: 'enemy', selection: 'back' },
+    skip: { side: 'enemy', selection: 'skip' },
+    all: { side: 'enemy', selection: 'all' },
+    allies: { side: 'ally', selection: 'team' },
+    'all-allies': { side: 'ally', selection: 'all' },
+    'other-allies': { side: 'ally', selection: 'others' },
+    self: { side: 'ally', selection: 'self' },
+};
+
+export function parseTarget(raw: string): ParsedTarget {
+    const key = raw.trim().toLowerCase();
+    const mapped = TARGET_MAP[key];
+    if (!mapped) {
+        throw new Error(`Unknown target value: "${raw}"`);
+    }
+    return { raw, side: mapped.side, selection: mapped.selection };
+}

--- a/supabase/migrations/20260613000001_add_targeting_to_ship_templates.sql
+++ b/supabase/migrations/20260613000001_add_targeting_to_ship_templates.sql
@@ -1,0 +1,8 @@
+-- Add ship targeting/pattern data to ship_templates.
+-- Verbatim game strings (parsed at runtime by src/utils/targetingParser.ts).
+-- Charged columns are an OVERRIDE: empty means "charged targets the same as active".
+ALTER TABLE public.ship_templates
+  ADD COLUMN IF NOT EXISTS active_target   text,
+  ADD COLUMN IF NOT EXISTS active_pattern  text,
+  ADD COLUMN IF NOT EXISTS charged_target  text,
+  ADD COLUMN IF NOT EXISTS charged_pattern text;


### PR DESCRIPTION
## Summary

Foundation phase for positional targeting — ingests the gathered ship target/pattern game data into the data model so the later positional-combat phase has a clean, validated contract to build on. **Data layer only: no combat-engine, geometry, or UI changes** (those are deferred to follow-on phases).

- **DB:** migration adds 4 nullable text columns to `ship_templates` (`active_target`, `active_pattern`, `charged_target`, `charged_pattern`) holding verbatim game strings (mirrors how `*_skill_text` is stored).
- **Parser:** new pure, dependency-free `src/utils/targetingParser.ts` tokenizes the two axes — target (`side` enemy/ally + `selection` front/back/skip/all/team/others/self) and pattern (`shape` + `range` + `modifiers`). `parseShipTargeting` resolves **charged-targeting inheritance**: an empty charged column means "charged targets the same as active" (gated on the ship actually having a charged skill), so blanks are an override-only convention, not absence.
- **Coverage gate:** a corpus test over `docs/ship-targeting.csv` asserts all ~147 ships tokenize with no unknown shape/target and no throw (skips cleanly if the gitignored CSV is absent).
- **Plumbing:** raw strings thread from the template fetch onto the `Ship`/`ShipData` model (`select('*')` already returns the new columns).
- **Populate script:** server-side `scripts/populate-ship-targeting.ts` (+ `populate-targeting` npm script) loads the CSV into `ship_templates` using the service-role key, with `--dry-run` and unmatched-name reporting in both directions.

Data-quality handled in the parser (not the data): `Patern`→`Pattern` typo, `Prolonged_` underscore, `Range-0`, `whole-lane`, and `Double-Pickaxe` (now captured as a `double` modifier).

## Test Plan

- [x] `npx vitest run` — 2054 tests pass (incl. 23 new parser tests + corpus gate over 146 rows)
- [x] `npm run lint` — 0 warnings; `npx tsc --noEmit` — clean
- [x] Existing suite unchanged (no engine behaviour touched)
- [ ] **Maintainer:** apply the migration via Supabase dashboard/CLI
- [ ] **Maintainer:** `npm run populate-targeting -- --dry-run` → confirm 0 unmatched, then `npm run populate-targeting`

🤖 Generated with [Claude Code](https://claude.com/claude-code)