### PR TITLE
fix(combat): bySide unification PR2 — side predicates + enemy reactive-routing fix

### DIFF
--- a/docs/superpowers/plans/2026-06-16-combat-engine-unify-pr2-side-predicates.md
+++ b/docs/superpowers/plans/2026-06-16-combat-engine-unify-pr2-side-predicates.md
@@ -1,0 +1,377 @@
+# Combat Engine bySide Unification — PR2: Side Predicates + Enemy Reactive-Routing Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the player-centric `isEnemySide` predicate inside `registerReactiveListeners` with a per-call `isOpposing` / `isSameSideAlly`, and fix `grantExtraAction` to resolve its granter from the combined roster — so an ENEMY-side ship's opposing/ally reactive triggers fire against the correct side (the campaign's first bug fix: the lone enemy Liberator that kills a player ship finally gets its `on-enemy-destroyed` extra action).
+
+**Architecture:** Today `registerReactiveListeners` is called twice (player owners + enemy owners) with the SAME player-centric `isEnemySide` predicate, so for an enemy owner "an enemy died" only ever means "an enemy-SIDE actor died" — never its real opponent (a player). And `grantExtraAction` resolves the granter from `allPlayerActorsById`, dropping any enemy granter even when its trigger fired. PR2 parameterizes the listener factory with a per-call `isOpposing(actorId)` (player call passes today's `isEnemySide`; enemy call passes its negation) and derives `isSameSideAlly(actorId, ownerId) = !isOpposing(actorId) && actorId !== ownerId` internally, then switches the two `grantExtraAction` granter lookups to the combined `allActorsById` map (PR1 deferred this accessor here, to its first consumer). The reactive/event layer is already side-agnostic, so this is a predicate-parameterization + one-map-swap refactor, not new machinery.
+
+**Tech Stack:** TypeScript, Vitest. Reactive listener factory in `src/utils/combat/triggers.ts`; engine wiring + roster in `src/utils/combat/engine.ts`.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-combat-engine-bySide-unification-design.md` (§4 PR2 row; root-cause memo: `project-enemy-side-reactive-routing-gap`).
+
+**Safety gate (re-derived from the spec's PR2 row):** **BYTE-IDENTICAL** DPS + healing goldens. PR2 touches behavior-adjacent code, but only the PLAYER viewpoint is exercised by the goldens, and the player call passes `isOpposing: isEnemySide` — algebraically identical to today (`!isOpposing(x) === !isEnemySide(x)`, and every `on-ally-*` check was already combined with `!== ownerId`). So **any golden move here is a refactor LEAK** (predicate semantics drifted on the player path), NOT acceptable churn — fix the seam, never `vitest -u`. The behavioral fix lives entirely on the ENEMY call, which no DPS/healing golden exercises (single-target healing: enemies are undamaged, nothing on the enemy side dies → no opposing/ally enemy reaction has a triggering event). The fix is proven by NEW team-vs-team tests.
+
+**Branch:** `feat/combat-engine-unify-pr2` off the current `feat/combat-sim-phase5-pr2` tip (PR1 merged there as `f379c7d3`). Work in the main checkout — do NOT create a fresh worktree (esbuild crash). Stacks on PR1; accept the rebase-`--onto`/retarget friction.
+
+---
+
+## File structure
+
+- **Modify** `src/utils/combat/triggers.ts` — rename the `registerReactiveListeners` arg `isEnemySide` → `isOpposing`; add an internal `isSameSideAlly` helper; replace the 9 in-listener predicate uses; update the args docstring AND the factory-level trigger-by-trigger summary docstring (~140-174, which also names `isEnemySide`). Also relax the now-stale "granter is always a player actor" comment on the `grantExtraAction` delegate docstring if present.
+- **Modify** `src/utils/combat/engine.ts` — introduce the combined `allActorsById` accessor (PR1-deferred, first consumer is here); pass `isOpposing` to both `registerReactiveListeners` call sites (player = `isEnemySide`, enemy = its negation); switch the two `grantExtraAction` granter lookups (`grantExtraAction` body + the Path-B `pendingExtraActions` flush) from `allPlayerActorsById` to `allActorsById`; update the stale "granter is always a player actor" comment.
+- **Create** `src/utils/combat/__tests__/enemyReactiveRouting.test.ts` — Task 1 unit test of `registerReactiveListeners` predicate routing (enemy owner) + Task 2 end-to-end team-vs-team enemy-Liberator extra-action repro.
+
+No production caller change. No changelog entry (internal refactor; the user-facing consequence — enemy reactive abilities firing in the simulator — is part of the broader unification, surfaced when the simulator ships, not a standalone shipped feature this PR). If the reviewer disagrees, a one-line changelog note ("enemy ships' reactive abilities now fire correctly in the combat simulator") is acceptable.
+
+---
+
+## Task 1: Parameterize the reactive-listener predicate (`isEnemySide` → `isOpposing` / `isSameSideAlly`)
+
+**Files:**
+- Modify: `src/utils/combat/triggers.ts` — `registerReactiveListeners` args type + body (~192-413)
+- Modify: `src/utils/combat/engine.ts` — the two `registerReactiveListeners` call sites (~1840 player, ~1861 enemy)
+- Test: `src/utils/combat/__tests__/enemyReactiveRouting.test.ts` (new)
+
+**Why this is byte-identical for goldens:** the player call passes `isOpposing: isEnemySide`, so `isOpposing(x) === isEnemySide(x)` and `isSameSideAlly(x, owner) === !isEnemySide(x) && x !== owner` — exactly the existing player-side expressions (every `on-ally-*` listener already combined `!isEnemySide(...)` with an `!== ownerId` guard, verified below). The enemy call flips to the correct semantics; no golden exercises enemy opposing/ally reactions.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `src/utils/combat/__tests__/enemyReactiveRouting.test.ts`. This drives `registerReactiveListeners` directly with a fake bus and a spy `enqueue`, mirroring the import style of `triggers.test.ts` (`createEventBus` from `../events`, `registerReactiveListeners` + `Intent` + `ReactiveAbility` from `../triggers`, `ab(...)` builder). Construct ONE enemy owner `'E1'` with two reactive abilities — an `on-enemy-destroyed` and an `on-ally-destroyed` (use the simplest non-extra-action payloads, e.g. a `buff`/`heal` config; the factory only ENQUEUES, so the config body is irrelevant to this test). Wire `isOpposing` so PLAYER ids are opposing to the enemy owner:
+
+```typescript
+import { describe, expect, it, vi } from 'vitest';
+import { createEventBus } from '../events';
+import { registerReactiveListeners, Intent, ReactiveAbility } from '../triggers';
+import { Ability } from '../../../types/abilities';
+
+let idCounter = 0;
+const ab = (partial: Partial<Ability> & Pick<Ability, 'type' | 'config' | 'trigger'>): Ability => ({
+    id: `er${++idCounter}`,
+    target: 'self',
+    conditions: [],
+    ...partial,
+});
+
+// Reactive ability wrapper mirrors what the engine partitions onto a runtime
+// (sourceSlot is opaque to registerReactiveListeners — it only rides into the Intent).
+const ra = (ability: Ability): ReactiveAbility => ({ ability, sourceSlot: 'passive' });
+
+describe('registerReactiveListeners — enemy-owner side routing (bySide PR2)', () => {
+    it('routes an enemy owner\'s on-enemy-destroyed to OPPOSING (player) deaths, not same-side', () => {
+        const bus = createEventBus();
+        const enqueued: Intent[] = [];
+        const onEnemyDestroyed = ab({
+            type: 'buff', trigger: 'on-enemy-destroyed',
+            config: { type: 'buff', buffName: 'X', stat: 'attack', value: 1, turns: 1 } as never,
+        });
+        // For enemy owner E1, the PLAYER ids are opposing.
+        const isOpposing = (id: string) => id === 'P1' || id === 'P2';
+        registerReactiveListeners({
+            bus,
+            perOwner: [{ ownerId: 'E1', reactiveAbilities: [ra(onEnemyDestroyed)] }],
+            enqueue: (i) => enqueued.push(i),
+            isOpposing,
+        });
+        bus.emit({ type: 'ship-destroyed', actorId: 'P1', round: 1 } as never); // opposing → fires
+        bus.emit({ type: 'ship-destroyed', actorId: 'E2', round: 1 } as never); // same side → no
+        expect(enqueued).toHaveLength(1);
+        expect(enqueued[0].ownerId).toBe('E1');
+    });
+
+    it('routes an enemy owner\'s on-ally-destroyed to SAME-side non-self deaths only', () => {
+        const bus = createEventBus();
+        const enqueued: Intent[] = [];
+        const onAllyDestroyed = ab({
+            type: 'buff', trigger: 'on-ally-destroyed',
+            config: { type: 'buff', buffName: 'Y', stat: 'attack', value: 1, turns: 1 } as never,
+        });
+        const isOpposing = (id: string) => id === 'P1';
+        registerReactiveListeners({
+            bus,
+            perOwner: [{ ownerId: 'E1', reactiveAbilities: [ra(onAllyDestroyed)] }],
+            enqueue: (i) => enqueued.push(i),
+            isOpposing,
+        });
+        bus.emit({ type: 'ship-destroyed', actorId: 'E2', round: 1 } as never); // same-side ally → fires
+        bus.emit({ type: 'ship-destroyed', actorId: 'E1', round: 1 } as never); // self → no (on-destroyed's job)
+        bus.emit({ type: 'ship-destroyed', actorId: 'P1', round: 1 } as never); // opposing → no
+        expect(enqueued).toHaveLength(1);
+    });
+
+    it('player-call parity: isOpposing = isEnemySide reproduces the legacy player routing', () => {
+        const bus = createEventBus();
+        const enqueued: Intent[] = [];
+        const onAllyDestroyed = ab({
+            type: 'buff', trigger: 'on-ally-destroyed',
+            config: { type: 'buff', buffName: 'Z', stat: 'attack', value: 1, turns: 1 } as never,
+        });
+        const isEnemySide = (id: string) => id === 'enemy'; // legacy player-side predicate
+        registerReactiveListeners({
+            bus,
+            perOwner: [{ ownerId: 'attacker', reactiveAbilities: [ra(onAllyDestroyed)] }],
+            enqueue: (i) => enqueued.push(i),
+            isOpposing: isEnemySide,
+        });
+        bus.emit({ type: 'ship-destroyed', actorId: 'T1', round: 1 } as never);    // ally player → fires
+        bus.emit({ type: 'ship-destroyed', actorId: 'enemy', round: 1 } as never); // enemy → no
+        bus.emit({ type: 'ship-destroyed', actorId: 'attacker', round: 1 } as never); // self → no
+        expect(enqueued).toHaveLength(1);
+    });
+});
+```
+
+> NOTE on event-literal typing: the bus `emit` is typed to `CombatEvent`. If `as never` casts are rejected by lint/tsc, mirror how `triggers.test.ts` constructs `ship-destroyed` events (it imports `CombatEvent`) and build a properly-typed event object instead — the goal is a real `ship-destroyed` event with the `actorId` field. Likewise mirror the real `BuffConfig` shape from `types/abilities` for the ability `config` rather than `as never` if the cast is rejected.
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `npx vitest run src/utils/combat/__tests__/enemyReactiveRouting.test.ts`
+Expected: FAIL — `registerReactiveListeners` has no `isOpposing` arg yet (tsc/type error on the call, or the arg is ignored so routing is wrong).
+
+- [ ] **Step 3: Rename the arg and add `isSameSideAlly` in `triggers.ts`**
+
+In `registerReactiveListeners`'s args type (~192), rename the field and rewrite its docstring:
+
+```typescript
+    /** True for any actor on the side OPPOSING this listener set's owners. The engine
+     *  passes a per-call predicate: the PLAYER registration passes `isEnemySide`
+     *  (opposing = enemy-side); the ENEMY registration passes its negation (opposing =
+     *  player-side). Replaces the old player-centric `isEnemySide` arg so an enemy
+     *  owner's opposing/ally reactions route against the correct side (bySide PR2). */
+    isOpposing: (actorId: string) => boolean;
+```
+
+In the destructure (~210), swap `isEnemySide` → `isOpposing` and add the same-side-ally helper directly after it:
+
+```typescript
+    const { bus, perOwner, enqueue, isOpposing, roleOf } = args;
+    // Same-side ally = NOT opposing AND not the owner itself (own events route to the
+    // self-scoped triggers). Replaces the old `!isEnemySide(x) && x !== ownerId` pattern;
+    // for the player call (isOpposing = isEnemySide) this is byte-identical.
+    const isSameSideAlly = (actorId: string, ownerId: string): boolean =>
+        !isOpposing(actorId) && actorId !== ownerId;
+```
+
+- [ ] **Step 4: Replace the 8 in-listener predicate uses**
+
+Apply these exact swaps inside the listener bodies (each preserves player-call semantics; verified against the current source):
+
+| Trigger | Old | New |
+|---------|-----|-----|
+| `on-ally-debuff-inflicted` (`debuff-applied`) | `e.sourceId !== ownerId && !isEnemySide(e.sourceId)` | `isSameSideAlly(e.sourceId, ownerId)` |
+| `on-ally-debuff-inflicted` (`dot-applied`) | `e.sourceId !== ownerId && !isEnemySide(e.sourceId)` | `isSameSideAlly(e.sourceId, ownerId)` |
+| `on-ally-crit-dot` | `e.viaCrit && e.sourceId !== ownerId && !isEnemySide(e.sourceId)` | `e.viaCrit && isSameSideAlly(e.sourceId, ownerId)` |
+| `on-ally-crit` (guard) | `if (e.actorId === ownerId \|\| isEnemySide(e.actorId)) return;` | `if (!isSameSideAlly(e.actorId, ownerId)) return;` |
+| `on-ally-attacked` (guard) | `if (e.targetId === ownerId \|\| isEnemySide(e.targetId)) return;` | `if (!isSameSideAlly(e.targetId, ownerId)) return;` |
+| `on-ally-destroyed` | `e.actorId !== ownerId && !isEnemySide(e.actorId)` | `isSameSideAlly(e.actorId, ownerId)` |
+| `on-enemy-destroyed` | `if (isEnemySide(e.actorId))` | `if (isOpposing(e.actorId))` |
+| `on-enemy-repaired` | `if (isEnemySide(e.casterId))` | `if (isOpposing(e.casterId))` |
+| `on-enemy-cleansed` | `if (isEnemySide(e.casterId))` | `if (isOpposing(e.casterId))` |
+
+Leave each listener's explanatory comment intact except where it says "isEnemySide" verbatim — update the prose to "opposing / same-side ally" wording. This includes the factory-level summary docstring (~140-174), which names `isEnemySide` several times. After this step there must be ZERO remaining `isEnemySide` references inside `triggers.ts` (grep to confirm: `grep -n isEnemySide src/utils/combat/triggers.ts` → no hits). NOTE: the swap table has 9 rows (the `on-ally-debuff-inflicted` trigger contributes two listeners) — all 9 must be swapped; the grep gate is the authoritative check.
+
+- [ ] **Step 5: Update both engine call sites**
+
+In `engine.ts`, the PLAYER registration (~1840) — change the field to pass the existing `isEnemySide` under the new name (byte-identical):
+
+```typescript
+    registerReactiveListeners({
+        bus,
+        perOwner: reactivePerOwner,
+        enqueue: (intent) => intentQueue.push(intent),
+        isOpposing: isEnemySide,
+        roleOf: (id) => roleByActorId.get(id),
+    });
+```
+
+The ENEMY registration (~1861) — pass the NEGATION (player-side actors are opposing to an enemy owner):
+
+```typescript
+        registerReactiveListeners({
+            bus,
+            perOwner: enemyReactivePerOwner,
+            enqueue: (intent) => enemyIntentQueue.push(intent),
+            // Enemy owners: the PLAYER team is opposing. Negating the player-centric
+            // isEnemySide flips on-enemy-* / on-ally-* to the enemy's own frame
+            // (bySide PR2 — fixes the enemy reactive-routing bug).
+            isOpposing: (id: string) => !isEnemySide(id),
+            roleOf: (id) => roleByActorId.get(id),
+        });
+```
+
+> Keep `isEnemySide` (engine.ts ~1830) exactly as-is — it stays the player-frame primitive that both calls are derived from. (Its own full unification into `bySide()` is PR3+, not here.)
+>
+> KNOWN OUT-OF-SCOPE (do NOT fix here): the enemy call's `roleOf` still reads `roleByActorId`, which is populated with PLAYER roles only — so an enemy `on-ally-attacked` role filter (enemy Graphite) stays dormant. That is a roleOf-map gap, not a predicate gap; it belongs to a later PR. Flag it, don't chase it.
+
+- [ ] **Step 6: Run the unit test + type-check**
+
+Run: `npx vitest run src/utils/combat/__tests__/enemyReactiveRouting.test.ts` → all 3 cases PASS.
+Run: `npx tsc --noEmit` → clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/utils/combat/triggers.ts src/utils/combat/engine.ts src/utils/combat/__tests__/enemyReactiveRouting.test.ts
+git commit -m "fix(combat): route enemy reactive triggers via per-call isOpposing predicate (bySide PR2 task 1)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Fix `grantExtraAction` to resolve the granter from the combined roster
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts` — introduce `allActorsById` (after `allActors`, ~1596); `grantExtraAction` body (~2490); Path-B `pendingExtraActions` flush (~2653); stale comment (~2482)
+- Test: `src/utils/combat/__tests__/enemyReactiveRouting.test.ts` (append the end-to-end repro)
+
+**Why Task 1 alone isn't enough:** after Task 1, the enemy Liberator's `on-enemy-destroyed` listener FIRES when a player dies (the predicate is fixed) and routes through the executor's `extra-action` branch into `grantExtraAction`. But `grantExtraAction` resolves the granter from `allPlayerActorsById`, which has no enemy ids → `if (!granter) return;` silently drops it. `processExtraActionGrants` itself already works for any actor (it bumps the `pending` / `endOfRoundPending` maps, both seeded from `roundActors === allActors`, which includes enemy ids). So the ONLY missing piece is the granter lookup.
+
+- [ ] **Step 1: Write the failing end-to-end repro test**
+
+Append to `enemyReactiveRouting.test.ts` a team-vs-team `runCombat` scenario, grounded in the `twoTeamBattle.test.ts` harness (positioned actors + `healTargetId` to unlock the enemy roster) and the `reactiveExtraAction.test.ts` ability builders (the `extra-action` / `on-enemy-destroyed` passive). Set up: an ENEMY attacker carrying a Liberator-style passive (`type:'extra-action'`, `target:'self'`, `trigger:'on-enemy-destroyed'`, `config:{ type:'extra-action', oncePerRound:true }`) plus a plain damage active strong enough to one-shot a fragile PLAYER ship; TWO player ships (a fragile victim + a tanky survivor set as `healTargetId`) so the player team is not wiped and combat continues.
+
+Assert via a **non-vacuous control comparison** (per the spec's vacuous-isolation-trap warning): run the identical battle twice — once with the extra-action passive present, once absent — and assert the enemy Liberator takes exactly ONE more turn WITH the passive. Count the enemy Liberator's `turn-started` events (`events.filter(e => e.type==='turn-started' && e.actorId===LIBERATOR_ID).length`). Both runs must produce identical damage (the passive is non-damaging) → the kill happens in both → the only delta is the extra action.
+
+```typescript
+// (sketch — fill in positioned builders + ids from twoTeamBattle.test.ts)
+const liberatorTurns = (withPassive: boolean): number => {
+    const { events, LIBERATOR_ID } = runTeamBattle({ withExtraActionPassive: withPassive });
+    return events.filter(e => e.type === 'turn-started' && e.actorId === LIBERATOR_ID).length;
+};
+it('enemy Liberator gains its on-enemy-destroyed extra action after killing a player ship', () => {
+    const withPassive = liberatorTurns(true);
+    const without = liberatorTurns(false);
+    // Sanity: the kill actually happens in BOTH runs (non-vacuous baseline).
+    expect(/* a player ship destroyed in the control run */).toBe(true);
+    // The fix: exactly one extra action (once per round, single kill).
+    expect(withPassive).toBe(without + 1);
+});
+```
+
+> The exact extra-turn LANDING ROUND (same-round Path A vs next-round Path B) depends on when a real positioned player victim's death is reconciled — OBSERVE it from the live engine while implementing and pin it in a comment; the regression PROPERTY asserted is the total-turn delta (`+1`), which is timing-independent. If you also want a per-round assertion, add it only after observing the real behavior — never guess it.
+
+- [ ] **Step 2: Run the repro, verify it fails**
+
+Run: `npx vitest run src/utils/combat/__tests__/enemyReactiveRouting.test.ts -t "extra action after killing"`
+Expected: FAIL — `withPassive === without` (the grant is dropped by the player-only granter lookup), so `withPassive === without + 1` is false.
+
+- [ ] **Step 3: Introduce the combined `allActorsById` accessor**
+
+In `engine.ts`, immediately AFTER the `allActors` definition (~1596, the PR1 seam), add (PR1 explicitly deferred this accessor to its first consumer — here):
+
+```typescript
+    // Combined id→actor map over the unified roster (bySide unification PR2 — first
+    // consumer). Unlike allPlayerActorsById (attacker + team only), this includes the
+    // dummy enemy and every enemy attacker, so a reactive granter on EITHER side
+    // resolves. Used by grantExtraAction; companion actorsBySide lands in PR3.
+    const allActorsById = new Map<string, CombatActor>(allActors.map((a) => [a.id, a]));
+```
+
+(`allActorsById` is read in Step 4, so it is not an unused binding — no `--max-warnings 0` issue.)
+
+- [ ] **Step 4: Switch the two `grantExtraAction` granter lookups + fix the stale comment**
+
+In `grantExtraAction` (~2490): `const granter = allPlayerActorsById.get(granterId);` → `const granter = allActorsById.get(granterId);`
+
+In the Path-B flush (~2653): `const granter = allPlayerActorsById.get(g.granterId);` → `const granter = allActorsById.get(g.granterId);`
+
+Update the now-stale comment block above `grantExtraAction` (~2481-2483) — replace "The granter is always a player actor (the ship whose death-passive fired); a missing id is impossible (the reactive owner ids ARE player ids)" with:
+
+```typescript
+        // onto pendingExtraActions; the next round's pool build flushes it. The granter is the
+        // ship whose reactive passive fired — a PLAYER or (since bySide PR2) an ENEMY actor; it
+        // is resolved from the combined allActorsById roster. A missing id is impossible (every
+        // reactive owner id is in allActors) → skip defensively rather than throw mid-drain.
+```
+
+> Do NOT touch the `healTarget` lookup (`allPlayerActorsById.get(healTargetId)`, ~1536) or any other `allPlayerActorsById` use — the heal target is always a player; only the two granter lookups change.
+
+- [ ] **Step 5: Run the repro + type-check**
+
+Run: `npx vitest run src/utils/combat/__tests__/enemyReactiveRouting.test.ts` → all cases PASS (`withPassive === without + 1`).
+Run: `npx tsc --noEmit` → clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/combat/engine.ts src/utils/combat/__tests__/enemyReactiveRouting.test.ts
+git commit -m "fix(combat): resolve extra-action granter from combined roster so enemy grants land (bySide PR2 task 2)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Verify byte-identical + clean, then open the PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full test suite**
+
+Run: `npm test`
+Expected: ALL green (prior count + the new `enemyReactiveRouting.test.ts` cases).
+
+- [ ] **Step 2: Goldens byte-identical — the load-bearing check**
+
+Run: `git status --porcelain '*.snap'` and `git diff --stat origin/feat/combat-sim-phase5-pr2 -- '*.snap'`
+Expected: NO `.snap` file modified. The only changed files are `triggers.ts`, `engine.ts`, and the new test file.
+If any golden moved: **STOP.** The player-call predicate semantics leaked (the player call must remain `isOpposing: isEnemySide`, exactly reproducing the old expressions). Re-check Task 1 Step 4's swaps against the table and Task 1 Step 5's player call. NEVER run `vitest -u`. (A healing-golden move would mean an enemy attacker in a synthetic fixture actually had a triggering opposing/ally reaction — if so, audit whether it's a legitimate latent-bug fix and escalate to the user before accepting; the spec's expectation is byte-identical.)
+
+- [ ] **Step 3: Lint**
+
+Run: `npm run lint`
+Expected: 0 warnings/errors (`--max-warnings 0`). `allActorsById` is read by `grantExtraAction`; no unused-binding warning.
+
+- [ ] **Step 4: Skill audit (sanity — untouched)**
+
+Run: `npm run audit:skills`
+Expected: 0 findings / 141 ships (no parser/ability change in this PR).
+
+- [ ] **Step 5: Manual `/simulator` smoke check**
+
+The dev server serves `/simulator` on :3000 (already on this branch). Place a lone enemy Liberator (R4) vs a fragile player ship; confirm that when the enemy Liberator kills the player ship it takes a second action that round (the codified repro from `project-enemy-side-reactive-routing-gap`). Note the result in the PR body.
+
+- [ ] **Step 6: Push and open the PR**
+
+```bash
+gh auth switch --hostname github.com --user TheSusort
+git push --no-verify origin feat/combat-engine-unify-pr2 | cat
+gh pr create --base feat/combat-sim-phase5-pr2 \
+  --title "fix(combat): bySide unification PR2 — side predicates + enemy reactive-routing fix" \
+  --body "$(cat <<'EOF'
+Second slice of the team-agnostic bySide engine unification (spec: docs/superpowers/specs/2026-06-16-combat-engine-bySide-unification-design.md, §4 PR2). Stacked on PR1 (#118).
+
+## What
+- `registerReactiveListeners` now takes a per-call `isOpposing(actorId)` instead of the player-centric `isEnemySide`, and derives `isSameSideAlly(id, owner) = !isOpposing(id) && id !== owner` internally. The player registration passes `isOpposing: isEnemySide` (byte-identical); the enemy registration passes its negation.
+- `grantExtraAction` (and the Path-B pending-grant flush) now resolve the granter from the combined `allActorsById` roster instead of the player-only `allPlayerActorsById`, so an enemy granter's grant lands.
+
+## Fixes
+- An ENEMY-side ship's opposing/ally reactive triggers (`on-enemy-destroyed`, `on-ally-destroyed`, `on-ally-attacked`, `on-enemy-repaired`/`-cleansed`) now fire against the correct side. The codified repro — a lone enemy Liberator that kills a player ship now gets its `on-enemy-destroyed` extra action — passes (verified by a control-comparison team-vs-team test + a `/simulator` smoke check). Retires the `project-enemy-side-reactive-routing-gap` bug class.
+
+## Safety
+- BYTE-IDENTICAL DPS + healing goldens (verified: no `.snap` movement). The player call is algebraically identical to today; the behavioral change lives entirely on the enemy call, which no golden exercises.
+- New `enemyReactiveRouting.test.ts`: 3 predicate unit tests + 1 end-to-end enemy-Liberator extra-action repro (non-vacuous control comparison).
+
+## Out of scope (flagged, deferred)
+- Enemy `on-ally-attacked` role filters (enemy Graphite) stay dormant — the enemy `roleOf` map carries player roles only. That is a roleOf-map gap, not a predicate gap; a later PR.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+NOTE: PR base is the stacked branch `feat/combat-sim-phase5-pr2`. CodeRabbit only auto-reviews base=main PRs — retarget to main and rebase `--onto` once PR1's chain merges. Poll `mergeState=CLEAN`; npm-audit RED is the pre-existing vite advisory (non-blocker). The user merges PRs ("merge when green").
+
+---
+
+## Definition of done
+
+- [ ] `registerReactiveListeners` takes `isOpposing` (not `isEnemySide`); `isSameSideAlly` derived internally; all 8 in-listener predicate uses swapped; zero `isEnemySide` references remain in `triggers.ts`.
+- [ ] Player call passes `isOpposing: isEnemySide`; enemy call passes `isOpposing: (id) => !isEnemySide(id)`.
+- [ ] `allActorsById` defined once over `allActors`; both `grantExtraAction` granter lookups use it; the stale "granter is always a player actor" comment updated. `allPlayerActorsById` otherwise untouched (incl. `healTarget`).
+- [ ] `enemyReactiveRouting.test.ts`: 3 predicate unit tests + the control-comparison enemy-Liberator extra-action repro, all green.
+- [ ] `npm test` green; goldens BYTE-IDENTICAL (no `.snap` in the diff).
+- [ ] `npm run lint` clean; `npx tsc --noEmit` clean; `audit:skills` 0/141.
+- [ ] `/simulator` smoke check confirms enemy Liberator takes its extra action on a kill.
+- [ ] PR opened against `feat/combat-sim-phase5-pr2`.

--- a/src/utils/combat/__tests__/allyCritDot.test.ts
+++ b/src/utils/combat/__tests__/allyCritDot.test.ts
@@ -187,7 +187,7 @@ describe('allyCritDot – Task 2: on-ally-crit-dot reactive listener', () => {
             bus: handBus,
             perOwner: [{ ownerId: 'attacker', reactiveAbilities: [ra] }],
             enqueue: (intent) => enqueued.push(intent),
-            isEnemySide: (id) => id === 'enemy',
+            isOpposing: (id) => id === 'enemy',
         });
 
         const baseEvent = {

--- a/src/utils/combat/__tests__/enemyActions.test.ts
+++ b/src/utils/combat/__tests__/enemyActions.test.ts
@@ -54,7 +54,7 @@ describe('Phase 4c PR 4 — enemy-action triggers', () => {
                 },
             ],
             enqueue: (i) => enqueued.push(i),
-            isEnemySide: (id) => id === 'enemy',
+            isOpposing: (id) => id === 'enemy',
         });
         bus.emit({
             type: 'heal-performed',
@@ -87,7 +87,7 @@ describe('Phase 4c PR 4 — enemy-action triggers', () => {
                 },
             ],
             enqueue: (i) => enqueued.push(i),
-            isEnemySide: (id) => id === 'enemy',
+            isOpposing: (id) => id === 'enemy',
         });
         bus.emit({ type: 'cleanse-performed', casterId: 'enemy', count: 1, round: 1 });
         bus.emit({ type: 'cleanse-performed', casterId: 'ally', count: 1, round: 1 });

--- a/src/utils/combat/__tests__/enemyReactiveRouting.test.ts
+++ b/src/utils/combat/__tests__/enemyReactiveRouting.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for the per-call isOpposing predicate in registerReactiveListeners.
+ *
+ * Purpose: verify that enemy owners' on-enemy-destroyed / on-ally-destroyed triggers route
+ * against the CORRECT side (the player team is opposing for an enemy owner, not the enemy
+ * side). This is the bySide PR2 fix. Other reactive triggers (on-ally-crit, etc.) are
+ * covered by triggers.test.ts.
+ *
+ * These tests drive registerReactiveListeners directly with a fake bus and spy enqueue,
+ * so they are fast, isolated, and free of golden-snapshot concerns.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createEventBus } from '../events';
+import { registerReactiveListeners, ReactiveAbility, Intent } from '../triggers';
+import type { Ability } from '../../../types/abilities';
+
+// ---------------------------------------------------------------------------
+// Minimal ability builder (mirrors the ab() helper in triggers.test.ts)
+// ---------------------------------------------------------------------------
+let idCounter = 0;
+const ab = (partial: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `g${++idCounter}`,
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    ...partial,
+});
+
+// A simple buff ability config used in reactive slots (no extra-action complexity).
+const buffAbility = (trigger: Ability['trigger']): Ability =>
+    ab({
+        type: 'buff',
+        target: 'self',
+        trigger,
+        config: {
+            type: 'buff',
+            buffName: 'Attack Up',
+            parsedEffects: { attack: 20 },
+            stacks: 1,
+            isStackable: false,
+        },
+    });
+
+const makeRA = (trigger: Ability['trigger']): ReactiveAbility => ({
+    ability: buffAbility(trigger),
+    sourceSlot: 'passive',
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — enemy owner E1 with on-enemy-destroyed
+//   isOpposing = (id) => id === 'P1' || id === 'P2'  (player team is opposing)
+//   Emitting ship-destroyed for P1 (opposing) → should enqueue once
+//   Emitting ship-destroyed for E2 (same-side) → should NOT enqueue
+// ---------------------------------------------------------------------------
+describe('enemy owner on-enemy-destroyed', () => {
+    it('fires for an opposing (player) actor death and NOT for a same-side actor death', () => {
+        const bus = createEventBus();
+        const enqueued: Intent[] = [];
+
+        const isOpposing = (id: string) => id === 'P1' || id === 'P2';
+
+        registerReactiveListeners({
+            bus,
+            perOwner: [
+                {
+                    ownerId: 'E1',
+                    reactiveAbilities: [makeRA('on-enemy-destroyed')],
+                },
+            ],
+            enqueue: (intent) => enqueued.push(intent),
+            isOpposing,
+        });
+
+        // Opposing actor dies → should fire
+        bus.emit({ type: 'ship-destroyed', actorId: 'P1', round: 1 });
+
+        // Same-side actor dies → should NOT fire
+        bus.emit({ type: 'ship-destroyed', actorId: 'E2', round: 1 });
+
+        expect(enqueued.length).toBe(1);
+        expect(enqueued[0].ownerId).toBe('E1');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — enemy owner E1 with on-ally-destroyed
+//   isOpposing = (id) => id === 'P1'
+//   E2 (same-side non-self) → should fire
+//   E1 (self) → should NOT fire (self-death goes to on-destroyed)
+//   P1 (opposing) → should NOT fire (opposing is never an ally)
+// ---------------------------------------------------------------------------
+describe('enemy owner on-ally-destroyed', () => {
+    it('fires for same-side non-self and NOT for self or opposing actors', () => {
+        const bus = createEventBus();
+        const enqueued: Intent[] = [];
+
+        const isOpposing = (id: string) => id === 'P1';
+
+        registerReactiveListeners({
+            bus,
+            perOwner: [
+                {
+                    ownerId: 'E1',
+                    reactiveAbilities: [makeRA('on-ally-destroyed')],
+                },
+            ],
+            enqueue: (intent) => enqueued.push(intent),
+            isOpposing,
+        });
+
+        // E2: same-side, non-self → fires
+        bus.emit({ type: 'ship-destroyed', actorId: 'E2', round: 1 });
+
+        // E1: self → does NOT fire (own death is on-destroyed's job)
+        bus.emit({ type: 'ship-destroyed', actorId: 'E1', round: 1 });
+
+        // P1: opposing → does NOT fire (opposing is never an ally)
+        bus.emit({ type: 'ship-destroyed', actorId: 'P1', round: 1 });
+
+        expect(enqueued.length).toBe(1);
+        expect(enqueued[0].ownerId).toBe('E1');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — player-call parity
+//   owner 'attacker', isOpposing = isEnemySide = (id) => id === 'enemy'
+//   on-ally-destroyed:
+//     T1 (ally player) → fires
+//     'enemy' → does NOT fire (opposing)
+//     'attacker' (self) → does NOT fire
+// ---------------------------------------------------------------------------
+describe('player owner on-ally-destroyed (parity check)', () => {
+    it('fires for team ally death and NOT for enemy or self', () => {
+        const bus = createEventBus();
+        const enqueued: Intent[] = [];
+
+        // Classic player-call predicate: isEnemySide
+        const isOpposing = (id: string) => id === 'enemy';
+
+        registerReactiveListeners({
+            bus,
+            perOwner: [
+                {
+                    ownerId: 'attacker',
+                    reactiveAbilities: [makeRA('on-ally-destroyed')],
+                },
+            ],
+            enqueue: (intent) => enqueued.push(intent),
+            isOpposing,
+        });
+
+        // T1: ally player actor → fires
+        bus.emit({ type: 'ship-destroyed', actorId: 'T1', round: 1 });
+
+        // 'enemy': opposing actor → does NOT fire
+        bus.emit({ type: 'ship-destroyed', actorId: 'enemy', round: 1 });
+
+        // 'attacker': self → does NOT fire
+        bus.emit({ type: 'ship-destroyed', actorId: 'attacker', round: 1 });
+
+        expect(enqueued.length).toBe(1);
+        expect(enqueued[0].ownerId).toBe('attacker');
+    });
+});

--- a/src/utils/combat/__tests__/enemyReactiveRouting.test.ts
+++ b/src/utils/combat/__tests__/enemyReactiveRouting.test.ts
@@ -11,9 +11,12 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { createEventBus } from '../events';
+import { createEventBus, CombatEvent } from '../events';
 import { registerReactiveListeners, ReactiveAbility, Intent } from '../triggers';
-import type { Ability } from '../../../types/abilities';
+import type { Ability, ShipSkills } from '../../../types/abilities';
+import { runCombat, CombatEngineInput } from '../engine';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
 
 // ---------------------------------------------------------------------------
 // Minimal ability builder (mirrors the ab() helper in triggers.test.ts)
@@ -162,5 +165,220 @@ describe('player owner on-ally-destroyed (parity check)', () => {
 
         expect(enqueued.length).toBe(1);
         expect(enqueued[0].ownerId).toBe('attacker');
+    });
+});
+
+// ===========================================================================
+// END-TO-END repro (bySide PR2 task 2): an ENEMY granter's on-enemy-destroyed
+// extra-action must actually LAND, not just fire the listener.
+//
+// Task 1 fixed the listener PREDICATE so an enemy owner's on-enemy-destroyed FIRES
+// when a player ship dies. But the grant was still dropped: grantExtraAction
+// resolved the granter from allPlayerActorsById (attacker + team only, NO enemy ids),
+// so an enemy granter hit `if (!granter) return;` and the extra action was silently
+// lost. Task 2 switches the granter lookup to the combined allActorsById roster.
+//
+// This is a full runCombat team-vs-team battle (harness copied from
+// twoTeamBattle.test.ts): a positioned enemy attacker carries a one-shot damage active
+// PLUS a Liberator-style on-enemy-destroyed extra-action passive (shape from
+// reactiveExtraAction.test.ts). Two player ships are on the board — a fragile victim it
+// kills + a tankier survivor set as healTargetId (so the player team isn't wiped and the
+// enemy keeps walking). The passive is non-damaging, so the kill is identical with or
+// without it — a NON-VACUOUS control: the same battle runs twice, and we assert the
+// enemy's turn count is exactly +1 with the passive.
+//
+// OBSERVED extra-turn landing: the player victim is a real positioned actor reconciled
+// post-round, so the kill is registered post-round → Path B → the buffered grant lands
+// in the NEXT round (R+1). The asserted PROPERTY is the timing-independent +1 delta.
+// ===========================================================================
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
+
+let e2eIdc = 0;
+const e2eAb = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `e2e${++e2eIdc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+// Single-hit 100% basic attack (attack × 1 vs defence 0 = known per-hit damage).
+const e2eBasicAttack = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        e2eAb({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } }),
+    ],
+});
+
+// Liberator-style on-enemy-destroyed extra-action passive (non-damaging).
+const liberatorPassive = (): ShipSkills['slots'][number] => ({
+    slot: 'passive',
+    abilities: [
+        e2eAb({
+            type: 'extra-action',
+            target: 'self',
+            trigger: 'on-enemy-destroyed',
+            config: { type: 'extra-action', oncePerRound: true },
+        }),
+    ],
+});
+
+const e2eParsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const e2eBasePattern = (): ParsedPattern => ({
+    raw: 'base',
+    shape: 'base',
+    range: 0,
+    modifiers: {},
+});
+
+// A walked team actor that FIRES on the enemy roster.
+const teamAttackerAt = (
+    id: string,
+    position: Position,
+    selection: ParsedTarget['selection'],
+    attack: number,
+    hp: number
+): TeamActor => ({
+    id,
+    speed: 150,
+    chargeCount: 0,
+    startCharged: false,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    position,
+    target: e2eParsedTarget(selection),
+    pattern: e2eBasePattern(),
+    walk: {
+        shipSkills: { slots: [e2eBasicAttack()] },
+        stats: {
+            attack,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            hacking: 0,
+            defence: 0,
+            hp,
+        },
+        debuffLandingChance: 1,
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        hasChargedSkill: false,
+    },
+});
+
+// A positioned enemy attacker firing on the player roster. `slots` lets the Liberator
+// case add the on-enemy-destroyed passive alongside the damage active.
+const offensiveEnemyAt = (
+    id: string,
+    position: Position,
+    selection: ParsedTarget['selection'],
+    attack: number,
+    hp: number,
+    speed: number,
+    slots: ShipSkills['slots']
+): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack, crit: 0, critDamage: 0, defence: 0, hp, speed },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: e2eParsedTarget(selection),
+        pattern: e2eBasePattern(),
+        shipSkills: { slots },
+    }) as EnemyAttacker;
+
+// Build the battle. `withPassive` toggles the enemy Liberator's on-enemy-destroyed
+// extra-action passive (the control: identical otherwise).
+const liberatorBattle = (withPassive: boolean): CombatEngineInput => {
+    e2eIdc = 0;
+    const enemySlots: ShipSkills['slots'] = withPassive
+        ? [e2eBasicAttack(), liberatorPassive()]
+        : [e2eBasicAttack()];
+    return {
+        // Focus actor = the tanky SURVIVOR (heal target), positioned at the BACK (M3).
+        // Huge HP so it never dies → the player team is never wiped → combat continues.
+        attack: 1, // focus barely scratches the enemy so the enemy survives to keep acting
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: { slots: [e2eBasicAttack()] },
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 4,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        debuffLandingChance: 1,
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        healTargetId: 'attacker',
+        position: 'M3',
+        target: e2eParsedTarget('back'),
+        pattern: e2eBasePattern(),
+        // Fragile VICTIM player at the FRONT (M4): 1 HP so the enemy front attack one-shots it.
+        teamActors: [teamAttackerAt('player-victim', 'M4', 'back', 1, 1)],
+        // Single enemy Liberator at the front, fires `front` → anchors the front-most player
+        // (the fragile victim at M4), one-shots it (attack 5000 vs hp 1). speed 200 so it acts
+        // at the TOP of the round, before the players.
+        enemyAttackers: [
+            offensiveEnemyAt(
+                'enemy-liberator',
+                'M4',
+                'front',
+                5000,
+                1_000_000_000,
+                200,
+                enemySlots
+            ),
+        ],
+    };
+};
+
+const runE2E = (input: CombatEngineInput) => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    const TYPES: CombatEvent['type'][] = ['turn-started', 'ship-destroyed'];
+    for (const t of TYPES) bus.on(t, (e) => events.push(e as CombatEvent));
+    runCombat({ ...input, bus });
+    return events;
+};
+
+const countEnemyTurns = (events: CombatEvent[]) =>
+    events.filter((e) => e.type === 'turn-started' && e.actorId === 'enemy-liberator').length;
+
+describe('enemy on-enemy-destroyed extra-action lands end-to-end (bySide PR2 task 2)', () => {
+    it('grants the enemy Liberator exactly ONE extra action when it kills a player ship', () => {
+        const withEvents = runE2E(liberatorBattle(true));
+        const withoutEvents = runE2E(liberatorBattle(false));
+
+        // NON-VACUOUS baseline: a player ship is actually destroyed in the control run.
+        const victimDestroyed = withoutEvents.some(
+            (e) => e.type === 'ship-destroyed' && e.actorId === 'player-victim'
+        );
+        expect(victimDestroyed).toBe(true);
+
+        const turnsWith = countEnemyTurns(withEvents);
+        const turnsWithout = countEnemyTurns(withoutEvents);
+
+        // Once-per-round, single kill → exactly one extra action for the enemy granter.
+        // Before the fix the grant is dropped (player-only lookup) → turnsWith === turnsWithout.
+        expect(turnsWith).toBe(turnsWithout + 1);
     });
 });

