### PR TITLE
feat(combat): positional multi-target AoE + per-victim apply (positional phase 4, PR 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ supabase/.temp/
 docs/
 .claude/
 video/
+
+# husky internals (generated; symlinked in worktrees)
+.husky/_

--- a/docs/superpowers/plans/2026-06-15-positional-combat-phase4-pr1.md
+++ b/docs/superpowers/plans/2026-06-15-positional-combat-phase4-pr1.md
@@ -1,0 +1,347 @@
+# Positional Combat Phase 4 — PR 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a symmetric per-victim damage-apply path (so player attacks can damage and kill real enemy actors), wire `resolveCells` for multi-target AoE with per-hit re-resolution, and make the three Phase-2-deferred accounting paths per-victim-correct — all as a capability-only overlay that keeps DPS/healing goldens byte-identical.
+
+**Architecture:** Today `applyIncomingToTarget` (engine.ts:1919) is the *only* `currentHp`-decrement path and runs only enemy→player; player→enemy damage uses the cumulative-damage sink and never decrements a real enemy. PR 1 (a) extracts the victim-intake core into a reusable `applyVictimDamage` parameterized by a side-specific accounting sink (the enemy→player wrapper stays byte-identical), (b) adds a player→enemy wrapper, (c) adds a per-victim damage *calculator* (per-victim defense/affinity), and (d) a new `positionalApply.ts` that, for a positioned attacker with a damage ability, loops per hit → re-resolves anchor → `resolveCells` → applies full/50% damage per living occupant. The non-positional path is untouched.
+
+**Tech Stack:** TypeScript, Vitest. Engine code in `src/utils/combat/`, geometry in `src/utils/targeting/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-positional-combat-phase4-design.md`
+
+---
+
+## Workflow notes (read first)
+
+- **Worktree:** do this PR in its own git worktree off latest `main`. After creating it, **symlink the gitignored files** the test suite + pre-commit hook need: `.env` and `docs/ship-targeting.csv`, `docs/ship-skills.csv`, `docs/bios.csv`, `docs/combat-system.md` from the main checkout — else env-only tests fail and the hook blocks the commit.
+- **`gh auth switch --hostname github.com --user TheSusort`** before any PR/merge/gh-api op.
+- **Goldens are SYNTHETIC** (`healingGoldenParity.test.ts` + the DPS golden suite; hand-built `ab()` actors, no parser import). **Any diff = a bug. NEVER `vitest -u`.** The whole PR's safety invariant is: with no positions supplied, every golden is byte-identical. If one moves, the positional gate leaked — fix the gate.
+- **`docs/` is gitignored** → `git add -f` for spec/plan; docs-only commits use `--no-verify` (the pre-commit hook runs the full vitest suite).
+- **Changelog:** one evolving `UNRELEASED_CHANGES` entry for combat work — fold, don't add separate entries. PR 1 is capability-only (no user-visible behavior yet) → **no changelog entry** until Phase 5 wires a caller.
+- Test commands: `npm test -- <path>` (single file), `npm test` (full suite), `npm run lint`, `npx tsc --noEmit`, `npm run audit:skills`.
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/utils/combat/engine.ts` | `applyVictimDamage` core + two wrappers; wire positional apply at 3 damage sites; per-victim accounting | Modify |
+| `src/utils/combat/victimDamage.ts` | **new** pure per-victim damage calculator (attacker scalars + victim defense/affinity → damage) | Create |
+| `src/utils/combat/positionalApply.ts` | **new** per-hit loop: re-resolve anchor, `resolveCells`, role-scale, apply per living occupant | Create |
+| `src/utils/combat/playerTurn.ts` | expose attacker-side damage scalars on `PlayerTurnResult` for the positional path | Modify |
+| `src/utils/calculators/dpsSimulator.ts` (or wherever `RoundData` lives — confirm in Task 9) | additive `perTargetDamage` field | Modify |
+| `src/utils/combat/__tests__/*.test.ts` | unit/integration tests — combat tests live under `__tests__/` (matches `barrier.test.ts`/`healing.test.ts` whose fixtures Tasks 1 & 3 reuse; import them as `./barrier`, `./healing` from within `__tests__/`). NOTE: `targeting/` tests are flat (no `__tests__/`) per its own convention. | Create |
+
+---
+
+## Task 1: Characterization tests for the current victim-intake (lock behavior before refactor)
+
+**Files:**
+- Test: `src/utils/combat/__tests__/applyVictimDamage.characterization.test.ts` (new)
+
+Pin the *current* `applyIncomingToTarget` behavior through the engine so the Task 2 extraction is provably behavior-preserving. Use the existing healing-mode engine entry (`simulateHealing` adapter or a direct `runCombat` harness — match how `healing.test.ts` / `barrier.test.ts` drive it) with hand-built actors.
+
+- [ ] **Step 1: Write characterization tests** covering the victim-intake branches against a heal target:
+  - plain HP damage (shield 0) decrements `currentHp` by exactly the damage;
+  - shield absorbs first, overflow hits HP;
+  - Barrier carrier → full block, HP unchanged, `barrierAbsorbed` accrues, `hp-changed` still emitted once;
+  - lethal hit on a Cheat-Death carrier → survives at 1 HP, `cheat-death-activated` emitted, removable statuses cleared;
+  - lethal hit, no Cheat Death → `currentHp` 0, `ship-destroyed` emitted once.
+  (These mirror `barrier.test.ts` / Phase 4b death tests — reuse their fixture helpers.)
+- [ ] **Step 2: Run, expect PASS** (documents current behavior): `npm test -- src/utils/combat/__tests__/applyVictimDamage.characterization.test.ts`
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/combat/__tests__/applyVictimDamage.characterization.test.ts
+git commit -m "test(combat): characterize victim-intake before phase-4 extraction"
+```
+
+---
+
+## Task 2: Extract `applyVictimDamage` core (behavior-preserving)
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts:1919-2036` (the `applyIncomingToTarget` closure)
+
+Extract the body of `applyIncomingToTarget` into a closure `applyVictimDamage(damage, victim, sink)` where `sink` carries the three side-specific accumulators as callbacks/refs:
+
+```ts
+interface DamageAccountingSink {
+    addIncoming: (amount: number) => void;      // today: roundIncomingDamage += amount
+    addShieldAbsorbed: (amount: number) => void; // today: roundShieldAbsorbed += amount
+    addBarrierAbsorbed: (amount: number) => void;// today: roundBarrierAbsorbed += amount
+    onHealTargetDestroyed?: (victim: CombatActor) => void; // today: healTargetDestroyedRound write (guarded victim===healTarget)
+}
+```
+
+Everything else (Barrier detection via `selfBuffNamesForOwners`, shield drain, `currentHp` decrement, Cheat-Death intercept, `recordDestroyed`, `hp-changed` emits) is already victim-keyed → moves verbatim.
+
+`applyIncomingToTarget(damage, victim = healTarget!)` becomes a thin wrapper passing the **player-side sink** (the existing `roundIncomingDamage`/`roundShieldAbsorbed`/`roundBarrierAbsorbed` mutators + the `victim === healTarget` destroyed write). Behavior identical.
+
+- [ ] **Step 1:** Run the Task 1 characterization tests + full golden suite to confirm green baseline: `npm test`
+- [ ] **Step 2:** Perform the extraction (pure refactor — no behavior change). Keep `applyVictimDamage` as a closure inside `runCombat` (it needs `statusEngine`, `bus`, `r`, `recipientMaxHp`, `cheatDeathConsumed`, `recordDestroyed`).
+- [ ] **Step 3:** Run characterization + full suite, **expect byte-identical** (all green, no golden diff): `npm test`
+  - Expected: PASS, zero golden snapshot changes. If any golden moves, the extraction changed behavior — revert and redo.
+- [ ] **Step 4:** `npx tsc --noEmit && npm run lint`
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/engine.ts
+git commit -m "refactor(combat): extract applyVictimDamage core (behavior-preserving)"
+```
+
+---
+
+## Task 3: Player→enemy wrapper
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts` (near `applyIncomingToTarget`)
+- Test: `src/utils/combat/__tests__/applyOutgoingToEnemy.test.ts` (new)
+
+Add `applyOutgoingToEnemy(damage, enemyVictim)` — a second thin wrapper over `applyVictimDamage` with an **enemy-side sink** that does NOT touch the player-incoming accumulators (those are the tank's incoming bucket). For PR 1 the enemy-side sink may be a no-op for the three accumulators (enemy-incoming accounting is the Phase-5 symmetric surface); it still runs the full HP/shield/Barrier/Cheat-Death/`recordDestroyed` path so enemies actually take damage and die.
+
+- [ ] **Step 1: Write failing tests** with a hand-built enemy actor (positioned, real `currentHp`/`shieldPool`):
+  - damage decrements the enemy victim's `currentHp`;
+  - shield absorbs first;
+  - enemy carrying Barrier → full block;
+  - lethal damage, no Cheat Death → enemy `currentHp` 0 + `ship-destroyed` emitted;
+  - lethal on enemy Cheat-Death carrier → survives at 1.
+- [ ] **Step 2: Run, expect FAIL** (function undefined): `npm test -- src/utils/combat/__tests__/applyOutgoingToEnemy.test.ts`
+- [ ] **Step 3: Implement** the wrapper + enemy-side sink.
+- [ ] **Step 4: Run, expect PASS**; then `npm test` full suite **byte-identical** (no caller yet → goldens unmoved).
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/engine.ts src/utils/combat/__tests__/applyOutgoingToEnemy.test.ts
+git commit -m "feat(combat): player->enemy per-victim damage apply wrapper"
+```
+
+---
+
+## Task 4: Per-victim damage calculator
+
+**Files:**
+- Create: `src/utils/combat/victimDamage.ts`
+- Test: `src/utils/combat/__tests__/victimDamage.test.ts`
+
+A pure function turning attacker-side scalars + a per-hit crit outcome + a single victim's defensive profile into a damage number. Factor the per-victim-dependent math out of `playerTurn.ts:1110-1282` (`effectiveDefense`/`damageReduction` from victim defense+penetration, `affinityMult` from attacker-vs-victim affinity). Attacker-side scalars (`effectiveAttack`, `effectiveMultiplier + conditionalBonusPct`, `secondaryStatValue`, `effectiveCritDamage`, `outgoingDamageBuff`, `incomingDamageModifier`) are fixed per cast and passed in.
+
+```ts
+export interface AttackerDamageScalars {
+    effectiveAttack: number;
+    multiplierPct: number;        // effectiveMultiplier + conditionalBonusPct
+    secondaryStatValue: number;
+    effectiveCritDamage: number;  // percent
+    outgoingDamageBuffPct: number;
+    incomingDamageModifierPct: number;
+    defensePenetrationPct: number;
+    attackerAffinity: AffinityName;   // ship.ts:7 — for affinity matchup vs victim (affinityUtils.ts)
+}
+export interface VictimDefenseProfile {
+    defence: number;
+    defenceModifierPct: number;
+    affinity: AffinityName;
+}
+// didCrit = the per-hit crit outcome (hitCrits[h]); roleScale = 1 (origin) | 0.5 (covered)
+export function victimHitDamage(
+    s: AttackerDamageScalars, v: VictimDefenseProfile, didCrit: boolean, roleScale: number
+): number
+```
+
+**Parity constraint (the load-bearing test):** for a SINGLE victim and `hits` hits, `sum over h of victimHitDamage(s, v, hitCrits[h], 1)` must equal the current aggregate `directDamage` (minus passive/secondary which stay in their existing buckets — match the exact decomposition; see playerTurn.ts:1259-1282). Use full precision, no per-hit rounding.
+
+- [ ] **Step 1: Write failing tests**: (a) a hand-computed single-hit value through defense+crit+affinity; (b) **per-hit-vs-aggregate parity**: with a fixed `hitCrits` array, the per-hit sum equals the existing aggregate formula for the same inputs; (c) `roleScale: 0.5` halves the origin damage.
+- [ ] **Step 2: Run, expect FAIL**: `npm test -- src/utils/combat/__tests__/victimDamage.test.ts`
+- [ ] **Step 3: Implement** by mirroring the existing formula (defense reduction via `calculateDamageReduction`, `nonCritFactor`, `damageCritMultiplier` but per-hit binary instead of blended `critFraction`).
+- [ ] **Step 4: Run, expect PASS**.
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/victimDamage.ts src/utils/combat/__tests__/victimDamage.test.ts
+git commit -m "feat(combat): pure per-victim hit-damage calculator"
+```
+
+---
+
+## Task 5: `positionalApply` footprint expansion (no per-hit loop yet)
+
+**Files:**
+- Create: `src/utils/combat/positionalApply.ts`
+- Test: `src/utils/combat/__tests__/positionalApply.test.ts`
+
+A pure helper that, given a `ParsedPattern`, an `anchor`, and the living opposing roster, returns the per-cell victims with their role scale:
+
+```ts
+export interface FootprintHit { victim: CombatActor; roleScale: number; } // origin→1, covered→0.5
+export function footprintVictims(
+    pattern: ParsedPattern, anchor: Position, opposingLiving: CombatActor[]
+): FootprintHit[]
+```
+
+Use `resolveCells(pattern, anchor)` → for each `{position, role}`, look up the living occupant via a `byCell` map (mirror `positionalBinding.ts:53-58`); skip empty cells; `role === 'covered'` → 0.5 else 1.0. `not-self` cells carry no `origin` role — key scale off `role`, not position.
+
+- [ ] **Step 1: Write failing tests** with hand-built positioned actors (reuse `positionalBinding.test.ts`'s `actor()` helper style) + real `ParsedPattern`s from `parsePattern` (or the committed `corpusPatterns` fixture): single-target pattern → only origin victim; an AoE pattern → origin at 1.0 + covered at 0.5; a covered cell with no occupant contributes nothing.
+- [ ] **Step 2: Run, expect FAIL**: `npm test -- src/utils/combat/__tests__/positionalApply.test.ts`
+- [ ] **Step 3: Implement** `footprintVictims`.
+- [ ] **Step 4: Run, expect PASS**.
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/positionalApply.ts src/utils/combat/__tests__/positionalApply.test.ts
+git commit -m "feat(combat): positional footprint -> per-victim role-scaled list"
+```
+
+---
+
+## Task 6: `positionalApply` per-hit loop with re-resolution
+
+**Files:**
+- Modify: `src/utils/combat/positionalApply.ts`
+- Test: `src/utils/combat/__tests__/positionalApply.test.ts`
+
+Add the per-hit driver that ties together re-resolution, footprint, damage calc, and apply:
+
+```ts
+export function applyPositionalDamage(args: {
+    hits: number;
+    hitCrits: boolean[];
+    scalars: AttackerDamageScalars;
+    pattern: ParsedPattern;
+    actorPosition: Position;
+    target: ParsedTarget;
+    opposingLiving: CombatActor[];                 // re-read each hit (living filter)
+    statusOf?: (id: string) => ActorTargetingStatus | undefined;
+    acting?: { ignoresForcedTargeting?: boolean; provokedBy?: string };
+    defenseProfileOf: (v: CombatActor) => VictimDefenseProfile;
+    applyToVictim: (victim: CombatActor, damage: number) => void; // wrapper from Task 2/3
+    emitHit?: (victim: CombatActor, damage: number, didCrit: boolean) => void;
+}): void
+```
+
+For each hit `h`: `resolvePositionalTarget(actorPosition, target, opposingLiving (living-filtered now), statusOf, acting)` → anchor actor. **If null → whiff: no damage, no event** (spec §5.1). Else `footprintVictims(pattern, anchorActor.position, opposingLiving)` → for each `{victim, roleScale}`: `victimHitDamage(scalars, defenseProfileOf(victim), hitCrits[h] ?? false, roleScale)` → `applyToVictim(victim, dmg)` + `emitHit?.(...)`. Because `applyToVictim` decrements `currentHp`, a victim that dies on hit `h` is filtered out of the living roster for hit `h+1` → re-resolution redirects.
+
+- [ ] **Step 1: Write failing tests**:
+  - 3-hit single-target: anchor dies to hit 1 (set its HP so hit-1 damage is lethal) → hits 2-3 land on the next living target (assert via `applyToVictim` spy);
+  - all opposing dead before a hit → that hit invokes neither `applyToVictim` nor `emitHit`;
+  - AoE multi-hit: each hit applies origin full + covered half.
+- [ ] **Step 2: Run, expect FAIL**.
+- [ ] **Step 3: Implement** the loop.
+- [ ] **Step 4: Run, expect PASS**.
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/positionalApply.ts src/utils/combat/__tests__/positionalApply.test.ts
+git commit -m "feat(combat): positional per-hit apply loop with re-resolution"
+```
+
+---
+
+## Task 7: Expose attacker scalars on `PlayerTurnResult`
+
+**Files:**
+- Modify: `src/utils/combat/playerTurn.ts:103-126` (interface) and `:1635-1660` (return)
+
+Add an optional `positionalScalars?: AttackerDamageScalars` and `hitCrits?: boolean[]` to `PlayerTurnResult`, populated from the values already computed at `playerTurn.ts:1080-1268`. Optional + only read by the positional engine branch → non-positional callers ignore it.
+
+- [ ] **Step 1: Write failing test** (`playerTurn` unit or via engine) asserting the returned `positionalScalars` reproduce the aggregate `directDamage` when fed through `victimHitDamage` for the bound single victim (parity guard at the integration boundary).
+- [ ] **Step 2: Run, expect FAIL**.
+- [ ] **Step 3: Implement** — populate the new fields from existing locals; **do not change** the existing aggregate `directDamage` computation or the single `ability-performed` emit.
+- [ ] **Step 4: Run, expect PASS**; `npm test` full suite **byte-identical**.
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/playerTurn.ts
+git commit -m "feat(combat): expose attacker damage scalars for positional apply"
+```
+
+---
+
+## Task 8: Wire positional apply into the focus + team damage sites
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts:2452-2503` (focus), `:2569-2617` (team)
+- Test: `src/utils/combat/__tests__/positionalDamage.integration.test.ts` (new)
+
+At each site, after `runPlayerTurn` returns, **if** `isPositional(actor.position, enemyAttackerActors) && input.target/teamTarget && turn.positionalScalars && <firing skill has a damage ability>`: call `applyPositionalDamage(...)` against `enemyAttackerActors` with `applyToVictim = applyOutgoingToEnemy`, the `statusLookupFor`/`provokerOf` already built at the site, and `defenseProfileOf` reading each enemy actor's stats. **Suppress** the cumulative-sink credit for the positional case (the existing `enemyHpDecline: selectedEnemy ? 0 : …` already zeroes the sink; ensure `creditDamage(...'direct'...)` for the focus/team turn is likewise gated so positional damage isn't double-counted into `cumulativeDamage`). Non-positional path unchanged.
+
+> Decide & document at this task: in positional mode the focus/team `turn.directDamage` must NOT also feed `creditDamage`/`cumulativeDamage` (that's the DPS-sink model). Gate it on the same positional condition.
+
+- [ ] **Step 1: Write failing integration test**: a positioned focus attacker + a positioned enemy team (must set `healTargetId` so `enemyAttackerActors` is populated — engine throws otherwise); assert the targeted enemy's `currentHp` declines by the computed damage, and an AoE skill also damages covered enemies at 50%.
+- [ ] **Step 2: Run, expect FAIL**.
+- [ ] **Step 3: Implement** focus + team wiring.
+- [ ] **Step 4: Run, expect PASS**; `npm test` full suite **byte-identical** (no production caller passes positions).
+- [ ] **Step 5:** `npx tsc --noEmit && npm run lint`
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/combat/engine.ts src/utils/combat/__tests__/positionalDamage.integration.test.ts
+git commit -m "feat(combat): wire positional AoE apply at focus + team damage sites"
+```
+
+---
+
+## Task 9: Wire enemy site + per-target accounting (takenLeeches / targetHpPct / enemyHpDecline)
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts:2812-2999` (enemy site), accounting at `:1736-1753`, `:2858`, `targetHpPct` reads
+- Test: extend `positionalDamage.integration.test.ts`
+
+Enemy→player AoE: at the enemy site, when positional, drive `applyPositionalDamage` against `allPlayerActors` with `applyToVictim = applyIncomingToTarget` (the player-side wrapper) so an enemy AoE can hit multiple player ships. Then make the three accounting paths per-victim-correct:
+- **`takenLeeches`** — currently collected for `healTarget` only (engine.ts:1736). Resolve/credit leech against the **actual hit player victim**, not the heal target. (Scope: keep it correct per-victim; the unified per-actor heal surface is Phase 5.)
+- **`targetHpPct`** — report the real victim's HP% for the victim being hit.
+- **`enemyHpDecline`** — for a positionally-selected enemy on focus/team, decline now comes from the Task-8 real decrement; drop the `selectedEnemy ? 0 :` placeholder's reliance on the sink for the selected enemy (the enemy actor's `currentHp` is authoritative). Leave the enemy-turn site's real-HP derivation (`:2858`) as-is.
+
+- [ ] **Step 1: Write failing tests**: (a) an enemy AoE hits two player ships, both `currentHp` decline (origin full, covered half); (b) a `damage-taken` leecher among the hit victims leeches off the damage *it* took; (c) `targetHpPct`/`enemyHpDecline` reflect the real victim.
+- [ ] **Step 2: Run, expect FAIL**.
+- [ ] **Step 3: Implement**.
+- [ ] **Step 4: Run, expect PASS**; `npm test` full suite **byte-identical**.
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/engine.ts src/utils/combat/__tests__/positionalDamage.integration.test.ts
+git commit -m "feat(combat): enemy-side AoE apply + per-victim leech/HP accounting"
+```
+
+---
+
+## Task 10: Additive `perTargetDamage` result field
+
+**Files:**
+- Modify: the `RoundData` definition (confirm location — `dpsSimulator.ts:90-126`) + the round-assembly sites
+- Test: extend `positionalDamage.integration.test.ts` + a golden additive-shape check
+
+Add an **additive, optional** `perTargetDamage?: Record<string, number>` (victim id → damage this round) populated only when the positional path ran. Existing fields untouched. Lock the field name + key type here (victim actor id) per the spec-review note.
+
+- [ ] **Step 1: Write failing test** asserting `perTargetDamage` maps each hit victim id to its received damage in a positional round, and is `undefined`/absent in a non-positional round.
+- [ ] **Step 2: Run, expect FAIL**.
+- [ ] **Step 3: Implement** the additive field + population.
+- [ ] **Step 4: Run, expect PASS**; `npm test` full suite — goldens may show **purely additive** churn ONLY if a snapshot serializes the new key on a non-positional run; if so, confirm the value is absent/empty and the churn is additive-only (like `barrierAbsorbed`/`resistedDebuffs`), then accept. **Numeric trajectories must not change.**
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(combat): additive perTargetDamage round field"
+```
+
+---
+
+## Task 11: Final verification + holistic review
+
+**Files:** none (verification only)
+
+- [ ] **Step 1:** `npm test` — full suite green; DPS + healing goldens **byte-identical** (diff the snapshot files vs `main`; only additive `perTargetDamage` keys allowed, no numeric changes).
+- [ ] **Step 2:** `npm run audit:skills` — expect 0 findings / 141 ships.
+- [ ] **Step 3:** `npx tsc --noEmit && npm run lint` — clean (lint max-warnings 0).
+- [ ] **Step 4:** Final holistic self-review against the spec §5: generalized apply byte-identical wrapper; player→enemy decrement + death; per-hit re-resolution; whiff emits nothing; covered=50% damage-only; accounting per-victim; capability-only (no production caller passes positions).
+- [ ] **Step 5:** Open PR (`gh auth switch` first). PR body: capability-only, goldens byte-identical, links the spec. Request CodeRabbit; poll `mergeState=CLEAN`.
+
+---
+
+## Out of scope (this PR)
+
+- Death-fallback inter-turn retargeting, Harvester `on-ally-destroyed` activation, Salvation dead-recipient filtering → **PR 2**.
+- Full side-symmetric per-actor-per-side result surface + enemy-incoming accounting buckets → **Phase 5**.
+- Global per-hit refactor of the non-positional outgoing path → separate later phase.
+- Any production caller passing positions / simulator UI → **Phase 5**.

--- a/docs/superpowers/specs/2026-06-15-positional-combat-phase4-design.md
+++ b/docs/superpowers/specs/2026-06-15-positional-combat-phase4-design.md
@@ -1,0 +1,162 @@
+# Positional Combat Phase 4 — Multi-target AoE + Per-target Accounting + Death-fallback
+
+**Date:** 2026-06-15
+**Status:** Design (pre-implementation)
+**Phase:** Positional combat phase 4 of 5 (1=geometry resolver #106, 2=engine positional target-selection #108, 3=forced targeting + stealth #109, Provoke #112; **4=this**; 5=simulator page).
+**Predecessors merged:** PR #106 (board geometry `resolveCells`), #108 (positional target-selection + single-anchor binding), #109 (forced targeting/stealth), #112 (Provoke).
+
+---
+
+## 1. Problem & goal
+
+Phases 1–3 + Provoke built the positional *target-selection* machinery: a board, a geometry resolver (`resolveCells`), `selectTargets` (row-first column-priority), and `resolvePositionalTarget` (forced targeting + stealth resolving a single anchor). But three things are still missing or dormant, all deferred from Phase 2 with inline notes:
+
+1. **Multi-target AoE consequences.** `resolveCells` is built but **UNWIRED**. A positional attack today binds to and damages a **single** anchor; covered cells of an AoE pattern take nothing.
+2. **Per-target accounting.** Because only one victim is ever damaged per turn, three accounting paths still hard-credit the bound heal target rather than the actual victim: `takenLeeches`, `enemyHpDecline`, `targetHpPct`.
+3. **Death-fallback / dead-recipient filtering.** Ships can't currently die mid-combat in the positional overlay, so: the Harvester `on-ally-destroyed` extra-action trigger is wired-but-dormant (Phase 4b), and Salvation's `all-allies` on-destroyed heal counts the dead caster in gross `directHeal`.
+
+**Goal:** make AoE patterns land on anchor + covered cells with correct per-victim consequences, make the three accounting paths per-victim-correct, and handle deaths (intra-cast and inter-turn retargeting, Harvester activation, Salvation dead-recipient filtering) — all as a **capability-only overlay** that leaves DPS/healing behavior (and goldens) byte-identical.
+
+**Key structural finding (verified in code 2026-06-15, drives PR 1):** `applyIncomingToTarget` (engine.ts:1919, sole `currentHp` decrement at :1963) applies per-victim damage on the **enemy→player** direction ONLY (enemy attacks the tank/player victim; DoT ticks). The **player→enemy** direction (focus + team sites) never calls it — a selected enemy's HP is modeled via the cumulative-damage **sink** (`enemyHpDecline`, engine.ts:3218), forced to `0` for a positionally-selected enemy (`selectedEnemy ? 0 : …`). **Consequence: today player attacks do not decrement a real enemy actor's HP — enemies cannot die from player attacks even in positional mode.** This is the "dummy-enemy-vs-real-actor duality" the team-agnostic principle flagged. Therefore "multi-target AoE *consequences*" requires PR 1 to **build a symmetric per-victim apply path for the player→enemy direction** (enemies take per-target/AoE damage, HP declines, can die), not merely wire `resolveCells`. User-ratified 2026-06-15: build the symmetric enemy-victim apply in PR 1; defer only the unified *result surface* to Phase 5.
+
+**Non-goals (explicitly deferred):**
+- **Full side-symmetric per-actor-per-side result surface → Phase 5.** Phase 4 does only the *incremental* per-target accounting needed for AoE/leech/death correctness. The mirror is not unified here.
+- **Global per-hit refactor of the non-positional outgoing damage path → its own later phase.** The outgoing aggregate event stays. Per-hit application happens *only* on the new positional path (see §4).
+- **Simulator page / any production caller that passes positions → Phase 5.**
+
+---
+
+## 2. Scope decisions (user-ratified during brainstorming, 2026-06-15)
+
+- **Phase 4 = all three sub-capabilities, sliced into 2 PRs** (AoE+accounting, then death-fallback).
+- **Accounting depth = incremental.** Only the per-victim correctness AoE/leech/death require; the full symmetric result surface + team-vs-team display is Phase 5.
+- **Mid-cast death = re-resolve per hit, *on the positional path only*.** A multi-hit/AoE cast re-runs target selection per hit, so later hits redirect off a target that died to an earlier hit. The non-positional aggregate path is NOT converted to per-hit (that global refactor is a separate later phase).
+- **Result surface = additive.** New per-victim accounting is exposed as new fields alongside today's player-centric `RoundData`; no restructure. Goldens churn at most additively (and only if a positional test snapshot is added — production goldens stay byte-identical).
+
+---
+
+## 3. Confirmed game model (from prior phases — do NOT re-litigate)
+
+- Board: pointy-top hexes, 3 rows T/M/B × 4 cols; col 4 = front (nearest enemy), col 1 = back; enemy board is a display-only horizontal mirror (resolver is frame-agnostic). Axial coords + 6 directions are fixed in `board.ts`.
+- **Covered-cell damage = 50% of origin damage; covered scaling is DAMAGE-ONLY** — heals/buffs/debuffs apply uniformly across the footprint (no 50%). Origin = 100%.
+- Anchor selection (front/back/skip → which enemy cell) is Phase 2's job and already shipped; Phase 4 consumes the resolved anchor and expands it via `resolveCells`.
+- `resolveCells` clips out-of-board offsets silently and may return origin-only or (for `not-self` patterns) zero cells — **not an error.** `not-self` results carry no `origin` role (key off `role`, not position). The `all` shape returns all 12 cells as `origin`, ignoring the anchor.
+- Forced targeting precedence (already shipped): Concentrate Fire → Taunt → Provoke → stealth-filter, resolved inside `resolvePositionalTarget`.
+
+---
+
+## 4. Architecture — the isolation principle (the spine)
+
+Phase 4 adds a **positional damage-application path** activated only when the acting actor has a `position` and the run supplies board positions.
+
+- **Non-positional runs** (every DPS/healing run today; every golden): Phase 2's single-anchor binding + the existing **aggregate** outgoing damage assembly (playerTurn.ts ~1167–1295: `effectiveMultiplier = rawMultiplier * hits`, blended per-hit crit multiplier, **one** `ability-performed` event). **Untouched → byte-identical.** This is the load-bearing safety invariant.
+- **Positional runs** (Phase 5+): a new parallel apply routine does the per-hit loop, `resolveCells` expansion, and per-victim apply. The existing aggregate routine is *not* refactored.
+
+**Why per-hit lives only on the positional path:** today the enemy-attack path already emits `attacked` per hit (since 4c PR 1), and crit-scoped reactives (`on-crit`, `on-ally-crit`) already fire per *critting* hit via the `critHits` field — so Sentinel's follow-up tap and Cultivator's per-hit ally-damage repair are already per-hit-correct. The only genuinely-aggregate path is the **player's own outgoing damage event**, and converting *that* globally is a large refactor (split damage assembly; migrate every crit-scoped trigger from "read `critHits`" to "fire per event"; intentionally re-baseline goldens). That is deferred. Phase 4's positional apply path gets per-hit re-resolution for free because it is new code with no golden contract.
+
+---
+
+## 5. PR 1 — Positional multi-target AoE + per-hit re-resolution + per-target accounting
+
+### 5.1 New positional apply routine
+
+**Two pieces:** (a) a **generalized per-victim apply** so the player→enemy direction can decrement a real enemy actor's HP (today only enemy→player can), and (b) a **positional multi-target routine** that expands the anchor into a footprint and applies per-hit per-victim.
+
+**(a) Generalized per-victim apply (the structural core).** `applyIncomingToTarget` is closured over `healTarget` and player-side accumulators (`roundIncomingDamage`, player Barrier/Cheat-Death), so it cannot be reused as-is for enemy victims. Extract its victim-intake core — shield drain → Barrier full-immunity guard → Cheat-Death intercept → `currentHp` decrement → `hp-changed`/`ship-destroyed` emission (engine.ts:1928-2032) — into a reusable function parameterized by the victim and side-specific accounting hooks. The existing enemy→player call becomes a thin wrapper over it (**must stay byte-identical** — guarded by goldens + characterization tests). A new player→enemy wrapper credits the enemy victim. This is what lets a player AoE actually damage and kill enemy actors. Enemy-side Barrier/Cheat-Death (from the enemy-team-support PRs) resolve through the same shared core.
+
+**(b) Positional multi-target routine** (proposed `src/utils/combat/positionalApply.ts`) consumed at the **3 `runPlayerTurn` damage sites** wired in Phase 2 (focus / team / enemy). When the acting actor is positional (`isPositional` + positions supplied) **and** the firing skill carries a damage ability, the engine calls this routine *instead of* the single-anchor binding; otherwise it falls through to today's path.
+
+For each **hit** `h` in `damageInputsFromSkill(gatedSkill).hits`:
+
+1. **Re-resolve the anchor** for this hit via the existing `resolvePositionalTarget(...)` (forced targeting → stealth → `selectTargets` row-first column-priority over the *currently living* opposing roster). A target that died to hit `h-1` is gone from the roster, so hit `h` redirects. If no living target → this hit whiffs entirely: **no damage, and no event emitted** (per spec-review clarification).
+2. **Expand** `resolveCells(pattern, anchor)` → `{position, role}[]`. (`pattern` = the ability's `ParsedPattern`; single-target abilities resolve to origin-only.)
+3. **Per cell**, find the living occupant on the target side (`byCell`, ≤1 actor/cell, already living-only per Phase 3). For each occupant `victim`:
+   - Compute this hit's damage using the already-drawn per-hit crit outcome `hitCrits[h]` (full crit multiplier if that hit crit, else none) through the shared crit-independent pipeline (defense/affinity/outgoing/incoming) — same factors as today's assembly, applied per hit at full precision (no per-hit rounding) so a single-target multi-hit's *total* equals the aggregate.
+   - Scale by **role**: origin → ×1.0; covered → ×0.5 (damage only).
+   - Apply via the **generalized per-victim apply** from (a) — player→enemy wrapper for focus/team sites, enemy→player wrapper for the enemy site. Each victim runs its own shield → Barrier → Cheat-Death → HP independently.
+   - Emit a per-hit `ability-performed` (and, where the established convention emits it, the per-hit `attacked`) targeting `victim`, so per-hit reactives on victims fire correctly.
+
+> **Per-hit-event note for the implementer:** the *outgoing* path that today emits one aggregate `ability-performed` is the non-positional path and stays. The positional routine emits per-hit, per-victim events. Confirm during planning that crit-scoped triggers consuming these positional events do not double-count (positional events carry per-hit `didCrit`, not an aggregate `critHits`).
+
+### 5.2 Per-target accounting (incremental)
+
+With multiple victims per turn, three Phase-2-deferred paths become per-victim *correctness* (keyed off the actual victim, not the bound heal target). Phase 2 left inline notes at each:
+
+- **`takenLeeches`** — a `basis:'damage-taken'` leech must read the damage the **hit victim** took, and credit that victim's owner, not the heal target.
+- **`enemyHpDecline`** — for a positionally-selected enemy, HP now declines via the §5.1(a) per-victim apply (real decrement), *replacing* the Phase-2 `selectedEnemy ? 0 : cumulative-sink` placeholder at the focus/team sites. The enemy-turn site already derives decline from the real victim's HP (engine.ts:2858, "do NOT convert to a `selected ? 0 :` ternary") — keep that.
+- **`targetHpPct`** — report the **real victim's** HP%, not the heal target's.
+
+**Exposure is additive:** introduce a per-victim accounting map (proposed `RoundData.perTargetDamage` or similar, keyed by victim actor id) **alongside** existing player-centric fields. No restructure of existing `RoundData` fields, no adapter rewrite. This is the minimal seam; the full symmetric surface is Phase 5.
+
+### 5.3 Inertness / golden guarantee
+
+The new routine runs only when positions are supplied. No production caller does → DPS and healing runs take the unchanged aggregate path → **DPS + healing goldens byte-identical.** New behavior is covered exclusively by new positional tests using hand-built positioned fixtures.
+
+### 5.4 PR 1 tests
+
+- Per-hit re-resolution: a 3-hit single-target skill where the anchor dies to hit 1 → hits 2–3 redirect to the next living target.
+- AoE footprint: origin victim takes full, covered victims take 50%; a covered cell with no living occupant contributes nothing.
+- Per-victim independence: two victims, one with Barrier (full block) and one without; one with Cheat-Death — each resolves its own path.
+- Per-victim accounting: `takenLeeches` credit the actually-hit victim; `enemyHpDecline`/`targetHpPct` reflect the real victim.
+- **Inertness:** an existing-shaped non-positional run is byte-identical (guarded by the unchanged goldens).
+
+---
+
+## 6. PR 2 — Death-fallback retargeting + dead-recipient filtering
+
+Now that AoE/focus-fire can kill ships, deaths happen mid-combat on both sides.
+
+- **Inter-turn retargeting.** `selectTargets` already filters living, so the *next* attacker naturally re-selects a living target. PR 2 verifies dead actors are excluded from rosters between turns, and that an ability whose entire target side is dead whiffs cleanly. (Intra-cast retargeting is PR 1's per-hit re-resolution.)
+- **Harvester `on-ally-destroyed`.** The extra-action trigger wired in Phase 4b is dormant only because no ally could die. With positional AoE/focus-fire it becomes reachable — no new machinery, just exercised and tested (extra turn granted on a real ally death).
+- **Salvation dead-recipient filtering.** Salvation's `all-allies` on-destroyed heal resolves recipients including the dead caster, inflating gross `directHeal` (Phase 4b KNOWN LIMITATION). Filter dead recipients out of the gross accounting so the heal credits only living recipients. (`effectiveHeal`/`overheal` already credit only the live target — this aligns gross with them.)
+
+### 6.1 PR 2 tests
+- Focus-fire kills target A → the later attacker this round retargets to target B.
+- All-targets-dead → ability whiffs, no crash, no spurious credit.
+- Harvester extra-action fires on a real ally death (positioned fixture where an enemy AoE kills an ally).
+- Salvation gross `directHeal` excludes the dead caster.
+- **Inertness:** goldens byte-identical.
+
+---
+
+## 7. Components & boundaries
+
+| Unit | Responsibility | Depends on |
+|---|---|---|
+| `resolveCells` (existing, UNWIRED) | anchor + pattern → `{position, role}[]` | `board.ts`, `patternOffsets.ts` |
+| `selectTargets` / `resolvePositionalTarget` (existing) | living-roster, forced-targeting, stealth, anchor selection | `board.ts`, status query helpers |
+| **`positionalApply.ts` (new, PR 1)** | per-hit loop: re-resolve anchor, expand cells, per-victim damage + accounting | the two above + `applyIncomingToTarget` |
+| **Generalized per-victim apply (new, PR 1)** | shield/Barrier/Cheat-Death/HP intake for ANY victim; player→enemy + enemy→player wrappers | status engine |
+| `applyIncomingToTarget` (existing) | becomes a thin enemy→player wrapper over the generalized core (byte-identical) | generalized apply |
+| Per-victim accounting map (new field, PR 1) | additive per-target damage/HP/leech/targetHpPct | — |
+| Death triggers (existing, PR 2 activates) | Harvester `on-ally-destroyed`; Salvation dead-recipient filter | `triggers.ts`, engine death path |
+
+Each unit is independently testable; the positional routine is the only new file and is dormant without positions.
+
+---
+
+## 8. Risks & mitigations
+
+- **Golden leakage** (the positional path firing in a non-positional run): mitigated by the byte-identical golden gate on both PRs — any drift means the `isPositional` gate leaked; fix the gate, never `vitest -u`.
+- **Extraction risk** (§5.1a): refactoring `applyIncomingToTarget`'s intake core touches the engine's most fragile, most-tested path. Mitigate by extracting first as a pure behavior-preserving refactor (the enemy→player wrapper produces identical results) gated by the full golden suite + targeted characterization tests, *before* adding the player→enemy wrapper or any positional caller.
+- **Per-hit numeric drift** vs the aggregate (single-target multi-hit): apply per-hit at full precision and sum without per-hit rounding so totals match the aggregate; covered by a per-hit-vs-aggregate equality test on the positional path.
+- **Per-hit event double-counting** in crit-scoped triggers: planning task must characterize how positional per-hit `ability-performed`/`attacked` events interact with `on-crit`/`on-ally-crit` (which today read aggregate `critHits`).
+- **`runCombat`/`runPlayerTurn` size** (~2,650 / ~980 lines): keep the per-hit loop in the new `positionalApply.ts` module rather than inlining, per the structural-debt note.
+
+---
+
+## 9. Testing strategy
+
+- **Byte-identical DPS + healing goldens** is the acceptance gate for both PRs (synthetic fixtures, never `-u`). New positional scenarios are appended/hand-written, never regenerated.
+- Co-located unit tests in `src/utils/combat/` and `src/utils/targeting/` (no `__tests__/` subdir in `targeting/`, matching the existing convention).
+- `audit:skills` stays 0 findings / 141 ships; lint + tsc clean.
+- Worktree env gotcha: a fresh worktree lacks gitignored `.env` + `docs/*.csv` → symlink them from the main checkout or env-only tests fail and the pre-commit hook blocks.
+
+---
+
+## 10. PR sequence summary
+
+1. **PR 1 — Symmetric per-victim apply + positional multi-target AoE + per-hit re-resolution + per-target accounting.** Extract the generalized per-victim apply (enemy→player wrapper byte-identical) + add the player→enemy wrapper so enemies take real per-target damage and can die; wire `resolveCells`; new `positionalApply.ts` per-hit loop; per-victim leech/HP-decline/targetHpPct; additive per-target accounting field. Capability-only.
+2. **PR 2 — Death-fallback + dead-recipient filtering.** Inter-turn retargeting verification; Harvester `on-ally-destroyed` activation; Salvation dead-recipient filter. Capability-only.
+
+Both preserve byte-identical goldens. Phase 5 (simulator page) is the first production caller that supplies positions and is where the full side-symmetric per-actor-per-side result surface lands.

--- a/src/utils/calculators/dpsSimulator.ts
+++ b/src/utils/calculators/dpsSimulator.ts
@@ -118,8 +118,11 @@ export interface RoundData {
     /** Number of EXTRA focus-actor turns this round (extra actions). Set only when
      *  ≥ 1 — undefined preserves the legacy RoundData shape (golden snapshots). */
     extraTurns?: number;
-    /** Victim actor id → damage dealt to it this round. Populated ONLY by the positional
-     *  apply path (gated on positions + pattern); absent in non-positional runs. */
+    /** Victim actor id → total damage dealt TO it this round, keyed by victim regardless of
+     *  attacker side. In a round where both sides act positionally this map contains BOTH enemy
+     *  victims (from player/team fire) AND player victims (from enemy fire) — do NOT sum it as
+     *  one-directional output. Populated ONLY by the positional apply path (gated on positions +
+     *  pattern); absent in non-positional runs. */
     perTargetDamage?: Record<string, number>;
     activeCorrosionStacks: number;
     activeInfernoStacks: number;

--- a/src/utils/calculators/dpsSimulator.ts
+++ b/src/utils/calculators/dpsSimulator.ts
@@ -118,6 +118,9 @@ export interface RoundData {
     /** Number of EXTRA focus-actor turns this round (extra actions). Set only when
      *  ≥ 1 — undefined preserves the legacy RoundData shape (golden snapshots). */
     extraTurns?: number;
+    /** Victim actor id → damage dealt to it this round. Populated ONLY by the positional
+     *  apply path (gated on positions + pattern); absent in non-positional runs. */
+    perTargetDamage?: Record<string, number>;
     activeCorrosionStacks: number;
     activeInfernoStacks: number;
     activeBombCount: number;

--- a/src/utils/calculators/dpsSimulator.ts
+++ b/src/utils/calculators/dpsSimulator.ts
@@ -45,6 +45,10 @@ export interface DPSSimulationInput {
     affinityCritCap?: number;
     /** Additive pp reduction on effective crit rate (25 for disadvantage, 0 otherwise). */
     affinityCritPenalty?: number;
+    /** RAW affinity of the focus attacker — the SAME matchup the page resolved into the pre-resolved
+     *  affinityDamageModifier/affinityCritCap/affinityCritPenalty above, so the two never disagree
+     *  (positional plumbing; forwarded to the engine's attackerAffinity). Absent → neutral default. */
+    affinity?: AffinityName;
     /** Attacker hacking stat. Landing chance = clamp(hacking - enemySecurity, 0, 100) / 100. Default 200. */
     hacking?: number;
     /** Defender security stat. Default 100. */
@@ -190,6 +194,10 @@ export function deriveTeamEngineActors(
                 affinityDamageModifier: aff.damageModifier,
                 affinityCritCap: aff.critCap,
                 affinityCritPenalty: aff.critPenalty,
+                // RAW affinity — the SAME t.affinity fed to computeAffinityModifiers above, so the
+                // walk bundle's affinityDamageModifier and attackerAffinity never disagree
+                // (positional plumbing; the engine threads it onto the runtime's attackerAffinity).
+                affinity: t.affinity,
                 hasChargedSkill: teamHasChargedSkill,
             },
         };
@@ -269,6 +277,9 @@ export function simulateDPS(input: DPSSimulationInput): DPSSimulationResult {
         affinityDamageModifier,
         affinityCritCap,
         affinityCritPenalty,
+        // RAW focus affinity — same matchup as the pre-resolved affinityDamageModifier above
+        // (positional plumbing; the engine threads it onto the focus runtime's attackerAffinity).
+        affinity: input.affinity,
         defence,
         hp,
         allyChargePerRound,

--- a/src/utils/combat/__tests__/applyOutgoingToEnemy.test.ts
+++ b/src/utils/combat/__tests__/applyOutgoingToEnemy.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for the engine's player→enemy victim-intake wrapper (`applyOutgoingToEnemy` in
+ * `engine.ts`). This is the second thin wrapper over the shared `applyVictimDamage` core
+ * (Task 2), carrying an ENEMY-SIDE sink whose accounting hooks are no-ops for PR 1 (the
+ * tank-incoming round accumulators must NOT move when a player attacks an enemy) and which
+ * omits `onHealTargetDestroyed`. The wrapper still runs the FULL HP/shield/Barrier/
+ * Cheat-Death/recordDestroyed path on the enemy victim, so enemies actually take damage and
+ * can die.
+ *
+ * REACHABILITY: there is NO production call site for `applyOutgoingToEnemy` yet — Task 8 wires
+ * it into the player→enemy damage sites. So it cannot be exercised through normal `runCombat`
+ * flow today. To test the REAL closure (not a mock), `runCombat` accepts a narrow test-only tap
+ * `__testTapApplyOutgoingToEnemy` that hands the genuine closure out once on the first round it
+ * is built. Each test runs a healing-mode `runCombat` (the cheapest way to spin up the engine's
+ * statusEngine/bus/recordDestroyed/recipientMaxHp context the closure captures), captures the
+ * real wrapper through the tap, then invokes it against a hand-built enemy `CombatActor` victim
+ * and observes the genuine mutations/emissions. The enemy-side accounting is verified to be a
+ * no-op by checking the tank-incoming round accumulators (incomingDamage/shieldAbsorbed/
+ * barrierAbsorbed) are untouched by the wrapper's calls.
+ *
+ * Behaviors verified against a hand-built enemy victim:
+ *   1. plain HP damage (shield 0) — currentHp drops by exactly the damage;
+ *   2. shield absorbs first, overflow hits HP;
+ *   3. enemy carrying Barrier → full block, HP unchanged, barriered:true;
+ *   4. lethal damage, no Cheat Death → currentHp 0 + ship-destroyed emitted once;
+ *   5. lethal damage on an enemy Cheat-Death carrier → survives at 1 HP;
+ *   6. enemy-side sink is a no-op: tank-incoming round accumulators stay at 0.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createActor, CombatActor } from '../state';
+import { createEventBus, CombatEvent } from '../events';
+import { ShipSkills } from '../../../types/abilities';
+
+type ApplyOutgoing = (
+    damage: number,
+    enemyVictim: CombatActor
+) => { shieldBefore: number; hpDamage: number; barriered: boolean };
+
+/** A hand-built enemy victim CombatActor with a given id and HP. */
+const enemyVictim = (id: string, hp: number): CombatActor =>
+    createActor({
+        id,
+        side: 'enemy',
+        kind: 'enemy',
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            defence: 0,
+            hp,
+            speed: 50,
+        },
+    });
+
+/** A no-payload always-active self-buff (recurring) the enemy attacker carries on its own id. */
+const selfBuffSkills = (buffName: string): ShipSkills => ({
+    slots: [
+        {
+            slot: 'passive',
+            abilities: [
+                {
+                    id: `${buffName}-self`,
+                    type: 'buff',
+                    target: 'self',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config: {
+                        type: 'buff',
+                        buffName,
+                        stacks: 1,
+                        isStackable: false,
+                        duration: 'recurring',
+                        parsedEffects: {},
+                    },
+                },
+            ],
+        },
+    ],
+});
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+/** A minimal enemy attacker; optional shipSkills lets it carry a self-buff under its own id. */
+const enemyAttacker = (id: string, shipSkills?: ShipSkills): EnemyAttacker => ({
+    id,
+    stats: { attack: 0, crit: 0, critDamage: 0, speed: 50 },
+    chargeCount: 0,
+    startCharged: false,
+    ...(shipSkills ? { shipSkills } : {}),
+});
+
+const healBase = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [] },
+    enemyDefense: 0,
+    enemyHp: 10_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    debuffLandingChance: 1,
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 10_000,
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+/**
+ * Spin up the engine in healing mode and capture the REAL `applyOutgoingToEnemy` closure via the
+ * test tap. Returns the captured wrapper, the bus events, and the round accounting so the no-op
+ * sink can be asserted. `enemyAttackers` are passed so any self-buff carrier exists as a real
+ * enemy actor whose id matches the hand-built victim's id (so selfBuffNamesForOwners sees it).
+ */
+const captureWrapper = (overrides: Partial<CombatEngineInput> = {}) => {
+    const bus = createEventBus();
+    const destroyed: Extract<CombatEvent, { type: 'ship-destroyed' }>[] = [];
+    const cheated: Extract<CombatEvent, { type: 'cheat-death-activated' }>[] = [];
+    bus.on('ship-destroyed', (e) => destroyed.push(e));
+    bus.on('cheat-death-activated', (e) => cheated.push(e));
+    let wrapper: ApplyOutgoing | undefined;
+    const result = runCombat({
+        ...healBase(overrides),
+        bus,
+        __testTapApplyOutgoingToEnemy: (fn) => {
+            if (!wrapper) wrapper = fn;
+        },
+    } as CombatEngineInput);
+    if (!wrapper) throw new Error('test tap was never invoked — applyOutgoingToEnemy not built');
+    return { wrapper, destroyed, cheated, result };
+};
+
+describe('applyOutgoingToEnemy (player→enemy per-victim damage apply wrapper)', () => {
+    it('plain HP damage (no shield): decrements the enemy victim HP by exactly the damage', () => {
+        const { wrapper } = captureWrapper();
+        const victim = enemyVictim('e1', 10_000);
+        const out = wrapper(3000, victim);
+        expect(victim.currentHp).toBe(7000);
+        expect(victim.shieldPool).toBe(0);
+        expect(out).toMatchObject({ hpDamage: 3000, barriered: false });
+        expect(victim.destroyedRound).toBeUndefined();
+    });
+
+    it('shield absorbs first, overflow spills to enemy HP', () => {
+        const { wrapper } = captureWrapper();
+        const victim = enemyVictim('e1', 10_000);
+        victim.shieldPool = 2500;
+        const out = wrapper(4000, victim);
+        expect(victim.shieldPool).toBe(0);
+        expect(victim.currentHp).toBe(8500); // only the 1500 overflow drained HP
+        expect(out).toMatchObject({ shieldBefore: 2500, hpDamage: 1500, barriered: false });
+    });
+
+    it('enemy carrying Barrier: full block — HP unchanged, barriered true', () => {
+        // The Barrier carrier exists as a real enemy attacker so its self-buff is registered under
+        // its own id; the hand-built victim reuses that same id so selfBuffNamesForOwners sees it.
+        const { wrapper } = captureWrapper({
+            enemyAttackers: [enemyAttacker('barrierEnemy', selfBuffSkills('Barrier'))],
+        });
+        const victim = enemyVictim('barrierEnemy', 10_000);
+        const out = wrapper(5000, victim);
+        expect(victim.currentHp).toBe(10_000); // fully blocked
+        expect(victim.shieldPool).toBe(0); // Barrier never touches the shield
+        expect(out).toMatchObject({ hpDamage: 0, barriered: true });
+    });
+
+    it('lethal damage, no Cheat Death: enemy HP reaches 0, ship-destroyed emitted once', () => {
+        const { wrapper, destroyed } = captureWrapper();
+        const victim = enemyVictim('e1', 2000);
+        const out = wrapper(3000, victim);
+        expect(victim.currentHp).toBe(0);
+        expect(out.barriered).toBe(false);
+        const forVictim = destroyed.filter((d) => d.actorId === 'e1');
+        expect(forVictim).toHaveLength(1);
+        expect(victim.destroyedRound).toBe(1);
+    });
+
+    it('lethal damage on an enemy Cheat-Death carrier: survives at 1 HP, no destroy', () => {
+        const { wrapper, cheated, destroyed } = captureWrapper({
+            enemyAttackers: [enemyAttacker('cdEnemy', selfBuffSkills('Cheat Death'))],
+        });
+        const victim = enemyVictim('cdEnemy', 2000);
+        wrapper(3000, victim);
+        expect(victim.currentHp).toBe(1); // floored, not destroyed
+        expect(victim.destroyedRound).toBeUndefined();
+        expect(cheated.filter((c) => c.actorId === 'cdEnemy')).toHaveLength(1);
+        expect(destroyed.filter((d) => d.actorId === 'cdEnemy')).toHaveLength(0);
+    });
+
+    it('enemy-side sink is a no-op: tank-incoming round accumulators stay untouched', () => {
+        const { wrapper, result } = captureWrapper();
+        // Drive several enemy-victim intakes through the wrapper — none should touch the
+        // tank-incoming buckets (those belong to the enemy→player direction only).
+        wrapper(3000, enemyVictim('e1', 10_000));
+        wrapper(4000, enemyVictim('e2', 10_000));
+        const rounds = result.healing!.rounds;
+        // No enemy attacked the tank in this scenario, so all incoming accumulators are 0 and
+        // must STAY 0 despite the wrapper's calls (the enemy-side sink writes nothing here).
+        expect(rounds[0].incomingDamage).toBe(0);
+        expect(rounds[0].shieldAbsorbed).toBe(0);
+        expect(rounds[0].barrierAbsorbed).toBe(0);
+    });
+});

