### PR TITLE
feat(database): add Squad Leaders page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ const ShipIndexPage = lazy(() => import('./pages/database/ShipIndexPage'));
 const ShipLorePage = lazy(() => import('./pages/database/ShipLorePage'));
 const ImplantIndexPage = lazy(() => import('./pages/database/ImplantIndexPage'));
 const EffectIndexPage = lazy(() => import('./pages/database/EffectIndexPage'));
+const SquadLeadersPage = lazy(() => import('./pages/database/SquadLeadersPage'));
 const LeaderboardPage = lazy(() => import('./pages/database/LeaderboardPage'));
 
 // Calculator pages
@@ -281,6 +282,12 @@ const App: React.FC = () => {
                                                                                         path="/buffs"
                                                                                         element={
                                                                                             <EffectIndexPage />
+                                                                                        }
+                                                                                    />
+                                                                                    <Route
+                                                                                        path="/squad-leaders"
+                                                                                        element={
+                                                                                            <SquadLeadersPage />
                                                                                         }
                                                                                     />
                                                                                     <Route

--- a/src/components/squadLeaders/SquadLeaderCard.tsx
+++ b/src/components/squadLeaders/SquadLeaderCard.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { SquadLeader, SquadLeaderEffect } from '../../constants/squadLeaders';
+import { RARITIES } from '../../constants/rarities';
+
+const STEP_LABELS = ['I', 'II', 'III'] as const;
+
+// Ally-targeted effects read as buffs (green); enemy-targeted effects read as
+// debuffs (red) — mirrors the buff/debuff colouring on the Effect Index page.
+const effectColorClass = (effect: SquadLeaderEffect): string =>
+    effect.target === 'all-enemies' ? 'text-red-400' : 'text-green-400';
+
+const EffectLine: React.FC<{ effect: SquadLeaderEffect }> = ({ effect }) => (
+    <li className={`text-sm ${effectColorClass(effect)}`}>
+        {effect.text}
+        {effect.recurrence === 'per-round' && (
+            <span className="text-theme-text-secondary"> (per round)</span>
+        )}
+        {effect.condition && (
+            <span className="text-theme-text-secondary"> — {effect.condition.text}</span>
+        )}
+    </li>
+);
+
+interface Props {
+    leader: SquadLeader;
+}
+
+export const SquadLeaderCard: React.FC<Props> = ({ leader }) => {
+    const rarity = RARITIES[leader.rarity];
+
+    return (
+        <div className={`bg-dark p-4 border ${rarity.borderColor}`}>
+            <div className="flex items-center justify-between mb-3">
+                <h3 className="text-lg font-semibold">{leader.name}</h3>
+                <span className={`text-xs uppercase font-medium ${rarity.textColor}`}>
+                    {rarity.label}
+                </span>
+            </div>
+
+            <div className="space-y-3">
+                {leader.stages.map((effects, stepIndex) =>
+                    effects.length > 0 ? (
+                        <div key={stepIndex} className="flex gap-3">
+                            <span className="w-6 shrink-0 text-sm font-semibold text-theme-text-secondary">
+                                {STEP_LABELS[stepIndex]}
+                            </span>
+                            <ul className="space-y-1">
+                                {effects.map((effect, effectIndex) => (
+                                    <EffectLine key={effectIndex} effect={effect} />
+                                ))}
+                            </ul>
+                        </div>
+                    ) : null
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default SquadLeaderCard;

--- a/src/components/ui/layout/Sidebar.tsx
+++ b/src/components/ui/layout/Sidebar.tsx
@@ -336,6 +336,7 @@ export const Sidebar: React.FC = () => {
                     { path: '/ships/lore', label: 'Lore' },
                     { path: '/implants', label: 'Implants' },
                     { path: '/buffs', label: 'Effects' },
+                    { path: '/squad-leaders', label: 'Squad Leaders' },
                 ],
             },
             { path: '/shared-encounters', label: 'Shared Encounters' },

--- a/src/constants/seo.ts
+++ b/src/constants/seo.ts
@@ -97,6 +97,12 @@ export const SEO_CONFIG = {
             'Browse all buffs, debuffs, and effects in Starborne Frontiers. Search and filter through 155+ game effects.',
         keywords: 'starborne, frontiers, buffs, debuffs, effects, status effects, abilities',
     },
+    squadLeaders: {
+        title: 'Squad Leaders - Starborne Frontiers Calculator',
+        description:
+            'Browse squad leaders for every faction in Starborne Frontiers and the bonuses each grants across its three upgrade steps.',
+        keywords: 'starborne, frontiers, squad leaders, faction bonuses, fleet buffs, database',
+    },
     documentation: {
         title: 'Documentation',
         description:

--- a/src/constants/squadLeaders.ts
+++ b/src/constants/squadLeaders.ts
@@ -1,0 +1,1483 @@
+import type { StatName, StatType } from '../types/stats';
+import type { ShipRoleCategory } from './shipTypes';
+import type { FactionName } from './factions';
+
+/**
+ * Squad Leaders — pre-fight stat-modifier data (combat-realism epic, sub-project F).
+ *
+ * Each of the 10 factions has exactly THREE squad leaders, one per rarity tier
+ * (rare / epic / legendary). Each leader has a name and THREE upgrade stages, and
+ * each stage carries a set of effects. Effects fall into three shapes:
+ *
+ *   1. Raw stat increases        → `kind: 'stat'`     (e.g. +20% Attack to all allies)
+ *   2. Combat modifiers          → `kind: 'modifier'` (conditional damage, shield/round, heal mods)
+ *   3. Enemy effects             → any of the above with `target: 'all-enemies'` and a NEGATIVE
+ *                                  value (decreased enemy stats, reduced enemy damage/heal output)
+ *
+ * THIS FILE IS DATA-ONLY. No engine wiring lives here — sub-project F will read this const to
+ * establish combat-entry base stats. The types mirror the existing combat vocabulary
+ * (`Stat`, `ParsedBuffEffects` / `ModifierChannel`, `Condition`) so F can consume it directly.
+ *
+ * Fill-in convention:
+ *   - Always populate `text` with the verbatim in-game tooltip line. It is the source of truth;
+ *     the structured fields are best-effort and can be refined later when F models them.
+ *   - `stages` are ADDITIVE DELTAS: stages[0] holds only what step I adds, stages[1] only what
+ *     step II adds, stages[2] only what step III adds. Steps stack — a leader upgraded to step III
+ *     has step I + II + III all active simultaneously.
+ *   - `target: 'all-allies'` for a squad leader means "all allied units OF THE LEADER'S FACTION"
+ *     (the leader is keyed under that faction below). Auras are faction-gated, not fleet-wide.
+ *   - Use signed values: positive = buff to the target, negative = reduction.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SquadLeaderRarity = 'rare' | 'epic' | 'legendary';
+
+/**
+ * Who an effect lands on.
+ * - 'all-allies'  : all allied units of the LEADER'S faction (auras are faction-gated).
+ * - 'all-enemies' : every enemy unit (used for enemy stat / output reductions).
+ * - 'self'        : reserved; squad leaders are not deployed units, so rarely used.
+ */
+export type SquadLeaderTarget = 'all-allies' | 'self' | 'all-enemies';
+
+/**
+ * Whether an effect is applied once at combat entry or accrues over the fight.
+ * - 'static'    : set once before round 1, constant for the fight (most stat boosts). DEFAULT.
+ * - 'per-round' : re-applied / accrues each round (e.g. "generate shield each round").
+ */
+export type SquadLeaderRecurrence = 'static' | 'per-round';
+
+/**
+ * Combat channels a `modifier` effect can push, beyond raw stats.
+ * Mirrors `ModifierChannel` / `ParsedBuffEffects` in the combat code, plus shield generation.
+ */
+export type SquadLeaderModifierChannel =
+    | 'outgoingDamage' // dealt damage; + = deals more
+    | 'incomingDamage' // taken damage; on enemies + = they take more, on allies - = they take less
+    | 'outgoingCritDamage' // crit damage dealt; + = bigger crits
+    | 'incomingCritDamage' // crit damage taken; on enemies - = they take smaller crits
+    | 'outgoingRepair' // healing/repair output; on enemies - = reduced enemy repair output
+    | 'outgoingHeal' // alias of outgoingRepair (game term is "Repair"); kept for compatibility
+    | 'incomingHeal' // healing/repair received
+    | 'damageReduction' // flat % mitigation
+    | 'shieldGeneration'; // shield granted (pair with recurrence: 'per-round' for shield/round)
+
+/**
+ * Optional gate for conditional effects (conditional damage/heal, "vs enemies with X", etc.).
+ * `text` is required; structured fields mirror `Condition` in `src/types/abilities.ts` and are
+ * filled in later when F models the gate.
+ */
+export interface SquadLeaderCondition {
+    /** Verbatim condition text from the tooltip. Source of truth. */
+    text: string;
+    hpComparator?: 'below' | 'above';
+    hpPercent?: number;
+    hpSubject?: 'self' | 'ally' | 'enemy';
+    /** Requires the subject to carry a named status, e.g. "Concentrate Fire". */
+    statusName?: string;
+    /** Narrows recipients to a ship role, e.g. only ATTACKER allies. */
+    role?: ShipRoleCategory;
+}
+
+interface SquadLeaderEffectBase {
+    /** Verbatim in-game text for this line. ALWAYS fill this. */
+    text: string;
+    target: SquadLeaderTarget;
+    /** Present only for conditional effects. */
+    condition?: SquadLeaderCondition;
+    /** Defaults to 'static' when omitted. */
+    recurrence?: SquadLeaderRecurrence;
+}
+
+export type SquadLeaderEffect =
+    | (SquadLeaderEffectBase & {
+          kind: 'stat';
+          stat: StatName;
+          /** Signed. Negative = decrease (use for enemy stat reductions). */
+          value: number;
+          valueType: StatType; // 'flat' | 'percentage'
+      })
+    | (SquadLeaderEffectBase & {
+          kind: 'modifier';
+          channel: SquadLeaderModifierChannel;
+          /** Signed percentage unless the channel is noted otherwise. */
+          value: number;
+      })
+    | (SquadLeaderEffectBase & {
+          // Escape hatch: capture something not yet expressible above. Fill `text`; model later.
+          kind: 'other';
+      });
+
+/** One squad leader: a name, its rarity tier, and its three additive upgrade steps. */
+export interface SquadLeader {
+    name: string;
+    rarity: SquadLeaderRarity;
+    /** stages[0] = step I, stages[1] = step II, stages[2] = step III. */
+    stages: [SquadLeaderEffect[], SquadLeaderEffect[], SquadLeaderEffect[]];
+}
+
+// ---------------------------------------------------------------------------
+// Data — fill in below. (name + 3 additive steps per leader; one per rarity per faction)
+//
+// Marauders is filled in as the worked reference. Note how:
+//   - each stage holds ONLY that step's added effects (additive),
+//   - 'all-allies' = all Marauder units,
+//   - enemy reductions use target 'all-enemies' + negative values,
+//   - "crit power" maps to the `critDamage` stat,
+//   - "direct damage to secondary targets" is a conditional `outgoingDamage` modifier.
+// ---------------------------------------------------------------------------
+
+export const SQUAD_LEADERS: Record<FactionName, SquadLeader[]> = {
+    ATLAS_SYNDICATE: [
+        {
+            name: 'Intern',
+            rarity: 'rare',
+            stages: [
+                // I — +3% Attack
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 3,
+                        valueType: 'percentage',
+                        text: '+3% Attack',
+                    },
+                ],
+                // II — +2% Attack & +2% Crit Power
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 2,
+                        valueType: 'percentage',
+                        text: '+2% Attack',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'critDamage',
+                        value: 2,
+                        valueType: 'percentage',
+                        text: '+2% Crit Power',
+                    },
+                ],
+                // III — +3% Crit Power
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'critDamage',
+                        value: 3,
+                        valueType: 'percentage',
+                        text: '+3% Crit Power',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Broker',
+            rarity: 'epic',
+            stages: [
+                // I — +8% Attack
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 8,
+                        valueType: 'percentage',
+                        text: '+8% Attack',
+                    },
+                ],
+                // II — +8% Crit Power
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'critDamage',
+                        value: 8,
+                        valueType: 'percentage',
+                        text: '+8% Crit Power',
+                    },
+                ],
+                // III — Start combat shielded for 20% of max HP
+                [
+                    {
+                        kind: 'modifier',
+                        target: 'all-allies',
+                        channel: 'shieldGeneration',
+                        value: 20,
+                        text: 'Start combat shielded for 20% of max HP',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Negotiator',
+            rarity: 'legendary',
+            stages: [
+                // I — +10% Attack & +10% Crit Power
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 10,
+                        valueType: 'percentage',
+                        text: '+10% Attack',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'critDamage',
+                        value: 10,
+                        valueType: 'percentage',
+                        text: '+10% Crit Power',
+                    },
+                ],
+                // II - start combat shielded for 25% of max HP
+                [
+                    {
+                        kind: 'modifier',
+                        target: 'all-allies',
+                        channel: 'shieldGeneration',
+                        value: 2,
+                        text: 'Start combat shielded for 2% of max HP',
+                    },
+                ],
+                // III - Enemy units lose 15 speed and 10% crit damage
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-enemies',
+                        stat: 'speed',
+                        value: -15,
+                        valueType: 'flat',
+                        text: 'Enemy units lose 15 speed',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-enemies',
+                        stat: 'critDamage',
+                        value: -10,
+                        valueType: 'percentage',
+                        text: 'Enemy units lose 10% crit damage',
+                    },
+                ],
+            ],
+        },
+    ],
+    BINDERBURG: [
+        {
+            name: 'Augmentor',
+            rarity: 'rare',
+            stages: [
+                // I — +3% HP
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hp',
+                        value: 3,
+                        valueType: 'percentage',
+                        text: '+3% HP',
+                    },
+                ],
+                // II — 2% HP & +10 security
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hp',
+                        value: 2,
+                        valueType: 'percentage',
+                        text: '+2% HP',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'security',
+                        value: 10,
+                        valueType: 'flat',
+                        text: '+10 Security',
+                    },
+                ],
+                // III — +20 Security
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'security',
+                        value: 20,
+                        valueType: 'flat',
+                        text: '+20 Security',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Pollinator',
+            rarity: 'epic',
+            stages: [
+                // I — +8% HP
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hp',
+                        value: 8,
+                        valueType: 'percentage',
+                        text: '+8% HP',
+                    },
+                ],
+                // II — +8% Defense
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'defence',
+                        value: 8,
+                        valueType: 'percentage',
+                        text: '+8% Defense',
+                    },
+                ],
+                // III — Gain security equal to 0.8% of the units defense value
+                // TODO: add an effect for this
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'security',
+                        value: 0.8,
+                        valueType: 'percentage',
+                        text: 'Gain security equal to of 0.8% defense',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Swarmcaller',
+            rarity: 'legendary',
+            stages: [
+                // I — +10% HP & +10% Defense
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hp',
+                        value: 10,
+                        valueType: 'percentage',
+                        text: '+10% HP',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'defence',
+                        value: 10,
+                        valueType: 'percentage',
+                        text: '+10% Defense',
+                    },
+                ],
+                // II — Gain security equal to 1.2% of the units defense value
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'security',
+                        value: 1.2,
+                        valueType: 'percentage',
+                        text: 'Gain security equal to 1.2% of the units defense value',
+                    },
+                ],
+                // III — Enemy units lose 30 hacking
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-enemies',
+                        stat: 'hacking',
+                        value: -30,
+                        valueType: 'flat',
+                        text: 'Enemy units lose 30 hacking',
+                    },
+                ],
+            ],
+        },
+    ],
+    EVERLIVING: [
+        {
+            name: 'Elixir',
+            rarity: 'rare',
+            stages: [
+                // I — +3% Defense
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'defence',
+                        value: 3,
+                        valueType: 'percentage',
+                        text: '+3% Defense',
+                    },
+                ],
+                // II — +2% Defense & +2% HP
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'defence',
+                        value: 2,
+                        valueType: 'percentage',
+                        text: '+2% Defense',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hp',
+                        value: 2,
+                        valueType: 'percentage',
+                        text: '+2% HP',
+                    },
+                ],
+                // III — +3% HP
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hp',
+                        value: 3,
+                        valueType: 'percentage',
+                        text: '+3% HP',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Soothsayer',
+            rarity: 'epic',
+            stages: [
+                // I — +8% HP
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hp',
+                        value: 8,
+                        valueType: 'percentage',
+                        text: '+8% HP',
+                    },
+                ],
+                // II — +20 Security
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'security',
+                        value: 20,
+                        valueType: 'flat',
+                        text: '+20 Security',
+                    },
+                ],
+                // III — +10% Outgoing repair
+                [
+                    {
+                        kind: 'modifier',
+                        target: 'all-allies',
+                        channel: 'outgoingHeal',
+                        value: 10,
+                        text: '+10% Outgoing repair',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Malachi',
+            rarity: 'legendary',
+            stages: [
+                // I — +10% HP & +25 security
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hp',
+                        value: 10,
+                        valueType: 'percentage',
+                        text: '+10% HP',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'security',
+                        value: 25,
+                        valueType: 'flat',
+                        text: '+25 Security',
+                    },
+                ],
+                // II — +15% Outgoing repair
+                [
+                    {
+                        kind: 'modifier',
+                        target: 'all-allies',
+                        channel: 'outgoingHeal',
+                        value: 15,
+                        text: '+15% Outgoing repair',
+                    },
+                ],
+                // III — Enemy ships get -15% Outgoing repair
+                [
+                    {
+                        kind: 'modifier',
+                        target: 'all-enemies',
+                        channel: 'outgoingHeal',
+                        value: -15,
+                        text: 'Enemy ships get -15% Outgoing repair',
+                    },
+                ],
+            ],
+        },
+    ],
+    FRONTIER_LEGION: [
+        {
+            name: 'Corporal',
+            rarity: 'rare',
+            stages: [
+                // I — +3% Attack
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 3,
+                        valueType: 'percentage',
+                        text: '+3% Attack',
+                    },
+                ],
+                // II — +2% Attack & +2% Crit Power
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 2,
+                        valueType: 'percentage',
+                        text: '+2% Attack',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'critDamage',
+                        value: 2,
+                        valueType: 'percentage',
+                        text: '+2% Crit Power',
+                    },
+                ],
+                // III — +3% Crit Power
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'critDamage',
+                        value: 3,
+                        valueType: 'percentage',
+                        text: '+3% Crit Power',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Lieutenant',
+            rarity: 'epic',
+            stages: [
+                // I — +8% Attack
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 8,
+                        valueType: 'percentage',
+                        text: '+8% Attack',
+                    },
+                ],
+                // II — +8% Defense Penetration
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'defensePenetration',
+                        value: 8,
+                        valueType: 'percentage',
+                        text: '+8% Defense Penetration',
+                    },
+                ],
+                // III — +5% attack for each other alive Legion ally
+                // TODO: add an effect for this
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 5,
+                        valueType: 'percentage',
+                        text: '+5% attack for each other alive Legion ally',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Colonel',
+            rarity: 'legendary',
+            stages: [
+                // I — +10% Attack & +7.5% Defense Penetration
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 10,
+                        valueType: 'percentage',
+                        text: '+10% Attack',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'defensePenetration',
+                        value: 7.5,
+                        valueType: 'percentage',
+                        text: '+7.5% Defense Penetration',
+                    },
+                ],
+                // II — +7.5% attack for each other alive Legion ally
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 7.5,
+                        valueType: 'percentage',
+                        text: '+7.5% attack for each other alive Legion ally',
+                    },
+                ],
+                // III — Enemy units lose 15% attack
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-enemies',
+                        stat: 'attack',
+                        value: -15,
+                        valueType: 'percentage',
+                        text: 'Enemy units lose 15% attack',
+                    },
+                ],
+            ],
+        },
+    ],
+    GELECEK: [
+        {
+            name: 'Chimera',
+            rarity: 'rare',
+            stages: [
+                // I — +5 Hacking
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hacking',
+                        value: 5,
+                        valueType: 'flat',
+                        text: '+5 Hacking',
+                    },
+                ],
+                // II — +5 Speed & +5 Hacking
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'speed',
+                        value: 5,
+                        valueType: 'flat',
+                        text: '+5 Speed',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hacking',
+                        value: 5,
+                        valueType: 'flat',
+                        text: '+5 Hacking',
+                    },
+                ],
+                // III - +5 speed
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'speed',
+                        value: 5,
+                        valueType: 'flat',
+                        text: '+5 Speed',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Medusa',
+            rarity: 'epic',
+            stages: [
+                // I — +20 hacking
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hacking',
+                        value: 20,
+                        valueType: 'flat',
+                        text: '+20 Hacking',
+                    },
+                ],
+                // II — +8% HP
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hp',
+                        value: 8,
+                        valueType: 'percentage',
+                        text: '+8% HP',
+                    },
+                ],
+                // III — Repairs 5% HP after inflicting a debuff on an enemy
+                // TODO: add an effect for this
+                [
+                    {
+                        kind: 'modifier',
+                        target: 'all-allies',
+                        channel: 'incomingHeal',
+                        value: 5,
+                        text: 'Repairs 5% HP after inflicting a debuff on an enemy',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Cerberus',
+            rarity: 'legendary',
+            stages: [
+                // I — +10% HP & +25 hacking
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hp',
+                        value: 10,
+                        valueType: 'percentage',
+                        text: '+10% HP',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hacking',
+                        value: 25,
+                        valueType: 'flat',
+                        text: '+25 Hacking',
+                    },
+                ],
+                // II — Repairs 7.5% HP after inflicting a debuff on an enemy
+                [
+                    {
+                        kind: 'modifier',
+                        target: 'all-allies',
+                        channel: 'incomingHeal',
+                        value: 7.5,
+                        text: 'Repairs 7.5% HP after inflicting a debuff on an enemy',
+                    },
+                ],
+                // III — Enemy units lose 30 security
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-enemies',
+                        stat: 'security',
+                        value: -30,
+                        valueType: 'flat',
+                        text: 'Enemy units lose 30 security',
+                    },
+                ],
+            ],
+        },
+    ],
+    MPL: [
+        {
+            name: 'Gold Digger',
+            rarity: 'rare',
+            stages: [
+                // I — +3% HP
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hp',
+                        value: 3,
+                        valueType: 'percentage',
+                        text: '+3% HP',
+                    },
+                ],
+                // II — +10 security
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'security',
+                        value: 10,
+                        valueType: 'flat',
+                        text: '+10 security',
+                    },
+                ],
+                // III — +20 security
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'security',
+                        value: 20,
+                        valueType: 'flat',
+                        text: '+20 security',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Overseer',
+            rarity: 'epic',
+            stages: [
+                // I — +8% HP
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hp',
+                        value: 8,
+                        valueType: 'percentage',
+                        text: '+8% HP',
+                    },
+                ],
+                // II — +8% Attack
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 8,
+                        valueType: 'percentage',
+                        text: '+8% Attack',
+                    },
+                ],
+                // III — -5% incoming direct damage
+                [
+                    {
+                        kind: 'modifier',
+                        target: 'all-enemies',
+                        channel: 'incomingDamage',
+                        value: -5,
+                        text: '-5% incoming direct damage',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Midas',
+            rarity: 'legendary',
+            stages: [
+                // I — +10% HP & +10% Attack
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hp',
+                        value: 10,
+                        valueType: 'percentage',
+                        text: '+10% HP',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 10,
+                        valueType: 'percentage',
+                        text: '+10% Attack',
+                    },
+                ],
+                // II - -7.5% incoming direct damage
+                [
+                    {
+                        kind: 'modifier',
+                        target: 'all-enemies',
+                        channel: 'incomingDamage',
+                        value: -7.5,
+                        text: '-7.5% incoming direct damage',
+                    },
+                ],
+                // III - Enemy units lose 15% crit rate
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-enemies',
+                        stat: 'crit',
+                        value: -15,
+                        valueType: 'percentage',
+                        text: 'Enemy units lose 15% crit rate',
+                    },
+                ],
+            ],
+        },
+    ],
+    MARAUDERS: [
+        {
+            name: 'Puppet',
+            rarity: 'rare',
+            stages: [
+                // I — +5 Hacking
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hacking',
+                        value: 5,
+                        valueType: 'flat',
+                        text: '+5 Hacking',
+                    },
+                ],
+                // II — +5 Speed & +5 Hacking
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'speed',
+                        value: 5,
+                        valueType: 'flat',
+                        text: '+5 Speed',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hacking',
+                        value: 5,
+                        valueType: 'flat',
+                        text: '+5 Hacking',
+                    },
+                ],
+                // III — +5 Speed
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'speed',
+                        value: 5,
+                        valueType: 'flat',
+                        text: '+5 Speed',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Reaper',
+            rarity: 'epic',
+            stages: [
+                // I — +8% Attack
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 8,
+                        valueType: 'percentage',
+                        text: '+8% Attack',
+                    },
+                ],
+                // II — +8% Crit Power
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'critDamage',
+                        value: 8,
+                        valueType: 'percentage',
+                        text: '+8% Crit Power',
+                    },
+                ],
+                // III — +20% direct damage to secondary targets
+                [
+                    {
+                        kind: 'modifier',
+                        target: 'all-allies',
+                        channel: 'outgoingDamage',
+                        value: 20,
+                        condition: { text: 'direct damage to secondary targets' },
+                        text: '+20% direct damage to secondary targets',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Brandisher',
+            rarity: 'legendary',
+            stages: [
+                // I — +10% Attack & +10% Crit Power
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 10,
+                        valueType: 'percentage',
+                        text: '+10% Attack',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'critDamage',
+                        value: 10,
+                        valueType: 'percentage',
+                        text: '+10% Crit Power',
+                    },
+                ],
+                // II — +25% direct damage to secondary targets
+                [
+                    {
+                        kind: 'modifier',
+                        target: 'all-allies',
+                        channel: 'outgoingDamage',
+                        value: 25,
+                        condition: { text: 'direct damage to secondary targets' },
+                        text: '+25% direct damage to secondary targets',
+                    },
+                ],
+                // III — Enemy units lose 15 Security and 10% Defence
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-enemies',
+                        stat: 'security',
+                        value: -15,
+                        valueType: 'flat',
+                        text: 'Enemy units lose 15 Security',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-enemies',
+                        stat: 'defence',
+                        value: -10,
+                        valueType: 'percentage',
+                        text: 'Enemy units lose 10% Defence',
+                    },
+                ],
+            ],
+        },
+    ],
+    TERRAN_COMBINE: [
+        {
+            name: 'Prototype',
+            rarity: 'rare',
+            stages: [
+                // I — +3% defence
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'defence',
+                        value: 3,
+                        valueType: 'percentage',
+                        text: '+3% Defence',
+                    },
+                ],
+                // II — +2% defence & +2% hp
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'defence',
+                        value: 2,
+                        valueType: 'percentage',
+                        text: '+2% Defence',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hp',
+                        value: 2,
+                        valueType: 'percentage',
+                        text: '+2% HP',
+                    },
+                ],
+                // III — +3% hp
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hp',
+                        value: 3,
+                        valueType: 'percentage',
+                        text: '+3% HP',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Optimizer',
+            rarity: 'epic',
+            stages: [
+                // I — +8% Defense
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'defence',
+                        value: 8,
+                        valueType: 'percentage',
+                        text: '+8% Defence',
+                    },
+                ],
+                // II — +20 Security
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'security',
+                        value: 20,
+                        valueType: 'flat',
+                        text: '+20 Security',
+                    },
+                ],
+                // III — -10% incoming crit damage
+                // TODO: add an effect for this
+                [
+                    {
+                        kind: 'modifier',
+                        target: 'all-enemies',
+                        channel: 'incomingCritDamage',
+                        value: -10,
+                        text: '-10% incoming crit damage',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Architect',
+            rarity: 'legendary',
+            stages: [
+                // I — +10% Defense & +25 Security
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'defence',
+                        value: 10,
+                        valueType: 'percentage',
+                        text: '+10% Defence',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'security',
+                        value: 25,
+                        valueType: 'flat',
+                        text: '+25 Security',
+                    },
+                ],
+                // II — -15% incoming crit damage
+                [
+                    {
+                        kind: 'modifier',
+                        target: 'all-enemies',
+                        channel: 'incomingCritDamage',
+                        value: -15,
+                        text: '-15% incoming crit damage',
+                    },
+                ],
+                // III — Enemy units lose 20% Defence
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-enemies',
+                        stat: 'defence',
+                        value: -20,
+                        valueType: 'percentage',
+                        text: 'Enemy units lose 20% Defence',
+                    },
+                ],
+            ],
+        },
+    ],
+    TIANCHAO: [
+        {
+            name: 'Infiltrator',
+            rarity: 'rare',
+            stages: [
+                // I — +5 hacking
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hacking',
+                        value: 5,
+                        valueType: 'flat',
+                        text: '+5 hacking',
+                    },
+                ],
+                // II — +5 speed & +5 hacking
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'speed',
+                        value: 5,
+                        valueType: 'flat',
+                        text: '+5 speed',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hacking',
+                        value: 5,
+                        valueType: 'flat',
+                        text: '+5 hacking',
+                    },
+                ],
+                // III — +5 speed
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'speed',
+                        value: 5,
+                        valueType: 'flat',
+                        text: '+5 speed',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Cipher',
+            rarity: 'epic',
+            stages: [
+                // I — +8% Attack
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 8,
+                        valueType: 'percentage',
+                        text: '+8% Attack',
+                    },
+                ],
+                // II — +20 hacking
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hacking',
+                        value: 20,
+                        valueType: 'flat',
+                        text: '+20 hacking',
+                    },
+                ],
+                // III — +10% outgoing crit damage while in Stealth.
+                // TODO: add an effect for this
+                [
+                    {
+                        kind: 'modifier',
+                        target: 'all-allies',
+                        channel: 'outgoingCritDamage',
+                        value: 10,
+                        text: '+10% outgoing crit damage while in Stealth.',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Serpent',
+            rarity: 'legendary',
+            stages: [
+                // I — +10% Attack & +25 Hacking
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 10,
+                        valueType: 'percentage',
+                        text: '+10% Attack',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hacking',
+                        value: 25,
+                        valueType: 'flat',
+                        text: '+25 Hacking',
+                    },
+                ],
+                // II — +15% outgoing crit damage while in Stealth.
+                // TODO: add an effect for this
+                [
+                    {
+                        kind: 'modifier',
+                        target: 'all-allies',
+                        channel: 'outgoingCritDamage',
+                        value: 15,
+                        text: '+15% outgoing crit damage while in Stealth.',
+                    },
+                ],
+                // III — Enemy units lose 25% crit power
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-enemies',
+                        stat: 'critDamage',
+                        value: -25,
+                        valueType: 'percentage',
+                        text: 'Enemy units lose 25% crit power',
+                    },
+                ],
+            ],
+        },
+    ],
+    XAOC: [
+        {
+            name: 'Genghis',
+            rarity: 'rare',
+            stages: [
+                // I — +3% Attack
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 3,
+                        valueType: 'percentage',
+                        text: '+3% Attack',
+                    },
+                ],
+                // II — +2% Attack & +2% Crit Power
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 2,
+                        valueType: 'percentage',
+                        text: '+2% Attack',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'critDamage',
+                        value: 2,
+                        valueType: 'percentage',
+                        text: '+2% Crit Power',
+                    },
+                ],
+                // III — +3% Crit Power
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'critDamage',
+                        value: 3,
+                        valueType: 'percentage',
+                        text: '+3% Crit Power',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Predator',
+            rarity: 'epic',
+            stages: [
+                // I — +8% HP
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hp',
+                        value: 8,
+                        valueType: 'percentage',
+                        text: '+8% HP',
+                    },
+                ],
+                // II — +8% Attack
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 8,
+                        valueType: 'percentage',
+                        text: '+8% Attack',
+                    },
+                ],
+                // III — +5% Outgoing direct damage
+                [
+                    {
+                        kind: 'modifier',
+                        target: 'all-allies',
+                        channel: 'outgoingDamage',
+                        value: 5,
+                        text: '+5% Outgoing direct damage',
+                    },
+                ],
+            ],
+        },
+        {
+            name: 'Viper',
+            rarity: 'legendary',
+            stages: [
+                // I — +10% HP & +10% Attack
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'hp',
+                        value: 10,
+                        valueType: 'percentage',
+                        text: '+10% HP',
+                    },
+                    {
+                        kind: 'stat',
+                        target: 'all-allies',
+                        stat: 'attack',
+                        value: 10,
+                        valueType: 'percentage',
+                        text: '+10% Attack',
+                    },
+                ],
+                // II — +7.5% Outgoing direct damage
+                [
+                    {
+                        kind: 'modifier',
+                        target: 'all-allies',
+                        channel: 'outgoingDamage',
+                        value: 7.5,
+                        text: '+7.5% Outgoing direct damage',
+                    },
+                ],
+                // III — Enemy units lose 20 speed
+                [
+                    {
+                        kind: 'stat',
+                        target: 'all-enemies',
+                        stat: 'speed',
+                        value: -20,
+                        valueType: 'flat',
+                        text: 'Enemy units lose 20 speed',
+                    },
+                ],
+            ],
+        },
+    ],
+};

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -148,6 +148,16 @@ const DocumentationPage: React.FC = () => {
                             </li>
                             <li className="[counter-increment:index]">
                                 <a
+                                    href="#squad-leaders"
+                                    className="text-primary hover:text-primary-light"
+                                >
+                                    <span className="before:content-[counter(index)'.'] before:mr-2">
+                                        Squad Leaders
+                                    </span>
+                                </a>
+                            </li>
+                            <li className="[counter-increment:index]">
+                                <a
                                     href="#leaderboards"
                                     className="text-primary hover:text-primary-light"
                                 >
@@ -1954,6 +1964,55 @@ const DocumentationPage: React.FC = () => {
                                     like &quot;hacking&quot; or &quot;security&quot; to find effects
                                     that interact with specific stats.
                                 </p>
+                            </div>
+                        </div>
+                    </section>
+
+                    {/* Squad Leaders Section */}
+                    <section id="squad-leaders" className="space-y-4 [counter-increment:section]">
+                        <h2 className="text-2xl font-bold before:content-[counter(section)'.'] before:mr-2">
+                            Squad Leaders
+                        </h2>
+                        <div className="card space-y-4">
+                            <h3 className="text-xl font-semibold mb-2">
+                                Faction Squad Leaders and Their Bonuses
+                            </h3>
+                            <p className="text-theme-text">
+                                Each faction has three squad leaders — one rare, one epic, and one
+                                legendary — and each leader grants fleet-wide bonuses to that
+                                faction&apos;s units. A leader has three upgrade steps (I, II, III)
+                                whose bonuses are cumulative: a leader upgraded to step III has all
+                                three steps active at once.
+                            </p>
+
+                            <div className="p-4 bg-dark-lighter">
+                                <h4 className="font-semibold text-primary mb-2">Features</h4>
+                                <ul className="text-theme-text list-disc pl-4 space-y-1">
+                                    <li>Browse every faction&apos;s three squad leaders</li>
+                                    <li>Filter by faction and rarity</li>
+                                    <li>Search by leader name or effect text</li>
+                                    <li>See each step&apos;s effects laid out I / II / III</li>
+                                </ul>
+                            </div>
+
+                            <div className="p-4 bg-dark-lighter">
+                                <h4 className="font-semibold text-primary mb-2">Reading Effects</h4>
+                                <div className="space-y-3 text-theme-text">
+                                    <div>
+                                        <span className="text-green-400 font-semibold">
+                                            Ally bonuses:
+                                        </span>{' '}
+                                        Stat increases and combat modifiers granted to your own
+                                        faction&apos;s units (e.g., +8% Attack, shield each round).
+                                    </div>
+                                    <div>
+                                        <span className="text-red-400 font-semibold">
+                                            Enemy effects:
+                                        </span>{' '}
+                                        Reductions applied to enemy units (e.g., lower Defence or
+                                        Security, reduced enemy repair output).
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </section>

--- a/src/pages/database/SquadLeadersPage.tsx
+++ b/src/pages/database/SquadLeadersPage.tsx
@@ -1,0 +1,143 @@
+import React, { useMemo, useState } from 'react';
+import { PageLayout } from '../../components/ui';
+import { FilterPanel, FilterConfig } from '../../components/filters/FilterPanel';
+import { usePersistedFilters } from '../../hooks/usePersistedFilters';
+import Seo from '../../components/seo/Seo';
+import { SEO_CONFIG } from '../../constants/seo';
+import { SQUAD_LEADERS } from '../../constants/squadLeaders';
+import { FACTIONS } from '../../constants/factions';
+import { RARITIES } from '../../constants/rarities';
+import { SquadLeaderCard } from '../../components/squadLeaders/SquadLeaderCard';
+
+const FACTION_KEYS = Object.keys(SQUAD_LEADERS);
+
+// Rarity filter options, legendary-first to match the rest of the app.
+const RARITY_OPTIONS = (['legendary', 'epic', 'rare'] as const).map((r) => ({
+    value: r,
+    label: RARITIES[r].label,
+}));
+
+export const SquadLeadersPage: React.FC = () => {
+    const [isFilterOpen, setIsFilterOpen] = useState(false);
+    const [searchQuery, setSearchQuery] = useState('');
+    const { state, setState, clearFilters } = usePersistedFilters('squad-leaders-filters', {
+        sort: { field: 'name', direction: 'asc' },
+    });
+
+    const selectedFactions = useMemo(() => state.filters.factions ?? [], [state.filters.factions]);
+    const selectedRarities = useMemo(() => state.filters.rarities ?? [], [state.filters.rarities]);
+    const hasActiveFilters =
+        selectedFactions.length > 0 || selectedRarities.length > 0 || searchQuery.length > 0;
+
+    const setSelectedFactions = (factions: string[]) =>
+        setState((prev) => ({ ...prev, filters: { ...prev.filters, factions } }));
+    const setSelectedRarities = (rarities: string[]) =>
+        setState((prev) => ({ ...prev, filters: { ...prev.filters, rarities } }));
+
+    const filters: FilterConfig[] = [
+        {
+            id: 'faction',
+            label: 'Faction',
+            values: selectedFactions,
+            onChange: setSelectedFactions,
+            options: FACTION_KEYS.map((key) => ({ value: key, label: FACTIONS[key].name })),
+        },
+        {
+            id: 'rarity',
+            label: 'Rarity',
+            values: selectedRarities,
+            onChange: setSelectedRarities,
+            options: RARITY_OPTIONS,
+        },
+    ];
+
+    const groups = useMemo(() => {
+        const query = searchQuery.toLowerCase();
+        return FACTION_KEYS.filter(
+            (key) => selectedFactions.length === 0 || selectedFactions.includes(key)
+        )
+            .map((key) => {
+                const leaders = SQUAD_LEADERS[key].filter((leader) => {
+                    const matchesRarity =
+                        selectedRarities.length === 0 || selectedRarities.includes(leader.rarity);
+                    const matchesSearch =
+                        query === '' ||
+                        leader.name.toLowerCase().includes(query) ||
+                        leader.stages.some((stage) =>
+                            stage.some((effect) => effect.text.toLowerCase().includes(query))
+                        );
+                    return matchesRarity && matchesSearch;
+                });
+                return { key, leaders };
+            })
+            .filter((group) => group.leaders.length > 0);
+    }, [selectedFactions, selectedRarities, searchQuery]);
+
+    const totalCount = groups.reduce((sum, group) => sum + group.leaders.length, 0);
+
+    return (
+        <>
+            <Seo {...SEO_CONFIG.squadLeaders} />
+            <PageLayout
+                title="Squad Leaders"
+                description="Browse squad leaders for every faction and the bonuses each grants across its three upgrade steps. Step bonuses are cumulative — a leader at step III has all three steps active."
+            >
+                <div className="space-y-6">
+                    <div className="flex flex-col">
+                        {totalCount > 0 && (
+                            <span className="text-sm text-theme-text-secondary">
+                                Showing {totalCount} squad leaders
+                            </span>
+                        )}
+
+                        <FilterPanel
+                            filters={filters}
+                            isOpen={isFilterOpen}
+                            onToggle={() => setIsFilterOpen(!isFilterOpen)}
+                            onClear={() => {
+                                clearFilters();
+                                setSearchQuery('');
+                            }}
+                            hasActiveFilters={hasActiveFilters}
+                            searchValue={searchQuery}
+                            onSearchChange={setSearchQuery}
+                            searchPlaceholder="Search by name or effect..."
+                        />
+                    </div>
+
+                    {groups.length > 0 ? (
+                        <div className="space-y-8">
+                            {groups.map(({ key, leaders }) => (
+                                <section key={key} className="space-y-3">
+                                    <div className="flex items-center gap-2 border-b border-dark-border pb-2">
+                                        {FACTIONS[key] && (
+                                            <img
+                                                src={FACTIONS[key].iconUrl}
+                                                alt={FACTIONS[key].name}
+                                                className="w-6 h-6"
+                                            />
+                                        )}
+                                        <h2 className="text-xl font-semibold">
+                                            {FACTIONS[key]?.name ?? key}
+                                        </h2>
+                                    </div>
+                                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                                        {leaders.map((leader) => (
+                                            <SquadLeaderCard key={leader.name} leader={leader} />
+                                        ))}
+                                    </div>
+                                </section>
+                            ))}
+                        </div>
+                    ) : (
+                        <div className="text-center py-8 text-theme-text-secondary bg-dark-lighter border-2 border-dashed">
+                            No squad leaders match your filters
+                        </div>
+                    )}
+                </div>
+            </PageLayout>
+        </>
+    );
+};
+
+export default SquadLeadersPage;


### PR DESCRIPTION
## Summary

Adds a read-only **Squad Leaders** page under the Database nav group (`/squad-leaders`), listing every faction's three squad leaders (rare / epic / legendary) and the bonuses each grants across its three cumulative upgrade steps.

This also lands the squad-leader **data model** (`src/constants/squadLeaders.ts`) as prep for the combat-realism epic **sub-project F** (pre-fight stat modifiers) — the page is the first consumer; the engine wiring comes later.

## What's included

- **`src/constants/squadLeaders.ts`** — data + types. Effects are modelled as `stat` / `modifier` / conditional, with ally (`all-allies`) vs enemy (`all-enemies`) targets, mirroring the existing combat vocabulary so F can consume it directly. All 10 factions filled in.
- **`SquadLeadersPage`** — groups leaders by faction (icon + name) with rarity-bordered cards; steps **I / II / III** shown cumulatively; ally bonuses green, enemy reductions red, conditions/`per-round` annotated.
- **Filters** — faction + rarity + name/effect search via `FilterPanel` + `usePersistedFilters`, following the `ImplantIndexPage` pattern.
- **Wiring** — lazy route (`App.tsx`), nav item under Database (`Sidebar`), SEO meta (`seo.ts`), in-app docs section + TOC (`DocumentationPage`), and an `UNRELEASED_CHANGES` changelog entry.

## Testing

- `tsc --noEmit`, `eslint`, and `npm run build` clean.
- Full Vitest suite passes (2277 tests).
- Verified live in-browser: all 30 leaders render grouped by faction with correct rarity colours and ally/enemy colour-coding; search ("stealth") correctly narrows to Tianchao's Cipher + Serpent.

## Notes

A couple of source-data wordings worth a glance (data-only, non-blocking): Binderburg Pollinator III reads "Gain security equal to of 0.8% defense" (stray "of"), and Atlas Negotiator II "Start combat shielded for 2% of max HP" looks low next to Broker's 20%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)