--- a/src/utils/combat/__tests__/healing.test.ts
+++ b/src/utils/combat/__tests__/healing.test.ts
@@ -1471,7 +1471,7 @@ describe('healing — Task 9: reactive listeners (on-ally-critically-repaired / 
             bus: handBus,
             perOwner: [{ ownerId: 'attacker', reactiveAbilities: [ra] }],
             enqueue: (intent) => enqueued.push(intent),
-            isEnemySide: (id) => id === 'enemy',
+            isOpposing: (id) => id === 'enemy',
         });
         const base = { round: 1, amount: 1000 };
 
@@ -1531,7 +1531,7 @@ describe('healing — Task 9: reactive listeners (on-ally-critically-repaired / 
             bus: handBus,
             perOwner: [{ ownerId: 'attacker', reactiveAbilities: [ra] }],
             enqueue: (intent) => enqueued.push(intent),
-            isEnemySide: (id) => id === 'enemy',
+            isOpposing: (id) => id === 'enemy',
         });
         const base = {
             round: 1,
@@ -1579,7 +1579,7 @@ describe('healing — Task 9: reactive listeners (on-ally-critically-repaired / 
             bus: handBus,
             perOwner: [{ ownerId: 'attacker', reactiveAbilities: [ra] }],
             enqueue: (intent) => enqueued.push(intent),
-            isEnemySide: (id) => id === 'enemy',
+            isOpposing: (id) => id === 'enemy',
         });
         const base = { round: 1, targetId: 'enemy', buffName: 'Speed Down II' };
 