--- a/src/utils/combat/__tests__/applyOutgoingToEnemy.test.ts
+++ b/src/utils/combat/__tests__/applyOutgoingToEnemy.test.ts
@@ -24,7 +24,21 @@
  *   3. enemy carrying Barrier → full block, HP unchanged, barriered:true;
  *   4. lethal damage, no Cheat Death → currentHp 0 + ship-destroyed emitted once;
  *   5. lethal damage on an enemy Cheat-Death carrier → survives at 1 HP;
- *   6. enemy-side sink is a no-op: tank-incoming round accumulators stay at 0.
+ *   6. enemy-side sink is a no-op: invoking the wrapper DURING the run does not bump the tank's
+ *      round-incoming accumulators (incomingDamage/shieldAbsorbed/barrierAbsorbed) that are
+ *      snapshotted into the round result AFTER the wrapper runs.
+ *
+ * NON-VACUITY (behaviour #6): the round accumulators (roundIncomingDamage/…) are CLOSURE
+ * variables reset at the top of each round and folded into `rounds[r]` only at post-round
+ * assembly. Invoking the wrapper post-`runCombat` (as the other 5 behaviours do) can never move
+ * those already-finalized numbers, so a post-run assertion on them would be VACUOUS — it would
+ * pass even if the enemy sink bumped the accumulators. To make #6 genuinely catch a regression we
+ * invoke the captured wrapper MID-RUN (inside the test tap, after the accumulators are reset to 0
+ * for the round but before they are snapshotted). The same closure variables back both the
+ * enemy-side sink (no-op) and the player-side sink (which DOES bump them), so if the enemy sink
+ * ever started crediting incoming/shield/barrier, the bump would land in `rounds[0]` and the
+ * assertion below would FAIL. Proven by inverting the sink locally (addIncoming → += amount) which
+ * flips rounds[0].incomingDamage to non-zero and reds the test.
  */
 import { describe, it, expect } from 'vitest';
 import { runCombat, CombatEngineInput } from '../engine';
@@ -123,7 +137,17 @@ const healBase = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput
  * sink can be asserted. `enemyAttackers` are passed so any self-buff carrier exists as a real
  * enemy actor whose id matches the hand-built victim's id (so selfBuffNamesForOwners sees it).
  */
-const captureWrapper = (overrides: Partial<CombatEngineInput> = {}) => {
+const captureWrapper = (
+    overrides: Partial<CombatEngineInput> = {},
+    /**
+     * Optional MID-RUN hook. When provided, it is called with the genuine wrapper INSIDE the test
+     * tap — i.e. during the round, after the round-incoming accumulators are reset to 0 but before
+     * they are snapshotted into the round result. This is what makes the no-op assertion in
+     * behaviour #6 non-vacuous: any accumulator bump the enemy sink performed here would surface in
+     * `result.healing.rounds[0]`. Behaviours 1-5 omit it and invoke the wrapper post-run instead.
+     */
+    invokeDuringRun?: (fn: ApplyOutgoing) => void
+) => {
     const bus = createEventBus();
     const destroyed: Extract<CombatEvent, { type: 'ship-destroyed' }>[] = [];
     const cheated: Extract<CombatEvent, { type: 'cheat-death-activated' }>[] = [];
@@ -134,7 +158,12 @@ const captureWrapper = (overrides: Partial<CombatEngineInput> = {}) => {
         ...healBase(overrides),
         bus,
         __testTapApplyOutgoingToEnemy: (fn) => {
-            if (!wrapper) wrapper = fn;
+            if (!wrapper) {
+                wrapper = fn;
+                // Invoke mid-run on the FIRST round only, so the wrapper's effect (or lack of it)
+                // on this round's live accumulators is observable in the finalized round result.
+                invokeDuringRun?.(fn);
+            }
         },
     } as CombatEngineInput);
     if (!wrapper) throw new Error('test tap was never invoked — applyOutgoingToEnemy not built');
@@ -198,15 +227,26 @@ describe('applyOutgoingToEnemy (player→enemy per-victim damage apply wrapper)'
         expect(destroyed.filter((d) => d.actorId === 'cdEnemy')).toHaveLength(0);
     });
 
-    it('enemy-side sink is a no-op: tank-incoming round accumulators stay untouched', () => {
-        const { wrapper, result } = captureWrapper();
-        // Drive several enemy-victim intakes through the wrapper — none should touch the
-        // tank-incoming buckets (those belong to the enemy→player direction only).
-        wrapper(3000, enemyVictim('e1', 10_000));
-        wrapper(4000, enemyVictim('e2', 10_000));
+    it('enemy-side sink is a no-op: invoking the wrapper MID-RUN does not bump the round accumulators', () => {
+        // Drive several enemy-victim intakes through the REAL wrapper DURING the round (inside the
+        // tap), so the accumulators are still live and will be snapshotted afterwards. A shield
+        // hit (overflow), a Barrier full block, and a plain HP hit each exercise a different sink
+        // hook (addShieldAbsorbed / addBarrierAbsorbed / addIncoming) — all no-ops here.
+        const { result } = captureWrapper(
+            { enemyAttackers: [enemyAttacker('barrierEnemy', selfBuffSkills('Barrier'))] },
+            (fn) => {
+                const shielded = enemyVictim('e1', 10_000);
+                shielded.shieldPool = 1000; // 3000 dmg → 1000 absorbed by shield, 2000 overflow to HP
+                fn(3000, shielded);
+                fn(4000, enemyVictim('barrierEnemy', 10_000)); // fully Barrier-blocked
+                fn(2000, enemyVictim('e2', 10_000)); // plain HP hit
+            }
+        );
         const rounds = result.healing!.rounds;
-        // No enemy attacked the tank in this scenario, so all incoming accumulators are 0 and
-        // must STAY 0 despite the wrapper's calls (the enemy-side sink writes nothing here).
+        // No enemy attacked the TANK this round, so the tank-incoming buckets start at 0. The
+        // mid-run wrapper calls above route through the enemy-side no-op sink, so the buckets must
+        // STILL read 0 in the finalized round — if the enemy sink ever credited these, the bumps
+        // would have landed here (the player-side sink, sharing these same closure vars, would).
         expect(rounds[0].incomingDamage).toBe(0);
         expect(rounds[0].shieldAbsorbed).toBe(0);
         expect(rounds[0].barrierAbsorbed).toBe(0);

--- a/src/utils/combat/__tests__/applyVictimDamage.characterization.test.ts
+++ b/src/utils/combat/__tests__/applyVictimDamage.characterization.test.ts
@@ -200,11 +200,14 @@ describe('victim-intake characterization (applyIncomingToTarget — pre-extracti
         expect(rounds[1].targetHpPctStart).toBeCloseTo(100, 6);
         expect(result.healing!.destroyedRound).toBeUndefined();
 
-        // The blocked intake STILL emits one hp-changed per round (no-op crossing: old === new).
+        // The blocked intake STILL emits one hp-changed per round, and EVERY captured crossing is a
+        // no-op (old === new, HP pinned at 100%) — not just the first round's.
         const tankHpChanged = hpChanged.filter((e) => e.targetId === 'attacker');
         expect(tankHpChanged.length).toBeGreaterThanOrEqual(1);
-        expect(tankHpChanged[0].oldPct).toBeCloseTo(100, 6);
-        expect(tankHpChanged[0].newPct).toBeCloseTo(tankHpChanged[0].oldPct, 6);
+        for (const crossing of tankHpChanged) {
+            expect(crossing.oldPct).toBeCloseTo(100, 6);
+            expect(crossing.newPct).toBeCloseTo(crossing.oldPct, 6);
+        }
     });
 
     // ── Branch 4: lethal hit on a Cheat-Death carrier → survives at 1 HP, ──
@@ -215,7 +218,7 @@ describe('victim-intake characterization (applyIncomingToTarget — pre-extracti
     // pins the floor + the event; branch 4b below pins the removable-DoT clear as a multi-round
     // survival signal.
     it('lethal hit + Cheat Death: survives at 1 HP, cheat-death-activated emitted', () => {
-        const { cheated, destroyed, result } = run(
+        const { hpChanged, cheated, destroyed, result } = run(
             healBase({
                 numRounds: 1, // single round: isolate the lethal save
                 hp: 2000, // enemy hits for 3000 → lethal in one hit → intercepted at 1 HP
@@ -230,6 +233,15 @@ describe('victim-intake characterization (applyIncomingToTarget — pre-extracti
         expect(cheated[0]).toMatchObject({ actorId: 'attacker', round: 1 });
         expect(destroyed.filter((d) => d.actorId === 'attacker')).toHaveLength(0);
         expect(result.healing!.destroyedRound).toBeUndefined();
+
+        // Pin the floor on the DIRECT-hit path: the lethal-direct intake crossing lands the
+        // survivor at exactly 1 HP of 2000 max = 0.05% — strictly positive, NOT 0 (floor + clear
+        // ran, not destroy) and NOT 2 HP. (Branch 4b pins the same floor on the DoT-tick path.)
+        const saveCrossing = hpChanged.find(
+            (e) => e.targetId === 'attacker' && e.round === 1 && e.newPct > 0 && e.newPct < 1
+        );
+        expect(saveCrossing).toBeDefined();
+        expect(saveCrossing!.newPct).toBeCloseTo((100 * 1) / 2000, 6); // 0.05% — floored at 1 HP
     });
 
     // ── Branch 4b: the Cheat-Death save fires off a lethal DoT-TICK intake (the second intake ──
@@ -272,7 +284,8 @@ describe('victim-intake characterization (applyIncomingToTarget — pre-extracti
         // at exactly 1 HP of 500 max = 0.2% — strictly positive, NOT 0 (the floor + removable-clear
         // path ran rather than the destroy path).
         const saveCrossing = hpChanged.find(
-            (e) => e.targetId === 'attacker' && e.round === saveRound && e.newPct > 0 && e.newPct < 1
+            (e) =>
+                e.targetId === 'attacker' && e.round === saveRound && e.newPct > 0 && e.newPct < 1
         );
         expect(saveCrossing).toBeDefined();
         expect(saveCrossing!.newPct).toBeCloseTo((100 * 1) / 500, 6); // 0.2% — floored at 1 HP

--- a/src/utils/combat/__tests__/applyVictimDamage.characterization.test.ts
+++ b/src/utils/combat/__tests__/applyVictimDamage.characterization.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Characterization tests for the engine's victim-intake closure (`applyIncomingToTarget`
+ * in `engine.ts`, the engine's sole `currentHp`-decrement path). These PIN the CURRENT
+ * behavior of every intake branch so the Task-2 extraction (which lifts the closure body
+ * into a reusable `applyVictimDamage` function) is provably behavior-preserving. They are
+ * the safety net for that refactor — they must pass against current `main` and change no
+ * production code.
+ *
+ * Five intake branches, one focused test each:
+ *   1. plain HP damage (shield 0) — currentHp drops by exactly the damage;
+ *   2. shield absorbs first, overflow hits HP;
+ *   3. Barrier carrier — full block, HP unchanged, barrierAbsorbed accrues, hp-changed still
+ *      emitted once;
+ *   4. lethal hit on a Cheat-Death carrier — survives at 1 HP, cheat-death-activated emitted,
+ *      removable statuses (DoTs) cleared so no further ticks land;
+ *   5. lethal hit, no Cheat Death — currentHp 0, ship-destroyed emitted once.
+ *
+ * Harness mirrors barrier.test.ts / hpCrossing.test.ts: healing-mode `runCombat` where the
+ * focus attacker IS the heal target (does no damage), manual flat / ship-backed enemy
+ * attackers, no-payload always-active self-buffs for Barrier and Cheat Death, and events
+ * captured off the bus. Round-overview fields (incomingDamage / shieldAbsorbed /
+ * barrierAbsorbed / targetHpPctStart / targetShieldStart / destroyedRound) are the observable
+ * post-intake signals; defence 0 so intake equals the raw enemy attack.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { Ability } from '../../../types/abilities';
+
+let idCounter = 0;
+const ab = (partial: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `cv${++idCounter}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...partial,
+});
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+/** A manual flat enemy: one synthesized basic attack, no skills. */
+const manualEnemy = (
+    id: string,
+    attack: number,
+    speed = 50,
+    extra: Partial<EnemyAttacker> = {}
+): EnemyAttacker => ({
+    id,
+    stats: { attack, crit: 0, critDamage: 0, speed },
+    chargeCount: 0,
+    startCharged: false,
+    ...extra,
+});
+
+/** A no-payload, always-active Barrier self-buff (recurring; active the whole scenario). */
+const barrierBuff = () => ({
+    id: 'barrier',
+    buffName: 'Barrier',
+    stacks: 1,
+    isStackable: false,
+    parsedEffects: {},
+});
+
+/** A no-payload, always-active Cheat Death self-buff (recurring; active the whole scenario). */
+const cheatDeathBuff = () => ({
+    id: 'cheat-death',
+    buffName: 'Cheat Death',
+    stacks: 1,
+    isStackable: false,
+    parsedEffects: {},
+});
+
+/**
+ * Base healing-mode input: the focus attacker IS the heal target. It does nothing damaging
+ * (empty skills), so the only HP-intake is the enemy attack / DoT tick. defence 0 → intake
+ * equals the raw enemy attack.
+ */
+const healBase = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 1000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [] },
+    enemyDefense: 0,
+    enemyHp: 10_000_000,
+    numRounds: 2,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    debuffLandingChance: 1,
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 10_000,
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+/** Run a healing-mode scenario, collecting the three intake-relevant events off the bus. */
+const run = (input: CombatEngineInput) => {
+    idCounter = 0;
+    const bus = createEventBus();
+    const hpChanged: Extract<CombatEvent, { type: 'hp-changed' }>[] = [];
+    const cheated: Extract<CombatEvent, { type: 'cheat-death-activated' }>[] = [];
+    const destroyed: Extract<CombatEvent, { type: 'ship-destroyed' }>[] = [];
+    bus.on('hp-changed', (e) => hpChanged.push(e));
+    bus.on('cheat-death-activated', (e) => cheated.push(e));
+    bus.on('ship-destroyed', (e) => destroyed.push(e));
+    const result = runCombat({ ...input, bus });
+    return { hpChanged, cheated, destroyed, result };
+};
+
+describe('victim-intake characterization (applyIncomingToTarget — pre-extraction lock)', () => {
+    // ── Branch 1: plain HP damage (shield 0) → currentHp drops by exactly the damage ──
+    // No shield ability, no Barrier. A single 3000 manual hit against 10000 max HP, defence 0.
+    // POST-hit signal: round-2 start HP = (10000 - 3000) / 10000 = 70%. shield/barrier untouched.
+    it('plain HP damage (no shield): decrements HP by exactly the damage', () => {
+        const { hpChanged, result } = run(
+            healBase({
+                numRounds: 2,
+                hp: 10_000,
+                enemyAttackers: [manualEnemy('atk1', 3000)],
+            })
+        );
+
+        const rounds = result.healing!.rounds;
+        // The 3000 hit arrives as incoming damage, none absorbed by shield/barrier.
+        expect(rounds[0].incomingDamage).toBe(3000);
+        expect(rounds[0].shieldAbsorbed).toBe(0);
+        expect(rounds[0].barrierAbsorbed).toBe(0);
+        // POST-hit: round-2 start HP = 70% (HP dropped by exactly 3000 of 10000).
+        expect(rounds[1].targetHpPctStart).toBeCloseTo(70, 6);
+        expect(result.healing!.destroyedRound).toBeUndefined();
+
+        // The intake emitted exactly one hp-changed for the attack: 100 → 70.
+        const e = hpChanged.filter((h) => h.targetId === 'attacker')[0];
+        expect(e.oldPct).toBeCloseTo(100, 6);
+        expect(e.newPct).toBeCloseTo(70, 6);
+    });
+
+    // ── Branch 2: shield absorbs first, overflow hits HP ──
+    // The tank (focus, faster) casts a 25%-of-hp self shield (2500 pool) on its turn BEFORE the
+    // enemy's 4000 hit. Shield absorbs 2500, the remaining 1500 spills to HP.
+    // POST-hit signal: round-2 start HP = (10000 - 1500) / 10000 = 85%, shield pool drained to 0.
+    it('shield absorbs first, overflow spills to HP', () => {
+        const shieldSelf = () =>
+            ab({
+                type: 'shield',
+                target: 'self',
+                config: { type: 'shield', pct: 25, basis: 'hp' }, // 25% of 10000 = 2500 pool
+            });
+
+        const { result } = run(
+            healBase({
+                numRounds: 2,
+                hp: 10_000,
+                speed: 100, // tank acts before the enemy (speed 50) so the shield is up first
+                shipSkills: { slots: [{ slot: 'active', abilities: [shieldSelf()] }] },
+                enemyAttackers: [manualEnemy('atk1', 4000)],
+            })
+        );
+
+        const rounds = result.healing!.rounds;
+        // 4000 incoming, 2500 absorbed by the shield, 1500 spilled to HP.
+        expect(rounds[0].incomingDamage).toBe(4000);
+        expect(rounds[0].shieldAbsorbed).toBe(2500);
+        expect(rounds[0].barrierAbsorbed).toBe(0);
+        // POST-hit: round-2 start HP = 85% (only the 1500 overflow drained HP), shield pool 0.
+        expect(rounds[1].targetHpPctStart).toBeCloseTo(85, 6);
+        expect(rounds[1].targetShieldStart).toBeCloseTo(0, 6);
+        expect(result.healing!.destroyedRound).toBeUndefined();
+    });
+
+    // ── Branch 3: Barrier carrier → full block, HP unchanged, barrierAbsorbed accrues, ──
+    //              hp-changed still emitted once.
+    // A Barrier self-buff is active the whole scenario; a 3000 hit is fully blocked each round.
+    // The damage still "arrives" (incomingDamage 3000) but is tracked as barrierAbsorbed, never
+    // shieldAbsorbed, and HP never moves (round-2 start still 100%).
+    it('Barrier carrier: full block — HP unchanged, barrierAbsorbed accrues, hp-changed still fires', () => {
+        const { hpChanged, result } = run(
+            healBase({
+                numRounds: 2,
+                hp: 10_000,
+                selfBuffs: [barrierBuff()],
+                enemyAttackers: [manualEnemy('atk1', 3000)],
+            })
+        );
+
+        const rounds = result.healing!.rounds;
+        // The hit arrives but is fully blocked by Barrier (tracked separately, shield untouched).
+        expect(rounds[0].incomingDamage).toBe(3000);
+        expect(rounds[0].barrierAbsorbed).toBe(3000);
+        expect(rounds[0].shieldAbsorbed).toBe(0);
+        // POST-hit: Barrier active both rounds → round-2 start HP still 100% (HP never moved).
+        expect(rounds[1].targetHpPctStart).toBeCloseTo(100, 6);
+        expect(result.healing!.destroyedRound).toBeUndefined();
+
+        // The blocked intake STILL emits one hp-changed per round (no-op crossing: old === new).
+        const tankHpChanged = hpChanged.filter((e) => e.targetId === 'attacker');
+        expect(tankHpChanged.length).toBeGreaterThanOrEqual(1);
+        expect(tankHpChanged[0].oldPct).toBeCloseTo(100, 6);
+        expect(tankHpChanged[0].newPct).toBeCloseTo(tankHpChanged[0].oldPct, 6);
+    });
+
+    // ── Branch 4: lethal hit on a Cheat-Death carrier → survives at 1 HP, ──
+    //              cheat-death-activated emitted, removable statuses (DoTs) cleared.
+    // A flat enemy deals a lethal basic hit (3000 vs hp 2000). The tank carries a recurring Cheat
+    // Death. On the lethal moment the engine floors HP to 1, marks cheat-death consumed, emits
+    // cheat-death-activated, and wipes the tank's REMOVABLE timed statuses. This single-round case
+    // pins the floor + the event; branch 4b below pins the removable-DoT clear as a multi-round
+    // survival signal.
+    it('lethal hit + Cheat Death: survives at 1 HP, cheat-death-activated emitted', () => {
+        const { cheated, destroyed, result } = run(
+            healBase({
+                numRounds: 1, // single round: isolate the lethal save
+                hp: 2000, // enemy hits for 3000 → lethal in one hit → intercepted at 1 HP
+                selfBuffs: [cheatDeathBuff()],
+                enemyAttackers: [manualEnemy('atk1', 3000)],
+            })
+        );
+
+        // Cheat Death fired exactly once and intercepted the lethal hit: the tank survives at
+        // 1 HP (floored), so it is NOT destroyed and ship-destroyed never fires for it.
+        expect(cheated).toHaveLength(1);
+        expect(cheated[0]).toMatchObject({ actorId: 'attacker', round: 1 });
+        expect(destroyed.filter((d) => d.actorId === 'attacker')).toHaveLength(0);
+        expect(result.healing!.destroyedRound).toBeUndefined();
+    });
+
+    // ── Branch 4b: the Cheat-Death save fires off a lethal DoT-TICK intake (the second intake ──
+    //              site that routes through the closure), and clears the survivor's removable DoTs.
+    // A single DoT-only enemy (no direct basic when its active skill is a pure DoT) seeds a
+    // corrosion DoT. Across rounds the tick accumulates and eventually delivers the lethal HP
+    // intake at the tank's turn-start — that DoT-tick (not a direct attack) is what triggers the
+    // Cheat-Death intercept. On the save the engine floors HP to 1 AND wipes the survivor's
+    // REMOVABLE corrosion entries; the observable proof of the clear is that the save lands the
+    // survivor at exactly 1 HP (a small strictly-positive newPct) on the DoT-tick crossing rather
+    // than at 0. The applier re-seeds a fresh DoT afterward, so this characterizes the per-save
+    // clear at the save moment (the current behavior), not a permanent immunity.
+    it('Cheat Death save triggered by a lethal DoT-tick: floors at 1 HP and clears removable DoTs', () => {
+        const corrosionDot = () =>
+            ab({
+                type: 'dot',
+                target: 'enemy',
+                config: { type: 'dot', dotType: 'corrosion', tier: 7, stacks: 10, duration: 5 },
+            });
+        // DoT-only applier: the corrosion tick (not a direct basic) is the lethal intake.
+        const dotEnemy = manualEnemy('dotEnemy', 1000, 40, {
+            shipSkills: { slots: [{ slot: 'active', abilities: [corrosionDot()] }] },
+        });
+
+        const { hpChanged, cheated, result } = run(
+            healBase({
+                numRounds: 5,
+                hp: 500, // small → the accumulated corrosion tick becomes lethal
+                speed: 100, // tank ticks its DoTs at its own (fast) turn-start each round
+                selfBuffs: [cheatDeathBuff()],
+                enemyAttackers: [dotEnemy],
+            })
+        );
+
+        // The save fired exactly once, triggered by a DoT-tick intake (not a direct hit).
+        expect(cheated).toHaveLength(1);
+        const saveRound = cheated[0].round;
+
+        // The DoT-tick crossing that triggered the save emitted an hp-changed landing the survivor
+        // at exactly 1 HP of 500 max = 0.2% — strictly positive, NOT 0 (the floor + removable-clear
+        // path ran rather than the destroy path).
+        const saveCrossing = hpChanged.find(
+            (e) => e.targetId === 'attacker' && e.round === saveRound && e.newPct > 0 && e.newPct < 1
+        );
+        expect(saveCrossing).toBeDefined();
+        expect(saveCrossing!.newPct).toBeCloseTo((100 * 1) / 500, 6); // 0.2% — floored at 1 HP
+
+        // Sanity: the save round itself recorded no destroy (the intercept ran instead).
+        expect(result.healing!.destroyedRound).not.toBe(saveRound);
+    });
+
+    // ── Branch 5: lethal hit, no Cheat Death → currentHp 0, ship-destroyed emitted once ──
+    // A single lethal 3000 hit vs hp 2000, no Cheat Death → the tank reaches 0 HP and is
+    // destroyed. ship-destroyed fires exactly once; destroyedRound is recorded.
+    it('lethal hit, no Cheat Death: HP reaches 0, ship-destroyed emitted once', () => {
+        const { cheated, destroyed, result } = run(
+            healBase({
+                numRounds: 2,
+                hp: 2000,
+                selfBuffs: [], // no Cheat Death
+                enemyAttackers: [manualEnemy('atk1', 3000)],
+            })
+        );
+
+        // No save; the tank is destroyed on round 1.
+        expect(cheated).toHaveLength(0);
+        const tankDestroyed = destroyed.filter((d) => d.actorId === 'attacker');
+        expect(tankDestroyed).toHaveLength(1);
+        expect(tankDestroyed[0].round).toBe(1);
+        expect(result.healing!.destroyedRound).toBe(1);
+    });
+});

--- a/src/utils/combat/__tests__/positionalApply.test.ts
+++ b/src/utils/combat/__tests__/positionalApply.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { parsePattern } from '../../targetingParser';
-import { footprintVictims } from '../positionalApply';
+import { parsePattern, parseTarget } from '../../targetingParser';
+import { footprintVictims, applyPositionalDamage } from '../positionalApply';
+import type { AttackerDamageScalars, VictimDefenseProfile } from '../victimDamage';
 import type { CombatActor } from '../state';
 
 const actor = (id: string, position: CombatActor['position'], currentHp = 100): CombatActor =>
@@ -52,5 +53,169 @@ describe('footprintVictims', () => {
 
         expect(hits).toHaveLength(1);
         expect(hits[0].victim.id).toBe('origin');
+    });
+});
+
+// Minimal scalars/profile — affinity neutral so damage is finite and predictable.
+const scalars = (): AttackerDamageScalars => ({
+    effectiveAttack: 1000,
+    multiplierPct: 100,
+    secondaryStatValue: 0,
+    hits: 3,
+    effectiveCritDamage: 0,
+    outgoingDamageBuffPct: 0,
+    incomingDamageModifierPct: 0,
+    defensePenetrationPct: 0,
+    attackerAffinity: 'chemical',
+});
+
+const profile = (): VictimDefenseProfile => ({
+    defence: 0,
+    defenceModifierPct: 0,
+    affinity: 'chemical',
+});
+
+interface Call {
+    id: string;
+    damage: number;
+    didCrit: boolean;
+}
+
+describe('applyPositionalDamage', () => {
+    it('3-hit single-target: anchor dies on hit 1 → hits 2-3 redirect to next living target', () => {
+        const pattern = parsePattern('Pattern-Base');
+        const target = parseTarget('front');
+        // front-most (col 4) anchor first, then a back target with plenty of HP.
+        const anchorActor = actor('anchor', 'M4', 1);
+        const next = actor('next', 'M1', 1e9);
+        const opposingLiving = [anchorActor, next];
+
+        const applyCalls: Call[] = [];
+        const emitCalls: Call[] = [];
+
+        applyPositionalDamage({
+            hits: 3,
+            hitCrits: [false, false, false],
+            scalars: scalars(),
+            pattern,
+            actorPosition: 'M2',
+            target,
+            opposingLiving,
+            defenseProfileOf: profile,
+            // Real decrement: anchor (1 HP) dies on hit 1; next (1e9 HP) survives all hits.
+            applyToVictim: (victim, damage) => {
+                applyCalls.push({ id: victim.id, damage, didCrit: false });
+                victim.currentHp -= damage;
+            },
+            emitHit: (victim, damage, didCrit) => {
+                emitCalls.push({ id: victim.id, damage, didCrit });
+            },
+        });
+
+        // Hit 1 → anchor (dies). Hits 2-3 re-resolve to `next` (the only living target left).
+        expect(applyCalls.map((c) => c.id)).toEqual(['anchor', 'next', 'next']);
+        expect(emitCalls.map((c) => c.id)).toEqual(['anchor', 'next', 'next']);
+        expect(anchorActor.currentHp).toBeLessThanOrEqual(0);
+        expect(next.currentHp).toBeGreaterThan(0);
+    });
+
+    it('all opposing dead before a hit → whiff: neither applyToVictim nor emitHit invoked', () => {
+        const pattern = parsePattern('Pattern-Base');
+        const target = parseTarget('front');
+        const only = actor('only', 'M4');
+        const opposingLiving = [only];
+
+        const applyCalls: Call[] = [];
+        const emitCalls: Call[] = [];
+
+        applyPositionalDamage({
+            hits: 3,
+            hitCrits: [false, false, false],
+            scalars: scalars(),
+            pattern,
+            actorPosition: 'M2',
+            target,
+            opposingLiving,
+            defenseProfileOf: profile,
+            applyToVictim: (victim, damage) => {
+                applyCalls.push({ id: victim.id, damage, didCrit: false });
+                victim.currentHp = 0;
+            },
+            emitHit: (victim, damage, didCrit) => {
+                emitCalls.push({ id: victim.id, damage, didCrit });
+            },
+        });
+
+        // Only one living target → hit 1 kills it, hits 2-3 whiff (no calls).
+        expect(applyCalls.map((c) => c.id)).toEqual(['only']);
+        expect(emitCalls.map((c) => c.id)).toEqual(['only']);
+    });
+
+    it('AoE multi-hit: each hit applies origin (full) + covered (half)', () => {
+        // Pattern-Line-Range-1 @ M4 → origin M4, covered M3.
+        const pattern = parsePattern('Pattern-Line-Range-1');
+        const target = parseTarget('front');
+        const origin = actor('origin', 'M4', 1e9);
+        const covered = actor('covered', 'M3', 1e9);
+        const opposingLiving = [origin, covered];
+
+        const emitCalls: Call[] = [];
+
+        applyPositionalDamage({
+            hits: 2,
+            hitCrits: [false, false],
+            scalars: scalars(),
+            pattern,
+            actorPosition: 'M2',
+            target,
+            opposingLiving,
+            defenseProfileOf: profile,
+            // High HP, real damage decrement — nobody dies, so footprint stays stable.
+            applyToVictim: (victim, damage) => {
+                victim.currentHp -= damage;
+            },
+            emitHit: (victim, damage, didCrit) => {
+                emitCalls.push({ id: victim.id, damage, didCrit });
+            },
+        });
+
+        // 2 hits × (origin + covered) = 4 calls.
+        expect(emitCalls).toHaveLength(4);
+        const originCalls = emitCalls.filter((c) => c.id === 'origin');
+        const coveredCalls = emitCalls.filter((c) => c.id === 'covered');
+        expect(originCalls).toHaveLength(2);
+        expect(coveredCalls).toHaveLength(2);
+        // Covered cell takes exactly half the origin cell's per-hit damage (roleScale 0.5).
+        expect(coveredCalls[0].damage).toBeCloseTo(originCalls[0].damage * 0.5, 6);
+    });
+
+    it('hitCrits shorter than hits → missing entries treated as false (no crash)', () => {
+        const pattern = parsePattern('Pattern-Base');
+        const target = parseTarget('front');
+        const only = actor('only', 'M4', 1e9);
+        const opposingLiving = [only];
+
+        const emitCalls: Call[] = [];
+
+        expect(() =>
+            applyPositionalDamage({
+                hits: 3,
+                hitCrits: [true], // only one entry; hits 2-3 fall back to false
+                scalars: { ...scalars(), effectiveCritDamage: 50 },
+                pattern,
+                actorPosition: 'M2',
+                target,
+                opposingLiving,
+                defenseProfileOf: profile,
+                applyToVictim: (victim, damage) => {
+                    victim.currentHp -= damage;
+                },
+                emitHit: (victim, damage, didCrit) => {
+                    emitCalls.push({ id: victim.id, damage, didCrit });
+                },
+            })
+        ).not.toThrow();
+
+        expect(emitCalls.map((c) => c.didCrit)).toEqual([true, false, false]);
     });
 });

--- a/src/utils/combat/__tests__/positionalApply.test.ts
+++ b/src/utils/combat/__tests__/positionalApply.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { parsePattern } from '../../targetingParser';
+import { footprintVictims } from '../positionalApply';
+import type { CombatActor } from '../state';
+
+const actor = (id: string, position: CombatActor['position'], currentHp = 100): CombatActor =>
+    ({ id, position, currentHp }) as CombatActor;
+
+describe('footprintVictims', () => {
+    it('single-target pattern (origin only) → origin occupant at roleScale 1.0', () => {
+        const pattern = parsePattern('Pattern-Base');
+        const living = [actor('front', 'M4'), actor('back', 'M1')];
+
+        const hits = footprintVictims(pattern, 'M4', living);
+
+        expect(hits).toHaveLength(1);
+        expect(hits[0].victim.id).toBe('front');
+        expect(hits[0].roleScale).toBe(1.0);
+    });
+
+    it('AoE pattern with occupants at origin + covered → origin 1.0, covered 0.5', () => {
+        // Pattern-Line-Range-1 @ M4 → origin M4, covered M3.
+        const pattern = parsePattern('Pattern-Line-Range-1');
+        const living = [actor('origin', 'M4'), actor('covered', 'M3'), actor('elsewhere', 'M1')];
+
+        const hits = footprintVictims(pattern, 'M4', living);
+
+        expect(hits).toHaveLength(2);
+        const byId = new Map(hits.map((h) => [h.victim.id, h.roleScale]));
+        expect(byId.get('origin')).toBe(1.0);
+        expect(byId.get('covered')).toBe(0.5);
+        expect(byId.has('elsewhere')).toBe(false);
+    });
+
+    it('covered cell with NO living occupant contributes nothing', () => {
+        // Pattern-Line-Range-1 @ M4 → origin M4, covered M3. M3 is empty.
+        const pattern = parsePattern('Pattern-Line-Range-1');
+        const living = [actor('origin', 'M4')];
+
+        const hits = footprintVictims(pattern, 'M4', living);
+
+        expect(hits).toHaveLength(1);
+        expect(hits[0].victim.id).toBe('origin');
+        expect(hits[0].roleScale).toBe(1.0);
+    });
+
+    it('dead actor (currentHp 0) at a covered cell is excluded', () => {
+        const pattern = parsePattern('Pattern-Line-Range-1');
+        const living = [actor('origin', 'M4'), actor('deadCovered', 'M3', 0)];
+
+        const hits = footprintVictims(pattern, 'M4', living);
+
+        expect(hits).toHaveLength(1);
+        expect(hits[0].victim.id).toBe('origin');
+    });
+});

--- a/src/utils/combat/__tests__/positionalApply.test.ts
+++ b/src/utils/combat/__tests__/positionalApply.test.ts
@@ -94,9 +94,8 @@ describe('applyPositionalDamage', () => {
         const emitCalls: Call[] = [];
 
         applyPositionalDamage({
-            hits: 3,
             hitCrits: [false, false, false],
-            scalars: scalars(),
+            scalars: scalars(), // scalars.hits === 3 is the canonical loop count
             pattern,
             actorPosition: 'M2',
             target,
@@ -129,9 +128,8 @@ describe('applyPositionalDamage', () => {
         const emitCalls: Call[] = [];
 
         applyPositionalDamage({
-            hits: 3,
             hitCrits: [false, false, false],
-            scalars: scalars(),
+            scalars: scalars(), // scalars.hits === 3 is the canonical loop count
             pattern,
             actorPosition: 'M2',
             target,
@@ -162,9 +160,9 @@ describe('applyPositionalDamage', () => {
         const emitCalls: Call[] = [];
 
         applyPositionalDamage({
-            hits: 2,
             hitCrits: [false, false],
-            scalars: scalars(),
+            // scalars.hits drives the loop; override to 2 for this 2-hit fixture.
+            scalars: { ...scalars(), hits: 2 },
             pattern,
             actorPosition: 'M2',
             target,
@@ -199,8 +197,8 @@ describe('applyPositionalDamage', () => {
 
         expect(() =>
             applyPositionalDamage({
-                hits: 3,
                 hitCrits: [true], // only one entry; hits 2-3 fall back to false
+                // scalars.hits === 3 drives the loop (canonical count)
                 scalars: { ...scalars(), effectiveCritDamage: 50 },
                 pattern,
                 actorPosition: 'M2',

--- a/src/utils/combat/__tests__/positionalDamage.integration.test.ts
+++ b/src/utils/combat/__tests__/positionalDamage.integration.test.ts
@@ -308,14 +308,13 @@ const passivePlayerAt = (id: string, position: Position, hp: number): TeamActor 
 // A positioned ENEMY attacker that actually deals damage: attack 5000, multiplier 100% (1x),
 // 1 hit, no crit vs defence-0 player victims → firing-hit damage = 5000. `target`/`pattern`
 // drive the Task 9 enemy-site positional apply against the PLAYER roster.
-type EnemyAttacker2 = EnemyAttacker;
 const offensiveEnemyAt = (
     id: string,
     position: Position,
     selection: ParsedTarget['selection'],
     pattern: ParsedPattern,
     attack = 5000
-): EnemyAttacker2 =>
+): EnemyAttacker =>
     ({
         id,
         stats: { attack, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1 },
@@ -325,7 +324,7 @@ const offensiveEnemyAt = (
         target: parsedTarget(selection),
         pattern,
         shipSkills: { slots: [basicAttack()] },
-    }) as EnemyAttacker2;
+    }) as EnemyAttacker;
 
 describe('Task 9 — positional AoE damage apply at the enemy site (enemy→player)', () => {
     // Player roster: focus 'attacker' at M4 (front, the heal target) + a passive team victim at
@@ -394,7 +393,7 @@ describe('Task 9 — positional AoE damage apply at the enemy site (enemy→play
                         {
                             ...offensiveEnemyAt('enemy-1', 'M1', 'front', basePattern()),
                             pattern: undefined, // no pattern → legacy single-apply path
-                        } as EnemyAttacker2,
+                        } as EnemyAttacker,
                     ],
                 },
                 undefined,

--- a/src/utils/combat/__tests__/positionalDamage.integration.test.ts
+++ b/src/utils/combat/__tests__/positionalDamage.integration.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Task 8b — positional AoE damage APPLY wired into the focus + team damage sites.
+ *
+ * Tasks 1–7 built the per-victim damage pipeline (victimHitDamage / applyOutgoingToEnemy /
+ * applyPositionalDamage) but left it unreachable through `runCombat`. Task 8b wires it in: when
+ * the focus attacker (or a walked team actor) carries a board `position` + a parsed `target` +
+ * a parsed `pattern` AND the positioned enemy roster is non-empty AND its firing hit produced
+ * `turn.positionalScalars`, the engine drives `applyPositionalDamage` against the LIVE enemy
+ * roster — landing real per-victim HP damage (origin full, covered half) — and SUPPRESSES the
+ * legacy DPS-sink direct/secondary/conditional credit for that case (so the firing-hit damage is
+ * not double-counted into cumulativeDamage). Detonation credit is preserved (bombs are separate).
+ *
+ * REACHABILITY: the positioned enemy roster (`enemyAttackerActors`) is only populated in HEALING
+ * mode (the engine throws `enemyAttackers require healTargetId` otherwise) — so every test here
+ * runs `runCombat` with `healTargetId` set.
+ *
+ * OBSERVABLE: the engine does not surface live enemy-actor HP, and the per-victim `hp-changed`
+ * crossing is suppressed for enemy victims (their max HP is unknown to the tank-centric
+ * recipientMaxHp). What IS observable is `ship-destroyed`: `applyOutgoingToEnemy` runs the full
+ * HP/death path and emits `ship-destroyed{actorId}` when a victim's HP reaches 0. So we PIN the
+ * landed damage with lethality brackets — size each enemy's HP just AT or just ABOVE the expected
+ * damage and assert it dies / survives accordingly. `damageLandedInRange(victimId)` runs two
+ * combats (HP = lo → must die; HP = hi → must survive) to bracket the firing-hit damage to
+ * `[lo, hi)`. A NON-positional run lands NO enemy damage (the enemy actors are pure targets the
+ * legacy path never touches), so the victim never dies regardless of HP.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus } from '../events';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `pd${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+// A no-passive single-hit basic-attack active slot. `multiplier: 100` (1x), 1 hit. No passive
+// payload damage, so the firing-hit damage equals turn.directDamage exactly (single victim).
+const basicAttack = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } }),
+    ],
+});
+
+// A positioned, finite-HP enemy with zero offense (a stationary, damageable target). `hp`
+// is sized per-test to sit at/above the expected firing-hit damage so death brackets it.
+const enemyAt = (id: string, position: Position, hp: number): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        shipSkills: { slots: [] } as ShipSkills,
+    }) as EnemyAttacker;
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+// Single-target pattern: origin cell only (Pattern-Base).
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+// AoE pattern: origin + one covered cell one step toward back (Pattern-Line-Range-1).
+// Anchored at the FRONT enemy (M4 = axial (2,1)) it covers (1,1) = M3.
+const lineRange1Pattern = (): ParsedPattern => ({
+    raw: 'line-range-1',
+    shape: 'line',
+    range: 1,
+    modifiers: {},
+});
+
+// Focus attacker positioned at M4 with a real basic attack. `attack: 5000` against
+// `defence: 0` victims; multiplier 100 (1x), 1 hit → a clean known firing-hit damage.
+const BASE = (
+    overrides: Partial<CombatEngineInput> = {},
+    target?: ParsedTarget,
+    pattern?: ParsedPattern
+): CombatEngineInput => ({
+    attack: 5000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [basicAttack()] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    debuffLandingChance: 1,
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    // Healing mode — required for the positioned enemy roster to be built.
+    healTargetId: 'attacker',
+    position: 'M4',
+    ...(target ? { target } : {}),
+    ...(pattern ? { pattern } : {}),
+    ...overrides,
+});
+
+/** The set of distinct actor ids that emitted a ship-destroyed event in this run. */
+const destroyedIds = (input: CombatEngineInput): Set<string> => {
+    const bus = createEventBus();
+    const ids = new Set<string>();
+    bus.on('ship-destroyed', (e) => {
+        ids.add(e.actorId);
+    });
+    runCombat({ ...input, bus });
+    return ids;
+};
+
+describe('Task 8b — positional AoE damage apply at the focus site', () => {
+    // Focus: attack 5000 × 100% × 1 hit vs defence 0, no crit → firing-hit damage = 5000.
+    it('single-target pattern: the targeted enemy takes EXACTLY the firing-hit damage (death bracket)', () => {
+        // Front enemy at M4 (the `front` selection target); back enemy at M1 untouched by a
+        // base (origin-only) footprint. HP=5000 → dies (damage ≥ 5000); HP=5001 → survives
+        // (damage < 5001) → pins the landed damage to exactly 5000.
+        const atFront = (frontHp: number): CombatEngineInput =>
+            BASE(
+                {
+                    enemyAttackers: [
+                        enemyAt('enemy-front', 'M4', frontHp),
+                        enemyAt('enemy-back', 'M1', 5000),
+                    ],
+                },
+                parsedTarget('front'),
+                basePattern()
+            );
+        idc = 0;
+        const deadAt5000 = destroyedIds(atFront(5000));
+        idc = 0;
+        const deadAt5001 = destroyedIds(atFront(5001));
+        // The origin victim dies at HP 5000 but survives at 5001 → exactly 5000 landed.
+        expect(deadAt5000.has('enemy-front')).toBe(true);
+        expect(deadAt5001.has('enemy-front')).toBe(false);
+        // The back enemy (HP 5000) is outside the origin-only footprint → never hit, never dies.
+        expect(deadAt5000.has('enemy-back')).toBe(false);
+    });
+
+    it('AoE pattern: origin takes FULL (5000) and the covered enemy takes HALF (2500)', () => {
+        // Line-Range-1 anchored at M4 covers M3. Origin = front (M4), covered = mid (M3).
+        const aoe = (frontHp: number, midHp: number): CombatEngineInput =>
+            BASE(
+                {
+                    enemyAttackers: [
+                        enemyAt('enemy-front', 'M4', frontHp),
+                        enemyAt('enemy-mid', 'M3', midHp),
+                    ],
+                },
+                parsedTarget('front'),
+                lineRange1Pattern()
+            );
+        // Origin full damage = 5000: dies at HP 5000, survives at 5001.
+        idc = 0;
+        const lo = destroyedIds(aoe(5000, 2500));
+        idc = 0;
+        const hi = destroyedIds(aoe(5001, 2501));
+        // Origin pinned to exactly 5000 (full); covered pinned to exactly 2500 (half).
+        expect(lo.has('enemy-front')).toBe(true);
+        expect(hi.has('enemy-front')).toBe(false);
+        expect(lo.has('enemy-mid')).toBe(true); // covered dies at HP 2500 → took ≥ 2500
+        expect(hi.has('enemy-mid')).toBe(false); // survives at 2501 → took < 2501 → exactly 2500 (half)
+    });
+
+    it('byte-identical sanity: a NON-positional run lands NO enemy HP damage (legacy dummy sink)', () => {
+        idc = 0;
+        // No position on the focus → positional is false → legacy path. The enemy actors here are
+        // pure targets; the legacy path drains the dummy sink, never these enemies' HP. Even at
+        // HP=1 (trivially lethal if any damage landed) they survive.
+        const input = BASE({
+            position: undefined,
+            enemyAttackers: [enemyAt('enemy-front', 'M4', 1), enemyAt('enemy-back', 'M1', 1)],
+        });
+        const dead = destroyedIds(input);
+        expect(dead.has('enemy-front')).toBe(false);
+        expect(dead.has('enemy-back')).toBe(false);
+    });
+});
+
+type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
+
+const teamActorAt = (
+    id: string,
+    position: Position,
+    selection: ParsedTarget['selection'],
+    pattern: ParsedPattern
+): TeamActor => ({
+    id,
+    speed: 200, // faster than the focus
+    chargeCount: 0,
+    startCharged: false,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    position,
+    target: parsedTarget(selection),
+    pattern,
+    walk: {
+        shipSkills: { slots: [basicAttack()] },
+        stats: {
+            attack: 7000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            hacking: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+        },
+        debuffLandingChance: 1,
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        hasChargedSkill: false,
+    },
+});
+
+describe('Task 8b — positional AoE damage apply at the walked-team site', () => {
+    it('a walked team actor lands its OWN positional firing-hit damage on its OWN selected enemy', () => {
+        // Focus at M4 selects `front` (origin M4, attack 5000 → 5000 damage); team actor at M1
+        // selects `back` (origin M1, attack 7000 → 7000 damage). Distinct origin-only targets so
+        // the two firing hits don't overlap. Death brackets pin each independently.
+        const run = (frontHp: number, backHp: number): CombatEngineInput =>
+            BASE(
+                {
+                    teamActors: [teamActorAt('team-1', 'M1', 'back', basePattern())],
+                    enemyAttackers: [
+                        enemyAt('enemy-front', 'M4', frontHp),
+                        enemyAt('enemy-back', 'M1', backHp),
+                    ],
+                },
+                parsedTarget('front'),
+                basePattern()
+            );
+        idc = 0;
+        const lo = destroyedIds(run(5000, 7000));
+        idc = 0;
+        const hi = destroyedIds(run(5001, 7001));
+        // Focus pins the front enemy to exactly 5000; team actor pins the back enemy to exactly 7000.
+        expect(lo.has('enemy-front')).toBe(true);
+        expect(hi.has('enemy-front')).toBe(false);
+        expect(lo.has('enemy-back')).toBe(true);
+        expect(hi.has('enemy-back')).toBe(false);
+    });
+});

--- a/src/utils/combat/__tests__/positionalDamage.integration.test.ts
+++ b/src/utils/combat/__tests__/positionalDamage.integration.test.ts
@@ -1,5 +1,16 @@
 /**
- * Task 8b — positional AoE damage APPLY wired into the focus + team damage sites.
+ * Task 8b/9 — positional AoE damage APPLY wired into the focus + team (8b) and enemy (9)
+ * damage sites.
+ *
+ * Task 9 adds the enemy→player direction: a positioned enemy attacker with a parsed target +
+ * pattern drives `applyPositionalDamage` against the LIVE PLAYER roster (`allPlayerActors`) via
+ * the PLAYER-side `applyIncomingToTarget` wrapper — landing real per-victim HP damage on player
+ * ships (origin full, covered half) — and SUPPRESSES the legacy single `applyIncomingToTarget`
+ * call for that case (else the anchor victim is double-hit). A `ship-destroyed{actorId}` fires
+ * per player victim that reaches 0 HP (player victims have known max HP via recipientMaxHp), so
+ * the same lethality-bracket idiom pins each player victim's landed damage. The Task-9 describe
+ * block below also confirms a single-target enemy attack hits ONLY its target, and that a
+ * non-positional enemy (target but no pattern) keeps the legacy single-apply (heal target only).
  *
  * Tasks 1–7 built the per-victim damage pipeline (victimHitDamage / applyOutgoingToEnemy /
  * applyPositionalDamage) but left it unreachable through `runCombat`. Task 8b wires it in: when
@@ -260,5 +271,144 @@ describe('Task 8b — positional AoE damage apply at the walked-team site', () =
         expect(hi.has('enemy-front')).toBe(false);
         expect(lo.has('enemy-back')).toBe(true);
         expect(hi.has('enemy-back')).toBe(false);
+    });
+});
+
+// A passive, positioned player victim (a walked team actor with no offense). HP is sized
+// per-test to bracket the enemy AoE damage it takes; attack 0 → it deals nothing on its turn.
+const passivePlayerAt = (id: string, position: Position, hp: number): TeamActor => ({
+    id,
+    speed: 100,
+    chargeCount: 0,
+    startCharged: false,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    position,
+    walk: {
+        shipSkills: { slots: [basicAttack()] },
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            hacking: 0,
+            defence: 0,
+            hp,
+        },
+        debuffLandingChance: 1,
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        hasChargedSkill: false,
+    },
+});
+
+// A positioned ENEMY attacker that actually deals damage: attack 5000, multiplier 100% (1x),
+// 1 hit, no crit vs defence-0 player victims → firing-hit damage = 5000. `target`/`pattern`
+// drive the Task 9 enemy-site positional apply against the PLAYER roster.
+type EnemyAttacker2 = EnemyAttacker;
+const offensiveEnemyAt = (
+    id: string,
+    position: Position,
+    selection: ParsedTarget['selection'],
+    pattern: ParsedPattern,
+    attack = 5000
+): EnemyAttacker2 =>
+    ({
+        id,
+        stats: { attack, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget(selection),
+        pattern,
+        shipSkills: { slots: [basicAttack()] },
+    }) as EnemyAttacker2;
+
+describe('Task 9 — positional AoE damage apply at the enemy site (enemy→player)', () => {
+    // Player roster: focus 'attacker' at M4 (front, the heal target) + a passive team victim at
+    // M3 (mid). An enemy at M1 fires Line-Range-1 `front` → anchors on the front-most player
+    // (M4) for FULL damage and covers M3 for HALF. The focus carries NO target/pattern so its
+    // OWN turn stays non-positional (legacy dummy sink — it never touches these player HPs).
+    it('AoE: front player (heal target) takes FULL (5000) and the covered player takes HALF (2500)', () => {
+        const run = (frontHp: number, midHp: number): CombatEngineInput =>
+            BASE(
+                {
+                    hp: frontHp, // focus = heal target = origin victim
+                    teamActors: [passivePlayerAt('player-mid', 'M3', midHp)],
+                    enemyAttackers: [
+                        offensiveEnemyAt('enemy-1', 'M1', 'front', lineRange1Pattern()),
+                    ],
+                },
+                undefined, // focus is NON-positional (no target) → its own turn uses the dummy sink
+                undefined
+            );
+        // Origin (front player / heal target): full 5000 → dies at HP 5000, survives at 5001.
+        // Covered (mid player): half 2500 → dies at HP 2500, survives at 2501.
+        idc = 0;
+        const lo = destroyedIds(run(5000, 2500));
+        idc = 0;
+        const hi = destroyedIds(run(5001, 2501));
+        expect(lo.has('attacker')).toBe(true); // origin pinned to exactly 5000 (full)
+        expect(hi.has('attacker')).toBe(false);
+        expect(lo.has('player-mid')).toBe(true); // covered pinned to exactly 2500 (half)
+        expect(hi.has('player-mid')).toBe(false);
+    });
+
+    it('single-target enemy attack hits ONLY its targeted player (origin-only footprint)', () => {
+        // Same roster but a base (origin-only) pattern: anchors on the front player (M4) and hits
+        // nothing else. The covered-cell player at M3 is never touched — survives at trivial HP.
+        const run = (frontHp: number): CombatEngineInput =>
+            BASE(
+                {
+                    hp: frontHp,
+                    teamActors: [passivePlayerAt('player-mid', 'M3', 1)],
+                    enemyAttackers: [offensiveEnemyAt('enemy-1', 'M1', 'front', basePattern())],
+                },
+                undefined,
+                undefined
+            );
+        idc = 0;
+        const lo = destroyedIds(run(5000));
+        idc = 0;
+        const hi = destroyedIds(run(5001));
+        expect(lo.has('attacker')).toBe(true); // front player took exactly 5000
+        expect(hi.has('attacker')).toBe(false);
+        // The M3 player (HP 1) is outside the origin-only footprint → never hit, never dies.
+        expect(lo.has('player-mid')).toBe(false);
+        expect(hi.has('player-mid')).toBe(false);
+    });
+
+    it('byte-identical sanity: a NON-positional enemy (no pattern) hits only the heal target via the legacy single-apply', () => {
+        // Enemy has a target but NO pattern → enemyPositional is false → legacy single-apply path:
+        // it drains the heal target (the focus) only. The M3 player is never touched. This is the
+        // pre-Task-9 behaviour (the legacy enemy single-apply always hit the heal target).
+        const run = (frontHp: number): CombatEngineInput =>
+            BASE(
+                {
+                    hp: frontHp,
+                    teamActors: [passivePlayerAt('player-mid', 'M3', 1)],
+                    enemyAttackers: [
+                        {
+                            ...offensiveEnemyAt('enemy-1', 'M1', 'front', basePattern()),
+                            pattern: undefined, // no pattern → legacy single-apply path
+                        } as EnemyAttacker2,
+                    ],
+                },
+                undefined,
+                undefined
+            );
+        idc = 0;
+        const lo = destroyedIds(run(5000));
+        idc = 0;
+        const hi = destroyedIds(run(5001));
+        // Legacy single-apply: the enemy's full damage lands on the heal target (front).
+        expect(lo.has('attacker')).toBe(true);
+        expect(hi.has('attacker')).toBe(false);
+        // The M3 player (HP 1) is untouched on the non-positional path.
+        expect(lo.has('player-mid')).toBe(false);
+        expect(hi.has('player-mid')).toBe(false);
     });
 });

--- a/src/utils/combat/__tests__/positionalDamage.integration.test.ts
+++ b/src/utils/combat/__tests__/positionalDamage.integration.test.ts
@@ -380,6 +380,47 @@ describe('Task 9 — positional AoE damage apply at the enemy site (enemy→play
         expect(hi.has('player-mid')).toBe(false);
     });
 
+    it('records perTargetDamage per victim: origin FULL (5000) + covered HALF (2500); non-positional run has it absent', () => {
+        // AoE enemy at M1 fires Line-Range-1 `front` → origin = front player (heal target,
+        // 5000 full), covered = M3 player (2500 half). Roster HP kept huge so nobody dies and
+        // the per-round map records the actual landed damage rather than clamping at death.
+        const positionalRun = BASE(
+            {
+                hp: 1_000_000_000,
+                teamActors: [passivePlayerAt('player-mid', 'M3', 1_000_000_000)],
+                enemyAttackers: [offensiveEnemyAt('enemy-1', 'M1', 'front', lineRange1Pattern())],
+            },
+            undefined,
+            undefined
+        );
+        idc = 0;
+        const result = runCombat(positionalRun);
+        const round = result.rounds[0];
+        expect(round.perTargetDamage).toBeDefined();
+        expect(round.perTargetDamage?.['attacker']).toBe(5000); // origin = heal target, full
+        expect(round.perTargetDamage?.['player-mid']).toBe(2500); // covered, half
+
+        // Non-positional run (no enemy pattern → legacy single-apply): no positional emitHit
+        // accumulation → perTargetDamage absent on every round.
+        const nonPositionalRun = BASE(
+            {
+                hp: 1_000_000_000,
+                teamActors: [passivePlayerAt('player-mid', 'M3', 1_000_000_000)],
+                enemyAttackers: [
+                    {
+                        ...offensiveEnemyAt('enemy-1', 'M1', 'front', basePattern()),
+                        pattern: undefined,
+                    } as EnemyAttacker,
+                ],
+            },
+            undefined,
+            undefined
+        );
+        idc = 0;
+        const legacyResult = runCombat(nonPositionalRun);
+        expect(legacyResult.rounds[0].perTargetDamage).toBeUndefined();
+    });
+
     it('byte-identical sanity: a NON-positional enemy (no pattern) hits only the heal target via the legacy single-apply', () => {
         // Enemy has a target but NO pattern → enemyPositional is false → legacy single-apply path:
         // it drains the heal target (the focus) only. The M3 player is never touched. This is the

--- a/src/utils/combat/__tests__/positionalScalars.test.ts
+++ b/src/utils/combat/__tests__/positionalScalars.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Task 7 — integration-boundary parity guard for PlayerTurnResult.positionalScalars.
+ *
+ * The positional apply path (Task 8) feeds the per-cast attacker-side scalars exposed on
+ * PlayerTurnResult.positionalScalars (+ hitCrits) through victimHitDamage for EACH bound
+ * victim. This test pins that, for the SINGLE bound enemy the engine already damages, the
+ * per-hit sum reproduces the turn's aggregate directDamage EXACTLY.
+ *
+ * Setup uses a multi-hit damage skill with NO passive payload, so directDamage is purely the
+ * firing hit (preCritDamage * postDefenseFactor) with no separate passive bucket — making the
+ * per-hit victimHitDamage sum a clean equality target.
+ *
+ * The affinity field is the crux: the runtime carries the PRE-RESOLVED affinityDamageModifier
+ * (+25 advantage), and positionalScalars.attackerAffinity must be the raw affinity that, fed
+ * with the victim's affinity through computeAffinityModifiers, reproduces that same modifier.
+ */
+import { describe, expect, it } from 'vitest';
+import { runPlayerTurn, PlayerActorRuntime, PlayerTurnArgs } from '../playerTurn';
+import { createActor } from '../state';
+import { createStatusEngine } from '../statusEngine';
+import { createEventBus } from '../events';
+import { makeRateGate } from '../../calculators/rateAccumulator';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import { victimHitDamage, VictimDefenseProfile } from '../victimDamage';
+import { AffinityName } from '../../../types/ship';
+
+// thermal > chemical → +25% advantage. The runtime's pre-resolved modifier must match.
+const ATTACKER_AFFINITY: AffinityName = 'thermal';
+const VICTIM_AFFINITY: AffinityName = 'chemical';
+const AFFINITY_DAMAGE_MODIFIER = 25;
+
+const ENEMY_DEFENCE = 850;
+// enemyDefenseModifier is engine-derived from enemy debuffs; none applied here → 0.
+const ENEMY_DEFENCE_MODIFIER_PCT = 0;
+
+function makeRuntime(skills: ShipSkills): PlayerActorRuntime {
+    // Crit gate that crits on every other hit (deterministic, mixed crit pattern).
+    let n = 0;
+    const everyOther: PlayerActorRuntime['activeCritGate'] = () => {
+        n += 1;
+        return n % 2 === 0;
+    };
+    const actor = createActor({
+        id: 'attacker',
+        side: 'player',
+        kind: 'attacker',
+        stats: {
+            attack: 12000,
+            crit: 50,
+            critDamage: 65,
+            defensePenetration: 20,
+            defence: 0,
+            hp: 20000,
+            speed: 100,
+        },
+        chargeCount: 0,
+        startCharged: false,
+    });
+
+    return {
+        actor,
+        focus: true,
+        castSkills: skills,
+        reactiveAbilities: [],
+        timedSelfBySlot: [],
+        timedEnemyBySlot: [],
+        hasChargedSkill: false,
+        attack: 12000,
+        crit: 50,
+        critDamage: 65,
+        defensePenetration: 20,
+        defence: 0,
+        hp: 20000,
+        healModifier: 0,
+        debuffLandingChance: 1,
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        affinityDamageModifier: AFFINITY_DAMAGE_MODIFIER,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        affinityDisadvantage: false,
+        attackerAffinity: ATTACKER_AFFINITY,
+        activeCritGate: everyOther,
+        chargedCritGate: everyOther,
+        activeHealCritGate: () => false,
+        chargedHealCritGate: () => false,
+        debuffLandingGate: makeRateGate(),
+        extendChanceGate: makeRateGate(),
+        landsTimedEnemyApplication: () => true,
+        selfBuffLookup: new Map(),
+        enemyDebuffLookup: new Map(),
+    };
+}
+
+function makeArgs(runtime: PlayerActorRuntime): PlayerTurnArgs {
+    const enemy = createActor({
+        id: 'enemy',
+        side: 'enemy',
+        kind: 'enemy',
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            defence: ENEMY_DEFENCE,
+            hp: 10_000_000,
+            speed: 50,
+        },
+    });
+
+    const statusEngine = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+    statusEngine.beginRound(1);
+
+    return {
+        runtime,
+        enemy,
+        statusEngine,
+        corrosionEntries: [],
+        infernoEntries: [],
+        pendingBombs: [],
+        pendingAccumulators: [],
+        enemyDefense: ENEMY_DEFENCE,
+        enemyHp: 10_000_000,
+        enemyType: undefined,
+        bus: createEventBus(),
+        round: 1,
+        enemyHpDecline: 0,
+    } as PlayerTurnArgs;
+}
+
+describe('PlayerTurnResult.positionalScalars — integration-boundary parity', () => {
+    it('per-hit victimHitDamage sum over the bound enemy equals the turn directDamage', () => {
+        const skills: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'multi-hit',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 80, hits: 4 },
+                        } as Ability,
+                    ],
+                },
+            ],
+        };
+
+        const runtime = makeRuntime(skills);
+        const result = runPlayerTurn(makeArgs(runtime));
+
+        // positionalScalars must be populated for a damage cast.
+        expect(result.positionalScalars).toBeDefined();
+        const s = result.positionalScalars!;
+
+        // The per-hit crit array matches the firing ability's hit count.
+        expect(result.hitCrits).toHaveLength(4);
+
+        // The bound enemy's defensive profile (mirrors the aggregate the engine used).
+        const victim: VictimDefenseProfile = {
+            defence: ENEMY_DEFENCE,
+            defenceModifierPct: ENEMY_DEFENCE_MODIFIER_PCT,
+            affinity: VICTIM_AFFINITY,
+        };
+
+        const sum = result.hitCrits.reduce(
+            (acc, didCrit) => acc + victimHitDamage(s, victim, didCrit, 1),
+            0
+        );
+
+        // No passive payload → directDamage is exactly the firing hit's aggregate.
+        expect(sum).toBeCloseTo(result.directDamage, 8);
+        expect(result.directDamage).toBeGreaterThan(0);
+    });
+});

