### PR TITLE
feat(sim): simulateBattle adapter + symmetric battle result (combat simulator phase 5, PR 1)

### DIFF
--- a/docs/superpowers/plans/2026-06-15-combat-simulator-phase5-pr1.md
+++ b/docs/superpowers/plans/2026-06-15-combat-simulator-phase5-pr1.md
@@ -1,0 +1,149 @@
+# Combat Simulator Phase 5 — PR 1 Implementation Plan (`simulateBattle` adapter + symmetric result)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A `simulateBattle` adapter that runs two positioned squads through the existing `runCombat` and assembles a per-round, per-ship **symmetric result surface** (damage dealt/taken, healing, shields, HP curve, death, events) for both teams — the data layer the `/simulator` page (PR 2) renders.
+
+**Architecture:** Page-first (full engine unify deferred). The Phase-4 positional path already runs both directions (player→enemy + enemy→player) when positions are supplied, and the engine emits a rich event stream. So PR 1 = (a) a pure **event-driven assembler** (`event stream + rosters → symmetric BattleResult`) + (b) the `simulateBattle` adapter that derives both teams, builds `CombatEngineInput` (positions + `enemyAttackers` + a `healTargetId` workaround + a tapped bus), runs `runCombat(numRounds=30)`, and feeds events to the assembler. **No engine-internal change → DPS/healing goldens byte-identical.**
+
+**Tech Stack:** TypeScript, Vitest. New `src/utils/calculators/battleSimulator.ts`. Reuses `runCombat` (engine.ts), `deriveTeamEngineActors` (dpsSimulator.ts), `parseShipTargeting` (targetingParser.ts), `createEventBus`/`CombatEvent` (events.ts).
+
+**Spec:** `docs/superpowers/specs/2026-06-15-combat-simulator-phase5-design.md` (§4.2 surface, §11 PR 1).
+
+---
+
+## Workflow notes (read first)
+- **Branch + worktree:** branch `feat/combat-sim-phase5-pr1` off latest `origin/main` in a new worktree `.worktrees/sim-pr1`. Symlink the gitignored `.env` + `docs/ship-targeting.csv`/`ship-skills.csv`/`bios.csv`/`combat-system.md` + `.husky/_` from the main checkout (else env tests fail + the pre-commit hook breaks).
+- **`gh auth switch --hostname github.com --user TheSusort`** before any PR/gh op.
+- **Goldens byte-identical:** PR 1 adds a NEW caller only; no engine change. `git diff origin/main -- '*.snap'` must be empty. NEVER blind `vitest -u`.
+- `docs/` gitignored → `git add -f`; docs commits `--no-verify`. New tests → `src/utils/combat/__tests__/` or `src/utils/calculators/__tests__/`.
+- Test cmds: `npm test -- <path>`, `npm test`, `npm run lint`, `npx tsc --noEmit`, `npm run audit:skills`.
+
+---
+
+## File structure
+| File | Responsibility | Change |
+|---|---|---|
+| `src/utils/calculators/battleSimulator.ts` | **new** — `simulateBattle(input): BattleResult`; the event-driven `assembleBattleResult(...)`; result types | Create |
+| `src/utils/calculators/__tests__/battleAssemble.test.ts` | **new** — assembler unit tests (synthetic event streams) | Create |
+| `src/utils/combat/__tests__/twoTeamBattle.test.ts` | **new** — end-to-end two-team harness through `runCombat` | Create |
+
+---
+
+## Task 1: Characterization spike — confirm mutual positional combat emits for both sides
+
+**File:** `src/utils/combat/__tests__/twoTeamBattle.test.ts` (new)
+
+Before building the assembler, PROVE the data source: a tiny 2v2 positioned battle through `runCombat` (healing mode, `healTargetId` = a player ship) must emit damage events for BOTH directions (player→enemy AND enemy→player).
+
+- [ ] **Step 1: Write the spike test.** Hand-build (reuse the `ab()`/`manualEnemy`/positioned-actor style from `src/utils/combat/__tests__/positionalDamage.integration.test.ts`): a player side with 2 positioned actors (one as focus `attacker`, one as a walked `teamActor`, each with a damage `shipSkills` + `position` + parsed `target`/`pattern`), and `enemyAttackers` with 2 positioned actors (damage skills + position + target/pattern). Set `healTargetId` to a player ship. Pass a captured `bus` (collect all events). `numRounds: 3`.
+- [ ] **Step 2: Run + assert mutual emission.** Assert the event stream contains `ability-performed`/`attacked` events where (a) a player actor damages an enemy actor (targetId ∈ enemy ids) AND (b) an enemy actor damages a player actor (targetId ∈ player ids), and `hp-changed`/`ship-destroyed` for both sides as HP allows. Also capture which event types carry the per-victim damage (ability-performed vs attacked vs perTargetDamage in the returned rounds) — **document the findings in a comment block** (this is the contract the assembler relies on). Run: `npm test -- src/utils/combat/__tests__/twoTeamBattle.test.ts`.
+- [ ] **Step 3: Pin the data-source contract in the comment (verified during plan review — confirm it holds):**
+  - **damage TAKEN (per victim, both directions)** = `RoundData.perTargetDamage` (keyed by victim id; fed by `emitHit` at all 3 attack sites — symmetric).
+  - **damage DEALT (per attacker, both directions)** = sum of `ability-performed.damage` grouped by `actorId` (enemy actors walk `runPlayerTurn` and emit it too).
+  - **readable event-log lines** come from `ability-performed` / `heal-performed` / `ship-destroyed` (these carry attacker attribution) — **NOT `attacked`**, which carries NO damage amount and fires only for the anchor victim (not per AoE-covered cell). Do not try to reconstruct dealt-damage from `attacked`.
+  If any of this is FALSE in practice, STOP and report — Task 2 depends on it.
+- [ ] **Step 4: Commit** `test(combat): characterize two-team positional battle event stream`.
+
+---
+
+## Task 2: Symmetric result types + pure event-driven assembler
+
+**Files:** `src/utils/calculators/battleSimulator.ts` (create — types + `assembleBattleResult`), `src/utils/calculators/__tests__/battleAssemble.test.ts`
+
+Define the symmetric surface (§4.2) and a PURE assembler from the event stream (+ roster + per-round `perTargetDamage` from the rounds, per Task 1's findings).
+
+```ts
+export interface ShipRoundState {
+    actorId: string;
+    side: 'player' | 'enemy';
+    damageDealt: number;
+    damageTaken: number;
+    healingDone: number;
+    healingReceived: number;
+    shieldsAbsorbed: number;
+    hpPct: number;            // end-of-round
+    alive: boolean;
+    activeBuffs: string[];    // from buff-applied/expired tracking (names)
+    activeDebuffs: string[];
+}
+export interface BattleRound {
+    round: number;
+    ships: ShipRoundState[];          // every living-or-just-died actor, both sides
+    events: BattleLogEvent[];         // ordered: who hit/healed/killed whom (for the log)
+}
+export interface BattleResult {
+    rounds: BattleRound[];            // trimmed at termination
+    outcome: { winner: 'player' | 'enemy' | 'draw'; lastRound: number };
+    roster: { actorId: string; side: 'player'|'enemy'; name: string; position: Position }[];
+}
+export function assembleBattleResult(args: {
+    events: CombatEvent[];
+    perRoundPerTarget: Record<number, Record<string, number>>; // from RoundData.perTargetDamage by round
+    roster: Array<{ actorId: string; side: 'player'|'enemy'; name: string; position: Position; maxHp: number }>;
+    numRounds: number;
+}): BattleResult
+```
+
+Assembler logic (driven by Task 1's confirmed sources): group events by round; per round per actor accumulate `damageDealt` = sum of `ability-performed.damage` by `actorId`; `damageTaken` = `perRoundPerTarget` by victim id; heals/HP/death/buffs from events; track `hpPct` from the latest `hp-changed.newPct` (default 100); `alive` false once `ship-destroyed`; collect a readable `events` log per round. Compute `outcome`: the first round where all of one side's actors are destroyed → winner = other side, `lastRound` = that round; trim later rounds; no wipe by round `numRounds` → `draw`.
+
+> **Attribution edge (document in the assembler, not a bug):** `ability-performed.damage` is the attacker's aggregate for the turn; the per-victim split in `perTargetDamage` has NO source id. So per-actor `damageDealt` and per-actor `damageTaken` are each sound, but you CANNOT cross-tab "how much X dealt to specific victim Y" in an AoE round from this data. §4.2 does not require that cross-tab — keep dealt and taken as separate per-actor totals.
+
+- [ ] **Step 1: Write failing tests** with HAND-BUILT synthetic `CombatEvent[]` (no `runCombat`): (a) a player ability-performed + an enemy attacked → correct damageDealt/damageTaken on both sides; (b) heal-performed → healingDone/Received; (c) hp-changed → hpPct; (d) ship-destroyed → alive=false + (when a side fully dies) outcome.winner + rounds trimmed; (e) no-wipe → draw at numRounds.
+- [ ] **Step 2: Run, expect FAIL** (`npm test -- src/utils/calculators/__tests__/battleAssemble.test.ts`).
+- [ ] **Step 3: Implement** types + `assembleBattleResult` (pure; no engine import — only `CombatEvent` type + `Position`).
+- [ ] **Step 4: Run, expect PASS.** `npm test` full suite byte-identical.
+- [ ] **Step 5: Commit** `feat(sim): symmetric battle result types + pure event-driven assembler`.
+
+---
+
+## Task 3: `simulateBattle` adapter — derive teams, run engine, assemble
+
+**Files:** `src/utils/calculators/battleSimulator.ts` (add `simulateBattle` + input types), tests in `twoTeamBattle.test.ts`
+
+```ts
+export interface BattlePlacement { ship: Ship; statOverrides?: Partial<CombatStatBlock>; position: Position; }
+export interface BattleSimulationInput { playerTeam: BattlePlacement[]; enemyTeam: BattlePlacement[]; rounds?: number; /* default 30 */ }
+export function simulateBattle(input: BattleSimulationInput): BattleResult
+```
+
+Implementation:
+- Derive each placed ship's combat stats (reuse the `deriveTeamEngineActors`-style stat derivation in `dpsSimulator.ts`; apply `statOverrides`), affinity, and `parseShipTargeting(ship)` → per-actor `target`/`pattern` (active; charged where applicable).
+- Build `CombatEngineInput`: player side = one ship as the focus `attacker` + the rest as `teamActors` (each with `walk` block, `position`, `target`, `pattern`); enemy side = `enemyAttackers` (each with `position`, `target`, `pattern`, stats, `shipSkills`); **`healTargetId` = the focus player ship's id** (vestigial requirement so `enemyAttackers` populate + the enemy positional path runs — document inline). Provide a fresh `bus`.
+- Run `runCombat({ ..., numRounds: rounds ?? 30, bus })`; collect `bus` events + the returned `rounds[].perTargetDamage`.
+- Build the `roster` (id/side/name/position/maxHp) and call `assembleBattleResult(...)`; return the `BattleResult`.
+- **Actor-id derivation rule (required):** the engine throws on duplicate `enemyAttackers` ids and on collision with reserved ids (`'attacker'`, `'enemy'`) or player actor ids (engine.ts ~1490/1494). The adapter MUST mint globally-unique actor ids across BOTH squads and avoid the reserved ones (e.g. prefix `p:`/`e:` + ship id + placement index). Map these back to ship names for the `roster`.
+
+- [ ] **Step 1: Write failing end-to-end test** in `twoTeamBattle.test.ts`: two small real-ish squads (hand-built `Ship`-shaped objects or fixtures) → `simulateBattle` → assert per-ship per-round `damageDealt`/`damageTaken` are non-zero on both sides, a ship that should die has `alive:false` + a sensible `outcome.winner`, and the 30-round cap / early termination behaves (e.g. a one-sided matchup wipes the weaker team and trims rounds).
+- [ ] **Step 2: Run, expect FAIL.**
+- [ ] **Step 3: Implement** `simulateBattle` (derivation + engine wiring + assemble).
+- [ ] **Step 4: Run, expect PASS;** `npm test` full suite **byte-identical** (`git diff origin/main -- '*.snap'` empty — new caller only). `npx tsc --noEmit && npm run lint`.
+- [ ] **Step 5: Commit** `feat(sim): simulateBattle adapter (positioned squads -> runCombat -> symmetric result)`.
+
+---
+
+## Task 4: Two-team harness hardening + edge cases
+
+**File:** `src/utils/combat/__tests__/twoTeamBattle.test.ts` (extend)
+
+Lock the adapter's correctness on the cases PR 2 + the deferred unify will rely on:
+- [ ] **Step 1:** Add tests: (a) **win/loss/draw** outcomes (one-sided wipe → winner; mutual survival to cap → draw); (b) **death-round** correctness (a ship destroyed round N has `alive:false` from N on, absent/decayed after); (c) **healing** ships register `healingDone`/`healingReceived`; (d) **AoE** spreads `damageTaken` across covered enemy cells (origin full / covered half) via the symmetric surface — the fixture MUST place victims so a multi-cell AoE pattern (e.g. `line`/`cone` range ≥1) actually covers ≥2 enemy cells (a single-target parsed pattern won't exercise the covered-half path); (e) per-round `events` log lists the right attacker→victim lines.
+- [ ] **Step 2: Run, expect PASS** (these exercise Tasks 2–3; fix any gaps surfaced).
+- [ ] **Step 3:** full suite byte-identical; tsc + lint clean.
+- [ ] **Step 4: Commit** `test(sim): two-team battle outcomes, death-round, healing, AoE accounting`.
+
+---
+
+## Task 5: Final verification + PR
+
+- [ ] **Step 1:** `npm test` full suite green; **DPS/healing goldens byte-identical** (`git diff origin/main -- '*.snap'` empty).
+- [ ] **Step 2:** `npm run audit:skills` (0/141), `npx tsc --noEmit && npm run lint` clean.
+- [ ] **Step 3:** Holistic self-review vs spec §4.2/§11: symmetric surface exposes per-round per-ship damage dealt/taken/heal/shields/HP/death + events for both sides; `simulateBattle` is the page↔engine seam; engine untouched (byte-identical); `healTargetId` workaround documented.
+- [ ] **Step 4:** Open PR (`gh auth switch` first), base `main`. Body: page-first PR 1 of 2, data layer for `/simulator`, byte-identical, links spec. No changelog yet (no user-visible surface until PR 2's page). Poll CodeRabbit `mergeState`.
+
+---
+
+## Out of scope (later)
+- The `/simulator` page UI → **PR 2**.
+- Full team-agnostic engine unification (A1..An) → **deferred later phase** (page becomes its harness).
+- Per-victim defense-debuff sourcing / full leech symmetry inside the engine → deferred unify phase (the assembler surfaces what the positional path provides today).

--- a/docs/superpowers/plans/2026-06-15-combat-simulator-phase5-pr1.md
+++ b/docs/superpowers/plans/2026-06-15-combat-simulator-phase5-pr1.md
@@ -22,6 +22,7 @@
 ---
 
 ## File structure
+
 | File | Responsibility | Change |
 |---|---|---|
 | `src/utils/calculators/battleSimulator.ts` | **new** — `simulateBattle(input): BattleResult`; the event-driven `assembleBattleResult(...)`; result types | Create |

--- a/docs/superpowers/specs/2026-06-15-combat-simulator-phase5-design.md
+++ b/docs/superpowers/specs/2026-06-15-combat-simulator-phase5-design.md
@@ -1,0 +1,148 @@
+# Combat Simulator — Positional Phase 5 (team-agnostic unification + board playback)
+
+**Date:** 2026-06-15
+**Status:** Design (pre-implementation)
+**Phase:** Positional combat phase 5 of 5 — the END-STATE goal. (1=geometry resolver #106, 2=positional target-selection #108, 3=forced targeting/stealth #109, Provoke #112, 4=multi-target AoE + per-victim apply #114 + death-fallback #115.)
+
+---
+
+## 1. Problem & goal
+
+Phases 1–4 built the positional combat machinery (board geometry, positional target-selection, forced targeting/stealth/Provoke, multi-target AoE + per-victim damage/death) but it is **all dormant**: no production caller passes board positions, so it never runs and DPS/healing goldens stay byte-identical.
+
+Phase 5 is the **combat simulator page** — the original END-STATE goal: place two squads on the existing 3×4 hex board, run the combat engine, and watch the battle unfold **round-by-round, per-ship** (damage dealt/taken, healing, shields, HP, death) in a board-centric playback. It is the **first production caller that passes board positions**, so it activates everything Phases 1–4 built.
+
+**Goal:** a working `/simulator` page where the user places two real fleet squads (with optional inline stat overrides), runs a battle to resolution, and steps through per-round per-ship results over both boards — backed by a **team-agnostic unified engine** that produces one **symmetric per-actor-per-side** result surface.
+
+**Non-goals:** AI/opponent recommendation, save/share of battles, animation polish beyond a round stepper, balance tuning. Multi-battle comparison (the calculators' multi-config compare) is out — the simulator runs ONE battle.
+
+---
+
+## 2. Scope decisions (user-ratified during brainstorming, 2026-06-15)
+
+- **PAGE-FIRST sequencing (re-decided 2026-06-15 after the unify-cost audit).** A working `/simulator` ships first on today's engine; the full internal team-agnostic unification is deferred to a later incremental phase. Rationale: the unify audit found ~20 hardcoded player-vs-enemy asymmetries across the ~3,780-line dual-path `runCombat` → ~10 sequential engine-surgery PRs with **no user-visible payoff until the page**. Meanwhile the Phase-4 **positional path is already nearly per-actor-per-side symmetric** (`drivePositionalApply` runs for both sides with a side-specific roster + `applyVictimDamage` side-sink + per-victim `emitHit`), so the page can be built on it now.
+- **PR sequencing: PR 1 (adapter + thin symmetric result) → PR 2 (page) → later phase (incremental engine unification A1..An, page as live harness).**
+- **Subsystem A is RE-SCOPED to a thin symmetric result surface** assembled from the existing positional path's per-victim data + the event stream (`ability-performed`/`attacked`/`hp-changed`/`heal-performed`/`ship-destroyed`) + final actor HP/`destroyedRound`. NOT the full internal unify (that becomes the deferred later phase; the team-agnostic end-state is unchanged, just sequenced after a usable page).
+- **DPS and healing modes are UNTOUCHED** by page-first (the simulator runs through the existing positional/healing-mode paths with both teams positioned). Goldens stay **byte-identical** for PR 1 + PR 2 (no engine-internal change; the simulator is a new caller). Audited churn only becomes a concern in the later unification phase.
+- **Battle model:** both sides are **real fleet ships**, with **optional inline per-placed-ship stat overrides** (for what-if opponents the user doesn't own).
+- **Result/display:** **full per-round, per-ship, board-centric playback** (step through rounds over both boards).
+- **Termination:** run until one team is fully destroyed, OR a **30-round cap** (matches in-game PvP).
+- **Route:** top-level **`/simulator`**.
+- **Page layout (validated via mockup):** two `FormationGrid` boards (Your Team / Enemy Team, enemy mirrored so col 4 = front), a round stepper (◀▶ arrows + slider/scrubber + play), a turn-order strip, a per-round event log, and a click-to-pin per-ship detail card (HP, damage dealt/taken, healing, shields, active buffs/debuffs).
+
+---
+
+## 3. Confirmed model (from prior phases — do NOT re-litigate)
+
+- Board: 3 rows T/M/B × 4 cols; **col 4 = front (nearest enemy), col 1 = back**; enemy board is a display-only horizontal mirror; geometry/axial in `src/utils/targeting/board.ts`; `resolveCells(pattern, anchor)` resolves footprints (origin 100% / covered 50% damage-only).
+- Targeting: `parseShipTargeting(ship)` → `{active?, charged?}` each `{target: ParsedTarget, pattern: ParsedPattern}` from the ship's raw `activeTarget`/`activePattern`/`chargedTarget`/`chargedPattern`. The engine consumes `position`/`target`/`pattern` per actor (Phase 2–4): `resolvePositionalTarget` (forced-targeting CF→Taunt→Provoke→stealth + row-first column-priority selection) + `drivePositionalApply` (per-hit re-resolution, footprint, per-victim apply via `applyVictimDamage`).
+- Single speed-ordered queue already spans all actors (team → attacker → enemy tiebreak); per-actor status stores, reactive triggers, death/revive all exist.
+- `RoundData.perTargetDamage?` (victim id → damage this round, both directions) is the Phase-4 seam the symmetric surface generalizes.
+
+---
+
+## 4. Subsystem A — Symmetric result surface (page-first scope)
+
+> **PAGE-FIRST RE-SCOPE (2026-06-15):** Under page-first, subsystem A is the **thin symmetric result surface assembled from the existing positional path**, NOT the full engine unification. §4.2 (the surface shape) is what PR 1 builds. §4.1 + §4.3–§4.5 below describe the **deferred** full internal unification (the later A1..An phase) and are retained as the end-state reference — they are NOT in the page-first PRs.
+
+### 4.2 The symmetric result surface *(PR 1 — this is the page-first deliverable)*
+
+A single result structure keyed by `(side, actorId)` carrying, per round and as battle totals: `damageDealt`, `damageTaken`, `healingDone`, `healingReceived`, `shieldsAbsorbed`, `hp`/`hpPct`, `alive`/`destroyedRound`, plus active buffs/debuffs and a per-round **event list** (who hit/healed/killed whom, for the event log). **Under page-first this is assembled by the `simulateBattle` adapter (PR 1)** from: the positional path's per-victim `emitHit`/`perTargetDamage` (damage dealt+taken, both sides), the combat event stream (`ability-performed`/`attacked`/`hp-changed`/`heal-performed`/`ship-destroyed` — all carry actor/target ids + round), and final actor `currentHp`/`destroyedRound`. The Phase-4 deferred gaps (per-victim leech, per-victim incoming attribution) are surfaced at this assembly layer for the simulator; the engine internals are untouched, so DPS/healing surfaces + goldens stay byte-identical.
+
+### 4.1 (DEFERRED — later unification phase) The unification
+
+Today `runCombat` is **player-centric**: a focus attacker (+ optional walked team) attacks either a **dummy enemy SINK** (DPS mode: cumulative-damage scalar drives enemy HP% for gates) or the enemy-attackers attack a bound **heal target** (healing mode). The enemy side is a single-scalar **mirror**.
+
+Unify into **one `bySide(...)` machinery**: two teams (`sideA`, `sideB`), every ship a real `CombatActor` in the existing single speed-ordered queue, each actor targeting the **opposing** side, with **per-actor-per-side accounting** throughout. There is no dummy sink and no pre-bound heal target in the unified model — both are degenerate inputs (see §4.3). *(This is the deferred end-state; PR 1 instead assembles the §4.2 surface from the existing positional path.)*
+
+### 4.3 (DEFERRED) Degenerate reductions (how DPS/healing keep working)
+
+- **DPS mode:** sideA = focus attacker (+ walked team); sideB = a **1-ship enemy team** carrying today's dummy stats. The player attacks a real enemy actor whose HP declines per-victim. The legacy `RoundData` (directDamage/cumulative/teamDamage/enemyHpPct) is projected from the symmetric surface for sideA.
+- **Healing mode:** sideA = player team + heal target; sideB = the enemy-attackers team (already real actors attacking the heal target). With no positions supplied, enemy→heal-target binding is preserved. Legacy `HealingRoundData` projected from the symmetric surface.
+
+### 4.4 Expected churn + safety
+
+- **Likely audited churn:** DPS goldens reading enemy **HP%-threshold gates** — the dummy sink's *integer-percent* HP becomes a real actor's *exact-percent* HP (`enemyHpDecline` per-victim). Each such golden change is audited as a legitimate model correction and human-confirmed.
+- **Likely byte-identical:** modes with no enemy-HP-gate; healing mode (enemy→heal-target binding preserved, no positions).
+- **Safety harness:** (1) **characterization tests** on the degenerate reductions (pin today's DPS/healing numbers through the unified engine before/after); (2) a small **two-team battle harness** (tiny synthetic squads, hand-built `ab()` actors) that exercises the symmetric surface directly and becomes the unify's correctness proof. The unify ships behind these BEFORE B/C consume it.
+
+### 4.5 Boundaries
+`runCombat` stays the entry point; the unification is internal. The symmetric result is a new exported structure. `applyVictimDamage`, `drivePositionalApply`, `resolvePositionalTarget`, `resolveCells`, the status engine, and reactive triggers are reused unchanged where possible.
+
+---
+
+## 5. Subsystem B — `simulateBattle` adapter
+
+A new `src/utils/calculators/battleSimulator.ts` (mirrors `simulateDPS`/`simulateHealing`):
+
+- **Input:** two squads, each a list of `{ ship | statOverrides, position }`, + global config (round cap = 30).
+- **Derivation:** for each placed ship, derive its `CombatActor`-level stats (reuse `deriveTeamEngineActors`-style stat/affinity derivation for BOTH sides) and resolve `parseShipTargeting(ship)` → per-actor `target`/`pattern` (active + charged); apply optional stat overrides.
+- **Engine call:** `runCombat` with both teams positioned, run to termination (one side wiped or 30 rounds).
+- **Output:** the assembled **per-round per-ship symmetric result** the page renders (§4.2), plus battle outcome (winner, rounds elapsed).
+
+The adapter is the single seam between page state and the engine; the page holds no engine logic.
+
+---
+
+## 6. Subsystem C — Simulator page UI
+
+- **Route:** top-level `/simulator` (new lazy-loaded route in `src/App.tsx`).
+- **Placement:** two `FormationGrid` boards (Your Team / Enemy Team, enemy mirrored). Ship selection via `useShips`/`ShipSelector` per cell; optional inline stat-override editor per placed ship.
+- **Run:** a Run action calls `simulateBattle` (memoized like the calculator pages).
+- **Playback (validated layout):** round stepper — `⏮ ◀ Round N/total ▶ ⏭`, a slider/scrubber, and Play (auto-advance); a turn-order strip for the current round; a per-round **event log**; click any ship cell to **pin** its per-round detail card (HP, damage dealt/taken, healing received, shields, active buffs/debuffs). Per-cell: HP bar, shield bar, this-round effect (damage/heal), dead state.
+- **Components:** reuse UI primitives (`card`, `Button`, `StatCard`, `PageLayout`, chart components) per project conventions; new sim-specific components (board pair, round stepper, event log, ship-round card) under `src/components/simulator/` (or similar).
+- **Docs/changelog:** update `DocumentationPage.tsx` + add an `UNRELEASED_CHANGES` entry when C ships (the first user-visible Phase-5 surface).
+
+---
+
+## 7. Components & boundaries
+
+| Unit | Responsibility | PR |
+|---|---|---|
+| `runCombat` unified `bySide` core + symmetric result | one machinery, both teams real, per-actor-per-side accounting | A |
+| Degenerate-reduction projections (`RoundData`/`HealingRoundData` from symmetric) | keep DPS/healing adapters working | A |
+| Characterization + two-team battle harness tests | prove the unify | A |
+| `battleSimulator.ts` (`simulateBattle`) | squads+positions+targeting+overrides → runCombat → assembled result | B |
+| `/simulator` page + board pair / stepper / event log / ship-round card | placement, run, playback | C |
+
+Each unit is independently testable; the page holds no engine logic; the adapter is the only page↔engine seam.
+
+---
+
+## 8. Battle configuration
+
+- **Termination:** one side fully destroyed OR **30-round cap** (in-game PvP). Outcome = winner | draw-at-cap + rounds elapsed.
+- **Targeting:** per-ship parsed `active`/`charged` target+pattern from ship data; positions from board placement; forced-targeting/stealth/Provoke resolve in-engine.
+- **Turn order:** existing single speed-ordered queue across both teams.
+- **Overrides:** optional per-placed-ship stat overrides (default = real ship stats).
+
+---
+
+## 9. Risks & mitigations
+
+- **PR 1/2 golden safety:** the simulator is a NEW caller; engine internals are untouched, so DPS/healing goldens stay **byte-identical**. The risk is the *assembly* — the symmetric result must correctly derive both sides' per-round numbers from the positional path + events. Mitigate with a **two-team synthetic battle harness** (hand-built squads) that pins expected per-ship per-round damage/heal/HP/death.
+- **`enemyAttackers` requires `healTargetId`:** the engine populates the enemy team only in healing mode (gated on `healTargetId`). The adapter must set a `healTargetId` (a player ship) to get both teams as real positioned actors — a vestigial requirement to work around in PR 1, documented in the plan.
+- **Deferred-unify churn (later phase only):** the full `bySide` unification will churn DPS/healing goldens (integer-pct sink → exact-pct actor, etc.) — handled with characterization + audited churn THEN, not in PR 1/2.
+- **`runCombat` size (~3,780 lines):** the deferred unify extracts `bySide` into focused units; out of scope for page-first.
+- **Termination/stalemate:** 30-round cap bounds healer-vs-healer; the engine already handles dead actors / death-fallback (Phase 4).
+- **Performance:** a full battle is ≤30 rounds × a dozen actors — well within a memoized synchronous run (no web worker needed initially).
+
+---
+
+## 10. Testing strategy
+
+- **Two-team battle harness (PR 1):** synthetic squads (hand-built `ab()` actors) exercising the symmetric surface — per-actor damage dealt/taken, healing, death-round, win condition, 30-round cap. The adapter's correctness proof.
+- **Adapter tests (PR 1):** squads+positions+targeting+overrides → expected per-ship per-round result; targeting resolution from real ship data; the `healTargetId` workaround verified.
+- **Goldens (PR 1 + PR 2):** DPS/healing goldens stay **byte-identical** (engine untouched) — confirm `git diff -- '*.snap'` empty.
+- **Page (PR 2):** component/integration tests for placement, run, round stepping, pinned card; reuse the calculator-page test patterns.
+- **Always:** `audit:skills` 0/141, tsc + lint clean. Synthetic goldens, never blind `-u`.
+
+---
+
+## 11. PR sequence summary (PAGE-FIRST)
+
+1. **PR 1 — `simulateBattle` adapter + thin symmetric result surface.** Two positioned squads + parsed targeting + overrides → `runCombat` (both teams positioned, run to termination) → assembled per-round per-ship **symmetric result** (§4.2) built from the positional path's per-victim data + the event stream + final actor HP/destroyed-round + outcome. Engine internals untouched → DPS/healing **goldens byte-identical**.
+2. **PR 2 — `/simulator` page.** Two-board placement (`FormationGrid`), fleet selection (`useShips`/`ShipSelector`), optional per-ship overrides, Run, board-centric round-stepper playback (arrows + slider + play, turn-order strip, event log, pinned ship-round card). New `/simulator` route. Docs + changelog. → a usable simulator.
+3. **LATER PHASE (deferred) — incremental engine unification (A1..An).** Collapse the dual-path `runCombat` into one team-agnostic `bySide` machinery (the ~10 increments from the asymmetry audit), with the live `/simulator` page as the test harness and audited/human-confirmed golden churn. The §4.1/§4.3–§4.5 end-state. NOT in scope for the page-first PRs.
+
+This delivers a usable simulator (PR 1+2), then completes the team-agnostic end-state (later phase).

--- a/src/utils/calculators/__tests__/battleAssemble.test.ts
+++ b/src/utils/calculators/__tests__/battleAssemble.test.ts
@@ -125,6 +125,28 @@ describe('assembleBattleResult — hpPct from cumulative taken', () => {
         });
         expect(find(result, 1, 'attacker').hpPct).toBe(0);
     });
+
+    it('yields hpPct 0 (not NaN) for an actor with maxHp 0', () => {
+        const zeroHpRoster: ReturnType<typeof roster> = [
+            { actorId: 'attacker', side: 'player', name: 'Focus', position: 'M4', maxHp: 0 },
+            {
+                actorId: 'enemy-front',
+                side: 'enemy',
+                name: 'EnemyFront',
+                position: 'M4',
+                maxHp: 10000,
+            },
+        ];
+        const result = assembleBattleResult({
+            events: [],
+            perRoundPerTarget: {},
+            roster: zeroHpRoster,
+            numRounds: 1,
+        });
+        const hp = find(result, 1, 'attacker').hpPct;
+        expect(hp).toBe(0);
+        expect(Number.isNaN(hp)).toBe(false);
+    });
 });
 
 describe('assembleBattleResult — heals', () => {

--- a/src/utils/calculators/__tests__/battleAssemble.test.ts
+++ b/src/utils/calculators/__tests__/battleAssemble.test.ts
@@ -172,6 +172,25 @@ describe('assembleBattleResult — death + outcome + trim', () => {
         expect(result.rounds.map((r) => r.round)).toEqual([1, 2]);
     });
 
+    it('does not declare a spurious winner when one side is empty (empty enemy side)', () => {
+        // Only player actors present; enemy side empty. [].every(...) === true would
+        // mark the empty side as "wiped" at round 1 and award a bogus winner. The guard
+        // (members.length > 0) makes this fail safe to draw at numRounds instead.
+        const playerOnlyRoster: ReturnType<typeof roster> = [
+            { actorId: 'attacker', side: 'player', name: 'Focus', position: 'M4', maxHp: 10000 },
+            { actorId: 'player-team', side: 'player', name: 'Team', position: 'M3', maxHp: 10000 },
+        ];
+        const result = assembleBattleResult({
+            events: [],
+            perRoundPerTarget: {},
+            roster: playerOnlyRoster,
+            numRounds: 3,
+        });
+        expect(result.outcome.winner).toBe('draw');
+        expect(result.outcome.lastRound).toBe(3);
+        expect(result.rounds.map((r) => r.round)).toEqual([1, 2, 3]);
+    });
+
     it('returns draw at numRounds when neither side fully wiped', () => {
         const events: CombatEvent[] = [
             { type: 'ship-destroyed', actorId: 'enemy-front', round: 2 },

--- a/src/utils/calculators/__tests__/battleAssemble.test.ts
+++ b/src/utils/calculators/__tests__/battleAssemble.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Combat Simulator Phase 5 — PR 1, Task 2: pure event-driven battle assembler.
+ *
+ * These tests feed HAND-BUILT synthetic CombatEvent[] + perRoundPerTarget (NO runCombat)
+ * into `assembleBattleResult` and assert the symmetric result surface. The data-source
+ * contract they encode is pinned in twoTeamBattle.test.ts (Task 1):
+ *   - damage DEALT per attacker = ability-performed.damage summed by actorId
+ *   - damage TAKEN per victim   = perRoundPerTarget[round][victimId]
+ *   - heals = heal-performed { casterId, targets[], amount }
+ *   - death = ship-destroyed { actorId }
+ *   - buffs = buff-applied / buff-expired / debuff-applied
+ *   - hpPct = maxHp - cumulative(damageTaken) over rounds <= r
+ */
+import { describe, it, expect } from 'vitest';
+import { assembleBattleResult } from '../battleSimulator';
+import type { CombatEvent } from '../../combat/events';
+import type { Position } from '../../../types/encounters';
+
+const roster = (): Array<{
+    actorId: string;
+    side: 'player' | 'enemy';
+    name: string;
+    position: Position;
+    maxHp: number;
+}> => [
+    { actorId: 'attacker', side: 'player', name: 'Focus', position: 'M4', maxHp: 10000 },
+    { actorId: 'player-team', side: 'player', name: 'Team', position: 'M3', maxHp: 10000 },
+    { actorId: 'enemy-front', side: 'enemy', name: 'EnemyFront', position: 'M4', maxHp: 10000 },
+    { actorId: 'enemy-back', side: 'enemy', name: 'EnemyBack', position: 'M1', maxHp: 10000 },
+];
+
+const find = (result: ReturnType<typeof assembleBattleResult>, round: number, actorId: string) =>
+    result.rounds.find((r) => r.round === round)!.ships.find((s) => s.actorId === actorId)!;
+
+describe('assembleBattleResult — symmetric damage dealt/taken', () => {
+    it('credits ability-performed.damage to the attacker (dealt) both directions', () => {
+        const events: CombatEvent[] = [
+            {
+                type: 'ability-performed',
+                actorId: 'attacker',
+                targetId: 'enemy-front',
+                round: 1,
+                abilityType: 'damage',
+                damage: 5000,
+            },
+            {
+                type: 'ability-performed',
+                actorId: 'enemy-front',
+                targetId: 'attacker',
+                round: 1,
+                abilityType: 'damage',
+                damage: 3000,
+            },
+        ];
+        const perRoundPerTarget = { 1: { 'enemy-front': 5000, attacker: 3000 } };
+        const result = assembleBattleResult({
+            events,
+            perRoundPerTarget,
+            roster: roster(),
+            numRounds: 1,
+        });
+
+        expect(find(result, 1, 'attacker').damageDealt).toBe(5000);
+        expect(find(result, 1, 'attacker').damageTaken).toBe(3000);
+        expect(find(result, 1, 'enemy-front').damageDealt).toBe(3000);
+        expect(find(result, 1, 'enemy-front').damageTaken).toBe(5000);
+    });
+
+    it('sums multiple ability-performed for the same attacker in a round', () => {
+        const events: CombatEvent[] = [
+            {
+                type: 'ability-performed',
+                actorId: 'attacker',
+                targetId: 'enemy-front',
+                round: 1,
+                abilityType: 'damage',
+                damage: 1000,
+            },
+            {
+                type: 'ability-performed',
+                actorId: 'attacker',
+                targetId: 'enemy-back',
+                round: 1,
+                abilityType: 'damage',
+                damage: 1500,
+            },
+        ];
+        const result = assembleBattleResult({
+            events,
+            perRoundPerTarget: {},
+            roster: roster(),
+            numRounds: 1,
+        });
+        expect(find(result, 1, 'attacker').damageDealt).toBe(2500);
+    });
+});
+
+describe('assembleBattleResult — hpPct from cumulative taken', () => {
+    it('derives hpPct from maxHp minus cumulative damage taken', () => {
+        const perRoundPerTarget = {
+            1: { attacker: 3000 },
+            2: { attacker: 2000 },
+        };
+        const result = assembleBattleResult({
+            events: [],
+            perRoundPerTarget,
+            roster: roster(),
+            numRounds: 2,
+        });
+        // round 1: 3000 of 10000 taken => 70%
+        expect(find(result, 1, 'attacker').hpPct).toBe(70);
+        // round 2: cumulative 5000 of 10000 => 50%
+        expect(find(result, 2, 'attacker').hpPct).toBe(50);
+        // untouched actor stays at 100
+        expect(find(result, 1, 'player-team').hpPct).toBe(100);
+    });
+
+    it('clamps hpPct to 0 when cumulative taken exceeds maxHp', () => {
+        const perRoundPerTarget = { 1: { attacker: 99999 } };
+        const result = assembleBattleResult({
+            events: [],
+            perRoundPerTarget,
+            roster: roster(),
+            numRounds: 1,
+        });
+        expect(find(result, 1, 'attacker').hpPct).toBe(0);
+    });
+});
+
+describe('assembleBattleResult — heals', () => {
+    it('credits healingDone to caster (full amount) and splits received across targets', () => {
+        const events: CombatEvent[] = [
+            {
+                type: 'heal-performed',
+                casterId: 'attacker',
+                targets: ['attacker', 'player-team'],
+                round: 1,
+                amount: 4000,
+            },
+        ];
+        const result = assembleBattleResult({
+            events,
+            perRoundPerTarget: {},
+            roster: roster(),
+            numRounds: 1,
+        });
+        expect(find(result, 1, 'attacker').healingDone).toBe(4000);
+        // 4000 split evenly across 2 recipients => 2000 each (approximation: no per-recipient breakdown)
+        expect(find(result, 1, 'attacker').healingReceived).toBe(2000);
+        expect(find(result, 1, 'player-team').healingReceived).toBe(2000);
+        expect(find(result, 1, 'attacker').shieldsAbsorbed).toBe(0);
+    });
+});
+
+describe('assembleBattleResult — death + outcome + trim', () => {
+    it('marks actor dead from the destroy round onward and wipes side -> winner + trim', () => {
+        const events: CombatEvent[] = [
+            { type: 'ship-destroyed', actorId: 'enemy-front', round: 2 },
+            { type: 'ship-destroyed', actorId: 'enemy-back', round: 2 },
+        ];
+        const result = assembleBattleResult({
+            events,
+            perRoundPerTarget: {},
+            roster: roster(),
+            numRounds: 4,
+        });
+        expect(find(result, 1, 'enemy-front').alive).toBe(true);
+        expect(find(result, 2, 'enemy-front').alive).toBe(false);
+        expect(result.outcome.winner).toBe('player');
+        expect(result.outcome.lastRound).toBe(2);
+        // trimmed: no rounds after lastRound
+        expect(result.rounds.map((r) => r.round)).toEqual([1, 2]);
+    });
+
+    it('returns draw at numRounds when neither side fully wiped', () => {
+        const events: CombatEvent[] = [
+            { type: 'ship-destroyed', actorId: 'enemy-front', round: 2 },
+        ];
+        const result = assembleBattleResult({
+            events,
+            perRoundPerTarget: {},
+            roster: roster(),
+            numRounds: 3,
+        });
+        expect(result.outcome.winner).toBe('draw');
+        expect(result.outcome.lastRound).toBe(3);
+        expect(result.rounds.map((r) => r.round)).toEqual([1, 2, 3]);
+    });
+});
+
+describe('assembleBattleResult — buff tracking', () => {
+    it('tracks activeBuffs / activeDebuffs membership across rounds', () => {
+        const events: CombatEvent[] = [
+            {
+                type: 'buff-applied',
+                actorId: 'attacker',
+                round: 1,
+                buffName: 'Inc. ATK',
+                duration: 2,
+            },
+            {
+                type: 'debuff-applied',
+                sourceId: 'attacker',
+                targetId: 'enemy-front',
+                round: 1,
+                buffName: 'Defense Shred',
+            },
+            { type: 'buff-expired', actorId: 'attacker', round: 2, buffName: 'Inc. ATK' },
+        ];
+        const result = assembleBattleResult({
+            events,
+            perRoundPerTarget: {},
+            roster: roster(),
+            numRounds: 3,
+        });
+        // round 1: attacker has buff, enemy-front has debuff
+        expect(find(result, 1, 'attacker').activeBuffs).toContain('Inc. ATK');
+        expect(find(result, 1, 'enemy-front').activeDebuffs).toContain('Defense Shred');
+        // round 2: buff expired
+        expect(find(result, 2, 'attacker').activeBuffs).not.toContain('Inc. ATK');
+        // debuff persists (no expiry event)
+        expect(find(result, 2, 'enemy-front').activeDebuffs).toContain('Defense Shred');
+    });
+});
+
+describe('assembleBattleResult — per-round event log', () => {
+    it('logs damage, heal, death lines (not attacked)', () => {
+        const events: CombatEvent[] = [
+            {
+                type: 'ability-performed',
+                actorId: 'attacker',
+                targetId: 'enemy-front',
+                round: 1,
+                abilityType: 'damage',
+                damage: 5000,
+            },
+            { type: 'attacked', attackerId: 'enemy-front', targetId: 'attacker', round: 1 },
+            {
+                type: 'heal-performed',
+                casterId: 'attacker',
+                targets: ['attacker'],
+                round: 1,
+                amount: 1000,
+            },
+            { type: 'ship-destroyed', actorId: 'enemy-front', round: 1 },
+        ];
+        const result = assembleBattleResult({
+            events,
+            perRoundPerTarget: {},
+            roster: roster(),
+            numRounds: 1,
+        });
+        const log = result.rounds[0].events;
+        expect(log).toContainEqual({
+            round: 1,
+            kind: 'damage',
+            actorId: 'attacker',
+            targetId: 'enemy-front',
+            amount: 5000,
+        });
+        expect(log).toContainEqual({
+            round: 1,
+            kind: 'heal',
+            actorId: 'attacker',
+            targetId: 'attacker',
+            amount: 1000,
+        });
+        expect(log).toContainEqual({ round: 1, kind: 'death', actorId: 'enemy-front' });
+        // `attacked` is NOT logged (no amount)
+        expect(log.some((e) => (e as { kind: string }).kind === 'attacked')).toBe(false);
+    });
+});
+
+describe('assembleBattleResult — roster passthrough', () => {
+    it('returns the roster without maxHp', () => {
+        const result = assembleBattleResult({
+            events: [],
+            perRoundPerTarget: {},
+            roster: roster(),
+            numRounds: 1,
+        });
+        expect(result.roster).toEqual([
+            { actorId: 'attacker', side: 'player', name: 'Focus', position: 'M4' },
+            { actorId: 'player-team', side: 'player', name: 'Team', position: 'M3' },
+            { actorId: 'enemy-front', side: 'enemy', name: 'EnemyFront', position: 'M4' },
+            { actorId: 'enemy-back', side: 'enemy', name: 'EnemyBack', position: 'M1' },
+        ]);
+    });
+});

--- a/src/utils/calculators/battleSimulator.ts
+++ b/src/utils/calculators/battleSimulator.ts
@@ -87,6 +87,20 @@ interface RosterEntry {
 const clampPct = (value: number): number => Math.max(0, Math.min(100, value));
 
 /**
+ * The CombatEvent types `assembleBattleResult` actually consumes. The `simulateBattle`
+ * adapter subscribes its event bus from THIS list, so adding a consumed event type here
+ * can't silently leave the adapter unsubscribed (the two would otherwise drift apart).
+ */
+export const ASSEMBLED_EVENT_TYPES = [
+    'ability-performed',
+    'heal-performed',
+    'ship-destroyed',
+    'buff-applied',
+    'buff-expired',
+    'debuff-applied',
+] as const satisfies readonly CombatEvent['type'][];
+
+/**
  * Precondition: expects BOTH sides of `roster` to be non-empty. The wipe checks guard
  * against empty sides (a side with zero members is never treated as "wiped"), so a
  * degenerate single-side roster fails safe to `draw` at numRounds rather than awarding
@@ -275,10 +289,17 @@ export function assembleBattleResult(args: {
 /** A ship placed on the board for a battle: the ship (skills + base stats +
  *  affinity + raw targeting strings), optional combat-stat overrides (fully derived
  *  stats from the page in PR2; falls back to the ship's baseStats here), and its grid
- *  position (drives the positional combat path on both sides). */
+ *  position (drives the positional combat path on both sides).
+ *
+ *  WARNING: with no `statOverrides` this resolves to UN-GEARED base stats → combat
+ *  results are MEANINGLESS (no gear/refits/engineering). `statOverrides` is kept
+ *  optional only for test ergonomics. PR2's page MUST pass fully gear/refit/engineering-
+ *  resolved stats (including `speed`) via `statOverrides`. */
 export interface BattlePlacement {
     ship: Ship;
-    statOverrides?: Partial<CombatStatBlock>;
+    /** Fully-derived combat stats (gear + refits + engineering). `speed` drives turn order.
+     *  See the WARNING on `BattlePlacement`: omitting this yields un-geared base stats. */
+    statOverrides?: Partial<CombatStatBlock & { speed: number }>;
     position: Position;
 }
 
@@ -290,8 +311,12 @@ export interface BattleSimulationInput {
 }
 
 /** The combat stats simulateBattle resolves per placement. Derived from the ship's
- *  baseStats, then `statOverrides` win field-by-field. The page (PR2) passes fully
- *  gear/refit/engineering-resolved stats via `statOverrides`. */
+ *  baseStats, then `statOverrides` win field-by-field. `speed` drives turn order on
+ *  both sides (focus, walked team actors, enemy attackers).
+ *
+ *  WARNING: with no `statOverrides`, `resolveStats` resolves to UN-GEARED base stats →
+ *  combat results are MEANINGLESS (no gear/refits/engineering). PR2's page MUST pass
+ *  fully gear/refit/engineering-resolved stats via `statOverrides`. */
 interface DerivedCombatStats {
     attack: number;
     crit: number;
@@ -300,10 +325,16 @@ interface DerivedCombatStats {
     hacking: number;
     defence: number;
     hp: number;
+    /** Turn-order speed. Defaults to baseStats.speed ?? 100. */
+    speed: number;
 }
 
 /** Resolve a placement's combat stats: ship.baseStats as the floor (with the page's
- *  magic defaults — hacking ?? 200), then `statOverrides` applied field-by-field. */
+ *  magic defaults — hacking ?? 200, speed ?? 100), then `statOverrides` applied
+ *  field-by-field.
+ *
+ *  WARNING: with no `statOverrides` this returns UN-GEARED base stats → combat results
+ *  are MEANINGLESS. PR2's page MUST pass fully gear/refit/engineering-resolved stats. */
 function resolveStats(p: BattlePlacement): DerivedCombatStats {
     const b = p.ship.baseStats;
     const o = p.statOverrides ?? {};
@@ -315,6 +346,42 @@ function resolveStats(p: BattlePlacement): DerivedCombatStats {
         hacking: o.hacking ?? b.hacking ?? 200,
         defence: o.defence ?? b.defence ?? 0,
         hp: o.hp ?? b.hp ?? 0,
+        speed: o.speed ?? b.speed ?? 100,
+    };
+}
+
+/** Shape `DerivedCombatStats` into the walk bundle's `stats` (player team actors).
+ *  Centralized so a future stat addition can't be missed at one of the call sites. */
+function toWalkStats(
+    stats: DerivedCombatStats
+): Pick<
+    DerivedCombatStats,
+    'attack' | 'crit' | 'critDamage' | 'defensePenetration' | 'hacking' | 'defence' | 'hp' | 'speed'
+> {
+    return {
+        attack: stats.attack,
+        crit: stats.crit,
+        critDamage: stats.critDamage,
+        defensePenetration: stats.defensePenetration,
+        hacking: stats.hacking,
+        defence: stats.defence,
+        hp: stats.hp,
+        speed: stats.speed,
+    };
+}
+
+/** Shape `DerivedCombatStats` into the enemy attacker's `stats` bundle. Centralized so a
+ *  future stat addition can't be missed at one of the call sites. */
+function toEnemyStats(
+    stats: DerivedCombatStats
+): Pick<DerivedCombatStats, 'attack' | 'crit' | 'critDamage' | 'speed' | 'defence' | 'hp'> {
+    return {
+        attack: stats.attack,
+        crit: stats.crit,
+        critDamage: stats.critDamage,
+        speed: stats.speed,
+        defence: stats.defence,
+        hp: stats.hp,
     };
 }
 
@@ -328,7 +395,7 @@ interface PlacementPlan {
     shipSkills: ReturnType<typeof buildShipAbilities>;
     affinity: AffinityName | undefined;
     /** Parsed ACTIVE targeting ({ target, pattern }); undefined if the ship has no targeting data. */
-    target: SkillTargeting | undefined;
+    targeting: SkillTargeting | undefined;
     chargeCount: number;
 }
 
@@ -344,7 +411,7 @@ function planPlacement(p: BattlePlacement, id: string): PlacementPlan {
         stats: resolveStats(p),
         shipSkills: buildShipAbilities(p.ship),
         affinity: p.ship.affinity,
-        target: targeting.active,
+        targeting: targeting.active,
         chargeCount: p.ship.chargeSkillCharge ?? 0,
     };
 }
@@ -421,25 +488,17 @@ export function simulateBattle(input: BattleSimulationInput): BattleResult {
         const aff = computeAffinityModifiers(plan.affinity, enemyRepAffinity);
         return {
             id: plan.id,
-            speed: 100,
+            speed: plan.stats.speed,
             chargeCount: plan.chargeCount,
             startCharged: false,
             selfBuffs: [],
             enemyDebuffs: [],
             position: plan.position,
-            target: plan.target?.target,
-            pattern: plan.target?.pattern,
+            target: plan.targeting?.target,
+            pattern: plan.targeting?.pattern,
             walk: {
                 shipSkills: plan.shipSkills,
-                stats: {
-                    attack: plan.stats.attack,
-                    crit: plan.stats.crit,
-                    critDamage: plan.stats.critDamage,
-                    defensePenetration: plan.stats.defensePenetration,
-                    hacking: plan.stats.hacking,
-                    defence: plan.stats.defence,
-                    hp: plan.stats.hp,
-                },
+                stats: toWalkStats(plan.stats),
                 debuffLandingChance: landingChance(plan, aff, enemyRepSecurity),
                 selfDotModifier: 0,
                 defensePenetrationBuff: 0,
@@ -458,14 +517,7 @@ export function simulateBattle(input: BattleSimulationInput): BattleResult {
             const aff = computeAffinityModifiers(plan.affinity, playerRepAffinity);
             return {
                 id: plan.id,
-                stats: {
-                    attack: plan.stats.attack,
-                    crit: plan.stats.crit,
-                    critDamage: plan.stats.critDamage,
-                    speed: 100,
-                    defence: plan.stats.defence,
-                    hp: plan.stats.hp,
-                },
+                stats: toEnemyStats(plan.stats),
                 chargeCount: plan.chargeCount,
                 startCharged: false,
                 shipSkills: plan.shipSkills,
@@ -474,8 +526,8 @@ export function simulateBattle(input: BattleSimulationInput): BattleResult {
                 affinityCritPenalty: aff.critPenalty,
                 debuffLandingChance: landingChance(plan, aff, playerRepSecurity),
                 position: plan.position,
-                target: plan.target?.target,
-                pattern: plan.target?.pattern,
+                target: plan.targeting?.target,
+                pattern: plan.targeting?.pattern,
                 affinity: plan.affinity,
             };
         }
@@ -484,15 +536,8 @@ export function simulateBattle(input: BattleSimulationInput): BattleResult {
     // ----- Capture the event stream + run -----
     const bus = createEventBus();
     const events: CombatEvent[] = [];
-    const EVENT_TYPES: CombatEvent['type'][] = [
-        'ability-performed',
-        'heal-performed',
-        'ship-destroyed',
-        'buff-applied',
-        'buff-expired',
-        'debuff-applied',
-    ];
-    for (const t of EVENT_TYPES) {
+    // Subscribe exactly the events the assembler consumes (shared list — can't drift).
+    for (const t of ASSEMBLED_EVENT_TYPES) {
         bus.on(t, (e) => events.push(e as CombatEvent));
     }
 
@@ -521,9 +566,10 @@ export function simulateBattle(input: BattleSimulationInput): BattleResult {
         affinity: focus.affinity,
         defence: focus.stats.defence,
         hp: focus.stats.hp,
+        speed: focus.stats.speed,
         position: focus.position,
-        target: focus.target?.target,
-        pattern: focus.target?.pattern,
+        target: focus.targeting?.target,
+        pattern: focus.targeting?.pattern,
         // VESTIGIAL: enemyAttackers only populate (and enemies only fire on players) when
         // healTargetId is set — the engine throws otherwise. Point it at the focus player id.
         healTargetId: focus.id,

--- a/src/utils/calculators/battleSimulator.ts
+++ b/src/utils/calculators/battleSimulator.ts
@@ -1,0 +1,241 @@
+/**
+ * Combat Simulator Phase 5 — PR 1, Task 2: symmetric battle-result types + a PURE
+ * event-driven assembler.
+ *
+ * `assembleBattleResult` takes the raw combat event stream + per-round per-victim damage
+ * map + a roster (all as plain data) and produces a symmetric, render-ready BattleResult.
+ * It has NO engine dependency and NO side effects — it only imports the CombatEvent union
+ * (combat/events) and the Position type (types/encounters).
+ *
+ * Data-source contract (pinned in combat/__tests__/twoTeamBattle.test.ts, Task 1):
+ *   - damage DEALT per attacker = `ability-performed.damage` summed by `actorId`.
+ *   - damage TAKEN per victim   = `perRoundPerTarget[round][victimId]` (the reliable,
+ *     symmetric source for BOTH sides; we do NOT use `hp-changed`).
+ *   - heals = `heal-performed` { casterId, targets[], amount } (healing mode only).
+ *   - death = `ship-destroyed` { actorId }.
+ *   - buffs = `buff-applied` / `buff-expired` / `debuff-applied`.
+ *
+ * HP% is derived as maxHp - cumulative(damageTaken over rounds <= r), uniform for both
+ * sides (ignores healing/shields on the HP curve — acceptable for PR1's surface).
+ *
+ * `simulateBattle` (the runCombat wrapper that produces these inputs) is Task 3 — NOT here.
+ */
+import type { CombatEvent } from '../combat/events';
+import type { Position } from '../../types/encounters';
+
+export interface ShipRoundState {
+    actorId: string;
+    side: 'player' | 'enemy';
+    damageDealt: number;
+    damageTaken: number;
+    healingDone: number;
+    healingReceived: number;
+    /**
+     * Shield absorption. The `heal-performed` payload carries no shield channel flag
+     * (just { casterId, targets[], amount }), so this is always 0 for PR1.
+     */
+    shieldsAbsorbed: number;
+    /** End-of-round HP%, from maxHp - cumulative damageTaken. */
+    hpPct: number;
+    alive: boolean;
+    activeBuffs: string[];
+    activeDebuffs: string[];
+}
+
+export interface BattleLogEvent {
+    round: number;
+    kind: 'damage' | 'heal' | 'death';
+    actorId: string;
+    targetId?: string;
+    amount?: number;
+}
+
+export interface BattleRound {
+    round: number;
+    ships: ShipRoundState[];
+    events: BattleLogEvent[];
+}
+
+export interface BattleResult {
+    /** Trimmed at termination (no rounds after outcome.lastRound). */
+    rounds: BattleRound[];
+    outcome: { winner: 'player' | 'enemy' | 'draw'; lastRound: number };
+    roster: Array<{ actorId: string; side: 'player' | 'enemy'; name: string; position: Position }>;
+}
+
+interface RosterEntry {
+    actorId: string;
+    side: 'player' | 'enemy';
+    name: string;
+    position: Position;
+    maxHp: number;
+}
+
+const clampPct = (value: number): number => Math.max(0, Math.min(100, value));
+
+export function assembleBattleResult(args: {
+    events: CombatEvent[];
+    perRoundPerTarget: Record<number, Record<string, number>>;
+    roster: RosterEntry[];
+    numRounds: number;
+}): BattleResult {
+    const { events, perRoundPerTarget, roster, numRounds } = args;
+
+    // Round of first destruction per actor (earliest ship-destroyed).
+    const destroyedAt = new Map<string, number>();
+    for (const e of events) {
+        if (e.type === 'ship-destroyed') {
+            const prev = destroyedAt.get(e.actorId);
+            if (prev === undefined || e.round < prev) destroyedAt.set(e.actorId, e.round);
+        }
+    }
+
+    // Running buff/debuff sets per actor, mutated as we walk rounds in order.
+    const activeBuffs = new Map<string, Set<string>>();
+    const activeDebuffs = new Map<string, Set<string>>();
+    const ensure = (map: Map<string, Set<string>>, id: string): Set<string> => {
+        let set = map.get(id);
+        if (!set) {
+            set = new Set<string>();
+            map.set(id, set);
+        }
+        return set;
+    };
+
+    // Cumulative damage taken per actor across rounds (for HP% derivation).
+    const cumulativeTaken = new Map<string, number>();
+
+    const rounds: BattleRound[] = [];
+    let lastRound = numRounds;
+    let winner: 'player' | 'enemy' | 'draw' = 'draw';
+
+    for (let round = 1; round <= numRounds; round++) {
+        const roundEvents = events.filter((e) => 'round' in e && e.round === round);
+
+        // Buff/debuff transitions for this round (apply before snapshotting the round).
+        for (const e of roundEvents) {
+            if (e.type === 'buff-applied') {
+                ensure(activeBuffs, e.actorId).add(e.buffName);
+            } else if (e.type === 'buff-expired') {
+                activeBuffs.get(e.actorId)?.delete(e.buffName);
+            } else if (e.type === 'debuff-applied') {
+                ensure(activeDebuffs, e.targetId).add(e.buffName);
+            }
+        }
+
+        // Damage dealt per attacker this round (ability-performed.damage by actorId).
+        const dealt = new Map<string, number>();
+        for (const e of roundEvents) {
+            if (e.type === 'ability-performed' && typeof e.damage === 'number') {
+                dealt.set(e.actorId, (dealt.get(e.actorId) ?? 0) + e.damage);
+            }
+        }
+
+        // Healing done (caster, full amount) + received (split evenly across targets —
+        // approximation: heal-performed carries no per-recipient breakdown).
+        const healDone = new Map<string, number>();
+        const healReceived = new Map<string, number>();
+        for (const e of roundEvents) {
+            if (e.type === 'heal-performed') {
+                healDone.set(e.casterId, (healDone.get(e.casterId) ?? 0) + e.amount);
+                const per = e.targets.length > 0 ? e.amount / e.targets.length : 0;
+                for (const tid of e.targets) {
+                    healReceived.set(tid, (healReceived.get(tid) ?? 0) + per);
+                }
+            }
+        }
+
+        // Accumulate this round's per-victim taken damage into the running cumulative.
+        const takenThisRound = perRoundPerTarget[round] ?? {};
+
+        const ships: ShipRoundState[] = roster.map((entry) => {
+            const taken = takenThisRound[entry.actorId] ?? 0;
+            const cumulative = (cumulativeTaken.get(entry.actorId) ?? 0) + taken;
+            cumulativeTaken.set(entry.actorId, cumulative);
+
+            const destroyRound = destroyedAt.get(entry.actorId);
+            const alive = destroyRound === undefined || round < destroyRound;
+
+            return {
+                actorId: entry.actorId,
+                side: entry.side,
+                damageDealt: dealt.get(entry.actorId) ?? 0,
+                damageTaken: taken,
+                healingDone: healDone.get(entry.actorId) ?? 0,
+                healingReceived: healReceived.get(entry.actorId) ?? 0,
+                shieldsAbsorbed: 0,
+                hpPct: clampPct((100 * (entry.maxHp - cumulative)) / entry.maxHp),
+                alive,
+                activeBuffs: [...(activeBuffs.get(entry.actorId) ?? [])],
+                activeDebuffs: [...(activeDebuffs.get(entry.actorId) ?? [])],
+            };
+        });
+
+        // Readable per-round log: damage (ability-performed), heal (heal-performed),
+        // death (ship-destroyed). NOT `attacked` (no amount).
+        const log: BattleLogEvent[] = [];
+        for (const e of roundEvents) {
+            if (e.type === 'ability-performed' && typeof e.damage === 'number') {
+                log.push({
+                    round,
+                    kind: 'damage',
+                    actorId: e.actorId,
+                    targetId: e.targetId,
+                    amount: e.damage,
+                });
+            } else if (e.type === 'heal-performed') {
+                for (const tid of e.targets) {
+                    log.push({
+                        round,
+                        kind: 'heal',
+                        actorId: e.casterId,
+                        targetId: tid,
+                        amount: e.targets.length > 0 ? e.amount / e.targets.length : e.amount,
+                    });
+                }
+                if (e.targets.length === 0) {
+                    log.push({ round, kind: 'heal', actorId: e.casterId, amount: e.amount });
+                }
+            } else if (e.type === 'ship-destroyed') {
+                log.push({ round, kind: 'death', actorId: e.actorId });
+            }
+        }
+
+        rounds.push({ round, ships, events: log });
+
+        // Termination: first round where ALL of one side's actors are destroyed.
+        const playerWiped = roster
+            .filter((r) => r.side === 'player')
+            .every((r) => {
+                const d = destroyedAt.get(r.actorId);
+                return d !== undefined && d <= round;
+            });
+        const enemyWiped = roster
+            .filter((r) => r.side === 'enemy')
+            .every((r) => {
+                const d = destroyedAt.get(r.actorId);
+                return d !== undefined && d <= round;
+            });
+
+        if (playerWiped || enemyWiped) {
+            lastRound = round;
+            // If both wiped in the same round, treat as a draw.
+            winner = playerWiped && enemyWiped ? 'draw' : playerWiped ? 'enemy' : 'player';
+            break;
+        }
+    }
+
+    // Trim any rounds after termination (break already stops appending, but guard anyway).
+    const trimmed = rounds.filter((r) => r.round <= lastRound);
+
+    return {
+        rounds: trimmed,
+        outcome: { winner, lastRound },
+        roster: roster.map(({ actorId, side, name, position }) => ({
+            actorId,
+            side,
+            name,
+            position,
+        })),
+    };
+}

--- a/src/utils/calculators/battleSimulator.ts
+++ b/src/utils/calculators/battleSimulator.ts
@@ -466,7 +466,18 @@ function planPlacement(p: BattlePlacement, id: string): PlacementPlan {
  * avoiding the reserved `'attacker'`/`'enemy'` ids and any duplicate (runCombat throws on either).
  */
 export function simulateBattle(input: BattleSimulationInput): BattleResult {
+    // Validate inputs up front (trust boundary): empty teams or a bad round count
+    // would otherwise flow through and produce misleading draw/empty outcomes.
+    if (input.playerTeam.length === 0) {
+        throw new Error('simulateBattle: playerTeam is empty');
+    }
+    if (input.enemyTeam.length === 0) {
+        throw new Error('simulateBattle: enemyTeam is empty');
+    }
     const numRounds = input.rounds ?? 30;
+    if (input.rounds !== undefined && (!Number.isInteger(numRounds) || numRounds < 1)) {
+        throw new Error('simulateBattle: rounds must be a positive integer');
+    }
 
     // The engine's focus actor is ALWAYS the reserved id `'attacker'` (its damage/per-victim
     // rows key off it), so player[0] must carry that id — minting `p:...` for it and pointing

--- a/src/utils/calculators/battleSimulator.ts
+++ b/src/utils/calculators/battleSimulator.ts
@@ -39,9 +39,26 @@ import { computeAffinityModifiers } from './affinityUtils';
 export interface ShipRoundState {
     actorId: string;
     side: 'player' | 'enemy';
+    /**
+     * Attacker's per-turn aggregate (`ability-performed.damage` by `actorId`, anchor full).
+     * Uses a DIFFERENT base from `damageTaken` (which is per-victim from `perTargetDamage`,
+     * AoE origin full / covered half), so they are NOT expected to reconcile: under AoE,
+     * `Σ damageDealt ≠ Σ damageTaken` — by design. (Per-hit/per-victim event fidelity is a
+     * deferred follow-up.)
+     */
     damageDealt: number;
+    /**
+     * Per-victim damage from `perRoundPerTarget[round][victimId]` (AoE origin full / covered
+     * half). Uses a DIFFERENT base from `damageDealt` (the attacker's per-turn aggregate), so
+     * the two do NOT reconcile under AoE — see `damageDealt`.
+     */
     damageTaken: number;
     healingDone: number;
+    /**
+     * Heal `amount` split EVENLY across the heal's targets — the `heal-performed` event
+     * carries no per-recipient breakdown, so this is an approximation (not a true per-recipient
+     * amount).
+     */
     healingReceived: number;
     /**
      * Shield absorption. The `heal-performed` payload carries no shield channel flag
@@ -52,6 +69,12 @@ export interface ShipRoundState {
     hpPct: number;
     alive: boolean;
     activeBuffs: string[];
+    /**
+     * Infliction-only: there is no `debuff-expired` event in the stream, so once a debuff is
+     * added it accumulates and persists for the rest of the battle. This is asymmetric with
+     * `activeBuffs`, which DOES expire via `buff-expired`. Consumers should not expect debuffs
+     * to clear over time.
+     */
     activeDebuffs: string[];
 }
 
@@ -197,7 +220,10 @@ export function assembleBattleResult(args: {
                 healingDone: healDone.get(entry.actorId) ?? 0,
                 healingReceived: healReceived.get(entry.actorId) ?? 0,
                 shieldsAbsorbed: 0,
-                hpPct: clampPct((100 * (entry.maxHp - cumulative)) / entry.maxHp),
+                hpPct:
+                    entry.maxHp > 0
+                        ? clampPct((100 * (entry.maxHp - cumulative)) / entry.maxHp)
+                        : 0,
                 alive,
                 activeBuffs: [...(activeBuffs.get(entry.actorId) ?? [])],
                 activeDebuffs: [...(activeDebuffs.get(entry.actorId) ?? [])],

--- a/src/utils/calculators/battleSimulator.ts
+++ b/src/utils/calculators/battleSimulator.ts
@@ -18,6 +18,11 @@
  * HP% is derived as maxHp - cumulative(damageTaken over rounds <= r), uniform for both
  * sides (ignores healing/shields on the HP curve — acceptable for PR1's surface).
  *
+ * Debuff persistence: `activeDebuffs` is infliction-only — there is no `debuff-expired`
+ * event in the stream, so once a debuff is added it accumulates and persists for the rest
+ * of the battle. This is asymmetric with `activeBuffs`, which DOES expire via `buff-expired`.
+ * A PR2 consumer should not expect debuffs to clear over time.
+ *
  * `simulateBattle` (the runCombat wrapper that produces these inputs) is Task 3 — NOT here.
  */
 import type { CombatEvent } from '../combat/events';
@@ -73,6 +78,12 @@ interface RosterEntry {
 
 const clampPct = (value: number): number => Math.max(0, Math.min(100, value));
 
+/**
+ * Precondition: expects BOTH sides of `roster` to be non-empty. The wipe checks guard
+ * against empty sides (a side with zero members is never treated as "wiped"), so a
+ * degenerate single-side roster fails safe to `draw` at numRounds rather than awarding
+ * a spurious winner at round 1.
+ */
 export function assembleBattleResult(args: {
     events: CombatEvent[];
     perRoundPerTarget: Record<number, Record<string, number>>;
@@ -194,6 +205,10 @@ export function assembleBattleResult(args: {
                     });
                 }
                 if (e.targets.length === 0) {
+                    // Divergence from the aggregation site above: that splits `amount`
+                    // across targets, so an empty-targets heal credits nobody's
+                    // healingReceived. Here the log instead surfaces a single full-amount
+                    // line so the heal is still visible in the per-round log.
                     log.push({ round, kind: 'heal', actorId: e.casterId, amount: e.amount });
                 }
             } else if (e.type === 'ship-destroyed') {
@@ -204,18 +219,21 @@ export function assembleBattleResult(args: {
         rounds.push({ round, ships, events: log });
 
         // Termination: first round where ALL of one side's actors are destroyed.
-        const playerWiped = roster
-            .filter((r) => r.side === 'player')
-            .every((r) => {
-                const d = destroyedAt.get(r.actorId);
-                return d !== undefined && d <= round;
-            });
-        const enemyWiped = roster
-            .filter((r) => r.side === 'enemy')
-            .every((r) => {
-                const d = destroyedAt.get(r.actorId);
-                return d !== undefined && d <= round;
-            });
+        // A side counts as wiped only if it has >=1 member AND all are destroyed —
+        // an empty side ([].every(...) === true) must NOT be treated as wiped, or a
+        // degenerate single-side roster would award a spurious winner at round 1.
+        const isWiped = (side: 'player' | 'enemy'): boolean => {
+            const members = roster.filter((r) => r.side === side);
+            return (
+                members.length > 0 &&
+                members.every((r) => {
+                    const d = destroyedAt.get(r.actorId);
+                    return d !== undefined && d <= round;
+                })
+            );
+        };
+        const playerWiped = isWiped('player');
+        const enemyWiped = isWiped('enemy');
 
         if (playerWiped || enemyWiped) {
             lastRound = round;

--- a/src/utils/calculators/battleSimulator.ts
+++ b/src/utils/calculators/battleSimulator.ts
@@ -27,6 +27,14 @@
  */
 import type { CombatEvent } from '../combat/events';
 import type { Position } from '../../types/encounters';
+import type { Ship, AffinityName } from '../../types/ship';
+import type { CombatStatBlock } from '../../types/calculator';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../combat/engine';
+import { createEventBus } from '../combat/events';
+import { buildShipAbilities } from '../abilities/buildShipAbilities';
+import { selectFiringSkill } from '../abilities/applyAbilities';
+import { parseShipTargeting, SkillTargeting } from '../targetingParser';
+import { computeAffinityModifiers } from './affinityUtils';
 
 export interface ShipRoundState {
     actorId: string;
@@ -256,4 +264,298 @@ export function assembleBattleResult(args: {
             position,
         })),
     };
+}
+
+// ===========================================================================
+// Task 3: `simulateBattle` — the runCombat wrapper that turns two positioned
+// squads into the symmetric BattleResult above. New caller only (no engine
+// change) — goldens stay byte-identical.
+// ===========================================================================
+
+/** A ship placed on the board for a battle: the ship (skills + base stats +
+ *  affinity + raw targeting strings), optional combat-stat overrides (fully derived
+ *  stats from the page in PR2; falls back to the ship's baseStats here), and its grid
+ *  position (drives the positional combat path on both sides). */
+export interface BattlePlacement {
+    ship: Ship;
+    statOverrides?: Partial<CombatStatBlock>;
+    position: Position;
+}
+
+export interface BattleSimulationInput {
+    playerTeam: BattlePlacement[];
+    enemyTeam: BattlePlacement[];
+    /** Fixed round cap. Default 30. The result is trimmed at the first wipe. */
+    rounds?: number;
+}
+
+/** The combat stats simulateBattle resolves per placement. Derived from the ship's
+ *  baseStats, then `statOverrides` win field-by-field. The page (PR2) passes fully
+ *  gear/refit/engineering-resolved stats via `statOverrides`. */
+interface DerivedCombatStats {
+    attack: number;
+    crit: number;
+    critDamage: number;
+    defensePenetration: number;
+    hacking: number;
+    defence: number;
+    hp: number;
+}
+
+/** Resolve a placement's combat stats: ship.baseStats as the floor (with the page's
+ *  magic defaults — hacking ?? 200), then `statOverrides` applied field-by-field. */
+function resolveStats(p: BattlePlacement): DerivedCombatStats {
+    const b = p.ship.baseStats;
+    const o = p.statOverrides ?? {};
+    return {
+        attack: o.attack ?? b.attack ?? 0,
+        crit: o.crit ?? b.crit ?? 0,
+        critDamage: o.critDamage ?? b.critDamage ?? 0,
+        defensePenetration: o.defensePenetration ?? b.defensePenetration ?? 0,
+        hacking: o.hacking ?? b.hacking ?? 200,
+        defence: o.defence ?? b.defence ?? 0,
+        hp: o.hp ?? b.hp ?? 0,
+    };
+}
+
+/** Per-placement plan: its minted actor id, derived stats, ship skills, affinity,
+ *  parsed active targeting, charge threshold, and its display name for the roster. */
+interface PlacementPlan {
+    id: string;
+    name: string;
+    position: Position;
+    stats: DerivedCombatStats;
+    shipSkills: ReturnType<typeof buildShipAbilities>;
+    affinity: AffinityName | undefined;
+    /** Parsed ACTIVE targeting ({ target, pattern }); undefined if the ship has no targeting data. */
+    target: SkillTargeting | undefined;
+    chargeCount: number;
+}
+
+function planPlacement(p: BattlePlacement, id: string): PlacementPlan {
+    const targeting = parseShipTargeting(p.ship);
+    // Use the ACTIVE targeting (target + pattern). The engine input takes ONE target/pattern
+    // per actor, so charged-skill targeting is a follow-up (PR2) — when a ship's charged
+    // skill targets differently the active selection is used for every turn here.
+    return {
+        id,
+        name: p.ship.name,
+        position: p.position,
+        stats: resolveStats(p),
+        shipSkills: buildShipAbilities(p.ship),
+        affinity: p.ship.affinity,
+        target: targeting.active,
+        chargeCount: p.ship.chargeSkillCharge ?? 0,
+    };
+}
+
+/**
+ * Thin adapter over the combat engine: positions two squads, runs a fixed-round mutual
+ * battle through `runCombat`, and assembles the symmetric `BattleResult` from the event
+ * stream + per-round per-victim damage.
+ *
+ * Side mapping (mirrors how the DPS/healing adapters feed the engine):
+ *   - player[0]  → the focus `attacker` (its stats/position/target/pattern ride the top-level input).
+ *   - player[1+] → `teamActors`, each with a `walk` bundle (own stats + skills + affinity-resolved
+ *                  rates), position, target, pattern.
+ *   - enemyTeam  → `enemyAttackers`, each with stats + shipSkills + position/target/pattern.
+ *
+ * `healTargetId` is set to the focus player actor's id as a VESTIGIAL workaround: the engine only
+ * builds the positioned enemy roster (and lets enemies fire on players) when `healTargetId` is set
+ * — it throws otherwise. The battle is driven by positions on both sides, not by the heal pipeline,
+ * which stays inert beyond unlocking the enemy roster.
+ *
+ * Affinity: each actor's matchup is resolved against the FIRST opposing placement's affinity (the
+ * single-opponent-affinity convention the DPS/healing adapters already use). The RAW affinity is
+ * also threaded so the engine's positional path and the pre-resolved modifiers never disagree.
+ *
+ * Actor ids are minted globally-unique across both squads (`p:<shipId>:<idx>` / `e:<shipId>:<idx>`),
+ * avoiding the reserved `'attacker'`/`'enemy'` ids and any duplicate (runCombat throws on either).
+ */
+export function simulateBattle(input: BattleSimulationInput): BattleResult {
+    const numRounds = input.rounds ?? 30;
+
+    // The engine's focus actor is ALWAYS the reserved id `'attacker'` (its damage/per-victim
+    // rows key off it), so player[0] must carry that id — minting `p:...` for it and pointing
+    // healTargetId there fails the engine's "is a player actor" check. The REST of the player
+    // team + every enemy get minted globally-unique ids that avoid `'attacker'`/`'enemy'`.
+    const FOCUS_ID = 'attacker';
+    const playerPlans = input.playerTeam.map((p, i) =>
+        planPlacement(p, i === 0 ? FOCUS_ID : `p:${p.ship.id}:${i}`)
+    );
+    const enemyPlans = input.enemyTeam.map((p, i) => planPlacement(p, `e:${p.ship.id}:${i}`));
+
+    // Representative opposing affinity for each side's matchup resolution (first opponent).
+    const enemyRepAffinity = enemyPlans[0]?.affinity;
+    const playerRepAffinity = playerPlans[0]?.affinity;
+
+    // Landing chance from an actor's hacking vs the opposing security. baseStats carry a
+    // `security` field; the enemy/player representative security drives the clamp. Default 100.
+    const enemyRepSecurity = input.enemyTeam[0]?.ship.baseStats.security ?? 100;
+    const playerRepSecurity = input.playerTeam[0]?.ship.baseStats.security ?? 100;
+
+    const landingChance = (
+        plan: PlacementPlan,
+        aff: ReturnType<typeof computeAffinityModifiers>,
+        defenderSecurity: number
+    ): number => {
+        const effectiveHacking = plan.stats.hacking * (1 + aff.damageModifier / 100);
+        return Math.min(100, Math.max(0, effectiveHacking - defenderSecurity)) / 100;
+    };
+
+    const hasCharged = (plan: PlacementPlan): boolean => {
+        const charged = selectFiringSkill(plan.shipSkills, 'charged');
+        return plan.chargeCount >= 1 && (charged?.abilities.length ?? 0) > 0;
+    };
+
+    // ----- Focus player actor (player[0]) -----
+    const focus = playerPlans[0];
+    if (!focus) {
+        throw new Error('simulateBattle: playerTeam must contain at least one placement');
+    }
+    const focusAff = computeAffinityModifiers(focus.affinity, enemyRepAffinity);
+    const focusLanding = landingChance(focus, focusAff, enemyRepSecurity);
+
+    // ----- The rest of the player team → walked teamActors -----
+    const teamActors: TeamActorEngineInput[] = playerPlans.slice(1).map((plan) => {
+        const aff = computeAffinityModifiers(plan.affinity, enemyRepAffinity);
+        return {
+            id: plan.id,
+            speed: 100,
+            chargeCount: plan.chargeCount,
+            startCharged: false,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            position: plan.position,
+            target: plan.target?.target,
+            pattern: plan.target?.pattern,
+            walk: {
+                shipSkills: plan.shipSkills,
+                stats: {
+                    attack: plan.stats.attack,
+                    crit: plan.stats.crit,
+                    critDamage: plan.stats.critDamage,
+                    defensePenetration: plan.stats.defensePenetration,
+                    hacking: plan.stats.hacking,
+                    defence: plan.stats.defence,
+                    hp: plan.stats.hp,
+                },
+                debuffLandingChance: landingChance(plan, aff, enemyRepSecurity),
+                selfDotModifier: 0,
+                defensePenetrationBuff: 0,
+                affinityDamageModifier: aff.damageModifier,
+                affinityCritCap: aff.critCap,
+                affinityCritPenalty: aff.critPenalty,
+                affinity: plan.affinity,
+                hasChargedSkill: hasCharged(plan),
+            },
+        };
+    });
+
+    // ----- Enemy team → enemyAttackers -----
+    const enemyAttackers: NonNullable<CombatEngineInput['enemyAttackers']> = enemyPlans.map(
+        (plan) => {
+            const aff = computeAffinityModifiers(plan.affinity, playerRepAffinity);
+            return {
+                id: plan.id,
+                stats: {
+                    attack: plan.stats.attack,
+                    crit: plan.stats.crit,
+                    critDamage: plan.stats.critDamage,
+                    speed: 100,
+                    defence: plan.stats.defence,
+                    hp: plan.stats.hp,
+                },
+                chargeCount: plan.chargeCount,
+                startCharged: false,
+                shipSkills: plan.shipSkills,
+                affinityDamageModifier: aff.damageModifier,
+                affinityCritCap: aff.critCap,
+                affinityCritPenalty: aff.critPenalty,
+                debuffLandingChance: landingChance(plan, aff, playerRepSecurity),
+                position: plan.position,
+                target: plan.target?.target,
+                pattern: plan.target?.pattern,
+                affinity: plan.affinity,
+            };
+        }
+    );
+
+    // ----- Capture the event stream + run -----
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    const EVENT_TYPES: CombatEvent['type'][] = [
+        'ability-performed',
+        'heal-performed',
+        'ship-destroyed',
+        'buff-applied',
+        'buff-expired',
+        'debuff-applied',
+    ];
+    for (const t of EVENT_TYPES) {
+        bus.on(t, (e) => events.push(e as CombatEvent));
+    }
+
+    const { rounds: engineRounds } = runCombat({
+        attack: focus.stats.attack,
+        crit: focus.stats.crit,
+        critDamage: focus.stats.critDamage,
+        defensePenetration: focus.stats.defensePenetration,
+        chargeCount: focus.chargeCount,
+        shipSkills: focus.shipSkills,
+        // The dummy player-offense enemy target (vestigial alongside the positioned roster):
+        // a huge HP / 0 defence punching bag — the real per-victim damage flows positionally.
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        debuffLandingChance: focusLanding,
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: hasCharged(focus),
+        startCharged: false,
+        affinityDamageModifier: focusAff.damageModifier,
+        affinityCritCap: focusAff.critCap,
+        affinityCritPenalty: focusAff.critPenalty,
+        affinity: focus.affinity,
+        defence: focus.stats.defence,
+        hp: focus.stats.hp,
+        position: focus.position,
+        target: focus.target?.target,
+        pattern: focus.target?.pattern,
+        // VESTIGIAL: enemyAttackers only populate (and enemies only fire on players) when
+        // healTargetId is set — the engine throws otherwise. Point it at the focus player id.
+        healTargetId: focus.id,
+        teamActors,
+        enemyAttackers,
+        bus,
+    });
+
+    // Per-round per-victim damage, keyed by each returned round's own `round` field
+    // (the rows are player-centric but each carries the round's full perTargetDamage map).
+    const perRoundPerTarget: Record<number, Record<string, number>> = {};
+    for (const rd of engineRounds) {
+        perRoundPerTarget[rd.round] = rd.perTargetDamage ?? {};
+    }
+
+    // Roster: every placed ship, with maxHp from its derived stats.
+    const roster: RosterEntry[] = [
+        ...playerPlans.map((plan) => ({
+            actorId: plan.id,
+            side: 'player' as const,
+            name: plan.name,
+            position: plan.position,
+            maxHp: plan.stats.hp,
+        })),
+        ...enemyPlans.map((plan) => ({
+            actorId: plan.id,
+            side: 'enemy' as const,
+            name: plan.name,
+            position: plan.position,
+            maxHp: plan.stats.hp,
+        })),
+    ];
+
+    return assembleBattleResult({ events, perRoundPerTarget, roster, numRounds });
 }

--- a/src/utils/combat/__tests__/twoTeamBattle.test.ts
+++ b/src/utils/combat/__tests__/twoTeamBattle.test.ts
@@ -384,7 +384,15 @@ describe('Two-team positional battle — characterization spike (Phase 5 PR 1, T
 const makeShip = (
     id: string,
     name: string,
-    opts: { activeTarget: string; activePattern: string } = {
+    opts: {
+        activeTarget: string;
+        activePattern: string;
+        // Override the active skill text — defaults to a single-hit 100% damage skill. The
+        // healer cases pass a bare-repair phrasing the parser flips to an ally heal.
+        activeSkillText?: string;
+        // Ship class — defaults to 'Attacker'. Only matters for skill-text parsing branches.
+        type?: Ship['type'];
+    } = {
         activeTarget: 'front',
         activePattern: 'Pattern-Base',
     }
@@ -393,7 +401,7 @@ const makeShip = (
     name,
     rarity: 'legendary',
     faction: 'TERRAN_COMBINE',
-    type: 'Attacker',
+    type: opts.type ?? 'Attacker',
     baseStats: {
         hp: 0,
         attack: 0,
@@ -410,7 +418,8 @@ const makeShip = (
     affinity: 'antimatter',
     // A single-hit 100% active damage skill (corpus phrasing with the <unit-damage> tag so
     // skillTextParser produces a real damage ability) — so the engine fires actual damage.
-    activeSkillText: 'This Unit deals <unit-damage>100% damage</unit-damage>.',
+    activeSkillText:
+        opts.activeSkillText ?? 'This Unit deals <unit-damage>100% damage</unit-damage>.',
     chargeSkillCharge: 0,
     activeTarget: opts.activeTarget,
     activePattern: opts.activePattern,
@@ -557,5 +566,220 @@ describe('simulateBattle adapter (Phase 5 PR 1, Task 3)', () => {
         const finalRound = result.rounds[result.rounds.length - 1];
         const deadEnemies = finalRound.ships.filter((s) => s.side === 'enemy' && !s.alive);
         expect(deadEnemies.length).toBeGreaterThan(0);
+    });
+});
+
+// ===========================================================================
+// Phase 5 PR 1, Task 4: HARDEN the two-team harness with edge cases the PR2 page +
+// the deferred unify will rely on — win/loss/draw outcomes, death-round correctness,
+// healing attribution, AoE per-victim accounting, and the per-round event log.
+// Driven through `simulateBattle` (the Task 3 adapter), reusing the makeShip /
+// placement helpers above. These EXERCISE the Task 2/3 code; they do not change it.
+// ===========================================================================
+
+// Targeting-string shorthands for the placements below (the engine's raw active
+// columns parseShipTargeting reads). FRONT/BACK anchor enemy selections; ALLIES is an
+// ally-side selection used by the support healer (its heal recipient is decided by the
+// parsed heal ability's target, not by this column).
+const FRONT = { activeTarget: 'front', activePattern: 'Pattern-Base' } as const;
+const BACK = { activeTarget: 'back', activePattern: 'Pattern-Base' } as const;
+
+describe('simulateBattle adapter — edge cases (Phase 5 PR 1, Task 4)', () => {
+    it('outcome: a one-sided wipe in the ENEMY→PLAYER direction makes the enemy the winner', () => {
+        // Mirror of the player-wins case above: fragile players (tiny HP) vs strong enemies
+        // (huge attack + huge HP). Players die fast; enemies never die → enemy team wins.
+        const result = simulateBattle({
+            playerTeam: [
+                placement(makeShip('p1', 'Player Front', FRONT), 'M4', 1, 5000),
+                placement(makeShip('p2', 'Player Back', BACK), 'M3', 1, 5000),
+            ],
+            enemyTeam: [
+                placement(makeShip('e1', 'Enemy Front', FRONT), 'M4', 100_000, 1_000_000_000),
+                placement(makeShip('e2', 'Enemy Back', BACK), 'M1', 100_000, 1_000_000_000),
+            ],
+        });
+
+        expect(result.outcome.winner).toBe('enemy');
+        expect(result.outcome.lastRound).toBeLessThan(30);
+
+        // At least one player ship ends not-alive in the final round.
+        const finalRound = result.rounds[result.rounds.length - 1];
+        const deadPlayers = finalRound.ships.filter((s) => s.side === 'player' && !s.alive);
+        expect(deadPlayers.length).toBeGreaterThan(0);
+    });
+
+    it('outcome: two tanky low-damage squads that cannot kill each other within the cap → DRAW', () => {
+        // Huge HP + 1 attack on every ship → no ship can be wiped in 3 rounds. The battle runs
+        // to the cap with no side wiped → draw at the final round, all 3 rounds present.
+        const result = simulateBattle({
+            playerTeam: [
+                placement(makeShip('p1', 'Player Front', FRONT), 'M4', 1, 1_000_000_000),
+                placement(makeShip('p2', 'Player Back', BACK), 'M3', 1, 1_000_000_000),
+            ],
+            enemyTeam: [
+                placement(makeShip('e1', 'Enemy Front', FRONT), 'M4', 1, 1_000_000_000),
+                placement(makeShip('e2', 'Enemy Back', BACK), 'M1', 1, 1_000_000_000),
+            ],
+            rounds: 3,
+        });
+
+        expect(result.outcome.winner).toBe('draw');
+        expect(result.outcome.lastRound).toBe(3);
+        // The full (untrimmed) round window is present for a draw — no early termination.
+        expect(result.rounds).toHaveLength(3);
+        expect(result.rounds.map((r) => r.round)).toEqual([1, 2, 3]);
+    });
+
+    it('death-round: a victim is alive for rounds < N and not alive for rounds >= N', () => {
+        // Strong players (1800 attack vs 5000-HP enemies) → an enemy dies once cumulative
+        // damage crosses its HP. 1800/round: r1=1800, r2=3600 (alive), r3=5400 (>=5000 → dead).
+        // So the front enemy is alive rounds 1-2 and not alive from round 3. Players are
+        // immortal (huge HP) so the battle keeps running through the death round.
+        const result = simulateBattle({
+            playerTeam: [
+                placement(makeShip('p1', 'Player Front', FRONT), 'M4', 1800, 1_000_000_000),
+                placement(makeShip('p2', 'Player Back', BACK), 'M3', 1800, 1_000_000_000),
+            ],
+            enemyTeam: [
+                placement(makeShip('e1', 'Enemy Front', FRONT), 'M4', 1, 5000),
+                placement(makeShip('e2', 'Enemy Back', BACK), 'M1', 1, 1_000_000_000),
+            ],
+            rounds: 5,
+        });
+
+        // Track the front enemy (the focus fires `front` → anchors it) across rounds.
+        const VICTIM = 'e:e1:0';
+        const stateAt = (round: number) =>
+            result.rounds.find((r) => r.round === round)?.ships.find((s) => s.actorId === VICTIM);
+
+        // Sanity: it took the expected per-round damage before dying.
+        expect(stateAt(1)?.damageTaken).toBe(1800);
+
+        // Alive strictly before the death round, not-alive from it onward (trimmed result).
+        expect(stateAt(1)?.alive).toBe(true);
+        expect(stateAt(2)?.alive).toBe(true);
+        expect(stateAt(3)?.alive).toBe(false);
+        // The transition is monotonic: once dead, it never flips back to alive.
+        for (const round of result.rounds) {
+            const s = round.ships.find((x) => x.actorId === VICTIM);
+            if (round.round >= 3) expect(s?.alive).toBe(false);
+        }
+    });
+
+    it('healing: a healer credits healingDone and the damaged ally it heals gets healingReceived', () => {
+        // player[0] = focus 'attacker' (the heal target / damaged ally), taking enemy fire.
+        // player[1] = a support healer with a bare active repair the parser flips to an ally
+        // heal — its recipient routes to the focus (the engine's heal target). The enemy keeps
+        // the focus damaged so the heal lands on a hurt ally.
+        const result = simulateBattle({
+            playerTeam: [
+                placement(makeShip('p1', 'Focus', FRONT), 'M4', 5000, 1_000_000),
+                placement(
+                    makeShip('p2', 'Healer', {
+                        activeTarget: 'allies',
+                        activePattern: 'Pattern-Base',
+                        activeSkillText: 'This Unit repairs 30% of its Max HP.',
+                        type: 'Support',
+                    }),
+                    'M3',
+                    0,
+                    1_000_000
+                ),
+            ],
+            enemyTeam: [placement(makeShip('e1', 'Enemy', FRONT), 'M4', 5000, 1_000_000_000)],
+            rounds: 3,
+        });
+
+        const HEALER = 'p:p2:1';
+        const FOCUS = 'attacker';
+        const healerStates = result.rounds.flatMap((r) =>
+            r.ships.filter((s) => s.actorId === HEALER)
+        );
+        const focusStates = result.rounds.flatMap((r) =>
+            r.ships.filter((s) => s.actorId === FOCUS)
+        );
+
+        // The healer repairs an ally → its healingDone is positive in at least one round.
+        expect(healerStates.some((s) => s.healingDone > 0)).toBe(true);
+        // The damaged focus is the recipient → its healingReceived is positive.
+        expect(focusStates.some((s) => s.healingReceived > 0)).toBe(true);
+        // And the focus actually took damage that round (the heal lands on a hurt ally).
+        expect(focusStates.some((s) => s.damageTaken > 0)).toBe(true);
+    });
+
+    it('AoE accounting: a 2-cell pattern hits the origin for FULL and the covered cell for HALF', () => {
+        // One enemy at M1 fires Pattern-Line-Range-1 anchored on the front-most player (M4) →
+        // covers M3 as the second cell. Origin (front player) takes full damage; the covered
+        // player takes half. Players carry no offense so only the enemy AoE lands this round.
+        const result = simulateBattle({
+            playerTeam: [
+                placement(makeShip('p1', 'Front', FRONT), 'M4', 0, 1_000_000_000),
+                placement(makeShip('p2', 'Mid', BACK), 'M3', 0, 1_000_000_000),
+            ],
+            enemyTeam: [
+                placement(
+                    makeShip('e1', 'AoE Enemy', {
+                        activeTarget: 'front',
+                        activePattern: 'Pattern-Line-Range-1',
+                    }),
+                    'M1',
+                    5000,
+                    1_000_000_000
+                ),
+            ],
+            rounds: 1,
+        });
+
+        const r1 = result.rounds[0];
+        const origin = r1.ships.find((s) => s.actorId === 'attacker')!; // front-most player
+        const covered = r1.ships.find((s) => s.actorId === 'p:p2:1')!; // M3, the 2nd AoE cell
+
+        // Both AoE cells were struck (the footprint genuinely covers 2 occupied cells).
+        expect(origin.damageTaken).toBeGreaterThan(0);
+        expect(covered.damageTaken).toBeGreaterThan(0);
+        // Origin full (5000) / covered half (2500) → origin === 2 × covered.
+        expect(origin.damageTaken).toBe(5000);
+        expect(covered.damageTaken).toBe(2500);
+        expect(origin.damageTaken).toBe(covered.damageTaken * 2);
+    });
+
+    it('event log: a round carries the expected damage/death lines and no spurious entries', () => {
+        // Strong players one-shot a fragile front enemy. Round 1: damage lines for the firing
+        // attackers and a death line for the wiped enemy; no `attacked`-derived or other noise.
+        const result = simulateBattle({
+            playerTeam: [
+                placement(makeShip('p1', 'Player Front', FRONT), 'M4', 5000, 1_000_000_000),
+                placement(makeShip('p2', 'Player Back', BACK), 'M3', 5000, 1_000_000_000),
+            ],
+            enemyTeam: [
+                placement(makeShip('e1', 'Enemy Front', FRONT), 'M4', 1, 5000),
+                placement(makeShip('e2', 'Enemy Back', BACK), 'M1', 1, 1_000_000_000),
+            ],
+            rounds: 3,
+        });
+
+        const r1 = result.rounds[0];
+
+        // Only the three modelled log kinds appear — `attacked` (no amount) is NOT logged.
+        for (const e of r1.events) {
+            expect(['damage', 'heal', 'death']).toContain(e.kind);
+        }
+
+        // The focus's damage line: attacker → its anchored enemy, full firing-hit amount.
+        const focusDamage = r1.events.find((e) => e.kind === 'damage' && e.actorId === 'attacker');
+        expect(focusDamage).toBeDefined();
+        expect(focusDamage?.targetId).toBe('e:e1:0'); // focus fires `front` → front enemy
+        expect(focusDamage?.amount).toBe(5000);
+
+        // The wiped front enemy produces exactly one death line that round.
+        const deaths = r1.events.filter((e) => e.kind === 'death');
+        expect(deaths.map((e) => e.actorId)).toContain('e:e1:0');
+        expect(deaths.filter((e) => e.actorId === 'e:e1:0')).toHaveLength(1);
+
+        // No spurious death line for a ship that did NOT die this round (the back enemy / players).
+        const deathIds = new Set(deaths.map((e) => e.actorId));
+        expect(deathIds.has('e:e2:1')).toBe(false);
+        expect(deathIds.has('attacker')).toBe(false);
+        expect(deathIds.has('p:p2:1')).toBe(false);
     });
 });

--- a/src/utils/combat/__tests__/twoTeamBattle.test.ts
+++ b/src/utils/combat/__tests__/twoTeamBattle.test.ts
@@ -569,6 +569,52 @@ describe('simulateBattle adapter (Phase 5 PR 1, Task 3)', () => {
     });
 });
 
+describe('simulateBattle adapter — input validation (review fix)', () => {
+    // Shared valid placements reused across the throwing cases.
+    const validPlayer = placement(
+        makeShip('p1', 'Player', { activeTarget: 'front', activePattern: 'Pattern-Base' }),
+        'M4',
+        5000,
+        1_000_000_000
+    );
+    const validEnemy = placement(
+        makeShip('e1', 'Enemy', { activeTarget: 'front', activePattern: 'Pattern-Base' }),
+        'M4',
+        5000,
+        1_000_000_000
+    );
+
+    it('throws when enemyTeam is empty', () => {
+        expect(() => simulateBattle({ playerTeam: [validPlayer], enemyTeam: [] })).toThrow(
+            'simulateBattle: enemyTeam is empty'
+        );
+    });
+
+    it('throws when playerTeam is empty', () => {
+        expect(() => simulateBattle({ playerTeam: [], enemyTeam: [validEnemy] })).toThrow(
+            'simulateBattle: playerTeam is empty'
+        );
+    });
+
+    it('throws when rounds is 0 (not a positive integer)', () => {
+        expect(() =>
+            simulateBattle({ playerTeam: [validPlayer], enemyTeam: [validEnemy], rounds: 0 })
+        ).toThrow('simulateBattle: rounds must be a positive integer');
+    });
+
+    it('throws when rounds is non-integer (2.5)', () => {
+        expect(() =>
+            simulateBattle({ playerTeam: [validPlayer], enemyTeam: [validEnemy], rounds: 2.5 })
+        ).toThrow('simulateBattle: rounds must be a positive integer');
+    });
+
+    it('still runs a valid battle with default rounds (rounds undefined)', () => {
+        const result = simulateBattle({ playerTeam: [validPlayer], enemyTeam: [validEnemy] });
+        expect(result.outcome).toBeDefined();
+        expect(result.rounds.length).toBeGreaterThan(0);
+    });
+});
+
 // ===========================================================================
 // Phase 5 PR 1, Task 4: HARDEN the two-team harness with edge cases the PR2 page +
 // the deferred unify will rely on — win/loss/draw outcomes, death-round correctness,

--- a/src/utils/combat/__tests__/twoTeamBattle.test.ts
+++ b/src/utils/combat/__tests__/twoTeamBattle.test.ts
@@ -72,6 +72,8 @@ import { createEventBus, CombatEvent } from '../events';
 import { Ability, ShipSkills } from '../../../types/abilities';
 import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
 import type { Position } from '../../../types/encounters';
+import { simulateBattle, BattlePlacement } from '../../calculators/battleSimulator';
+import type { Ship } from '../../../types/ship';
 
 type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
 type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
@@ -366,5 +368,194 @@ describe('Two-team positional battle — characterization spike (Phase 5 PR 1, T
         // their max HP). Pins the HP-crossing source for the player direction.
         expect(hpChanged.length).toBeGreaterThan(0);
         expect(hpChanged.some((e) => PLAYER_IDS.has(e.targetId))).toBe(true);
+    });
+});
+
+// ===========================================================================
+// Phase 5 PR 1, Task 3: end-to-end `simulateBattle` adapter (positioned squads →
+// runCombat → symmetric BattleResult). Driven through `simulateBattle`, not raw runCombat.
+// ===========================================================================
+
+// Minimal Ship factory: only the fields simulateBattle reads — baseStats (stat
+// derivation), affinity, charge threshold, the raw active targeting strings
+// (parseShipTargeting → target+pattern), and a single-hit damage active skill so
+// the ship fires real damage. statOverrides on the placement supply the combat
+// stats actually used; baseStats only need to be present/valid.
+const makeShip = (
+    id: string,
+    name: string,
+    opts: { activeTarget: string; activePattern: string } = {
+        activeTarget: 'front',
+        activePattern: 'Pattern-Base',
+    }
+): Ship => ({
+    id,
+    name,
+    rarity: 'legendary',
+    faction: 'TERRAN_COMBINE',
+    type: 'Attacker',
+    baseStats: {
+        hp: 0,
+        attack: 0,
+        defence: 0,
+        hacking: 200,
+        security: 100,
+        crit: 0,
+        critDamage: 0,
+        speed: 100,
+    },
+    equipment: {},
+    implants: {},
+    refits: [],
+    affinity: 'antimatter',
+    // A single-hit 100% active damage skill (corpus phrasing with the <unit-damage> tag so
+    // skillTextParser produces a real damage ability) — so the engine fires actual damage.
+    activeSkillText: 'This Unit deals <unit-damage>100% damage</unit-damage>.',
+    chargeSkillCharge: 0,
+    activeTarget: opts.activeTarget,
+    activePattern: opts.activePattern,
+});
+
+const placement = (
+    ship: Ship,
+    position: Position,
+    attack: number,
+    hp: number
+): BattlePlacement => ({
+    ship,
+    position,
+    statOverrides: {
+        attack,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        hacking: 200,
+        defence: 0,
+        hp,
+    },
+});
+
+describe('simulateBattle adapter (Phase 5 PR 1, Task 3)', () => {
+    it('produces non-zero per-ship damage dealt/taken on BOTH sides', () => {
+        const result = simulateBattle({
+            playerTeam: [
+                placement(
+                    makeShip('p1', 'Player Front', {
+                        activeTarget: 'front',
+                        activePattern: 'Pattern-Base',
+                    }),
+                    'M4',
+                    5000,
+                    1_000_000_000
+                ),
+                placement(
+                    makeShip('p2', 'Player Back', {
+                        activeTarget: 'back',
+                        activePattern: 'Pattern-Base',
+                    }),
+                    'M3',
+                    5000,
+                    1_000_000_000
+                ),
+            ],
+            enemyTeam: [
+                placement(
+                    makeShip('e1', 'Enemy Front', {
+                        activeTarget: 'front',
+                        activePattern: 'Pattern-Base',
+                    }),
+                    'M4',
+                    5000,
+                    1_000_000_000
+                ),
+                placement(
+                    makeShip('e2', 'Enemy Back', {
+                        activeTarget: 'back',
+                        activePattern: 'Pattern-Base',
+                    }),
+                    'M1',
+                    5000,
+                    1_000_000_000
+                ),
+            ],
+            rounds: 3,
+        });
+
+        // Roster covers all four placed ships, both sides represented.
+        expect(result.roster.filter((r) => r.side === 'player')).toHaveLength(2);
+        expect(result.roster.filter((r) => r.side === 'enemy')).toHaveLength(2);
+
+        // Aggregate dealt/taken per side across all rounds.
+        const sumBySide = (sel: (s: { damageDealt: number; damageTaken: number }) => number) => {
+            const out: Record<'player' | 'enemy', number> = { player: 0, enemy: 0 };
+            for (const round of result.rounds) {
+                for (const s of round.ships) out[s.side] += sel(s);
+            }
+            return out;
+        };
+        const dealt = sumBySide((s) => s.damageDealt);
+        const taken = sumBySide((s) => s.damageTaken);
+
+        // BOTH sides deal AND take damage (symmetric mutual combat).
+        expect(dealt.player).toBeGreaterThan(0);
+        expect(dealt.enemy).toBeGreaterThan(0);
+        expect(taken.player).toBeGreaterThan(0);
+        expect(taken.enemy).toBeGreaterThan(0);
+    });
+
+    it('marks a low-HP ship dead and a one-sided matchup wipes the weaker team before round 30', () => {
+        // Strong players (high attack, huge HP) vs fragile enemies (tiny HP, no offense
+        // worth surviving). Enemies die fast; players never die → enemy team wiped early.
+        const result = simulateBattle({
+            playerTeam: [
+                placement(
+                    makeShip('p1', 'Player Front', {
+                        activeTarget: 'front',
+                        activePattern: 'Pattern-Base',
+                    }),
+                    'M4',
+                    100_000,
+                    1_000_000_000
+                ),
+                placement(
+                    makeShip('p2', 'Player Back', {
+                        activeTarget: 'back',
+                        activePattern: 'Pattern-Base',
+                    }),
+                    'M3',
+                    100_000,
+                    1_000_000_000
+                ),
+            ],
+            enemyTeam: [
+                placement(
+                    makeShip('e1', 'Enemy Front', {
+                        activeTarget: 'front',
+                        activePattern: 'Pattern-Base',
+                    }),
+                    'M4',
+                    1,
+                    5000
+                ),
+                placement(
+                    makeShip('e2', 'Enemy Back', {
+                        activeTarget: 'back',
+                        activePattern: 'Pattern-Base',
+                    }),
+                    'M1',
+                    1,
+                    5000
+                ),
+            ],
+        });
+
+        // The default 30-round cap was NOT reached — the battle terminated early on a wipe.
+        expect(result.outcome.lastRound).toBeLessThan(30);
+        expect(result.outcome.winner).toBe('player');
+
+        // At least one enemy ship ends not-alive in the final round.
+        const finalRound = result.rounds[result.rounds.length - 1];
+        const deadEnemies = finalRound.ships.filter((s) => s.side === 'enemy' && !s.alive);
+        expect(deadEnemies.length).toBeGreaterThan(0);
     });
 });

--- a/src/utils/combat/__tests__/twoTeamBattle.test.ts
+++ b/src/utils/combat/__tests__/twoTeamBattle.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Combat Simulator Phase 5 — PR 1, Task 1: CHARACTERIZATION SPIKE (tests only).
+ *
+ * Goal: before building the battle-result assembler (Task 2), PROVE the data source.
+ * A tiny 2v2 POSITIONED battle through `runCombat` must emit usable damage data for BOTH
+ * directions (player→enemy AND enemy→player), so the assembler can attribute per-attacker
+ * dealt damage and per-victim taken damage symmetrically. This test pins exactly which
+ * events/fields carry that data, observed from the live engine (not assumed).
+ *
+ * Harness style is copied wholesale from positionalDamage.integration.test.ts (the ab()/
+ * basicAttack()/parsedTarget()/pattern helpers, the positioned-actor builders, healTargetId
+ * to unlock the enemy roster). No new harness is invented.
+ *
+ * ========================== PINNED DATA-SOURCE CONTRACT ==========================
+ * (Observed from runCombat on the 2v2 below. Field names verified against
+ *  src/utils/combat/events.ts + the playerTurn.ts:~1301 emit + engine.ts emitHit/3477.)
+ *
+ * DAMAGE DEALT, per attacker  →  `ability-performed` event, keyed by `actorId`.
+ *   - { type:'ability-performed', actorId, targetId, round, abilityType:'damage',
+ *       damage, didCrit?, critHits?, didHit? }
+ *   - Emitted ONCE per firing turn for the firing damage hit; `damage` is the full
+ *     directDamage of that hit (playerTurn.ts). `actorId` = the firing actor, `targetId`
+ *     = the anchor enemy it fired at (from the firing actor's perspective).
+ *   - SYMMETRIC: the enemy attacker turn runs the SAME runPlayerTurn code path with
+ *     `enemy: tgt` bound to a live PLAYER actor, so an enemy firing emits ability-performed
+ *     with actorId = ENEMY id and targetId = PLAYER id. Both directions appear in one stream.
+ *     => player→enemy : actorId∈players, targetId∈enemies
+ *     => enemy→player : actorId∈enemies, targetId∈players
+ *
+ * DAMAGE TAKEN, per victim  →  `RoundData.perTargetDamage` (Record<victimId, number>).
+ *   - Accumulated by a SINGLE shared `emitHit` inside drivePositionalApply (engine.ts:~2260),
+ *     used identically at ALL THREE positional sites (focus→enemy, team→enemy, enemy→player).
+ *     Each victim's per-round landed damage (origin full / covered half across the AoE
+ *     footprint) is summed into the map by victim id.
+ *   - SYMMETRIC: enemy victim ids AND player victim ids both appear here (whichever side
+ *     was struck by a positional firing hit that round). This is the per-victim "damage taken"
+ *     surface the Task-2 assembler will read.
+ *   - The field is set on RoundData ONLY when the map is non-empty (else absent) — so a
+ *     non-positional run leaves it undefined (keeps legacy goldens byte-identical).
+ *
+ * `attacked` event  →  NO damage amount; ANCHOR victim only.
+ *   - { type:'attacked', targetId, attackerId, round, didCrit? } — carries the attacker id
+ *     and the single struck `tgt` (the anchor victim of the enemy's positional/legacy attack),
+ *     NOT every AoE-covered victim, and NO numeric damage. So `attacked` is useful for "who
+ *     hit whom / crit?" but is NOT a damage source — use ability-performed/perTargetDamage.
+ *
+ * HEALS / HP / DEATH:
+ *   - heals: `heal-performed` { casterId, targets[], amount, critHits? } (healing mode only).
+ *   - HP fraction crossings: `hp-changed` { targetId, oldPct, newPct } — tank-side (heal
+ *     target + player victims with known max HP) per HP-intake event; enemy-dummy integer
+ *     granularity post-round. NOTE: per-victim hp-changed is SUPPRESSED for enemy victims
+ *     (their max HP is unknown to the engine) — so enemy "taken damage" comes from
+ *     perTargetDamage, not hp-changed.
+ *   - death: `ship-destroyed` { actorId } — emitted once per actor (player OR enemy) whose
+ *     HP first reaches 0. Fires for BOTH sides as HP allows.
+ * ================================================================================
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `tt${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+// A single-hit basic attack: multiplier 100% (1x), 1 hit, no passive payload — so the firing
+// hit's directDamage equals attack × 1 vs defence 0 (clean known per-victim damage).
+const basicAttack = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } }),
+    ],
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+// Origin-only (single-target) footprint.
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+// A walked team actor that FIRES: own position + target + pattern + a damage skill.
+const teamAttackerAt = (
+    id: string,
+    position: Position,
+    selection: ParsedTarget['selection'],
+    attack: number,
+    hp: number
+): TeamActor => ({
+    id,
+    speed: 150,
+    chargeCount: 0,
+    startCharged: false,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    position,
+    target: parsedTarget(selection),
+    pattern: basePattern(),
+    walk: {
+        shipSkills: { slots: [basicAttack()] },
+        stats: {
+            attack,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            hacking: 0,
+            defence: 0,
+            hp,
+        },
+        debuffLandingChance: 1,
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        hasChargedSkill: false,
+    },
+});
+
+// A positioned ENEMY attacker that FIRES on the player roster: position + target + pattern +
+// a damage skill so its firing hit produces positionalScalars (Task 9 enemy site).
+const offensiveEnemyAt = (
+    id: string,
+    position: Position,
+    selection: ParsedTarget['selection'],
+    attack: number,
+    hp: number
+): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack, crit: 0, critDamage: 0, defence: 0, hp, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget(selection),
+        pattern: basePattern(),
+        shipSkills: { slots: [basicAttack()] },
+    }) as EnemyAttacker;
+
+// 2v2 base: focus 'attacker' at M4 fires `front` (an enemy), plus one walked team attacker;
+// two offensive enemies fire `front` (a player). healTargetId unlocks the enemy roster.
+// HP/attack args parameterized so we can run a "huge HP, nobody dies" variant (to read
+// perTargetDamage as actual landed damage) and a "low HP, both sides die" variant.
+const battle = (opts: {
+    playerHp: number;
+    enemyHp: number;
+    playerAttack: number;
+    enemyAttack: number;
+}): CombatEngineInput => ({
+    // Focus actor (player side, the heal target / front-most player at M4).
+    attack: opts.playerAttack,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [basicAttack()] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 3,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    debuffLandingChance: 1,
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: opts.playerHp,
+    // Healing mode — required for the positioned enemy roster to be built.
+    healTargetId: 'attacker',
+    position: 'M4',
+    // Focus fires on the front enemy (origin M4 from the enemy roster's front).
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    // Player side second actor: walked team attacker at M3 firing the back enemy.
+    teamActors: [teamAttackerAt('player-team', 'M3', 'back', opts.playerAttack, opts.playerHp)],
+    // Enemy side: two offensive attackers. enemy-front fires `front` (anchors the front-most
+    // player = the focus at M4); enemy-back fires `back` (anchors the back-most player = M3).
+    enemyAttackers: [
+        offensiveEnemyAt('enemy-front', 'M4', 'front', opts.enemyAttack, opts.enemyHp),
+        offensiveEnemyAt('enemy-back', 'M1', 'back', opts.enemyAttack, opts.enemyHp),
+    ],
+});
+
+const PLAYER_IDS = new Set(['attacker', 'player-team']);
+const ENEMY_IDS = new Set(['enemy-front', 'enemy-back']);
+
+/** Run a battle, capturing the full event stream + the round data. */
+const run = (input: CombatEngineInput) => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    const ALL_TYPES: CombatEvent['type'][] = [
+        'ability-performed',
+        'attacked',
+        'hp-changed',
+        'ship-destroyed',
+        'heal-performed',
+    ];
+    for (const t of ALL_TYPES) {
+        bus.on(t, (e) => events.push(e as CombatEvent));
+    }
+    const result = runCombat({ ...input, bus });
+    return { events, result };
+};
+
+describe('Two-team positional battle — characterization spike (Phase 5 PR 1, Task 1)', () => {
+    it('emits ability-performed for BOTH directions (player→enemy AND enemy→player)', () => {
+        idc = 0;
+        // Huge HP both sides so nobody dies and every actor keeps firing all 3 rounds.
+        const { events } = run(
+            battle({
+                playerHp: 1_000_000_000,
+                enemyHp: 1_000_000_000,
+                playerAttack: 5000,
+                enemyAttack: 5000,
+            })
+        );
+        const abilityPerformed = events.filter(
+            (e): e is Extract<CombatEvent, { type: 'ability-performed' }> =>
+                e.type === 'ability-performed'
+        );
+
+        // player→enemy: a player actor dealt damage to an enemy.
+        const playerToEnemy = abilityPerformed.filter(
+            (e) => PLAYER_IDS.has(e.actorId) && ENEMY_IDS.has(e.targetId)
+        );
+        // enemy→player: an enemy actor dealt damage to a player.
+        const enemyToPlayer = abilityPerformed.filter(
+            (e) => ENEMY_IDS.has(e.actorId) && PLAYER_IDS.has(e.targetId)
+        );
+
+        expect(playerToEnemy.length).toBeGreaterThan(0);
+        expect(enemyToPlayer.length).toBeGreaterThan(0);
+
+        // The DEALT-damage field is `damage` on ability-performed, and it is the real landed
+        // amount (attack 5000 × 100% vs defence 0, no crit = 5000).
+        expect(playerToEnemy.every((e) => e.damage === 5000)).toBe(true);
+        expect(enemyToPlayer.every((e) => e.damage === 5000)).toBe(true);
+    });
+
+    it('RoundData.perTargetDamage records per-victim TAKEN damage for BOTH enemy and player victims', () => {
+        idc = 0;
+        // Huge HP so perTargetDamage records the actual landed damage (no death clamping).
+        const { result } = run(
+            battle({
+                playerHp: 1_000_000_000,
+                enemyHp: 1_000_000_000,
+                playerAttack: 5000,
+                enemyAttack: 5000,
+            })
+        );
+
+        // Union every round's perTargetDamage victim ids.
+        const victimIds = new Set<string>();
+        for (const round of result.rounds) {
+            if (round.perTargetDamage) {
+                for (const id of Object.keys(round.perTargetDamage)) victimIds.add(id);
+            }
+        }
+
+        // BOTH directions land per-victim damage: player attackers hit the enemy roster, and
+        // enemy attackers hit the player roster — all flow through the shared emitHit.
+        const enemyVictims = [...victimIds].filter((id) => ENEMY_IDS.has(id));
+        const playerVictims = [...victimIds].filter((id) => PLAYER_IDS.has(id));
+        expect(enemyVictims.length).toBeGreaterThan(0); // enemy victims (player→enemy)
+        expect(playerVictims.length).toBeGreaterThan(0); // player victims (enemy→player)
+
+        // Per-victim amounts are the real landed firing-hit damage (origin full = 5000).
+        const round0 = result.rounds[0].perTargetDamage!;
+        // Focus fires `front` → front enemy; team fires `back` → back enemy.
+        expect(round0['enemy-front']).toBe(5000);
+        expect(round0['enemy-back']).toBe(5000);
+        // enemy-front fires `front` → front-most player (focus); enemy-back fires `back` → M3 player.
+        expect(round0['attacker']).toBe(5000);
+        expect(round0['player-team']).toBe(5000);
+    });
+
+    it('`attacked` events carry an attacker + anchor victim but NO damage amount', () => {
+        idc = 0;
+        const { events } = run(
+            battle({
+                playerHp: 1_000_000_000,
+                enemyHp: 1_000_000_000,
+                playerAttack: 5000,
+                enemyAttack: 5000,
+            })
+        );
+        const attacked = events.filter(
+            (e): e is Extract<CombatEvent, { type: 'attacked' }> => e.type === 'attacked'
+        );
+        expect(attacked.length).toBeGreaterThan(0);
+        // Anchor victims only: enemy attackers struck players (the anchor `tgt`).
+        expect(attacked.every((e) => ENEMY_IDS.has(e.attackerId))).toBe(true);
+        expect(attacked.every((e) => PLAYER_IDS.has(e.targetId))).toBe(true);
+        // CONTRACT PIN: `attacked` carries NO numeric damage field — it is not a damage source.
+        expect(attacked.every((e) => !('damage' in e))).toBe(true);
+    });
+
+    it('ship-destroyed fires for BOTH sides when HP is low enough', () => {
+        idc = 0;
+        // Low HP both sides: 5000 attack lands exactly 5000/turn, HP 5000 → first hit kills.
+        const { events } = run(
+            battle({
+                playerHp: 5000,
+                enemyHp: 5000,
+                playerAttack: 5000,
+                enemyAttack: 5000,
+            })
+        );
+        const destroyed = new Set(
+            events
+                .filter(
+                    (e): e is Extract<CombatEvent, { type: 'ship-destroyed' }> =>
+                        e.type === 'ship-destroyed'
+                )
+                .map((e) => e.actorId)
+        );
+        const destroyedEnemies = [...destroyed].filter((id) => ENEMY_IDS.has(id));
+        const destroyedPlayers = [...destroyed].filter((id) => PLAYER_IDS.has(id));
+        // BOTH sides take lethal damage → ship-destroyed fires for each.
+        expect(destroyedEnemies.length).toBeGreaterThan(0);
+        expect(destroyedPlayers.length).toBeGreaterThan(0);
+    });
+
+    it('hp-changed fires for player victims (tank-side, known max HP)', () => {
+        idc = 0;
+        const { events } = run(
+            battle({
+                playerHp: 1_000_000_000,
+                enemyHp: 1_000_000_000,
+                playerAttack: 5000,
+                enemyAttack: 5000,
+            })
+        );
+        const hpChanged = events.filter(
+            (e): e is Extract<CombatEvent, { type: 'hp-changed' }> => e.type === 'hp-changed'
+        );
+        // Player victims take HP damage → hp-changed crossings fire for them (the engine knows
+        // their max HP). Pins the HP-crossing source for the player direction.
+        expect(hpChanged.length).toBeGreaterThan(0);
+        expect(hpChanged.some((e) => PLAYER_IDS.has(e.targetId))).toBe(true);
+    });
+});

--- a/src/utils/combat/__tests__/twoTeamBattle.test.ts
+++ b/src/utils/combat/__tests__/twoTeamBattle.test.ts
@@ -46,11 +46,22 @@
  *
  * HEALS / HP / DEATH:
  *   - heals: `heal-performed` { casterId, targets[], amount, critHits? } (healing mode only).
- *   - HP fraction crossings: `hp-changed` { targetId, oldPct, newPct } — tank-side (heal
- *     target + player victims with known max HP) per HP-intake event; enemy-dummy integer
- *     granularity post-round. NOTE: per-victim hp-changed is SUPPRESSED for enemy victims
- *     (their max HP is unknown to the engine) — so enemy "taken damage" comes from
- *     perTargetDamage, not hp-changed.
+ *   - HP fraction crossings: `hp-changed` { targetId, oldPct, newPct }. This fires for BOTH
+ *     sides, but with caveats that make it UNSUITABLE as a sole HP source:
+ *       * Positioned enemy ATTACKERS DO emit hp-changed from round 2 onward — they walk
+ *         `runPlayerTurn` and set `lastTurnCtxByActor`, so `recipientMaxHp` knows their
+ *         `effectiveMaxHp` and the `maxHp > 0` gate passes. Suppression holds ONLY for
+ *         (a) the legacy dummy `enemy` actor and (b) round 1, before any enemy turn has run.
+ *       * So enemy hp-changed events DO appear — but at integer / low granularity and with
+ *         round-1-suppression timing that differs from the player side. Treat hp-changed as
+ *         informational, NOT as a reliable per-actor HP curve.
+ *   - PER-VICTIM DAMAGE TAKEN (reliable, symmetric): `RoundData.perTargetDamage`
+ *     (Record<victimId, number>) is the RELIABLE per-victim damage-taken source for BOTH
+ *     directions — use it, not hp-changed. The Task-2 assembler should derive each actor's
+ *     HP% as `maxHp - cumulative(perTargetDamage for that victim)` over rounds, using the
+ *     roster's maxHp. This is uniform for both sides and independent of hp-changed timing /
+ *     granularity quirks. (It ignores healing/shields applied to HP — acceptable for PR1's
+ *     surface; refine if needed.)
  *   - death: `ship-destroyed` { actorId } — emitted once per actor (player OR enemy) whose
  *     HP first reaches 0. Fires for BOTH sides as HP allows.
  * ================================================================================


### PR DESCRIPTION
## Combat Simulator Phase 5 — PR 1 of 2 (page-first data layer)

The data layer for the upcoming `/simulator` page: run two positioned squads through the existing combat engine and get a per-round, per-ship **symmetric result** for both teams. **Capability-only — a new caller, no engine-internal change → DPS/healing goldens byte-identical.**

### Why page-first
The planning audit found the full team-agnostic engine unification is ~10 sequential engine-surgery PRs with no payoff until the page. Since the Phase-4 positional path is already nearly per-actor-per-side symmetric (`drivePositionalApply` both sides + `applyVictimDamage` side-sink + per-victim `perTargetDamage`), this PR builds the simulator on today's engine and **defers the full `bySide` unification to a later phase** (with the live page as its harness).

### What's here (`src/utils/calculators/battleSimulator.ts`)
- **`assembleBattleResult`** — a PURE, event-driven assembler: `{events, perRoundPerTarget, roster, numRounds}` → `BattleResult` (per-round per-ship `damageDealt`/`damageTaken`/`healingDone`/`healingReceived`/`shieldsAbsorbed`/`hpPct`/`alive`/buffs/debuffs + a per-round event log + `outcome` {winner, lastRound}). Data sources (characterized + verified): damage-dealt = `ability-performed` by `actorId`; damage-taken = `perTargetDamage` by victim id; HP% = cumulative-taken vs roster maxHp; heals = `heal-performed`; death = `ship-destroyed`.
- **`simulateBattle`** — derives both positioned squads' stats + affinity + `parseShipTargeting`, mints unique actor ids, builds the `CombatEngineInput` (focus + `teamActors` + `enemyAttackers`, all positioned; `healTargetId` = focus as the vestigial workaround that unlocks the enemy roster), taps a bus, runs `runCombat(numRounds=30)`, and assembles.

### Verification
- Full suite **2302 green**; DPS/healing **goldens byte-identical** (`git diff main -- '*.snap'` empty); `audit:skills` 0/141; tsc + lint clean.
- A two-team battle harness verifies mutual damage, win/loss/**draw**, death-round transitions, healing, and **AoE accounting** (origin full / covered half) — control-probe-verified non-vacuous.
- Subagent-driven, every task spec + quality reviewed + final holistic review.

### Known approximations (documented at the field + deferred to the unify phase)
`healingReceived` even-split across heal targets; `shieldsAbsorbed` stubbed 0 (no shield channel in the event); `activeDebuffs` infliction-only (persists); `damageDealt` (attacker aggregate) and `damageTaken` (per-victim) don't reconcile under AoE by design; charged-skill targeting uses the active selection; single-representative affinity. **PR 2 must pass gear/refit/engineering-resolved stats via `statOverrides`** (the adapter floors to un-geared base stats otherwise — warned at the field).

### Next
**PR 2** — the `/simulator` page (two-board placement, fleet selection, Run, board-centric round-stepper playback) renders this `BattleResult`.

Spec: `docs/superpowers/specs/2026-06-15-combat-simulator-phase5-design.md`
Plan: `docs/superpowers/plans/2026-06-15-combat-simulator-phase5-pr1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)