--- a/src/utils/combat/__tests__/hpCrossing.test.ts
+++ b/src/utils/combat/__tests__/hpCrossing.test.ts
@@ -365,7 +365,7 @@ describe('Phase 4c PR 3 Task 3 — on-hp-threshold-crossed listener', () => {
             bus,
             perOwner: [{ ownerId, reactiveAbilities: [ra] }],
             enqueue: (intent) => enqueued.push(intent),
-            isEnemySide: (id) => id === 'enemy-dummy',
+            isOpposing: (id) => id === 'enemy-dummy',
         });
         const fire = (oldPct: number, newPct: number, targetId = ownerId, round = 1) =>
             bus.emit({ type: 'hp-changed', targetId, round, oldPct, newPct });

--- a/src/utils/combat/__tests__/triggers.test.ts
+++ b/src/utils/combat/__tests__/triggers.test.ts
@@ -1466,7 +1466,7 @@ describe('on-attacked live trigger (Task 4)', () => {
             bus,
             perOwner,
             enqueue: (i) => intents.push(i),
-            isEnemySide: (id) => id === 'enemy',
+            isOpposing: (id) => id === 'enemy',
         });
         bus.emit(event);
         return intents;
@@ -1535,7 +1535,7 @@ describe('on-attacked live trigger (Task 4)', () => {
             bus,
             perOwner: [{ ownerId: 't', reactiveAbilities: [ra] }],
             enqueue: (i) => intents.push(i),
-            isEnemySide: (id) => id === 'enemy',
+            isOpposing: (id) => id === 'enemy',
         });
         // Before any event: no intents enqueued
         expect(intents).toHaveLength(0);