--- a/src/utils/combat/__tests__/state.test.ts
+++ b/src/utils/combat/__tests__/state.test.ts
@@ -74,6 +74,22 @@ describe('createActor', () => {
         });
         expect(actor.charges).toBe(0);
     });
+
+    it('threads raw affinity onto the actor (positional plumbing)', () => {
+        const actor = createActor({
+            id: 'a',
+            side: 'player',
+            kind: 'attacker',
+            stats: baseStats,
+            affinity: 'thermal',
+        });
+        expect(actor.affinity).toBe('thermal');
+    });
+
+    it('leaves affinity undefined when omitted (neutral default downstream)', () => {
+        const actor = createActor({ id: 'a', side: 'player', kind: 'attacker', stats: baseStats });
+        expect(actor.affinity).toBeUndefined();
+    });
 });
 
 describe('selectNextActor', () => {

--- a/src/utils/combat/__tests__/victimDamage.test.ts
+++ b/src/utils/combat/__tests__/victimDamage.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import { victimHitDamage, AttackerDamageScalars, VictimDefenseProfile } from '../victimDamage';
+import { calculateDamageReduction } from '../../autogear/priorityScore';
+import { computeAffinityModifiers } from '../../calculators/affinityUtils';
+
+describe('victimHitDamage', () => {
+    it('(a) hand-computed single-hit value: no crit, no buffs, neutral affinity', () => {
+        // Simple inputs: 1 hit, no crit, no buffs/modifiers, no pen.
+        // effectiveAttack = 1000, multiplierPct = 100 (raw 100 * 1 hit), no secondary.
+        // preCritDamage = 1000 * (100/100) + 0 = 1000
+        // victim defence = 1000, no modifier, no pen → effectiveDefense = 1000
+        // damageReduction = calculateDamageReduction(1000)
+        // nonCritFactor = (1 - dr/100) * 1 * 1 * 1
+        // per-hit (no crit, roleScale 1) = (1000/1) * 1 * nonCritFactor
+        const s: AttackerDamageScalars = {
+            effectiveAttack: 1000,
+            multiplierPct: 100,
+            secondaryStatValue: 0,
+            hits: 1,
+            effectiveCritDamage: 50,
+            outgoingDamageBuffPct: 0,
+            incomingDamageModifierPct: 0,
+            defensePenetrationPct: 0,
+            attackerAffinity: 'antimatter', // neutral vs anything
+        };
+        const v: VictimDefenseProfile = {
+            defence: 1000,
+            defenceModifierPct: 0,
+            affinity: 'thermal',
+        };
+
+        const dr = calculateDamageReduction(1000);
+        const expected = 1000 * (1 - dr / 100);
+
+        expect(victimHitDamage(s, v, false, 1)).toBeCloseTo(expected, 10);
+    });
+
+    it('(b) PARITY: sum of per-hit damages equals aggregate preCritDamage * postDefenseFactor', () => {
+        // Mirror the engine's aggregate formula inline from the same inputs.
+        const effectiveAttack = 1234;
+        const rawMultiplier = 80;
+        const hits = 4;
+        const effectiveMultiplier = rawMultiplier * hits; // 320 — multiplier ALREADY includes hits
+        const conditionalBonusPct = 35;
+        const secondaryStatValue = 217.5;
+        const effectiveCritDamage = 65;
+        const outgoingDamageBuffPct = 30;
+        const incomingDamageModifierPct = -10;
+        const defensePenetrationPct = 20;
+
+        const victimDefence = 850;
+        const victimDefenceModifierPct = 15;
+        const attackerAffinity = 'thermal';
+        const victimAffinity = 'chemical'; // thermal > chemical → advantage
+
+        // Aggregate side (replicating playerTurn lines 1115-1276).
+        const effectivePen = defensePenetrationPct;
+        const effectiveDefense =
+            victimDefence * (1 + victimDefenceModifierPct / 100) * (1 - effectivePen / 100);
+        const damageReduction =
+            effectiveDefense > 0 ? calculateDamageReduction(effectiveDefense) : 0;
+        const affinityDamageModifier = computeAffinityModifiers(
+            attackerAffinity,
+            victimAffinity
+        ).damageModifier;
+        const affinityMult = 1 + affinityDamageModifier / 100;
+        const preCritDamage =
+            effectiveAttack * ((effectiveMultiplier + conditionalBonusPct) / 100) +
+            secondaryStatValue;
+        const nonCritFactor =
+            (1 - damageReduction / 100) *
+            (1 + outgoingDamageBuffPct / 100) *
+            (1 + incomingDamageModifierPct / 100) *
+            affinityMult;
+
+        // A fixed per-hit crit pattern across the 4 hits.
+        const hitCrits = [true, false, true, false];
+        const critHits = hitCrits.filter(Boolean).length;
+        const critFraction = hits > 0 ? critHits / hits : 0;
+        const damageCritMultiplier = 1 + critFraction * (effectiveCritDamage / 100);
+        const postDefenseFactor = damageCritMultiplier * nonCritFactor;
+        const aggregate = preCritDamage * postDefenseFactor;
+
+        // Per-victim side.
+        const s: AttackerDamageScalars = {
+            effectiveAttack,
+            multiplierPct: effectiveMultiplier + conditionalBonusPct,
+            secondaryStatValue,
+            hits,
+            effectiveCritDamage,
+            outgoingDamageBuffPct,
+            incomingDamageModifierPct,
+            defensePenetrationPct,
+            attackerAffinity,
+        };
+        const v: VictimDefenseProfile = {
+            defence: victimDefence,
+            defenceModifierPct: victimDefenceModifierPct,
+            affinity: victimAffinity,
+        };
+
+        const sum = hitCrits.reduce((acc, didCrit) => acc + victimHitDamage(s, v, didCrit, 1), 0);
+
+        expect(sum).toBeCloseTo(aggregate, 10);
+    });
+
+    it('(c) roleScale 0.5 yields exactly half the roleScale 1.0 damage', () => {
+        const s: AttackerDamageScalars = {
+            effectiveAttack: 900,
+            multiplierPct: 240,
+            secondaryStatValue: 120,
+            hits: 3,
+            effectiveCritDamage: 55,
+            outgoingDamageBuffPct: 20,
+            incomingDamageModifierPct: 5,
+            defensePenetrationPct: 10,
+            attackerAffinity: 'electric',
+        };
+        const v: VictimDefenseProfile = {
+            defence: 700,
+            defenceModifierPct: -5,
+            affinity: 'thermal',
+        };
+
+        const origin = victimHitDamage(s, v, true, 1);
+        const covered = victimHitDamage(s, v, true, 0.5);
+
+        expect(covered).toBeCloseTo(origin * 0.5, 12);
+    });
+
+    it('(d) affinity advantage increases and disadvantage decreases damage', () => {
+        const base: AttackerDamageScalars = {
+            effectiveAttack: 1000,
+            multiplierPct: 150,
+            secondaryStatValue: 0,
+            hits: 1,
+            effectiveCritDamage: 50,
+            outgoingDamageBuffPct: 0,
+            incomingDamageModifierPct: 0,
+            defensePenetrationPct: 0,
+            attackerAffinity: 'thermal',
+        };
+        const v: VictimDefenseProfile = {
+            defence: 800,
+            defenceModifierPct: 0,
+            affinity: 'antimatter', // neutral
+        };
+
+        const neutral = victimHitDamage(base, v, false, 1);
+
+        // thermal > chemical → advantage (+25%)
+        const advantage = victimHitDamage(base, { ...v, affinity: 'chemical' }, false, 1);
+        // thermal < electric → disadvantage (-25%)
+        const disadvantage = victimHitDamage(base, { ...v, affinity: 'electric' }, false, 1);
+
+        expect(advantage).toBeGreaterThan(neutral);
+        expect(disadvantage).toBeLessThan(neutral);
+        expect(advantage).toBeCloseTo(neutral * 1.25, 10);
+        expect(disadvantage).toBeCloseTo(neutral * 0.75, 10);
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2237,7 +2237,6 @@ export function runCombat(input: CombatEngineInput): {
             applyToVictim: (victim: CombatActor, damage: number) => void;
         }): void => {
             applyPositionalDamage({
-                hits: args.scalars.hits,
                 hitCrits: args.hitCrits ?? [],
                 scalars: args.scalars,
                 pattern: args.pattern,
@@ -2762,6 +2761,17 @@ export function runCombat(input: CombatEngineInput): {
                     // apply to perform (the existing positionalSelection tests set position+target
                     // to exercise target binding only, never a pattern, so they keep the legacy
                     // single-sink credit and never enter this branch).
+                    //
+                    // DELIBERATELY no `selectedEnemy != null` precondition (CodeRabbit raised this):
+                    // in positional/simulator mode there is NO dummy enemy sink to fall back to.
+                    // When per-hit resolution inside applyPositionalDamage finds no living opposing
+                    // actor, the correct behaviour is for the attacker to WHIFF (deal 0) — see the
+                    // death-fallback all-dead-whiff test. Gating `positional` on a pre-resolved
+                    // living target would instead route the firing hit back to the legacy dummy
+                    // sink, recording PHANTOM damage against a target that no longer exists. So we
+                    // enter the positional branch on pattern/target/scalars alone and let the
+                    // per-hit live re-resolution own the whiff. (Credit suppression below pairs with
+                    // this: the per-victim apply is the ONLY damage path here.)
                     const positional =
                         isPositional(actor.position, enemyAttackerActors) &&
                         input.target != null &&

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3119,6 +3119,11 @@ export function runCombat(input: CombatEngineInput): {
                     // runPlayerTurn `enemy`+containers, and the applyIncomingToTarget intake).
                     const tgt = selectedPlayer ?? healTarget!;
                     const targetDead = tgt.currentHp <= 0;
+                    // This enemy attacker's parsed pattern (Task 9) — REQUIRED for the enemy-site
+                    // positional apply (footprint expansion). An enemy with a target but NO pattern
+                    // stays on the legacy single-apply path (same `pattern != null` guard as the
+                    // focus/team sites). Undefined for every current fixture → enemyPositional false.
+                    const enemyPattern = enemyPatternById.get(actor.id);
                     let damage = 0;
                     // Hoisted for use in the post-else `attacked` emit (Task 8): enemyTurn is
                     // scoped inside the else block below; this flag carries its roundCrit out.
@@ -3127,6 +3132,13 @@ export function runCombat(input: CombatEngineInput): {
                     // enemyTurn.hitCrits in the ship-backed branch; stays [] on the dead-target
                     // path and on the manual flat-enemy path (which has no hitCrits to surface).
                     let enemyHitCrits: boolean[] = [];
+                    // Hoisted positional-apply state (Task 9): the enemy-site mirror of the focus/team
+                    // sites. enemyPositional gates BOTH the drivePositionalApply call AND the single-
+                    // apply suppression below; enemyScalars carries this turn's firing-hit scalars out
+                    // of the else block (enemyTurn is scoped inside it). Both stay false/null on the
+                    // dead-target path and whenever the enemy is non-positional → legacy single-apply.
+                    let enemyPositional = false;
+                    let enemyScalars: AttackerDamageScalars | undefined;
                     if (targetDead) {
                         // Cadence-only: bank a charge (or fire+reset at cap) without resolving the
                         // attack. Mirrors runPlayerTurn's preTurn charge step. No skill-fired/
@@ -3218,6 +3230,19 @@ export function runCombat(input: CombatEngineInput): {
                         enemyTurnDidCrit = enemyTurn.roundCrit;
                         // Hoist per-hit crit array for the per-hit `attacked` emit (Phase 4c Task 3).
                         enemyHitCrits = enemyTurn.hitCrits;
+                        // Positional gate (Task 9, enemy site): mirror of the focus/team gates, but
+                        // the OPPOSING roster from the enemy's view is the PLAYER team
+                        // (allPlayerActors), the parsed target rides on enemyTargetById, and the
+                        // parsed pattern on enemyPatternById. When true, the firing-hit damage lands
+                        // per-victim via drivePositionalApply (below) against the live player roster
+                        // and the legacy single-apply is SUPPRESSED. No production caller threads
+                        // position+target+pattern for an enemy yet → false for every golden.
+                        enemyPositional =
+                            isPositional(actor.position, allPlayerActors) &&
+                            enemyTarget != null &&
+                            enemyPattern != null &&
+                            enemyTurn.positionalScalars != null;
+                        enemyScalars = enemyTurn.positionalScalars;
                         // Record the enemy actor's round-scoped ctx (parity with player/team branches;
                         // its own future DoT entries would tick with this ctx).
                         lastTurnCtxByActor.set(actor.id, enemyTurn.turnCtx);
@@ -3281,13 +3306,59 @@ export function runCombat(input: CombatEngineInput): {
                         // hpDamage comes straight from the closure (0 under Barrier — damage fully
                         // blocked, not shield-absorbed — otherwise damage - absorbed). barriered = the
                         // attack was fully blocked by an active Barrier (decision #7, below).
-                        // Route the enemy's incoming to its selected victim (`tgt`). Legacy path:
-                        // tgt === healTarget! → no-arg-equivalent call, byte-identical. Positional
-                        // path: drains the SELECTED player actor instead of the heal target.
-                        const { shieldBefore, hpDamage, barriered } = applyIncomingToTarget(
-                            damage,
-                            tgt
-                        );
+                        // Route the enemy's incoming damage. Two mutually-exclusive paths:
+                        //
+                        //  - NON-positional (legacy): a SINGLE applyIncomingToTarget(damage, tgt)
+                        //    drains the bound victim (tgt === healTarget! on the legacy path → the
+                        //    no-arg-equivalent call, byte-identical). Returns the shield/HP/Barrier
+                        //    outcome consumed by the damage-taken leech block below.
+                        //
+                        //  - POSITIONAL (Task 9): drivePositionalApply lands the firing hit per-victim
+                        //    across the LIVE PLAYER roster (origin full / covered half) via the
+                        //    PLAYER-side applyIncomingToTarget wrapper — each player victim takes REAL
+                        //    HP/shield/death damage. The single apply is SUPPRESSED (else the anchor
+                        //    victim would be double-hit: once by the AoE loop, once by the single
+                        //    apply). enemyPattern is non-null via the enemyPositional gate.
+                        //
+                        // DEFERRED (Phase-5, documented in Step C): on the positional path the per-
+                        // victim shield/HP outcomes are not surfaced, so shieldBefore/hpDamage/barriered
+                        // fall back to neutral defaults — the heal-target damage-taken HEAL/SHIELD leech
+                        // (takenLeeches) is NOT re-derived from the anchor victim's AoE hit. Inert today
+                        // (no fixture runs a "when damaged" reactive in healing mode), so the legacy
+                        // single-target leech path stays byte-identical; per-victim leech symmetry is the
+                        // Phase-5 follow-up. The non-positional path keeps the exact legacy leech values.
+                        let shieldBefore = 0;
+                        let hpDamage = 0;
+                        let barriered = false;
+                        if (enemyPositional) {
+                            drivePositionalApply({
+                                scalars: enemyScalars!,
+                                hitCrits: enemyHitCrits,
+                                pattern: enemyPattern!,
+                                target: enemyTarget!,
+                                actingPosition: actor.position!,
+                                ignoresForcedTargeting: actor.ignoresForcedTargeting,
+                                actingId: actor.id,
+                                opposingLiving: allPlayerActors,
+                                // PLAYER-side wrapper: each player victim takes real incoming damage.
+                                // Every victim's OWN currentHp/shield is mutated and recordDestroyed
+                                // fires for it (its targetHpPct/death derive from the victim itself —
+                                // applyVictimDamage reads recipientMaxHp(victim.id)). DEFERRED (Phase-5):
+                                // playerSink.addIncoming bumps the TANK's roundIncomingDamage bucket
+                                // for EVERY victim — so a covered non-heal-target victim's AoE share
+                                // currently inflates the heal target's reported per-round incomingDamage.
+                                // The healing-accounting model has one row (the heal target's); per-
+                                // victim incoming attribution is the Phase-5 symmetric-accounting surface.
+                                // Inert today (no production caller threads enemy position+pattern).
+                                applyToVictim: (victim, dmgToVictim) =>
+                                    applyIncomingToTarget(dmgToVictim, victim),
+                            });
+                        } else {
+                            ({ shieldBefore, hpDamage, barriered } = applyIncomingToTarget(
+                                damage,
+                                tgt
+                            ));
+                        }
 
                         // Damage-taken procs (per ATTACK, on the aggregate — spec §5): applied
                         // AFTER this attack's drain so the proc never absorbs its own trigger.
@@ -3311,7 +3382,24 @@ export function runCombat(input: CombatEngineInput): {
                         // damage taken at all, so its damage-taken procs are skipped entirely — there is
                         // nothing to leech from. (Distinct from a shield absorb, where the convention
                         // still leeches off the full attack: a shield takes the hit, Barrier nullifies it.)
-                        if (takenLeeches.length > 0 && healingCtx && !barriered) {
+                        //
+                        // POSITIONAL DEFERRAL (Task 9, Step C — Phase-5 follow-up): this damage-taken
+                        // leech is single-target heal-target infrastructure (takenLeeches is collected
+                        // ONLY for the heal target; the healing-accounting model has one row, the heal
+                        // target's). On the positional path the heal target took only its OWN per-victim
+                        // AoE share (origin full / covered half), and shieldBefore/hpDamage are not
+                        // surfaced per victim — crediting off the aggregate `damage` here would be wrong.
+                        // So the leech is gated to the NON-positional path: the legacy heal-target leech
+                        // stays byte-identical, and full per-victim leech symmetry (every player victim
+                        // procing its OWN damage-taken reactive off the damage IT took) is the documented
+                        // Phase-5 follow-up. Inert today either way (no fixture runs a damage-taken
+                        // reactive in healing mode → takenLeeches is empty).
+                        if (
+                            !enemyPositional &&
+                            takenLeeches.length > 0 &&
+                            healingCtx &&
+                            !barriered
+                        ) {
                             const rt = runtimesById.get(healTarget!.id);
                             for (const e of takenLeeches) {
                                 if (e.requiresHpDamage && !(shieldBefore > 0 && hpDamage > 0)) {

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -867,10 +867,12 @@ export interface CombatEngineInput {
     affinity?: AffinityName;
     /** TEST-ONLY tap (Phase 4 PR1, Task 3): receives the genuine `applyOutgoingToEnemy` closure
      *  once on the first round it is built, so unit tests can exercise the player→enemy victim
-     *  wrapper against a hand-built enemy actor BEFORE Task 8 wires a production caller. Never set
-     *  by production code; the closure runs the real applyVictimDamage path (no mocks).
-     *  TODO(Task 8): remove once positional wiring provides a production caller; fold these
-     *  tests into positionalDamage.integration.test.ts. */
+     *  wrapper against a hand-built enemy actor. Never set by production code; the closure runs the
+     *  real applyVictimDamage path (no mocks).
+     *  KEPT (not removed once Task 8/9 wired production callers): `applyOutgoingToEnemy.test.ts`
+     *  behaviour #6 — the enemy-side sink is a no-op (tank accumulators stay 0) — is unique coverage
+     *  the positionalDamage integration test cannot observe (it only sees `ship-destroyed`). Inert
+     *  (optional, never set in production). Revisit if that no-op contract gains an observable seam. */
     __testTapApplyOutgoingToEnemy?: (
         fn: (
             damage: number,
@@ -2215,6 +2217,10 @@ export function runCombat(input: CombatEngineInput): {
         // defense-debuff SOURCE differs BY DIRECTION: the focus/team sites read the ENEMY victim's
         // defense debuffs, while the enemy site reads the PLAYER victim's defense debuffs (sourced
         // from a different place). So this single zero-stub eventually splits into two lookups.
+        // SAME Phase-5 caveat applies to victimHitDamage's incoming/outgoing damage modifiers:
+        // they're carried as attacker-fixed scalars here, but in the aggregate they derive from the
+        // BOUND victim's debuffs — so a covered (non-anchor) victim's incoming/outgoing modifiers are
+        // an approximation today (exact for the anchor). Per-victim re-sourcing covers these too.
         // No emitHit: runPlayerTurn already emits ONE aggregate ability-performed per turn;
         // per-hit/per-victim event fidelity is a documented Phase-5 follow-up.
         const drivePositionalApply = (args: {

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2,7 +2,8 @@ import { EnemyBaseClass, SelectedGameBuff, TeamActorInput } from '../../types/ca
 import type { ShipTypeName } from '../../constants/shipTypes';
 import { AbilityTarget, ShipSkills } from '../../types/abilities';
 import type { Position } from '../../types/encounters';
-import type { ParsedTarget } from '../targetingParser';
+import type { AffinityName } from '../../types/ship';
+import type { ParsedTarget, ParsedPattern } from '../targetingParser';
 import { makeRateGate } from '../calculators/rateAccumulator';
 import type { RoundData } from '../calculators/dpsSimulator';
 import {
@@ -335,6 +336,13 @@ export interface EnemyActorInput {
     ignoresForcedTargeting?: boolean;
     /** Pre-parsed targeting preference for this enemy (positional plumbing — set but not yet consumed). */
     target?: ParsedTarget;
+    /** Pre-parsed positional pattern for this enemy (positional plumbing — set but not yet consumed by apply). */
+    pattern?: ParsedPattern;
+    /** RAW affinity of this enemy attacker — the SAME affinity the adapter fed to
+     *  computeAffinityModifiers to produce `affinityDamageModifier` above (positional plumbing —
+     *  set but not yet consumed by apply). Threaded onto the runtime's attackerAffinity + the
+     *  CombatActor.affinity. Absent → neutral default ('antimatter') downstream. */
+    affinity?: AffinityName;
 }
 
 /** Build a full PlayerActorRuntime for a healing-mode enemy attacker.
@@ -419,6 +427,7 @@ export function buildEnemyPlayerActorRuntime(
         startCharged: e.startCharged,
         position: e.position,
         ignoresForcedTargeting: e.ignoresForcedTargeting,
+        affinity: e.affinity,
     });
 
     // Resolved affinity fields — pre-computed by the adapter via computeAffinityModifiers
@@ -463,6 +472,11 @@ export function buildEnemyPlayerActorRuntime(
         affinityCritCap: resolvedCritCap,
         affinityCritPenalty: resolvedCritPenalty,
         affinityDisadvantage,
+        // RAW affinity — sourced from the SAME e.affinity the adapter fed to
+        // computeAffinityModifiers for resolvedDamageMod, so the two never disagree. Positional
+        // plumbing: read by victimHitDamage for per-victim re-resolution (Task 8b/9). Undefined →
+        // neutral 'antimatter' default downstream.
+        attackerAffinity: e.affinity,
         allyChargePerRound: undefined,
         activeCritGate: enemyActiveCritGate,
         chargedCritGate: enemyChargedCritGate,
@@ -723,6 +737,12 @@ export type TeamActorEngineInput = TeamActorInput & {
         hasChargedSkill: boolean;
         /** Caster heal-modifier stat (healing calc). Default 0. */
         healModifier?: number;
+        /** RAW affinity of this team actor — the SAME affinity (TeamActorInput.affinity) the
+         *  adapter fed to computeAffinityModifiers to produce `affinityDamageModifier` in this
+         *  bundle, so the two never disagree. Positional plumbing — set but not yet consumed by
+         *  apply (threaded onto the runtime's attackerAffinity + the CombatActor.affinity).
+         *  Absent → neutral default ('antimatter') downstream. */
+        affinity?: AffinityName;
     };
     /** Board position of this team actor (positional plumbing — set but not yet consumed). */
     position?: Position;
@@ -730,6 +750,8 @@ export type TeamActorEngineInput = TeamActorInput & {
     ignoresForcedTargeting?: boolean;
     /** Pre-parsed targeting preference for this team actor (positional plumbing — set but not yet consumed). */
     target?: ParsedTarget;
+    /** Pre-parsed positional pattern for this team actor (positional plumbing — set but not yet consumed by apply). */
+    pattern?: ParsedPattern;
 };
 
 export interface CombatEngineInput {
@@ -815,6 +837,12 @@ export interface CombatEngineInput {
         ignoresForcedTargeting?: boolean;
         /** Pre-parsed targeting preference for this enemy attacker (positional plumbing — set but not yet consumed). */
         target?: ParsedTarget;
+        /** Pre-parsed positional pattern for this enemy attacker (positional plumbing — set but not yet consumed by apply). */
+        pattern?: ParsedPattern;
+        /** RAW affinity of this enemy attacker — the SAME affinity the adapter fed to
+         *  computeAffinityModifiers for `affinityDamageModifier` above (positional plumbing —
+         *  set but not yet consumed by apply). Absent → neutral default ('antimatter') downstream. */
+        affinity?: AffinityName;
     }[];
     /** Emit-only event tap. Listeners must not read or mutate combat state. */
     bus?: CombatEventBus;
@@ -824,6 +852,13 @@ export interface CombatEngineInput {
     ignoresForcedTargeting?: boolean;
     /** Pre-parsed targeting preference for the focus attacker (positional plumbing — set but not yet consumed). */
     target?: ParsedTarget;
+    /** Pre-parsed positional pattern for the focus attacker (positional plumbing — set but not yet consumed by apply). */
+    pattern?: ParsedPattern;
+    /** RAW affinity of the focus attacker — the SAME affinity matchup the page resolved into the
+     *  pre-resolved `affinityDamageModifier` above, so the two never disagree (positional plumbing
+     *  — set but not yet consumed by apply). Threaded onto the attacker runtime's attackerAffinity
+     *  + the CombatActor.affinity. Absent → neutral default ('antimatter') downstream. */
+    affinity?: AffinityName;
     /** TEST-ONLY tap (Phase 4 PR1, Task 3): receives the genuine `applyOutgoingToEnemy` closure
      *  once on the first round it is built, so unit tests can exercise the player→enemy victim
      *  wrapper against a hand-built enemy actor BEFORE Task 8 wires a production caller. Never set
@@ -1027,6 +1062,7 @@ export function runCombat(input: CombatEngineInput): {
         startCharged,
         position: input.position,
         ignoresForcedTargeting: input.ignoresForcedTargeting,
+        affinity: input.affinity,
     });
     const enemy = createActor({
         id: 'enemy',
@@ -1094,6 +1130,9 @@ export function runCombat(input: CombatEngineInput): {
             startCharged: t.startCharged,
             position: t.position,
             ignoresForcedTargeting: t.ignoresForcedTargeting,
+            // RAW affinity rides on the walk bundle (set by the adapter from TeamActorInput.affinity
+            // — the SAME source as the walk's affinityDamageModifier). Legacy (no walk) → undefined.
+            affinity: t.walk?.affinity,
         })
     );
 
@@ -1109,6 +1148,16 @@ export function runCombat(input: CombatEngineInput): {
         }
     }
 
+    // Per-team-actor parsed positional pattern (Task 8a), mirroring teamTargetById. The pattern
+    // lives only on the TeamActorEngineInput — thread it to the team-turn call site by id for the
+    // Task 8b apply path. Empty for every non-positional input (no pattern set) → inert today.
+    const teamPatternById = new Map<string, ParsedPattern>();
+    for (const t of teamActors) {
+        if (t.pattern) {
+            teamPatternById.set(t.id, t.pattern);
+        }
+    }
+
     // Per-enemy-attacker parsed positional target (Task C3, side-symmetric). The enemy's
     // `position` already rides on its CombatActor (buildEnemyPlayerActorRuntime → createActor),
     // but its parsed `target` lives only on the EnemyActorInput — thread it to the enemy-turn
@@ -1119,6 +1168,16 @@ export function runCombat(input: CombatEngineInput): {
     for (const e of input.enemyAttackers ?? []) {
         if (e.target) {
             enemyTargetById.set(e.id, e.target);
+        }
+    }
+
+    // Per-enemy-attacker parsed positional pattern (Task 8a), mirroring enemyTargetById /
+    // teamPatternById. The pattern lives only on the EnemyActorInput — thread it to the enemy-turn
+    // call site by id for the Task 8b apply path. Empty for every non-positional input → inert today.
+    const enemyPatternById = new Map<string, ParsedPattern>();
+    for (const e of input.enemyAttackers ?? []) {
+        if (e.pattern) {
+            enemyPatternById.set(e.id, e.pattern);
         }
     }
 
@@ -1218,6 +1277,11 @@ export function runCombat(input: CombatEngineInput): {
         affinityCritCap,
         affinityCritPenalty,
         affinityDisadvantage,
+        // RAW focus affinity — sourced from the SAME input.affinity the page resolved into the
+        // pre-resolved affinityDamageModifier above, so the two never disagree. Positional
+        // plumbing: read by victimHitDamage for per-victim re-resolution (Task 8b/9). Undefined →
+        // neutral 'antimatter' default downstream.
+        attackerAffinity: input.affinity,
         allyChargePerRound,
         activeCritGate,
         chargedCritGate,
@@ -1295,6 +1359,11 @@ export function runCombat(input: CombatEngineInput): {
             affinityCritCap: w.affinityCritCap,
             affinityCritPenalty: w.affinityCritPenalty,
             affinityDisadvantage: teamAffinityDisadvantage,
+            // RAW affinity — sourced from the SAME w.affinity (TeamActorInput.affinity) the adapter
+            // fed to computeAffinityModifiers for w.affinityDamageModifier, so the two never
+            // disagree. Positional plumbing: read by victimHitDamage (Task 8b/9). Undefined →
+            // neutral 'antimatter' default downstream.
+            attackerAffinity: w.affinity,
             allyChargePerRound: undefined, // attacker-only manual input
             activeCritGate: teamActiveCritGate,
             chargedCritGate: teamChargedCritGate,

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -35,6 +35,7 @@ import {
 } from './statusEngine';
 import { liveGateConditions } from './abilityStatusGating';
 import { isPositional, resolvePositionalTarget } from './positionalBinding';
+import { applyPositionalDamage } from './positionalApply';
 import { CHEAT_DEATH_BUFFS } from './cheatDeathBuffs';
 import { BARRIER_BUFFS } from './barrierBuffs';
 import { CombatEventBus, createEventBus } from './events';
@@ -748,9 +749,11 @@ export type TeamActorEngineInput = TeamActorInput & {
     position?: Position;
     /** Attacker ignores Taunt/Provoke (positional plumbing — not yet populated by a production caller). */
     ignoresForcedTargeting?: boolean;
-    /** Pre-parsed targeting preference for this team actor (positional plumbing — set but not yet consumed). */
+    /** Pre-parsed targeting preference for this team actor. Consumed by the walked-team
+     *  positional target selection AND the Task 8b positional apply at the team damage site. */
     target?: ParsedTarget;
-    /** Pre-parsed positional pattern for this team actor (positional plumbing — set but not yet consumed by apply). */
+    /** Pre-parsed positional pattern for this team actor. Consumed by the Task 8b positional
+     *  apply at the team damage site (origin/covered footprint expansion). */
     pattern?: ParsedPattern;
 };
 
@@ -850,9 +853,11 @@ export interface CombatEngineInput {
     position?: Position;
     /** Attacker ignores Taunt/Provoke (positional plumbing — not yet populated by a production caller). */
     ignoresForcedTargeting?: boolean;
-    /** Pre-parsed targeting preference for the focus attacker (positional plumbing — set but not yet consumed). */
+    /** Pre-parsed targeting preference for the focus attacker. Consumed by the focus positional
+     *  target selection AND the Task 8b positional apply at the focus damage site. */
     target?: ParsedTarget;
-    /** Pre-parsed positional pattern for the focus attacker (positional plumbing — set but not yet consumed by apply). */
+    /** Pre-parsed positional pattern for the focus attacker. Consumed by the Task 8b positional
+     *  apply at the focus damage site (origin/covered footprint expansion). */
     pattern?: ParsedPattern;
     /** RAW affinity of the focus attacker — the SAME affinity matchup the page resolved into the
      *  pre-resolved `affinityDamageModifier` above, so the two never disagree (positional plumbing
@@ -2670,6 +2675,58 @@ export function runCombat(input: CombatEngineInput): {
                         pendingResisted.length = 0;
                     }
 
+                    // Positional APPLY (Task 8b, GATED). When the focus attacker is positional,
+                    // carries a parsed target, AND its firing hit produced scalars (a damage
+                    // ability fired → turn.positionalScalars is set), drive the per-victim apply
+                    // loop against the LIVE enemy roster. Re-resolves anchor + footprint per hit;
+                    // origin cells take full damage, covered cells half. Each victim's HP/shield/
+                    // Barrier/Cheat-Death/death is mutated through the real applyOutgoingToEnemy.
+                    // No production caller threads position+target+pattern yet, so this is false
+                    // for every existing test/golden → byte-identical.
+                    // The pattern is REQUIRED for footprint expansion — without it there is no
+                    // apply to perform (the existing positionalSelection tests set position+target
+                    // to exercise target binding only, never a pattern, so they keep the legacy
+                    // single-sink credit and never enter this branch).
+                    const positional =
+                        isPositional(actor.position, enemyAttackerActors) &&
+                        input.target != null &&
+                        input.pattern != null &&
+                        turn.positionalScalars != null;
+                    if (positional) {
+                        applyPositionalDamage({
+                            hits: turn.positionalScalars!.hits,
+                            hitCrits: turn.hitCrits ?? [],
+                            scalars: turn.positionalScalars!,
+                            // Non-null via the `positional` gate (input.pattern/target != null).
+                            pattern: input.pattern!,
+                            actorPosition: actor.position!,
+                            target: input.target!,
+                            opposingLiving: enemyAttackerActors,
+                            statusOf: statusLookupFor(enemyAttackerActors),
+                            acting: {
+                                ignoresForcedTargeting: actor.ignoresForcedTargeting,
+                                provokedBy: provokerOf(statusEngine, actor.id),
+                            },
+                            // defenceModifierPct 0 for PR1 — per-victim defense-debuff sourcing is
+                            // a documented Phase-5/9 refinement; the integration test uses no enemy
+                            // defense debuffs so parity is exact.
+                            defenseProfileOf: (v) => ({
+                                defence: v.stats.defence,
+                                defenceModifierPct: 0,
+                                affinity: v.affinity ?? 'antimatter',
+                            }),
+                            // applyToVictim is (victim, damage); applyOutgoingToEnemy is
+                            // (damage, victim) — adapt the argument order.
+                            applyToVictim: (victim, damage) => applyOutgoingToEnemy(damage, victim),
+                            // NO emitHit (intentionally omitted): runPlayerTurn already emits ONE
+                            // aggregate `ability-performed` against the bound primary target; adding
+                            // per-hit emitHit here would double-emit. For PR1 (capability-only) we
+                            // apply real per-victim HP/death but leave the event surface as the
+                            // existing aggregate emit. Per-hit/per-victim event fidelity is a
+                            // documented Phase-5 follow-up.
+                        });
+                    }
+
                     // Fold the focus turn's numeric damage into the round accumulator.
                     // += (not =) on detonation: with a FASTER enemy, the enemy's bomb/
                     // accumulator bursts ran earlier this round — a plain assignment would
@@ -2679,9 +2736,18 @@ export function runCombat(input: CombatEngineInput): {
                     // secondary/conditional are display sub-buckets already rolled into
                     // turn.directDamage — they must NOT be routed through creditDamage or the
                     // standing-leech hook would double-count them.
-                    d.secondary += turn.secondaryDamage;
-                    d.conditional += turn.conditionalDamage;
-                    creditDamage(actor.id, 'direct', turn.directDamage);
+                    //
+                    // Credit SUPPRESSION for the positional case (Task 8b): the firing-hit damage
+                    // now lands per-victim via applyPositionalDamage above, so it must NOT also be
+                    // folded into cumulativeDamage here (that would double-count it). Skip the
+                    // direct/secondary/conditional credits; KEEP detonation (bombs are a separate
+                    // mechanic, out of scope). The existing `enemyHpDecline: selected ? 0 : ...`
+                    // already zeroes the legacy single-sink decline for the positional path.
+                    if (!positional) {
+                        d.secondary += turn.secondaryDamage;
+                        d.conditional += turn.conditionalDamage;
+                        creditDamage(actor.id, 'direct', turn.directDamage);
+                    }
                     creditDamage(actor.id, 'detonation', turn.detonationDamage);
                     focusTurns.push(turn);
 
@@ -2769,14 +2835,67 @@ export function runCombat(input: CombatEngineInput): {
                         selfDebuffNames: ownerDebuffNames(actor.id),
                     });
 
+                    // Positional APPLY (Task 8b, GATED) — mirror of the focus site, keyed to THIS
+                    // team actor's own position / parsed target (teamTargetById) / parsed pattern
+                    // (teamPatternById). Drives the per-victim apply loop against the LIVE enemy
+                    // roster when this walked team actor is positional, has a parsed target, AND its
+                    // firing hit produced scalars. No production caller threads these yet → false for
+                    // every existing test/golden → byte-identical.
+                    // The pattern (teamPatternById) is REQUIRED for footprint expansion — without
+                    // it there is no apply to perform (the positionalSelection C2 test sets
+                    // position+target only, never a pattern, so it keeps the legacy single-sink
+                    // credit and never enters this branch).
+                    const teamPattern = teamPatternById.get(actor.id);
+                    const teamPositional =
+                        isPositional(actor.position, enemyAttackerActors) &&
+                        teamTarget != null &&
+                        teamPattern != null &&
+                        teamTurn.positionalScalars != null;
+                    if (teamPositional) {
+                        applyPositionalDamage({
+                            hits: teamTurn.positionalScalars!.hits,
+                            hitCrits: teamTurn.hitCrits ?? [],
+                            scalars: teamTurn.positionalScalars!,
+                            pattern: teamPattern,
+                            actorPosition: actor.position!,
+                            target: teamTarget,
+                            opposingLiving: enemyAttackerActors,
+                            statusOf: statusLookupFor(enemyAttackerActors),
+                            acting: {
+                                ignoresForcedTargeting: actor.ignoresForcedTargeting,
+                                provokedBy: provokerOf(statusEngine, actor.id),
+                            },
+                            // defenceModifierPct 0 for PR1 — see the focus-site note.
+                            defenseProfileOf: (v) => ({
+                                defence: v.stats.defence,
+                                defenceModifierPct: 0,
+                                affinity: v.affinity ?? 'antimatter',
+                            }),
+                            // applyToVictim is (victim, damage); applyOutgoingToEnemy is
+                            // (damage, victim) — adapt the argument order.
+                            applyToVictim: (victim, damage) => applyOutgoingToEnemy(damage, victim),
+                            // NO emitHit — same rationale as the focus site (runPlayerTurn already
+                            // emits the single aggregate ability-performed; per-hit fidelity is a
+                            // documented Phase-5 follow-up).
+                        });
+                    }
+
                     // Fold the team turn's damage into ITS OWN map entry (post-round assembly
                     // sums all non-focus entries into teamDamage). secondary/conditional are
                     // sub-buckets of direct (do NOT double-add) but kept distinct for the
                     // simulator-page seam.
+                    //
+                    // Credit SUPPRESSION for the positional case (Task 8b): same as the focus site —
+                    // the firing-hit damage already landed per-victim via applyPositionalDamage, so
+                    // skip the direct/secondary/conditional credit; KEEP detonation (bombs are out
+                    // of scope). The team's `enemyHpDecline: selected ? 0 : ...` already zeroed the
+                    // legacy single-sink decline for the positional path.
                     const td = dmg(actor.id);
-                    td.secondary += teamTurn.secondaryDamage;
-                    td.conditional += teamTurn.conditionalDamage;
-                    creditDamage(actor.id, 'direct', teamTurn.directDamage);
+                    if (!teamPositional) {
+                        td.secondary += teamTurn.secondaryDamage;
+                        td.conditional += teamTurn.conditionalDamage;
+                        creditDamage(actor.id, 'direct', teamTurn.directDamage);
+                    }
                     creditDamage(actor.id, 'detonation', teamTurn.detonationDamage);
 
                     // The team turn's result row fields (action/roundCrit/etc.) are NOT consumed

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -36,6 +36,7 @@ import {
 import { liveGateConditions } from './abilityStatusGating';
 import { isPositional, resolvePositionalTarget } from './positionalBinding';
 import { applyPositionalDamage } from './positionalApply';
+import type { AttackerDamageScalars } from './victimDamage';
 import { CHEAT_DEATH_BUFFS } from './cheatDeathBuffs';
 import { BARRIER_BUFFS } from './barrierBuffs';
 import { CombatEventBus, createEventBus } from './events';
@@ -2192,6 +2193,56 @@ export function runCombat(input: CombatEngineInput): {
         // closure is per-round-identical in behaviour (only `r` differs), so capturing it on the
         // first round it is built is sufficient. Inert in production (the field is never set).
         input.__testTapApplyOutgoingToEnemy?.(applyOutgoingToEnemy);
+
+        // Shared positional-apply driver (Task 9, Step A) — the ONE place the three attack
+        // sites (focus / walked-team / enemy) drive `applyPositionalDamage`. Each site has
+        // already GATED (isPositional + non-null target/pattern/positionalScalars) and computed
+        // its own `positional` flag (also used for credit suppression); this helper just runs the
+        // per-victim apply against the resolved inputs. What differs per site is parameterized:
+        //  - `scalars`/`hitCrits` — sourced from that site's turn result,
+        //  - `pattern`/`target` — that actor's parsed pattern + parsed target,
+        //  - `opposingLiving` — focus/team → enemyAttackerActors; enemy → allPlayerActors,
+        //  - `applyToVictim` — focus/team → applyOutgoingToEnemy; enemy → applyIncomingToTarget,
+        //  - `acting` — the firing actor's position / ignoresForcedTargeting / id (for provokerOf).
+        // `defenseProfileOf` is identical across all three sites in PR1 (defenceModifierPct 0 —
+        // per-victim defense-debuff sourcing is the documented Phase-5 refinement) so it lives here.
+        // No emitHit: runPlayerTurn already emits ONE aggregate ability-performed per turn;
+        // per-hit/per-victim event fidelity is a documented Phase-5 follow-up.
+        const drivePositionalApply = (args: {
+            scalars: AttackerDamageScalars;
+            // hitCrits is co-populated with positionalScalars by Task 7 (both are set iff a damage
+            // ability fired), so the `?? []` below is DEFENSIVE only — never empty when scalars != null.
+            hitCrits?: boolean[];
+            pattern: ParsedPattern;
+            target: ParsedTarget;
+            actingPosition: Position;
+            ignoresForcedTargeting?: boolean;
+            actingId: string;
+            opposingLiving: CombatActor[];
+            applyToVictim: (victim: CombatActor, damage: number) => void;
+        }): void => {
+            applyPositionalDamage({
+                hits: args.scalars.hits,
+                hitCrits: args.hitCrits ?? [],
+                scalars: args.scalars,
+                pattern: args.pattern,
+                actorPosition: args.actingPosition,
+                target: args.target,
+                opposingLiving: args.opposingLiving,
+                statusOf: statusLookupFor(args.opposingLiving),
+                acting: {
+                    ignoresForcedTargeting: args.ignoresForcedTargeting,
+                    provokedBy: provokerOf(statusEngine, args.actingId),
+                },
+                defenseProfileOf: (v) => ({
+                    defence: v.stats.defence,
+                    defenceModifierPct: 0,
+                    affinity: v.affinity ?? 'antimatter',
+                }),
+                applyToVictim: args.applyToVictim,
+            });
+        };
+
         if (healTarget) {
             currentRoundHealing = new Map<string, ActorHealing>();
             const targetMaxHp = recipientMaxHp(healTarget.id);
@@ -2693,37 +2744,18 @@ export function runCombat(input: CombatEngineInput): {
                         input.pattern != null &&
                         turn.positionalScalars != null;
                     if (positional) {
-                        applyPositionalDamage({
-                            hits: turn.positionalScalars!.hits,
-                            hitCrits: turn.hitCrits ?? [],
+                        // Opposing roster = enemyAttackerActors; player→enemy victim wrapper.
+                        // pattern/target are non-null via the `positional` gate above.
+                        drivePositionalApply({
                             scalars: turn.positionalScalars!,
-                            // Non-null via the `positional` gate (input.pattern/target != null).
+                            hitCrits: turn.hitCrits,
                             pattern: input.pattern!,
-                            actorPosition: actor.position!,
                             target: input.target!,
+                            actingPosition: actor.position!,
+                            ignoresForcedTargeting: actor.ignoresForcedTargeting,
+                            actingId: actor.id,
                             opposingLiving: enemyAttackerActors,
-                            statusOf: statusLookupFor(enemyAttackerActors),
-                            acting: {
-                                ignoresForcedTargeting: actor.ignoresForcedTargeting,
-                                provokedBy: provokerOf(statusEngine, actor.id),
-                            },
-                            // defenceModifierPct 0 for PR1 — per-victim defense-debuff sourcing is
-                            // a documented Phase-5/9 refinement; the integration test uses no enemy
-                            // defense debuffs so parity is exact.
-                            defenseProfileOf: (v) => ({
-                                defence: v.stats.defence,
-                                defenceModifierPct: 0,
-                                affinity: v.affinity ?? 'antimatter',
-                            }),
-                            // applyToVictim is (victim, damage); applyOutgoingToEnemy is
-                            // (damage, victim) — adapt the argument order.
                             applyToVictim: (victim, damage) => applyOutgoingToEnemy(damage, victim),
-                            // NO emitHit (intentionally omitted): runPlayerTurn already emits ONE
-                            // aggregate `ability-performed` against the bound primary target; adding
-                            // per-hit emitHit here would double-emit. For PR1 (capability-only) we
-                            // apply real per-victim HP/death but leave the event surface as the
-                            // existing aggregate emit. Per-hit/per-victim event fidelity is a
-                            // documented Phase-5 follow-up.
                         });
                     }
 
@@ -2852,31 +2884,18 @@ export function runCombat(input: CombatEngineInput): {
                         teamPattern != null &&
                         teamTurn.positionalScalars != null;
                     if (teamPositional) {
-                        applyPositionalDamage({
-                            hits: teamTurn.positionalScalars!.hits,
-                            hitCrits: teamTurn.hitCrits ?? [],
+                        // Same direction as the focus site (player→enemy); keyed to THIS team
+                        // actor's position / parsed target / parsed pattern. Non-null via the gate.
+                        drivePositionalApply({
                             scalars: teamTurn.positionalScalars!,
+                            hitCrits: teamTurn.hitCrits,
                             pattern: teamPattern,
-                            actorPosition: actor.position!,
                             target: teamTarget,
+                            actingPosition: actor.position!,
+                            ignoresForcedTargeting: actor.ignoresForcedTargeting,
+                            actingId: actor.id,
                             opposingLiving: enemyAttackerActors,
-                            statusOf: statusLookupFor(enemyAttackerActors),
-                            acting: {
-                                ignoresForcedTargeting: actor.ignoresForcedTargeting,
-                                provokedBy: provokerOf(statusEngine, actor.id),
-                            },
-                            // defenceModifierPct 0 for PR1 — see the focus-site note.
-                            defenseProfileOf: (v) => ({
-                                defence: v.stats.defence,
-                                defenceModifierPct: 0,
-                                affinity: v.affinity ?? 'antimatter',
-                            }),
-                            // applyToVictim is (victim, damage); applyOutgoingToEnemy is
-                            // (damage, victim) — adapt the argument order.
                             applyToVictim: (victim, damage) => applyOutgoingToEnemy(damage, victim),
-                            // NO emitHit — same rationale as the focus site (runPlayerTurn already
-                            // emits the single aggregate ability-performed; per-hit fidelity is a
-                            // documented Phase-5 follow-up).
                         });
                     }
 

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2206,6 +2206,10 @@ export function runCombat(input: CombatEngineInput): {
         //  - `acting` — the firing actor's position / ignoresForcedTargeting / id (for provokerOf).
         // `defenseProfileOf` is identical across all three sites in PR1 (defenceModifierPct 0 —
         // per-victim defense-debuff sourcing is the documented Phase-5 refinement) so it lives here.
+        // NOTE: that Phase-5 refinement is TWO directions, not one — the eventual per-victim
+        // defense-debuff SOURCE differs BY DIRECTION: the focus/team sites read the ENEMY victim's
+        // defense debuffs, while the enemy site reads the PLAYER victim's defense debuffs (sourced
+        // from a different place). So this single zero-stub eventually splits into two lookups.
         // No emitHit: runPlayerTurn already emits ONE aggregate ability-performed per turn;
         // per-hit/per-victim event fidelity is a documented Phase-5 follow-up.
         const drivePositionalApply = (args: {
@@ -3301,6 +3305,11 @@ export function runCombat(input: CombatEngineInput): {
                         processExtraActionGrants(qi, actor, enemyTurn.extraActionGrants);
                     }
                     if (damage > 0) {
+                        // Phase-5 per-victim accounting TODOs (see detailed notes below): (1)
+                        // takenLeeches gated to non-positional — per-victim leech needs the symmetric
+                        // heal surface; (2) playerSink.addIncoming attributes every victim's AoE share
+                        // to the tank's incoming bucket.
+                        //
                         // Shield-first drain → HP → ship-destroyed → roundIncoming/roundShield. The
                         // shieldBefore/hpDamage are captured for the punch-through gate (Quixilver) below.
                         // hpDamage comes straight from the closure (0 under Barrier — damage fully

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -1944,6 +1944,11 @@ export function runCombat(input: CombatEngineInput): {
         // The helper `dmg(id)` lazily creates entries on first write — actors that never
         // produce damage in a round simply have no entry, keeping the map sparse.
         const roundDamage = new Map<string, ActorDamage>();
+        // Per-round per-victim positional damage accumulator (victim actor id → summed damage
+        // dealt to it this round). Populated ONLY by the positional apply path's emitHit
+        // callback (all three attack sites); stays EMPTY on non-positional rounds, so the
+        // RoundData.perTargetDamage field is set only when non-empty → goldens byte-identical.
+        const roundPerTargetDamage = new Map<string, number>();
         const dmg = (id: string): ActorDamage => {
             let d = roundDamage.get(id);
             if (!d) {
@@ -2244,6 +2249,15 @@ export function runCombat(input: CombatEngineInput): {
                     affinity: v.affinity ?? 'antimatter',
                 }),
                 applyToVictim: args.applyToVictim,
+                // Pure ACCUMULATOR (not a bus emit): record per-victim damage into the
+                // per-round map so the RoundData row can expose perTargetDamage. Identical
+                // across all three sites (focus / team / enemy), so it lives here.
+                emitHit: (victim, damage) => {
+                    roundPerTargetDamage.set(
+                        victim.id,
+                        (roundPerTargetDamage.get(victim.id) ?? 0) + damage
+                    );
+                },
             });
         };
 
@@ -3653,6 +3667,11 @@ export function runCombat(input: CombatEngineInput): {
             ...(hasWalkedTeam ? { teamDamage: Math.round(teamRoundDamage) } : {}),
             // extraTurns set ONLY when ≥ 1 (undefined preserves legacy RoundData shape).
             ...(focusTurns.length > 1 ? { extraTurns: focusTurns.length - 1 } : {}),
+            // perTargetDamage set ONLY when the positional path recorded victim damage this
+            // round (map non-empty). Non-positional rounds leave it absent → goldens byte-identical.
+            ...(roundPerTargetDamage.size > 0
+                ? { perTargetDamage: Object.fromEntries(roundPerTargetDamage) }
+                : {}),
             activeCorrosionStacks: totalStacks(corrosionEntries),
             activeInfernoStacks: totalStacks(infernoEntries),
             activeBombCount: pendingBombs.length,

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -824,6 +824,16 @@ export interface CombatEngineInput {
     ignoresForcedTargeting?: boolean;
     /** Pre-parsed targeting preference for the focus attacker (positional plumbing — set but not yet consumed). */
     target?: ParsedTarget;
+    /** TEST-ONLY tap (Phase 4 PR1, Task 3): receives the genuine `applyOutgoingToEnemy` closure
+     *  once on the first round it is built, so unit tests can exercise the player→enemy victim
+     *  wrapper against a hand-built enemy actor BEFORE Task 8 wires a production caller. Never set
+     *  by production code; the closure runs the real applyVictimDamage path (no mocks). */
+    __testTapApplyOutgoingToEnemy?: (
+        fn: (
+            damage: number,
+            enemyVictim: CombatActor
+        ) => { shieldBefore: number; hpDamage: number; barriered: boolean }
+    ) => void;
 }
 
 /** One round's healing accounting (healing mode only). `perActor` mirrors the round
@@ -2084,6 +2094,28 @@ export function runCombat(input: CombatEngineInput): {
             victim: CombatActor = healTarget!
         ): { shieldBefore: number; hpDamage: number; barriered: boolean } =>
             applyVictimDamage(damage, victim, playerSink);
+        // Player→enemy intake (Phase 4 PR1, Task 3) — the symmetric THIN wrapper over
+        // applyVictimDamage for the direction where a PLAYER attacks an ENEMY victim. The enemy
+        // victim still runs the FULL HP/shield/Barrier/Cheat-Death/recordDestroyed path (enemies
+        // actually take damage and can die), but the round accumulators here (roundIncomingDamage/
+        // roundShieldAbsorbed/roundBarrierAbsorbed) are the TANK's incoming bucket — they must NOT
+        // move when a player hits an enemy. So this sink's accounting hooks are no-ops for PR 1
+        // (enemy-incoming accounting is the deferred Phase-5 symmetric surface) and it omits
+        // onHealTargetDestroyed (the enemy victim is never the heal target). Task 8 wires a caller.
+        const enemySink: DamageAccountingSink = {
+            addIncoming: () => {},
+            addShieldAbsorbed: () => {},
+            addBarrierAbsorbed: () => {},
+        };
+        const applyOutgoingToEnemy = (
+            damage: number,
+            enemyVictim: CombatActor
+        ): { shieldBefore: number; hpDamage: number; barriered: boolean } =>
+            applyVictimDamage(damage, enemyVictim, enemySink);
+        // TEST-ONLY: hand the genuine wrapper out once (no production caller until Task 8). The
+        // closure is per-round-identical in behaviour (only `r` differs), so capturing it on the
+        // first round it is built is sufficient. Inert in production (the field is never set).
+        input.__testTapApplyOutgoingToEnemy?.(applyOutgoingToEnemy);
         if (healTarget) {
             currentRoundHealing = new Map<string, ActorHealing>();
             const targetMaxHp = recipientMaxHp(healTarget.id);

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -901,17 +901,6 @@ export interface HealingRoundEngine {
 }
 
 /**
- * The combat-engine turn loop (combat-system.md §10). Each round builds a turn queue
- * (buildTurnQueue, speed-ordered) and every actor takes one turn: the attacker (default
- * speed 100) runs the full damage/buff/DoT-application pipeline; the enemy (default
- * speed 50) ticks the DoT containers it carries (DoTs tick at the start of the
- * afflicted ship's turn). When enemySpeed > speed the order inverts — the enemy acts
- * before the attacker, deferring round-1 DoT ticks to round 2. The round's RoundData
- * row is assembled after all turns. At default speeds the attacker always precedes the
- * enemy, making this a byte-identical relocation of the old single-block round —
- * events are write-only taps that never read or change a sim value.
- */
-/**
  * Side-specific accounting hooks for {@link applyVictimDamage}. Everything keyed off the
  * `victim` (Barrier/shield/HP/Cheat-Death/recordDestroyed/hp-changed) lives in the shared
  * core; the four bits that differ between the healing-mode player intake and (future)
@@ -928,6 +917,17 @@ interface DamageAccountingSink {
     /** today: the `if (victim === healTarget) healTargetDestroyedRound = …` write */
     onHealTargetDestroyed?: (victim: CombatActor) => void;
 }
+/**
+ * The combat-engine turn loop (combat-system.md §10). Each round builds a turn queue
+ * (buildTurnQueue, speed-ordered) and every actor takes one turn: the attacker (default
+ * speed 100) runs the full damage/buff/DoT-application pipeline; the enemy (default
+ * speed 50) ticks the DoT containers it carries (DoTs tick at the start of the
+ * afflicted ship's turn). When enemySpeed > speed the order inverts — the enemy acts
+ * before the attacker, deferring round-1 DoT ticks to round 2. The round's RoundData
+ * row is assembled after all turns. At default speeds the attacker always precedes the
+ * enemy, making this a byte-identical relocation of the old single-block round —
+ * events are write-only taps that never read or change a sim value.
+ */
 export function runCombat(input: CombatEngineInput): {
     rounds: RoundData[];
     rawTotals: {
@@ -2064,18 +2064,18 @@ export function runCombat(input: CombatEngineInput): {
         // healTargetDestroyedRound write). Signature, default `victim = healTarget!`, and return
         // value are unchanged, so every existing call site stays byte-identical.
         const playerSink: DamageAccountingSink = {
-            addIncoming: (a) => {
-                roundIncomingDamage += a;
+            addIncoming: (amount) => {
+                roundIncomingDamage += amount;
             },
-            addShieldAbsorbed: (a) => {
-                roundShieldAbsorbed += a;
+            addShieldAbsorbed: (amount) => {
+                roundShieldAbsorbed += amount;
             },
-            addBarrierAbsorbed: (a) => {
-                roundBarrierAbsorbed += a;
+            addBarrierAbsorbed: (amount) => {
+                roundBarrierAbsorbed += amount;
             },
-            onHealTargetDestroyed: (v) => {
-                if (v === healTarget) {
-                    healTargetDestroyedRound = v.destroyedRound;
+            onHealTargetDestroyed: (victim) => {
+                if (victim === healTarget) {
+                    healTargetDestroyedRound = victim.destroyedRound;
                 }
             },
         };

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -827,7 +827,9 @@ export interface CombatEngineInput {
     /** TEST-ONLY tap (Phase 4 PR1, Task 3): receives the genuine `applyOutgoingToEnemy` closure
      *  once on the first round it is built, so unit tests can exercise the player→enemy victim
      *  wrapper against a hand-built enemy actor BEFORE Task 8 wires a production caller. Never set
-     *  by production code; the closure runs the real applyVictimDamage path (no mocks). */
+     *  by production code; the closure runs the real applyVictimDamage path (no mocks).
+     *  TODO(Task 8): remove once positional wiring provides a production caller; fold these
+     *  tests into positionalDamage.integration.test.ts. */
     __testTapApplyOutgoingToEnemy?: (
         fn: (
             damage: number,

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -911,6 +911,23 @@ export interface HealingRoundEngine {
  * enemy, making this a byte-identical relocation of the old single-block round —
  * events are write-only taps that never read or change a sim value.
  */
+/**
+ * Side-specific accounting hooks for {@link applyVictimDamage}. Everything keyed off the
+ * `victim` (Barrier/shield/HP/Cheat-Death/recordDestroyed/hp-changed) lives in the shared
+ * core; the four bits that differ between the healing-mode player intake and (future)
+ * other intakes are injected here so the core stays caller-agnostic. The legacy player
+ * wrapper supplies a sink that performs exactly the original closure's mutations.
+ */
+interface DamageAccountingSink {
+    /** today: roundIncomingDamage += amount */
+    addIncoming: (amount: number) => void;
+    /** today: roundShieldAbsorbed += amount */
+    addShieldAbsorbed: (amount: number) => void;
+    /** today: roundBarrierAbsorbed += amount */
+    addBarrierAbsorbed: (amount: number) => void;
+    /** today: the `if (victim === healTarget) healTargetDestroyedRound = …` write */
+    onHealTargetDestroyed?: (victim: CombatActor) => void;
+}
 export function runCombat(input: CombatEngineInput): {
     rounds: RoundData[];
     rawTotals: {
@@ -1916,11 +1933,19 @@ export function runCombat(input: CombatEngineInput): {
         // so the enemy's incoming drains the actor its parsed target picked. Heal-target-specific
         // bookkeeping (healTargetDestroyedRound) stays gated on `victim === healTarget` below so
         // it is never written for a non-heal-target victim.
-        const applyIncomingToTarget = (
+        // Shared damage-intake core (Phase 4 PR 1, Task 2): the byte-identical body of the
+        // legacy applyIncomingToTarget closure with the four side-specific accounting bits
+        // hoisted into `sink`. Everything keyed off `victim` (Barrier full-immunity, shield
+        // drain, HP decrement, Cheat-Death intercept, recordDestroyed, hp-changed) is moved
+        // verbatim. Kept inside runCombat — it captures statusEngine/bus/r/recipientMaxHp/
+        // cheatDeathConsumed/cheatDeathConsumedRound/recordDestroyed/BARRIER_BUFFS/
+        // CHEAT_DEATH_BUFFS/selfBuffNamesForOwners exactly as before.
+        const applyVictimDamage = (
             damage: number,
-            victim: CombatActor = healTarget!
+            victim: CombatActor,
+            sink: DamageAccountingSink
         ): { shieldBefore: number; hpDamage: number; barriered: boolean } => {
-            roundIncomingDamage += damage;
+            sink.addIncoming(damage);
             // Capture the pre-drain HP + the target's current effective max HP for the
             // tank-side hp-changed emission below (Phase 4c PR 3). Read BEFORE the drain
             // so oldPct reflects the entering state and a Cheat-Death save's oldPct stays
@@ -1943,7 +1968,7 @@ export function runCombat(input: CombatEngineInput): {
                 BARRIER_BUFFS.has(n)
             );
             if (carriesBarrier) {
-                roundBarrierAbsorbed += damage;
+                sink.addBarrierAbsorbed(damage);
                 if (victim.currentHp > 0 && maxHp > 0) {
                     bus.emit({
                         type: 'hp-changed',
@@ -1958,7 +1983,7 @@ export function runCombat(input: CombatEngineInput): {
             const shieldBefore = victim.shieldPool;
             const absorbed = Math.min(victim.shieldPool, damage);
             victim.shieldPool -= absorbed;
-            roundShieldAbsorbed += absorbed;
+            sink.addShieldAbsorbed(absorbed);
             const hpDamage = damage - absorbed;
             victim.currentHp = Math.max(0, victim.currentHp - hpDamage);
             // At the lethal moment, intercept once per combat: a carrier of a CHEAT_DEATH_BUFFS
@@ -2009,11 +2034,10 @@ export function runCombat(input: CombatEngineInput): {
                     // off the heal target's runtime field below.
                     recordDestroyed(victim, r, bus);
                     // healTargetDestroyedRound tracks the HEAL TARGET specifically — only write it
-                    // when the victim IS the heal target. A positional-selected non-heal-target
-                    // victim records its own destroyedRound (on `victim`) without touching this.
-                    if (victim === healTarget) {
-                        healTargetDestroyedRound = victim.destroyedRound;
-                    }
+                    // when the victim IS the heal target. The guard lives in the sink callback so a
+                    // positional-selected non-heal-target victim records its own destroyedRound (on
+                    // `victim`) without touching this.
+                    sink.onHealTargetDestroyed?.(victim);
                 }
             }
             // Tank-side hp-changed (Phase 4c PR 3): ONCE per HP-intake event — this closure
@@ -2034,6 +2058,32 @@ export function runCombat(input: CombatEngineInput): {
             }
             return { shieldBefore, hpDamage, barriered: false };
         };
+        // Legacy healing-mode player intake — a THIN wrapper over applyVictimDamage. The sink
+        // reproduces exactly the original closure's mutations (roundIncomingDamage /
+        // roundShieldAbsorbed / roundBarrierAbsorbed bumps + the heal-target-gated
+        // healTargetDestroyedRound write). Signature, default `victim = healTarget!`, and return
+        // value are unchanged, so every existing call site stays byte-identical.
+        const playerSink: DamageAccountingSink = {
+            addIncoming: (a) => {
+                roundIncomingDamage += a;
+            },
+            addShieldAbsorbed: (a) => {
+                roundShieldAbsorbed += a;
+            },
+            addBarrierAbsorbed: (a) => {
+                roundBarrierAbsorbed += a;
+            },
+            onHealTargetDestroyed: (v) => {
+                if (v === healTarget) {
+                    healTargetDestroyedRound = v.destroyedRound;
+                }
+            },
+        };
+        const applyIncomingToTarget = (
+            damage: number,
+            victim: CombatActor = healTarget!
+        ): { shieldBefore: number; hpDamage: number; barriered: boolean } =>
+            applyVictimDamage(damage, victim, playerSink);
         if (healTarget) {
             currentRoundHealing = new Map<string, ActorHealing>();
             const targetMaxHp = recipientMaxHp(healTarget.id);

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1666,7 +1666,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
               outgoingDamageBuffPct: outgoingDamageBuff,
               incomingDamageModifierPct: incomingDamageModifier,
               defensePenetrationPct: effectivePen,
-              attackerAffinity: attackerAffinity ?? 'antimatter',
+              attackerAffinity: attackerAffinity ?? actor.affinity ?? 'antimatter',
           }
         : undefined;
 

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -8,6 +8,7 @@ import {
     SelectedGameBuff,
 } from '../../types/calculator';
 import { Ability, ShipSkills, Skill } from '../../types/abilities';
+import type { AffinityName } from '../../types/ship';
 import type { ConditionContext } from '../abilities/evaluateConditions';
 import {
     selectFiringSkill,
@@ -47,6 +48,7 @@ import {
 import { CombatEventBus } from './events';
 import { synthesizeResisted } from './shared';
 import { buildActorConditionContext, type ReactiveAbility } from './triggers';
+import type { AttackerDamageScalars } from './victimDamage';
 
 type StatusEngine = ReturnType<typeof createStatusEngine>;
 
@@ -125,6 +127,13 @@ export interface PlayerTurnResult {
     /** Extra-action grants this turn fired (pre-gated). The ENGINE owns queue
      *  re-insertion + the oncePerRound/backstop bookkeeping. */
     extraActionGrants: ExtraActionGrant[];
+    /** Per-cast attacker-side damage scalars for the positional apply path (Task 7).
+     *  Populated from the SAME locals that feed the aggregate `directDamage`, so feeding
+     *  these + `hitCrits` through `victimHitDamage` for the bound victim's defense profile
+     *  reproduces the firing hit exactly (Task-4 parity). Read ONLY by the future positional
+     *  engine branch (Task 8); non-positional callers ignore it → goldens byte-identical.
+     *  Present whenever a damage ability fired this cast (else undefined). */
+    positionalScalars?: AttackerDamageScalars;
     turnCtx: PlayerRoundCtx; // round-scoped context for the enemy's DoT tick (this actor)
 }
 
@@ -157,6 +166,12 @@ export interface PlayerActorRuntime {
     affinityCritCap: number;
     affinityCritPenalty: number;
     affinityDisadvantage: boolean;
+    /** Raw attacker affinity (Task 7). The numeric modifiers above are PRE-RESOLVED
+     *  (computeAffinityModifiers) against the bound enemy and cannot be inverted, so the
+     *  positional apply path — which re-resolves per VICTIM — needs the raw affinity here.
+     *  Optional: absent → `'antimatter'` (neutral vs anything, modifier 0), matching the
+     *  default neutral matchup; surfaced only on positionalScalars. */
+    attackerAffinity?: AffinityName;
     allyChargePerRound?: number; // attacker-only manual input
     // Per-actor deterministic gates (own instances — determinism isolation)
     activeCritGate: RateGate;
@@ -673,6 +688,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         affinityCritCap,
         affinityCritPenalty,
         affinityDisadvantage,
+        attackerAffinity,
         defence,
         hp,
         allyChargePerRound,
@@ -1632,6 +1648,28 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         incomingHealPct: incomingHealBuff,
     };
 
+    // Per-cast attacker-side scalars for the positional apply path (Task 7). Sourced from
+    // the SAME locals that assemble the aggregate `directDamage` above (preCritDamage +
+    // postDefenseFactor): effectiveMultiplier ALREADY folds the hit count, so multiplierPct
+    // is `effectiveMultiplier + conditionalBonusPct` and `hits` re-splits it per hit inside
+    // victimHitDamage. attackerAffinity is the RAW affinity (the runtime's numeric
+    // affinityDamageModifier is pre-resolved vs the bound enemy and can't be inverted);
+    // defaults to neutral 'antimatter' when unset → modifier 0, matching the default matchup.
+    // Only present when a damage ability actually fired (else there is nothing to apply).
+    const positionalScalars: AttackerDamageScalars | undefined = hasDamageAbility
+        ? {
+              effectiveAttack,
+              multiplierPct: effectiveMultiplier + conditionalBonusPct,
+              secondaryStatValue,
+              hits,
+              effectiveCritDamage,
+              outgoingDamageBuffPct: outgoingDamageBuff,
+              incomingDamageModifierPct: incomingDamageModifier,
+              defensePenetrationPct: effectivePen,
+              attackerAffinity: attackerAffinity ?? 'antimatter',
+          }
+        : undefined;
+
     return {
         action,
         roundCrit,
@@ -1648,6 +1686,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         conditionalDamage,
         detonationDamage,
         extraActionGrants,
+        positionalScalars,
         turnCtx,
     };
 }

--- a/src/utils/combat/positionalApply.ts
+++ b/src/utils/combat/positionalApply.ts
@@ -1,6 +1,12 @@
 import type { Position } from '../../types/encounters';
-import type { ParsedPattern } from '../targetingParser';
+import type { ParsedPattern, ParsedTarget } from '../targetingParser';
 import { resolveCells, type CellRole } from '../targeting/resolvePattern';
+import { resolvePositionalTarget, type ActorTargetingStatus } from './positionalBinding';
+import {
+    victimHitDamage,
+    type AttackerDamageScalars,
+    type VictimDefenseProfile,
+} from './victimDamage';
 import type { CombatActor } from './state';
 
 /**
@@ -48,4 +54,80 @@ export function footprintVictims(
         hits.push({ victim, roleScale: roleScaleFor(role) });
     }
     return hits;
+}
+
+/**
+ * Per-hit positional damage driver with live re-resolution.
+ *
+ * Drives `hits` discrete hits of one skill. For EACH hit it re-resolves the anchor and
+ * re-expands the footprint against the LIVE `opposingLiving` roster — so when a victim
+ * dies mid-skill (its `currentHp` drops to 0 inside `applyToVictim`), it disappears from
+ * the roster and later hits redirect to the next living target automatically. This is the
+ * heart of the task: target resolution and footprint expansion MUST run inside the loop.
+ *
+ * Whiff (spec §5.1): if `resolvePositionalTarget` returns `null` for a hit (no living
+ * opposing actor resolvable — e.g. everything died), that hit lands nothing: no
+ * `applyToVictim`, no `emitHit`.
+ *
+ * PURE module: `applyToVictim` / `emitHit` are injected callbacks (engine wiring lives in
+ * Task 8); this file imports no engine state.
+ */
+export function applyPositionalDamage(args: {
+    hits: number;
+    hitCrits: boolean[];
+    scalars: AttackerDamageScalars;
+    pattern: ParsedPattern;
+    actorPosition: Position;
+    target: ParsedTarget;
+    /** The live roster; re-read each hit (it mutates as victims die). */
+    opposingLiving: CombatActor[];
+    statusOf?: (id: string) => ActorTargetingStatus | undefined;
+    acting?: { ignoresForcedTargeting?: boolean; provokedBy?: string };
+    defenseProfileOf: (v: CombatActor) => VictimDefenseProfile;
+    /** Engine wrapper — decrements the victim's currentHp (Task 8 passes applyOutgoingToEnemy). */
+    applyToVictim: (victim: CombatActor, damage: number) => void;
+    emitHit?: (victim: CombatActor, damage: number, didCrit: boolean) => void;
+}): void {
+    const {
+        hits,
+        hitCrits,
+        scalars,
+        pattern,
+        actorPosition,
+        target,
+        opposingLiving,
+        statusOf,
+        acting,
+        defenseProfileOf,
+        applyToVictim,
+        emitHit,
+    } = args;
+
+    for (let h = 0; h < hits; h++) {
+        // Re-resolve the anchor against the LIVE roster (a victim killed on an earlier hit
+        // is already gone from opposingLiving via currentHp === 0 filtering).
+        const anchorActor = resolvePositionalTarget(
+            actorPosition,
+            target,
+            opposingLiving,
+            statusOf,
+            acting
+        );
+        if (anchorActor === null || anchorActor.position === undefined) {
+            // WHIFF — no living target resolvable for this hit. Skip entirely.
+            continue;
+        }
+
+        const didCrit = hitCrits[h] ?? false;
+
+        for (const { victim, roleScale } of footprintVictims(
+            pattern,
+            anchorActor.position,
+            opposingLiving
+        )) {
+            const dmg = victimHitDamage(scalars, defenseProfileOf(victim), didCrit, roleScale);
+            applyToVictim(victim, dmg);
+            emitHit?.(victim, dmg, didCrit);
+        }
+    }
 }

--- a/src/utils/combat/positionalApply.ts
+++ b/src/utils/combat/positionalApply.ts
@@ -59,11 +59,14 @@ export function footprintVictims(
 /**
  * Per-hit positional damage driver with live re-resolution.
  *
- * Drives `hits` discrete hits of one skill. For EACH hit it re-resolves the anchor and
+ * Drives `scalars.hits` discrete hits of one skill. For EACH hit it re-resolves the anchor and
  * re-expands the footprint against the LIVE `opposingLiving` roster — so when a victim
  * dies mid-skill (its `currentHp` drops to 0 inside `applyToVictim`), it disappears from
  * the roster and later hits redirect to the next living target automatically. This is the
  * heart of the task: target resolution and footprint expansion MUST run inside the loop.
+ *
+ * The per-hit loop count is `scalars.hits` — the SAME field victimHitDamage reads to re-split
+ * the folded multiplier, keeping hit count from a single canonical source.
  *
  * Whiff (spec §5.1): if `resolvePositionalTarget` returns `null` for a hit (no living
  * opposing actor resolvable — e.g. everything died), that hit lands nothing: no
@@ -73,7 +76,6 @@ export function footprintVictims(
  * Task 8); this file imports no engine state.
  */
 export function applyPositionalDamage(args: {
-    hits: number;
     hitCrits: boolean[];
     scalars: AttackerDamageScalars;
     pattern: ParsedPattern;
@@ -89,7 +91,6 @@ export function applyPositionalDamage(args: {
     emitHit?: (victim: CombatActor, damage: number, didCrit: boolean) => void;
 }): void {
     const {
-        hits,
         hitCrits,
         scalars,
         pattern,
@@ -103,7 +104,10 @@ export function applyPositionalDamage(args: {
         emitHit,
     } = args;
 
-    for (let h = 0; h < hits; h++) {
+    // Canonical hit count: derive the loop count from `scalars.hits` (the single source of
+    // truth that victimHitDamage also reads), avoiding silent under/over-application from a
+    // divergent separate `hits` arg.
+    for (let h = 0; h < scalars.hits; h++) {
         // Re-resolve the anchor against the LIVE roster (a victim killed on an earlier hit
         // is already gone from opposingLiving via currentHp === 0 filtering).
         const anchorActor = resolvePositionalTarget(

--- a/src/utils/combat/positionalApply.ts
+++ b/src/utils/combat/positionalApply.ts
@@ -1,0 +1,51 @@
+import type { Position } from '../../types/encounters';
+import type { ParsedPattern } from '../targetingParser';
+import { resolveCells, type CellRole } from '../targeting/resolvePattern';
+import type { CombatActor } from './state';
+
+/**
+ * One footprint cell that landed on a living opposing actor.
+ * `roleScale` is the per-cell damage multiplier: origin cells deal full damage
+ * (1.0), covered/splash cells deal half (0.5).
+ */
+export interface FootprintHit {
+    victim: CombatActor;
+    /** origin → 1.0, covered (any non-origin role) → 0.5 */
+    roleScale: number;
+}
+
+/** Per-cell damage scale keyed off the resolved CellRole. */
+const roleScaleFor = (role: CellRole): number => (role === 'origin' ? 1.0 : 0.5);
+
+/**
+ * Expand a positional pattern footprint into the list of living victims it hits.
+ *
+ * PURE helper. Given a parsed pattern, the resolved anchor position, and the living
+ * opposing roster, returns one {@link FootprintHit} per occupied footprint cell with
+ * its role scale. Empty cells contribute nothing; dead actors are not in the roster
+ * map and so are never hit.
+ *
+ * `not-self` patterns produce only non-origin (covered) cells — the scale is keyed off
+ * the resolved `role`, never off whether the cell equals the anchor.
+ */
+export function footprintVictims(
+    pattern: ParsedPattern,
+    anchor: Position,
+    opposingLiving: CombatActor[]
+): FootprintHit[] {
+    // Mirror positionalBinding.byCell: living, positioned actors, ≤1 per cell.
+    const byCell = new Map<Position, CombatActor>();
+    for (const a of opposingLiving) {
+        if (a.position !== undefined && a.currentHp > 0) {
+            byCell.set(a.position, a);
+        }
+    }
+
+    const hits: FootprintHit[] = [];
+    for (const { position, role } of resolveCells(pattern, anchor)) {
+        const victim = byCell.get(position);
+        if (!victim) continue; // empty cell: contributes nothing
+        hits.push({ victim, roleScale: roleScaleFor(role) });
+    }
+    return hits;
+}

--- a/src/utils/combat/state.ts
+++ b/src/utils/combat/state.ts
@@ -1,4 +1,5 @@
 import type { Position } from '../../types/encounters';
+import type { AffinityName } from '../../types/ship';
 import type { CombatEventBus } from './events';
 
 /** Per-actor damage contributions within one round (spec: per-actor accounting —
@@ -117,6 +118,10 @@ export interface CombatActor {
     /** Attacker ignores Taunt/Provoke forced targeting (not Concentrate Fire). Positional
      *  plumbing — set at construction, consumed by resolvePositionalTarget. */
     ignoresForcedTargeting?: boolean;
+    /** RAW affinity of this actor (positional plumbing — set at construction, not yet consumed
+     *  by apply). The positional damage calculator's `defenseProfileOf(victim)` will read this
+     *  for per-victim affinity re-resolution (Task 8b/9). Absent → treated as neutral downstream. */
+    affinity?: AffinityName;
 }
 
 export function createActor(
@@ -126,6 +131,7 @@ export function createActor(
         startCharged?: boolean;
         position?: Position;
         ignoresForcedTargeting?: boolean;
+        affinity?: AffinityName;
     }
 ): CombatActor {
     // startCharged is a one-shot initialiser (it seeds `charges`), deliberately NOT
@@ -144,6 +150,7 @@ export function createActor(
         pendingAccumulators: [],
         position: partial.position,
         ignoresForcedTargeting: partial.ignoresForcedTargeting,
+        affinity: partial.affinity,
     };
 }
 

--- a/src/utils/combat/victimDamage.ts
+++ b/src/utils/combat/victimDamage.ts
@@ -1,0 +1,100 @@
+import { AffinityName } from '../../types/ship';
+import { calculateDamageReduction } from '../autogear/priorityScore';
+import { computeAffinityModifiers } from '../calculators/affinityUtils';
+
+/**
+ * Pure per-victim hit-damage calculator.
+ *
+ * AoE / re-resolution hits land on victims with DIFFERENT defense and affinity,
+ * so per-victim damage cannot be derived from the single aggregate the engine
+ * computes today (playerTurn.ts:1080-1282). This module recomputes one hit's
+ * contribution against a single victim's defensive profile.
+ *
+ * The decomposition (proven algebraically identical to the engine aggregate in
+ * the parity test): the engine's blended crit multiplier
+ *
+ *     damageCritMultiplier = 1 + (critHits/hits) * (cd/100)
+ *
+ * is equivalent to splitting `preCritDamage` evenly across `hits` and critting
+ * each hit individually:
+ *
+ *     sum_h [1 + (hitCrits[h]?1:0) * cd/100] = hits + critHits*cd/100
+ *                                            = hits * (1 + critFraction*cd/100)
+ *                                            = hits * damageCritMultiplier
+ *
+ * so  sum_h (preCritDamage/hits) * critMult_h * nonCritFactor
+ *       = preCritDamage * nonCritFactor * damageCritMultiplier
+ *       = preCritDamage * postDefenseFactor   (the aggregate, minus passive).
+ *
+ * Passive payload damage is a SEPARATE bucket and is NOT handled here.
+ *
+ * PURE: no engine state, full precision, no per-hit rounding.
+ */
+export interface AttackerDamageScalars {
+    /** attack * (1 + attackBuff/100) — attacker-fixed. */
+    effectiveAttack: number;
+    /**
+     * effectiveMultiplier + conditionalBonusPct, where
+     * effectiveMultiplier = rawMultiplier * hits (multiplier ALREADY includes hit count).
+     */
+    multiplierPct: number;
+    /** Secondary-stat damage (defense/hp scaling), added once inside preCritDamage. */
+    secondaryStatValue: number;
+    /** Hit count — needed to split preCritDamage into per-hit shares. */
+    hits: number;
+    /** critDamage + critDamageBuff, percent. */
+    effectiveCritDamage: number;
+    outgoingDamageBuffPct: number;
+    incomingDamageModifierPct: number;
+    defensePenetrationPct: number;
+    /** Attacker affinity; matched against the victim's affinity via computeAffinityModifiers. */
+    attackerAffinity: AffinityName;
+}
+
+export interface VictimDefenseProfile {
+    defence: number;
+    /** enemyDefenseModifier — percent. */
+    defenceModifierPct: number;
+    affinity: AffinityName;
+}
+
+/**
+ * Damage dealt to a single victim by ONE hit of a multi-hit skill.
+ *
+ * @param s        attacker-side scalars (fixed across victims)
+ * @param v        this victim's defensive profile
+ * @param didCrit  the per-hit crit outcome (hitCrits[h])
+ * @param roleScale 1 (origin) | 0.5 (covered) positional split factor
+ */
+export function victimHitDamage(
+    s: AttackerDamageScalars,
+    v: VictimDefenseProfile,
+    didCrit: boolean,
+    roleScale: number
+): number {
+    // preCritDamage assembled exactly as the engine, then split evenly per hit.
+    const preCritDamage = s.effectiveAttack * (s.multiplierPct / 100) + s.secondaryStatValue;
+    const perHitShare = s.hits > 0 ? preCritDamage / s.hits : 0;
+
+    // Per-VICTIM defense (mirrors playerTurn.ts:1115-1117).
+    const effectiveDefense =
+        v.defence * (1 + v.defenceModifierPct / 100) * (1 - s.defensePenetrationPct / 100);
+    const damageReduction = effectiveDefense > 0 ? calculateDamageReduction(effectiveDefense) : 0;
+
+    // Per-VICTIM affinity (attacker vs this victim), matching computeAffinityModifiers.
+    const affinityDamageModifier = computeAffinityModifiers(
+        s.attackerAffinity,
+        v.affinity
+    ).damageModifier;
+    const affinityMult = 1 + affinityDamageModifier / 100;
+
+    const nonCritFactor =
+        (1 - damageReduction / 100) *
+        (1 + s.outgoingDamageBuffPct / 100) *
+        (1 + s.incomingDamageModifierPct / 100) *
+        affinityMult;
+
+    const hitCritMultiplier = 1 + (didCrit ? 1 : 0) * (s.effectiveCritDamage / 100);
+
+    return perHitShare * hitCritMultiplier * nonCritFactor * roleScale;
+}


### PR DESCRIPTION
## Positional Combat Phase 4 — PR 1 of 2

Capability-only overlay that makes multi-target AoE damage land with real per-victim consequences. **No production caller passes board positions yet** (Phase 5 simulator is the first), so the positional path is dormant and **all DPS/healing goldens are byte-identical** — the load-bearing safety invariant for this whole series.

### What it adds
- **Symmetric per-victim apply.** Extracted the victim-intake core (`applyVictimDamage`, behavior-preserving) so both directions can decrement a real actor's HP: `applyIncomingToTarget` (enemy→player, unchanged) + new `applyOutgoingToEnemy` (player→enemy). Enemies can now take damage and die from player attacks — the "dummy-enemy-vs-real-actor duality" the team-agnostic principle flagged.
- **Multi-target AoE.** Wires the previously-unwired `resolveCells`: a damage ability resolves anchor + covered cells (origin 100% / covered 50%, damage-only), each cell's living occupant a real victim on its own defense/affinity/Cheat-Death/Barrier path (`footprintVictims`).
- **Per-hit re-resolution.** `applyPositionalDamage` re-runs target selection per hit on the live roster, so a mid-cast death redirects later hits; a hit with no living target whiffs (no damage, no event).
- **Pure per-victim damage calc** (`victimDamage.ts`) with a 10-digit parity test proving the per-hit decomposition sums to the engine aggregate for a single victim.
- Wired at all 3 attack sites via a shared `drivePositionalApply` helper (focus/team → enemies; enemy → players); legacy DPS-sink credit suppressed on the positional path.
- Additive `RoundData.perTargetDamage` (victim id → damage this round; absent in non-positional runs).

### Verification
- DPS + healing **goldens byte-identical** (`git diff origin/main -- '*.snap'` empty).
- Full suite **2269 passing**, `audit:skills` **0/141**, tsc + lint clean.
- Subagent-driven, every task spec + quality reviewed + final holistic review.

### Deferred to Phase 5 (documented inline, grep `Phase-5`)
- Full side-symmetric per-actor-per-side result surface + team-vs-team display.
- Per-victim `takenLeeches` + per-victim incoming-damage attribution (gated to non-positional so the heal-target case stays byte-identical; inert today).
- Per-victim defense-debuff + incoming/outgoing-modifier sourcing (anchor exact; covered victims approximated via attacker-fixed scalars today).

### Next
**PR 2** — death-fallback retargeting + Harvester `on-ally-destroyed` activation + Salvation dead-recipient filtering. Then Phase 5 (simulator page).

Spec: `docs/superpowers/specs/2026-06-15-positional-combat-phase4-design.md`
Plan: `docs/superpowers/plans/2026-06-15-positional-combat-phase4-pr1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)