### PR TITLE
feat(targeting): forced targeting + stealth (positional phase 3)

### DIFF
--- a/docs/superpowers/plans/2026-06-14-forced-targeting-stealth.md
+++ b/docs/superpowers/plans/2026-06-14-forced-targeting-stealth.md
@@ -327,6 +327,8 @@ export function buildForcedTargetingStatus(
 
 (Buff-name constants live in `src/constants/buffs.ts`; the existing query helpers use bare string literals, so match that style.)
 
+**Caveat for the Phase-4 applier follow-up (not this PR):** the always-active enemy-debuff snapshot (`enemyAlwaysSnap`, statusEngine.ts ~702) ignores `enemyTargetId`, so an *always-active* Concentrate Fire would surface as `concentrated` for **every** queried id. This is harmless in Phase 3 (read-only, no applier — nothing applies CF, so the flag is never set in goldens/tests). But when Provoke/CF application is wired later, Concentrate Fire MUST be applied as a per-target (`enemyTargetId`-keyed) timed debuff, not an always-active seed, or it will over-mark all actors.
+
 - [ ] **Step 4: Run the test to verify it passes**
 
 Run: `npx vitest run src/utils/combat/__tests__/forcedTargetingStatus.test.ts`
@@ -444,7 +446,7 @@ const statusLookupFor = (roster: CombatActor[]) => {
 };
 ```
 
-then pass `statusLookupFor(enemyAttackerActors)` as the 4th arg. Place `statusLookupFor` where all 3 call sites can see it and `statusEngine` is in scope (it is, throughout the turn loop). Confirm the chosen scope does not rebuild the map more than once per turn unnecessarily (acceptable either way for these roster sizes, but keep it tidy).
+then pass `statusLookupFor(enemyAttackerActors)` as the 4th arg. **Placement anchor:** the 3 call sites (~2429 focus, ~2541 team, ~2779 enemy) all live in the same per-actor turn-processing body inside the round loop, but ~350 lines apart. Define `statusLookupFor` once at the top of the round loop body (near the `statusEngine.beginRound(r)` region, ~line 1791) or at the top of the per-turn block above ~2429 — anywhere all 3 sites see it and `statusEngine` is in scope. Confirm the chosen scope does not rebuild the map more than once per turn unnecessarily (acceptable either way for these roster sizes, but keep it tidy).
 
 - [ ] **Step 4: Wire the team call site** (engine.ts ~2540-2547):
 

--- a/docs/superpowers/plans/2026-06-14-forced-targeting-stealth.md
+++ b/docs/superpowers/plans/2026-06-14-forced-targeting-stealth.md
@@ -1,0 +1,536 @@
+# Forced Targeting & Stealth (Positional Phase 3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make positional target resolution honour stealth and the forced-targeting statuses (Taunt, Concentrate Fire), as a capability-only overlay on the existing engine.
+
+**Architecture:** A new optional `statusOf` callback on `resolvePositionalTarget` injects per-actor targeting statuses; when present (enemy-side selection) the resolver applies Concentrate Fire → Taunt forced targeting and a stealth filter before delegating to `selectTargets`. A thin read-helper `buildForcedTargetingStatus` composes the existing status-query helpers into that callback, wired at the 3 engine call sites. No production caller passes positions, so all DPS/healing goldens stay byte-identical.
+
+**Tech Stack:** TypeScript, Vitest. Files: `src/utils/combat/positionalBinding.ts`, `src/utils/combat/triggers.ts`, `src/utils/combat/engine.ts`.
+
+**Spec:** `docs/superpowers/specs/2026-06-14-forced-targeting-stealth-design.md`
+
+## Pre-flight / environment
+
+- `gh auth switch --hostname github.com --user TheSusort` before any PR/merge op.
+- This work runs in its own git worktree (a parallel session may own the main checkout). When creating the worktree, **symlink the gitignored `.env` and `docs/*.csv` / `docs/combat-system.md` reference files from the main checkout into the worktree** or env-dependent tests + the pre-commit hook break (Phase 2 gotcha).
+- Dev server is :3000. Do not `vitest -u` goldens — any golden diff is a leak to fix, never a re-baseline.
+- `docs/` is gitignored → spec/plan commits need `git add -f` and `--no-verify` (the pre-commit hook runs the full suite).
+- Branch off current `main` (Phase 2 `e735e14f` merged): `git checkout -b feat/combat-engine-positional-phase3-forced-targeting`.
+
+## File Structure
+
+- **`src/utils/combat/positionalBinding.ts`** (modify) — owns the `ActorTargetingStatus` type (the `statusOf` contract) and the resolution logic. The type lives here, not in `triggers.ts`, because positionalBinding is the consumer/seam and imports nothing from triggers (no import cycle; `triggers.ts` type-imports it).
+- **`src/utils/combat/triggers.ts`** (modify) — adds `buildForcedTargetingStatus` next to the existing `selfBuffNamesForOwners` / `ownerDebuffNamesFor` query helpers it composes.
+- **`src/utils/combat/engine.ts`** (modify) — builds the status map per opposing roster at the 3 `resolvePositionalTarget` call sites and passes `statusOf`.
+- **`src/utils/combat/positionalBinding.test.ts`** (modify) — extends the existing co-located tests with `statusOf` cases.
+- **`src/utils/combat/__tests__/forcedTargetingStatus.test.ts`** (create) — unit tests for `buildForcedTargetingStatus` against a real status engine.
+- **`src/utils/combat/__tests__/positionalSelection.test.ts`** (modify) — adds a Taunt-redirect integration test mirroring the existing Task C1 focus-turn test.
+- **`docs/combat-system.md`** (modify) — annotate §9 that Concentrate Fire is on the target, not the team.
+
+---
+
+### Task 1: `resolvePositionalTarget` gains `statusOf` (stealth + forced targeting)
+
+**Files:**
+- Modify: `src/utils/combat/positionalBinding.ts`
+- Test: `src/utils/combat/positionalBinding.test.ts`
+
+The resolution logic is fully exercised here with a **stub `statusOf`** (a plain function/Map) — no status engine involved, keeping these tests pure.
+
+- [ ] **Step 1: Write the failing tests** — append to `positionalBinding.test.ts`. Add a `statusOf` stub helper and a `describe` block:
+
+```ts
+import { colOf } from '../targeting/board'; // (only if a test needs it; otherwise omit)
+import type { ActorTargetingStatus } from './positionalBinding';
+
+// Build a statusOf stub from a partial map keyed by actor id.
+const statusFrom =
+    (m: Record<string, Partial<ActorTargetingStatus>>) =>
+    (id: string): ActorTargetingStatus | undefined => {
+        const s = m[id];
+        return s
+            ? { stealthed: false, taunting: false, concentrated: false, ...s }
+            : undefined;
+    };
+
+describe('resolvePositionalTarget — stealth + forced targeting (statusOf)', () => {
+    // M4 front-most, M1 back-most.
+    const enemies = [actor('front', 'M4'), actor('back', 'M1')];
+
+    it('omitting statusOf is identical to the Phase-2 result', () => {
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), enemies)?.id).toBe('front');
+    });
+
+    it('statusOf returning undefined for every id is identical to Phase-2', () => {
+        const so = statusFrom({});
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), enemies, so)?.id).toBe('front');
+    });
+
+    it('stealth filter excludes a stealthed enemy (front stealthed → front picks back)', () => {
+        const so = statusFrom({ front: { stealthed: true } });
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), enemies, so)?.id).toBe('back');
+    });
+
+    it('all-stealthed fallback: every enemy stealthed → still targetable (front → front)', () => {
+        const so = statusFrom({ front: { stealthed: true }, back: { stealthed: true } });
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), enemies, so)?.id).toBe('front');
+    });
+
+    it('Taunt forces the taunting actor even when it is not the default anchor', () => {
+        // front selection would pick M4(front); back taunts → redirect to back.
+        const so = statusFrom({ back: { taunting: true } });
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), enemies, so)?.id).toBe('back');
+    });
+
+    it('Concentrate Fire forces the marked actor and reaches it through stealth', () => {
+        // back is both stealthed AND concentrated → CF bypasses stealth, forces back.
+        const so = statusFrom({ back: { stealthed: true, concentrated: true } });
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), enemies, so)?.id).toBe('back');
+    });
+
+    it('Concentrate Fire beats a simultaneous Taunt (priority CF > Taunt)', () => {
+        // front taunts, back is concentrated → CF wins → back.
+        const so = statusFrom({ front: { taunting: true }, back: { concentrated: true } });
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), enemies, so)?.id).toBe('back');
+    });
+
+    it('multi-taunt with no round data → front-most (colOf descending), not roster order', () => {
+        // Roster lists back(M1) before front(M4); both taunt; front-most (M4) must win.
+        const rosterBackFirst = [actor('back', 'M1'), actor('front', 'M4')];
+        const so = statusFrom({ front: { taunting: true }, back: { taunting: true } });
+        expect(
+            resolvePositionalTarget('M4', enemyTarget('front'), rosterBackFirst, so)?.id
+        ).toBe('front');
+    });
+
+    it('multi-taunt honours tauntAppliedRound when present (later round wins over front-most)', () => {
+        // back is back-most but applied later → back wins despite front being front-most.
+        const so = statusFrom({
+            front: { taunting: true, tauntAppliedRound: 1 },
+            back: { taunting: true, tauntAppliedRound: 2 },
+        });
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), enemies, so)?.id).toBe('back');
+    });
+
+    it('ally-side selection ignores statusOf (no stealth/forced targeting)', () => {
+        // side:'ally' → Phase-2 path; opposing map has no caster cell → null (unchanged).
+        const allyTarget: ParsedTarget = { raw: 'ally', side: 'ally', selection: 'self' };
+        const so = statusFrom({ front: { taunting: true } });
+        expect(resolvePositionalTarget('M4', allyTarget, enemies, so)).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/utils/combat/positionalBinding.test.ts`
+Expected: FAIL — `ActorTargetingStatus` not exported / `statusOf` arg ignored so stealth/taunt/CF cases return `front`.
+
+- [ ] **Step 3: Implement** — rewrite `src/utils/combat/positionalBinding.ts` to add the type, the param, and the resolution logic. Full file:
+
+```ts
+import { selectTargets } from '../targeting/selectTargets';
+import { colOf } from '../targeting/board';
+import type { Position } from '../../types/encounters';
+import type { ParsedTarget } from '../targetingParser';
+import type { CombatActor } from './state';
+
+/** Per-actor targeting statuses consulted during positional resolution.
+ *  An `undefined` lookup result (see resolvePositionalTarget) is treated as all-false. */
+export interface ActorTargetingStatus {
+    /** Self-buff 'Stealth' — untargetable unless all opposing actors are stealthed. */
+    stealthed: boolean;
+    /** Self-buff 'Taunt' — forces opposing attackers to target this actor. */
+    taunting: boolean;
+    /** Enemy-debuff 'Concentrate Fire' on this actor — force-targeted, bypasses stealth. */
+    concentrated: boolean;
+    /** Round the Taunt was applied (most-recent-wins tiebreak). Unset today → front-most. */
+    tauntAppliedRound?: number;
+}
+
+export function isPositional(
+    actorPosition: Position | undefined,
+    opposingLiving: CombatActor[]
+): boolean {
+    return !!actorPosition && opposingLiving.some((a) => a.position !== undefined);
+}
+
+/**
+ * Resolve the positional target anchor to a single living CombatActor.
+ *
+ * When `statusOf` is omitted, or the target is ally-side, behaviour is identical to
+ * Phase 2 (the load-bearing byte-identical-goldens guarantee). When `statusOf` is supplied
+ * AND `target.side === 'enemy'`, forced targeting and stealth run before `selectTargets`:
+ *   1. Concentrate Fire (bypasses stealth) — force the marked actor (front-most if many).
+ *   2. Taunt (before stealth) — force the taunting actor (latest tauntAppliedRound else front-most).
+ *   3. Stealth filter — drop stealthed cells; if that empties the set, restore all.
+ * `statusOf(id)` returning `undefined` is treated as all-false (never throws/skips).
+ */
+export function resolvePositionalTarget(
+    actorPosition: Position,
+    target: ParsedTarget,
+    opposingLiving: CombatActor[],
+    statusOf?: (id: string) => ActorTargetingStatus | undefined
+): CombatActor | null {
+    const byCell = new Map<Position, CombatActor>();
+    for (const a of opposingLiving) {
+        if (a.position !== undefined && a.currentHp > 0) {
+            byCell.set(a.position, a);
+        }
+    }
+    if (byCell.size === 0) {
+        return null;
+    }
+
+    // Candidate cells; the stealth filter narrows this list, byCell stays intact for lookup.
+    let cells = [...byCell.keys()];
+
+    if (statusOf && target.side === 'enemy') {
+        const actors = [...byCell.values()];
+        // Front-most among candidates: highest column first (col 4 = front).
+        const frontMost = (cands: CombatActor[]): CombatActor =>
+            [...cands].sort((x, y) => colOf(y.position!) - colOf(x.position!))[0];
+
+        // 1. Concentrate Fire — bypasses stealth.
+        const concentrated = actors.filter((a) => statusOf(a.id)?.concentrated);
+        if (concentrated.length) {
+            return frontMost(concentrated);
+        }
+
+        // 2. Taunt — evaluated before the stealth filter.
+        const taunting = actors.filter((a) => statusOf(a.id)?.taunting);
+        if (taunting.length) {
+            const round = (a: CombatActor) => statusOf(a.id)?.tauntAppliedRound ?? -Infinity;
+            const maxRound = Math.max(...taunting.map(round));
+            const latest = taunting.filter((a) => round(a) === maxRound);
+            return frontMost(latest);
+        }
+
+        // 3. Stealth filter — restore all if every candidate is stealthed.
+        const visible = cells.filter((p) => !statusOf(byCell.get(p)!.id)?.stealthed);
+        if (visible.length) {
+            cells = visible;
+        }
+    }
+
+    const { anchor } = selectTargets(target, {
+        casterPosition: actorPosition,
+        enemyOccupied: cells,
+    });
+    return anchor ? (byCell.get(anchor) ?? null) : null;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/utils/combat/positionalBinding.test.ts`
+Expected: PASS (all existing + new cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/positionalBinding.ts src/utils/combat/positionalBinding.test.ts
+git commit -m "feat(targeting): statusOf-driven stealth + forced targeting in resolvePositionalTarget"
+```
+
+---
+
+### Task 2: `buildForcedTargetingStatus` read helper
+
+**Files:**
+- Modify: `src/utils/combat/triggers.ts` (next to `selfBuffNamesForOwners` ~line 635)
+- Test: `src/utils/combat/__tests__/forcedTargetingStatus.test.ts` (create)
+
+Composes the existing query helpers into a per-actor status map. Reads only — applying Concentrate Fire to an actor's store is deferred (no applier in Phase 3); the test seeds the status engine directly.
+
+- [ ] **Step 1: Write the failing test** — create `forcedTargetingStatus.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { createStatusEngine } from '../statusEngine';
+import { buildForcedTargetingStatus } from '../triggers';
+import type { SelectedGameBuff } from '../../../types/calculator';
+
+// Always-active seed (skillDuration null → appears in snapshot every round for owner 'attacker';
+// enemyDebuffs with no enemyTargetId resolve to the default '__enemy__' target).
+const buff = (buffName: string): SelectedGameBuff =>
+    ({
+        id: buffName,
+        buffName,
+        stacks: 1,
+        parsedEffects: {},
+        isStackable: false,
+        skillDuration: null,
+    }) as SelectedGameBuff;
+
+describe('buildForcedTargetingStatus', () => {
+    it('reads Stealth and Taunt from the self-buff store', () => {
+        const se = createStatusEngine({ selfBuffs: [buff('Stealth'), buff('Taunt')], enemyDebuffs: [] });
+        se.beginRound(1);
+        const map = buildForcedTargetingStatus(se, ['attacker']);
+        expect(map.get('attacker')).toMatchObject({ stealthed: true, taunting: true, concentrated: false });
+    });
+
+    it('reads Concentrate Fire from the per-target enemy-debuff store', () => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [buff('Concentrate Fire')] });
+        se.beginRound(1);
+        const map = buildForcedTargetingStatus(se, ['__enemy__']);
+        expect(map.get('__enemy__')).toMatchObject({ concentrated: true, stealthed: false, taunting: false });
+    });
+
+    it('absent statuses → all-false', () => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        se.beginRound(1);
+        const map = buildForcedTargetingStatus(se, ['attacker']);
+        expect(map.get('attacker')).toEqual({ stealthed: false, taunting: false, concentrated: false });
+    });
+});
+```
+
+NOTE: if the always-active seed does not surface in `snapshot().activeSelfBuffs` (verify by reading `createStatusEngine` `isAlwaysActive` at statusEngine.ts:234 — `skillDuration: null` qualifies), mirror the seed shape used in `src/utils/combat/__tests__/enemyBuffSelfDebuffGate.test.ts`. Call `se.beginRound(1)` before querying (the snapshot reads the current round's active sets).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/utils/combat/__tests__/forcedTargetingStatus.test.ts`
+Expected: FAIL — `buildForcedTargetingStatus` is not exported from `triggers.ts`.
+
+- [ ] **Step 3: Implement** — add to `src/utils/combat/triggers.ts` directly after `selfBuffNamesForOwners` (and after `ownerDebuffNamesFor`). Import the type:
+
+```ts
+import type { ActorTargetingStatus } from './positionalBinding';
+```
+
+```ts
+/** Per-actor forced-targeting/stealth status, read from the status engine for the given
+ *  actor ids. Stealth/Taunt are self-buffs (selfBuffNamesForOwners); Concentrate Fire is a
+ *  debuff on the focus target (ownerDebuffNamesFor). Read-half only — no applier wiring this
+ *  phase (Concentrate Fire application is deferred). `tauntAppliedRound` is left unset (the
+ *  query layer exposes no application round → callers degrade to front-most board order). */
+export function buildForcedTargetingStatus(
+    statusEngine: StatusEngine,
+    actorIds: string[]
+): Map<string, ActorTargetingStatus> {
+    const map = new Map<string, ActorTargetingStatus>();
+    for (const id of actorIds) {
+        const selfNames = selfBuffNamesForOwners(statusEngine, [id]);
+        const debuffNames = ownerDebuffNamesFor(statusEngine, id);
+        map.set(id, {
+            stealthed: selfNames.includes('Stealth'),
+            taunting: selfNames.includes('Taunt'),
+            concentrated: debuffNames.includes('Concentrate Fire'),
+        });
+    }
+    return map;
+}
+```
+
+(Buff-name constants live in `src/constants/buffs.ts`; the existing query helpers use bare string literals, so match that style.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/utils/combat/__tests__/forcedTargetingStatus.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/triggers.ts src/utils/combat/__tests__/forcedTargetingStatus.test.ts
+git commit -m "feat(targeting): buildForcedTargetingStatus read helper"
+```
+
+---
+
+### Task 3: Wire `statusOf` at the 3 engine call sites + Taunt-redirect integration test
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts` (call sites ~2430 focus, ~2542 team, ~2780 enemy; import ~line 56)
+- Test: `src/utils/combat/__tests__/positionalSelection.test.ts` (add a Taunt-redirect test)
+
+`buildForcedTargetingStatus` is already imported region (`./triggers`). `statusEngine` is in scope at all 3 sites.
+
+- [ ] **Step 1: Write the failing integration test** — append to `positionalSelection.test.ts`. It mirrors the existing Task C1 focus-turn helpers (`focusAbilityTargetId`, `BASE`, `enemyAt`). The back-most enemy (M1) carries a Taunt self-buff; with `front` selection the focus must redirect to the taunter (M1) instead of the front-most (M4):
+
+```ts
+import { Ability } from '../../../types/abilities';
+
+// A positioned enemy that self-buffs Taunt on its active slot (no damage), so it carries
+// Taunt once it acts. Give it speed > focus so it acts first and Taunt is live when the
+// focus resolves targets in the same round (focus default speed is low here).
+const tauntingEnemyAt = (id: string, position: Position): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1000 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        ab({
+                            type: 'buff',
+                            target: 'self',
+                            config: {
+                                type: 'buff',
+                                buffName: 'Taunt',
+                                parsedEffects: {},
+                                stacks: 1,
+                                isStackable: false,
+                                duration: 99,
+                            } as Ability['config'],
+                        }),
+                    ],
+                },
+            ],
+        } as ShipSkills,
+    }) as EnemyAttacker;
+
+describe('Phase 3 — Taunt forces the focus attacker to redirect', () => {
+    it('front selection redirects to the back-most enemy when it carries Taunt', () => {
+        idc = 0;
+        const input: CombatEngineInput = {
+            ...BASE('front'),
+            numRounds: 2, // round 1 enemy self-buffs Taunt; assert the focus hit's target
+            enemyAttackers: [
+                enemyAt('enemy-front', 'M4'),
+                tauntingEnemyAt('enemy-back', 'M1'),
+            ],
+        };
+        // Without Taunt, front → 'enemy-front'. With Taunt on the back enemy, the focus's
+        // ability-performed targetId must be 'enemy-back'.
+        expect(focusAbilityTargetId(input)).toBe('enemy-back');
+    });
+});
+```
+
+IMPLEMENTATION NOTE on timing: the assertion needs Taunt live when the focus resolves. Two viable setups — pick whichever makes the RED test fail then GREEN cleanly:
+  (a) enemy speed 1000 ≫ focus so the enemy self-buffs Taunt **before** the focus acts in round 1 (above); `focusAbilityTargetId` returns the **first** focus `ability-performed`.
+  (b) if turn order makes round-1 Taunt unavailable to the focus, give the enemy a **passive-slot** Taunt self-buff (seeded at round-1 start via `seedPassiveTimedStatuses`, present before any turn) and keep `numRounds: 1`.
+Verify the chosen setup actually fails RED before wiring (Step 2).
+
+- [ ] **Step 2: Run the new test to verify it fails (RED)**
+
+Run: `npx vitest run src/utils/combat/__tests__/positionalSelection.test.ts -t "Taunt forces"`
+Expected: FAIL — focus binds `enemy-front` (statusOf not yet wired, so Taunt is ignored).
+
+- [ ] **Step 3: Wire the focus call site** (engine.ts ~2428-2435). Replace the `resolvePositionalTarget(...)` call with one that passes a status lookup built over the opposing roster:
+
+```ts
+                    const selectedEnemy =
+                        isPositional(actor.position, enemyAttackerActors) && input.target
+                            ? resolvePositionalTarget(
+                                  actor.position!,
+                                  input.target,
+                                  enemyAttackerActors,
+                                  (() => {
+                                      const m = buildForcedTargetingStatus(
+                                          statusEngine,
+                                          enemyAttackerActors.map((a) => a.id)
+                                      );
+                                      return (id: string) => m.get(id);
+                                  })()
+                              )
+                            : null;
+```
+
+Prefer a small local helper to avoid repeating the IIFE three times — e.g. near the top of the per-round/turn scope define:
+
+```ts
+const statusLookupFor = (roster: CombatActor[]) => {
+    const m = buildForcedTargetingStatus(statusEngine, roster.map((a) => a.id));
+    return (id: string) => m.get(id);
+};
+```
+
+then pass `statusLookupFor(enemyAttackerActors)` as the 4th arg. Place `statusLookupFor` where all 3 call sites can see it and `statusEngine` is in scope (it is, throughout the turn loop). Confirm the chosen scope does not rebuild the map more than once per turn unnecessarily (acceptable either way for these roster sizes, but keep it tidy).
+
+- [ ] **Step 4: Wire the team call site** (engine.ts ~2540-2547):
+
+```ts
+                    const selectedTeamEnemy =
+                        isPositional(actor.position, enemyAttackerActors) && teamTarget
+                            ? resolvePositionalTarget(
+                                  actor.position!,
+                                  teamTarget,
+                                  enemyAttackerActors,
+                                  statusLookupFor(enemyAttackerActors)
+                              )
+                            : null;
+```
+
+- [ ] **Step 5: Wire the enemy call site** (engine.ts ~2778-2781) — opposing roster is `allPlayerActors`:
+
+```ts
+                    const selectedPlayer =
+                        isPositional(actor.position, allPlayerActors) && enemyTarget
+                            ? resolvePositionalTarget(
+                                  actor.position!,
+                                  enemyTarget,
+                                  allPlayerActors,
+                                  statusLookupFor(allPlayerActors)
+                              )
+                            : null;
+```
+
+Add the import if `buildForcedTargetingStatus` is not already pulled from `./triggers` (engine.ts ~line 48-57):
+
+```ts
+    buildForcedTargetingStatus,
+```
+
+- [ ] **Step 6: Run the integration test to verify it passes (GREEN)**
+
+Run: `npx vitest run src/utils/combat/__tests__/positionalSelection.test.ts`
+Expected: PASS — including the existing C1/C2/C3 tests (statusOf returns all-false for statusless rosters → unchanged) and the new Taunt-redirect test.
+
+- [ ] **Step 7: Confirm goldens are byte-identical**
+
+Run: `npx vitest run src/utils/calculators/__tests__/dpsGoldenParity.test.ts src/utils/calculators/__tests__/healingGoldenParity.test.ts`
+Expected: PASS with no snapshot writes. Then `git status` / `git diff --stat` must show **no `__snapshots__` or golden file changed**. If one moved, the gate leaked — fix the wiring, never `vitest -u`.
+
+- [ ] **Step 8: Full suite + lint + types**
+
+Run: `npx vitest run` then `npm run lint` then `npx tsc --noEmit`
+Expected: all green, 0 warnings.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/utils/combat/engine.ts src/utils/combat/__tests__/positionalSelection.test.ts
+git commit -m "feat(targeting): wire forced targeting + stealth into the 3 positional call sites"
+```
+
+---
+
+### Task 4: Doc — annotate combat-system.md §9 (Concentrate Fire on the target)
+
+**Files:**
+- Modify: `docs/combat-system.md` (the Forced Targeting table, ~line 210)
+
+- [ ] **Step 1: Edit the Concentrate Fire row** — append a clarifying note that it is modelled as a debuff on the target ship, not the team:
+
+In the forced-targeting table, change the Concentrate Fire description to note the model used by the simulator, e.g. add a trailing sentence: *"(Simulator model: applied as a debuff on the focus target ship — 'all attacks redirected to this unit' — not a team-wide debuff.)"*
+
+- [ ] **Step 2: Commit** (docs are gitignored → force-add, skip the hook)
+
+```bash
+git add -f docs/combat-system.md
+git commit --no-verify -m "docs: clarify Concentrate Fire is modelled as a target-side debuff"
+```
+
+---
+
+## Wrap-up (after all tasks)
+
+- [ ] Add ONE entry to the evolving combat/DPS `UNRELEASED_CHANGES` block in `src/constants/changelog.ts` ONLY if this surfaces to users. It does not (capability-only, no production caller) → **skip the changelog** per CLAUDE.md (internal/no user-visible behaviour change).
+- [ ] Final holistic review (per subagent-driven-development), then open the PR with `gh` (auth-switch first). PR body should state: capability-only overlay, goldens byte-identical, Provoke is the immediate follow-up.
+- [ ] After merge, update `project_combat_engine_current_state.md` memory: Phase 3 merged; NEXT = Provoke (applier→actor resolution via timed-buff `sourceId`), then Phase 4.
+
+## Non-goals (do not implement here)
+
+- Provoke (next PR).
+- Per-ability "can target stealth" exception (needs `ParsedTarget` + parser work).
+- Per-target damage accounting / AoE splash / death-fallback (Phase 4).
+- A status-engine application-round query for exact "last-applied" taunt (the `tauntAppliedRound` field is the seam).

--- a/docs/superpowers/specs/2026-06-14-forced-targeting-stealth-design.md
+++ b/docs/superpowers/specs/2026-06-14-forced-targeting-stealth-design.md
@@ -44,6 +44,11 @@ goldens remain byte-identical.
   this chain in the follow-up PR.
 - **Concentrate Fire** bypasses stealth and is applied **only to the anchor target**
   (user-confirmed) — i.e. it is a single-actor marker, never a team-wide debuff.
+  **Note:** combat-system.md §9 (line 210) describes CF as a debuff "applied to a team";
+  that description is **stale**. The user-confirmed model is the one used here — CF is a
+  debuff on the *target* actor, which is why the `concentrated` flag is read from the
+  per-target enemy-debuff store (§4.1), not from the attacker. Treat the spec as
+  authoritative over §9 on this point.
 - **Taunt:** if multiple ships taunt, "last applied wins". The status query layer exposes
   no application round, so this PR degrades to a deterministic **front-most board order**
   tiebreak; the resolution helper carries an optional `tauntAppliedRound` field so exact
@@ -76,7 +81,17 @@ export function buildForcedTargetingStatus(
   `'Stealth'` / `'Taunt'`.
 - `concentrated`: `ownerDebuffNamesFor(statusEngine, id)` includes `'Concentrate Fire'`
   (Concentrate Fire is a debuff on the focus target, so it lives in the per-target store,
-  not the self-buff store).
+  not the self-buff store). engine.ts already reads a player actor's own debuffs from this
+  store via `ownerDebuffNamesFor(statusEngine, ownerId)` (~line 1440), confirming
+  per-actor-id keying works.
+
+**Applier deferral (important):** Phase 3 has **no production path that *applies*
+Concentrate Fire** to a specific actor's per-target store — that wiring (an attacker
+marking a victim) belongs to the simulator/Phase-4 work, exactly like Provoke's applier.
+So `buildForcedTargetingStatus` is the *read* half only. The CF/Taunt/Stealth test
+fixtures (§6) therefore set up the status-engine store state directly (or assert against a
+stubbed `statusOf`), rather than driving an in-game applier. This keeps Phase 3 a pure
+read-and-resolve capability.
 
 Buff-name constants already exist in `src/constants/buffs.ts` (`'Stealth'`, `'Taunt'`,
 `'Concentrate Fire'`). Reference them rather than re-typing literals where a constant is
@@ -98,21 +113,31 @@ export function resolvePositionalTarget(
 **When `statusOf` is omitted → Phase-2 behaviour verbatim** (the load-bearing
 backward-compat guarantee — every existing positional test omits it and stays green).
 
+`statusOf(id)` returns `(ActorTargetingStatus | undefined)`; an `undefined` result (actor
+not in the map, or no relevant statuses) **must be treated as all-`false`** — never throw,
+never skip the actor. This is the actual production shape (a status map is built but every
+actor is statusless), and it is the real basis for the byte-identical-goldens guarantee
+(see §5).
+
 When `statusOf` is provided **and `target.side === 'enemy'`**, resolution runs before
 delegating to `selectTargets`:
 
-1. Build the `position → actor` map of living, positioned opposing actors (as today;
-   invariant ≤1 actor per cell). If empty → return `null`.
+1. Build the `position → actor` map (`byCell`) of living, positioned opposing actors (as
+   today; invariant ≤1 actor per cell). If empty → return `null`. **`byCell` stays intact**
+   for the final anchor→actor lookup; the stealth filter (step 4) operates on a *derived
+   candidate cell list*, never by mutating `byCell`.
 2. **Concentrate Fire** (bypasses stealth): among the mapped actors, collect those whose
-   status is `concentrated`. If any, force-target one — front-most (highest column) when
-   multiple. Return that actor.
+   status is `concentrated`. If any, force-target one — **front-most when multiple, computed
+   by explicitly sorting candidates by `colOf` descending** (do not rely on `byCell`
+   insertion/roster order, which is not column-ordered). Return that actor.
 3. **Taunt** (evaluated before stealth): else collect `taunting` actors. If any,
-   force-target one — most-recent `tauntAppliedRound` if present, otherwise/tie front-most.
-   Return that actor.
-4. **Stealth filter**: else remove `stealthed` cells from the candidate set. If the set
-   becomes empty (all stealthed), restore the full set (no-targets-without-stealth
-   fallback). Call `selectTargets` over the surviving cells and map the resulting anchor
-   back to its actor (as today).
+   force-target one — most-recent `tauntAppliedRound` if present, otherwise/tie the same
+   explicit front-most (`colOf` descending) tiebreak. Return that actor.
+4. **Stealth filter**: else build the candidate cell list `[...byCell.keys()]` minus the
+   `stealthed` cells. If that list becomes empty (all stealthed), restore the full
+   `[...byCell.keys()]` (no-targets-without-stealth fallback). Call `selectTargets` over the
+   surviving cells and map the resulting anchor back to its actor via the untouched
+   `byCell` (as today).
 
 Ally-side selection (`target.side === 'ally'`) returns the caster anchor unchanged — no
 stealth or forced-targeting branch.
@@ -123,7 +148,7 @@ targeting only changes *which* actor is returned. `resolveCells`/splash stay unw
 
 ### 4.3 Engine wiring — 3 call sites in `src/utils/combat/engine.ts`
 
-At each existing `resolvePositionalTarget` call (focus ~2429, team ~2541, enemy ~2779):
+At each existing `resolvePositionalTarget` call (focus ~2430, team ~2542, enemy ~2780):
 build the status map for the opposing roster with `buildForcedTargetingStatus(statusEngine,
 <opposingIds>)` and pass `(id) => map.get(id)` as the new `statusOf` arg.
 
@@ -142,6 +167,11 @@ all-`false` for them → identical anchor selection → no snapshot churn. The s
 **no golden snapshot file appears in the diff.** If one moves, the gate leaked — fix the
 gate, never `vitest -u`.
 
+Note the two distinct code paths: the *omitted-`statusOf`* path (existing Phase-2 tests)
+and the *provided-`statusOf`-returning-all-`false`* path (the real production shape once the
+simulator passes positions). **Both** must be byte-identical to Phase-2 selection, and §6
+asserts both explicitly.
+
 ## 6. Testing
 
 - **`positionalBinding.test.ts`** (extend): with `statusOf` —
@@ -150,8 +180,10 @@ gate, never `vitest -u`.
   - Taunt forces the taunting actor even when it is not the default anchor;
   - Concentrate Fire forces the marked actor and reaches it through stealth;
   - priority: Concentrate Fire beats a simultaneous Taunt;
-  - multi-taunt → front-most;
-  - `statusOf` omitted → identical to the Phase-2 result.
+  - multi-taunt → front-most (asserts the explicit `colOf`-descending tiebreak, not roster order);
+  - `statusOf` omitted → identical to the Phase-2 result;
+  - **`statusOf` provided but returning `undefined` for every id → identical to the
+    Phase-2 result** (the production all-statusless shape; the real goldens-invariant basis).
 - **`triggers` test**: `buildForcedTargetingStatus` reads `Stealth`/`Taunt` (self-buff) and
   `Concentrate Fire` (enemy-debuff) into the right flags; absent statuses → all `false`.
 - **Engine integration test**: a positional scenario where an opposing actor carries Taunt

--- a/docs/superpowers/specs/2026-06-14-forced-targeting-stealth-design.md
+++ b/docs/superpowers/specs/2026-06-14-forced-targeting-stealth-design.md
@@ -139,8 +139,11 @@ delegating to `selectTargets`:
    surviving cells and map the resulting anchor back to its actor via the untouched
    `byCell` (as today).
 
-Ally-side selection (`target.side === 'ally'`) returns the caster anchor unchanged — no
-stealth or forced-targeting branch.
+Ally-side selection (`target.side === 'ally'`) skips the stealth/forced-targeting branch
+entirely and returns `null` (the function resolves an *opposing*-side target, and an
+ally-side target has no opposing actor; the engine then falls back to its legacy
+heal-target binding). This matches the `CombatActor | null` contract — `null` means "no
+positional opposing target".
 
 The function still returns a single `CombatActor | null` (the anchor actor); forced
 targeting only changes *which* actor is returned. `resolveCells`/splash stay unwired

--- a/docs/superpowers/specs/2026-06-14-forced-targeting-stealth-design.md
+++ b/docs/superpowers/specs/2026-06-14-forced-targeting-stealth-design.md
@@ -1,0 +1,176 @@
+# Positional Combat Phase 3 — Forced Targeting & Stealth
+
+**Date:** 2026-06-14
+**Status:** Design approved (pending spec review)
+**Phase:** 3 of 5 in the positional-combat decomposition (1 = geometry resolver [#106], 2 = engine positional target-selection [#108], **3 = forced targeting + stealth [this]**, 4 = multi-target consequences/AoE accounting/death-fallback, 5 = simulator page).
+
+## 1. Goal
+
+Make positional target resolution honour the game's forced-targeting and stealth rules
+(combat-system.md §9): a stealthed ship is untargetable, a taunting ship pulls attacks,
+and a Concentrate-Fire-marked ship is force-targeted (bypassing stealth). This builds
+directly on Phase 2's `resolvePositionalTarget` seam and stays a **capability-only
+overlay** — no production caller passes positions yet, so all existing DPS/healing
+goldens remain byte-identical.
+
+## 2. Scope
+
+**In (the "redirect-marker" family — shared machinery, no applier tracking):**
+
+- **Stealth** — exclude stealthed actors from the targetable set (enemy-side selection
+  only); if *all* living opposing actors are stealthed, they all become targetable
+  ("unless no targets without stealth are available", per the buff text).
+- **Taunt** — a buff on a friendly ship forces opposing attackers to target it.
+- **Concentrate Fire** — a debuff applied **only to the anchor/focus target** ("all
+  attacks are redirected to this unit"); force-targets that actor and **bypasses stealth**.
+
+**Out — immediate follow-up PR:**
+
+- **Provoke** — a debuff on the *attacker* forcing it to attack *whoever applied it*.
+  Requires resolving the debuff's applier back to a living opposing actor. The status
+  engine tracks `sourceId` for timed buffs, so it is feasible, but it is distinctly more
+  work and gets its own PR.
+
+**Deferred (not in the data model today):**
+
+- The per-ability **"skill can target stealthed ships"** exception. `ParsedTarget` has no
+  `canTargetStealth` flag and there is no parser for it. Concentrate Fire's bypass covers
+  the main practical case. Add this later with the parsing/data work it needs.
+
+## 3. Game rules (from combat-system.md §9, user-confirmed)
+
+- **Order:** forced targeting is evaluated **before** the stealth filter.
+- **Forced-target priority:** Concentrate Fire → Taunt (§9 lists CF first). Provoke joins
+  this chain in the follow-up PR.
+- **Concentrate Fire** bypasses stealth and is applied **only to the anchor target**
+  (user-confirmed) — i.e. it is a single-actor marker, never a team-wide debuff.
+- **Taunt:** if multiple ships taunt, "last applied wins". The status query layer exposes
+  no application round, so this PR degrades to a deterministic **front-most board order**
+  tiebreak; the resolution helper carries an optional `tauntAppliedRound` field so exact
+  ordering is a trivial future add if the engine ever supplies it.
+- **Stealth** affects **enemy-side (offensive) selection only**. Ally-side selection
+  (heals/buffs anchoring on the caster) ignores stealth and forced targeting entirely.
+
+## 4. Components
+
+### 4.1 `buildForcedTargetingStatus` — new helper in `src/utils/combat/triggers.ts`
+
+Co-located with the existing `selfBuffNamesForOwners` / `ownerDebuffNamesFor` query
+helpers it composes.
+
+```ts
+export interface ActorTargetingStatus {
+    stealthed: boolean;     // self-buff 'Stealth'
+    taunting: boolean;      // self-buff 'Taunt'
+    concentrated: boolean;  // enemy-debuff 'Concentrate Fire' on this actor
+    tauntAppliedRound?: number; // UNSET this PR (no round data in query layer)
+}
+
+export function buildForcedTargetingStatus(
+    statusEngine: StatusEngine,
+    actorIds: string[]
+): Map<string, ActorTargetingStatus>;
+```
+
+- `stealthed` / `taunting`: `selfBuffNamesForOwners(statusEngine, [id])` includes
+  `'Stealth'` / `'Taunt'`.
+- `concentrated`: `ownerDebuffNamesFor(statusEngine, id)` includes `'Concentrate Fire'`
+  (Concentrate Fire is a debuff on the focus target, so it lives in the per-target store,
+  not the self-buff store).
+
+Buff-name constants already exist in `src/constants/buffs.ts` (`'Stealth'`, `'Taunt'`,
+`'Concentrate Fire'`). Reference them rather than re-typing literals where a constant is
+exported; otherwise inline the literal names matching the existing query-helper style.
+
+### 4.2 `resolvePositionalTarget` gains an optional `statusOf` — `src/utils/combat/positionalBinding.ts`
+
+New optional 4th parameter:
+
+```ts
+export function resolvePositionalTarget(
+    actorPosition: Position,
+    target: ParsedTarget,
+    opposingLiving: CombatActor[],
+    statusOf?: (id: string) => ActorTargetingStatus | undefined
+): CombatActor | null;
+```
+
+**When `statusOf` is omitted → Phase-2 behaviour verbatim** (the load-bearing
+backward-compat guarantee — every existing positional test omits it and stays green).
+
+When `statusOf` is provided **and `target.side === 'enemy'`**, resolution runs before
+delegating to `selectTargets`:
+
+1. Build the `position → actor` map of living, positioned opposing actors (as today;
+   invariant ≤1 actor per cell). If empty → return `null`.
+2. **Concentrate Fire** (bypasses stealth): among the mapped actors, collect those whose
+   status is `concentrated`. If any, force-target one — front-most (highest column) when
+   multiple. Return that actor.
+3. **Taunt** (evaluated before stealth): else collect `taunting` actors. If any,
+   force-target one — most-recent `tauntAppliedRound` if present, otherwise/tie front-most.
+   Return that actor.
+4. **Stealth filter**: else remove `stealthed` cells from the candidate set. If the set
+   becomes empty (all stealthed), restore the full set (no-targets-without-stealth
+   fallback). Call `selectTargets` over the surviving cells and map the resulting anchor
+   back to its actor (as today).
+
+Ally-side selection (`target.side === 'ally'`) returns the caster anchor unchanged — no
+stealth or forced-targeting branch.
+
+The function still returns a single `CombatActor | null` (the anchor actor); forced
+targeting only changes *which* actor is returned. `resolveCells`/splash stay unwired
+(Phase 4).
+
+### 4.3 Engine wiring — 3 call sites in `src/utils/combat/engine.ts`
+
+At each existing `resolvePositionalTarget` call (focus ~2429, team ~2541, enemy ~2779):
+build the status map for the opposing roster with `buildForcedTargetingStatus(statusEngine,
+<opposingIds>)` and pass `(id) => map.get(id)` as the new `statusOf` arg.
+
+- Focus + team sites: opposing roster = `enemyAttackerActors`.
+- Enemy site: opposing roster = `allPlayerActors`.
+
+`statusEngine` is already in scope at all three sites. The map can be built per turn at the
+call site (small rosters; no need to hoist). Side-symmetric per the team-agnostic principle.
+
+## 5. Why goldens stay byte-identical
+
+The status map is computed unconditionally whenever positional resolution runs, but it only
+*changes* selection when an actor carries Stealth / Taunt / Concentrate Fire. No synthetic
+golden fixture and no Phase-2 integration test applies any of these statuses, so the map is
+all-`false` for them → identical anchor selection → no snapshot churn. The safety check is:
+**no golden snapshot file appears in the diff.** If one moves, the gate leaked — fix the
+gate, never `vitest -u`.
+
+## 6. Testing
+
+- **`positionalBinding.test.ts`** (extend): with `statusOf` —
+  - stealth filter excludes a stealthed enemy;
+  - all-stealthed fallback (every enemy stealthed → still targetable);
+  - Taunt forces the taunting actor even when it is not the default anchor;
+  - Concentrate Fire forces the marked actor and reaches it through stealth;
+  - priority: Concentrate Fire beats a simultaneous Taunt;
+  - multi-taunt → front-most;
+  - `statusOf` omitted → identical to the Phase-2 result.
+- **`triggers` test**: `buildForcedTargetingStatus` reads `Stealth`/`Taunt` (self-buff) and
+  `Concentrate Fire` (enemy-debuff) into the right flags; absent statuses → all `false`.
+- **Engine integration test**: a positional scenario where an opposing actor carries Taunt
+  → focus-fire redirects to it (asserts the binding, not damage accounting — Phase 4).
+  Plus the byte-identical goldens confirmation.
+
+## 7. Non-goals / follow-ups (explicit)
+
+- Provoke (next PR — applier→actor resolution via timed-buff `sourceId`).
+- Per-ability "can target stealth" exception (needs `ParsedTarget` + parser work).
+- Per-target damage accounting, AoE splash, death-fallback retargeting (Phase 4).
+- Exact "last-applied" taunt ordering (needs a status-engine application-round query;
+  the `tauntAppliedRound` field is the seam for it).
+
+## 8. References
+
+- combat-system.md §9 (Create Ordered Target List — forced targeting + stealth steps).
+- Phase 2: `docs/superpowers/specs/2026-06-14-positional-target-selection-design.md`,
+  `src/utils/combat/positionalBinding.ts`, `src/utils/targeting/selectTargets.ts`.
+- Buff constants: `src/constants/buffs.ts` (`Stealth`, `Taunt`, `Concentrate Fire`, `Provoke`).
+- Status query layer: `selfBuffNamesForOwners` / `ownerDebuffNamesFor` in
+  `src/utils/combat/triggers.ts`.

--- a/src/utils/combat/__tests__/forcedTargetingStatus.test.ts
+++ b/src/utils/combat/__tests__/forcedTargetingStatus.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { createStatusEngine } from '../statusEngine';
+import { buildForcedTargetingStatus } from '../triggers';
+import type { SelectedGameBuff } from '../../../types/calculator';
+
+// Always-active seed (skillDuration null → appears every round for owner 'attacker';
+// enemyDebuffs with no enemyTargetId resolve to the default '__enemy__' target).
+const buff = (buffName: string): SelectedGameBuff =>
+    ({
+        id: buffName,
+        buffName,
+        stacks: 1,
+        parsedEffects: {},
+        isStackable: false,
+        skillDuration: null,
+    }) as SelectedGameBuff;
+
+describe('buildForcedTargetingStatus', () => {
+    it('reads Stealth and Taunt from the self-buff store', () => {
+        const se = createStatusEngine({
+            selfBuffs: [buff('Stealth'), buff('Taunt')],
+            enemyDebuffs: [],
+        });
+        se.beginRound(1);
+        const map = buildForcedTargetingStatus(se, ['attacker']);
+        expect(map.get('attacker')).toMatchObject({
+            stealthed: true,
+            taunting: true,
+            concentrated: false,
+        });
+    });
+    it('reads Concentrate Fire from the per-target enemy-debuff store', () => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [buff('Concentrate Fire')] });
+        se.beginRound(1);
+        const map = buildForcedTargetingStatus(se, ['__enemy__']);
+        expect(map.get('__enemy__')).toMatchObject({
+            concentrated: true,
+            stealthed: false,
+            taunting: false,
+        });
+    });
+    it('absent statuses → all-false', () => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        se.beginRound(1);
+        const map = buildForcedTargetingStatus(se, ['attacker']);
+        expect(map.get('attacker')).toEqual({
+            stealthed: false,
+            taunting: false,
+            concentrated: false,
+        });
+    });
+});

--- a/src/utils/combat/__tests__/positionalSelection.test.ts
+++ b/src/utils/combat/__tests__/positionalSelection.test.ts
@@ -300,3 +300,61 @@ describe('Task C3 — enemy attacker positional target selection (side-symmetric
         expect(hit.has('team-1')).toBe(false);
     });
 });
+
+// ============================================================================
+// Phase 3 — Taunt forces the focus attacker to redirect.
+//
+// A back-most enemy (M1) carries a Taunt self-buff. The focus attacker at M4 selects
+// `front` — which without Taunt resolves to the front-most enemy (M4). With Taunt LIVE
+// when the focus resolves its target, resolvePositionalTarget (now wired with a statusOf
+// lookup) must redirect the focus to the taunter (M1) instead.
+//
+// To make Taunt LIVE before the focus resolves its target, the taunter casts a Taunt
+// self-buff from an ACTIVE slot and runs with speed ≫ the focus, so it takes its turn
+// (self-buffing) first and the buff is in the status engine when the focus acts.
+// ============================================================================
+
+// A pure-target enemy with a high-speed ACTIVE-slot Taunt self-buff. With speed ≫ focus,
+// it acts first and self-buffs Taunt before the focus resolves its target. Its own basic
+// attack would target the player heal target (irrelevant to the focus's selection).
+const tauntingEnemyAt = (id: string, position: Position): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1000 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        ab({
+                            type: 'buff',
+                            target: 'self',
+                            config: {
+                                type: 'buff',
+                                buffName: 'Taunt',
+                                parsedEffects: {},
+                                stacks: 1,
+                                isStackable: false,
+                                duration: 99,
+                            } as Ability['config'],
+                        }),
+                    ],
+                },
+            ],
+        } as ShipSkills,
+    }) as EnemyAttacker;
+
+describe('Phase 3 — Taunt forces the focus attacker to redirect', () => {
+    it('front selection redirects to the back-most enemy when it carries Taunt', () => {
+        idc = 0;
+        const input: CombatEngineInput = {
+            ...BASE('front'),
+            numRounds: 2,
+            enemyAttackers: [enemyAt('enemy-front', 'M4'), tauntingEnemyAt('enemy-back', 'M1')],
+        };
+        expect(focusAbilityTargetId(input)).toBe('enemy-back');
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -49,6 +49,7 @@ import {
     Intent,
     MAX_INTENT_GENERATIONS,
     buildActorConditionContext,
+    buildForcedTargetingStatus,
     executeIntent,
     ownerDebuffNamesFor,
     partitionReactiveAbilities,
@@ -1790,6 +1791,17 @@ export function runCombat(input: CombatEngineInput): {
         // tick here, before any turn fires). Sources notify via sourceFired in turn.
         statusEngine.beginRound(r);
 
+        // Forced-targeting/stealth lookup for a roster (phase 3). Reads the status engine
+        // for each actor's Concentrate Fire / Taunt / Stealth flags so resolvePositionalTarget
+        // can redirect or stealth-filter. Identical to phase 2 when no such status is live.
+        const statusLookupFor = (roster: CombatActor[]) => {
+            const m = buildForcedTargetingStatus(
+                statusEngine,
+                roster.map((a) => a.id)
+            );
+            return (id: string) => m.get(id);
+        };
+
         // Combat-start seeding (round 1) for PASSIVE-sourced finite (timed) self-statuses.
         // Player runtimes face the dummy enemy, so an `enemy-type` gate resolves against
         // `enemyType`. Enemy-attacker runtimes face the player heal target (which has no
@@ -2430,7 +2442,8 @@ export function runCombat(input: CombatEngineInput): {
                             ? resolvePositionalTarget(
                                   actor.position!,
                                   input.target,
-                                  enemyAttackerActors
+                                  enemyAttackerActors,
+                                  statusLookupFor(enemyAttackerActors)
                               )
                             : null;
                     // Positional target (phase 2): the selected enemy actor, else the dummy sink.
@@ -2542,7 +2555,8 @@ export function runCombat(input: CombatEngineInput): {
                             ? resolvePositionalTarget(
                                   actor.position!,
                                   teamTarget,
-                                  enemyAttackerActors
+                                  enemyAttackerActors,
+                                  statusLookupFor(enemyAttackerActors)
                               )
                             : null;
                     // Same `tgt` consolidation as the focus turn: both branches are full
@@ -2777,7 +2791,12 @@ export function runCombat(input: CombatEngineInput): {
                     const enemyTarget = enemyTargetById.get(actor.id);
                     const selectedPlayer =
                         isPositional(actor.position, allPlayerActors) && enemyTarget
-                            ? resolvePositionalTarget(actor.position!, enemyTarget, allPlayerActors)
+                            ? resolvePositionalTarget(
+                                  actor.position!,
+                                  enemyTarget,
+                                  allPlayerActors,
+                                  statusLookupFor(allPlayerActors)
+                              )
                             : null;
                     // The enemy's victim THIS turn: the positionally-selected player actor, else the
                     // legacy heal target. A full CombatActor in both cases, so every per-victim

--- a/src/utils/combat/positionalBinding.test.ts
+++ b/src/utils/combat/positionalBinding.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { ParsedTarget } from '../targetingParser';
 import { isPositional, resolvePositionalTarget } from './positionalBinding';
+import type { ActorTargetingStatus } from './positionalBinding';
 import type { CombatActor } from './state';
 
 const actor = (id: string, position: CombatActor['position'], currentHp = 100): CombatActor =>
@@ -58,5 +59,69 @@ describe('resolvePositionalTarget', () => {
     it('excludes dead actors but still resolves a living one', () => {
         const mixed = [actor('dead', 'M4', 0), actor('alive', 'M1', 50)];
         expect(resolvePositionalTarget('M4', enemyTarget('front'), mixed)?.id).toBe('alive');
+    });
+});
+
+// Build a statusOf stub from a partial map keyed by actor id.
+const statusFrom =
+    (m: Record<string, Partial<ActorTargetingStatus>>) =>
+    (id: string): ActorTargetingStatus | undefined => {
+        const s = m[id];
+        return s ? { stealthed: false, taunting: false, concentrated: false, ...s } : undefined;
+    };
+
+describe('resolvePositionalTarget — stealth + forced targeting (statusOf)', () => {
+    const enemies = [actor('front', 'M4'), actor('back', 'M1')]; // M4 front-most, M1 back-most
+
+    it('omitting statusOf is identical to the Phase-2 result', () => {
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), enemies)?.id).toBe('front');
+    });
+    it('statusOf returning undefined for every id is identical to Phase-2', () => {
+        expect(
+            resolvePositionalTarget('M4', enemyTarget('front'), enemies, statusFrom({}))?.id
+        ).toBe('front');
+    });
+    it('stealth filter excludes a stealthed enemy (front stealthed → front picks back)', () => {
+        const so = statusFrom({ front: { stealthed: true } });
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), enemies, so)?.id).toBe('back');
+    });
+    it('all-stealthed fallback: every enemy stealthed → still targetable (front → front)', () => {
+        const so = statusFrom({ front: { stealthed: true }, back: { stealthed: true } });
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), enemies, so)?.id).toBe('front');
+    });
+    it('Taunt forces the taunting actor even when it is not the default anchor', () => {
+        const so = statusFrom({ back: { taunting: true } });
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), enemies, so)?.id).toBe('back');
+    });
+    it('Concentrate Fire forces the marked actor and reaches it through stealth', () => {
+        const so = statusFrom({ back: { stealthed: true, concentrated: true } });
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), enemies, so)?.id).toBe('back');
+    });
+    it('Concentrate Fire beats a simultaneous Taunt (priority CF > Taunt)', () => {
+        const so = statusFrom({ front: { taunting: true }, back: { concentrated: true } });
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), enemies, so)?.id).toBe('back');
+    });
+    it('multi-taunt with no round data → front-most (colOf descending), not roster order', () => {
+        const rosterBackFirst = [actor('back', 'M1'), actor('front', 'M4')];
+        const so = statusFrom({ front: { taunting: true }, back: { taunting: true } });
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), rosterBackFirst, so)?.id).toBe(
+            'front'
+        );
+    });
+    it('multi-taunt honours tauntAppliedRound when present (later round wins over front-most)', () => {
+        const so = statusFrom({
+            front: { taunting: true, tauntAppliedRound: 1 },
+            back: { taunting: true, tauntAppliedRound: 2 },
+        });
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), enemies, so)?.id).toBe('back');
+    });
+    it('ally-side selection ignores statusOf (no stealth/forced targeting)', () => {
+        const allyTarget: ParsedTarget = { raw: 'ally', side: 'ally', selection: 'self' };
+        const so = statusFrom({ front: { taunting: true } });
+        expect(resolvePositionalTarget('M4', allyTarget, enemies, so)).toBeNull();
+    });
+    it('statusOf supplied but opposing list empty → null (statusOf not consulted)', () => {
+        const so = statusFrom({ x: { taunting: true } });
+        expect(resolvePositionalTarget('M4', enemyTarget('front'), [], so)).toBeNull();
     });
 });

--- a/src/utils/combat/positionalBinding.ts
+++ b/src/utils/combat/positionalBinding.ts
@@ -1,16 +1,22 @@
 import { selectTargets } from '../targeting/selectTargets';
+import { colOf } from '../targeting/board';
 import type { Position } from '../../types/encounters';
 import type { ParsedTarget } from '../targetingParser';
 import type { CombatActor } from './state';
 
-/**
- * Positional selection is active for an actor only when:
- *   1. the acting actor itself has a board position, AND
- *   2. at least one opposing (living) actor has a board position.
- *
- * When this returns false the caller should fall back to the legacy
- * index-based targeting.
- */
+/** Per-actor targeting statuses consulted during positional resolution.
+ *  An `undefined` lookup result (see resolvePositionalTarget) is treated as all-false. */
+export interface ActorTargetingStatus {
+    /** Self-buff 'Stealth' — untargetable unless all opposing actors are stealthed. */
+    stealthed: boolean;
+    /** Self-buff 'Taunt' — forces opposing attackers to target this actor. */
+    taunting: boolean;
+    /** Enemy-debuff 'Concentrate Fire' on this actor — force-targeted, bypasses stealth. */
+    concentrated: boolean;
+    /** Round the Taunt was applied (most-recent-wins tiebreak). Unset today → front-most. */
+    tauntAppliedRound?: number;
+}
+
 export function isPositional(
     actorPosition: Position | undefined,
     opposingLiving: CombatActor[]
@@ -21,19 +27,19 @@ export function isPositional(
 /**
  * Resolve the positional target anchor to a single living CombatActor.
  *
- * Steps:
- *   1. Build a position→actor map from the living (currentHp > 0) opposing actors
- *      that have a board position. Invariant: at most one actor per cell.
- *   2. Call selectTargets to obtain the anchor cell.
- *   3. Look up and return the actor at that cell, or null if no valid target.
- *
- * Returns null when the opposing side has no living positioned actors, or when
- * selectTargets cannot find a target (empty side).
+ * When `statusOf` is omitted, or the target is ally-side, behaviour is identical to
+ * Phase 2 (the load-bearing byte-identical-goldens guarantee). When `statusOf` is supplied
+ * AND `target.side === 'enemy'`, forced targeting and stealth run before `selectTargets`:
+ *   1. Concentrate Fire (bypasses stealth) — force the marked actor (front-most if many).
+ *   2. Taunt (before stealth) — force the taunting actor (latest tauntAppliedRound else front-most).
+ *   3. Stealth filter — drop stealthed cells; if that empties the set, restore all.
+ * `statusOf(id)` returning `undefined` is treated as all-false (never throws/skips).
  */
 export function resolvePositionalTarget(
     actorPosition: Position,
     target: ParsedTarget,
-    opposingLiving: CombatActor[]
+    opposingLiving: CombatActor[],
+    statusOf?: (id: string) => ActorTargetingStatus | undefined
 ): CombatActor | null {
     const byCell = new Map<Position, CombatActor>();
     for (const a of opposingLiving) {
@@ -41,15 +47,52 @@ export function resolvePositionalTarget(
             byCell.set(a.position, a);
         }
     }
-
     if (byCell.size === 0) {
         return null;
     }
 
+    // Ally-side targets do not resolve through the opposing list.
+    if (target.side === 'ally') {
+        return null;
+    }
+
+    // Candidate cells; the stealth filter narrows this list, byCell stays intact for lookup.
+    let cells = [...byCell.keys()];
+
+    if (statusOf) {
+        const actors = [...byCell.values()];
+        // Front-most among candidates: highest column first (col 4 = front).
+        // Precondition: callers must guarantee cands is non-empty (returns undefined on []).
+        const frontMost = (cands: CombatActor[]): CombatActor =>
+            [...cands].sort((x, y) => colOf(y.position!) - colOf(x.position!))[0];
+
+        // 1. Concentrate Fire — bypasses stealth.
+        const concentrated = actors.filter((a) => statusOf(a.id)?.concentrated);
+        if (concentrated.length) {
+            return frontMost(concentrated);
+        }
+
+        // 2. Taunt — evaluated before the stealth filter.
+        const taunting = actors.filter((a) => statusOf(a.id)?.taunting);
+        if (taunting.length) {
+            // -Infinity sentinel: when all taunters lack tauntAppliedRound, every round(a) is -Infinity,
+            // they all tie at maxRound, and frontMost resolves the tie (roundless multi-taunt → front-most).
+            const round = (a: CombatActor) => statusOf(a.id)?.tauntAppliedRound ?? -Infinity;
+            const maxRound = Math.max(...taunting.map(round));
+            const latest = taunting.filter((a) => round(a) === maxRound);
+            return frontMost(latest);
+        }
+
+        // 3. Stealth filter — restore all if every candidate is stealthed.
+        const visible = cells.filter((p) => !statusOf(byCell.get(p)!.id)?.stealthed);
+        if (visible.length) {
+            cells = visible;
+        }
+    }
+
     const { anchor } = selectTargets(target, {
         casterPosition: actorPosition,
-        enemyOccupied: [...byCell.keys()],
+        enemyOccupied: cells,
     });
-
     return anchor ? (byCell.get(anchor) ?? null) : null;
 }

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -17,6 +17,7 @@ import {
 // Type-only import (erased at runtime) → no circular-import cycle even though playerTurn.ts
 // imports buildActorConditionContext/ReactiveAbility from this module.
 import type { PlayerActorRuntime, PlayerRoundCtx, HealingRuntimeCtx } from './playerTurn';
+import type { ActorTargetingStatus } from './positionalBinding';
 
 /** The trigger values the engine consumes — defined next to AbilityTrigger in
  *  types/abilities.ts (so UI consumers don't import the engine for one constant)
@@ -676,6 +677,28 @@ export function ownerDebuffNamesFor(statusEngine: StatusEngine, targetId: string
         names.add(s.active.buffName);
     }
     return [...names];
+}
+
+/** Per-actor forced-targeting/stealth status, read from the status engine for the given
+ *  actor ids. Stealth/Taunt are self-buffs (selfBuffNamesForOwners); Concentrate Fire is a
+ *  debuff on the focus target (ownerDebuffNamesFor). Read-half only — no applier wiring this
+ *  phase. `tauntAppliedRound` is left unset (the query layer exposes no application round →
+ *  callers degrade to front-most board order). */
+export function buildForcedTargetingStatus(
+    statusEngine: StatusEngine,
+    actorIds: string[]
+): Map<string, ActorTargetingStatus> {
+    const map = new Map<string, ActorTargetingStatus>();
+    for (const id of actorIds) {
+        const selfNames = selfBuffNamesForOwners(statusEngine, [id]);
+        const debuffNames = ownerDebuffNamesFor(statusEngine, id);
+        map.set(id, {
+            stealthed: selfNames.includes('Stealth'),
+            taunting: selfNames.includes('Taunt'),
+            concentrated: debuffNames.includes('Concentrate Fire'),
+        });
+    }
+    return map;
 }
 
 function payloadFromConfig(cfg: {


### PR DESCRIPTION
## Summary

Positional-combat **Phase 3 of 5** (1 = geometry resolver #106, 2 = engine positional target-selection #108, **3 = forced targeting + stealth [this]**, 4 = multi-target AoE/accounting/death-fallback, 5 = simulator page).

Makes positional target resolution honour **stealth** and the **forced-targeting** statuses **Taunt** and **Concentrate Fire**, as a **capability-only overlay** on the existing engine — no production caller passes positions/statuses yet, so all DPS + healing goldens stay **byte-identical**.

- **`resolvePositionalTarget`** (`positionalBinding.ts`) gains an optional `statusOf` callback. When supplied (enemy-side selection only) it resolves **Concentrate Fire → Taunt → stealth-filter** before delegating to `selectTargets`: CF force-targets the marked actor and bypasses stealth; Taunt force-targets the taunter (most-recent `tauntAppliedRound` if present, else front-most by column); the stealth filter drops stealthed cells, restoring all when every candidate is stealthed. Omitted `statusOf` (or an all-false map) → Phase-2 behaviour verbatim.
- **`buildForcedTargetingStatus`** (`triggers.ts`) — read-only helper composing the existing `selfBuffNamesForOwners` (Stealth/Taunt) + `ownerDebuffNamesFor` (Concentrate Fire, a debuff on the target) into a per-actor `ActorTargetingStatus` map.
- **Engine wiring** (`engine.ts`) — a `statusLookupFor(roster)` helper built once per round feeds the lookup at all 3 `resolvePositionalTarget` sites (focus/team use `enemyAttackerActors`; enemy uses `allPlayerActors`), side-symmetric per the team-agnostic principle.

Concentrate Fire is modelled as a debuff **on the focus target** ("all attacks redirected to this unit"), not a team-wide debuff — combat-system.md §9's "applied to a team" wording is stale; the committed spec is authoritative (user-confirmed).

## Test Plan

- [x] `resolvePositionalTarget` unit tests (stub `statusOf`): stealth filter, all-stealthed fallback, Taunt force, CF force-through-stealth, CF>Taunt priority, multi-taunt front-most + `tauntAppliedRound`, omitted/undefined `statusOf` = Phase-2, empty roster.
- [x] `buildForcedTargetingStatus` unit tests (real status engine): Stealth/Taunt self-buffs, Concentrate Fire enemy-debuff, absent → all-false.
- [x] Engine integration test: a Taunt-carrying back-most enemy redirects the focus attacker's bind (`positionalSelection.test.ts`).
- [x] **Goldens byte-identical** — DPS + healing parity pass, no snapshot file changed.
- [x] Full suite 2170 pass; lint (max-warnings 0) + tsc clean.

## Follow-ups (deferred)

- **Provoke** (debuff on the attacker → forces it to target the applier; needs applier→actor resolution via timed-buff `sourceId`) — immediate next PR.
- Per-ability **"can target stealth"** exception (not in the `ParsedTarget` data model yet).
- End-to-end engine tests for **stealth** and **Concentrate Fire** (CF needs an applier, which lands with the simulator/Phase 4); the resolver logic + the read helper are each unit-tested.
- Spec `docs/superpowers/specs/2026-06-14-forced-targeting-stealth-design.md`, plan `docs/superpowers/plans/2026-06-14-forced-targeting-stealth.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)