### PR TITLE
feat(targeting): skill targeting footprint in skill hovercards

### DIFF
--- a/docs/superpowers/plans/2026-06-14-skill-targeting-footprint-hovercard.md
+++ b/docs/superpowers/plans/2026-06-14-skill-targeting-footprint-hovercard.md
@@ -1,0 +1,688 @@
+# Skill Targeting Footprint in Hovercards Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render a compact SVG "targeting footprint" board diagram inside ship-skill hovercards for Active and Charge skills that carry targeting data.
+
+**Architecture:** Two pure helpers (`pickDisplayAnchor`, `targetingLabel`) + one presentational SVG component (`SkillTargetingBoard`) that consumes the already-merged targeting model (`parseShipTargeting` → `ParsedPattern`/`SkillTargeting`) and geometry resolver (`resolveCells`, `board.ts`). The component is rendered by `SkillTooltip` via a new optional `targeting` prop; `ShipSkillList` and `ShipIndexPage` supply that prop. Display-only — no engine changes.
+
+**Tech Stack:** React 18 + TypeScript, Vitest + React Testing Library, TailwindCSS, SVG.
+
+**Spec:** `docs/superpowers/specs/2026-06-14-skill-targeting-footprint-hovercard-design.md`
+
+**Sub-skills:** @superpowers:test-driven-development for every code task; @superpowers:verification-before-completion before claiming done.
+
+---
+
+## Working directory
+
+All work happens in the worktree `.worktrees/skill-targeting-footprint` (branch `feat/skill-targeting-footprint-hovercard`). Run all commands from there. The git pre-commit hook runs the full Vitest suite + lint-staged; that is expected.
+
+## File Structure
+
+- **Create** `src/utils/targeting/targetingDisplay.ts` — pure: `pickDisplayAnchor(pattern)` (auto-fit anchor) + `targetingLabel(targeting)` (caption string). Co-located because both are display-only derivations of the parsed targeting; neither belongs in the geometry core (`resolvePattern.ts`).
+- **Create** `src/utils/targeting/__tests__/targetingDisplay.test.ts` — unit tests for both helpers.
+- **Create** `src/components/ship/SkillTargetingBoard.tsx` — presentational SVG (single/dual board, caption, legend).
+- **Create** `src/components/ship/__tests__/SkillTargetingBoard.test.tsx` — render tests.
+- **Modify** `src/components/ship/SkillTooltip.tsx` — add optional `targeting?: SkillTargeting` prop; render the board after the skill text.
+- **Modify** `src/components/ship/ShipSkillList.tsx` — compute `parseShipTargeting(ship)`, pass `.active`/`.charged` per row.
+- **Modify** `src/pages/database/ShipIndexPage.tsx` — pass targeting to the Active and Charge `SkillTooltip`s.
+- **Modify** `src/constants/changelog.ts` — `UNRELEASED_CHANGES` entry.
+- **Modify** `src/pages/DocumentationPage.tsx` — short note about footprints in skill hovercards.
+
+> **Naming note (deviation from spec):** spec floated `displayAnchor.ts`; this plan uses `targetingDisplay.ts` since the file holds both the anchor picker and the caption helper. Functionally identical.
+
+---
+
+### Task 1: `pickDisplayAnchor` auto-fit helper
+
+**Files:**
+- Create: `src/utils/targeting/targetingDisplay.ts`
+- Test: `src/utils/targeting/__tests__/targetingDisplay.test.ts`
+
+Background: `resolveCells(pattern, anchor)` returns only on-board cells (off-board cells are clipped away). So the anchor that yields the **most** cells is the one that clips least — that is our display anchor. Ties are broken by a fixed center-front preference order for deterministic, prototype-like framing. Per spec, pixel-identical reproduction of the prototype's hand-picked anchors is a **non-goal**.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/utils/targeting/__tests__/targetingDisplay.test.ts
+import { describe, it, expect } from 'vitest';
+import { pickDisplayAnchor } from '../targetingDisplay';
+import { parseShipTargeting } from '../../targetingParser';
+import { resolveCells } from '../resolvePattern';
+import { OFFSET_TABLES, patternSignature } from '../patternOffsets';
+
+function activePattern(pattern: string) {
+    return parseShipTargeting({ activeTarget: 'front', activePattern: pattern }).active!.pattern;
+}
+
+describe('pickDisplayAnchor', () => {
+    it('returns an anchor whose footprint is fully on-board for a standard cone', () => {
+        const pattern = activePattern('Pattern-Cone-Range-1');
+        const anchor = pickDisplayAnchor(pattern);
+        const expected = OFFSET_TABLES[patternSignature(pattern)].length;
+        expect(resolveCells(pattern, anchor).length).toBe(expected); // nothing clipped
+    });
+
+    it('returns an anchor whose footprint is fully on-board for a backline pattern', () => {
+        const pattern = activePattern('Pattern-Backline-Range-2');
+        const anchor = pickDisplayAnchor(pattern);
+        const expected = OFFSET_TABLES[patternSignature(pattern)].length;
+        expect(resolveCells(pattern, anchor).length).toBe(expected);
+    });
+
+    it('is deterministic (tie-break) for whole-board "all" patterns', () => {
+        const pattern = activePattern('Pattern-All'); // resolves 12 cells from any anchor
+        expect(pickDisplayAnchor(pattern)).toBe(pickDisplayAnchor(pattern));
+        expect(resolveCells(pattern, pickDisplayAnchor(pattern)).length).toBe(12);
+    });
+});
+```
+
+> If `'Pattern-All'` does not parse to `shape: 'all'`, replace it in the third test with any pattern known to resolve 12 cells, or drop to asserting determinism only. Confirm during the red/green run.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest --run src/utils/targeting/__tests__/targetingDisplay.test.ts`
+Expected: FAIL — `pickDisplayAnchor` is not exported / module missing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/utils/targeting/targetingDisplay.ts
+import { Position } from '../../types/encounters';
+import { ParsedPattern } from '../targetingParser';
+import { ALL_POSITIONS } from './board';
+import { resolveCells } from './resolvePattern';
+
+// Center-front bias so footprints frame like the prototype; also the deterministic
+// tie-break when several anchors clip equally little.
+const ANCHOR_PREFERENCE: Position[] = [
+    'M3', 'M4', 'M2', 'M1',
+    'T3', 'T4', 'T2', 'T1',
+    'B3', 'B4', 'B2', 'B1',
+];
+
+/**
+ * Pick the board cell to anchor a footprint preview on: the anchor that leaves the
+ * most cells on-board (resolveCells clips off-board cells), tie-broken by ANCHOR_PREFERENCE.
+ * Pure. Throws only if resolveCells throws (unknown pattern signature) — callers guard.
+ */
+export function pickDisplayAnchor(pattern: ParsedPattern): Position {
+    let best: Position = ANCHOR_PREFERENCE[0];
+    let bestCount = -1;
+    let bestRank = Infinity;
+    for (const anchor of ALL_POSITIONS) {
+        const count = resolveCells(pattern, anchor).length;
+        const rank = ANCHOR_PREFERENCE.indexOf(anchor);
+        if (count > bestCount || (count === bestCount && rank < bestRank)) {
+            best = anchor;
+            bestCount = count;
+            bestRank = rank;
+        }
+    }
+    return best;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest --run src/utils/targeting/__tests__/targetingDisplay.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/targeting/targetingDisplay.ts src/utils/targeting/__tests__/targetingDisplay.test.ts
+git commit -m "feat(targeting): pickDisplayAnchor auto-fit helper"
+```
+
+---
+
+### Task 2: `targetingLabel` caption helper
+
+**Files:**
+- Modify: `src/utils/targeting/targetingDisplay.ts`
+- Test: `src/utils/targeting/__tests__/targetingDisplay.test.ts`
+
+Caption format (` · `-joined): `<shape> · <range?> · <side selection>`. Range rules from spec:
+- numeric `0` → omit the range segment;
+- `'all'` → `Whole board` (and no separate range segment);
+- `'lane'` → `Whole lane`;
+- numeric `>= 1` → `Range N`.
+
+- [ ] **Step 1: Add failing tests**
+
+```ts
+// append to targetingDisplay.test.ts
+import { targetingLabel } from '../targetingDisplay';
+import { parseShipTargeting } from '../../targetingParser';
+
+function active(target: string, pattern: string) {
+    return parseShipTargeting({ activeTarget: target, activePattern: pattern }).active!;
+}
+
+describe('targetingLabel', () => {
+    it('labels a ranged cone', () => {
+        expect(targetingLabel(active('front', 'Pattern-Cone-Range-1')))
+            .toBe('Cone · Range 1 · enemy front');
+    });
+    it('omits range for single-target base patterns', () => {
+        const label = targetingLabel(active('front', 'Pattern-Base'));
+        expect(label).toBe('Single target · enemy front');
+        expect(label).not.toContain('Range');
+    });
+});
+```
+
+> Verify the exact `activePattern` strings that parse to `shape: 'base'` and `shape: 'cone'` against `parseShipTargeting`/the corpus during the red run; adjust the literal strings (e.g. `'Pattern-Base-Range-0'`) if needed so the parse is valid. The asserted **output** strings are the contract.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest --run src/utils/targeting/__tests__/targetingDisplay.test.ts -t targetingLabel`
+Expected: FAIL — `targetingLabel` not exported.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// add to src/utils/targeting/targetingDisplay.ts
+import { ParsedPattern, ParsedTarget, SkillTargeting } from '../targetingParser';
+
+function cap(s: string): string {
+    return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function shapeSegment(p: ParsedPattern): string {
+    if (p.shape === 'base') return 'Single target';
+    if (p.shape === 'all') return 'Whole board';
+    const prefixes = [
+        p.modifiers.reverse && 'Reverse',
+        p.modifiers.prolonged && 'Prolonged',
+        p.modifiers.double && 'Double',
+    ].filter(Boolean);
+    const suffixes = [
+        p.modifiers.fromCentre && 'from centre',
+        p.modifiers.notSelf && 'not self',
+        p.modifiers.anchorMod && `(${p.modifiers.anchorMod})`,
+    ].filter(Boolean);
+    return [...prefixes, cap(p.shape), ...suffixes].join(' ');
+}
+
+function rangeSegment(p: ParsedPattern): string | null {
+    if (p.shape === 'all' || p.range === 'all') return null; // covered by shapeSegment
+    if (p.range === 'lane') return 'Whole lane';
+    if (typeof p.range === 'number' && p.range >= 1) return `Range ${p.range}`;
+    return null; // range 0 → omit
+}
+
+function targetSegment(t: ParsedTarget): string {
+    return `${t.side} ${t.selection}`;
+}
+
+/** Human-readable one-line caption for a skill's targeting, e.g. "Cone · Range 1 · enemy front". */
+export function targetingLabel({ pattern, target }: SkillTargeting): string {
+    return [shapeSegment(pattern), rangeSegment(pattern), targetSegment(target)]
+        .filter(Boolean)
+        .join(' · ');
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx vitest --run src/utils/targeting/__tests__/targetingDisplay.test.ts`
+Expected: PASS (all tests in file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/targeting/targetingDisplay.ts src/utils/targeting/__tests__/targetingDisplay.test.ts
+git commit -m "feat(targeting): targetingLabel caption helper"
+```
+
+---
+
+### Task 3: `SkillTargetingBoard` SVG component
+
+**Files:**
+- Create: `src/components/ship/SkillTargetingBoard.tsx`
+- Test: `src/components/ship/__tests__/SkillTargetingBoard.test.tsx`
+
+Renders the footprint. **Support** (`pattern.modifiers.support` OR `target.side === 'ally'`) → one own-board. **Attacker** → your (empty) board + `▶` + mirrored enemy board carrying the footprint. Geometry reuses `positionToAxial` (same axial table the prototype's `AX` used) with the prototype's `rawXY`/`hexPath`/`mirror` math (W=44, H=38, mirror `110 - x`). Each hex group carries `data-position` and `data-role` for testing. Guards `resolveCells` with try/catch (unknown signature → render nothing).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/components/ship/__tests__/SkillTargetingBoard.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { SkillTargetingBoard } from '../SkillTargetingBoard';
+import { parseShipTargeting } from '../../../utils/targetingParser';
+
+function active(target: string, pattern: string) {
+    return parseShipTargeting({ activeTarget: target, activePattern: pattern }).active!;
+}
+
+describe('SkillTargetingBoard', () => {
+    it('renders two boards + arrow for an enemy (attacker) pattern', () => {
+        const { container, getByText } = render(
+            <SkillTargetingBoard targeting={active('front', 'Pattern-Cone-Range-1')} />
+        );
+        expect(container.querySelectorAll('[data-board]').length).toBe(2);
+        expect(getByText('▶')).toBeInTheDocument();
+        expect(container.querySelectorAll('[data-role="origin"]').length).toBeGreaterThan(0);
+        expect(container.querySelectorAll('[data-role="covered"]').length).toBeGreaterThan(0);
+    });
+
+    it('renders a single board for a support (ally) pattern', () => {
+        const { container, queryByText } = render(
+            <SkillTargetingBoard targeting={active('allies', 'Pattern-Circle-Support-Range-1')} />
+        );
+        expect(container.querySelectorAll('[data-board]').length).toBe(1);
+        expect(queryByText('▶')).toBeNull();
+    });
+
+    it('shows the caption', () => {
+        const { getByText } = render(
+            <SkillTargetingBoard targeting={active('front', 'Pattern-Cone-Range-1')} />
+        );
+        expect(getByText('Cone · Range 1 · enemy front')).toBeInTheDocument();
+    });
+});
+```
+
+> Confirm `'allies'` parses to `side: 'ally'` and the support pattern string is valid during the red run; substitute a known ally/support pair from the corpus if not. The structural assertions (board count, arrow, roles) are the contract.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest --run src/components/ship/__tests__/SkillTargetingBoard.test.tsx`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement the component**
+
+```tsx
+// src/components/ship/SkillTargetingBoard.tsx
+import React from 'react';
+import { Position } from '../../types/encounters';
+import { SkillTargeting } from '../../utils/targetingParser';
+import { ALL_POSITIONS, positionToAxial } from '../../utils/targeting/board';
+import { CellRole, resolveCells } from '../../utils/targeting/resolvePattern';
+import { pickDisplayAnchor, targetingLabel } from '../../utils/targeting/targetingDisplay';
+
+const W = 44;
+const H = 38;
+const HEX_RX = 21;
+const HEX_RY = 24;
+
+const COLORS: Record<CellRole | 'empty', { fill: string; stroke: string }> = {
+    origin: { fill: '#7a1020', stroke: '#e0455f' },
+    covered: { fill: '#6a4012', stroke: '#e09a45' },
+    empty: { fill: '#222a3d', stroke: '#37445e' },
+};
+
+function rawXY(pos: Position): [number, number] {
+    const { q, r } = positionToAxial(pos);
+    return [(q + r / 2) * W, r * H];
+}
+
+function hexPath(cx: number, cy: number): string {
+    const pts: string[] = [];
+    for (let i = 0; i < 6; i++) {
+        const a = (Math.PI / 180) * (60 * i - 90);
+        pts.push(
+            `${(cx + HEX_RX * Math.cos(a)).toFixed(1)},${(cy + HEX_RY * Math.sin(a)).toFixed(1)}`
+        );
+    }
+    return pts.join(' ');
+}
+
+interface BoardProps {
+    ox: number;
+    oy: number;
+    mirror: boolean;
+    roles: Map<Position, CellRole>;
+    label: string;
+}
+
+const Board: React.FC<BoardProps> = ({ ox, oy, mirror, roles, label }) => (
+    <g data-board={label}>
+        {ALL_POSITIONS.map((pos) => {
+            let [x, y] = rawXY(pos);
+            if (mirror) x = 110 - x;
+            const cx = ox + x + 30;
+            const cy = oy + y + 22;
+            const role = roles.get(pos);
+            const colors = COLORS[role ?? 'empty'];
+            return (
+                <g key={pos} data-position={pos} data-role={role ?? 'empty'}>
+                    <polygon
+                        points={hexPath(cx, cy)}
+                        fill={colors.fill}
+                        stroke={colors.stroke}
+                        strokeWidth={1.4}
+                    />
+                    <text
+                        x={cx}
+                        y={cy + 4}
+                        textAnchor="middle"
+                        fontSize={10}
+                        fill={role ? '#fff' : '#6b7794'}
+                    >
+                        {pos}
+                    </text>
+                </g>
+            );
+        })}
+    </g>
+);
+
+interface SkillTargetingBoardProps {
+    targeting: SkillTargeting;
+}
+
+export const SkillTargetingBoard: React.FC<SkillTargetingBoardProps> = ({ targeting }) => {
+    let roles: Map<Position, CellRole>;
+    try {
+        const anchor = pickDisplayAnchor(targeting.pattern);
+        roles = new Map(resolveCells(targeting.pattern, anchor).map((c) => [c.position, c.role]));
+    } catch {
+        return null; // unknown pattern signature — show nothing rather than crash
+    }
+
+    const isSupport =
+        targeting.pattern.modifiers.support === true || targeting.target.side === 'ally';
+    const caption = targetingLabel(targeting);
+
+    return (
+        <div className="mt-2 text-[11px] text-theme-text/70">
+            <div className="mb-1">{caption}</div>
+            {isSupport ? (
+                <svg width={178} height={120} role="img" aria-label={`Targeting footprint: ${caption}`}>
+                    <Board ox={0} oy={12} mirror={false} roles={roles} label="own" />
+                    <text x={89} y={112} textAnchor="middle" fontSize={10} fill="#5a6a86">
+                        your board
+                    </text>
+                </svg>
+            ) : (
+                <svg width={402} height={120} role="img" aria-label={`Targeting footprint: ${caption}`}>
+                    <Board ox={0} oy={12} mirror={false} roles={new Map()} label="team" />
+                    <text x={201} y={62} textAnchor="middle" fontSize={20} fill="#6ca8ff">
+                        ▶
+                    </text>
+                    <Board ox={224} oy={12} mirror roles={roles} label="enemy" />
+                </svg>
+            )}
+            <div className="flex gap-3 mt-1">
+                <span className="inline-flex items-center gap-1">
+                    <span className="inline-block w-2 h-2 bg-[#e0455f]" />
+                    origin
+                </span>
+                <span className="inline-flex items-center gap-1">
+                    <span className="inline-block w-2 h-2 bg-[#e09a45]" />
+                    covered
+                </span>
+            </div>
+        </div>
+    );
+};
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx vitest --run src/components/ship/__tests__/SkillTargetingBoard.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/ship/SkillTargetingBoard.tsx src/components/ship/__tests__/SkillTargetingBoard.test.tsx
+git commit -m "feat(targeting): SkillTargetingBoard footprint diagram"
+```
+
+---
+
+### Task 4: Add `targeting` prop to `SkillTooltip`
+
+**Files:**
+- Modify: `src/components/ship/SkillTooltip.tsx`
+
+Pure prop addition — the board renders inside `content` (so both `inline` and boxed variants show it). No behavior change when the prop is absent. (No new test here; covered by Task 3's component tests + Task 5/6 wiring. The pre-commit suite still runs.)
+
+- [ ] **Step 1: Add the import and prop**
+
+In `src/components/ship/SkillTooltip.tsx`, add imports near the top:
+
+```tsx
+import { SkillTargeting } from '../../utils/targetingParser';
+import { SkillTargetingBoard } from './SkillTargetingBoard';
+```
+
+Extend the props interface and destructuring:
+
+```tsx
+interface SkillTooltipProps {
+    skillText: string;
+    skillType: string;
+    charge?: number;
+    inline?: boolean;
+    targeting?: SkillTargeting;
+}
+
+export const SkillTooltip: React.FC<SkillTooltipProps> = ({
+    skillText,
+    skillType,
+    charge,
+    inline,
+    targeting,
+}) => {
+```
+
+- [ ] **Step 2: Render the board after the text block**
+
+In the `content` JSX, immediately after the closing `</div>` of the `text-sm text-theme-text mb-2` block (currently line ~89) and before the closing `</>`:
+
+```tsx
+            {targeting && <SkillTargetingBoard targeting={targeting} />}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/ship/SkillTooltip.tsx
+git commit -m "feat(targeting): optional targeting prop on SkillTooltip"
+```
+
+---
+
+### Task 5: Wire `ShipSkillList`
+
+**Files:**
+- Modify: `src/components/ship/ShipSkillList.tsx`
+
+- [ ] **Step 1: Compute targeting and pass per row**
+
+Replace the file body with:
+
+```tsx
+import React from 'react';
+import { Ship } from '../../types/ship';
+import { getShipSkillRows } from '../../utils/ship/skillRows';
+import { parseShipTargeting } from '../../utils/targetingParser';
+import { SkillTooltip } from './SkillTooltip';
+
+export const ShipSkillList: React.FC<{ ship: Ship }> = ({ ship }) => {
+    const rows = getShipSkillRows(ship);
+    if (rows.length === 0) return null;
+
+    const targeting = parseShipTargeting(ship);
+
+    return (
+        <div className="space-y-3">
+            {rows.map((row) => (
+                <div key={row.label}>
+                    <SkillTooltip
+                        inline
+                        skillText={row.text}
+                        skillType={row.label}
+                        charge={row.charge}
+                        targeting={
+                            row.label === 'Active'
+                                ? targeting.active
+                                : row.label === 'Charge'
+                                  ? targeting.charged
+                                  : undefined
+                        }
+                    />
+                </div>
+            ))}
+        </div>
+    );
+};
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/ship/ShipSkillList.tsx
+git commit -m "feat(targeting): show footprint in ShipSkillList skill rows"
+```
+
+---
+
+### Task 6: Wire `ShipIndexPage`
+
+**Files:**
+- Modify: `src/pages/database/ShipIndexPage.tsx`
+
+- [ ] **Step 1: Import the parser**
+
+Add near the other imports (the file already imports `SkillTooltip` from `'../../components/ship/SkillTooltip'`):
+
+```tsx
+import { parseShipTargeting } from '../../utils/targetingParser';
+```
+
+- [ ] **Step 2: Pass targeting to the Active `SkillTooltip`**
+
+Find the Active skill `SkillTooltip` (around line 409):
+
+```tsx
+                                                            <SkillTooltip
+                                                                skillText={ship.activeSkillText}
+                                                                skillType="Active Skill"
+                                                            />
+```
+
+Add the prop:
+
+```tsx
+                                                            <SkillTooltip
+                                                                skillText={ship.activeSkillText}
+                                                                skillType="Active Skill"
+                                                                targeting={
+                                                                    parseShipTargeting(ship).active
+                                                                }
+                                                            />
+```
+
+- [ ] **Step 3: Pass targeting to the Charge `SkillTooltip`**
+
+Find the Charge skill `SkillTooltip` (around line 454):
+
+```tsx
+                                                            <SkillTooltip
+                                                                skillText={ship.chargeSkillText}
+                                                                skillType="Charge Skill"
+                                                                charge={ship.chargeSkillCharge}
+                                                            />
+```
+
+Add the prop:
+
+```tsx
+                                                            <SkillTooltip
+                                                                skillText={ship.chargeSkillText}
+                                                                skillType="Charge Skill"
+                                                                charge={ship.chargeSkillCharge}
+                                                                targeting={
+                                                                    parseShipTargeting(ship).charged
+                                                                }
+                                                            />
+```
+
+> Passive `SkillTooltip`s are left untouched (no passive targeting in the data model).
+
+- [ ] **Step 4: Typecheck + lint**
+
+Run: `npx tsc --noEmit && npm run lint`
+Expected: no errors, 0 warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/database/ShipIndexPage.tsx
+git commit -m "feat(targeting): show footprint in ship database skill hovercards"
+```
+
+---
+
+### Task 7: Changelog + in-app docs
+
+**Files:**
+- Modify: `src/constants/changelog.ts`
+- Modify: `src/pages/DocumentationPage.tsx`
+
+- [ ] **Step 1: Add changelog entry**
+
+Add a plain-English bullet to the `UNRELEASED_CHANGES` array in `src/constants/changelog.ts`, matching the existing entry shape (inspect the array first). Suggested text:
+
+> "Skill hovercards now show a board diagram of each Active/Charge skill's targeting footprint — which cells the skill hits (red = primary target, orange = splash)."
+
+- [ ] **Step 2: Update DocumentationPage**
+
+Find the section of `src/pages/DocumentationPage.tsx` that covers the ship database / skills (search for "skill" / "hover"). Add one sentence noting that hovering an Active or Charge skill shows its targeting footprint on a board diagram. Use the existing markup/components in that section — do not hand-roll new containers.
+
+- [ ] **Step 3: Lint**
+
+Run: `npm run lint`
+Expected: 0 warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/constants/changelog.ts src/pages/DocumentationPage.tsx
+git commit -m "docs: changelog + in-app docs for skill targeting footprints"
+```
+
+---
+
+### Task 8: Final verification
+
+Apply @superpowers:verification-before-completion — run each command and confirm output before claiming done.
+
+- [ ] **Step 1: Full test suite**
+
+Run: `npm test`
+Expected: all tests pass (includes the targeting corpus + new tests).
+
+- [ ] **Step 2: Typecheck + lint**
+
+Run: `npx tsc --noEmit && npm run lint`
+Expected: no type errors; 0 lint warnings.
+
+- [ ] **Step 3: Manual smoke (optional but recommended)**
+
+Run `npm start` (dev server on :3000), open the ship database, hover an Active/Charge skill on a ship that has targeting data, and confirm the footprint board renders (dual board for enemy-targeting skills, single board for support skills), with a sensible caption and no console errors. Ships lacking targeting data should show the hovercard exactly as before (no board).
+
+- [ ] **Step 4: Report**
+
+Summarize: tests passing (count), typecheck clean, lint clean, manual smoke result. Then proceed to @superpowers:finishing-a-development-branch.

--- a/docs/superpowers/specs/2026-06-14-skill-targeting-footprint-hovercard-design.md
+++ b/docs/superpowers/specs/2026-06-14-skill-targeting-footprint-hovercard-design.md
@@ -81,6 +81,12 @@ No offset-table introspection and no hand-maintained per-pattern table. `'all'` 
 full from any anchor; `'lane'` always clips slightly on a 4-wide board, so "most on-board"
 yields the best available framing. Pure and unit-tested.
 
+**Non-goal:** pixel-identical reproduction of the prototype's hand-picked anchors. The
+prototype framed back-anchored / forward-support patterns at specific cells (e.g.
+`Cone-Back` → M2, `Backline` → M1); several candidates can yield the same on-board count,
+so auto-fit may frame those differently. Tests therefore assert "fully on-board / sensible
+and deterministic", **not** "equals the prototype anchor".
+
 ### 2. Board diagram — `src/components/ship/SkillTargetingBoard.tsx` (new)
 
 Presentational, SVG-based (adapts the prototype's `hexPath` / `rawXY` / mirror math,
@@ -112,7 +118,16 @@ Behavior:
 
 A small `targetingLabel(targeting): string` helper (co-located in the component file or in
 `displayAnchor.ts`/a sibling util) produces the caption from the parsed shape, range,
-modifiers, side, and selection.
+modifiers, side, and selection. Range rendering rules (pin these in the plan):
+
+- numeric `range: 0` → omit the range segment entirely (e.g. base/point-blank reads
+  `Single target · enemy front`, not `Range 0`);
+- `range: 'all'` → `Whole board` (no separate range segment);
+- `range: 'lane'` → `Whole lane`;
+- numeric `range >= 1` → `Range N`.
+
+Modifiers (`reverse`, `prolonged`, `notSelf`, `double`, `fromCentre`, `anchorMod`) are
+appended as short qualifiers where present; shape name is title-cased.
 
 ### 3. `SkillTooltip` integration
 
@@ -129,8 +144,9 @@ text. When absent, behavior is unchanged.
 
 - **`ShipSkillList`:** compute `const targeting = parseShipTargeting(ship)` once. For the
   Active row pass `targeting.active`; for the Charge row pass `targeting.charged`; pass
-  nothing for the Passive row. Row identity comes from the existing `row.label`
-  (`Active` / `Charge` / `Passive …`).
+  nothing for the Passive row. Row identity comes from the existing `row.label` — match the
+  exact strings `'Active'` and `'Charge'` (passive labels are `Passive R0` / `Passive R2` /
+  `Passive R4`, per `getShipSkillRows`), **not** a prefix match.
 - **`ShipIndexPage`:** same — compute `parseShipTargeting(ship)` and pass `.active` to the
   Active `SkillTooltip` and `.charged` to the Charge `SkillTooltip`.
 

--- a/docs/superpowers/specs/2026-06-14-skill-targeting-footprint-hovercard-design.md
+++ b/docs/superpowers/specs/2026-06-14-skill-targeting-footprint-hovercard-design.md
@@ -1,0 +1,175 @@
+# Skill Targeting Footprint in Hovercards — Design
+
+**Date:** 2026-06-14
+**Status:** Approved (design), pending spec review
+**Area:** Frontend / ship skill display (consumes positional geometry resolver, PR #106)
+
+## Context
+
+The positional-targeting foundation is merged:
+
+- **Data** (`src/utils/targetingParser.ts`, PR #105): `parseShipTargeting(ship)` →
+  `ShipTargeting { active?, charged? }`. Each `SkillTargeting` is
+  `{ target: ParsedTarget, pattern: ParsedPattern }`. Charged inheritance is already
+  handled (empty `chargedTarget`/`chargedPattern` fall back to the active values).
+- **Geometry** (`src/utils/targeting/`, PR #106): `resolveCells(pattern, anchor)` →
+  `ResolvedCell[]`, each `{ position: Position, role: 'origin' | 'covered' }`. Off-board
+  cells are clipped (not returned). `board.ts` exposes `ALL_POSITIONS` and axial-coordinate
+  helpers (`positionToAxial`). `'all'` patterns return all 12 cells; `'lane'` (support
+  whole-lane) is caster-centered and clips at the board edges.
+
+None of this is surfaced to users yet. Ship skills render as text only. We want to show
+each Active/Charge skill's targeting **footprint** as a small board diagram inside the
+existing skill hovercard, modeled on the approved prototype
+(`.superpowers/pattern-footprints-review-v3.html`): **red = origin** (caster / primary
+target), **orange = covered** (splash), dim = empty.
+
+This is a display-only feature. It does not touch the combat engine or the
+positional target-selection work (that is a separate arc, piece 2 of 5).
+
+### Where skills render today
+
+`SkillTooltip` (`src/components/ship/SkillTooltip.tsx`) is the single skill-rendering
+component. Confirmed call sites:
+
+- `ShipSkillList` (`src/components/ship/ShipSkillList.tsx`) — iterates
+  `getShipSkillRows(ship)` (Active, Charge, the refit-active Passive) and renders one
+  `SkillTooltip` per row, `inline`. Has `ship` in scope.
+- `ShipIndexPage` (`src/pages/database/ShipIndexPage.tsx`) — renders Active (line ~409),
+  Charge (~454), and Passives via `SkillTooltip` inside the portal `Tooltip`. Has `ship`
+  in scope.
+- `SkillAuditSection`, `SkillEditorModal` — admin/editor surfaces. They will not pass
+  targeting; the new prop is optional, so they are unaffected.
+
+Because every surface routes through `SkillTooltip`, integrating there satisfies
+"everywhere `SkillTooltip` renders" (the chosen scope).
+
+## Goal
+
+Render a compact SVG board diagram of a skill's targeting footprint beneath the skill text,
+for Active and Charge skills that carry targeting data. Passives show nothing (the data
+model has no passive targeting). Faithful to the prototype: attacker patterns show a
+two-board layout (your team + mirrored enemy with a `▶` arrow); support patterns show a
+single own-board.
+
+## Non-goals
+
+- No engine / target-selection behavior change.
+- No interactivity (no click, no anchor picking by the user).
+- No new targeting data; we consume what `parseShipTargeting` already produces.
+- Passive-skill footprints.
+
+## Design
+
+### 1. Display-anchor selection — `src/utils/targeting/displayAnchor.ts` (new)
+
+```ts
+export function pickDisplayAnchor(pattern: ParsedPattern): Position
+```
+
+The footprint is defined relative to an anchor cell; a bad anchor pushes cells off-board
+where `resolveCells` clips them, misrepresenting the shape. We pick the anchor
+**algorithmically** (auto-fit), since `resolveCells` already does the clipping for us:
+
+- For each candidate in `ALL_POSITIONS`, compute `resolveCells(pattern, candidate).length`.
+- Choose the candidate with the **most** on-board cells (= least clipped).
+- Break ties using a fixed preference order biased toward front-center
+  (e.g. `M3, M4, M2, M1, T3, …`) so previews echo the prototype's framing and are
+  deterministic.
+
+No offset-table introspection and no hand-maintained per-pattern table. `'all'` resolves
+full from any anchor; `'lane'` always clips slightly on a 4-wide board, so "most on-board"
+yields the best available framing. Pure and unit-tested.
+
+### 2. Board diagram — `src/components/ship/SkillTargetingBoard.tsx` (new)
+
+Presentational, SVG-based (adapts the prototype's `hexPath` / `rawXY` / mirror math,
+driven by `board.ts` axial coords — no new dependencies, not the heavy interactive
+`HexButton`).
+
+```tsx
+interface SkillTargetingBoardProps {
+    targeting: SkillTargeting;
+}
+```
+
+Behavior:
+
+1. `anchor = pickDisplayAnchor(targeting.pattern)`.
+2. `cells = resolveCells(targeting.pattern, anchor)` → build a `Map<Position, CellRole>`.
+3. **Support vs attacker:** support when `targeting.pattern.modifiers.support === true`
+   **or** `targeting.target.side === 'ally'`.
+   - **Support:** one own-board. The footprint includes the caster unless the pattern is
+     `notSelf` (whose offset table has no origin cell, so no red renders — matches the
+     prototype's "no origin").
+   - **Attacker:** two boards — your team (decorative/empty) on the left, a `▶` arrow, and
+     the mirrored enemy board on the right carrying the footprint.
+4. Render each of the 12 hexes: red fill for `origin`, orange for `covered`, dim otherwise,
+   with the position label (T1…B4).
+5. **Caption + legend:** a short human-readable caption derived from `ParsedTarget` +
+   `ParsedPattern` (e.g. `Cone · Range 1 · enemy front`) and a minimal origin/covered
+   legend. Kept compact for tooltip use.
+
+A small `targetingLabel(targeting): string` helper (co-located in the component file or in
+`displayAnchor.ts`/a sibling util) produces the caption from the parsed shape, range,
+modifiers, side, and selection.
+
+### 3. `SkillTooltip` integration
+
+Add an optional prop:
+
+```tsx
+targeting?: SkillTargeting;
+```
+
+When present, render `<SkillTargetingBoard targeting={targeting} />` after the parsed skill
+text. When absent, behavior is unchanged.
+
+### 4. Callers
+
+- **`ShipSkillList`:** compute `const targeting = parseShipTargeting(ship)` once. For the
+  Active row pass `targeting.active`; for the Charge row pass `targeting.charged`; pass
+  nothing for the Passive row. Row identity comes from the existing `row.label`
+  (`Active` / `Charge` / `Passive …`).
+- **`ShipIndexPage`:** same — compute `parseShipTargeting(ship)` and pass `.active` to the
+  Active `SkillTooltip` and `.charged` to the Charge `SkillTooltip`.
+
+### Data flow
+
+`ship` → `parseShipTargeting(ship)` → `{ active?, charged? }` → row-matched
+`SkillTargeting` → `SkillTargetingBoard` → `pickDisplayAnchor` + `resolveCells` → role map
+→ SVG board(s) + caption.
+
+## Edge cases
+
+- **No targeting on the ship** (`activePattern` empty / not backfilled): `parseShipTargeting`
+  yields `undefined` for that skill; the prop is undefined; nothing extra renders.
+- **`'all'` pattern:** whole board highlighted.
+- **`'lane'` (support whole-lane):** auto-fit minimizes edge clipping.
+- **`notSelf` patterns:** offset table has no origin cell → no red origin (intended).
+- **Charged inheritance:** already resolved by `parseShipTargeting`.
+- **Single-target `base` pattern:** renders a single origin cell — still informative
+  (shows front/back single-target); shown.
+
+## Testing
+
+- **`displayAnchor` unit tests:** representative patterns (line/cone/circle/backline) resolve
+  to an anchor whose footprint is fully on-board; `'all'` and `'lane'` do not throw and
+  return a sensible anchor; tie-break is deterministic.
+- **`SkillTargetingBoard` render tests (RTL):** support pattern renders one board; attacker
+  pattern renders two boards plus the arrow; the expected origin/covered positions are
+  present with the right roles; caption text is present.
+
+## Docs & changelog
+
+- Add a plain-English line to `UNRELEASED_CHANGES` in `src/constants/changelog.ts`.
+- Update the relevant skill/targeting section of `src/pages/DocumentationPage.tsx`.
+
+## Files
+
+- New: `src/utils/targeting/displayAnchor.ts` (+ test)
+- New: `src/components/ship/SkillTargetingBoard.tsx` (+ test)
+- Edit: `src/components/ship/SkillTooltip.tsx` (optional `targeting` prop)
+- Edit: `src/components/ship/ShipSkillList.tsx` (pass targeting per row)
+- Edit: `src/pages/database/ShipIndexPage.tsx` (pass targeting to Active/Charge)
+- Edit: `src/constants/changelog.ts`, `src/pages/DocumentationPage.tsx`

--- a/src/components/ship/ShipSkillList.tsx
+++ b/src/components/ship/ShipSkillList.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { Ship } from '../../types/ship';
 import { getShipSkillRows } from '../../utils/ship/skillRows';
+import { parseShipTargeting } from '../../utils/targetingParser';
 import { SkillTooltip } from './SkillTooltip';
 
 export const ShipSkillList: React.FC<{ ship: Ship }> = ({ ship }) => {
     const rows = getShipSkillRows(ship);
     if (rows.length === 0) return null;
+
+    const targeting = parseShipTargeting(ship);
 
     return (
         <div className="space-y-3">
@@ -16,6 +19,13 @@ export const ShipSkillList: React.FC<{ ship: Ship }> = ({ ship }) => {
                         skillText={row.text}
                         skillType={row.label}
                         charge={row.charge}
+                        targeting={
+                            row.label === 'Active'
+                                ? targeting.active
+                                : row.label === 'Charge'
+                                  ? targeting.charged
+                                  : undefined
+                        }
                     />
                 </div>
             ))}

--- a/src/components/ship/SkillTargetingBoard.tsx
+++ b/src/components/ship/SkillTargetingBoard.tsx
@@ -5,9 +5,9 @@ import { ALL_POSITIONS, positionToAxial } from '../../utils/targeting/board';
 import { CellRole, resolveCells } from '../../utils/targeting/resolvePattern';
 import { pickDisplayAnchor, targetingLabel } from '../../utils/targeting/targetingDisplay';
 
-// Compact single-board footprint. One board for both ally and enemy targets — the
-// resolved cells are identical regardless of side, so we draw one un-mirrored board
-// and let the caption convey which side it targets.
+// Compact single-board footprint shown as its own hovercard box (sibling to the
+// buff-description boxes). One board per skill; the enemy board is mirrored so its
+// front column faces the viewer the way enemies appear in-game.
 const W = 24;
 const H = 20;
 const HEX_RX = 11;
@@ -22,6 +22,9 @@ const GRID_PAD_X = 24;
 const GRID_PAD_Y = 15;
 const SVG_W = 108;
 const SVG_H = 70;
+// Mirroring maps x → (rawXmin + rawXmax) − x = 60 − x, which keeps the x-range onto
+// itself so the SVG dimensions stay valid for the mirrored (enemy) board.
+const MIRROR_CONST = -12 + 72;
 
 const COLORS: Record<CellRole | 'empty', { fill: string; stroke: string }> = {
     origin: { fill: '#7a1020', stroke: '#e0455f' },
@@ -58,24 +61,24 @@ export const SkillTargetingBoard: React.FC<SkillTargetingBoardProps> = ({ target
         return null; // unknown pattern signature — show nothing rather than crash
     }
 
-    const caption = targetingLabel(targeting);
-    const roleValues = Array.from(roles.values());
-    const hasOrigin = roleValues.includes('origin');
-    const hasCovered = roleValues.includes('covered');
+    const mirror = targeting.target.side === 'enemy';
 
     return (
-        <div className="mt-2 text-[11px] text-theme-text/70">
-            <div className="mb-1">{caption}</div>
+        <div className="bg-dark-lighter p-2 shadow-lg max-w-xs mb-1 border border-dark-border">
+            <div className="font-semibold text-sm text-primary">Targeting</div>
+            <div className="text-sm text-theme-text capitalize mb-1">
+                {targeting.target.selection}
+            </div>
             <svg
                 width={SVG_W}
                 height={SVG_H}
                 role="img"
-                aria-label={`Targeting footprint: ${caption}`}
+                aria-label={`Targeting footprint: ${targetingLabel(targeting)}`}
             >
                 <g data-board="footprint">
                     {ALL_POSITIONS.map((pos) => {
-                        const [x, y] = rawXY(pos);
-                        const cx = x + GRID_PAD_X;
+                        const [rawX, y] = rawXY(pos);
+                        const cx = (mirror ? MIRROR_CONST - rawX : rawX) + GRID_PAD_X;
                         const cy = y + GRID_PAD_Y;
                         const role = roles.get(pos);
                         const colors = COLORS[role ?? 'empty'];
@@ -93,20 +96,6 @@ export const SkillTargetingBoard: React.FC<SkillTargetingBoardProps> = ({ target
                     })}
                 </g>
             </svg>
-            <div className="flex gap-3 mt-1">
-                {hasOrigin && (
-                    <span className="inline-flex items-center gap-1">
-                        <span className="inline-block w-2 h-2 bg-[#e0455f]" />
-                        origin
-                    </span>
-                )}
-                {hasCovered && (
-                    <span className="inline-flex items-center gap-1">
-                        <span className="inline-block w-2 h-2 bg-[#e09a45]" />
-                        covered
-                    </span>
-                )}
-            </div>
         </div>
     );
 };

--- a/src/components/ship/SkillTargetingBoard.tsx
+++ b/src/components/ship/SkillTargetingBoard.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { Position } from '../../types/encounters';
+import { SkillTargeting } from '../../utils/targetingParser';
+import { ALL_POSITIONS, positionToAxial } from '../../utils/targeting/board';
+import { CellRole, resolveCells } from '../../utils/targeting/resolvePattern';
+import { pickDisplayAnchor, targetingLabel } from '../../utils/targeting/targetingDisplay';
+
+const W = 44;
+const H = 38;
+const HEX_RX = 21;
+const HEX_RY = 24;
+
+const COLORS: Record<CellRole | 'empty', { fill: string; stroke: string }> = {
+    origin: { fill: '#7a1020', stroke: '#e0455f' },
+    covered: { fill: '#6a4012', stroke: '#e09a45' },
+    empty: { fill: '#222a3d', stroke: '#37445e' },
+};
+
+function rawXY(pos: Position): [number, number] {
+    const { q, r } = positionToAxial(pos);
+    return [(q + r / 2) * W, r * H];
+}
+
+function hexPath(cx: number, cy: number): string {
+    const pts: string[] = [];
+    for (let i = 0; i < 6; i++) {
+        const a = (Math.PI / 180) * (60 * i - 90);
+        pts.push(
+            `${(cx + HEX_RX * Math.cos(a)).toFixed(1)},${(cy + HEX_RY * Math.sin(a)).toFixed(1)}`
+        );
+    }
+    return pts.join(' ');
+}
+
+interface BoardProps {
+    ox: number;
+    oy: number;
+    mirror: boolean;
+    roles: Map<Position, CellRole>;
+    label: string;
+}
+
+const Board: React.FC<BoardProps> = ({ ox, oy, mirror, roles, label }) => (
+    <g data-board={label}>
+        {ALL_POSITIONS.map((pos) => {
+            const [rawX, y] = rawXY(pos);
+            const x = mirror ? 110 - rawX : rawX;
+            const cx = ox + x + 30;
+            const cy = oy + y + 22;
+            const role = roles.get(pos);
+            const colors = COLORS[role ?? 'empty'];
+            return (
+                <g key={pos} data-position={pos} data-role={role ?? 'empty'}>
+                    <polygon
+                        points={hexPath(cx, cy)}
+                        fill={colors.fill}
+                        stroke={colors.stroke}
+                        strokeWidth={1.4}
+                    />
+                    <text
+                        x={cx}
+                        y={cy + 4}
+                        textAnchor="middle"
+                        fontSize={10}
+                        fill={role ? '#fff' : '#6b7794'}
+                    >
+                        {pos}
+                    </text>
+                </g>
+            );
+        })}
+    </g>
+);
+
+interface SkillTargetingBoardProps {
+    targeting: SkillTargeting;
+}
+
+export const SkillTargetingBoard: React.FC<SkillTargetingBoardProps> = ({ targeting }) => {
+    let roles: Map<Position, CellRole>;
+    try {
+        const anchor = pickDisplayAnchor(targeting.pattern);
+        roles = new Map(resolveCells(targeting.pattern, anchor).map((c) => [c.position, c.role]));
+    } catch {
+        return null; // unknown pattern signature — show nothing rather than crash
+    }
+
+    const isSupport =
+        targeting.pattern.modifiers.support === true || targeting.target.side === 'ally';
+    const caption = targetingLabel(targeting);
+
+    return (
+        <div className="mt-2 text-[11px] text-theme-text/70">
+            <div className="mb-1">{caption}</div>
+            {isSupport ? (
+                <svg
+                    width={178}
+                    height={120}
+                    role="img"
+                    aria-label={`Targeting footprint: ${caption}`}
+                >
+                    <Board ox={0} oy={12} mirror={false} roles={roles} label="own" />
+                    <text x={89} y={112} textAnchor="middle" fontSize={10} fill="#5a6a86">
+                        your board
+                    </text>
+                </svg>
+            ) : (
+                <svg
+                    width={402}
+                    height={120}
+                    role="img"
+                    aria-label={`Targeting footprint: ${caption}`}
+                >
+                    <Board ox={0} oy={12} mirror={false} roles={new Map()} label="team" />
+                    <text x={201} y={62} textAnchor="middle" fontSize={20} fill="#6ca8ff">
+                        ▶
+                    </text>
+                    <Board ox={224} oy={12} mirror roles={roles} label="enemy" />
+                </svg>
+            )}
+            <div className="flex gap-3 mt-1">
+                <span className="inline-flex items-center gap-1">
+                    <span className="inline-block w-2 h-2 bg-[#e0455f]" />
+                    origin
+                </span>
+                <span className="inline-flex items-center gap-1">
+                    <span className="inline-block w-2 h-2 bg-[#e09a45]" />
+                    covered
+                </span>
+            </div>
+        </div>
+    );
+};

--- a/src/components/ship/SkillTargetingBoard.tsx
+++ b/src/components/ship/SkillTargetingBoard.tsx
@@ -1,48 +1,56 @@
 import React from 'react';
-import { Position } from '../../types/encounters';
-import { SkillTargeting } from '../../utils/targetingParser';
-import { ALL_POSITIONS, positionToAxial } from '../../utils/targeting/board';
-import { CellRole, resolveCells } from '../../utils/targeting/resolvePattern';
-import { pickDisplayAnchor, targetingLabel } from '../../utils/targeting/targetingDisplay';
+import { SkillTargeting, TargetSide } from '../../utils/targetingParser';
+import { AoeCellRole, PatternCell, toPatternCells } from '../../utils/targeting/aoePattern';
+import { targetingLabel } from '../../utils/targeting/targetingDisplay';
+import { TARGETING_RULES } from '../../constants/targetingRules';
 
-// Compact single-board footprint shown as its own hovercard box (sibling to the
-// buff-description boxes). One board per skill; the enemy board is mirrored so its
-// front column faces the viewer the way enemies appear in-game.
-const W = 24;
-const H = 20;
-const HEX_RX = 11;
-const HEX_RY = 13;
-// Padding added to rawXY so the leftmost/topmost hex stays inside the SVG frame.
-// rawX ∈ [-12, 72], rawY ∈ [0, 40]. Hex half-extents: HEX_RX·cos(30°) ≈ 9.5 px wide,
-// HEX_RY = 13 px tall.
-// GRID_PAD_X=24: leftmost cx = -12+24 = 12, left vertex = 12-9.5 ≈ 2.5 ✓;
-//                rightmost cx = 72+24 = 96, right vertex = 96+9.5 ≈ 105.5 → width 108 ✓
-// GRID_PAD_Y=15: top vertex = 0+15-13 = 2 ✓; bottom vertex = 40+15+13 = 68 → height 70 ✓
-const GRID_PAD_X = 24;
-const GRID_PAD_Y = 15;
-const SVG_W = 108;
-const SVG_H = 70;
-// Mirroring maps x → (rawXmin + rawXmax) − x = 60 − x, which keeps the x-range onto
-// itself so the SVG dimensions stay valid for the mirrored (enemy) board.
-const MIRROR_CONST = -12 + 72;
+// Pointy-top hexes. Center-to-vertex radius; a small gap shrinks the drawn polygon so cells
+// read as separate. The SVG auto-fits its viewBox to the pattern's bounding box, so any
+// footprint centers and scales within the fixed-width left pane.
+const RADIUS = 22;
+const GAP = 2;
+const PAD = 6; // viewBox margin so the glow filter isn't clipped
 
-const COLORS: Record<CellRole | 'empty', { fill: string; stroke: string }> = {
-    origin: { fill: '#7a1020', stroke: '#e0455f' },
-    covered: { fill: '#6a4012', stroke: '#e09a45' },
-    empty: { fill: '#222a3d', stroke: '#37445e' },
+// Cell colors depend on the target side: enemy (attacker) reads red, ally (support) reads
+// green. Primary/caster is the stronger shade; splash/allies is the lighter shade.
+const ROLE_STYLE: Record<TargetSide, Record<AoeCellRole, { fill: string; stroke: string }>> = {
+    enemy: {
+        primary: { fill: 'rgba(255,59,92,0.18)', stroke: '#ff3b5c' }, // red
+        splash: { fill: 'rgba(255,138,156,0.18)', stroke: '#ff8a9c' }, // lighter red
+    },
+    ally: {
+        primary: { fill: 'rgba(22,163,74,0.26)', stroke: '#16a34a' }, // darker green (caster)
+        splash: { fill: 'rgba(74,222,128,0.20)', stroke: '#4ade80' }, // green
+    },
 };
 
-function rawXY(pos: Position): [number, number] {
-    const { q, r } = positionToAxial(pos);
-    return [(q + r / 2) * W, r * H];
+// Legend labels + swatch classes per side. Swatch classes are written as literals so
+// Tailwind's JIT picks them up.
+const LEGEND: Record<
+    TargetSide,
+    { primary: { label: string; dot: string }; splash: { label: string; dot: string } }
+> = {
+    enemy: {
+        primary: { label: 'Primary', dot: 'bg-[#ff3b5c]' },
+        splash: { label: 'Splash', dot: 'bg-[#ff8a9c]' },
+    },
+    ally: {
+        primary: { label: 'Caster', dot: 'bg-[#16a34a]' },
+        splash: { label: 'Allies', dot: 'bg-[#4ade80]' },
+    },
+};
+
+// Pointy-top axial → pixel.
+function axialToPixel(q: number, r: number): [number, number] {
+    return [RADIUS * Math.sqrt(3) * (q + r / 2), RADIUS * 1.5 * r];
 }
 
-function hexPath(cx: number, cy: number): string {
+function hexPoints(cx: number, cy: number, radius: number): string {
     const pts: string[] = [];
     for (let i = 0; i < 6; i++) {
         const a = (Math.PI / 180) * (60 * i - 90);
         pts.push(
-            `${(cx + HEX_RX * Math.cos(a)).toFixed(1)},${(cy + HEX_RY * Math.sin(a)).toFixed(1)}`
+            `${(cx + radius * Math.cos(a)).toFixed(1)},${(cy + radius * Math.sin(a)).toFixed(1)}`
         );
     }
     return pts.join(' ');
@@ -53,49 +61,102 @@ interface SkillTargetingBoardProps {
 }
 
 export const SkillTargetingBoard: React.FC<SkillTargetingBoardProps> = ({ targeting }) => {
-    let roles: Map<Position, CellRole>;
+    let cells: PatternCell[];
     try {
-        const anchor = pickDisplayAnchor(targeting.pattern);
-        roles = new Map(resolveCells(targeting.pattern, anchor).map((c) => [c.position, c.role]));
+        cells = toPatternCells(targeting.pattern);
     } catch {
         return null; // unknown pattern signature — show nothing rather than crash
     }
+    if (cells.length === 0) return null;
 
-    const mirror = targeting.target.side === 'enemy';
+    const side = targeting.target.side;
+    const mirror = side === 'enemy'; // attacker footprints face the enemy formation
+    const rule = TARGETING_RULES[targeting.target.selection];
+
+    // Place cells (mirrored horizontally for enemy) and compute the bounding box.
+    const placed = cells.map((c) => {
+        const [px, py] = axialToPixel(c.q, c.r);
+        return { cx: mirror ? -px : px, cy: py, role: c.role };
+    });
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const { cx, cy } of placed) {
+        minX = Math.min(minX, cx - RADIUS);
+        maxX = Math.max(maxX, cx + RADIUS);
+        minY = Math.min(minY, cy - RADIUS);
+        maxY = Math.max(maxY, cy + RADIUS);
+    }
+    const viewBox = `${(minX - PAD).toFixed(1)} ${(minY - PAD).toFixed(1)} ${(
+        maxX -
+        minX +
+        2 * PAD
+    ).toFixed(1)} ${(maxY - minY + 2 * PAD).toFixed(1)}`;
+
+    const hasPrimary = cells.some((c) => c.role === 'primary');
+    const hasSplash = cells.some((c) => c.role === 'splash');
+    const legend = LEGEND[side];
 
     return (
-        <div className="bg-dark-lighter p-2 shadow-lg max-w-xs mb-1 border border-dark-border">
-            <div className="font-semibold text-sm text-primary">Targeting</div>
-            <div className="text-sm text-theme-text capitalize mb-1">
-                {targeting.target.selection}
+        <div className="bg-dark-lighter p-2 shadow-lg max-w-sm mb-1 border border-dark-border">
+            <div className="flex items-stretch gap-3">
+                <div className="w-[130px] shrink-0 flex items-center justify-center">
+                    <svg
+                        viewBox={viewBox}
+                        role="img"
+                        aria-label={`Targeting footprint: ${targetingLabel(targeting)}`}
+                        className="w-full h-auto max-h-[110px]"
+                    >
+                        <defs>
+                            <filter id="aoe-glow" x="-50%" y="-50%" width="200%" height="200%">
+                                <feGaussianBlur in="SourceGraphic" stdDeviation="2" result="b" />
+                                <feMerge>
+                                    <feMergeNode in="b" />
+                                    <feMergeNode in="SourceGraphic" />
+                                </feMerge>
+                            </filter>
+                        </defs>
+                        <g filter="url(#aoe-glow)" data-cluster="footprint">
+                            {placed.map((p, i) => (
+                                <polygon
+                                    key={i}
+                                    data-role={p.role}
+                                    points={hexPoints(p.cx, p.cy, RADIUS - GAP)}
+                                    fill={ROLE_STYLE[side][p.role].fill}
+                                    stroke={ROLE_STYLE[side][p.role].stroke}
+                                    strokeWidth={1.5}
+                                />
+                            ))}
+                        </g>
+                    </svg>
+                </div>
+
+                <div className="border-l border-dark-border" />
+
+                <div className="flex-1 min-w-0">
+                    <div className="font-semibold text-sm text-primary">{rule.label}</div>
+                    <p className="text-sm text-theme-text mt-1">{rule.description}</p>
+                    <div className="flex gap-3 mt-2 text-[11px] text-theme-text/70">
+                        {hasPrimary && (
+                            <span className="inline-flex items-center gap-1">
+                                <span
+                                    className={`inline-block w-2 h-2 rounded-sm ${legend.primary.dot}`}
+                                />
+                                {legend.primary.label}
+                            </span>
+                        )}
+                        {hasSplash && (
+                            <span className="inline-flex items-center gap-1">
+                                <span
+                                    className={`inline-block w-2 h-2 rounded-sm ${legend.splash.dot}`}
+                                />
+                                {legend.splash.label}
+                            </span>
+                        )}
+                    </div>
+                </div>
             </div>
-            <svg
-                width={SVG_W}
-                height={SVG_H}
-                role="img"
-                aria-label={`Targeting footprint: ${targetingLabel(targeting)}`}
-            >
-                <g data-board="footprint">
-                    {ALL_POSITIONS.map((pos) => {
-                        const [rawX, y] = rawXY(pos);
-                        const cx = (mirror ? MIRROR_CONST - rawX : rawX) + GRID_PAD_X;
-                        const cy = y + GRID_PAD_Y;
-                        const role = roles.get(pos);
-                        const colors = COLORS[role ?? 'empty'];
-                        return (
-                            <polygon
-                                key={pos}
-                                data-position={pos}
-                                data-role={role ?? 'empty'}
-                                points={hexPath(cx, cy)}
-                                fill={colors.fill}
-                                stroke={colors.stroke}
-                                strokeWidth={1.4}
-                            />
-                        );
-                    })}
-                </g>
-            </svg>
         </div>
     );
 };

--- a/src/components/ship/SkillTargetingBoard.tsx
+++ b/src/components/ship/SkillTargetingBoard.tsx
@@ -29,8 +29,11 @@ const SUPPORT_LABEL_Y = 138;
 // Team board: ox=0, cx ∈ [19, 173], right vertex = 191.
 // Enemy board (mirrored, ox=ENEMY_OX): cx ∈ [ox+19, ox+173], right vertex = ox+191.
 // Arrow sits at horizontal midpoint between the two boards.
-// Choose ENEMY_OX=212 → gap between boards = (212+19) - 191 = 40 px wide enough.
-// Arrow x = (191 + 212+19)/2 = (191+231)/2 = 211, but centre of gap = 191 + 20 = 211. OK.
+// Choose ENEMY_OX=212 → vertex-to-vertex gap = (212+19) - 191 = 40 px? No:
+//   right vertex of team board  = 191 (HEX_RX·cos30° ≈ 18 → 173+18 = 191)
+//   left  vertex of enemy board = ENEMY_OX + 19 - 18 = 212 + 1 = 213
+//   true vertex-to-vertex gap   = 213 - 191 = 22 px ≈ 21 px — fine for the ▶ glyph.
+// Arrow x = midpoint of gap = (191 + 213)/2 = 202, but computed below as midpoint of board centres.
 // Total width = ENEMY_OX + 191 + 3 = 212 + 191 + 3 = 406.
 const ENEMY_OX = 212;
 const ATTACKER_SVG_W = ENEMY_OX + 191 + 3; // = 406
@@ -61,19 +64,18 @@ function hexPath(cx: number, cy: number): string {
 
 interface BoardProps {
     ox: number;
-    oy: number;
     mirror: boolean;
     roles: Map<Position, CellRole>;
     label: string;
 }
 
-const Board: React.FC<BoardProps> = ({ ox, oy, mirror, roles, label }) => (
+const Board: React.FC<BoardProps> = ({ ox, mirror, roles, label }) => (
     <g data-board={label}>
         {ALL_POSITIONS.map((pos) => {
             const [rawX, y] = rawXY(pos);
             const x = mirror ? 110 - rawX : rawX;
             const cx = ox + x + GRID_PAD_X;
-            const cy = oy + y + GRID_PAD_Y;
+            const cy = y + GRID_PAD_Y;
             const role = roles.get(pos);
             const colors = COLORS[role ?? 'empty'];
             return (
@@ -115,6 +117,9 @@ export const SkillTargetingBoard: React.FC<SkillTargetingBoardProps> = ({ target
     const isSupport =
         targeting.pattern.modifiers.support === true || targeting.target.side === 'ally';
     const caption = targetingLabel(targeting);
+    const roleValues = Array.from(roles.values());
+    const hasOrigin = roleValues.includes('origin');
+    const hasCovered = roleValues.includes('covered');
 
     return (
         <div className="mt-2 text-[11px] text-theme-text/70">
@@ -126,7 +131,7 @@ export const SkillTargetingBoard: React.FC<SkillTargetingBoardProps> = ({ target
                     role="img"
                     aria-label={`Targeting footprint: ${caption}`}
                 >
-                    <Board ox={0} oy={0} mirror={false} roles={roles} label="own" />
+                    <Board ox={0} mirror={false} roles={roles} label="own" />
                     <text
                         x={SUPPORT_LABEL_X}
                         y={SUPPORT_LABEL_Y}
@@ -144,7 +149,7 @@ export const SkillTargetingBoard: React.FC<SkillTargetingBoardProps> = ({ target
                     role="img"
                     aria-label={`Targeting footprint: ${caption}`}
                 >
-                    <Board ox={0} oy={0} mirror={false} roles={new Map()} label="team" />
+                    <Board ox={0} mirror={false} roles={new Map()} label="team" />
                     <text
                         x={ARROW_X}
                         y={Math.round(ATTACKER_SVG_H / 2)}
@@ -154,18 +159,40 @@ export const SkillTargetingBoard: React.FC<SkillTargetingBoardProps> = ({ target
                     >
                         ▶
                     </text>
-                    <Board ox={ENEMY_OX} oy={0} mirror roles={roles} label="enemy" />
+                    <Board ox={ENEMY_OX} mirror roles={roles} label="enemy" />
+                    <text
+                        x={97}
+                        y={SUPPORT_LABEL_Y}
+                        textAnchor="middle"
+                        fontSize={10}
+                        fill="#5a6a86"
+                    >
+                        your fleet
+                    </text>
+                    <text
+                        x={ENEMY_OX + 97}
+                        y={SUPPORT_LABEL_Y}
+                        textAnchor="middle"
+                        fontSize={10}
+                        fill="#5a6a86"
+                    >
+                        enemies
+                    </text>
                 </svg>
             )}
             <div className="flex gap-3 mt-1">
-                <span className="inline-flex items-center gap-1">
-                    <span className="inline-block w-2 h-2 bg-[#e0455f]" />
-                    origin
-                </span>
-                <span className="inline-flex items-center gap-1">
-                    <span className="inline-block w-2 h-2 bg-[#e09a45]" />
-                    covered
-                </span>
+                {hasOrigin && (
+                    <span className="inline-flex items-center gap-1">
+                        <span className="inline-block w-2 h-2 bg-[#e0455f]" />
+                        origin
+                    </span>
+                )}
+                {hasCovered && (
+                    <span className="inline-flex items-center gap-1">
+                        <span className="inline-block w-2 h-2 bg-[#e09a45]" />
+                        covered
+                    </span>
+                )}
             </div>
         </div>
     );

--- a/src/components/ship/SkillTargetingBoard.tsx
+++ b/src/components/ship/SkillTargetingBoard.tsx
@@ -9,6 +9,33 @@ const W = 44;
 const H = 38;
 const HEX_RX = 21;
 const HEX_RY = 24;
+// Padding added to each board's rawXY so the leftmost/topmost hex stays
+// inside the SVG frame.  rawX ∈ [-22, 132], rawY ∈ [0, 76].
+// Half-extents per hex: HEX_RX*cos(30°) ≈ 18 px wide, HEX_RY = 24 px tall.
+// With GRID_PAD_X=41: leftmost cx = -22+41 = 19, left vertex = 19-18 = 1 ✓
+// With GRID_PAD_Y=26: top vertex = 0+26-24 = 2, bottom vertex = 76+26+24 = 126 ✓
+const GRID_PAD_X = 41;
+const GRID_PAD_Y = 26;
+
+// ---- Support (single-board) SVG dimensions ----
+// Board cx ∈ [19, 173], right vertex = 173 + 18 = 191 → width 194 with 3 px spare.
+// Board cy ∈ [26, 102], bottom vertex = 102 + 24 = 126 → footer at y=138, height 142.
+const SUPPORT_SVG_W = 194;
+const SUPPORT_SVG_H = 142;
+const SUPPORT_LABEL_X = 97; // horizontal centre of the single board
+const SUPPORT_LABEL_Y = 138;
+
+// ---- Attacker (dual-board) SVG dimensions ----
+// Team board: ox=0, cx ∈ [19, 173], right vertex = 191.
+// Enemy board (mirrored, ox=ENEMY_OX): cx ∈ [ox+19, ox+173], right vertex = ox+191.
+// Arrow sits at horizontal midpoint between the two boards.
+// Choose ENEMY_OX=212 → gap between boards = (212+19) - 191 = 40 px wide enough.
+// Arrow x = (191 + 212+19)/2 = (191+231)/2 = 211, but centre of gap = 191 + 20 = 211. OK.
+// Total width = ENEMY_OX + 191 + 3 = 212 + 191 + 3 = 406.
+const ENEMY_OX = 212;
+const ATTACKER_SVG_W = ENEMY_OX + 191 + 3; // = 406
+const ATTACKER_SVG_H = SUPPORT_SVG_H; // same row geometry, same height
+const ARROW_X = Math.round((191 + ENEMY_OX + 19) / 2); // midpoint of gap ≈ 211
 
 const COLORS: Record<CellRole | 'empty', { fill: string; stroke: string }> = {
     origin: { fill: '#7a1020', stroke: '#e0455f' },
@@ -45,8 +72,8 @@ const Board: React.FC<BoardProps> = ({ ox, oy, mirror, roles, label }) => (
         {ALL_POSITIONS.map((pos) => {
             const [rawX, y] = rawXY(pos);
             const x = mirror ? 110 - rawX : rawX;
-            const cx = ox + x + 30;
-            const cy = oy + y + 22;
+            const cx = ox + x + GRID_PAD_X;
+            const cy = oy + y + GRID_PAD_Y;
             const role = roles.get(pos);
             const colors = COLORS[role ?? 'empty'];
             return (
@@ -94,28 +121,40 @@ export const SkillTargetingBoard: React.FC<SkillTargetingBoardProps> = ({ target
             <div className="mb-1">{caption}</div>
             {isSupport ? (
                 <svg
-                    width={178}
-                    height={120}
+                    width={SUPPORT_SVG_W}
+                    height={SUPPORT_SVG_H}
                     role="img"
                     aria-label={`Targeting footprint: ${caption}`}
                 >
-                    <Board ox={0} oy={12} mirror={false} roles={roles} label="own" />
-                    <text x={89} y={112} textAnchor="middle" fontSize={10} fill="#5a6a86">
+                    <Board ox={0} oy={0} mirror={false} roles={roles} label="own" />
+                    <text
+                        x={SUPPORT_LABEL_X}
+                        y={SUPPORT_LABEL_Y}
+                        textAnchor="middle"
+                        fontSize={10}
+                        fill="#5a6a86"
+                    >
                         your board
                     </text>
                 </svg>
             ) : (
                 <svg
-                    width={402}
-                    height={120}
+                    width={ATTACKER_SVG_W}
+                    height={ATTACKER_SVG_H}
                     role="img"
                     aria-label={`Targeting footprint: ${caption}`}
                 >
-                    <Board ox={0} oy={12} mirror={false} roles={new Map()} label="team" />
-                    <text x={201} y={62} textAnchor="middle" fontSize={20} fill="#6ca8ff">
+                    <Board ox={0} oy={0} mirror={false} roles={new Map()} label="team" />
+                    <text
+                        x={ARROW_X}
+                        y={Math.round(ATTACKER_SVG_H / 2)}
+                        textAnchor="middle"
+                        fontSize={20}
+                        fill="#6ca8ff"
+                    >
                         ▶
                     </text>
-                    <Board ox={224} oy={12} mirror roles={roles} label="enemy" />
+                    <Board ox={ENEMY_OX} oy={0} mirror roles={roles} label="enemy" />
                 </svg>
             )}
             <div className="flex gap-3 mt-1">

--- a/src/components/ship/SkillTargetingBoard.tsx
+++ b/src/components/ship/SkillTargetingBoard.tsx
@@ -5,40 +5,23 @@ import { ALL_POSITIONS, positionToAxial } from '../../utils/targeting/board';
 import { CellRole, resolveCells } from '../../utils/targeting/resolvePattern';
 import { pickDisplayAnchor, targetingLabel } from '../../utils/targeting/targetingDisplay';
 
-const W = 44;
-const H = 38;
-const HEX_RX = 21;
-const HEX_RY = 24;
-// Padding added to each board's rawXY so the leftmost/topmost hex stays
-// inside the SVG frame.  rawX ∈ [-22, 132], rawY ∈ [0, 76].
-// Half-extents per hex: HEX_RX*cos(30°) ≈ 18 px wide, HEX_RY = 24 px tall.
-// With GRID_PAD_X=41: leftmost cx = -22+41 = 19, left vertex = 19-18 = 1 ✓
-// With GRID_PAD_Y=26: top vertex = 0+26-24 = 2, bottom vertex = 76+26+24 = 126 ✓
-const GRID_PAD_X = 41;
-const GRID_PAD_Y = 26;
-
-// ---- Support (single-board) SVG dimensions ----
-// Board cx ∈ [19, 173], right vertex = 173 + 18 = 191 → width 194 with 3 px spare.
-// Board cy ∈ [26, 102], bottom vertex = 102 + 24 = 126 → footer at y=138, height 142.
-const SUPPORT_SVG_W = 194;
-const SUPPORT_SVG_H = 142;
-const SUPPORT_LABEL_X = 97; // horizontal centre of the single board
-const SUPPORT_LABEL_Y = 138;
-
-// ---- Attacker (dual-board) SVG dimensions ----
-// Team board: ox=0, cx ∈ [19, 173], right vertex = 191.
-// Enemy board (mirrored, ox=ENEMY_OX): cx ∈ [ox+19, ox+173], right vertex = ox+191.
-// Arrow sits at horizontal midpoint between the two boards.
-// Choose ENEMY_OX=212 → vertex-to-vertex gap = (212+19) - 191 = 40 px? No:
-//   right vertex of team board  = 191 (HEX_RX·cos30° ≈ 18 → 173+18 = 191)
-//   left  vertex of enemy board = ENEMY_OX + 19 - 18 = 212 + 1 = 213
-//   true vertex-to-vertex gap   = 213 - 191 = 22 px ≈ 21 px — fine for the ▶ glyph.
-// Arrow x = midpoint of gap = (191 + 213)/2 = 202, but computed below as midpoint of board centres.
-// Total width = ENEMY_OX + 191 + 3 = 212 + 191 + 3 = 406.
-const ENEMY_OX = 212;
-const ATTACKER_SVG_W = ENEMY_OX + 191 + 3; // = 406
-const ATTACKER_SVG_H = SUPPORT_SVG_H; // same row geometry, same height
-const ARROW_X = Math.round((191 + ENEMY_OX + 19) / 2); // midpoint of gap ≈ 211
+// Compact single-board footprint. One board for both ally and enemy targets — the
+// resolved cells are identical regardless of side, so we draw one un-mirrored board
+// and let the caption convey which side it targets.
+const W = 24;
+const H = 20;
+const HEX_RX = 11;
+const HEX_RY = 13;
+// Padding added to rawXY so the leftmost/topmost hex stays inside the SVG frame.
+// rawX ∈ [-12, 72], rawY ∈ [0, 40]. Hex half-extents: HEX_RX·cos(30°) ≈ 9.5 px wide,
+// HEX_RY = 13 px tall.
+// GRID_PAD_X=24: leftmost cx = -12+24 = 12, left vertex = 12-9.5 ≈ 2.5 ✓;
+//                rightmost cx = 72+24 = 96, right vertex = 96+9.5 ≈ 105.5 → width 108 ✓
+// GRID_PAD_Y=15: top vertex = 0+15-13 = 2 ✓; bottom vertex = 40+15+13 = 68 → height 70 ✓
+const GRID_PAD_X = 24;
+const GRID_PAD_Y = 15;
+const SVG_W = 108;
+const SVG_H = 70;
 
 const COLORS: Record<CellRole | 'empty', { fill: string; stroke: string }> = {
     origin: { fill: '#7a1020', stroke: '#e0455f' },
@@ -62,45 +45,6 @@ function hexPath(cx: number, cy: number): string {
     return pts.join(' ');
 }
 
-interface BoardProps {
-    ox: number;
-    mirror: boolean;
-    roles: Map<Position, CellRole>;
-    label: string;
-}
-
-const Board: React.FC<BoardProps> = ({ ox, mirror, roles, label }) => (
-    <g data-board={label}>
-        {ALL_POSITIONS.map((pos) => {
-            const [rawX, y] = rawXY(pos);
-            const x = mirror ? 110 - rawX : rawX;
-            const cx = ox + x + GRID_PAD_X;
-            const cy = y + GRID_PAD_Y;
-            const role = roles.get(pos);
-            const colors = COLORS[role ?? 'empty'];
-            return (
-                <g key={pos} data-position={pos} data-role={role ?? 'empty'}>
-                    <polygon
-                        points={hexPath(cx, cy)}
-                        fill={colors.fill}
-                        stroke={colors.stroke}
-                        strokeWidth={1.4}
-                    />
-                    <text
-                        x={cx}
-                        y={cy + 4}
-                        textAnchor="middle"
-                        fontSize={10}
-                        fill={role ? '#fff' : '#6b7794'}
-                    >
-                        {pos}
-                    </text>
-                </g>
-            );
-        })}
-    </g>
-);
-
 interface SkillTargetingBoardProps {
     targeting: SkillTargeting;
 }
@@ -114,8 +58,6 @@ export const SkillTargetingBoard: React.FC<SkillTargetingBoardProps> = ({ target
         return null; // unknown pattern signature — show nothing rather than crash
     }
 
-    const isSupport =
-        targeting.pattern.modifiers.support === true || targeting.target.side === 'ally';
     const caption = targetingLabel(targeting);
     const roleValues = Array.from(roles.values());
     const hasOrigin = roleValues.includes('origin');
@@ -124,62 +66,33 @@ export const SkillTargetingBoard: React.FC<SkillTargetingBoardProps> = ({ target
     return (
         <div className="mt-2 text-[11px] text-theme-text/70">
             <div className="mb-1">{caption}</div>
-            {isSupport ? (
-                <svg
-                    width={SUPPORT_SVG_W}
-                    height={SUPPORT_SVG_H}
-                    role="img"
-                    aria-label={`Targeting footprint: ${caption}`}
-                >
-                    <Board ox={0} mirror={false} roles={roles} label="own" />
-                    <text
-                        x={SUPPORT_LABEL_X}
-                        y={SUPPORT_LABEL_Y}
-                        textAnchor="middle"
-                        fontSize={10}
-                        fill="#5a6a86"
-                    >
-                        your board
-                    </text>
-                </svg>
-            ) : (
-                <svg
-                    width={ATTACKER_SVG_W}
-                    height={ATTACKER_SVG_H}
-                    role="img"
-                    aria-label={`Targeting footprint: ${caption}`}
-                >
-                    <Board ox={0} mirror={false} roles={new Map()} label="team" />
-                    <text
-                        x={ARROW_X}
-                        y={Math.round(ATTACKER_SVG_H / 2)}
-                        textAnchor="middle"
-                        fontSize={20}
-                        fill="#6ca8ff"
-                    >
-                        ▶
-                    </text>
-                    <Board ox={ENEMY_OX} mirror roles={roles} label="enemy" />
-                    <text
-                        x={97}
-                        y={SUPPORT_LABEL_Y}
-                        textAnchor="middle"
-                        fontSize={10}
-                        fill="#5a6a86"
-                    >
-                        your fleet
-                    </text>
-                    <text
-                        x={ENEMY_OX + 97}
-                        y={SUPPORT_LABEL_Y}
-                        textAnchor="middle"
-                        fontSize={10}
-                        fill="#5a6a86"
-                    >
-                        enemies
-                    </text>
-                </svg>
-            )}
+            <svg
+                width={SVG_W}
+                height={SVG_H}
+                role="img"
+                aria-label={`Targeting footprint: ${caption}`}
+            >
+                <g data-board="footprint">
+                    {ALL_POSITIONS.map((pos) => {
+                        const [x, y] = rawXY(pos);
+                        const cx = x + GRID_PAD_X;
+                        const cy = y + GRID_PAD_Y;
+                        const role = roles.get(pos);
+                        const colors = COLORS[role ?? 'empty'];
+                        return (
+                            <polygon
+                                key={pos}
+                                data-position={pos}
+                                data-role={role ?? 'empty'}
+                                points={hexPath(cx, cy)}
+                                fill={colors.fill}
+                                stroke={colors.stroke}
+                                strokeWidth={1.4}
+                            />
+                        );
+                    })}
+                </g>
+            </svg>
             <div className="flex gap-3 mt-1">
                 {hasOrigin && (
                     <span className="inline-flex items-center gap-1">

--- a/src/components/ship/SkillTooltip.tsx
+++ b/src/components/ship/SkillTooltip.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { parseSkillText, extractSkillNames } from '../../utils/skillTextParser';
 import { ClockIcon } from '../ui/icons';
+import { SkillTargeting } from '../../utils/targetingParser';
 import { BuffTooltip } from './BuffTooltip';
+import { SkillTargetingBoard } from './SkillTargetingBoard';
 
 interface SkillTooltipProps {
     skillText: string;
     skillType: string;
     charge?: number;
     inline?: boolean;
+    targeting?: SkillTargeting;
 }
 
 export const SkillTooltip: React.FC<SkillTooltipProps> = ({
@@ -15,6 +18,7 @@ export const SkillTooltip: React.FC<SkillTooltipProps> = ({
     skillType,
     charge,
     inline,
+    targeting,
 }) => {
     const segments = parseSkillText(skillText);
     const skillNames = extractSkillNames(skillText);
@@ -87,6 +91,7 @@ export const SkillTooltip: React.FC<SkillTooltipProps> = ({
                     return null;
                 })}
             </div>
+            {targeting && <SkillTargetingBoard targeting={targeting} />}
         </>
     );
 

--- a/src/components/ship/SkillTooltip.tsx
+++ b/src/components/ship/SkillTooltip.tsx
@@ -91,19 +91,22 @@ export const SkillTooltip: React.FC<SkillTooltipProps> = ({
                     return null;
                 })}
             </div>
-            {targeting && <SkillTargetingBoard targeting={targeting} />}
         </>
     );
 
     if (inline) {
-        return content;
+        return (
+            <>
+                {targeting && <SkillTargetingBoard targeting={targeting} />}
+                {content}
+            </>
+        );
     }
 
     return (
         <>
-            <div
-                className={`bg-dark-lighter p-2 shadow-lg ${targeting ? 'max-w-md' : 'max-w-xs'} border border-dark-border`}
-            >
+            {targeting && <SkillTargetingBoard targeting={targeting} />}
+            <div className="bg-dark-lighter p-2 shadow-lg max-w-xs border border-dark-border">
                 {content}
             </div>
 

--- a/src/components/ship/SkillTooltip.tsx
+++ b/src/components/ship/SkillTooltip.tsx
@@ -101,7 +101,9 @@ export const SkillTooltip: React.FC<SkillTooltipProps> = ({
 
     return (
         <>
-            <div className="bg-dark-lighter p-2 shadow-lg max-w-xs border border-dark-border">
+            <div
+                className={`bg-dark-lighter p-2 shadow-lg ${targeting ? 'max-w-md' : 'max-w-xs'} border border-dark-border`}
+            >
                 {content}
             </div>
 

--- a/src/components/ship/__tests__/SkillTargetingBoard.test.tsx
+++ b/src/components/ship/__tests__/SkillTargetingBoard.test.tsx
@@ -33,6 +33,42 @@ describe('SkillTargetingBoard', () => {
         expect(getByText('Cone · Range 1 · enemy front')).toBeInTheDocument();
     });
 
+    it('notSelf support pattern: single board, covered cells only, no origin in legend', () => {
+        // Pattern-Line-Support-Not-Self-Range-2 with allies target
+        // Signature: 'line|2|support+notSelf' → [cov(1,0), cov(2,0)] — no origin cells.
+        const { container, queryByText } = render(
+            <SkillTargetingBoard
+                targeting={active('allies', 'Pattern-Line-Support-Not-Self-Range-2')}
+            />
+        );
+        // Support layout: single board
+        expect(container.querySelectorAll('[data-board]').length).toBe(1);
+        // There are covered cells
+        expect(container.querySelectorAll('[data-role="covered"]').length).toBeGreaterThan(0);
+        // No origin cells anywhere (notSelf pattern has no ORIGIN in the offset table)
+        expect(container.querySelectorAll('[data-role="origin"]').length).toBe(0);
+        // Legend must NOT render the "origin" swatch
+        expect(queryByText('origin')).toBeNull();
+        // Legend must render the "covered" swatch
+        expect(queryByText('covered')).toBeInTheDocument();
+    });
+
+    it('all-pattern attacker: two boards, enemy board has 12 origin cells, team board has 0', () => {
+        // Pattern-All with target 'all' → shape 'all' → all 12 positions role 'origin'.
+        // target 'all' maps to side 'enemy' → attacker (dual-board) layout.
+        const { container } = render(
+            <SkillTargetingBoard targeting={active('all', 'Pattern-All')} />
+        );
+        // Attacker layout: two boards
+        expect(container.querySelectorAll('[data-board]').length).toBe(2);
+        const enemyBoard = container.querySelector('[data-board="enemy"]')!;
+        const teamBoard = container.querySelector('[data-board="team"]')!;
+        // Enemy board: all 12 cells are origin
+        expect(enemyBoard.querySelectorAll('[data-role="origin"]').length).toBe(12);
+        // Team board: empty map — no origin cells
+        expect(teamBoard.querySelectorAll('[data-role="origin"]').length).toBe(0);
+    });
+
     it('renders nothing when the pattern has an unknown signature (try/catch → null)', () => {
         // Construct a SkillTargeting whose pattern signature has no offset table entry.
         // shape='cone', range=99 produces signature "cone|99|" which is not in OFFSET_TABLES,

--- a/src/components/ship/__tests__/SkillTargetingBoard.test.tsx
+++ b/src/components/ship/__tests__/SkillTargetingBoard.test.tsx
@@ -8,22 +8,29 @@ function active(target: string, pattern: string) {
 }
 
 describe('SkillTargetingBoard', () => {
-    it('renders two boards + arrow for an enemy (attacker) pattern', () => {
-        const { container, getByText } = render(
+    it('renders a single board with origin + covered cells for an enemy pattern', () => {
+        const { container } = render(
             <SkillTargetingBoard targeting={active('front', 'Pattern-Cone-Range-1')} />
         );
-        expect(container.querySelectorAll('[data-board]').length).toBe(2);
-        expect(getByText('▶')).toBeInTheDocument();
+        // Single board for both sides — no second (empty) board, no arrow.
+        expect(container.querySelectorAll('[data-board]').length).toBe(1);
         expect(container.querySelectorAll('[data-role="origin"]').length).toBeGreaterThan(0);
         expect(container.querySelectorAll('[data-role="covered"]').length).toBeGreaterThan(0);
     });
 
     it('renders a single board for a support (ally) pattern', () => {
-        const { container, queryByText } = render(
+        const { container } = render(
             <SkillTargetingBoard targeting={active('allies', 'Pattern-Circle-Support-Range-1')} />
         );
         expect(container.querySelectorAll('[data-board]').length).toBe(1);
-        expect(queryByText('▶')).toBeNull();
+    });
+
+    it('does not render per-cell position labels (compact, label-free board)', () => {
+        const { container } = render(
+            <SkillTargetingBoard targeting={active('front', 'Pattern-Cone-Range-1')} />
+        );
+        // No <text> elements inside the board group (labels removed).
+        expect(container.querySelectorAll('svg text').length).toBe(0);
     });
 
     it('shows the caption', () => {
@@ -53,20 +60,13 @@ describe('SkillTargetingBoard', () => {
         expect(queryByText('covered')).toBeInTheDocument();
     });
 
-    it('all-pattern attacker: two boards, enemy board has 12 origin cells, team board has 0', () => {
-        // Pattern-All with target 'all' → shape 'all' → all 12 positions role 'origin'.
-        // target 'all' maps to side 'enemy' → attacker (dual-board) layout.
+    it('all-pattern: single board with all 12 cells as origin', () => {
+        // Pattern-All → shape 'all' → all 12 positions role 'origin'.
         const { container } = render(
             <SkillTargetingBoard targeting={active('all', 'Pattern-All')} />
         );
-        // Attacker layout: two boards
-        expect(container.querySelectorAll('[data-board]').length).toBe(2);
-        const enemyBoard = container.querySelector('[data-board="enemy"]')!;
-        const teamBoard = container.querySelector('[data-board="team"]')!;
-        // Enemy board: all 12 cells are origin
-        expect(enemyBoard.querySelectorAll('[data-role="origin"]').length).toBe(12);
-        // Team board: empty map — no origin cells
-        expect(teamBoard.querySelectorAll('[data-role="origin"]').length).toBe(0);
+        expect(container.querySelectorAll('[data-board]').length).toBe(1);
+        expect(container.querySelectorAll('[data-role="origin"]').length).toBe(12);
     });
 
     it('renders nothing when the pattern has an unknown signature (try/catch → null)', () => {

--- a/src/components/ship/__tests__/SkillTargetingBoard.test.tsx
+++ b/src/components/ship/__tests__/SkillTargetingBoard.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
 import { SkillTargetingBoard } from '../SkillTargetingBoard';
-import { parseShipTargeting } from '../../../utils/targetingParser';
+import { parseShipTargeting, SkillTargeting } from '../../../utils/targetingParser';
 
 function active(target: string, pattern: string) {
     return parseShipTargeting({ activeTarget: target, activePattern: pattern }).active!;
@@ -31,5 +31,18 @@ describe('SkillTargetingBoard', () => {
             <SkillTargetingBoard targeting={active('front', 'Pattern-Cone-Range-1')} />
         );
         expect(getByText('Cone · Range 1 · enemy front')).toBeInTheDocument();
+    });
+
+    it('renders nothing when the pattern has an unknown signature (try/catch → null)', () => {
+        // Construct a SkillTargeting whose pattern signature has no offset table entry.
+        // shape='cone', range=99 produces signature "cone|99|" which is not in OFFSET_TABLES,
+        // so resolveCells throws and the component returns null.
+        const broken = {
+            target: { raw: 'front', side: 'enemy', selection: 'front' },
+            pattern: { raw: 'Pattern-Cone-Range-99', shape: 'cone', range: 99, modifiers: {} },
+        } as unknown as SkillTargeting;
+        const { container } = render(<SkillTargetingBoard targeting={broken} />);
+        expect(container.querySelector('svg')).toBeNull();
+        expect(container.querySelector('[data-board]')).toBeNull();
     });
 });

--- a/src/components/ship/__tests__/SkillTargetingBoard.test.tsx
+++ b/src/components/ship/__tests__/SkillTargetingBoard.test.tsx
@@ -8,101 +8,97 @@ function active(target: string, pattern: string) {
 }
 
 describe('SkillTargetingBoard', () => {
-    it('renders a single board with origin + covered cells for an enemy pattern', () => {
+    it('renders the rule label and plain-English description for the selection', () => {
+        const { getByText } = render(
+            <SkillTargetingBoard targeting={active('skip', 'Pattern-Cone-Range-1')} />
+        );
+        expect(getByText('Skip')).toBeInTheDocument();
+        expect(getByText(/leaps the front line/i)).toBeInTheDocument();
+    });
+
+    it('renders one primary cell and splash cells for a cone', () => {
         const { container } = render(
             <SkillTargetingBoard targeting={active('front', 'Pattern-Cone-Range-1')} />
         );
-        // Single board for both sides — no second (empty) board, no arrow.
-        expect(container.querySelectorAll('[data-board]').length).toBe(1);
-        expect(container.querySelectorAll('[data-role="origin"]').length).toBeGreaterThan(0);
-        expect(container.querySelectorAll('[data-role="covered"]').length).toBeGreaterThan(0);
+        expect(container.querySelectorAll('[data-role="primary"]').length).toBe(1);
+        expect(container.querySelectorAll('[data-role="splash"]').length).toBeGreaterThan(0);
     });
 
-    it('renders a single board for a support (ally) pattern', () => {
-        const { container } = render(
-            <SkillTargetingBoard targeting={active('allies', 'Pattern-Circle-Support-Range-1')} />
-        );
-        expect(container.querySelectorAll('[data-board]').length).toBe(1);
-    });
-
-    it('does not render per-cell position labels (compact, label-free board)', () => {
+    it('colors enemy cells red (primary) and lighter red (splash)', () => {
         const { container } = render(
             <SkillTargetingBoard targeting={active('front', 'Pattern-Cone-Range-1')} />
         );
-        // No <text> elements inside the board group (labels removed).
-        expect(container.querySelectorAll('svg text').length).toBe(0);
+        expect(container.querySelector('[data-role="primary"]')!.getAttribute('stroke')).toBe(
+            '#ff3b5c'
+        );
+        expect(container.querySelector('[data-role="splash"]')!.getAttribute('stroke')).toBe(
+            '#ff8a9c'
+        );
     });
 
-    it('shows a "Targeting" header and the target selection (not shape/range)', () => {
-        const { getByText, queryByText } = render(
+    it('colors ally cells green (splash) and darker green (caster/primary)', () => {
+        const { container } = render(
+            <SkillTargetingBoard targeting={active('allies', 'Pattern-Cone-Support-Range-1')} />
+        );
+        expect(container.querySelector('[data-role="primary"]')!.getAttribute('stroke')).toBe(
+            '#16a34a'
+        );
+        expect(container.querySelector('[data-role="splash"]')!.getAttribute('stroke')).toBe(
+            '#4ade80'
+        );
+    });
+
+    it('mirrors the cluster for enemy (attacker) targets but not for ally targets', () => {
+        const base = active('skip', 'Pattern-Cone-Range-1'); // enemy side
+        const allyVariant = {
+            ...base,
+            target: { ...base.target, side: 'ally' as const },
+        };
+        // The primary sits at offset (0,0) (unaffected by a horizontal flip), so compare a
+        // splash cell, which is off-origin and moves when mirrored.
+        const firstSplashPoints = (t: SkillTargeting) => {
+            const { container } = render(<SkillTargetingBoard targeting={t} />);
+            return container.querySelector('[data-role="splash"]')!.getAttribute('points');
+        };
+        expect(firstSplashPoints(base)).not.toBe(firstSplashPoints(allyVariant));
+    });
+
+    it('shows Primary/Splash legend for enemy targets', () => {
+        const { getByText } = render(
             <SkillTargetingBoard targeting={active('front', 'Pattern-Cone-Range-1')} />
         );
-        expect(getByText('Targeting')).toBeInTheDocument();
-        expect(getByText('front')).toBeInTheDocument(); // CSS-capitalized to "Front"
-        // shape/range no longer shown as visible text
-        expect(queryByText('Cone · Range 1 · enemy front')).toBeNull();
+        expect(getByText('Primary')).toBeInTheDocument();
+        expect(getByText('Splash')).toBeInTheDocument();
+    });
+
+    it('notSelf ally pattern: splash cells only, no caster, Allies legend only', () => {
+        // 'line|2|support+notSelf' → only cov() cells, no origin/primary; ally side.
+        const { container, getByText, queryByText } = render(
+            <SkillTargetingBoard
+                targeting={active('allies', 'Pattern-Line-Support-Not-Self-Range-2')}
+            />
+        );
+        expect(container.querySelectorAll('[data-role="primary"]').length).toBe(0);
+        expect(container.querySelectorAll('[data-role="splash"]').length).toBeGreaterThan(0);
+        expect(queryByText('Caster')).toBeNull();
+        expect(getByText('Allies')).toBeInTheDocument();
     });
 
     it('puts the full shape/range/side caption in the SVG aria-label', () => {
         const { container } = render(
             <SkillTargetingBoard targeting={active('front', 'Pattern-Cone-Range-1')} />
         );
-        const svg = container.querySelector('svg')!;
-        expect(svg.getAttribute('aria-label')).toBe(
-            'Targeting footprint: Cone · Range 1 · enemy front'
+        expect(container.querySelector('svg')!.getAttribute('aria-label')).toContain(
+            'Cone · Range 1 · enemy front'
         );
     });
 
-    it('mirrors the board for enemy targets but not for ally targets', () => {
-        const xs = (targeting: ReturnType<typeof active>) => {
-            const { container } = render(<SkillTargetingBoard targeting={targeting} />);
-            const poly = container.querySelector('[data-position="T1"]')!;
-            return poly.getAttribute('points');
-        };
-        const enemyPts = xs(active('front', 'Pattern-Cone-Range-1'));
-        const allyPts = xs(active('allies', 'Pattern-Cone-Support-Range-1'));
-        // T1's polygon points differ between mirrored (enemy) and un-mirrored (ally) renders.
-        expect(enemyPts).not.toBe(allyPts);
-    });
-
-    it('notSelf support pattern: single board, covered cells only, no origin, no legend text', () => {
-        // Pattern-Line-Support-Not-Self-Range-2 with allies target
-        // Signature: 'line|2|support+notSelf' → [cov(1,0), cov(2,0)] — no origin cells.
-        const { container, queryByText } = render(
-            <SkillTargetingBoard
-                targeting={active('allies', 'Pattern-Line-Support-Not-Self-Range-2')}
-            />
-        );
-        // Single board
-        expect(container.querySelectorAll('[data-board]').length).toBe(1);
-        // There are covered cells
-        expect(container.querySelectorAll('[data-role="covered"]').length).toBeGreaterThan(0);
-        // No origin cells anywhere (notSelf pattern has no ORIGIN in the offset table)
-        expect(container.querySelectorAll('[data-role="origin"]').length).toBe(0);
-        // Legend removed entirely — no origin/covered swatch text
-        expect(queryByText('origin')).toBeNull();
-        expect(queryByText('covered')).toBeNull();
-    });
-
-    it('all-pattern: single board with all 12 cells as origin', () => {
-        // Pattern-All → shape 'all' → all 12 positions role 'origin'.
-        const { container } = render(
-            <SkillTargetingBoard targeting={active('all', 'Pattern-All')} />
-        );
-        expect(container.querySelectorAll('[data-board]').length).toBe(1);
-        expect(container.querySelectorAll('[data-role="origin"]').length).toBe(12);
-    });
-
-    it('renders nothing when the pattern has an unknown signature (try/catch → null)', () => {
-        // Construct a SkillTargeting whose pattern signature has no offset table entry.
-        // shape='cone', range=99 produces signature "cone|99|" which is not in OFFSET_TABLES,
-        // so resolveCells throws and the component returns null.
+    it('renders nothing for an unknown pattern signature (try/catch → null)', () => {
         const broken = {
             target: { raw: 'front', side: 'enemy', selection: 'front' },
             pattern: { raw: 'Pattern-Cone-Range-99', shape: 'cone', range: 99, modifiers: {} },
         } as unknown as SkillTargeting;
         const { container } = render(<SkillTargetingBoard targeting={broken} />);
         expect(container.querySelector('svg')).toBeNull();
-        expect(container.querySelector('[data-board]')).toBeNull();
     });
 });

--- a/src/components/ship/__tests__/SkillTargetingBoard.test.tsx
+++ b/src/components/ship/__tests__/SkillTargetingBoard.test.tsx
@@ -33,14 +33,39 @@ describe('SkillTargetingBoard', () => {
         expect(container.querySelectorAll('svg text').length).toBe(0);
     });
 
-    it('shows the caption', () => {
-        const { getByText } = render(
+    it('shows a "Targeting" header and the target selection (not shape/range)', () => {
+        const { getByText, queryByText } = render(
             <SkillTargetingBoard targeting={active('front', 'Pattern-Cone-Range-1')} />
         );
-        expect(getByText('Cone · Range 1 · enemy front')).toBeInTheDocument();
+        expect(getByText('Targeting')).toBeInTheDocument();
+        expect(getByText('front')).toBeInTheDocument(); // CSS-capitalized to "Front"
+        // shape/range no longer shown as visible text
+        expect(queryByText('Cone · Range 1 · enemy front')).toBeNull();
     });
 
-    it('notSelf support pattern: single board, covered cells only, no origin in legend', () => {
+    it('puts the full shape/range/side caption in the SVG aria-label', () => {
+        const { container } = render(
+            <SkillTargetingBoard targeting={active('front', 'Pattern-Cone-Range-1')} />
+        );
+        const svg = container.querySelector('svg')!;
+        expect(svg.getAttribute('aria-label')).toBe(
+            'Targeting footprint: Cone · Range 1 · enemy front'
+        );
+    });
+
+    it('mirrors the board for enemy targets but not for ally targets', () => {
+        const xs = (targeting: ReturnType<typeof active>) => {
+            const { container } = render(<SkillTargetingBoard targeting={targeting} />);
+            const poly = container.querySelector('[data-position="T1"]')!;
+            return poly.getAttribute('points');
+        };
+        const enemyPts = xs(active('front', 'Pattern-Cone-Range-1'));
+        const allyPts = xs(active('allies', 'Pattern-Cone-Support-Range-1'));
+        // T1's polygon points differ between mirrored (enemy) and un-mirrored (ally) renders.
+        expect(enemyPts).not.toBe(allyPts);
+    });
+
+    it('notSelf support pattern: single board, covered cells only, no origin, no legend text', () => {
         // Pattern-Line-Support-Not-Self-Range-2 with allies target
         // Signature: 'line|2|support+notSelf' → [cov(1,0), cov(2,0)] — no origin cells.
         const { container, queryByText } = render(
@@ -48,16 +73,15 @@ describe('SkillTargetingBoard', () => {
                 targeting={active('allies', 'Pattern-Line-Support-Not-Self-Range-2')}
             />
         );
-        // Support layout: single board
+        // Single board
         expect(container.querySelectorAll('[data-board]').length).toBe(1);
         // There are covered cells
         expect(container.querySelectorAll('[data-role="covered"]').length).toBeGreaterThan(0);
         // No origin cells anywhere (notSelf pattern has no ORIGIN in the offset table)
         expect(container.querySelectorAll('[data-role="origin"]').length).toBe(0);
-        // Legend must NOT render the "origin" swatch
+        // Legend removed entirely — no origin/covered swatch text
         expect(queryByText('origin')).toBeNull();
-        // Legend must render the "covered" swatch
-        expect(queryByText('covered')).toBeInTheDocument();
+        expect(queryByText('covered')).toBeNull();
     });
 
     it('all-pattern: single board with all 12 cells as origin', () => {

--- a/src/components/ship/__tests__/SkillTargetingBoard.test.tsx
+++ b/src/components/ship/__tests__/SkillTargetingBoard.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { SkillTargetingBoard } from '../SkillTargetingBoard';
+import { parseShipTargeting } from '../../../utils/targetingParser';
+
+function active(target: string, pattern: string) {
+    return parseShipTargeting({ activeTarget: target, activePattern: pattern }).active!;
+}
+
+describe('SkillTargetingBoard', () => {
+    it('renders two boards + arrow for an enemy (attacker) pattern', () => {
+        const { container, getByText } = render(
+            <SkillTargetingBoard targeting={active('front', 'Pattern-Cone-Range-1')} />
+        );
+        expect(container.querySelectorAll('[data-board]').length).toBe(2);
+        expect(getByText('▶')).toBeInTheDocument();
+        expect(container.querySelectorAll('[data-role="origin"]').length).toBeGreaterThan(0);
+        expect(container.querySelectorAll('[data-role="covered"]').length).toBeGreaterThan(0);
+    });
+
+    it('renders a single board for a support (ally) pattern', () => {
+        const { container, queryByText } = render(
+            <SkillTargetingBoard targeting={active('allies', 'Pattern-Circle-Support-Range-1')} />
+        );
+        expect(container.querySelectorAll('[data-board]').length).toBe(1);
+        expect(queryByText('▶')).toBeNull();
+    });
+
+    it('shows the caption', () => {
+        const { getByText } = render(
+            <SkillTargetingBoard targeting={active('front', 'Pattern-Cone-Range-1')} />
+        );
+        expect(getByText('Cone · Range 1 · enemy front')).toBeInTheDocument();
+    });
+});

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -6,6 +6,7 @@ export const CURRENT_VERSION = '1.63.0';
 // CHANGELOG (with the new version + today's date), clear this array back to [],
 // and bump CURRENT_VERSION. All three steps must happen together.
 export const UNRELEASED_CHANGES: string[] = [
+    "Skill hovercards now show a board diagram of each Active and Charge skill's targeting footprint — which cells the skill hits (red = primary target, orange = splash).",
     "DPS/Healing Calculator: finite-duration passive buffs now correctly expire. Buffs a ship grants itself at the start of combat for a set number of turns — such as Everliving Regeneration on Yazid and Tycho, Atlas Coordination, or Iridium's Taunt — were treated as permanent and even persisted through a destroyed-and-revived (Cheat Death) ship. They now run for their stated turns and clear on death like any other buff.",
     "Healing Calculator: the hover-gated round panel now has a dedicated Heal Target section showing the target's own active buffs (Cheat Death, Everliving Regeneration, Barrier, and the like) alongside the debuffs and damage-over-time effects currently on it (aggregated across all enemies) — a target-centric survivability view, separate from the per-enemy breakdown.",
     'Fixed voting on community gear recommendations — votes were silently failing due to a leftover from the old recommendation system in the database.',

--- a/src/constants/targetingRules.ts
+++ b/src/constants/targetingRules.ts
@@ -1,0 +1,52 @@
+import { TargetSelection } from '../utils/targetingParser';
+
+/**
+ * A targeting rule = how the game picks the target for a skill. Cards reference a rule by
+ * id (the parsed `TargetSelection`) and pull label/description from here, so copy is never
+ * hardcoded in components. Add a new rule by adding a row keyed on its selection id.
+ *
+ * `description` copy is intentionally short and editable.
+ */
+export interface TargetingRule {
+    id: TargetSelection;
+    label: string;
+    description: string;
+}
+
+export const TARGETING_RULES: Record<TargetSelection, TargetingRule> = {
+    front: {
+        id: 'front',
+        label: 'Front',
+        description: 'Strikes the front-most enemy in the lane.',
+    },
+    back: {
+        id: 'back',
+        label: 'Back',
+        description: 'Targets the rear-most unit, behind the front line.',
+    },
+    skip: {
+        id: 'skip',
+        label: 'Skip',
+        description: 'Leaps the front line to strike the unit behind it.',
+    },
+    all: {
+        id: 'all',
+        label: 'All',
+        description: 'Hits every valid target at once.',
+    },
+    team: {
+        id: 'team',
+        label: 'Team',
+        description: 'Affects your whole team.',
+    },
+    others: {
+        id: 'others',
+        label: 'Others',
+        description: 'Affects allies other than the caster.',
+    },
+    self: {
+        id: 'self',
+        label: 'Self',
+        description: 'Affects the caster only.',
+    },
+};

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -749,7 +749,10 @@ const DocumentationPage: React.FC = () => {
                                     Charge (with turn count), and Passive R1/R2/R4 — with full
                                     formatted skill text. Damage values are highlighted in orange,
                                     buff and debuff names are underlined with tooltip descriptions,
-                                    and beneficial effects appear in green.
+                                    and beneficial effects appear in green. Hovering an Active or
+                                    Charge skill shows a board diagram of its targeting footprint —
+                                    which cells the skill hits (red = primary target, orange =
+                                    splash).
                                 </p>
                             </div>
                         </div>
@@ -2421,19 +2424,18 @@ const DocumentationPage: React.FC = () => {
                                         <span className="text-primary">
                                             Enemy Hacking &amp; Heal-Target Security:
                                         </span>{' '}
-                                        Each enemy has a Hacking stat, and the heal target
-                                        has a Security stat. An enemy&apos;s debuffs — both timed
-                                        effects and damage-over-time — land based on its Hacking
-                                        versus the target&apos;s Security: the higher the
-                                        enemy&apos;s Hacking over the target&apos;s Security, the
-                                        more reliably its debuffs stick (and high enough Security
-                                        can shrug them off entirely). The exact landing chance is
-                                        (enemy Hacking − target Security), clamped to a 0–100%
-                                        range. Defaults: a freshly added manual enemy starts at 200
-                                        Hacking (picking an enemy ship fills Hacking from the
-                                        ship&apos;s stats), and the target&apos;s Security defaults
-                                        to 0 — so debuffs land at full chance until you raise the
-                                        target&apos;s Security.
+                                        Each enemy has a Hacking stat, and the heal target has a
+                                        Security stat. An enemy&apos;s debuffs — both timed effects
+                                        and damage-over-time — land based on its Hacking versus the
+                                        target&apos;s Security: the higher the enemy&apos;s Hacking
+                                        over the target&apos;s Security, the more reliably its
+                                        debuffs stick (and high enough Security can shrug them off
+                                        entirely). The exact landing chance is (enemy Hacking −
+                                        target Security), clamped to a 0–100% range. Defaults: a
+                                        freshly added manual enemy starts at 200 Hacking (picking an
+                                        enemy ship fills Hacking from the ship&apos;s stats), and
+                                        the target&apos;s Security defaults to 0 — so debuffs land
+                                        at full chance until you raise the target&apos;s Security.
                                     </p>
                                     <p className="text-theme-text mb-2">
                                         <span className="text-primary">

--- a/src/pages/database/ShipIndexPage.tsx
+++ b/src/pages/database/ShipIndexPage.tsx
@@ -348,276 +348,293 @@ export const ShipIndexPage: React.FC = () => {
 
                     <div className="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4 gap-4">
                         {filteredAndSortedShips.length > 0 ? (
-                            filteredAndSortedShips.map((ship, index) => (
-                                <div
-                                    key={ship.name}
-                                    data-tutorial={index === 0 ? 'ship-db-first-card' : undefined}
-                                >
-                                    <ShipDisplayImage
-                                        ship={ship}
-                                        panelVariant="compact"
-                                        onQuickAdd={onQuickAdd}
-                                        isAdded={addedShips.has(ship.name)}
-                                        onAddToComparison={addToComparison}
-                                        isInComparison={isInComparison(ship.id)}
-                                        onBioClick={setBioShipName}
+                            filteredAndSortedShips.map((ship, index) => {
+                                const shipTargeting = parseShipTargeting(ship);
+                                return (
+                                    <div
+                                        key={ship.name}
+                                        data-tutorial={
+                                            index === 0 ? 'ship-db-first-card' : undefined
+                                        }
                                     >
-                                        <div
-                                            className="flex flex-col items-center justify-center border-b border-dark-border pb-2 m-3"
-                                            {...(index === 0
-                                                ? { 'data-tutorial': 'ship-db-skill-buttons' }
-                                                : {})}
+                                        <ShipDisplayImage
+                                            ship={ship}
+                                            panelVariant="compact"
+                                            onQuickAdd={onQuickAdd}
+                                            isAdded={addedShips.has(ship.name)}
+                                            onAddToComparison={addToComparison}
+                                            isInComparison={isInComparison(ship.id)}
+                                            onBioClick={setBioShipName}
                                         >
-                                            <div className="flex flex-wrap gap-2 justify-center">
-                                                {ship.activeSkillText && (
-                                                    <div className="relative">
-                                                        <div
-                                                            ref={(el) => {
-                                                                tooltipRefs.current[
-                                                                    `${ship.name}_active`
-                                                                ] = el;
-                                                            }}
-                                                            onMouseEnter={() =>
-                                                                setActiveHover(ship.name)
-                                                            }
-                                                            onMouseLeave={() => setActiveHover('')}
-                                                        >
-                                                            <Button
-                                                                variant="secondary"
-                                                                size="xs"
-                                                                onClick={() =>
-                                                                    void copySkillText(
-                                                                        ship.name,
-                                                                        'Active',
-                                                                        ship.activeSkillText!
-                                                                    )
+                                            <div
+                                                className="flex flex-col items-center justify-center border-b border-dark-border pb-2 m-3"
+                                                {...(index === 0
+                                                    ? { 'data-tutorial': 'ship-db-skill-buttons' }
+                                                    : {})}
+                                            >
+                                                <div className="flex flex-wrap gap-2 justify-center">
+                                                    {ship.activeSkillText && (
+                                                        <div className="relative">
+                                                            <div
+                                                                ref={(el) => {
+                                                                    tooltipRefs.current[
+                                                                        `${ship.name}_active`
+                                                                    ] = el;
+                                                                }}
+                                                                onMouseEnter={() =>
+                                                                    setActiveHover(ship.name)
+                                                                }
+                                                                onMouseLeave={() =>
+                                                                    setActiveHover('')
                                                                 }
                                                             >
-                                                                {copiedSkill ===
-                                                                `${ship.name}_Active`
-                                                                    ? 'Copied!'
-                                                                    : 'Active'}
-                                                            </Button>
-                                                        </div>
-                                                        <Tooltip
-                                                            isVisible={activeHover === ship.name}
-                                                            targetElement={
-                                                                tooltipRefs.current[
-                                                                    `${ship.name}_active`
-                                                                ]
-                                                            }
-                                                        >
-                                                            <SkillTooltip
-                                                                skillText={ship.activeSkillText}
-                                                                skillType="Active Skill"
-                                                                targeting={
-                                                                    parseShipTargeting(ship).active
+                                                                <Button
+                                                                    variant="secondary"
+                                                                    size="xs"
+                                                                    onClick={() =>
+                                                                        void copySkillText(
+                                                                            ship.name,
+                                                                            'Active',
+                                                                            ship.activeSkillText!
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    {copiedSkill ===
+                                                                    `${ship.name}_Active`
+                                                                        ? 'Copied!'
+                                                                        : 'Active'}
+                                                                </Button>
+                                                            </div>
+                                                            <Tooltip
+                                                                isVisible={
+                                                                    activeHover === ship.name
                                                                 }
-                                                            />
-                                                        </Tooltip>
-                                                    </div>
-                                                )}
-                                                {ship.chargeSkillText && (
-                                                    <div className="relative">
-                                                        <div
-                                                            ref={(el) => {
-                                                                tooltipRefs.current[
-                                                                    `${ship.name}_charge`
-                                                                ] = el;
-                                                            }}
-                                                            onMouseEnter={() =>
-                                                                setChargeHover(ship.name)
-                                                            }
-                                                            onMouseLeave={() => setChargeHover('')}
-                                                        >
-                                                            <Button
-                                                                variant="secondary"
-                                                                size="xs"
-                                                                onClick={() =>
-                                                                    void copySkillText(
-                                                                        ship.name,
-                                                                        'Charge',
-                                                                        ship.chargeSkillText!
-                                                                    )
+                                                                targetElement={
+                                                                    tooltipRefs.current[
+                                                                        `${ship.name}_active`
+                                                                    ]
                                                                 }
                                                             >
-                                                                {copiedSkill ===
-                                                                `${ship.name}_Charge`
-                                                                    ? 'Copied!'
-                                                                    : 'Charge'}
-                                                            </Button>
+                                                                <SkillTooltip
+                                                                    skillText={ship.activeSkillText}
+                                                                    skillType="Active Skill"
+                                                                    targeting={shipTargeting.active}
+                                                                />
+                                                            </Tooltip>
                                                         </div>
-                                                        <Tooltip
-                                                            isVisible={chargeHover === ship.name}
-                                                            targetElement={
-                                                                tooltipRefs.current[
-                                                                    `${ship.name}_charge`
-                                                                ]
-                                                            }
-                                                        >
-                                                            <SkillTooltip
-                                                                skillText={ship.chargeSkillText}
-                                                                skillType="Charge Skill"
-                                                                charge={ship.chargeSkillCharge}
-                                                                targeting={
-                                                                    parseShipTargeting(ship).charged
+                                                    )}
+                                                    {ship.chargeSkillText && (
+                                                        <div className="relative">
+                                                            <div
+                                                                ref={(el) => {
+                                                                    tooltipRefs.current[
+                                                                        `${ship.name}_charge`
+                                                                    ] = el;
+                                                                }}
+                                                                onMouseEnter={() =>
+                                                                    setChargeHover(ship.name)
                                                                 }
-                                                            />
-                                                        </Tooltip>
-                                                    </div>
-                                                )}
-                                                {ship.firstPassiveSkillText && (
-                                                    <div className="relative">
-                                                        <div
-                                                            ref={(el) => {
-                                                                tooltipRefs.current[
-                                                                    `${ship.name}_passive1`
-                                                                ] = el;
-                                                            }}
-                                                            onMouseEnter={() =>
-                                                                setPassive1Hover(ship.name)
-                                                            }
-                                                            onMouseLeave={() =>
-                                                                setPassive1Hover('')
-                                                            }
-                                                        >
-                                                            <Button
-                                                                variant="secondary"
-                                                                size="xs"
-                                                                onClick={() =>
-                                                                    void copySkillText(
-                                                                        ship.name,
-                                                                        'Passive',
-                                                                        ship.firstPassiveSkillText!
-                                                                    )
+                                                                onMouseLeave={() =>
+                                                                    setChargeHover('')
                                                                 }
                                                             >
-                                                                {copiedSkill ===
-                                                                `${ship.name}_Passive`
-                                                                    ? 'Copied!'
-                                                                    : 'Passive'}
-                                                            </Button>
-                                                        </div>
-                                                        <Tooltip
-                                                            isVisible={passive1Hover === ship.name}
-                                                            targetElement={
-                                                                tooltipRefs.current[
-                                                                    `${ship.name}_passive1`
-                                                                ]
-                                                            }
-                                                        >
-                                                            <SkillTooltip
-                                                                skillText={
-                                                                    ship.firstPassiveSkillText
+                                                                <Button
+                                                                    variant="secondary"
+                                                                    size="xs"
+                                                                    onClick={() =>
+                                                                        void copySkillText(
+                                                                            ship.name,
+                                                                            'Charge',
+                                                                            ship.chargeSkillText!
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    {copiedSkill ===
+                                                                    `${ship.name}_Charge`
+                                                                        ? 'Copied!'
+                                                                        : 'Charge'}
+                                                                </Button>
+                                                            </div>
+                                                            <Tooltip
+                                                                isVisible={
+                                                                    chargeHover === ship.name
                                                                 }
-                                                                skillType="Passive Skill"
-                                                            />
-                                                        </Tooltip>
-                                                    </div>
-                                                )}
-                                                {ship.secondPassiveSkillText && (
-                                                    <div className="relative">
-                                                        <div
-                                                            ref={(el) => {
-                                                                tooltipRefs.current[
-                                                                    `${ship.name}_passive2`
-                                                                ] = el;
-                                                            }}
-                                                            onMouseEnter={() =>
-                                                                setPassive2Hover(ship.name)
-                                                            }
-                                                            onMouseLeave={() =>
-                                                                setPassive2Hover('')
-                                                            }
-                                                        >
-                                                            <Button
-                                                                variant="secondary"
-                                                                size="xs"
-                                                                onClick={() =>
-                                                                    void copySkillText(
-                                                                        ship.name,
-                                                                        'Passive R2',
-                                                                        ship.secondPassiveSkillText!
-                                                                    )
+                                                                targetElement={
+                                                                    tooltipRefs.current[
+                                                                        `${ship.name}_charge`
+                                                                    ]
                                                                 }
                                                             >
-                                                                {copiedSkill ===
-                                                                `${ship.name}_Passive R2`
-                                                                    ? 'Copied!'
-                                                                    : 'Passive R2'}
-                                                            </Button>
+                                                                <SkillTooltip
+                                                                    skillText={ship.chargeSkillText}
+                                                                    skillType="Charge Skill"
+                                                                    charge={ship.chargeSkillCharge}
+                                                                    targeting={
+                                                                        shipTargeting.charged
+                                                                    }
+                                                                />
+                                                            </Tooltip>
                                                         </div>
-                                                        <Tooltip
-                                                            isVisible={passive2Hover === ship.name}
-                                                            targetElement={
-                                                                tooltipRefs.current[
-                                                                    `${ship.name}_passive2`
-                                                                ]
-                                                            }
-                                                        >
-                                                            <SkillTooltip
-                                                                skillText={
-                                                                    ship.secondPassiveSkillText
+                                                    )}
+                                                    {ship.firstPassiveSkillText && (
+                                                        <div className="relative">
+                                                            <div
+                                                                ref={(el) => {
+                                                                    tooltipRefs.current[
+                                                                        `${ship.name}_passive1`
+                                                                    ] = el;
+                                                                }}
+                                                                onMouseEnter={() =>
+                                                                    setPassive1Hover(ship.name)
                                                                 }
-                                                                skillType="Passive Skill R2"
-                                                            />
-                                                        </Tooltip>
-                                                    </div>
-                                                )}
-                                                {ship.thirdPassiveSkillText && (
-                                                    <div className="relative">
-                                                        <div
-                                                            ref={(el) => {
-                                                                tooltipRefs.current[
-                                                                    `${ship.name}_passive3`
-                                                                ] = el;
-                                                            }}
-                                                            onMouseEnter={() =>
-                                                                setPassive3Hover(ship.name)
-                                                            }
-                                                            onMouseLeave={() =>
-                                                                setPassive3Hover('')
-                                                            }
-                                                        >
-                                                            <Button
-                                                                variant="secondary"
-                                                                size="xs"
-                                                                onClick={() =>
-                                                                    void copySkillText(
-                                                                        ship.name,
-                                                                        'Passive R4',
-                                                                        ship.thirdPassiveSkillText!
-                                                                    )
+                                                                onMouseLeave={() =>
+                                                                    setPassive1Hover('')
                                                                 }
                                                             >
-                                                                {copiedSkill ===
-                                                                `${ship.name}_Passive R4`
-                                                                    ? 'Copied!'
-                                                                    : 'Passive R4'}
-                                                            </Button>
-                                                        </div>
-                                                        <Tooltip
-                                                            isVisible={passive3Hover === ship.name}
-                                                            targetElement={
-                                                                tooltipRefs.current[
-                                                                    `${ship.name}_passive3`
-                                                                ]
-                                                            }
-                                                        >
-                                                            <SkillTooltip
-                                                                skillText={
-                                                                    ship.thirdPassiveSkillText
+                                                                <Button
+                                                                    variant="secondary"
+                                                                    size="xs"
+                                                                    onClick={() =>
+                                                                        void copySkillText(
+                                                                            ship.name,
+                                                                            'Passive',
+                                                                            ship.firstPassiveSkillText!
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    {copiedSkill ===
+                                                                    `${ship.name}_Passive`
+                                                                        ? 'Copied!'
+                                                                        : 'Passive'}
+                                                                </Button>
+                                                            </div>
+                                                            <Tooltip
+                                                                isVisible={
+                                                                    passive1Hover === ship.name
                                                                 }
-                                                                skillType="Passive Skill R4"
-                                                            />
-                                                        </Tooltip>
-                                                    </div>
-                                                )}
+                                                                targetElement={
+                                                                    tooltipRefs.current[
+                                                                        `${ship.name}_passive1`
+                                                                    ]
+                                                                }
+                                                            >
+                                                                <SkillTooltip
+                                                                    skillText={
+                                                                        ship.firstPassiveSkillText
+                                                                    }
+                                                                    skillType="Passive Skill"
+                                                                />
+                                                            </Tooltip>
+                                                        </div>
+                                                    )}
+                                                    {ship.secondPassiveSkillText && (
+                                                        <div className="relative">
+                                                            <div
+                                                                ref={(el) => {
+                                                                    tooltipRefs.current[
+                                                                        `${ship.name}_passive2`
+                                                                    ] = el;
+                                                                }}
+                                                                onMouseEnter={() =>
+                                                                    setPassive2Hover(ship.name)
+                                                                }
+                                                                onMouseLeave={() =>
+                                                                    setPassive2Hover('')
+                                                                }
+                                                            >
+                                                                <Button
+                                                                    variant="secondary"
+                                                                    size="xs"
+                                                                    onClick={() =>
+                                                                        void copySkillText(
+                                                                            ship.name,
+                                                                            'Passive R2',
+                                                                            ship.secondPassiveSkillText!
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    {copiedSkill ===
+                                                                    `${ship.name}_Passive R2`
+                                                                        ? 'Copied!'
+                                                                        : 'Passive R2'}
+                                                                </Button>
+                                                            </div>
+                                                            <Tooltip
+                                                                isVisible={
+                                                                    passive2Hover === ship.name
+                                                                }
+                                                                targetElement={
+                                                                    tooltipRefs.current[
+                                                                        `${ship.name}_passive2`
+                                                                    ]
+                                                                }
+                                                            >
+                                                                <SkillTooltip
+                                                                    skillText={
+                                                                        ship.secondPassiveSkillText
+                                                                    }
+                                                                    skillType="Passive Skill R2"
+                                                                />
+                                                            </Tooltip>
+                                                        </div>
+                                                    )}
+                                                    {ship.thirdPassiveSkillText && (
+                                                        <div className="relative">
+                                                            <div
+                                                                ref={(el) => {
+                                                                    tooltipRefs.current[
+                                                                        `${ship.name}_passive3`
+                                                                    ] = el;
+                                                                }}
+                                                                onMouseEnter={() =>
+                                                                    setPassive3Hover(ship.name)
+                                                                }
+                                                                onMouseLeave={() =>
+                                                                    setPassive3Hover('')
+                                                                }
+                                                            >
+                                                                <Button
+                                                                    variant="secondary"
+                                                                    size="xs"
+                                                                    onClick={() =>
+                                                                        void copySkillText(
+                                                                            ship.name,
+                                                                            'Passive R4',
+                                                                            ship.thirdPassiveSkillText!
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    {copiedSkill ===
+                                                                    `${ship.name}_Passive R4`
+                                                                        ? 'Copied!'
+                                                                        : 'Passive R4'}
+                                                                </Button>
+                                                            </div>
+                                                            <Tooltip
+                                                                isVisible={
+                                                                    passive3Hover === ship.name
+                                                                }
+                                                                targetElement={
+                                                                    tooltipRefs.current[
+                                                                        `${ship.name}_passive3`
+                                                                    ]
+                                                                }
+                                                            >
+                                                                <SkillTooltip
+                                                                    skillText={
+                                                                        ship.thirdPassiveSkillText
+                                                                    }
+                                                                    skillType="Passive Skill R4"
+                                                                />
+                                                            </Tooltip>
+                                                        </div>
+                                                    )}
+                                                </div>
                                             </div>
-                                        </div>
-                                    </ShipDisplayImage>
-                                </div>
-                            ))
+                                        </ShipDisplayImage>
+                                    </div>
+                                );
+                            })
                         ) : (
                             <div className="col-span-full text-center py-8 text-theme-text-secondary bg-dark-lighter border-2 border-dashed">
                                 No matching ships found

--- a/src/pages/database/ShipIndexPage.tsx
+++ b/src/pages/database/ShipIndexPage.tsx
@@ -24,6 +24,7 @@ import { StatName } from '../../types/stats';
 import { calculateTotalStats } from '../../utils/ship/statsCalculator';
 import { Modal } from '../../components/ui/layout/Modal';
 import { BioContent } from '../../components/ship/BioContent';
+import { parseShipTargeting } from '../../utils/targetingParser';
 
 export const ShipIndexPage: React.FC = () => {
     const { ships: templateShips, loading, error } = useShipsData();
@@ -409,6 +410,9 @@ export const ShipIndexPage: React.FC = () => {
                                                             <SkillTooltip
                                                                 skillText={ship.activeSkillText}
                                                                 skillType="Active Skill"
+                                                                targeting={
+                                                                    parseShipTargeting(ship).active
+                                                                }
                                                             />
                                                         </Tooltip>
                                                     </div>
@@ -455,6 +459,9 @@ export const ShipIndexPage: React.FC = () => {
                                                                 skillText={ship.chargeSkillText}
                                                                 skillType="Charge Skill"
                                                                 charge={ship.chargeSkillCharge}
+                                                                targeting={
+                                                                    parseShipTargeting(ship).charged
+                                                                }
                                                             />
                                                         </Tooltip>
                                                     </div>

--- a/src/utils/targeting/__tests__/targetingDisplay.test.ts
+++ b/src/utils/targeting/__tests__/targetingDisplay.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { pickDisplayAnchor } from '../targetingDisplay';
+import { parseShipTargeting } from '../../targetingParser';
+import { resolveCells } from '../resolvePattern';
+import { OFFSET_TABLES, patternSignature } from '../patternOffsets';
+
+function activePattern(pattern: string) {
+    return parseShipTargeting({ activeTarget: 'front', activePattern: pattern }).active!.pattern;
+}
+
+describe('pickDisplayAnchor', () => {
+    it('returns an anchor whose footprint is fully on-board for a standard cone', () => {
+        const pattern = activePattern('Pattern-Cone-Range-1');
+        const anchor = pickDisplayAnchor(pattern);
+        const expected = OFFSET_TABLES[patternSignature(pattern)].length;
+        expect(resolveCells(pattern, anchor).length).toBe(expected); // nothing clipped
+    });
+
+    it('returns an anchor whose footprint is fully on-board for a backline pattern', () => {
+        const pattern = activePattern('Pattern-Backline-Range-2');
+        const anchor = pickDisplayAnchor(pattern);
+        const expected = OFFSET_TABLES[patternSignature(pattern)].length;
+        expect(resolveCells(pattern, anchor).length).toBe(expected);
+    });
+
+    it('is deterministic (tie-break) for whole-board "all" patterns', () => {
+        const pattern = activePattern('Pattern-All'); // resolves 12 cells from any anchor
+        expect(pickDisplayAnchor(pattern)).toBe(pickDisplayAnchor(pattern));
+        expect(resolveCells(pattern, pickDisplayAnchor(pattern)).length).toBe(12);
+    });
+});

--- a/src/utils/targeting/__tests__/targetingDisplay.test.ts
+++ b/src/utils/targeting/__tests__/targetingDisplay.test.ts
@@ -25,7 +25,8 @@ describe('pickDisplayAnchor', () => {
 
     it('is deterministic (tie-break) for whole-board "all" patterns', () => {
         const pattern = activePattern('Pattern-All'); // resolves 12 cells from any anchor
-        expect(pickDisplayAnchor(pattern)).toBe(pickDisplayAnchor(pattern));
+        // All anchors tie on count; ANCHOR_PREFERENCE center-front bias picks M3.
+        expect(pickDisplayAnchor(pattern)).toBe('M3');
         expect(resolveCells(pattern, pickDisplayAnchor(pattern)).length).toBe(12);
     });
 });
@@ -44,5 +45,28 @@ describe('targetingLabel', () => {
         const label = targetingLabel(active('front', 'Pattern-Base'));
         expect(label).toBe('Single target · enemy front');
         expect(label).not.toContain('Range');
+    });
+
+    it('whole-board "all" pattern has no Range segment', () => {
+        // Pattern-All → shape 'all', range 'all'; rangeSegment returns null for shape==='all'
+        const label = targetingLabel(active('front', 'Pattern-All'));
+        expect(label).toBe('Whole board · enemy front');
+        expect(label).not.toContain('Range');
+    });
+
+    it('whole-lane support pattern shows "Whole lane" and no Range segment', () => {
+        // Pattern-Line-Support-whole-lane → shape 'line', range 'lane', modifiers.support=true
+        // support modifier is intentionally omitted from the caption (ally target side conveys it)
+        const label = targetingLabel(active('allies', 'Pattern-Line-Support-whole-lane'));
+        expect(label).toBe('Line · Whole lane · ally team');
+        expect(label).toContain('Whole lane');
+        expect(label).not.toContain('Range');
+    });
+
+    it('reverse modifier appears as prefix before shape name', () => {
+        // Pattern-Reverse-Cone-Range-1 → shape 'cone', range 1, modifiers.reverse=true
+        const label = targetingLabel(active('front', 'Pattern-Reverse-Cone-Range-1'));
+        expect(label).toBe('Reverse Cone · Range 1 · enemy front');
+        expect(label.startsWith('Reverse ')).toBe(true);
     });
 });

--- a/src/utils/targeting/__tests__/targetingDisplay.test.ts
+++ b/src/utils/targeting/__tests__/targetingDisplay.test.ts
@@ -1,35 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { pickDisplayAnchor, targetingLabel } from '../targetingDisplay';
+import { targetingLabel } from '../targetingDisplay';
 import { parseShipTargeting } from '../../targetingParser';
-import { resolveCells } from '../resolvePattern';
-import { OFFSET_TABLES, patternSignature } from '../patternOffsets';
-
-function activePattern(pattern: string) {
-    return parseShipTargeting({ activeTarget: 'front', activePattern: pattern }).active!.pattern;
-}
-
-describe('pickDisplayAnchor', () => {
-    it('returns an anchor whose footprint is fully on-board for a standard cone', () => {
-        const pattern = activePattern('Pattern-Cone-Range-1');
-        const anchor = pickDisplayAnchor(pattern);
-        const expected = OFFSET_TABLES[patternSignature(pattern)].length;
-        expect(resolveCells(pattern, anchor).length).toBe(expected); // nothing clipped
-    });
-
-    it('returns an anchor whose footprint is fully on-board for a backline pattern', () => {
-        const pattern = activePattern('Pattern-Backline-Range-2');
-        const anchor = pickDisplayAnchor(pattern);
-        const expected = OFFSET_TABLES[patternSignature(pattern)].length;
-        expect(resolveCells(pattern, anchor).length).toBe(expected);
-    });
-
-    it('is deterministic (tie-break) for whole-board "all" patterns', () => {
-        const pattern = activePattern('Pattern-All'); // resolves 12 cells from any anchor
-        // All anchors tie on count; ANCHOR_PREFERENCE center-front bias picks M3.
-        expect(pickDisplayAnchor(pattern)).toBe('M3');
-        expect(resolveCells(pattern, pickDisplayAnchor(pattern)).length).toBe(12);
-    });
-});
 
 function active(target: string, pattern: string) {
     return parseShipTargeting({ activeTarget: target, activePattern: pattern }).active!;

--- a/src/utils/targeting/__tests__/targetingDisplay.test.ts
+++ b/src/utils/targeting/__tests__/targetingDisplay.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { pickDisplayAnchor } from '../targetingDisplay';
+import { pickDisplayAnchor, targetingLabel } from '../targetingDisplay';
 import { parseShipTargeting } from '../../targetingParser';
 import { resolveCells } from '../resolvePattern';
 import { OFFSET_TABLES, patternSignature } from '../patternOffsets';
@@ -27,5 +27,22 @@ describe('pickDisplayAnchor', () => {
         const pattern = activePattern('Pattern-All'); // resolves 12 cells from any anchor
         expect(pickDisplayAnchor(pattern)).toBe(pickDisplayAnchor(pattern));
         expect(resolveCells(pattern, pickDisplayAnchor(pattern)).length).toBe(12);
+    });
+});
+
+function active(target: string, pattern: string) {
+    return parseShipTargeting({ activeTarget: target, activePattern: pattern }).active!;
+}
+
+describe('targetingLabel', () => {
+    it('labels a ranged cone', () => {
+        expect(targetingLabel(active('front', 'Pattern-Cone-Range-1'))).toBe(
+            'Cone · Range 1 · enemy front'
+        );
+    });
+    it('omits range for single-target base patterns', () => {
+        const label = targetingLabel(active('front', 'Pattern-Base'));
+        expect(label).toBe('Single target · enemy front');
+        expect(label).not.toContain('Range');
     });
 });

--- a/src/utils/targeting/aoePattern.ts
+++ b/src/utils/targeting/aoePattern.ts
@@ -1,0 +1,43 @@
+import { ParsedPattern } from '../targetingParser';
+import { ALL_POSITIONS, positionToAxial } from './board';
+import { OFFSET_TABLES, WHOLE_LANE, patternSignature } from './patternOffsets';
+
+export type AoeCellRole = 'primary' | 'splash';
+
+/** A single AoE cell in axial coordinates relative to the primary target (0,0). */
+export interface PatternCell {
+    q: number;
+    r: number;
+    role: AoeCellRole;
+}
+
+/**
+ * Convert a parsed pattern into its relative AoE footprint: a list of axial cells with the
+ * primary target at (0,0) and splash cells offset around it. Built from the per-signature
+ * offset tables (origin → 'primary', covered → 'splash'). Throws for an unknown signature —
+ * callers guard and render nothing.
+ *
+ * Special cases: whole-lane patterns use the caster-centred lane; 'all' (whole board) has no
+ * relative footprint, so it returns every formation cell as primary to convey "hits all".
+ */
+export function toPatternCells(pattern: ParsedPattern): PatternCell[] {
+    if (pattern.shape === 'all') {
+        return ALL_POSITIONS.map((pos) => {
+            const { q, r } = positionToAxial(pos);
+            return { q, r, role: 'primary' as const };
+        });
+    }
+
+    const offsets =
+        pattern.range === 'lane' ? WHOLE_LANE : OFFSET_TABLES[patternSignature(pattern)];
+    if (!offsets) {
+        throw new Error(
+            `No offset table for pattern signature: "${patternSignature(pattern)}" (${pattern.raw})`
+        );
+    }
+    return offsets.map((o) => ({
+        q: o.dq,
+        r: o.dr,
+        role: o.role === 'origin' ? ('primary' as const) : ('splash' as const),
+    }));
+}

--- a/src/utils/targeting/targetingDisplay.ts
+++ b/src/utils/targeting/targetingDisplay.ts
@@ -1,0 +1,84 @@
+import { Position } from '../../types/encounters';
+import { ParsedPattern, ParsedTarget, SkillTargeting } from '../targetingParser';
+import { ALL_POSITIONS } from './board';
+import { resolveCells } from './resolvePattern';
+
+// Center-front bias so footprints frame like the prototype; also the deterministic
+// tie-break when several anchors clip equally little.
+const ANCHOR_PREFERENCE: Position[] = [
+    'M3',
+    'M4',
+    'M2',
+    'M1',
+    'T3',
+    'T4',
+    'T2',
+    'T1',
+    'B3',
+    'B4',
+    'B2',
+    'B1',
+];
+
+/**
+ * Pick the board cell to anchor a footprint preview on: the anchor that leaves the
+ * most cells on-board (resolveCells clips off-board cells), tie-broken by ANCHOR_PREFERENCE.
+ * Pure. Throws only if resolveCells throws (unknown pattern signature) — callers guard.
+ */
+export function pickDisplayAnchor(pattern: ParsedPattern): Position {
+    let best: Position = ANCHOR_PREFERENCE[0];
+    let bestCount = -1;
+    let bestRank = Infinity;
+    for (const anchor of ALL_POSITIONS) {
+        const count = resolveCells(pattern, anchor).length;
+        const rank = ANCHOR_PREFERENCE.indexOf(anchor);
+        if (count > bestCount || (count === bestCount && rank < bestRank)) {
+            best = anchor;
+            bestCount = count;
+            bestRank = rank;
+        }
+    }
+    return best;
+}
+
+// ---------------------------------------------------------------------------
+// targetingLabel — human-readable caption
+// ---------------------------------------------------------------------------
+
+function cap(s: string): string {
+    return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function shapeSegment(p: ParsedPattern): string {
+    if (p.shape === 'base') return 'Single target';
+    if (p.shape === 'all') return 'Whole board';
+    const prefixes = [
+        p.modifiers.reverse && 'Reverse',
+        p.modifiers.prolonged && 'Prolonged',
+        p.modifiers.double && 'Double',
+    ].filter(Boolean);
+    const suffixes = [
+        p.modifiers.fromCentre && 'from centre',
+        p.modifiers.notSelf && 'not self',
+        p.modifiers.anchorMod && `(${p.modifiers.anchorMod})`,
+    ].filter(Boolean);
+    return [...prefixes, cap(p.shape), ...suffixes].join(' ');
+}
+
+function rangeSegment(p: ParsedPattern): string | null {
+    if (p.shape === 'all' || p.range === 'all') return null; // covered by shapeSegment
+    if (p.range === 'lane') return 'Whole lane';
+    if (typeof p.range === 'number' && p.range >= 1) return `Range ${p.range}`;
+    return null; // range 0 → omit
+}
+
+function targetSegment(t: ParsedTarget): string {
+    return `${t.side} ${t.selection}`;
+}
+
+/** Human-readable one-line caption for a skill's targeting, e.g. "Cone · Range 1 · enemy front". */
+export function targetingLabel({ pattern, target }: SkillTargeting): string {
+    return [shapeSegment(pattern), rangeSegment(pattern), targetSegment(target)]
+        .filter(Boolean)
+        .join(' · ');
+}

--- a/src/utils/targeting/targetingDisplay.ts
+++ b/src/utils/targeting/targetingDisplay.ts
@@ -5,6 +5,9 @@ import { resolveCells } from './resolvePattern';
 
 // Center-front bias so footprints frame like the prototype; also the deterministic
 // tie-break when several anchors clip equally little.
+// INVARIANT: ANCHOR_PREFERENCE must list every member of ALL_POSITIONS (all 12).
+// If any position is missing, ANCHOR_PREFERENCE.indexOf(anchor) returns -1, which
+// would always win every tie and silently break the center-front preference order.
 const ANCHOR_PREFERENCE: Position[] = [
     'M3',
     'M4',
@@ -49,6 +52,8 @@ function cap(s: string): string {
     return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
+// 'support' is intentionally omitted from the caption — the ally target side already
+// conveys it (see spec caption rules). Do NOT add a "Support" prefix here.
 function shapeSegment(p: ParsedPattern): string {
     if (p.shape === 'base') return 'Single target';
     if (p.shape === 'all') return 'Whole board';

--- a/src/utils/targeting/targetingDisplay.ts
+++ b/src/utils/targeting/targetingDisplay.ts
@@ -1,61 +1,7 @@
-import { Position } from '../../types/encounters';
 import { ParsedPattern, ParsedTarget, SkillTargeting } from '../targetingParser';
-import { ALL_POSITIONS } from './board';
-import { resolveCells } from './resolvePattern';
-
-// Center-front bias so footprints frame like the prototype; also the deterministic
-// tie-break when several anchors clip equally little.
-// INVARIANT: ANCHOR_PREFERENCE must list every member of ALL_POSITIONS (all 12).
-// If any position is missing, ANCHOR_PREFERENCE.indexOf(anchor) returns -1, which
-// would always win every tie and silently break the center-front preference order.
-const ANCHOR_PREFERENCE: Position[] = [
-    'M3',
-    'M4',
-    'M2',
-    'M1',
-    'T3',
-    'T4',
-    'T2',
-    'T1',
-    'B3',
-    'B4',
-    'B2',
-    'B1',
-];
-
-// Enforce the invariant at module load time so a future board change can't silently
-// break tie-breaking. Runs once — cheap enough to keep unconditional.
-/* istanbul ignore next */
-if (import.meta.env?.DEV) {
-    const missing = ALL_POSITIONS.filter((p) => !ANCHOR_PREFERENCE.includes(p));
-    if (missing.length) {
-        throw new Error(`ANCHOR_PREFERENCE missing positions: ${missing.join(', ')}`);
-    }
-}
-
-/**
- * Pick the board cell to anchor a footprint preview on: the anchor that leaves the
- * most cells on-board (resolveCells clips off-board cells), tie-broken by ANCHOR_PREFERENCE.
- * Pure. Throws only if resolveCells throws (unknown pattern signature) — callers guard.
- */
-export function pickDisplayAnchor(pattern: ParsedPattern): Position {
-    let best: Position = ANCHOR_PREFERENCE[0];
-    let bestCount = -1;
-    let bestRank = Infinity;
-    for (const anchor of ALL_POSITIONS) {
-        const count = resolveCells(pattern, anchor).length;
-        const rank = ANCHOR_PREFERENCE.indexOf(anchor);
-        if (count > bestCount || (count === bestCount && rank < bestRank)) {
-            best = anchor;
-            bestCount = count;
-            bestRank = rank;
-        }
-    }
-    return best;
-}
 
 // ---------------------------------------------------------------------------
-// targetingLabel — human-readable caption
+// targetingLabel — human-readable caption (used for the footprint's aria-label)
 // ---------------------------------------------------------------------------
 
 function cap(s: string): string {

--- a/src/utils/targeting/targetingDisplay.ts
+++ b/src/utils/targeting/targetingDisplay.ts
@@ -23,6 +23,16 @@ const ANCHOR_PREFERENCE: Position[] = [
     'B1',
 ];
 
+// Enforce the invariant at module load time so a future board change can't silently
+// break tie-breaking. Runs once — cheap enough to keep unconditional.
+/* istanbul ignore next */
+if (import.meta.env?.DEV) {
+    const missing = ALL_POSITIONS.filter((p) => !ANCHOR_PREFERENCE.includes(p));
+    if (missing.length) {
+        throw new Error(`ANCHOR_PREFERENCE missing positions: ${missing.join(', ')}`);
+    }
+}
+
 /**
  * Pick the board cell to anchor a footprint preview on: the anchor that leaves the
  * most cells on-board (resolveCells clips off-board cells), tie-broken by ANCHOR_PREFERENCE.


### PR DESCRIPTION
## Summary

Adds a data-driven **Targeting / AoE** module to ship-skill hovercards. For each Active/Charge skill it renders a compact two-pane box (on top of the skill text, like the buff-description boxes):

- **Left** — a pointy-top SVG hex cluster of the skill's **relative AoE footprint** (primary target + splash cells), auto-fit/centered with a soft glow.
- **Right** — the targeting **rule** label + a plain-English description, and a Primary/Splash legend.

**Side-aware:** enemy/attacker skills render **red** (primary) + **lighter red** (splash) and are **mirrored** to face the enemy formation; ally/support skills render **green** (allies) + **darker green** (caster), legend relabelled **Caster / Allies**.

### What's in it
- `src/constants/targetingRules.ts` — `TARGETING_RULES` keyed by the parsed `TargetSelection` (label + description; copy is never hardcoded in components).
- `src/utils/targeting/aoePattern.ts` — `toPatternCells(pattern)` adapter turning the merged offset tables into a relative `{q,r,role:'primary'|'splash'}[]` footprint.
- `src/components/ship/SkillTargetingBoard.tsx` — the two-pane box (pointy-top axial→pixel, auto-fit viewBox, glow filter, side colors/mirroring). Renders nothing for unknown pattern signatures.
- Wired via an optional `targeting` prop on `SkillTooltip`, supplied by `ShipSkillList` and `ShipIndexPage` from `parseShipTargeting(ship)`.
- Changelog + in-app docs updated.

## Test Plan
- [x] `npm test` — full suite green (incl. `targetingDisplay` caption + `SkillTargetingBoard` render tests: rule label/description, primary/splash cells, side colors, enemy mirroring, notSelf splash-only, unknown-signature → null)
- [x] `npx tsc --noEmit` clean; `npm run lint` 0 warnings
- [x] Manual smoke on `/ships/index`: enemy skills show red, mirrored footprints; ally skills show green with Caster/Allies; ships without targeting data show the hovercard unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)