@@ -1745,7 +1745,7 @@ describe('on-attacked live trigger (Task 4)', () => {
 // actor takes a direct hit. Unit-level harness mirroring the on-attacked
 // crit-filter tests: bare bus + registerReactiveListeners + manual emits.
 // Owner is 'graphite' (the reacting ship); 'tank' is another player actor;
-// 'enemy' and 'ea1' are enemy-side per the isEnemySide predicate.
+// 'enemy' and 'ea1' are enemy-side per the isOpposing predicate.
 // ----------------------------------------------------------------------
 describe('on-ally-attacked listener', () => {
     // Build a minimal on-ally-attacked reactive ability (Graphite/Cultivator shape).
@@ -1778,7 +1778,7 @@ describe('on-ally-attacked listener', () => {
             bus,
             perOwner: [{ ownerId: 'graphite', reactiveAbilities }],
             enqueue: (i) => intents.push(i),
-            isEnemySide: (id) => id === 'enemy' || id === 'ea1',
+            isOpposing: (id) => id === 'enemy' || id === 'ea1',
             roleOf,
         });
         for (const e of events) bus.emit(e);
@@ -1934,7 +1934,7 @@ describe('on-ally-attacked listener', () => {
 // Death-trigger live listeners (Task 5): on-destroyed / on-ally-destroyed /
 // on-enemy-destroyed. Unit-level tests driving registerReactiveListeners +
 // createEventBus directly. Owner is always 'A' (a player actor); 'B' is
-// another player actor; 'enemy' is enemy-side per the isEnemySide predicate.
+// another player actor; 'enemy' is enemy-side per the isOpposing predicate.
 // ----------------------------------------------------------------------
 describe('death-trigger live listeners (Task 5)', () => {
     // Build a minimal reactive ability carrying the given death trigger.
@@ -1964,7 +1964,7 @@ describe('death-trigger live listeners (Task 5)', () => {
             bus,
             perOwner: [{ ownerId: 'A', reactiveAbilities: [ra] }],
             enqueue: (i) => intents.push(i),
-            isEnemySide: (id) => id === 'enemy',
+            isOpposing: (id) => id === 'enemy',
         });
         bus.emit({ type: 'ship-destroyed', actorId: destroyedActorId, round: 1 });
         return intents;
@@ -2032,7 +2032,7 @@ describe('death-trigger live listeners (Task 5)', () => {
             bus,
             perOwner: [{ ownerId: 'A', reactiveAbilities: [ra] }],
             enqueue: (i) => intents.push(i),
-            isEnemySide: (id) => id === 'enemy',
+            isOpposing: (id) => id === 'enemy',
         });
         expect(intents).toHaveLength(0);
         bus.emit({ type: 'ship-destroyed', actorId: 'A', round: 1 });
@@ -2066,7 +2066,7 @@ describe('on-cheat-death-activated live listener (Task 8)', () => {
             bus,
             perOwner: [{ ownerId, reactiveAbilities: [ra] }],
             enqueue: (i) => intents.push(i),
-            isEnemySide: (id) => id === 'enemy',
+            isOpposing: (id) => id === 'enemy',
         });
         bus.emit({ type: 'cheat-death-activated', actorId: activatedActorId, round: 1 });
         return intents;
@@ -2091,7 +2091,7 @@ describe('on-cheat-death-activated live listener (Task 8)', () => {
             bus,
             perOwner: [{ ownerId: 'A', reactiveAbilities: [ra] }],
             enqueue: (i) => intents.push(i),
-            isEnemySide: (id) => id === 'enemy',
+            isOpposing: (id) => id === 'enemy',
         });
         expect(intents).toHaveLength(0);
         bus.emit({ type: 'cheat-death-activated', actorId: 'B', round: 1 });

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -1841,7 +1841,7 @@ export function runCombat(input: CombatEngineInput): {
         bus,
         perOwner: reactivePerOwner,
         enqueue: (intent) => intentQueue.push(intent),
-        isEnemySide,
+        isOpposing: isEnemySide,
         roleOf: (id) => roleByActorId.get(id),
     });
 
@@ -1862,7 +1862,10 @@ export function runCombat(input: CombatEngineInput): {
             bus,
             perOwner: enemyReactivePerOwner,
             enqueue: (intent) => enemyIntentQueue.push(intent),
-            isEnemySide,
+            // Enemy owners: the PLAYER team is opposing. Negating the player-centric
+            // isEnemySide flips on-enemy-* / on-ally-* to the enemy's own frame
+            // (bySide PR2 — fixes the enemy reactive-routing bug).
+            isOpposing: (id: string) => !isEnemySide(id),
             roleOf: (id) => roleByActorId.get(id),
         });
     }

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -1590,10 +1590,16 @@ export function runCombat(input: CombatEngineInput): {
     // The canonical, side-agnostic actor set, named once. Order MATTERS: it drives
     // the per-round turn order — `roundActors` is assigned to it each round —
     // [team…, attacker, dummy enemy, enemy attackers…], identical to the array
-    // `roundActors` used inline before PR1. The companion accessors allActorsById /
-    // actorsBySide arrive in later PRs with their first consumers (deferred —
-    // unread now = YAGNI/lint).
+    // `roundActors` used inline before PR1. The companion accessor `actorsBySide`
+    // arrives in a later PR with its first consumer (deferred — unread now =
+    // YAGNI/lint); `allActorsById` has now arrived in PR2 (defined just below).
     const allActors: CombatActor[] = [...teamCombatActors, attacker, enemy, ...enemyAttackerActors];
+
+    // Combined id→actor map over the unified roster (bySide unification PR2 — first
+    // consumer). Unlike allPlayerActorsById (attacker + team only), this includes the
+    // dummy enemy and every enemy attacker, so a reactive granter on EITHER side
+    // resolves. Used by grantExtraAction; companion actorsBySide lands in PR3.
+    const allActorsById = new Map<string, CombatActor>(allActors.map((a) => [a.id, a]));
 
     // Enemy-team charge grant (enemy-team PR3): the mirror of grantAllyCharges — bump every
     // ENEMY attacker's charges by `amount`, each capped at its own chargeCount, skipping 0. Lets
@@ -2481,16 +2487,17 @@ export function runCombat(input: CombatEngineInput): {
         // count so the selection loop re-picks it at its live speed-rank among the remaining
         // actors (same machinery the attacker/team turn branches use), so a during-turn death
         // grants a SAME-round extra turn. PATH B (no live loop — post-round enemy death): buffer
-        // onto pendingExtraActions; the next round's pool build flushes it. The granter is always
-        // a player actor (the ship whose death-passive fired); a missing id is impossible (the
-        // reactive owner ids ARE player ids) → skip defensively rather than throw mid-drain.
+        // onto pendingExtraActions; the next round's pool build flushes it. Since bySide PR2 the
+        // granter may be a PLAYER or ENEMY actor (the ship whose death-passive fired), resolved
+        // from the combined allActorsById roster; a missing id is impossible (every reactive owner
+        // id is in allActors) → skip defensively rather than throw mid-drain.
         const grantExtraAction = (
             granterId: string,
             abilityId: string,
             oncePerRound: boolean,
             endOfRound: boolean
         ): void => {
-            const granter = allPlayerActorsById.get(granterId);
+            const granter = allActorsById.get(granterId);
             if (!granter) return;
             if (inTurnLoop) {
                 processExtraActionGrants(granter, [{ abilityId, oncePerRound, endOfRound }]);
@@ -2653,7 +2660,7 @@ export function runCombat(input: CombatEngineInput): {
         if (pendingExtraActions.length > 0) {
             const flush = pendingExtraActions.splice(0, pendingExtraActions.length);
             for (const g of flush) {
-                const granter = allPlayerActorsById.get(g.granterId);
+                const granter = allActorsById.get(g.granterId);
                 if (!granter) continue;
                 processExtraActionGrants(granter, [
                     {

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -102,7 +102,7 @@ export type CombatEvent =
      *  (player or enemy); enemy-side emission carries NO numeric effect (Phase 4c PR 4 —
      *  cast-fires-regardless: emitted on every qualifying cast, with no check that a
      *  debuff actually existed to cleanse). The `on-enemy-cleansed` listener filters
-     *  `isEnemySide(casterId)`. */
+     *  `isOpposing(casterId)`. */
     | { type: 'cleanse-performed'; casterId: string; count: number; round: number }
     | {
           type: 'dot-ticked';

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -131,23 +131,22 @@ export function partitionReactiveAbilities(shipSkills: ShipSkills): {
 }
 
 /**
- * Register each player owner's reactive abilities as bus listeners. Listener bodies are
+ * Register each owner's reactive abilities as bus listeners. Listener bodies are
  * PURE (Phase 1 contract): they only `enqueue` an intent — never mutate combat state. Match
  * guards are now per OWNER (Task 6) so a team ship's reactive ability keys on ITS OWN events:
  *  - on-crit → ability-performed where actorId === ownerId; enqueues once per CRITTING HIT (critHits field; falls back to the didCrit binary for events without it)
  *  - on-debuff-inflicted → debuff-applied | dot-applied with `sourceId === ownerId`
- *  - on-ally-debuff-inflicted → debuff-applied OR dot-applied with `sourceId !== ownerId &&
- *    !isEnemySide(sourceId)` (any OTHER PLAYER's infliction is an ally-infliction from this
- *    owner's perspective — the attacker's inflictions trigger a team Oleander, and vice versa).
- *    Every enemy-side actor (dummy wall + enemy attackers) is excluded — an enemy is never an
- *    ally. The dot-applied subscription is now LIVE (the team dot-applied seam exists since Task 4).
- *  - on-ally-crit-dot → dot-applied with viaCrit from any OTHER PLAYER actor (ally crit-cast DoT;
- *    enemy-side sources excluded)
+ *  - on-ally-debuff-inflicted → debuff-applied OR dot-applied where the source is a same-side
+ *    ally (not opposing, not the owner itself). For the PLAYER registration this is any OTHER
+ *    PLAYER's infliction; for the ENEMY registration this is any other enemy actor's infliction.
+ *    The dot-applied subscription is now LIVE (the team dot-applied seam exists since Task 4).
+ *  - on-ally-crit-dot → dot-applied with viaCrit from any same-side ally (opposing sources
+ *    excluded, own casts excluded)
  *  - on-ally-critically-repaired → the OWNER's OWN heal-performed (casterId === ownerId) with
  *    >= 1 critting draw AND at least one non-self recipient (Pallas: "when THIS UNIT critically
  *    repairs an ally"). One enqueue per qualifying cast.
  *  - on-ally-crit → an ALLY's ability-performed with critting hits (mirrors on-crit ally-scoped):
- *    fires once PER CRITTING HIT; the owner's own casts and every enemy-side actor are excluded
+ *    fires once PER CRITTING HIT; the owner's own casts and every opposing actor are excluded
  *    (a walked enemy attacker now emits ability-performed, but its crit is NOT an ally crit).
  *  - start-of-round → round-started (global — every owner's start-of-round fires once per round)
  *  - on-bomb-detonated → bomb-detonated (global)
@@ -158,21 +157,22 @@ export function partitionReactiveAbilities(shipSkills: ShipSkills): {
  *    triggerCritFilter discriminates on the hit's own crit outcome: 'crit' → critting hits only,
  *    'non-crit' → non-critting only, absent → every hit. Each enqueued intent is per-event (not
  *    the shared const): eventCtx captures the attacker for "on that enemy" counter routing.
- *  - on-ally-attacked → attacked where targetId !== ownerId && !isEnemySide(targetId) (per hit;
- *    critFilter + roleFilter applied). Fires when ANY OTHER player actor is hit — own hits are
- *    on-attacked's job; an enemy-side target is never an ally. triggerCritFilter discriminates on
- *    the hit's own crit outcome (same contract as on-attacked); roleFilter (Graphite) matches the
- *    DAMAGED ally's role category via the optional roleOf lookup.
+ *  - on-ally-attacked → attacked where the target is a same-side ally (not opposing, not self)
+ *    (per hit; critFilter + roleFilter applied). Fires when ANY OTHER same-side actor is hit —
+ *    own hits are on-attacked's job; an opposing-side target is never an ally.
+ *    triggerCritFilter discriminates on the hit's own crit outcome (same contract as on-attacked);
+ *    roleFilter (Graphite) matches the DAMAGED ally's role category via the optional roleOf lookup.
  *  - on-destroyed → ship-destroyed where actorId === ownerId (self-scoped; mirrors on-attacked's
  *    target-scoped guard). One enqueue per destruction event.
- *  - on-ally-destroyed → ship-destroyed where actorId !== ownerId && !isEnemySide(actorId)
- *    (any OTHER player actor's destruction; mirrors on-ally-crit's ally scoping).
- *  - on-enemy-destroyed → ship-destroyed where isEnemySide(actorId)
- *    (any enemy-side actor — dummy wall + walked enemy attackers).
- *  - on-enemy-repaired → heal-performed where isEnemySide(casterId)
- *    (any enemy-side actor's repair cast — dummy wall + enemy attackers). One enqueue per cast.
- *  - on-enemy-cleansed → cleanse-performed where isEnemySide(casterId)
- *    (any enemy-side actor's cleanse cast — dummy wall + enemy attackers). One enqueue per cast.
+ *  - on-ally-destroyed → ship-destroyed where the actor is a same-side ally (not opposing, not self)
+ *    (any OTHER same-side actor's destruction; mirrors on-ally-crit's ally scoping).
+ *  - on-enemy-destroyed → ship-destroyed where isOpposing(actorId)
+ *    (any opposing-side actor — for players: dummy wall + walked enemy attackers;
+ *    for enemy owners: any player actor).
+ *  - on-enemy-repaired → heal-performed where isOpposing(casterId)
+ *    (any opposing-side actor's repair cast). One enqueue per cast.
+ *  - on-enemy-cleansed → cleanse-performed where isOpposing(casterId)
+ *    (any opposing-side actor's cleanse cast). One enqueue per cast.
  *  - on-hp-threshold-crossed → hp-changed where targetId === ownerId and the event is a
  *    DOWNWARD crossing of N (oldPct >= N > newPct), N read from the ability's self
  *    hp-threshold condition (trigger CONFIG — executeIntent scrubs it from the drain-time
@@ -193,21 +193,23 @@ export function registerReactiveListeners(args: {
     bus: CombatEventBus;
     perOwner: { ownerId: string; reactiveAbilities: ReactiveAbility[] }[];
     enqueue: (intent: Intent) => void;
-    /** True for ANY enemy-side actor id: the singular dummy wall enemy AND every enemy
-     *  ATTACKER (healing mode). Enemy attackers now walk runPlayerTurn (commit 6c456a14) and
-     *  therefore emit the full reactive event suite (`ability-performed` with crits,
-     *  `dot-applied`, `debuff-applied`, …) with `side === 'enemy'`. Ally-scoped player
-     *  listeners treat "any OTHER player actor" as an ally, so they MUST exclude every
-     *  enemy-side id — not just the dummy — or an enemy's crit/debuff wrongly fires a
-     *  player's on-ally-* reaction. The engine passes a predicate closing over the dummy id
-     *  + all enemy-attacker ids; for an attacker-only/DPS run only the dummy is enemy-side. */
-    isEnemySide: (actorId: string) => boolean;
+    /** True for any actor on the side OPPOSING this listener set's owners. The engine
+     *  passes a per-call predicate: the PLAYER registration passes the enemy-side
+     *  predicate (opposing = enemy-side); the ENEMY registration passes its negation
+     *  (opposing = player-side). This per-call approach ensures an enemy owner's
+     *  opposing/ally reactions route against the correct side (bySide PR2). */
+    isOpposing: (actorId: string) => boolean;
     /** Damaged-ally role lookup for role-filtered ally-damage reactions (Graphite).
      *  Returns the actor's ShipTypeName or undefined (manual actor / no ship picked).
      *  Optional: DPS-mode runs and unit fixtures omit it. */
     roleOf?: (actorId: string) => ShipTypeName | undefined;
 }): void {
-    const { bus, perOwner, enqueue, isEnemySide, roleOf } = args;
+    const { bus, perOwner, enqueue, isOpposing, roleOf } = args;
+    // Same-side ally = NOT opposing AND not the owner itself (own events route to the
+    // self-scoped triggers). For the player registration (opposing = enemy-side) this
+    // is byte-identical to the old pattern.
+    const isSameSideAlly = (actorId: string, ownerId: string): boolean =>
+        !isOpposing(actorId) && actorId !== ownerId;
     for (const { ownerId, reactiveAbilities } of perOwner) {
         for (const ra of reactiveAbilities) {
             const intent: Intent = { ability: ra.ability, sourceSlot: ra.sourceSlot, ownerId };
@@ -232,25 +234,25 @@ export function registerReactiveListeners(args: {
                     break;
                 case 'on-ally-debuff-inflicted':
                     bus.on('debuff-applied', (e) => {
-                        // Ally = ANY OTHER player's infliction. Exclude this owner (own
-                        // inflictions go to on-debuff-inflicted) AND every enemy-side actor
-                        // (dummy wall + enemy attackers — an enemy is never an ally).
-                        if (e.sourceId !== ownerId && !isEnemySide(e.sourceId)) enqueue(intent);
+                        // Ally = any OTHER same-side actor's infliction. Exclude this owner
+                        // (own inflictions go to on-debuff-inflicted) AND every opposing actor
+                        // (an opposing actor is never an ally).
+                        if (isSameSideAlly(e.sourceId, ownerId)) enqueue(intent);
                     });
                     bus.on('dot-applied', (e) => {
                         // Team DoT applications now emit dot-applied with the team sourceId
                         // (Task 4 seam, live since Task 6) — an ally DoT infliction triggers
                         // this listener exactly as an ally debuff does.
-                        if (e.sourceId !== ownerId && !isEnemySide(e.sourceId)) enqueue(intent);
+                        if (isSameSideAlly(e.sourceId, ownerId)) enqueue(intent);
                     });
                     break;
                 case 'on-ally-crit-dot':
                     bus.on('dot-applied', (e) => {
                         // Ally DoT infliction whose cast crit (viaCrit): any OTHER
-                        // player's crit-cast DoT. Own casts and every enemy-side actor are
-                        // excluded (mirrors on-ally-debuff-inflicted's ally scoping). One
+                        // same-side actor's crit-cast DoT. Own casts and every opposing actor
+                        // are excluded (mirrors on-ally-debuff-inflicted's ally scoping). One
                         // enqueue per qualifying infliction EVENT (per-infliction-event rule).
-                        if (e.viaCrit && e.sourceId !== ownerId && !isEnemySide(e.sourceId)) {
+                        if (e.viaCrit && isSameSideAlly(e.sourceId, ownerId)) {
                             enqueue(intent);
                         }
                     });
@@ -272,10 +274,10 @@ export function registerReactiveListeners(args: {
                 case 'on-ally-crit':
                     bus.on('ability-performed', (e) => {
                         // An ALLY's critting hits (mirrors on-crit with ally scoping):
-                        // fires once PER CRITTING HIT, own casts and every enemy-side actor
-                        // (dummy wall + enemy attackers) excluded — an enemy crit is NOT an
-                        // ally crit, even though a walked enemy now emits ability-performed.
-                        if (e.actorId === ownerId || isEnemySide(e.actorId)) return;
+                        // fires once PER CRITTING HIT, own casts and every opposing actor
+                        // excluded — an opposing crit is NOT an ally crit, even though a
+                        // walked enemy now emits ability-performed.
+                        if (!isSameSideAlly(e.actorId, ownerId)) return;
                         const n = e.critHits ?? (e.didCrit ? 1 : 0);
                         for (let i = 0; i < n; i++) enqueue(intent);
                     });
@@ -310,16 +312,16 @@ export function registerReactiveListeners(args: {
                     break;
                 case 'on-ally-attacked':
                     bus.on('attacked', (e) => {
-                        // Ally-scoped: fires when ANY OTHER player actor is hit — per HIT (the
-                        // engine emits one event per hit, PR 1). Excludes this owner (own hits
-                        // are on-attacked's job) and every enemy-side actor, mirroring
+                        // Ally-scoped: fires when ANY OTHER same-side actor is hit — per HIT
+                        // (the engine emits one event per hit, PR 1). Excludes this owner (own
+                        // hits are on-attacked's job) and every opposing actor, mirroring
                         // on-ally-destroyed's scoping. triggerCritFilter discriminates on the
                         // hit's own crit outcome, same contract as on-attacked. roleFilter
                         // (Graphite) matches the DAMAGED ally's role category; an unknown role
                         // never matches (conservative — a manual actor with no ship picked keeps
                         // role-filtered reactions dormant rather than inflating numbers); an
                         // EMPTY filter array is treated as absent (any ally), not never-match.
-                        if (e.targetId === ownerId || isEnemySide(e.targetId)) return;
+                        if (!isSameSideAlly(e.targetId, ownerId)) return;
                         const filter = ra.ability.triggerCritFilter;
                         if (filter === 'crit' && !e.didCrit) return;
                         if (filter === 'non-crit' && e.didCrit) return;
@@ -349,31 +351,34 @@ export function registerReactiveListeners(args: {
                     break;
                 case 'on-ally-destroyed':
                     bus.on('ship-destroyed', (e) => {
-                        // Ally-scoped: any OTHER player actor's destruction. Exclude this
-                        // owner (own death goes to on-destroyed) AND every enemy-side actor
-                        // (dummy wall + enemy attackers — an enemy is never an ally), mirroring
-                        // on-ally-crit's scoping.
-                        if (e.actorId !== ownerId && !isEnemySide(e.actorId)) enqueue(intent);
+                        // Ally-scoped: any OTHER same-side actor's destruction. Exclude this
+                        // owner (own death goes to on-destroyed) AND every opposing actor
+                        // (an opposing actor is never an ally), mirroring on-ally-crit's scoping.
+                        if (isSameSideAlly(e.actorId, ownerId)) enqueue(intent);
                     });
                     break;
                 case 'on-enemy-destroyed':
                     bus.on('ship-destroyed', (e) => {
-                        // Enemy-scoped: fires when any enemy-side actor (dummy wall + enemy
-                        // attackers) is destroyed. One enqueue per destruction event.
-                        if (isEnemySide(e.actorId)) enqueue(intent);
+                        // Opposing-scoped: fires when any opposing-side actor is destroyed.
+                        // For the player call: dummy wall + enemy attackers.
+                        // For the enemy call: any player actor. One enqueue per destruction event.
+                        if (isOpposing(e.actorId)) enqueue(intent);
                     });
                     break;
                 case 'on-enemy-repaired':
                     bus.on('heal-performed', (e) => {
-                        // Enemy-scoped: any enemy-side actor's repair (dummy wall + enemy
-                        // attackers). One enqueue per qualifying cast — Zosimos banks a charge.
-                        if (isEnemySide(e.casterId)) enqueue(intent);
+                        // Opposing-scoped: any opposing-side actor's repair. For the player
+                        // call: dummy wall + enemy attackers. For the enemy call: any player
+                        // actor. One enqueue per qualifying cast — Zosimos banks a charge.
+                        if (isOpposing(e.casterId)) enqueue(intent);
                     });
                     break;
                 case 'on-enemy-cleansed':
                     bus.on('cleanse-performed', (e) => {
-                        // Enemy-scoped: any enemy-side actor's cleanse. One enqueue per cast.
-                        if (isEnemySide(e.casterId)) enqueue(intent);
+                        // Opposing-scoped: any opposing-side actor's cleanse. For the player
+                        // call: enemy side. For the enemy call: player side.
+                        // One enqueue per cast.
+                        if (isOpposing(e.casterId)) enqueue(intent);
                     });
                     break;
                 case 'on-cheat-death-activated':


### PR DESCRIPTION
Second slice of the team-agnostic bySide engine unification (spec: `docs/superpowers/specs/2026-06-16-combat-engine-bySide-unification-design.md`, §4 PR2). Stacked on PR1 (#118).

## What
- `registerReactiveListeners` now takes a per-call `isOpposing(actorId)` instead of the player-centric `isEnemySide`, and derives `isSameSideAlly(id, owner) = !isOpposing(id) && id !== owner` internally. The player registration passes `isOpposing: isEnemySide` (algebraically byte-identical); the enemy registration passes its negation.
- `grantExtraAction` (and the Path-B pending-grant flush) now resolve the granter from the combined `allActorsById` roster (introduced here — the PR1-deferred accessor, getting its first consumer) instead of the player-only `allPlayerActorsById`, so an enemy granter's extra-action grant lands.

## Fixes
- An ENEMY-side ship's opposing/ally reactive triggers (`on-enemy-destroyed`, `on-ally-destroyed`, `on-ally-attacked`, `on-enemy-repaired`/`-cleansed`) now fire against the correct side. The codified repro — a lone enemy Liberator that kills a player ship now gets its `on-enemy-destroyed` extra action (lands round R+1, Path B) — passes via a non-vacuous control-comparison team-vs-team test. Retires the enemy-reactive-routing bug class.

## Safety
- **BYTE-IDENTICAL** DPS + healing goldens (verified: zero `.snap` movement vs the PR1 tip). The player call is algebraically identical to today; the behavioral change lives entirely on the enemy call, which no existing golden/fixture exercised (the new `enemyReactiveRouting.test.ts` is the first-ever coverage of the enemy reactive path).
- 2404 tests pass; tsc + lint clean; `audit:skills` 0/141.
- New `enemyReactiveRouting.test.ts`: 3 predicate unit tests + 1 end-to-end enemy-Liberator extra-action repro. Final holistic review independently reverted each of the two changes to confirm both are necessary and jointly sufficient.

## Out of scope (flagged, deferred)
- Enemy `on-ally-attacked` role filters (enemy Graphite) stay dormant — the enemy `roleOf` map carries player roles only. A roleOf-map gap, not a predicate gap; a later PR.
- Minor stale "player actor" wording in untouched condition-context JSDoc (triggers.ts) — deferred to PR3 where that framing gets unified.

## Stacking note
Base is `feat/combat-sim-phase5-pr2` (stacked on PR1). CodeRabbit only auto-reviews base=main PRs — retarget to main + rebase \`--onto\` once the PR1 chain merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)