### PR TITLE
feat(combat): positional target-selection (positional phase 2)

### DIFF
--- a/docs/superpowers/plans/2026-06-14-positional-target-selection.md
+++ b/docs/superpowers/plans/2026-06-14-positional-target-selection.md
@@ -544,8 +544,9 @@ Read the focus-turn `runPlayerTurn({...})` call (~2360) and how `enemy`, `target
   - `enemyHpDecline: 0` — explicitly override the cumulative expression; per-target decline
     is Phase 4 (gates read the target's entering HP — see spec).
   Otherwise the existing dummy binding, unchanged.
-  - If `isPositional` but `selectedEnemy` is null (no living target), skip the attack /
-    no-op for this action (document the chosen no-op; death-fallback is Phase 4).
+  - If `isPositional` but `selectedEnemy` is null (no living target), fall through to the
+    legacy dummy binding (`tgt = selectedEnemy ?? enemy` → `enemy`); the action still
+    resolves against the legacy target. A true no-op / death-fallback retarget is Phase 4.
 
 - [ ] **Step 4: Run** the new test → PASS. **Run full suite → goldens byte-identical.** If a
   golden moved, the gate is leaking (a non-positional input entered the branch) — fix the
@@ -578,7 +579,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
   actor's `position` + `target` (carried on its `CombatActor` / `TeamActorEngineInput`).
   Reuse `resolvePositionalTarget` and the same field-swap as C1 (selected actor's
   defence/max-HP/containers, `enemyHpDecline: 0`). As in C1: `isPositional` but `selected`
-  null → no-op for this action (death-fallback is Phase 4).
+  null → fall through to the legacy dummy binding (`?? enemy`); death-fallback is Phase 4.
 
 - [ ] **Step 4: Run** new test → PASS; **full suite goldens byte-identical.**
 
@@ -618,7 +619,8 @@ Read the enemy-attacker binding (~2700, `enemy: healTarget!`) and `applyIncoming
   and bind `enemy: selectedPlayer`, `targetId: selectedPlayer.id`, and route
   `applyIncomingToTarget` to `selectedPlayer` (generalize the helper from the hard-coded
   `healTarget`). Otherwise the existing `healTarget` binding.
-  - `selectedPlayer` null → no-op for this enemy action (Phase-4 death-fallback note).
+  - `selectedPlayer` null → fall through to the legacy `healTarget` binding (`?? healTarget`);
+    the enemy still attacks the legacy victim. Death-fallback retarget is Phase 4.
 
 - [ ] **Step 4: Run** new test → PASS; **full suite goldens byte-identical** (no caller
   passes enemy positions).

--- a/docs/superpowers/plans/2026-06-14-positional-target-selection.md
+++ b/docs/superpowers/plans/2026-06-14-positional-target-selection.md
@@ -38,10 +38,18 @@ working directory — never `git checkout` there.
 |------|----------------|--------|
 | `src/utils/targeting/board.ts` | board geometry (exists) | **Modify** — add `rowOf`/`colOf` accessors + `BoardRow` type |
 | `src/utils/targeting/selectTargets.ts` | pure selection: parsed target + occupancy → ordered list + anchor | **Create** |
-| `src/utils/targeting/__tests__/selectTargets.test.ts` | unit + golden selection tests | **Create** |
-| `src/utils/targeting/__tests__/board.test.ts` | board tests (exists) | **Modify** — add `rowOf`/`colOf` tests |
-| `src/utils/combat/engine.ts` | engine input + target binding seam | **Modify** — optional position/target fields, positional-mode helper, gated binding at 3 `runPlayerTurn` sites |
+| `src/utils/targeting/selectTargets.test.ts` | unit + golden selection tests (**co-located**, project convention) | **Create** |
+| `src/utils/targeting/board.test.ts` | board tests (exists, **co-located**) | **Modify** — add `rowOf`/`colOf` tests |
+| `src/utils/combat/positionalBinding.ts` | engine↔selectTargets glue: `isPositional`, `resolvePositionalTarget` (keeps `engine.ts` focused + unit-testable) | **Create** |
+| `src/utils/combat/state.ts` | `CombatActor` (exists) | **Modify** — add `position?: Position`; widen `createActor` param to accept it |
+| `src/utils/combat/engine.ts` | engine input + target binding seam | **Modify** — optional position/target on `CombatEngineInput`+`TeamActorEngineInput`+`enemyAttackers`(768)+`EnemyActorInput`(304); set `position` on actors; gated binding at 3 `runPlayerTurn` sites |
 | `src/utils/combat/__tests__/positionalSelection.test.ts` | engine integration tests (synthetic positioned teams) | **Create** |
+
+> **Test-file convention:** `src/utils/targeting/` uses **co-located** tests
+> (`board.test.ts` imports `'./board'`) — there is NO `__tests__/` subdir there. Put
+> `selectTargets.test.ts` co-located (`import { selectTargets } from './selectTargets'`,
+> `import type { ParsedTarget } from '../targetingParser'`). `src/utils/combat/` uses a
+> `__tests__/` subdir — `positionalSelection.test.ts` goes there.
 
 **Decomposition:** Part A is pure and carries zero engine risk — land it fully first. Part B
 adds optional input fields + the internal selection helper with **no behavior change**
@@ -56,12 +64,13 @@ adds optional input fields + the internal selection helper with **no behavior ch
 
 **Files:**
 - Modify: `src/utils/targeting/board.ts`
-- Test: `src/utils/targeting/__tests__/board.test.ts`
+- Test: `src/utils/targeting/board.test.ts` (co-located, exists)
 
-- [ ] **Step 1: Write failing tests** — append to `board.test.ts`:
+- [ ] **Step 1: Write failing tests** — append to `board.test.ts` (co-located; it imports
+  from `'./board'`):
 
 ```ts
-import { rowOf, colOf } from '../board';
+import { rowOf, colOf } from './board';
 
 describe('rowOf / colOf', () => {
   it('extracts the row letter', () => {
@@ -79,7 +88,7 @@ describe('rowOf / colOf', () => {
 
 - [ ] **Step 2: Run to verify failure**
 
-Run: `npm test -- src/utils/targeting/__tests__/board.test.ts`
+Run: `npm test -- src/utils/targeting/board.test.ts`
 Expected: FAIL — `rowOf`/`colOf` not exported.
 
 - [ ] **Step 3: Implement** — add to `board.ts`:
@@ -100,12 +109,12 @@ export function colOf(pos: Position): number {
 
 - [ ] **Step 4: Run to verify pass**
 
-Run: `npm test -- src/utils/targeting/__tests__/board.test.ts` → PASS.
+Run: `npm test -- src/utils/targeting/board.test.ts` → PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add src/utils/targeting/board.ts src/utils/targeting/__tests__/board.test.ts
+git add src/utils/targeting/board.ts src/utils/targeting/board.test.ts
 git commit -m "feat(targeting): rowOf/colOf board accessors
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
@@ -117,16 +126,16 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 **Files:**
 - Create: `src/utils/targeting/selectTargets.ts`
-- Test: `src/utils/targeting/__tests__/selectTargets.test.ts`
+- Test: `src/utils/targeting/selectTargets.test.ts` (co-located)
 
-- [ ] **Step 1: Write failing tests** — create `selectTargets.test.ts`. Use board layouts in
-the test names (the eyeball-against-game gate). `ParsedTarget` shapes mirror
+- [ ] **Step 1: Write failing tests** — create `selectTargets.test.ts` co-located. Use board
+layouts in the test names (the eyeball-against-game gate). `ParsedTarget` shapes mirror
 `targetingParser` output.
 
 ```ts
 import { describe, it, expect } from 'vitest';
-import { selectTargets, rowScanOrder } from '../selectTargets';
-import type { ParsedTarget } from '../../targetingParser';
+import { selectTargets, rowScanOrder } from './selectTargets';
+import type { ParsedTarget } from '../targetingParser';
 
 const enemy = (selection: ParsedTarget['selection']): ParsedTarget => ({
     raw: `enemy-${selection}`, side: 'enemy', selection,
@@ -193,7 +202,7 @@ describe('selectTargets — row-first scan (caster M, enemies only in top row T1
 
 - [ ] **Step 2: Run to verify failure**
 
-Run: `npm test -- src/utils/targeting/__tests__/selectTargets.test.ts`
+Run: `npm test -- src/utils/targeting/selectTargets.test.ts`
 Expected: FAIL — module not found.
 
 - [ ] **Step 3: Implement** — create `selectTargets.ts`:
@@ -276,7 +285,7 @@ export function selectTargets(target: ParsedTarget, ctx: SelectTargetsContext): 
 
 - [ ] **Step 4: Run to verify pass**
 
-Run: `npm test -- src/utils/targeting/__tests__/selectTargets.test.ts` → PASS.
+Run: `npm test -- src/utils/targeting/selectTargets.test.ts` → PASS.
 
 - [ ] **Step 5: Lint + types**
 
@@ -285,7 +294,7 @@ Run: `npm run lint && npx tsc --noEmit` → clean.
 - [ ] **Step 6: Commit**
 
 ```bash
-git add src/utils/targeting/selectTargets.ts src/utils/targeting/__tests__/selectTargets.test.ts
+git add src/utils/targeting/selectTargets.ts src/utils/targeting/selectTargets.test.ts
 git commit -m "feat(targeting): selectTargets — row-first anchor selection (front/back/skip/ally)
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
@@ -296,7 +305,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 ### Task A3: `selectTargets` — enemy `all` cross-row ordering
 
 **Files:**
-- Test: `src/utils/targeting/__tests__/selectTargets.test.ts` (append)
+- Test: `src/utils/targeting/selectTargets.test.ts` (append)
 
 (The implementation already handles `all` in A2; this task pins its cross-row behavior with
 dedicated goldens. If A2's `all` branch is already covered, this is a fast confirmation
@@ -325,7 +334,7 @@ describe('selectTargets — enemy all spans every row in scan order (caster M2)'
 running before committing A2 — implementer's choice).
 
 ```bash
-git add src/utils/targeting/__tests__/selectTargets.test.ts
+git add src/utils/targeting/selectTargets.test.ts
 git commit -m "test(targeting): pin selectTargets enemy-all cross-row ordering
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
@@ -342,16 +351,21 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 **Files:**
 - Modify: `src/utils/combat/engine.ts` (`CombatEngineInput` ~716; `TeamActorEngineInput`;
-  the `enemyAttackers` entry type ~768)
+  the inline `enemyAttackers` entry type ~768; **`EnemyActorInput` ~304**)
 
-Read the current `CombatEngineInput`, `TeamActorEngineInput`, and the `enemyAttackers` entry
-shape first.
+Read the current `CombatEngineInput`, `TeamActorEngineInput`, the inline `enemyAttackers`
+entry, and `EnemyActorInput` first. **Note:** there are TWO enemy-attacker input shapes —
+the inline `CombatEngineInput['enemyAttackers'][number]` (~768) AND the separate
+`EnemyActorInput` interface (~304) that `buildEnemyPlayerActorRuntime` actually consumes.
+The field must be added to **both** or it never reaches the actor builder.
 
 - [ ] **Step 1: Add optional fields (no consumption):**
   - `CombatEngineInput`: `position?: Position;` and `target?: ParsedTarget;` (the focus
     attacker's cell + parsed targeting).
   - `TeamActorEngineInput`: `position?: Position;` and `target?: ParsedTarget;`.
-  - `enemyAttackers[]` entry: `position?: Position;` and `target?: ParsedTarget;`.
+  - inline `enemyAttackers[]` entry (~768): `position?: Position;` and `target?: ParsedTarget;`.
+  - **`EnemyActorInput` (~304): `position?: Position;` and `target?: ParsedTarget;`** (the
+    shape `buildEnemyPlayerActorRuntime` reads).
   - Add imports: `import { Position } from '../../types/encounters';` and
     `import { ParsedTarget } from '../targetingParser';` (check they aren't already imported).
 
@@ -374,32 +388,85 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 ---
 
-### Task B2: internal `resolvePositionalTarget` helper (built, still unused)
+### Task B2a: `CombatActor.position` + `createActor` widening (set everywhere, read nowhere)
 
 **Files:**
-- Modify: `src/utils/combat/engine.ts`
-- Test: `src/utils/combat/__tests__/positionalSelection.test.ts` (create)
+- Modify: `src/utils/combat/state.ts` (`CombatActor` ~93; `createActor` param ~116)
+- Modify: `src/utils/combat/engine.ts` (the 3 `createActor` call sites)
 
-Add an engine-internal helper that, given an acting actor's position + parsed target and the
-*living, positioned* actors of the opposing side, returns the selected `CombatActor` (or
-`null`). This is the bridge between `selectTargets` (Positions) and the engine (actors).
+- [ ] **Step 1:** Add `position?: Position;` to the `CombatActor` interface (state.ts ~93;
+  add `import { Position } from '../../types/encounters'` there if absent).
 
-- [ ] **Step 1: Write the helper.** Place it near the actor setup (after `createActor`
-  helpers). Sketch:
+- [ ] **Step 2:** Widen `createActor`'s param (state.ts ~116) — its accepted partial is
+  `Pick<CombatActor,'id'|'side'|'kind'> & { stats; chargeCount?; startCharged? }`, which does
+  NOT include `position`. Add `position?: Position;` to that inline type and assign it onto
+  the returned actor (e.g. `position: partial.position` / spread).
+
+- [ ] **Step 3:** Set `position` at the 3 construction sites:
+  - attacker `createActor` (engine.ts ~961): `position: input.position` (the focus cell).
+  - team-actor `createActor` (engine.ts ~1007 region): `position: <teamActorInput>.position`.
+  - enemy-attacker `createActor` **inside `buildEnemyPlayerActorRuntime`** (engine.ts ~394):
+    `position: e.position` (from `EnemyActorInput`). This is a DIFFERENT function from the
+    top-level attacker/team setup — the enemy actor is built there, not in the main loop.
+
+- [ ] **Step 4:** `npx tsc --noEmit` clean; `npm test` — full suite green, **goldens
+  byte-identical** (`position` is set but read nowhere yet).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/state.ts src/utils/combat/engine.ts
+git commit -m "feat(combat): CombatActor.position threaded through createActor (unused)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task B2b: `positionalBinding.ts` — the selectTargets↔actor glue (built, unused)
+
+**Files:**
+- Create: `src/utils/combat/positionalBinding.ts`
+- Test: `src/utils/combat/positionalBinding.test.ts` (co-located; `src/utils/combat/` also has
+  a `__tests__/` dir, but a small co-located unit test for a pure helper is fine — match
+  whichever the implementer prefers; engine-integration tests go in `__tests__/`)
+
+Extract the glue into its own module so `engine.ts` doesn't grow and the helpers are
+unit-testable without importing the 3000-line engine.
+
+- [ ] **Step 1: Write failing tests** with hand-built `CombatActor`-shaped objects (only the
+  fields the helpers read: `id`, `position`, `currentHp`). Cases:
 
 ```ts
-import { selectTargets } from '../targeting/selectTargets';
-// ...
+// caster M4, positioned enemies front M4 / back M1, target front -> selects the M4 actor
+// same, target skip -> selects the M1 actor (2nd-from-front == back-most here)
+// caster has no position -> isPositional() === false
+// all opposing actors currentHp <= 0 -> resolvePositionalTarget() === null
+// opposing roster has no positions -> isPositional() === false
+```
 
-/** True when positional selection should run for `actor` against `opposingLiving`:
- *  a positioned opposing roster exists AND the acting actor has a position. */
-function isPositional(actorPosition: Position | undefined, opposingLiving: CombatActor[]): boolean {
+- [ ] **Step 2: Run** → FAIL (module missing).
+
+- [ ] **Step 3: Implement `positionalBinding.ts`:**
+
+```ts
+import { Position } from '../../types/encounters';
+import { ParsedTarget } from '../targetingParser';
+import { CombatActor } from './state';
+import { selectTargets } from '../targeting/selectTargets';
+
+/** Positional selection runs for an actor only when it has a position AND the opposing
+ *  side has at least one positioned actor (the spec's exact predicate). */
+export function isPositional(
+    actorPosition: Position | undefined,
+    opposingLiving: CombatActor[]
+): boolean {
     return !!actorPosition && opposingLiving.some((a) => a.position !== undefined);
 }
 
 /** Map the selectTargets anchor back to a single living positioned opposing actor.
- *  Returns null when no valid target (empty side / anchor null). Invariant: ≤1 actor/cell. */
-function resolvePositionalTarget(
+ *  null = no valid target (empty side / anchor null). Invariant: ≤1 living actor per cell. */
+export function resolvePositionalTarget(
     actorPosition: Position,
     target: ParsedTarget,
     opposingLiving: CombatActor[]
@@ -416,34 +483,16 @@ function resolvePositionalTarget(
 }
 ```
 
-  - This requires `CombatActor` to carry an optional `position`. Add `position?: Position` to
-    the `CombatActor` interface (`src/utils/combat/state.ts`) and thread it through
-    `createActor` (default `undefined`); set it from the input `position` when the
-    attacker / team / enemy actors are constructed (still consumed by nothing downstream).
+- [ ] **Step 4: Run** new test → PASS. Full suite → goldens byte-identical (nothing in the
+  engine imports this module yet).
 
-- [ ] **Step 2: Unit-test the helper directly** in `positionalSelection.test.ts` by importing
-  the engine module is awkward (helper not exported). Instead **export `resolvePositionalTarget`
-  and `isPositional`** (or move them into a small `src/utils/combat/positionalBinding.ts`
-  module and import into engine.ts — preferred for testability and to keep engine.ts focused).
-  Test with hand-built `CombatActor`-shaped objects:
+- [ ] **Step 5: Lint + types** clean.
 
-```ts
-// front caster vs positioned enemies front M4 / back M1 -> selects M4 actor
-// skip -> selects M1 actor (2nd from front; or fallback)
-// no caster position -> isPositional false
-// all enemies dead -> resolvePositionalTarget returns null
-```
-
-- [ ] **Step 3: Run** the new test → PASS. Run full suite → goldens byte-identical (helper
-  unused by the turn loop; `position` set but not read).
-
-- [ ] **Step 4: Lint + types** clean.
-
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add src/utils/combat/ src/utils/targeting/
-git commit -m "feat(combat): positional target-resolution helper (built, unused)
+git add src/utils/combat/positionalBinding.ts src/utils/combat/positionalBinding.test.ts
+git commit -m "feat(combat): positionalBinding glue (isPositional/resolvePositionalTarget, unused)
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 ```
@@ -467,24 +516,33 @@ Read the focus-turn `runPlayerTurn({...})` call (~2360) and how `enemy`, `target
 `enemyDefense`, `enemyHpDecline`, and the DoT containers are passed. The dummy `enemy`
 (created ~969) is the current binding.
 
-- [ ] **Step 1: Write failing engine test** — synthetic input with the focus attacker
-  positioned and a positioned enemy roster (use `enemyAttackers` entries given `position`
-  + zero/low attack so they're pure targets; the attacker's `target` = `front`). Tap the
-  `bus` and assert the focus attacker's `ability-performed` event carries
-  `targetId === <front enemy id>`. Add a second case: `target` = `back` → `targetId` ===
-  back enemy id. (See Task C3 / the spec for how `enemyAttackers` become positioned targets;
-  confirm enemy-attacker actors are built into `enemyAttackerActors` regardless of healing
-  mode, or set `healTargetId` to enable that path — document whichever the test needs.)
+- [ ] **Step 1: Write failing engine test.** **Required setup:** `enemyAttackerActors` is
+  only populated when `enemyAttackers` is non-empty AND `healTargetId` is set — `engine.ts`
+  ~1311 **throws** `enemyAttackers require healTargetId` otherwise (verified). So the test
+  MUST set `healTargetId` to a player actor id; there is no DPS-mode-only path to a positioned
+  enemy roster. Build: focus attacker positioned with `target: front`; `enemyAttackers` =
+  ≥2 entries each given a `position` (e.g. front M4 / back M1) + low/zero attack so they're
+  effectively pure targets; `healTargetId` = the focus (or a team) actor id. Tap the `bus`
+  and assert the focus attacker's `ability-performed` event carries `targetId === <M4 enemy
+  id>`. Add a second case: `target: back` → `targetId === <M1 enemy id>`.
 
 - [ ] **Step 2: Run** → FAIL (still binds the dummy; targetId === 'enemy').
 
 - [ ] **Step 3: Implement the gated branch** at the focus-turn call: compute
   `const selectedEnemy = isPositional(focusPosition, enemyAttackerActors) ? resolvePositionalTarget(focusPosition!, focusTarget!, enemyAttackerActors) : null;`
-  then when `selectedEnemy`:
+  then when `selectedEnemy`, swap the bare module vars the call currently passes (`enemy`,
+  `enemyDefense`, `enemyHp`, `corrosionEntries`/`infernoEntries`/`pendingBombs`/
+  `pendingAccumulators`, and `enemyHpDecline: cumulativeDamage + cumulativeTeamDamage`) for the
+  selected actor's fields:
   - bind `enemy: selectedEnemy`, `targetId: selectedEnemy.id`,
-  - pass `selectedEnemy`'s DoT/bomb/accumulator containers,
-  - `enemyDefense: selectedEnemy.stats.defence`, `enemyHp: <selectedEnemy max hp>`,
-  - `enemyHpDecline: 0` (per-target decline is Phase 4 — see spec).
+  - pass `selectedEnemy`'s OWN DoT/bomb/accumulator containers
+    (`selectedEnemy.corrosionEntries`, etc. — enemy attackers are real `CombatActor`s, so
+    these exist),
+  - `enemyDefense: selectedEnemy.stats.defence`,
+  - `enemyHp: selectedEnemy.stats.hp` (the selected actor's **max** HP — NOT `currentHp`,
+    which may have declined; and NOT the dummy's `enemyHp`),
+  - `enemyHpDecline: 0` — explicitly override the cumulative expression; per-target decline
+    is Phase 4 (gates read the target's entering HP — see spec).
   Otherwise the existing dummy binding, unchanged.
   - If `isPositional` but `selectedEnemy` is null (no living target), skip the attack /
     no-op for this action (document the chosen no-op; death-fallback is Phase 4).
@@ -518,7 +576,9 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 - [ ] **Step 3: Implement** the same gated branch at the team-turn call, using the team
   actor's `position` + `target` (carried on its `CombatActor` / `TeamActorEngineInput`).
-  Reuse `resolvePositionalTarget`.
+  Reuse `resolvePositionalTarget` and the same field-swap as C1 (selected actor's
+  defence/max-HP/containers, `enemyHpDecline: 0`). As in C1: `isPositional` but `selected`
+  null → no-op for this action (death-fallback is Phase 4).
 
 - [ ] **Step 4: Run** new test → PASS; **full suite goldens byte-identical.**
 
@@ -607,5 +667,6 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
   which player actor receives), never per-target damage totals (that accounting is Phase 4).
 - `resolveCells` (the geometry footprint resolver) is intentionally **not** imported by the
   engine this phase.
-- Prefer extracting `selectTargets`-to-actor glue into `src/utils/combat/positionalBinding.ts`
-  to keep `engine.ts` from growing and to make the helper unit-testable without the engine.
+- The `selectTargets`-to-actor glue lives in `src/utils/combat/positionalBinding.ts`
+  (Task B2b) — keeps `engine.ts` from growing and makes the helpers unit-testable without
+  importing the engine. `engine.ts` imports `{ isPositional, resolvePositionalTarget }` from it.

--- a/docs/superpowers/plans/2026-06-14-positional-target-selection.md
+++ b/docs/superpowers/plans/2026-06-14-positional-target-selection.md
@@ -1,0 +1,611 @@
+# Positional Target-Selection (Engine) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the combat engine the ability to select *which* opposing ship an attacker
+hits, from board positions (row-first scan + within-row front/back/skip), wired
+side-symmetrically — gated so that with no positions the engine behaves exactly as today.
+
+**Architecture:** A new pure `selectTargets` module (positions + parsed target → ordered
+list + anchor) layered on the existing geometry resolver, plus an *optional overlay* on the
+engine: positions/targets are optional inputs; positional mode is entered only when a
+positioned opposing roster exists AND the acting actor has a position, otherwise the engine
+uses today's hard-coded dummy-sink / heal-target binding. Phase 2 applies single-target
+(the selected anchor); AoE/stealth/forced-targeting/per-target accounting are later phases.
+
+**Tech Stack:** TypeScript, Vitest. Pure modules in `src/utils/targeting/`; engine in
+`src/utils/combat/engine.ts` + `playerTurn.ts`.
+
+**Spec:** `docs/superpowers/specs/2026-06-14-positional-target-selection-design.md`
+
+**Worktree:** all work happens in `.worktrees/positional-target-selection`
+(branch `feat/combat-engine-positional-target-selection`). A parallel session owns the main
+working directory — never `git checkout` there.
+
+**Workflow notes (from project memory):**
+- Run tests with `npm test` (Vitest). Lint: `npm run lint` (max-warnings 0). Types: `npx tsc --noEmit`.
+- **Never** regenerate goldens with `vitest -u`. Goldens must stay byte-identical; if one
+  changes, the positional gating is leaking — STOP and fix the gate, don't update the golden.
+- `git commit` runs a pre-commit hook that runs the full suite. For docs-only commits use
+  `--no-verify`. For code commits, let the hook run (it's the regression gate).
+- Commit messages end with the `Co-Authored-By: Claude Opus 4.8 (1M context)` trailer.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `src/utils/targeting/board.ts` | board geometry (exists) | **Modify** — add `rowOf`/`colOf` accessors + `BoardRow` type |
+| `src/utils/targeting/selectTargets.ts` | pure selection: parsed target + occupancy → ordered list + anchor | **Create** |
+| `src/utils/targeting/__tests__/selectTargets.test.ts` | unit + golden selection tests | **Create** |
+| `src/utils/targeting/__tests__/board.test.ts` | board tests (exists) | **Modify** — add `rowOf`/`colOf` tests |
+| `src/utils/combat/engine.ts` | engine input + target binding seam | **Modify** — optional position/target fields, positional-mode helper, gated binding at 3 `runPlayerTurn` sites |
+| `src/utils/combat/__tests__/positionalSelection.test.ts` | engine integration tests (synthetic positioned teams) | **Create** |
+
+**Decomposition:** Part A is pure and carries zero engine risk — land it fully first. Part B
+adds optional input fields + the internal selection helper with **no behavior change**
+(goldens byte-identical). Part C wires the gated positional branch into the three
+`runPlayerTurn` binding sites.
+
+---
+
+## Part A — Pure selection module
+
+### Task A1: board accessors `rowOf` / `colOf`
+
+**Files:**
+- Modify: `src/utils/targeting/board.ts`
+- Test: `src/utils/targeting/__tests__/board.test.ts`
+
+- [ ] **Step 1: Write failing tests** — append to `board.test.ts`:
+
+```ts
+import { rowOf, colOf } from '../board';
+
+describe('rowOf / colOf', () => {
+  it('extracts the row letter', () => {
+    expect(rowOf('T1')).toBe('T');
+    expect(rowOf('M3')).toBe('M');
+    expect(rowOf('B4')).toBe('B');
+  });
+  it('extracts the column number', () => {
+    expect(colOf('T1')).toBe(1);
+    expect(colOf('M3')).toBe(3);
+    expect(colOf('B4')).toBe(4);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm test -- src/utils/targeting/__tests__/board.test.ts`
+Expected: FAIL — `rowOf`/`colOf` not exported.
+
+- [ ] **Step 3: Implement** — add to `board.ts`:
+
+```ts
+export type BoardRow = 'T' | 'M' | 'B';
+
+/** The row letter of a Position ('T1' -> 'T'). */
+export function rowOf(pos: Position): BoardRow {
+    return pos[0] as BoardRow;
+}
+
+/** The 1-based column of a Position ('M3' -> 3); column 4 = front (nearest enemy). */
+export function colOf(pos: Position): number {
+    return Number(pos[1]);
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm test -- src/utils/targeting/__tests__/board.test.ts` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/targeting/board.ts src/utils/targeting/__tests__/board.test.ts
+git commit -m "feat(targeting): rowOf/colOf board accessors
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task A2: `selectTargets` — ally, empty, and enemy front/back/skip
+
+**Files:**
+- Create: `src/utils/targeting/selectTargets.ts`
+- Test: `src/utils/targeting/__tests__/selectTargets.test.ts`
+
+- [ ] **Step 1: Write failing tests** — create `selectTargets.test.ts`. Use board layouts in
+the test names (the eyeball-against-game gate). `ParsedTarget` shapes mirror
+`targetingParser` output.
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { selectTargets, rowScanOrder } from '../selectTargets';
+import type { ParsedTarget } from '../../targetingParser';
+
+const enemy = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: `enemy-${selection}`, side: 'enemy', selection,
+});
+const ally = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: `ally-${selection}`, side: 'ally', selection,
+});
+
+describe('rowScanOrder — caster row, descend with wraparound', () => {
+    it('T -> [T,M,B]', () => expect(rowScanOrder('T')).toEqual(['T', 'M', 'B']));
+    it('M -> [M,B,T]', () => expect(rowScanOrder('M')).toEqual(['M', 'B', 'T']));
+    it('B -> [B,T,M]', () => expect(rowScanOrder('B')).toEqual(['B', 'T', 'M']));
+});
+
+describe('selectTargets — ally side anchors on the caster', () => {
+    it('team/others/all/self all anchor on caster, ordered [caster]', () => {
+        for (const sel of ['team', 'others', 'all', 'self'] as const) {
+            const r = selectTargets(ally(sel), { casterPosition: 'M2', enemyOccupied: [], allyOccupied: ['M2', 'M3'] });
+            expect(r).toEqual({ ordered: ['M2'], anchor: 'M2' });
+        }
+    });
+});
+
+describe('selectTargets — empty enemy side', () => {
+    it('returns null anchor', () => {
+        expect(selectTargets(enemy('front'), { casterPosition: 'M2', enemyOccupied: [] }))
+            .toEqual({ ordered: [], anchor: null });
+    });
+});
+
+describe('selectTargets — within-row front/back/skip (caster M4 vs enemies M4,M2,M1)', () => {
+    const ctx = { casterPosition: 'M4' as const, enemyOccupied: ['M4', 'M2', 'M1'] as const };
+    it('front -> [M4,M2,M1], anchor M4', () => {
+        expect(selectTargets(enemy('front'), ctx)).toEqual({ ordered: ['M4', 'M2', 'M1'], anchor: 'M4' });
+    });
+    it('skip -> [M2,M1,M4], anchor M2', () => {
+        expect(selectTargets(enemy('skip'), ctx)).toEqual({ ordered: ['M2', 'M1', 'M4'], anchor: 'M2' });
+    });
+    it('back -> [M1,M2,M4], anchor M1', () => {
+        expect(selectTargets(enemy('back'), ctx)).toEqual({ ordered: ['M1', 'M2', 'M4'], anchor: 'M1' });
+    });
+});
+
+describe('selectTargets — single/two occupied fallbacks (caster M4)', () => {
+    it('skip with two enemies M4,M1 -> anchor M1, ordered [M1,M4]', () => {
+        expect(selectTargets(enemy('skip'), { casterPosition: 'M4', enemyOccupied: ['M4', 'M1'] }))
+            .toEqual({ ordered: ['M1', 'M4'], anchor: 'M1' });
+    });
+    it('one enemy M4: front/back/skip all -> [M4], anchor M4', () => {
+        for (const sel of ['front', 'back', 'skip'] as const) {
+            expect(selectTargets(enemy(sel), { casterPosition: 'M4', enemyOccupied: ['M4'] }))
+                .toEqual({ ordered: ['M4'], anchor: 'M4' });
+        }
+    });
+});
+
+describe('selectTargets — row-first scan (caster M, enemies only in top row T1,T3)', () => {
+    it('front descends M(empty)->B(empty)->T, picks front-most T3', () => {
+        expect(selectTargets(enemy('front'), { casterPosition: 'M2', enemyOccupied: ['T1', 'T3'] }))
+            .toEqual({ ordered: ['T3', 'T1'], anchor: 'T3' });
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm test -- src/utils/targeting/__tests__/selectTargets.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement** — create `selectTargets.ts`:
+
+```ts
+import { Position } from '../../types/encounters';
+import { ParsedTarget } from '../targetingParser';
+import { BoardRow, rowOf, colOf } from './board';
+
+export interface SelectTargetsContext {
+    /** The acting actor's own cell — REQUIRED (drives the row scan). */
+    casterPosition: Position;
+    /** Living, targetable enemy cells in the acting side's own frame (≤1 actor per cell). */
+    enemyOccupied: Position[];
+    /** Forward-looking (Phase-4 ally splash). UNUSED in Phase-2 selection. */
+    allyOccupied?: Position[];
+}
+
+export interface SelectionResult {
+    /** Full ordered target list; head === anchor. */
+    ordered: Position[];
+    /** null when the requested side has no living target. */
+    anchor: Position | null;
+}
+
+const ROWS: BoardRow[] = ['T', 'M', 'B'];
+
+/** Row scan order: start at the caster's row, descend a row, wrap bottom->top. */
+export function rowScanOrder(casterRow: BoardRow): BoardRow[] {
+    const i = ROWS.indexOf(casterRow);
+    return [ROWS[i], ROWS[(i + 1) % 3], ROWS[(i + 2) % 3]];
+}
+
+/** Occupied cells of `row`, sorted front->back (column 4 first). */
+function colsFrontToBack(row: BoardRow, occupied: Position[]): Position[] {
+    return occupied.filter((p) => rowOf(p) === row).sort((a, b) => colOf(b) - colOf(a));
+}
+
+export function selectTargets(target: ParsedTarget, ctx: SelectTargetsContext): SelectionResult {
+    // Ally side: support patterns anchor on the caster's own cell.
+    if (target.side === 'ally') {
+        return { ordered: [ctx.casterPosition], anchor: ctx.casterPosition };
+    }
+
+    // Enemy side.
+    if (ctx.enemyOccupied.length === 0) {
+        return { ordered: [], anchor: null };
+    }
+
+    const scan = rowScanOrder(rowOf(ctx.casterPosition));
+
+    // `all`: every living enemy, row-scan order then front->back within each row.
+    if (target.selection === 'all') {
+        const ordered = scan.flatMap((row) => colsFrontToBack(row, ctx.enemyOccupied));
+        return { ordered, anchor: ordered[0] };
+    }
+
+    // front/back/skip: first row in scan order with >=1 enemy.
+    const targetRow = scan.find((row) => ctx.enemyOccupied.some((p) => rowOf(p) === row))!;
+    const cols = colsFrontToBack(targetRow, ctx.enemyOccupied); // front->back
+
+    let ordered: Position[];
+    switch (target.selection) {
+        case 'back':
+            ordered = [...cols].reverse();
+            break;
+        case 'skip':
+            // 2nd-from-front anchor; continue toward the back, skipped front-most goes last.
+            // length 1 -> degrades to [cols[0]] (== front).
+            ordered = cols.length === 1 ? cols : [...cols.slice(1), cols[0]];
+            break;
+        case 'front':
+        default:
+            ordered = cols;
+            break;
+    }
+    return { ordered, anchor: ordered[0] };
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm test -- src/utils/targeting/__tests__/selectTargets.test.ts` → PASS.
+
+- [ ] **Step 5: Lint + types**
+
+Run: `npm run lint && npx tsc --noEmit` → clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/targeting/selectTargets.ts src/utils/targeting/__tests__/selectTargets.test.ts
+git commit -m "feat(targeting): selectTargets — row-first anchor selection (front/back/skip/ally)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task A3: `selectTargets` — enemy `all` cross-row ordering
+
+**Files:**
+- Test: `src/utils/targeting/__tests__/selectTargets.test.ts` (append)
+
+(The implementation already handles `all` in A2; this task pins its cross-row behavior with
+dedicated goldens. If A2's `all` branch is already covered, this is a fast confirmation
+task — still write the explicit cross-row golden.)
+
+- [ ] **Step 1: Write failing/confirming test** — append:
+
+```ts
+describe('selectTargets — enemy all spans every row in scan order (caster M2)', () => {
+    it('orders M row first (front->back), then B, then T', () => {
+        const r = selectTargets(
+            { raw: 'all', side: 'enemy', selection: 'all' },
+            { casterPosition: 'M2', enemyOccupied: ['T1', 'B3', 'M1', 'M4'] }
+        );
+        // scan M,B,T: M front->back = M4,M1 ; B = B3 ; T = T1
+        expect(r.ordered).toEqual(['M4', 'M1', 'B3', 'T1']);
+        expect(r.anchor).toBe('M4');
+    });
+});
+```
+
+- [ ] **Step 2: Run** → PASS (already implemented). If it FAILS, fix the `all` branch in
+`selectTargets.ts` to match.
+
+- [ ] **Step 3: Commit** (only if any change was needed; otherwise fold into A2's commit by
+running before committing A2 — implementer's choice).
+
+```bash
+git add src/utils/targeting/__tests__/selectTargets.test.ts
+git commit -m "test(targeting): pin selectTargets enemy-all cross-row ordering
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Part B — Engine input model + internal selection helper (no behavior change)
+
+> Goal: add the optional plumbing and the internal helper, **consumed by nothing yet**.
+> After every task in Part B the full suite + all DPS/healing goldens stay **byte-identical**.
+
+### Task B1: optional position/target fields on the engine input
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts` (`CombatEngineInput` ~716; `TeamActorEngineInput`;
+  the `enemyAttackers` entry type ~768)
+
+Read the current `CombatEngineInput`, `TeamActorEngineInput`, and the `enemyAttackers` entry
+shape first.
+
+- [ ] **Step 1: Add optional fields (no consumption):**
+  - `CombatEngineInput`: `position?: Position;` and `target?: ParsedTarget;` (the focus
+    attacker's cell + parsed targeting).
+  - `TeamActorEngineInput`: `position?: Position;` and `target?: ParsedTarget;`.
+  - `enemyAttackers[]` entry: `position?: Position;` and `target?: ParsedTarget;`.
+  - Add imports: `import { Position } from '../../types/encounters';` and
+    `import { ParsedTarget } from '../targetingParser';` (check they aren't already imported).
+
+- [ ] **Step 2: Verify nothing consumes them yet** — `npx tsc --noEmit` clean; no logic
+  references the new fields.
+
+- [ ] **Step 3: Run full suite + goldens**
+
+Run: `npm test`
+Expected: ALL pass, goldens byte-identical (optional fields, zero behavior change).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/combat/engine.ts
+git commit -m "feat(combat): optional position/target fields on engine input (positional plumbing)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task B2: internal `resolvePositionalTarget` helper (built, still unused)
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts`
+- Test: `src/utils/combat/__tests__/positionalSelection.test.ts` (create)
+
+Add an engine-internal helper that, given an acting actor's position + parsed target and the
+*living, positioned* actors of the opposing side, returns the selected `CombatActor` (or
+`null`). This is the bridge between `selectTargets` (Positions) and the engine (actors).
+
+- [ ] **Step 1: Write the helper.** Place it near the actor setup (after `createActor`
+  helpers). Sketch:
+
+```ts
+import { selectTargets } from '../targeting/selectTargets';
+// ...
+
+/** True when positional selection should run for `actor` against `opposingLiving`:
+ *  a positioned opposing roster exists AND the acting actor has a position. */
+function isPositional(actorPosition: Position | undefined, opposingLiving: CombatActor[]): boolean {
+    return !!actorPosition && opposingLiving.some((a) => a.position !== undefined);
+}
+
+/** Map the selectTargets anchor back to a single living positioned opposing actor.
+ *  Returns null when no valid target (empty side / anchor null). Invariant: ≤1 actor/cell. */
+function resolvePositionalTarget(
+    actorPosition: Position,
+    target: ParsedTarget,
+    opposingLiving: CombatActor[]
+): CombatActor | null {
+    const byCell = new Map<Position, CombatActor>();
+    for (const a of opposingLiving) {
+        if (a.position !== undefined && a.currentHp > 0) byCell.set(a.position, a);
+    }
+    const { anchor } = selectTargets(target, {
+        casterPosition: actorPosition,
+        enemyOccupied: [...byCell.keys()],
+    });
+    return anchor ? byCell.get(anchor) ?? null : null;
+}
+```
+
+  - This requires `CombatActor` to carry an optional `position`. Add `position?: Position` to
+    the `CombatActor` interface (`src/utils/combat/state.ts`) and thread it through
+    `createActor` (default `undefined`); set it from the input `position` when the
+    attacker / team / enemy actors are constructed (still consumed by nothing downstream).
+
+- [ ] **Step 2: Unit-test the helper directly** in `positionalSelection.test.ts` by importing
+  the engine module is awkward (helper not exported). Instead **export `resolvePositionalTarget`
+  and `isPositional`** (or move them into a small `src/utils/combat/positionalBinding.ts`
+  module and import into engine.ts — preferred for testability and to keep engine.ts focused).
+  Test with hand-built `CombatActor`-shaped objects:
+
+```ts
+// front caster vs positioned enemies front M4 / back M1 -> selects M4 actor
+// skip -> selects M1 actor (2nd from front; or fallback)
+// no caster position -> isPositional false
+// all enemies dead -> resolvePositionalTarget returns null
+```
+
+- [ ] **Step 3: Run** the new test → PASS. Run full suite → goldens byte-identical (helper
+  unused by the turn loop; `position` set but not read).
+
+- [ ] **Step 4: Lint + types** clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/ src/utils/targeting/
+git commit -m "feat(combat): positional target-resolution helper (built, unused)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Part C — Wire the gated positional branch into the binding sites
+
+> Each task gates strictly on `isPositional(...)`. With no positions passed, every branch
+> takes the existing path → goldens byte-identical. **Scoped OUT of Phase 2** (Phase 4):
+> multi-enemy DoT/bomb ticking, per-target cumulative HP decline, per-target damage
+> accounting. Phase-2 tests assert *selection* (which actor is bound / receives), not totals.
+
+### Task C1: player attacker → selected enemy (focus turn, engine.ts ~2360)
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts` (focus-turn `runPlayerTurn` call ~2360)
+- Test: `src/utils/combat/__tests__/positionalSelection.test.ts`
+
+Read the focus-turn `runPlayerTurn({...})` call (~2360) and how `enemy`, `targetId`,
+`enemyDefense`, `enemyHpDecline`, and the DoT containers are passed. The dummy `enemy`
+(created ~969) is the current binding.
+
+- [ ] **Step 1: Write failing engine test** — synthetic input with the focus attacker
+  positioned and a positioned enemy roster (use `enemyAttackers` entries given `position`
+  + zero/low attack so they're pure targets; the attacker's `target` = `front`). Tap the
+  `bus` and assert the focus attacker's `ability-performed` event carries
+  `targetId === <front enemy id>`. Add a second case: `target` = `back` → `targetId` ===
+  back enemy id. (See Task C3 / the spec for how `enemyAttackers` become positioned targets;
+  confirm enemy-attacker actors are built into `enemyAttackerActors` regardless of healing
+  mode, or set `healTargetId` to enable that path — document whichever the test needs.)
+
+- [ ] **Step 2: Run** → FAIL (still binds the dummy; targetId === 'enemy').
+
+- [ ] **Step 3: Implement the gated branch** at the focus-turn call: compute
+  `const selectedEnemy = isPositional(focusPosition, enemyAttackerActors) ? resolvePositionalTarget(focusPosition!, focusTarget!, enemyAttackerActors) : null;`
+  then when `selectedEnemy`:
+  - bind `enemy: selectedEnemy`, `targetId: selectedEnemy.id`,
+  - pass `selectedEnemy`'s DoT/bomb/accumulator containers,
+  - `enemyDefense: selectedEnemy.stats.defence`, `enemyHp: <selectedEnemy max hp>`,
+  - `enemyHpDecline: 0` (per-target decline is Phase 4 — see spec).
+  Otherwise the existing dummy binding, unchanged.
+  - If `isPositional` but `selectedEnemy` is null (no living target), skip the attack /
+    no-op for this action (document the chosen no-op; death-fallback is Phase 4).
+
+- [ ] **Step 4: Run** the new test → PASS. **Run full suite → goldens byte-identical.** If a
+  golden moved, the gate is leaking (a non-positional input entered the branch) — fix the
+  gate; do NOT update the golden.
+
+- [ ] **Step 5: Lint + types** clean. **Commit.**
+
+```bash
+git commit -am "feat(combat): positional target selection for player attacker (focus turn)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task C2: team actors → selected enemy (team turn, engine.ts ~2450)
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts` (team-turn `runPlayerTurn` call ~2450)
+- Test: `positionalSelection.test.ts`
+
+- [ ] **Step 1: Write failing test** — a positioned *team actor* (with its own `target`)
+  selecting among the positioned enemy roster; assert its `ability-performed` `targetId` is
+  the correctly-selected enemy (e.g. team actor in row B, `front` → enemy front-most in the
+  scan from B).
+
+- [ ] **Step 2: Run** → FAIL (binds dummy).
+
+- [ ] **Step 3: Implement** the same gated branch at the team-turn call, using the team
+  actor's `position` + `target` (carried on its `CombatActor` / `TeamActorEngineInput`).
+  Reuse `resolvePositionalTarget`.
+
+- [ ] **Step 4: Run** new test → PASS; **full suite goldens byte-identical.**
+
+- [ ] **Step 5: Lint + types clean. Commit.**
+
+```bash
+git commit -am "feat(combat): positional target selection for team actors
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task C3: enemy attackers → selected player actor (enemy turn, engine.ts ~2700) — side-symmetry
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts` (enemy-attacker `runPlayerTurn` call ~2700;
+  `applyIncomingToTarget` ~2814)
+- Test: `positionalSelection.test.ts`
+
+Read the enemy-attacker binding (~2700, `enemy: healTarget!`) and `applyIncomingToTarget`
+(~2814) which applies the enemy's damage to the heal target.
+
+- [ ] **Step 1: Write failing test** — positioned player team (focus + a team actor, each
+  with `position`), a positioned enemy attacker with `target` = `front`, `healTargetId` set
+  so the enemy walk runs. Assert the enemy's incoming routes to the *selected* player actor
+  (the one `selectTargets` picks from the enemy's frame over the player team), not
+  unconditionally to `healTargetId`. Observe via that actor's incoming/HP (the
+  `applyIncomingToTarget` target).
+
+- [ ] **Step 2: Run** → FAIL (always hits `healTarget`).
+
+- [ ] **Step 3: Implement** the gated branch: the opposing side for an enemy attacker is the
+  *player team* = `allPlayerActors`. When
+  `isPositional(enemyActor.position, allPlayerActors)`, compute
+  `selectedPlayer = resolvePositionalTarget(enemyActor.position!, enemyTarget!, allPlayerActors)`,
+  and bind `enemy: selectedPlayer`, `targetId: selectedPlayer.id`, and route
+  `applyIncomingToTarget` to `selectedPlayer` (generalize the helper from the hard-coded
+  `healTarget`). Otherwise the existing `healTarget` binding.
+  - `selectedPlayer` null → no-op for this enemy action (Phase-4 death-fallback note).
+
+- [ ] **Step 4: Run** new test → PASS; **full suite goldens byte-identical** (no caller
+  passes enemy positions).
+
+- [ ] **Step 5: Lint + types clean. Commit.**
+
+```bash
+git commit -am "feat(combat): positional target selection for enemy attackers (side-symmetric)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task C4: documentation + changelog
+
+**Files:**
+- Modify: `src/pages/DocumentationPage.tsx` (only if a user-facing surface changed — it does
+  NOT this phase; capability-only, no UI). **Likely skip.**
+- Modify: `src/constants/changelog.ts` — **skip**: no user-visible behavior change this
+  phase (no caller passes positions). Add a changelog entry only when the simulator (Phase 5)
+  exposes it.
+
+- [ ] **Step 1:** Confirm no user-facing behavior changed; record in the PR description that
+  this is engine-capability-only with goldens byte-identical. No changelog/doc edit.
+
+---
+
+## Final verification (before requesting review / PR)
+
+- [ ] `npm test` — full suite green; **all DPS/healing goldens byte-identical** (diff the
+  golden files against `main` to be certain).
+- [ ] `npm run lint` — 0 warnings.
+- [ ] `npx tsc --noEmit` — clean.
+- [ ] Re-read the spec's success criteria and confirm each is met.
+- [ ] `git diff main --stat` — only `src/utils/targeting/*`, `src/utils/combat/*` (+ the new
+  test files) changed; no golden file content changed.
+- [ ] Request code review (superpowers:requesting-code-review) before opening the PR.
+
+## Notes for the executor
+
+- **The fragile part is Part C.** The single safety property is: *no caller passes positions,
+  so `isPositional` is always false in every existing test → the existing path runs → goldens
+  byte-identical.* If any golden changes, STOP — the gate leaked; fix the predicate.
+- Phase-2 tests assert **selection** (which actor is bound / which `targetId` is emitted /
+  which player actor receives), never per-target damage totals (that accounting is Phase 4).
+- `resolveCells` (the geometry footprint resolver) is intentionally **not** imported by the
+  engine this phase.
+- Prefer extracting `selectTargets`-to-actor glue into `src/utils/combat/positionalBinding.ts`
+  to keep `engine.ts` from growing and to make the helper unit-testable without the engine.

--- a/docs/superpowers/specs/2026-06-14-positional-target-selection-design.md
+++ b/docs/superpowers/specs/2026-06-14-positional-target-selection-design.md
@@ -210,8 +210,28 @@ enemy attacker's `healTarget` binding (engine.ts ~2700–2747) — branch on pos
 team via the *same* `selectTargets`; their incoming routes through the existing
 `applyIncomingToTarget` path, generalized from "the heal target" to "the selected actor".
 
-**DPS HP%-gates:** in positional mode read the selected anchor's real `currentHp` (each
-positioned enemy is a real HP-tracking actor) rather than the dummy-sink cumulative scalar.
+**DPS HP%-gates:** in positional mode the attacker's turn resolves against the selected
+anchor's stat-block (its `defence` / entering `currentHp` drive the damage calc and
+HP%-gates) rather than the dummy sink.
+
+**Observability & the per-target-HP boundary (defines what Phase 2 can assert):** the engine
+credits damage by *source* actor, not target — there is no per-target damage record on the
+player→enemy direction (the dummy tracks only a cumulative scalar). Per-target damage
+accounting is Phase 4. So Phase 2's observable is the **binding itself**:
+
+- **player→enemy:** the attacker's `runPlayerTurn` is bound to the selected enemy actor
+  (`enemy:` arg), so the emitted `ability-performed` event carries `targetId = selected
+  enemy id` and the damage calc uses that enemy's `defence`. **Tests assert the emitted
+  `targetId`.**
+- **enemy→player:** the enemy attacker binds to the selected player actor and its incoming
+  routes through `applyIncomingToTarget` to that actor — observable via that actor's
+  incoming/HP, exactly as today's heal-target path is.
+
+Consequently **per-target HP does not *decline* from accumulated damage in Phase 2** (no
+per-target cumulative): HP%-gates evaluate against each positioned target's *entering* HP.
+The global `enemyHpDecline` scalar (which models the single dummy's decline) is **not**
+applied to a selected real target — `enemyHpDecline: 0` for that binding. Per-target HP
+accumulation/decline arrives with Phase-4 accounting.
 
 ### Data flow
 

--- a/docs/superpowers/specs/2026-06-14-positional-target-selection-design.md
+++ b/docs/superpowers/specs/2026-06-14-positional-target-selection-design.md
@@ -1,0 +1,242 @@
+# Positional Target-Selection (Engine) — Design
+
+**Date:** 2026-06-14
+**Status:** Approved (design), pending spec review
+**Phase:** Positional combat — piece 2 of 5 (engine target selection)
+
+## Context
+
+The positional-combat arc is decomposed into five sequential sub-projects:
+
+1. **Board geometry resolver** (PR #106) — pure: pattern + anchor → covered cells.
+2. **Engine positional target selection** (this spec) — column/row-priority + anchor
+   selection, wired into the engine, side-symmetric.
+3. Forced targeting (Taunt/Provoke/Concentrate Fire) + stealth.
+4. Multi-target consequences (AoE accounting, death-fallback retargeting, dead-recipient
+   filtering, Harvester on-ally-destroyed, per-actor-per-side results).
+5. Simulator page.
+
+Pieces 1 (geometry resolver, `src/utils/targeting/`) and the data foundation (PR #105,
+`src/utils/targetingParser.ts` → `ParsedTarget` / `ParsedPattern`) are merged. This spec is
+piece 2.
+
+### The problem this phase solves
+
+The combat engine today is pure focus-fire with **no target choice**:
+
+- Every player actor (attacker + team) attacks a single dummy `enemy` stat-block (DPS mode)
+  — the damage *sink*; its HP is never reduced, only a cumulative-damage scalar is tracked
+  for HP%-gates.
+- In healing mode, enemy attackers all hit the pre-bound `healTarget`.
+
+There is no board, no multiple targetable ships, and no selection logic anywhere. Real
+positional *selection* (which enemy gets hit) only becomes meaningful once the receiving
+side is a *positioned team of several ships*. This phase introduces that capability.
+
+### Scope decisions (ratified during brainstorming)
+
+- **Approach: optional positioned overlay on the existing engine** (not a new
+  team-agnostic entry point, not a positions-drive-selection-but-funnel-to-sink stub).
+  Positions are an *optional* addition; when present, target binding routes through a new
+  selection step; when absent, the engine behaves exactly as today.
+- **Capability-only — no UI.** No production caller passes positions in this phase. The
+  existing DPS/healing calculators are untouched and hit the backward-compat fallback, so
+  all existing goldens stay **byte-identical**. The new positional path is exercised solely
+  by new synthetic engine tests. The Phase-5 simulator becomes the first real caller.
+- **Full ordered-list selection, single-anchor apply.** `selectTargets` resolves every
+  target type to an ordered target list, but Phase 2 only *applies* to the **primary
+  anchor** (list head). `front`/`back`/`skip` (122 of the 147 corpus ships) get their
+  complete, correct single-target behavior now. The inherently multi-target selections
+  (`all`, ally `team`/`others`/`all-allies`) resolve to an ordered list + a deterministic
+  primary anchor; the *splash to the rest of the list* is deferred to Phase 4.
+
+## Non-goals (later phases)
+
+- Covered-cell AoE application and the role→damage-multiplier mapping (origin ×1.0,
+  covered ×0.5) — Phase 4. `resolveCells` is therefore **not wired into the engine** this
+  phase.
+- Stealth exclusion and forced targeting (Taunt/Provoke/Concentrate Fire) — Phase 3.
+- Death-fallback retargeting (a target dies mid-resolution → retarget), dead-recipient
+  filtering polish, per-actor-per-side result/reporting surface — Phase 4.
+- Any UI or simulator work — Phase 5.
+
+Phase 2 selects over the **living set at selection time** and stops there.
+
+## Confirmed selection model (ground-truth, user-ratified)
+
+Targeting is **row-first, then column within the row**. (Rows map directly between the two
+boards — T↔T, M↔M, B↔B — even though the columns are a horizontal mirror; see the geometry
+resolver spec.)
+
+### Row priority
+
+Scan starts at the **caster's own row** and **descends with wraparound** (down a row;
+bottom wraps to top), covering all three rows:
+
+| Caster row | Row scan order |
+|------------|----------------|
+| T | T, M, B |
+| M | M, B, T |
+| B | B, T, M |
+
+`targetRow` = the **first row in that order that contains ≥1 living enemy**.
+
+Example: a front attacker in the middle row, with an enemy only in the top row → scan
+M (empty), B (empty), T (occupied) → targetRow = T.
+
+### Column within the target row
+
+Let `cols` = the occupied columns of `targetRow`, sorted **front→back** (column 4 is the
+front / nearest the attacker; column 1 is the back). Then:
+
+| Selection | Anchor | Ordered list | Single-enemy fallback |
+|-----------|--------|--------------|-----------------------|
+| `front` | front-most (`cols[0]`) | `cols` (front→back) | — |
+| `back` | back-most (`cols[last]`) | `cols` reversed (back→front) | that enemy |
+| `skip` | 2nd-from-front (`cols[1]`) | `[cols[1], cols[2], …, cols[last], cols[0]]` — continue toward the back, the skipped front-most goes **last** | that enemy |
+
+Worked example — enemies at M4, M2, M1 (`cols = [4, 2, 1]`):
+
+- `front` → ordered `[M4, M2, M1]`, anchor M4
+- `skip`  → ordered `[M2, M1, M4]`, anchor M2
+- `back`  → ordered `[M1, M2, M4]`, anchor M1
+
+### Enemy `all` and ally selections
+
+- **`all` (enemy)** → ordered list = every living enemy, in (row-scan order, then front→back
+  within each row); anchor = head. (Splash to the full list is Phase 4.)
+- **Ally `team` / `others` / `all-allies` / `self`** → support patterns **anchor on the
+  caster's own cell** (the geometry resolver's confirmed rule); the `not-self`/`others`
+  exclusion is already baked into the pattern offset tables. So for `side: 'ally'`,
+  `anchor = casterPosition`. The ordered ally list (for Phase-4 splash) is the caster-frame
+  footprint, not a selection scan.
+
+### Empty side
+
+No living targets on the requested side → `anchor: null` (the engine treats this as "no
+valid target for this action"; death-fallback *retargeting* is Phase 4).
+
+## Design
+
+### New pure module — `src/utils/targeting/selectTargets.ts`
+
+Sits beside `board.ts` / `patternOffsets.ts` / `resolvePattern.ts`; dependency-free, fully
+unit-tested — the same isolation as the rest of the geometry layer.
+
+```ts
+export interface SelectTargetsContext {
+  casterPosition: Position;
+  enemyOccupied: Position[]; // living, targetable enemy cells (own frame)
+  allyOccupied: Position[];  // living ally cells, including the caster
+}
+
+export interface SelectionResult {
+  ordered: Position[];        // full ordered target list (head = anchor)
+  anchor: Position | null;    // null when the requested side has no living target
+}
+
+export function selectTargets(
+  target: ParsedTarget,        // from targetingParser: { side, selection, raw }
+  ctx: SelectTargetsContext
+): SelectionResult;
+```
+
+Algorithm:
+
+1. **Ally side** (`target.side === 'ally'`): `anchor = ctx.casterPosition`; `ordered` =
+   `[casterPosition]` for Phase 2 (full ally footprint is Phase-4 splash). `self` is the
+   same — caster only.
+2. **Enemy side:** if `ctx.enemyOccupied` is empty → `{ ordered: [], anchor: null }`.
+3. Compute the row scan order from `casterPosition`'s row (table above). Pick `targetRow` =
+   first row in that order with ≥1 cell in `enemyOccupied`.
+4. `cols` = occupied columns of `targetRow`, sorted front→back.
+5. Apply the `selection` rule (table above) to produce `ordered`; `anchor = ordered[0]`.
+   For `all`, `ordered` spans every living enemy across rows (row-scan order, front→back
+   within row).
+
+The row/column helpers (`rowScanOrder(row)`, `colsFrontToBack`) live in or beside
+`board.ts` (which already encodes "col 4 = front" and row/column extraction from a
+`Position`).
+
+### Engine integration (`src/utils/combat/engine.ts`, `playerTurn.ts`)
+
+**Positions in the model (all optional):**
+
+- `position?: Position` on the attacker input, each team actor input, and each enemy
+  attacker input.
+- A new optional **positioned enemy roster** input: real `CombatActor`s (built with the
+  existing `createActor`, carrying HP + DoT/bomb/accumulator containers like enemy
+  attackers already do). Player team actors are already real `CombatActor`s — they gain a
+  `position` and become targetable.
+
+**Positional mode detection:** "positions present on the relevant actors + a positioned
+receiving roster." When false, every binding below uses today's exact path.
+
+**Target binding (the seam):** at the points where the target is currently hard-coded —
+the player attacker's `enemy` (engine.ts ~969 / damage emission in `runPlayerTurn`) and the
+enemy attacker's `healTarget` binding (engine.ts ~2700–2747) — branch on positional mode:
+
+- **Positional:** build `enemyOccupied` / `allyOccupied` from *living* positioned actors
+  (own frame for the acting side), call `selectTargets`, map the returned `anchor` Position
+  → the actor occupying that cell → that actor is the target for this action.
+- **Non-positional:** today's binding (dummy sink for player attacks; `healTarget` for
+  enemy attacks). **Goldens byte-identical.**
+
+**Single-target apply:** only the anchor actor takes damage. `resolveCells` is not invoked.
+
+**Side-symmetry:** enemy attackers in positional mode select among the positioned player
+team via the *same* `selectTargets`; their incoming routes through the existing
+`applyIncomingToTarget` path, generalized from "the heal target" to "the selected actor".
+
+**DPS HP%-gates:** in positional mode read the selected anchor's real `currentHp` (each
+positioned enemy is a real HP-tracking actor) rather than the dummy-sink cumulative scalar.
+
+### Data flow
+
+```
+ParsedTarget (targetingParser) ─┐
+                                 ├─► selectTargets(target, ctx) ─► { ordered, anchor }
+caster + living occupied cells ─┘                                        │
+                                                                         ▼
+                                              engine maps anchor Position → CombatActor
+                                              → single-target damage apply (anchor only)
+```
+
+## Testing
+
+- **`selectTargets` unit + golden tests:** named goldens (board layout in the test name, to
+  eyeball against the game) for: row-scan with caster-row wraparound (incl. the
+  empty-near-rows case); `front`/`back`/`skip` column choice + ordered list on the
+  M4/M2/M1 worked example; `skip`/`back` single-occupied fallback; `all` cross-row ordering;
+  ally→caster anchor; empty-side `null`.
+- **Engine integration tests (synthetic positioned teams):** damage routes to the *selected*
+  anchor (front attacker hits front enemy; same-row-empty descends to the next row;
+  skip/back pick the right cell); a side-symmetric case (enemy attacker selecting among a
+  positioned player team and routing incoming to the selected actor).
+- **Regression:** full existing suite + all DPS/healing goldens **byte-identical** — the
+  fallback path proves no caller passes positions.
+- **Optional verification aid:** an HTML board visualization for selection cases, mirroring
+  the geometry-resolver verification path, if the maintainer wants to eyeball the row-scan.
+
+## Risks / notes
+
+- **The row/column tiebreaks are the ground-truth-sensitive part.** They live in one
+  documented place (`selectTargets` + the row-scan table) and are pinned by named golden
+  tests; a correction is a one-line edit + golden update — the same containment the offset
+  tables use.
+- **Touching the engine's most fragile seam** (the hard-coded target binding). Mitigation:
+  the positional branch is strictly additive and gated; the non-positional path is
+  unchanged and proven byte-identical by the golden regression. The selection seam is built
+  **side-symmetric**, so it is the team-agnostic seam the simulator (Phase 5) inherits — not
+  throwaway scaffolding.
+- **`resolveCells` stays unused by the engine** until Phase 4; computing footprints now
+  would be dead work given single-target apply.
+
+## Success criteria
+
+- `selectTargets` reproduces the confirmed row-first / within-row model, including the
+  M4/M2/M1 worked example and the caster-row wraparound.
+- In positional mode, player attacks and enemy attacks both route single-target damage to
+  the `selectTargets` anchor, via the same machinery (side-symmetric).
+- No caller passes positions → existing behavior unchanged; all DPS/healing goldens
+  byte-identical; full suite green; `lint` + `tsc` clean.

--- a/docs/superpowers/specs/2026-06-14-positional-target-selection-design.md
+++ b/docs/superpowers/specs/2026-06-14-positional-target-selection-design.md
@@ -122,8 +122,10 @@ Worked examples:
 
 ### Empty side
 
-No living targets on the requested side → `anchor: null` (the engine treats this as "no
-valid target for this action"; death-fallback *retargeting* is Phase 4).
+No living targets on the requested side → `anchor: null`. In Phase 2 the engine handles a
+null anchor by **falling back to the legacy dummy/heal-target binding** (the golden-safe
+minimal choice — only the positive-selection path diverges from today). A true no-op or
+death-fallback *retargeting* is Phase 4.
 
 ## Design
 
@@ -200,7 +202,7 @@ enemy attacker's `healTarget` binding (engine.ts ~2700–2747) — branch on pos
 - **Positional:** build the living-positioned `Map<Position, CombatActor>` for the target
   side (own frame for the acting side), call `selectTargets` with its keys as
   `enemyOccupied`, map the returned `anchor` Position → that map's actor → the target for
-  this action. (`anchor: null` → no valid target this action.)
+  this action. (`anchor: null` → fall back to the legacy binding below; Phase-2 minimal.)
 - **Non-positional:** today's binding (dummy sink for player attacks; `healTarget` for
   enemy attacks). **Goldens byte-identical.**
 

--- a/docs/superpowers/specs/2026-06-14-positional-target-selection-design.md
+++ b/docs/superpowers/specs/2026-06-14-positional-target-selection-design.md
@@ -89,17 +89,26 @@ M (empty), B (empty), T (occupied) → targetRow = T.
 Let `cols` = the occupied columns of `targetRow`, sorted **front→back** (column 4 is the
 front / nearest the attacker; column 1 is the back). Then:
 
-| Selection | Anchor | Ordered list | Single-enemy fallback |
-|-----------|--------|--------------|-----------------------|
-| `front` | front-most (`cols[0]`) | `cols` (front→back) | — |
-| `back` | back-most (`cols[last]`) | `cols` reversed (back→front) | that enemy |
-| `skip` | 2nd-from-front (`cols[1]`) | `[cols[1], cols[2], …, cols[last], cols[0]]` — continue toward the back, the skipped front-most goes **last** | that enemy |
+| Selection | Anchor | Ordered list |
+|-----------|--------|--------------|
+| `front` | front-most (`cols[0]`) | `cols` (front→back) |
+| `back` | back-most (`cols[last]`) | `cols` reversed (back→front) |
+| `skip` | 2nd-from-front (`cols[1]`) | `[cols[1], cols[2], …, cols[last], cols[0]]` — continue toward the back, the skipped front-most goes **last** |
 
-Worked example — enemies at M4, M2, M1 (`cols = [4, 2, 1]`):
+`front` and `back` degrade naturally for any `cols.length ≥ 1` (no special case). **`skip`
+needs a single-occupied fallback:** when `cols.length === 1`, `skip` resolves like `front`
+— `ordered = cols`, anchor `cols[0]`. (So for `cols.length === 1`, all three selections
+yield `ordered = cols`, anchor `cols[0]`.)
 
-- `front` → ordered `[M4, M2, M1]`, anchor M4
-- `skip`  → ordered `[M2, M1, M4]`, anchor M2
-- `back`  → ordered `[M1, M2, M4]`, anchor M1
+Worked examples:
+
+- 3 enemies at M4, M2, M1 (`cols = [4, 2, 1]`):
+  - `front` → ordered `[M4, M2, M1]`, anchor M4
+  - `skip`  → ordered `[M2, M1, M4]`, anchor M2
+  - `back`  → ordered `[M1, M2, M4]`, anchor M1
+- 2 enemies at M4, M1 (`cols = [4, 1]`): `skip` → anchor `cols[1]` = M1, ordered
+  `[cols[1], cols[0]] = [M1, M4]`.
+- 1 enemy at M4 (`cols = [4]`): `front`/`back`/`skip` all → anchor M4, ordered `[M4]`.
 
 ### Enemy `all` and ally selections
 
@@ -125,9 +134,9 @@ unit-tested — the same isolation as the rest of the geometry layer.
 
 ```ts
 export interface SelectTargetsContext {
-  casterPosition: Position;
-  enemyOccupied: Position[]; // living, targetable enemy cells (own frame)
-  allyOccupied: Position[];  // living ally cells, including the caster
+  casterPosition: Position;  // the acting actor's own cell — REQUIRED (drives the row scan)
+  enemyOccupied: Position[]; // living, targetable enemy cells (own frame); ≤1 actor per cell
+  allyOccupied?: Position[]; // forward-looking (Phase-4 ally splash); UNUSED in Phase-2 selection
 }
 
 export interface SelectionResult {
@@ -141,18 +150,19 @@ export function selectTargets(
 ): SelectionResult;
 ```
 
-Algorithm:
+Algorithm (branch on `target.side`/`selection` *before* the single-row work):
 
 1. **Ally side** (`target.side === 'ally'`): `anchor = ctx.casterPosition`; `ordered` =
    `[casterPosition]` for Phase 2 (full ally footprint is Phase-4 splash). `self` is the
-   same — caster only.
+   same — caster only. (`allyOccupied` is not consulted.)
 2. **Enemy side:** if `ctx.enemyOccupied` is empty → `{ ordered: [], anchor: null }`.
-3. Compute the row scan order from `casterPosition`'s row (table above). Pick `targetRow` =
-   first row in that order with ≥1 cell in `enemyOccupied`.
-4. `cols` = occupied columns of `targetRow`, sorted front→back.
-5. Apply the `selection` rule (table above) to produce `ordered`; `anchor = ordered[0]`.
-   For `all`, `ordered` spans every living enemy across rows (row-scan order, front→back
-   within row).
+3. **Enemy `all`:** iterate every row in `casterPosition`'s row-scan order, each row's cols
+   front→back; `ordered` = that full living-enemy list; `anchor = ordered[0]`. (Does **not**
+   use a single `targetRow`.) Return.
+4. **Enemy `front`/`back`/`skip`:** compute the row scan order from `casterPosition`'s row
+   (table above); `targetRow` = first row in that order with ≥1 cell in `enemyOccupied`;
+   `cols` = occupied columns of `targetRow`, sorted front→back; apply the within-row rule
+   (table above) to produce `ordered`; `anchor = ordered[0]`.
 
 The row/column helpers (`rowScanOrder(row)`, `colsFrontToBack`) live in or beside
 `board.ts` (which already encodes "col 4 = front" and row/column extraction from a
@@ -169,16 +179,28 @@ The row/column helpers (`rowScanOrder(row)`, `colsFrontToBack`) live in or besid
   attackers already do). Player team actors are already real `CombatActor`s — they gain a
   `position` and become targetable.
 
-**Positional mode detection:** "positions present on the relevant actors + a positioned
-receiving roster." When false, every binding below uses today's exact path.
+**Positional mode detection — exact predicate:** positional mode is on **iff a positioned
+receiving roster is supplied AND the acting actor has a `position`**. Any other shape
+(no roster, or the acting actor lacks a position) → non-positional fallback. This is the
+precondition that guarantees `selectTargets` always has a `casterPosition`; a
+partially-positioned input never enters the positional branch (so it can never half-bind or
+regress). When the predicate is false, every binding below uses today's exact path.
+
+**One-actor-per-cell invariant:** at most one living actor occupies any `Position`. The
+engine builds a `Map<Position, CombatActor>` over the *living, positioned* actors of the
+target side and feeds exactly that map's keys to `selectTargets` as `enemyOccupied`.
+`selectTargets` only ever returns Positions drawn from that input, so a non-null `anchor`
+always round-trips to exactly one actor. Actors without a `position` are **not** in the
+occupied set and are not targetable in positional mode.
 
 **Target binding (the seam):** at the points where the target is currently hard-coded —
 the player attacker's `enemy` (engine.ts ~969 / damage emission in `runPlayerTurn`) and the
 enemy attacker's `healTarget` binding (engine.ts ~2700–2747) — branch on positional mode:
 
-- **Positional:** build `enemyOccupied` / `allyOccupied` from *living* positioned actors
-  (own frame for the acting side), call `selectTargets`, map the returned `anchor` Position
-  → the actor occupying that cell → that actor is the target for this action.
+- **Positional:** build the living-positioned `Map<Position, CombatActor>` for the target
+  side (own frame for the acting side), call `selectTargets` with its keys as
+  `enemyOccupied`, map the returned `anchor` Position → that map's actor → the target for
+  this action. (`anchor: null` → no valid target this action.)
 - **Non-positional:** today's binding (dummy sink for player attacks; `healTarget` for
   enemy attacks). **Goldens byte-identical.**
 

--- a/src/utils/combat/__tests__/positionalSelection.test.ts
+++ b/src/utils/combat/__tests__/positionalSelection.test.ts
@@ -201,3 +201,86 @@ describe('Task C2 — walked team actor positional target selection (team turn)'
         expect(teamAbilityTargetId(input, 'team-1')).toBe('enemy-back');
     });
 });
+
+// ============================================================================
+// Task C3 — enemy attacker positional target selection (side-symmetric).
+//
+// The mirror of C1/C2: a positioned ENEMY attacker resolves its OWN parsed `target`
+// against the positioned PLAYER team (`allPlayerActors` = focus + walked team), and its
+// incoming damage lands on the SELECTED player actor — not unconditionally on the heal
+// target.
+//
+// Layout: the player team has the focus attacker at M4 (col 4 = front-most) and a walked
+// team actor at M1 (col 1 = back-most). The enemy attacker at M4 selects `front`, so from
+// its frame the front-most player is the focus (M4). The heal target is the TEAM actor
+// (M1) — so the legacy (unrouted) path would always drain the team actor's HP, while the
+// positional path drains the SELECTED focus actor's HP instead.
+//
+// Observable: `hp-changed` events carry the `targetId` of whichever actor took the hit
+// (emitted from applyIncomingToTarget). The focus actor (selected) must show an hp-changed
+// crossing; the heal target (team, NOT selected) must not be the one that was hit.
+//
+// RED baseline: the enemy always bombards the heal target, so the hit lands on the team
+// actor (M1) and no hp-changed targets the focus → assertion FAILS. After the gated branch
+// + applyIncomingToTarget re-route, the focus actor (front-most) takes the hit.
+// ============================================================================
+
+// A real damaging enemy attacker positioned with its own parsed target.
+const damagingEnemyAt = (
+    id: string,
+    position: Position,
+    selection: ParsedTarget['selection']
+): EnemyAttacker =>
+    ({
+        id,
+        stats: {
+            attack: 5000,
+            crit: 0,
+            critDamage: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 1,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget(selection),
+        shipSkills: { slots: [basicAttack()] },
+    }) as EnemyAttacker;
+
+// Run a combat and return the set of distinct player actor ids that took an hp-changed hit.
+const hpChangedTargets = (input: CombatEngineInput): Set<string> => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    bus.on('hp-changed', (e) => events.push(e as CombatEvent));
+    runCombat({ ...input, bus });
+    return new Set(
+        events
+            .filter(
+                (e): e is Extract<CombatEvent, { type: 'hp-changed' }> => e.type === 'hp-changed'
+            )
+            .map((e) => e.targetId)
+    );
+};
+
+describe('Task C3 — enemy attacker positional target selection (side-symmetric)', () => {
+    it("routes the enemy's incoming damage to its OWN positional selection (front → focus M4), not the heal target (team M1)", () => {
+        idc = 0;
+        // Player team: focus at M4 (front-most), walked team actor at M1 (back-most).
+        // Heal target = the TEAM actor (M1) so the legacy path drains it; the positioned
+        // enemy at M4 selects `front` → the focus (M4) actor.
+        const input: CombatEngineInput = {
+            ...BASE('front'),
+            // Focus attacker should NOT itself attack the player team — it has its own enemy
+            // target; we only care about the enemy's incoming routing. Keep its basic attack.
+            healTargetId: 'team-1',
+            teamActors: [teamActorAt('team-1', 'M1', 'front')],
+            enemyAttackers: [damagingEnemyAt('enemy-atk', 'M4', 'front')],
+        };
+        const hit = hpChangedTargets(input);
+        // The selected (front-most) player — the focus — received the enemy's incoming.
+        expect(hit.has('attacker')).toBe(true);
+        // The heal target (team actor, M1) was NOT the actor the enemy hit.
+        expect(hit.has('team-1')).toBe(false);
+    });
+});

--- a/src/utils/combat/__tests__/positionalSelection.test.ts
+++ b/src/utils/combat/__tests__/positionalSelection.test.ts
@@ -118,6 +118,22 @@ describe('Task C1 — player attacker positional target selection (focus turn)',
         idc = 0;
         expect(focusAbilityTargetId(BASE('back'))).toBe('enemy-back');
     });
+
+    it('skip selection binds the focus turn to the 2nd-from-front enemy (M2), distinct from front (M4) and back (M1)', () => {
+        // Three enemies in row M: M4 (front), M2 (middle), M1 (back).
+        // colsFrontToBack sorts cols [4,2,1]; skip = cols.slice(1) + cols[0] → anchor = cols[1] = M2 enemy.
+        // Confirms skip resolves a target that is neither front nor back.
+        idc = 0;
+        const input: CombatEngineInput = {
+            ...BASE('skip'),
+            enemyAttackers: [
+                enemyAt('enemy-front', 'M4'),
+                enemyAt('enemy-mid', 'M2'),
+                enemyAt('enemy-back', 'M1'),
+            ],
+        };
+        expect(focusAbilityTargetId(input)).toBe('enemy-mid');
+    });
 });
 
 // ============================================================================

--- a/src/utils/combat/__tests__/positionalSelection.test.ts
+++ b/src/utils/combat/__tests__/positionalSelection.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Task C1 — player attacker positional target selection (focus turn).
+ *
+ * When the focus attacker carries a board `position` AND the opposing (enemy) roster
+ * carries positions, the engine resolves the attacker's parsed target (e.g.
+ * `side:'enemy', selection:'front'`) against the positioned enemy roster and binds the
+ * focus turn to the SELECTED enemy actor — not the legacy dummy `'enemy'` binding.
+ *
+ * Positioned enemy roster (`enemyAttackerActors`) is only populated when `enemyAttackers`
+ * is non-empty AND `healTargetId` is set (the engine throws `enemyAttackers require
+ * healTargetId` otherwise). So this test runs in healing mode.
+ *
+ * Board geometry (selectTargets): caster at M4 scans its own row M first. Two enemies in
+ * row M — one at M4 (col 4 = front-most), one at M1 (col 1 = back-most). `front` selection
+ * anchors the front-most (M4 enemy); `back` selection anchors the back-most (M1 enemy).
+ *
+ * RED baseline (before the gated branch): the focus turn binds the dummy `enemy` actor, so
+ * the emitted `ability-performed` event carries `targetId === 'enemy'` regardless of
+ * position/target → both assertions FAIL. After the gated branch the event carries the
+ * selected enemy's id.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `ps${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+// A basic-attack active slot (100% / 1 hit) — gives the focus attacker a real damaging hit
+// so an `ability-performed` (damage) event is emitted with a targetId.
+const basicAttack = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } }),
+    ],
+});
+
+// A pure-target enemy: low/zero attack, big HP, positioned. Effectively a stationary target.
+const enemyAt = (id: string, position: Position): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        shipSkills: { slots: [] } as ShipSkills,
+    }) as EnemyAttacker;
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+// Focus attacker positioned at M4, with a real basic attack and a positional target.
+const BASE = (selection: ParsedTarget['selection']): CombatEngineInput => ({
+    attack: 5000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [basicAttack()] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    debuffLandingChance: 1,
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    // Healing mode — required for the positioned enemy roster to be built.
+    healTargetId: 'attacker',
+    // Focus attacker board position + parsed positional target.
+    position: 'M4',
+    target: parsedTarget(selection),
+    // Two positioned enemies in row M: M4 = front-most, M1 = back-most.
+    enemyAttackers: [enemyAt('enemy-front', 'M4'), enemyAt('enemy-back', 'M1')],
+});
+
+const focusAbilityTargetId = (input: CombatEngineInput): string | undefined => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    bus.on('ability-performed', (e) => events.push(e as CombatEvent));
+    runCombat({ ...input, bus });
+    const focusPerformed = events.find(
+        (e) => e.type === 'ability-performed' && e.actorId === 'attacker'
+    );
+    return focusPerformed && focusPerformed.type === 'ability-performed'
+        ? focusPerformed.targetId
+        : undefined;
+};
+
+describe('Task C1 — player attacker positional target selection (focus turn)', () => {
+    it('front selection binds the focus turn to the front-most enemy (M4)', () => {
+        idc = 0;
+        expect(focusAbilityTargetId(BASE('front'))).toBe('enemy-front');
+    });
+
+    it('back selection binds the focus turn to the back-most enemy (M1)', () => {
+        idc = 0;
+        expect(focusAbilityTargetId(BASE('back'))).toBe('enemy-back');
+    });
+});

--- a/src/utils/combat/__tests__/positionalSelection.test.ts
+++ b/src/utils/combat/__tests__/positionalSelection.test.ts
@@ -119,3 +119,85 @@ describe('Task C1 — player attacker positional target selection (focus turn)',
         expect(focusAbilityTargetId(BASE('back'))).toBe('enemy-back');
     });
 });
+
+// ============================================================================
+// Task C2 — walked TEAM actor positional target selection (team turn).
+//
+// A walked team actor carries its OWN board `position` and parsed `target`; the
+// engine resolves them against the SAME positioned enemy roster, independently of
+// the focus attacker. To pin team-actor-specific selection, the team actor uses the
+// OPPOSITE selection from the focus attacker so its `ability-performed.targetId`
+// resolves to a DIFFERENT enemy than the focus's.
+//
+// Layout: focus attacker at M4 selects `front` → enemy-front (M4). Walked team actor
+// at M1 selects `back` → enemy-back (M1). The team actor deals a real basic-attack hit,
+// so its own `ability-performed` event fires with targetId === selected enemy id.
+//
+// RED baseline: the team turn binds the dummy `enemy`, so the team actor's
+// `ability-performed.targetId === 'enemy'` → assertion FAILS. After the gated branch it
+// carries the selected enemy's id.
+// ============================================================================
+
+type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
+
+// A walked team actor with a real basic attack, its own position + parsed target.
+const teamActorAt = (
+    id: string,
+    position: Position,
+    selection: ParsedTarget['selection']
+): TeamActor => ({
+    id,
+    speed: 200, // faster than the focus so it acts first (order is irrelevant to selection)
+    chargeCount: 0,
+    startCharged: false,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    position,
+    target: parsedTarget(selection),
+    walk: {
+        shipSkills: { slots: [basicAttack()] },
+        stats: {
+            attack: 5000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            hacking: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+        },
+        debuffLandingChance: 1,
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        hasChargedSkill: false,
+    },
+});
+
+const teamAbilityTargetId = (input: CombatEngineInput, teamId: string): string | undefined => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    bus.on('ability-performed', (e) => events.push(e as CombatEvent));
+    runCombat({ ...input, bus });
+    const teamPerformed = events.find(
+        (e) => e.type === 'ability-performed' && e.actorId === teamId
+    );
+    return teamPerformed && teamPerformed.type === 'ability-performed'
+        ? teamPerformed.targetId
+        : undefined;
+};
+
+describe('Task C2 — walked team actor positional target selection (team turn)', () => {
+    it("binds the team turn to the team actor's OWN positional target (back → M1), distinct from the focus (front → M4)", () => {
+        idc = 0;
+        // Focus attacker at M4 selects `front`; team actor at M1 selects `back`.
+        const input: CombatEngineInput = {
+            ...BASE('front'),
+            teamActors: [teamActorAt('team-1', 'M1', 'back')],
+        };
+        // Focus resolves to the front-most enemy; team resolves to the back-most enemy.
+        expect(focusAbilityTargetId(input)).toBe('enemy-front');
+        expect(teamAbilityTargetId(input, 'team-1')).toBe('enemy-back');
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -1055,6 +1055,18 @@ export function runCombat(input: CombatEngineInput): {
         })
     );
 
+    // Per-team-actor parsed positional target (Task C2). The team actor's `position`
+    // already rides on its CombatActor (createActor above), but its parsed `target`
+    // lives only on the TeamActorEngineInput — thread it to the team-turn call site by
+    // id. Empty for every non-positional input (no team actor passes a target) → the
+    // gated branch never fires and the legacy binding stays byte-identical.
+    const teamTargetById = new Map<string, ParsedTarget>();
+    for (const t of teamActors) {
+        if (t.target) {
+            teamTargetById.set(t.id, t.target);
+        }
+    }
+
     // Deterministic event gates — replace Math.random / expected-value math so
     // identical inputs always produce identical output. Crit uses one gate PER
     // ACTION STREAM so the charged hit crits at exactly the crit rate regardless
@@ -2492,20 +2504,43 @@ export function runCombat(input: CombatEngineInput): {
                     // the legacy sourceFired block below is fully superseded for walked actors.
                     // ====================================================================
                     const teamMaxHp = baseHpFor(actor.id);
+                    // Positional target selection (Task C2, GATED). Mirrors the focus-turn
+                    // branch (C1) but keyed to THIS team actor's own board position
+                    // (`actor.position`) and parsed target (`teamTargetById` lookup), not the
+                    // focus attacker's. When `selectedTeamEnemy` is null — not positional, no
+                    // parsed target, or no living positioned enemy — we diverge NOTHING from the
+                    // legacy dummy `enemy` binding. No existing test threads a team target →
+                    // this branch never fires for them (goldens byte-identical).
+                    const teamTarget = teamTargetById.get(actor.id);
+                    const selectedTeamEnemy =
+                        isPositional(actor.position, enemyAttackerActors) && teamTarget
+                            ? resolvePositionalTarget(
+                                  actor.position!,
+                                  teamTarget,
+                                  enemyAttackerActors
+                              )
+                            : null;
+                    // Same `tgt` consolidation as the focus turn: both branches are full
+                    // CombatActors, so every per-target binding derives from `tgt` uniformly.
+                    // Legacy path tgt === enemy, whose stats/containers ARE the legacy module
+                    // vars (enemyDefense/enemyHp/corrosionEntries/…) → byte-identical.
+                    const tgt = selectedTeamEnemy ?? enemy;
                     const teamTurn = runPlayerTurn({
                         runtime: teamRuntimeById.get(actor.id)!,
-                        enemy,
+                        enemy: tgt,
                         statusEngine,
-                        corrosionEntries,
-                        infernoEntries,
-                        pendingBombs,
-                        pendingAccumulators,
-                        enemyDefense,
-                        enemyHp,
+                        corrosionEntries: tgt.corrosionEntries,
+                        infernoEntries: tgt.infernoEntries,
+                        pendingBombs: tgt.pendingBombs,
+                        pendingAccumulators: tgt.pendingAccumulators,
+                        enemyDefense: tgt.stats.defence,
+                        enemyHp: tgt.stats.hp,
                         enemyType,
                         bus,
                         round: r,
-                        enemyHpDecline: cumulativeDamage + cumulativeTeamDamage,
+                        enemyHpDecline: selectedTeamEnemy
+                            ? 0
+                            : cumulativeDamage + cumulativeTeamDamage,
                         grantAllyCharges,
                         // Healing mode only — walked team turns heal/shield through the same ctx.
                         healing: healingCtx,

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2836,6 +2836,10 @@ export function runCombat(input: CombatEngineInput): {
                             pendingAccumulators: tgt.pendingAccumulators,
                             enemyDefense: targetDefence,
                             enemyHp: targetMaxHpForEnemy,
+                            // NOTE: unlike the focus/team turns (which force 0 for a selected enemy sink),
+                            // the enemy-turn victim is a REAL player actor with live HP, so its decline
+                            // derives from tgt's actual HP for BOTH the legacy and positional paths.
+                            // Do NOT convert this to a `selected ? 0 : …` ternary.
                             enemyHpDecline: targetHpDecline,
                             // No class is carried on a CombatActor → undefined (no enemyType matchup).
                             enemyType: undefined,
@@ -2865,9 +2869,10 @@ export function runCombat(input: CombatEngineInput): {
                             // mutating the heal target. Player/team calls leave this falsy.
                             healEventOnly: true,
                             selfHpPct: enemySelfHpPct,
-                            // Heal target's live HP% (the enemy is bound to it). Inert for current
-                            // fixtures (a bare enemy has no `hpSubject:'target'` gate) but threaded
-                            // for consistency with the player-turn dispatches.
+                            // Reports the HEAL TARGET's HP%, not tgt's — when positional selection picks
+                            // a different player as `tgt`, this still tracks the heal target (not the
+                            // struck actor). Per-actor target-HP% is deferred to a later phase; inert
+                            // today (bare enemies have no `hpSubject:'target'` gate).
                             targetHpPct: healTargetHpPctNow(),
                         });
                         // Total damage the enemy dealt to the bound target this turn. secondary/

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -1067,6 +1067,19 @@ export function runCombat(input: CombatEngineInput): {
         }
     }
 
+    // Per-enemy-attacker parsed positional target (Task C3, side-symmetric). The enemy's
+    // `position` already rides on its CombatActor (buildEnemyPlayerActorRuntime → createActor),
+    // but its parsed `target` lives only on the EnemyActorInput — thread it to the enemy-turn
+    // call site by id, mirroring teamTargetById. Empty for every non-positional input (no enemy
+    // passes a target) → the gated branch never fires and the legacy heal-target binding stays
+    // byte-identical.
+    const enemyTargetById = new Map<string, ParsedTarget>();
+    for (const e of input.enemyAttackers ?? []) {
+        if (e.target) {
+            enemyTargetById.set(e.id, e.target);
+        }
+    }
+
     // Deterministic event gates — replace Math.random / expected-value math so
     // identical inputs always produce identical output. Crit uses one gate PER
     // ACTION STREAM so the charged hit crits at exactly the crit rate regardless
@@ -1873,16 +1886,23 @@ export function runCombat(input: CombatEngineInput): {
         // taken-leech punch-through gate; hpDamage is 0 under Barrier so the leech reads 0). Both
         // the per-attack enemy intake (below) and the tank DoT-tick intake (turn-start) route
         // through here so the bleed accounting is identical.
+        // `victim` defaults to the heal target — the legacy (non-positional) caller passes no
+        // arg, so every existing path reads/mutates `healTarget!` exactly as before (byte-
+        // identical). The positional enemy-turn path (Task C3) passes the SELECTED player actor
+        // so the enemy's incoming drains the actor its parsed target picked. Heal-target-specific
+        // bookkeeping (healTargetDestroyedRound) stays gated on `victim === healTarget` below so
+        // it is never written for a non-heal-target victim.
         const applyIncomingToTarget = (
-            damage: number
+            damage: number,
+            victim: CombatActor = healTarget!
         ): { shieldBefore: number; hpDamage: number; barriered: boolean } => {
             roundIncomingDamage += damage;
             // Capture the pre-drain HP + the target's current effective max HP for the
             // tank-side hp-changed emission below (Phase 4c PR 3). Read BEFORE the drain
             // so oldPct reflects the entering state and a Cheat-Death save's oldPct stays
             // the pre-hit value (not 1).
-            const hpBefore = healTarget!.currentHp;
-            const maxHp = recipientMaxHp(healTarget!.id);
+            const hpBefore = victim.currentHp;
+            const maxHp = recipientMaxHp(victim.id);
             // Barrier — FULL DAMAGE IMMUNITY (locked game rule). While the heal target carries
             // an active BARRIER_BUFFS status, ALL incoming damage is fully blocked: direct
             // attacks, DoT ticks, AND bomb detonations (all three funnel through this closure).
@@ -1895,28 +1915,28 @@ export function runCombat(input: CombatEngineInput): {
             // HP does not move → the emit below is a no-op crossing (oldPct === newPct), which we
             // still fire once for emission consistency. Detection mirrors the Cheat-Death check
             // (selfBuffNamesForOwners aggregates snapshot + timed + active ability self statuses).
-            const carriesBarrier = selfBuffNamesForOwners(statusEngine, [healTarget!.id]).some(
-                (n) => BARRIER_BUFFS.has(n)
+            const carriesBarrier = selfBuffNamesForOwners(statusEngine, [victim.id]).some((n) =>
+                BARRIER_BUFFS.has(n)
             );
             if (carriesBarrier) {
                 roundBarrierAbsorbed += damage;
-                if (healTarget!.currentHp > 0 && maxHp > 0) {
+                if (victim.currentHp > 0 && maxHp > 0) {
                     bus.emit({
                         type: 'hp-changed',
-                        targetId: healTarget!.id,
+                        targetId: victim.id,
                         round: r,
                         oldPct: (100 * hpBefore) / maxHp,
-                        newPct: (100 * healTarget!.currentHp) / maxHp,
+                        newPct: (100 * victim.currentHp) / maxHp,
                     });
                 }
-                return { shieldBefore: healTarget!.shieldPool, hpDamage: 0, barriered: true };
+                return { shieldBefore: victim.shieldPool, hpDamage: 0, barriered: true };
             }
-            const shieldBefore = healTarget!.shieldPool;
-            const absorbed = Math.min(healTarget!.shieldPool, damage);
-            healTarget!.shieldPool -= absorbed;
+            const shieldBefore = victim.shieldPool;
+            const absorbed = Math.min(victim.shieldPool, damage);
+            victim.shieldPool -= absorbed;
             roundShieldAbsorbed += absorbed;
             const hpDamage = damage - absorbed;
-            healTarget!.currentHp = Math.max(0, healTarget!.currentHp - hpDamage);
+            victim.currentHp = Math.max(0, victim.currentHp - hpDamage);
             // At the lethal moment, intercept once per combat: a carrier of a CHEAT_DEATH_BUFFS
             // buff survives at 1 HP instead of dying. The buff is 'recurring' (always-active), so
             // it is never stored/timed — consumption is the per-actor cheatDeathConsumed flag
@@ -1934,13 +1954,13 @@ export function runCombat(input: CombatEngineInput): {
             // ability-sourced case AND the non-attacker-owner case. selfBuffNamesForOwners
             // aggregates snapshot + timed + active ability self statuses keyed by the actor's
             // own id, covering every Cheat Death source.
-            if (healTarget!.currentHp <= 0) {
-                const targetId = healTarget!.id;
+            if (victim.currentHp <= 0) {
+                const targetId = victim.id;
                 const carriesCheatDeath = selfBuffNamesForOwners(statusEngine, [targetId]).some(
                     (n) => CHEAT_DEATH_BUFFS.has(n)
                 );
                 if (carriesCheatDeath && !cheatDeathConsumed.has(targetId)) {
-                    healTarget!.currentHp = 1;
+                    victim.currentHp = 1;
                     cheatDeathConsumed.add(targetId);
                     // Display-only: remember the round it was spent so the chip is dropped
                     // from rounds AFTER this one (see hideSpentCheatDeath). First write wins —
@@ -1955,16 +1975,21 @@ export function runCombat(input: CombatEngineInput): {
                     // the turn-start DoT-tick intake reads (healTarget.corrosion/infernoEntries).
                     // Both DoT types are removable; bombs (Blast, treated as persistent here) and
                     // accumulators are intentionally left untouched.
-                    healTarget!.corrosionEntries.length = 0;
-                    healTarget!.infernoEntries.length = 0;
+                    victim.corrosionEntries.length = 0;
+                    victim.infernoEntries.length = 0;
                     bus.emit({ type: 'cheat-death-activated', actorId: targetId, round: r });
                 } else {
                     // First reach 0 (no intercept) → record the destroyed round + emit
                     // ship-destroyed once (shared helper; idempotent via the per-actor
                     // destroyedRound field). The healing result reads the destroyed round back
                     // off the heal target's runtime field below.
-                    recordDestroyed(healTarget!, r, bus);
-                    healTargetDestroyedRound = healTarget!.destroyedRound;
+                    recordDestroyed(victim, r, bus);
+                    // healTargetDestroyedRound tracks the HEAL TARGET specifically — only write it
+                    // when the victim IS the heal target. A positional-selected non-heal-target
+                    // victim records its own destroyedRound (on `victim`) without touching this.
+                    if (victim === healTarget) {
+                        healTargetDestroyedRound = victim.destroyedRound;
+                    }
                 }
             }
             // Tank-side hp-changed (Phase 4c PR 3): ONCE per HP-intake event — this closure
@@ -1974,13 +1999,13 @@ export function runCombat(input: CombatEngineInput): {
             // counts as a downward crossing — spec §5). Exact percentages (the enemy dummy's
             // post-round emission stays integer-granularity — asymmetry intended, events.ts).
             // A killed tank emits ship-destroyed above, never a posthumous crossing.
-            if (healTarget!.currentHp > 0 && maxHp > 0) {
+            if (victim.currentHp > 0 && maxHp > 0) {
                 bus.emit({
                     type: 'hp-changed',
-                    targetId: healTarget!.id,
+                    targetId: victim.id,
                     round: r,
                     oldPct: (100 * hpBefore) / maxHp,
-                    newPct: (100 * healTarget!.currentHp) / maxHp,
+                    newPct: (100 * victim.currentHp) / maxHp,
                 });
             }
             return { shieldBefore, hpDamage, barriered: false };
@@ -2738,7 +2763,28 @@ export function runCombat(input: CombatEngineInput): {
                     // (consume-at-cap-and-reset, else +1) under the old `chargeCount > 0` guard.
                     // ====================================================================
                     const enemyRuntime = enemyPlayerRuntimeByActorId.get(actor.id)!;
-                    const targetDead = healTarget!.currentHp <= 0;
+                    // Positional target selection (Task C3, side-symmetric, GATED). Mirrors the
+                    // focus-turn (C1) and team-turn (C2) branches, but the OPPOSING roster from the
+                    // enemy's view is the PLAYER TEAM (`allPlayerActors` = focus + walked team), the
+                    // acting position is THIS enemy's board position (`actor.position`), and its
+                    // parsed target rides on `enemyTargetById` (keyed by enemy actor id). When
+                    // `selectedPlayer` is null — not positional, no parsed target, or no living
+                    // positioned player — we diverge NOTHING from the legacy `healTarget` victim
+                    // binding: the enemy's whole turn (defence/hp/decline lookup, the runPlayerTurn
+                    // bind, AND the applyIncomingToTarget intake) reads `tgt === healTarget!`, so
+                    // every existing path stays byte-identical. No existing test threads an enemy
+                    // target → this branch never fires for them.
+                    const enemyTarget = enemyTargetById.get(actor.id);
+                    const selectedPlayer =
+                        isPositional(actor.position, allPlayerActors) && enemyTarget
+                            ? resolvePositionalTarget(actor.position!, enemyTarget, allPlayerActors)
+                            : null;
+                    // The enemy's victim THIS turn: the positionally-selected player actor, else the
+                    // legacy heal target. A full CombatActor in both cases, so every per-victim
+                    // binding below derives from `tgt` uniformly (defence/maxHp/decline, the
+                    // runPlayerTurn `enemy`+containers, and the applyIncomingToTarget intake).
+                    const tgt = selectedPlayer ?? healTarget!;
+                    const targetDead = tgt.currentHp <= 0;
                     let damage = 0;
                     // Hoisted for use in the post-else `attacked` emit (Task 8): enemyTurn is
                     // scoped inside the else block below; this flag carries its roundCrit out.
@@ -2760,16 +2806,13 @@ export function runCombat(input: CombatEngineInput): {
                         // Target's CURRENT effective defence: prefer its last-turn ctx (live buffs),
                         // else its base defence (pre-first-turn fallback).
                         const targetDefence =
-                            lastTurnCtxByActor.get(healTarget!.id)?.effectiveDefence ??
-                            baseDefenceFor(healTarget!.id);
+                            lastTurnCtxByActor.get(tgt.id)?.effectiveDefence ??
+                            baseDefenceFor(tgt.id);
                         // Target's max-HP pool + its damage-so-far → the enemyHpPct the enemy's OWN
                         // condition gates read (a bare neutral enemy has no such gates, so this is inert
                         // for current fixtures; computed for correctness when Task 7+ adds gated kits).
-                        const targetMaxHpForEnemy = recipientMaxHp(healTarget!.id);
-                        const targetHpDecline = Math.max(
-                            0,
-                            targetMaxHpForEnemy - healTarget!.currentHp
-                        );
+                        const targetMaxHpForEnemy = recipientMaxHp(tgt.id);
+                        const targetHpDecline = Math.max(0, targetMaxHpForEnemy - tgt.currentHp);
                         // Enemy's OWN live HP% (Task 3): enemies are at full HP (or hp 0 → guard to 100).
                         const enemyActorMaxHp = enemyRuntime.hp;
                         const enemySelfHpPct =
@@ -2779,16 +2822,18 @@ export function runCombat(input: CombatEngineInput): {
                                 : 100;
                         const enemyTurn = runPlayerTurn({
                             runtime: enemyRuntime,
-                            // The heal target is the enemy's victim — bind it as the `enemy` arg so
+                            // The victim (`tgt`) is the enemy's target — bind it as the `enemy` arg so
                             // damage/debuffs resolve against it and route to its per-target store.
-                            enemy: healTarget!,
-                            targetId: healTarget!.id,
+                            // Legacy path: tgt === healTarget! (byte-identical). Positional path:
+                            // the selected player actor.
+                            enemy: tgt,
+                            targetId: tgt.id,
                             statusEngine,
                             // The TARGET's DoT/bomb/accumulator containers (enemy applications land here).
-                            corrosionEntries: healTarget!.corrosionEntries,
-                            infernoEntries: healTarget!.infernoEntries,
-                            pendingBombs: healTarget!.pendingBombs,
-                            pendingAccumulators: healTarget!.pendingAccumulators,
+                            corrosionEntries: tgt.corrosionEntries,
+                            infernoEntries: tgt.infernoEntries,
+                            pendingBombs: tgt.pendingBombs,
+                            pendingAccumulators: tgt.pendingAccumulators,
                             enemyDefense: targetDefence,
                             enemyHp: targetMaxHpForEnemy,
                             enemyHpDecline: targetHpDecline,
@@ -2897,7 +2942,13 @@ export function runCombat(input: CombatEngineInput): {
                         // hpDamage comes straight from the closure (0 under Barrier — damage fully
                         // blocked, not shield-absorbed — otherwise damage - absorbed). barriered = the
                         // attack was fully blocked by an active Barrier (decision #7, below).
-                        const { shieldBefore, hpDamage, barriered } = applyIncomingToTarget(damage);
+                        // Route the enemy's incoming to its selected victim (`tgt`). Legacy path:
+                        // tgt === healTarget! → no-arg-equivalent call, byte-identical. Positional
+                        // path: drains the SELECTED player actor instead of the heal target.
+                        const { shieldBefore, hpDamage, barriered } = applyIncomingToTarget(
+                            damage,
+                            tgt
+                        );
 
                         // Damage-taken procs (per ATTACK, on the aggregate — spec §5): applied
                         // AFTER this attack's drain so the proc never absorbs its own trigger.
@@ -2909,7 +2960,14 @@ export function runCombat(input: CombatEngineInput): {
                         // delta is below the fidelity of the flat enemy model — on the in-game
                         // verify list (spec §5).
                         // Same heal/shield fold as procStandingLeeches, but the recipient is fixed
-                        // to the heal target (enemy attacks only ever hit it).
+                        // to the heal target — the healing-accounting model is single-target. With
+                        // positional selection (Task C3) the enemy's HP/shield drain re-routes to the
+                        // selected player (`tgt`, above), but these damage-taken HEAL/SHIELD leech
+                        // procs still credit the heal target's accounting. Inert unless a player runs
+                        // a "when damaged, heal/shield" reactive (takenLeeches non-empty) — no current
+                        // fixture does — so the legacy path stays byte-identical. Retargeting the
+                        // single-target healing accounting to an arbitrary victim is out of scope for
+                        // Phase 2 (incoming-damage routing).
                         // Barrier carve-out (decision #7): an attack FULLY BLOCKED by Barrier deals no
                         // damage taken at all, so its damage-taken procs are skipped entirely — there is
                         // nothing to leech from. (Distinct from a shield absorb, where the convention
@@ -2952,7 +3010,10 @@ export function runCombat(input: CombatEngineInput): {
                         for (const hitCrit of hitOutcomes) {
                             bus.emit({
                                 type: 'attacked',
-                                targetId: healTarget!.id,
+                                // The actor actually hit this turn (`tgt`). Legacy path:
+                                // tgt === healTarget! → byte-identical. Positional path: the
+                                // selected player actor.
+                                targetId: tgt.id,
                                 attackerId: actor.id,
                                 round: r,
                                 ...(hitCrit ? { didCrit: true } : {}),

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -412,6 +412,7 @@ export function buildEnemyPlayerActorRuntime(
         },
         chargeCount: e.chargeCount,
         startCharged: e.startCharged,
+        position: e.position,
     });
 
     // Resolved affinity fields — pre-computed by the adapter via computeAffinityModifiers
@@ -983,6 +984,7 @@ export function runCombat(input: CombatEngineInput): {
         stats: { attack, crit, critDamage, defensePenetration, defence, hp, speed: speed ?? 100 },
         chargeCount,
         startCharged,
+        position: input.position,
     });
     const enemy = createActor({
         id: 'enemy',
@@ -1048,6 +1050,7 @@ export function runCombat(input: CombatEngineInput): {
                   },
             chargeCount: t.chargeCount,
             startCharged: t.startCharged,
+            position: t.position,
         })
     );
 

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -1,6 +1,8 @@
 import { EnemyBaseClass, SelectedGameBuff, TeamActorInput } from '../../types/calculator';
 import type { ShipTypeName } from '../../constants/shipTypes';
 import { AbilityTarget, ShipSkills } from '../../types/abilities';
+import type { Position } from '../../types/encounters';
+import type { ParsedTarget } from '../targetingParser';
 import { makeRateGate } from '../calculators/rateAccumulator';
 import type { RoundData } from '../calculators/dpsSimulator';
 import {
@@ -324,6 +326,10 @@ export interface EnemyActorInput {
      *  Computed by the healing adapter from enemy hacking vs heal-target security. Omitted →
      *  100% (1) for backward compatibility (every existing test/the dummy path omits it). */
     debuffLandingChance?: number;
+    /** Board position of this enemy (positional plumbing — set but not yet consumed). */
+    position?: Position;
+    /** Pre-parsed targeting preference for this enemy (positional plumbing — set but not yet consumed). */
+    target?: ParsedTarget;
 }
 
 /** Build a full PlayerActorRuntime for a healing-mode enemy attacker.
@@ -711,6 +717,10 @@ export type TeamActorEngineInput = TeamActorInput & {
         /** Caster heal-modifier stat (healing calc). Default 0. */
         healModifier?: number;
     };
+    /** Board position of this team actor (positional plumbing — set but not yet consumed). */
+    position?: Position;
+    /** Pre-parsed targeting preference for this team actor (positional plumbing — set but not yet consumed). */
+    target?: ParsedTarget;
 };
 
 export interface CombatEngineInput {
@@ -790,9 +800,17 @@ export interface CombatEngineInput {
          *  (computed by the healing adapter from enemy hacking vs heal-target security).
          *  Omitted → 100% (1) for backward compatibility. */
         debuffLandingChance?: number;
+        /** Board position of this enemy attacker (positional plumbing — set but not yet consumed). */
+        position?: Position;
+        /** Pre-parsed targeting preference for this enemy attacker (positional plumbing — set but not yet consumed). */
+        target?: ParsedTarget;
     }[];
     /** Emit-only event tap. Listeners must not read or mutate combat state. */
     bus?: CombatEventBus;
+    /** Board position of the focus attacker (positional plumbing — set but not yet consumed). */
+    position?: Position;
+    /** Pre-parsed targeting preference for the focus attacker (positional plumbing — set but not yet consumed). */
+    target?: ParsedTarget;
 }
 
 /** One round's healing accounting (healing mode only). `perActor` mirrors the round

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -33,6 +33,7 @@ import {
     createStatusEngine,
 } from './statusEngine';
 import { liveGateConditions } from './abilityStatusGating';
+import { isPositional, resolvePositionalTarget } from './positionalBinding';
 import { CHEAT_DEATH_BUFFS } from './cheatDeathBuffs';
 import { BARRIER_BUFFS } from './barrierBuffs';
 import { CombatEventBus, createEventBus } from './events';
@@ -2378,22 +2379,49 @@ export function runCombat(input: CombatEngineInput): {
                     // attackerRuntime (built once at setup); Task 4 adds team runtimes.
                     // ====================================================================
                     const attackerMaxHp = baseHpFor(actor.id);
+                    // Positional target selection (Task C1, GATED). When the focus attacker
+                    // (`actor`) carries a board position AND the positioned enemy roster
+                    // (`enemyAttackerActors`) has positioned actors, resolve the focus's parsed
+                    // target (`input.target`) to a single living enemy and bind THIS turn to it.
+                    // When `selectedEnemy` is null — not positional, OR positional but no living
+                    // positioned enemy target — we diverge NOTHING from the legacy dummy `enemy`
+                    // binding (keeps every existing path byte-identical; the null-target sub-case
+                    // is treated as a no-op fallthrough to legacy). No existing test passes
+                    // positions, so this branch never fires for them.
+                    const selectedEnemy =
+                        isPositional(actor.position, enemyAttackerActors) && input.target
+                            ? resolvePositionalTarget(
+                                  actor.position!,
+                                  input.target,
+                                  enemyAttackerActors
+                              )
+                            : null;
                     const turn = runPlayerTurn({
                         runtime: attackerRuntime,
-                        enemy,
+                        enemy: selectedEnemy ?? enemy,
                         statusEngine,
-                        corrosionEntries,
-                        infernoEntries,
-                        pendingBombs,
-                        pendingAccumulators,
-                        enemyDefense,
-                        enemyHp,
+                        corrosionEntries: selectedEnemy
+                            ? selectedEnemy.corrosionEntries
+                            : corrosionEntries,
+                        infernoEntries: selectedEnemy
+                            ? selectedEnemy.infernoEntries
+                            : infernoEntries,
+                        pendingBombs: selectedEnemy ? selectedEnemy.pendingBombs : pendingBombs,
+                        pendingAccumulators: selectedEnemy
+                            ? selectedEnemy.pendingAccumulators
+                            : pendingAccumulators,
+                        enemyDefense: selectedEnemy ? selectedEnemy.stats.defence : enemyDefense,
+                        // Selected enemy's MAX hp (stats.hp), NOT currentHp. Per-target HP decline
+                        // is a later phase — gates read the entering-round HP, so override to 0.
+                        enemyHp: selectedEnemy ? selectedEnemy.stats.hp : enemyHp,
                         enemyType,
                         bus,
                         round: r,
                         // enemyHpDecline: focus + team cumulative — the enemy's entering-round HP%
                         // reflects all players' damage so far (gates/HP% column react to it).
-                        enemyHpDecline: cumulativeDamage + cumulativeTeamDamage,
+                        // For a positional selected target, per-target decline is a later phase →
+                        // override to 0 (gates read entering HP).
+                        enemyHpDecline: selectedEnemy ? 0 : cumulativeDamage + cumulativeTeamDamage,
                         grantAllyCharges,
                         // Healing mode only — the SHARED ctx (undefined in DPS mode keeps the heal
                         // block inert, goldens byte-identical).

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2396,31 +2396,27 @@ export function runCombat(input: CombatEngineInput): {
                                   enemyAttackerActors
                               )
                             : null;
+                    // Positional target (phase 2): the selected enemy actor, else the dummy sink.
+                    // Both are full CombatActors, so all per-target bindings derive from `tgt`
+                    // uniformly. For the legacy (non-positional) path tgt === enemy, whose
+                    // stats.defence/stats.hp and DoT/bomb containers ARE the legacy module vars
+                    // (see ~line 1297) — so deriving every binding from `tgt` is byte-identical.
+                    // Per-target HP decline is a later phase, so enemyHpDecline stays its own
+                    // ternary (it is not an actor field): legacy = cumulative sum, selected = 0.
+                    const tgt = selectedEnemy ?? enemy;
                     const turn = runPlayerTurn({
                         runtime: attackerRuntime,
-                        enemy: selectedEnemy ?? enemy,
+                        enemy: tgt,
                         statusEngine,
-                        corrosionEntries: selectedEnemy
-                            ? selectedEnemy.corrosionEntries
-                            : corrosionEntries,
-                        infernoEntries: selectedEnemy
-                            ? selectedEnemy.infernoEntries
-                            : infernoEntries,
-                        pendingBombs: selectedEnemy ? selectedEnemy.pendingBombs : pendingBombs,
-                        pendingAccumulators: selectedEnemy
-                            ? selectedEnemy.pendingAccumulators
-                            : pendingAccumulators,
-                        enemyDefense: selectedEnemy ? selectedEnemy.stats.defence : enemyDefense,
-                        // Selected enemy's MAX hp (stats.hp), NOT currentHp. Per-target HP decline
-                        // is a later phase — gates read the entering-round HP, so override to 0.
-                        enemyHp: selectedEnemy ? selectedEnemy.stats.hp : enemyHp,
+                        corrosionEntries: tgt.corrosionEntries,
+                        infernoEntries: tgt.infernoEntries,
+                        pendingBombs: tgt.pendingBombs,
+                        pendingAccumulators: tgt.pendingAccumulators,
+                        enemyDefense: tgt.stats.defence,
+                        enemyHp: tgt.stats.hp,
                         enemyType,
                         bus,
                         round: r,
-                        // enemyHpDecline: focus + team cumulative — the enemy's entering-round HP%
-                        // reflects all players' damage so far (gates/HP% column react to it).
-                        // For a positional selected target, per-target decline is a later phase →
-                        // override to 0 (gates read entering HP).
                         enemyHpDecline: selectedEnemy ? 0 : cumulativeDamage + cumulativeTeamDamage,
                         grantAllyCharges,
                         // Healing mode only — the SHARED ctx (undefined in DPS mode keeps the heal

--- a/src/utils/combat/positionalBinding.test.ts
+++ b/src/utils/combat/positionalBinding.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import type { ParsedTarget } from '../targetingParser';
+import { isPositional, resolvePositionalTarget } from './positionalBinding';
+import type { CombatActor } from './state';
+
+const actor = (id: string, position: CombatActor['position'], currentHp = 100): CombatActor =>
+    ({ id, position, currentHp }) as CombatActor;
+
+const enemyTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: `enemy-${selection}`,
+    side: 'enemy',
+    selection,
+});
+
+describe('isPositional', () => {
+    it('false when caster has no position', () => {
+        expect(isPositional(undefined, [actor('e1', 'M4')])).toBe(false);
+    });
+
+    it('false when no opposing actor is positioned', () => {
+        expect(isPositional('M4', [actor('e1', undefined)])).toBe(false);
+    });
+
+    it('true when caster positioned and an opposing actor is positioned', () => {
+        expect(isPositional('M4', [actor('e1', 'M4')])).toBe(true);
+    });
+
+    it('false when opposing list is empty', () => {
+        expect(isPositional('M4', [])).toBe(false);
+    });
+});
+
+describe('resolvePositionalTarget', () => {
+    // M4 = column 4 (front-most), M1 = column 1 (back-most)
+    const enemies = [actor('front', 'M4'), actor('back', 'M1')];
+
+    it('front selects the front-most (M4) actor', () => {
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), enemies)?.id).toBe('front');
+    });
+
+    it('skip selects the 2nd-from-front (M1) actor', () => {
+        expect(resolvePositionalTarget('M4', enemyTarget('skip'), enemies)?.id).toBe('back');
+    });
+
+    it('back selects the back-most (M1) actor', () => {
+        expect(resolvePositionalTarget('M4', enemyTarget('back'), enemies)?.id).toBe('back');
+    });
+
+    it('returns null when all opposing actors are dead', () => {
+        const dead = [actor('e1', 'M4', 0), actor('e2', 'M1', -5)];
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), dead)).toBeNull();
+    });
+
+    it('returns null when opposing list is empty', () => {
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), [])).toBeNull();
+    });
+
+    it('excludes dead actors but still resolves a living one', () => {
+        const mixed = [actor('dead', 'M4', 0), actor('alive', 'M1', 50)];
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), mixed)?.id).toBe('alive');
+    });
+});

--- a/src/utils/combat/positionalBinding.ts
+++ b/src/utils/combat/positionalBinding.ts
@@ -1,0 +1,55 @@
+import { selectTargets } from '../targeting/selectTargets';
+import type { Position } from '../../types/encounters';
+import type { ParsedTarget } from '../targetingParser';
+import type { CombatActor } from './state';
+
+/**
+ * Positional selection is active for an actor only when:
+ *   1. the acting actor itself has a board position, AND
+ *   2. at least one opposing (living) actor has a board position.
+ *
+ * When this returns false the caller should fall back to the legacy
+ * index-based targeting.
+ */
+export function isPositional(
+    actorPosition: Position | undefined,
+    opposingLiving: CombatActor[]
+): boolean {
+    return !!actorPosition && opposingLiving.some((a) => a.position !== undefined);
+}
+
+/**
+ * Resolve the positional target anchor to a single living CombatActor.
+ *
+ * Steps:
+ *   1. Build a position→actor map from the living (currentHp > 0) opposing actors
+ *      that have a board position. Invariant: at most one actor per cell.
+ *   2. Call selectTargets to obtain the anchor cell.
+ *   3. Look up and return the actor at that cell, or null if no valid target.
+ *
+ * Returns null when the opposing side has no living positioned actors, or when
+ * selectTargets cannot find a target (empty side).
+ */
+export function resolvePositionalTarget(
+    actorPosition: Position,
+    target: ParsedTarget,
+    opposingLiving: CombatActor[]
+): CombatActor | null {
+    const byCell = new Map<Position, CombatActor>();
+    for (const a of opposingLiving) {
+        if (a.position !== undefined && a.currentHp > 0) {
+            byCell.set(a.position, a);
+        }
+    }
+
+    if (byCell.size === 0) {
+        return null;
+    }
+
+    const { anchor } = selectTargets(target, {
+        casterPosition: actorPosition,
+        enemyOccupied: [...byCell.keys()],
+    });
+
+    return anchor ? (byCell.get(anchor) ?? null) : null;
+}

--- a/src/utils/combat/state.ts
+++ b/src/utils/combat/state.ts
@@ -1,3 +1,4 @@
+import type { Position } from '../../types/encounters';
 import type { CombatEventBus } from './events';
 
 /** Per-actor damage contributions within one round (spec: per-actor accounting —
@@ -111,6 +112,8 @@ export interface CombatActor {
     pendingAccumulators: PendingAccumulator[];
     /** Round this actor first reached 0 HP (set once via recordDestroyed). Undefined while alive. */
     destroyedRound?: number;
+    /** Board position of this actor (positional plumbing — set at construction, not yet consumed). */
+    position?: Position;
 }
 
 export function createActor(
@@ -118,6 +121,7 @@ export function createActor(
         stats: ActorStats;
         chargeCount?: number;
         startCharged?: boolean;
+        position?: Position;
     }
 ): CombatActor {
     // startCharged is a one-shot initialiser (it seeds `charges`), deliberately NOT
@@ -134,6 +138,7 @@ export function createActor(
         infernoEntries: [],
         pendingBombs: [],
         pendingAccumulators: [],
+        position: partial.position,
     };
 }
 

--- a/src/utils/targeting/board.test.ts
+++ b/src/utils/targeting/board.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { ALL_POSITIONS, neighbors, inBoundsAxial, positionToAxial, axialToPosition } from './board';
+import {
+    ALL_POSITIONS,
+    neighbors,
+    inBoundsAxial,
+    positionToAxial,
+    axialToPosition,
+    rowOf,
+    colOf,
+} from './board';
 
 describe('board adjacency', () => {
     it('M2 has the confirmed six neighbors', () => {
@@ -51,5 +59,18 @@ describe('axial conversion', () => {
         expect(inBoundsAxial(-2, 1)).toBe(false); // past M1
         expect(inBoundsAxial(4, 0)).toBe(false); // past T4
         expect(axialToPosition(-2, 1)).toBeUndefined();
+    });
+});
+
+describe('rowOf / colOf', () => {
+    it('extracts the row letter', () => {
+        expect(rowOf('T1')).toBe('T');
+        expect(rowOf('M3')).toBe('M');
+        expect(rowOf('B4')).toBe('B');
+    });
+    it('extracts the column number', () => {
+        expect(colOf('T1')).toBe(1);
+        expect(colOf('M3')).toBe(3);
+        expect(colOf('B4')).toBe(4);
     });
 });

--- a/src/utils/targeting/board.ts
+++ b/src/utils/targeting/board.ts
@@ -1,5 +1,7 @@
 import { Position } from '../../types/encounters';
 
+export type BoardRow = 'T' | 'M' | 'B';
+
 export interface Axial {
     q: number;
     r: number;
@@ -59,4 +61,14 @@ export function neighbors(pos: Position): Position[] {
         if (n) out.push(n);
     }
     return out;
+}
+
+/** The row letter of a Position ('T1' -> 'T'). */
+export function rowOf(pos: Position): BoardRow {
+    return pos[0] as BoardRow;
+}
+
+/** The 1-based column of a Position ('M3' -> 3); column 4 = front (nearest enemy). */
+export function colOf(pos: Position): number {
+    return Number(pos[1]);
 }

--- a/src/utils/targeting/selectTargets.test.ts
+++ b/src/utils/targeting/selectTargets.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import type { ParsedTarget } from '../targetingParser';
+import { selectTargets, rowScanOrder } from './selectTargets';
+
+const enemy = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: `enemy-${selection}`,
+    side: 'enemy',
+    selection,
+});
+const ally = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: `ally-${selection}`,
+    side: 'ally',
+    selection,
+});
+
+describe('rowScanOrder — caster row, descend with wraparound', () => {
+    it('T -> [T,M,B]', () => expect(rowScanOrder('T')).toEqual(['T', 'M', 'B']));
+    it('M -> [M,B,T]', () => expect(rowScanOrder('M')).toEqual(['M', 'B', 'T']));
+    it('B -> [B,T,M]', () => expect(rowScanOrder('B')).toEqual(['B', 'T', 'M']));
+});
+
+describe('selectTargets — ally side anchors on the caster', () => {
+    it('team/others/all/self all anchor on caster, ordered [caster]', () => {
+        for (const sel of ['team', 'others', 'all', 'self'] as const) {
+            const r = selectTargets(ally(sel), {
+                casterPosition: 'M2',
+                enemyOccupied: [],
+                allyOccupied: ['M2', 'M3'],
+            });
+            expect(r).toEqual({ ordered: ['M2'], anchor: 'M2' });
+        }
+    });
+});
+
+describe('selectTargets — empty enemy side', () => {
+    it('returns null anchor', () => {
+        expect(selectTargets(enemy('front'), { casterPosition: 'M2', enemyOccupied: [] })).toEqual({
+            ordered: [],
+            anchor: null,
+        });
+    });
+});
+
+describe('selectTargets — within-row front/back/skip (caster M4 vs enemies M4,M2,M1)', () => {
+    const ctx = { casterPosition: 'M4' as const, enemyOccupied: ['M4', 'M2', 'M1'] as const };
+    it('front -> [M4,M2,M1], anchor M4', () => {
+        expect(selectTargets(enemy('front'), ctx)).toEqual({
+            ordered: ['M4', 'M2', 'M1'],
+            anchor: 'M4',
+        });
+    });
+    it('skip -> [M2,M1,M4], anchor M2', () => {
+        expect(selectTargets(enemy('skip'), ctx)).toEqual({
+            ordered: ['M2', 'M1', 'M4'],
+            anchor: 'M2',
+        });
+    });
+    it('back -> [M1,M2,M4], anchor M1', () => {
+        expect(selectTargets(enemy('back'), ctx)).toEqual({
+            ordered: ['M1', 'M2', 'M4'],
+            anchor: 'M1',
+        });
+    });
+});
+
+describe('selectTargets — single/two occupied fallbacks (caster M4)', () => {
+    it('skip with two enemies M4,M1 -> anchor M1, ordered [M1,M4]', () => {
+        expect(
+            selectTargets(enemy('skip'), { casterPosition: 'M4', enemyOccupied: ['M4', 'M1'] })
+        ).toEqual({ ordered: ['M1', 'M4'], anchor: 'M1' });
+    });
+    it('one enemy M4: front/back/skip all -> [M4], anchor M4', () => {
+        for (const sel of ['front', 'back', 'skip'] as const) {
+            expect(
+                selectTargets(enemy(sel), { casterPosition: 'M4', enemyOccupied: ['M4'] })
+            ).toEqual({ ordered: ['M4'], anchor: 'M4' });
+        }
+    });
+});
+
+describe('selectTargets — row-first scan (caster M, enemies only in top row T1,T3)', () => {
+    it('front descends M(empty)->B(empty)->T, picks front-most T3', () => {
+        expect(
+            selectTargets(enemy('front'), { casterPosition: 'M2', enemyOccupied: ['T1', 'T3'] })
+        ).toEqual({ ordered: ['T3', 'T1'], anchor: 'T3' });
+    });
+});
+
+// Task A3 — enemy all cross-row ordering
+describe('selectTargets — enemy all spans every row in scan order (caster M2)', () => {
+    it('orders M row first (front->back), then B, then T', () => {
+        const r = selectTargets(
+            { raw: 'all', side: 'enemy', selection: 'all' },
+            { casterPosition: 'M2', enemyOccupied: ['T1', 'B3', 'M1', 'M4'] }
+        );
+        // scan M,B,T: M front->back = M4,M1 ; B = B3 ; T = T1
+        expect(r.ordered).toEqual(['M4', 'M1', 'B3', 'T1']);
+        expect(r.anchor).toBe('M4');
+    });
+});

--- a/src/utils/targeting/selectTargets.ts
+++ b/src/utils/targeting/selectTargets.ts
@@ -1,0 +1,73 @@
+import { Position } from '../../types/encounters';
+import { ParsedTarget } from '../targetingParser';
+import { BoardRow, rowOf, colOf } from './board';
+
+export interface SelectTargetsContext {
+    /** The acting actor's own cell — REQUIRED (drives the row scan). */
+    casterPosition: Position;
+    /** Living, targetable enemy cells in the acting side's own frame (<=1 actor per cell). */
+    enemyOccupied: readonly Position[];
+    /** Forward-looking (Phase-4 ally splash). UNUSED in Phase-2 selection. */
+    allyOccupied?: readonly Position[];
+}
+
+export interface SelectionResult {
+    /** Full ordered target list; head === anchor. */
+    ordered: Position[];
+    /** null when the requested side has no living target. */
+    anchor: Position | null;
+}
+
+const ROWS: BoardRow[] = ['T', 'M', 'B'];
+
+/** Row scan order: start at the caster's row, descend a row, wrap bottom->top. */
+export function rowScanOrder(casterRow: BoardRow): BoardRow[] {
+    const i = ROWS.indexOf(casterRow);
+    return [ROWS[i], ROWS[(i + 1) % 3], ROWS[(i + 2) % 3]];
+}
+
+/** Occupied cells of `row`, sorted front->back (column 4 first). */
+function colsFrontToBack(row: BoardRow, occupied: readonly Position[]): Position[] {
+    return occupied.filter((p) => rowOf(p) === row).sort((a, b) => colOf(b) - colOf(a));
+}
+
+export function selectTargets(target: ParsedTarget, ctx: SelectTargetsContext): SelectionResult {
+    // Ally side: support patterns anchor on the caster's own cell.
+    if (target.side === 'ally') {
+        return { ordered: [ctx.casterPosition], anchor: ctx.casterPosition };
+    }
+
+    // Enemy side.
+    if (ctx.enemyOccupied.length === 0) {
+        return { ordered: [], anchor: null };
+    }
+
+    const scan = rowScanOrder(rowOf(ctx.casterPosition));
+
+    // `all`: every living enemy, row-scan order then front->back within each row.
+    if (target.selection === 'all') {
+        const ordered = scan.flatMap((row) => colsFrontToBack(row, ctx.enemyOccupied));
+        return { ordered, anchor: ordered[0] };
+    }
+
+    // front/back/skip: first row in scan order with >=1 enemy.
+    const targetRow = scan.find((row) => ctx.enemyOccupied.some((p) => rowOf(p) === row))!;
+    const cols = colsFrontToBack(targetRow, ctx.enemyOccupied); // front->back
+
+    let ordered: Position[];
+    switch (target.selection) {
+        case 'back':
+            ordered = [...cols].reverse();
+            break;
+        case 'skip':
+            // 2nd-from-front anchor; continue toward the back, skipped front-most goes last.
+            // length 1 -> degrades to [cols[0]] (== front).
+            ordered = cols.length === 1 ? cols : [...cols.slice(1), cols[0]];
+            break;
+        case 'front':
+        default:
+            ordered = cols;
+            break;
+    }
+    return { ordered, anchor: ordered[0] };
+}


### PR DESCRIPTION
## Summary

Phase 2 of 5 of the positional-combat arc (after #105 data foundation, #106 geometry resolver): the engine can now select **which** opposing ship an attacker hits, from board positions — side-symmetric (player→enemy and enemy→player).

- **New pure module** `src/utils/targeting/selectTargets.ts` (+ `rowOf`/`colOf`/`BoardRow` on `board.ts`): row-first scan (caster's row, descend with wraparound) → within-row `front`/`back`/`skip` column choice → ordered list + anchor. Fully unit-tested with named board-layout goldens.
- **Glue** `src/utils/combat/positionalBinding.ts` (`isPositional` / `resolvePositionalTarget`): maps the Position-level anchor back to a living, positioned `CombatActor` (≤1 actor per cell).
- **Engine wiring** at the 3 `runPlayerTurn` sites via a single `const tgt = selected ?? legacy` consolidation — focus/team turns select among `enemyAttackerActors`, enemy turns among `allPlayerActors`. `applyIncomingToTarget` gained an optional `victim` param so enemy incoming routes to the selected player.

## Scope & safety

- **Capability-only — no UI, no production caller passes positions yet.** The positional branch is gated on `isPositional` (acting actor has a position AND the opposing roster has positioned members); positions/targets arrive only via new optional input fields no existing input sets. So the feature is **inert for all existing inputs** and **all DPS/healing goldens are byte-identical** (no snapshot file in the diff vs main).
- **Single-anchor apply.** AoE/covered-cell splash, stealth, forced targeting (Taunt/Provoke/Concentrate Fire), per-actor-per-side accounting, per-target HP decline, and death-fallback are explicitly deferred to Phases 3–4 (documented inline). `resolveCells` stays unwired.
- The side-symmetric selection seam is the team-agnostic seam the Phase-5 simulator will inherit.

## Test Plan

- [x] `npm test` — full suite green (**2155 passed**); all DPS/healing goldens byte-identical
- [x] `npm run lint` — 0 warnings
- [x] `npx tsc --noEmit` — clean
- [x] New tests: `selectTargets` unit/goldens, `positionalBinding` unit, `positionalSelection` engine integration (focus→enemy front/back/skip, team→enemy, enemy→player side-symmetric)
- [x] Subagent-driven build with per-task spec + code-quality reviews and a final holistic review — all approved

Spec: `docs/superpowers/specs/2026-06-14-positional-target-selection-design.md`
Plan: `docs/superpowers/plans/2026-06-14-positional-target-selection.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)