### PR TITLE
feat(combat): E1 — symmetric incoming surface (per-victim AoE accounting)

### DIFF
--- a/docs/superpowers/plans/2026-06-19-per-victim-aoe-E1-symmetric-incoming-surface.md
+++ b/docs/superpowers/plans/2026-06-19-per-victim-aoe-E1-symmetric-incoming-surface.md
@@ -17,14 +17,17 @@
 - The adapter (`healingEngineAdapter.ts`) and `battleSimulator.ts` do **not** surface `perActorIncoming` into their result types — so no `.snap` golden serializes it. DPS/healing snapshot goldens cannot move.
 - `twoTeamBattle.test.ts` IS positional and WILL now populate enemy intake buckets, but it does **not** assert on `perActorIncoming` (it reads `perTargetDamage` = damage *dealt*, unchanged) → its assertions stay green.
 
-**Conclusion: E1 is FULLY byte-identical (zero `.snap` movement, every existing test green).** The new enemy intake buckets are observable only through the NEW test added in Task 1. If ANY existing golden or test moves, STOP — the invariant leaked; investigate, do not `vitest -u`.
+**One intentional test change (NOT golden churn):** `applyOutgoingToEnemy.test.ts` exists specifically to assert the enemy-side sink is a **no-op** (file header + behavior #6, `:229-252`). E1 makes that contract FALSE. The test currently stays green only by luck — its assertion reads the round *scalar* `rounds[0].incomingDamage`, which is sourced ONLY from the heal target's bucket (`engine.ts:4210`), not the enemy victims' buckets — so it is now **vacuous and misleading**. Task 2 deliberately CONVERTS this test into a positive per-victim-intake assertion (reading the enemy victims' own buckets) and rewrites the now-false header. This is an intentional test update, distinct from golden churn: **production code and all `.snap` files stay byte-identical.**
+
+**Conclusion: E1 is production byte-identical (zero `.snap` movement; every existing test green except the deliberate `applyOutgoingToEnemy.test.ts` rewrite).** The new enemy intake buckets are observable through the Task 1 integration test and the converted Task 2 unit test. If any `.snap` moves or any OTHER test changes, STOP — the invariant leaked; investigate, do not `vitest -u`.
 
 ---
 
 ## File Structure
 
 - **Modify:** `src/utils/combat/engine.ts` — replace the three no-op `enemySink` hooks (`:2442-2446`) with the `playerSink` bodies; update the stale `enemySink` comment (`:2433-2441`).
-- **Modify (test):** `src/utils/combat/__tests__/twoTeamBattle.test.ts` — add one `describe` block reusing the file's existing `battle()` / `run()` / `ENEMY_IDS` harness to prove the enemy victim now gets a per-actor intake bucket.
+- **Modify (test):** `src/utils/combat/__tests__/twoTeamBattle.test.ts` — add one `describe` block reusing the file's existing `battle()` / `run()` / `ENEMY_IDS` harness to prove the enemy victim now gets a per-actor intake bucket (integration-level).
+- **Modify (test):** `src/utils/combat/__tests__/applyOutgoingToEnemy.test.ts` — convert behavior #6 (`:229-252`) from "enemy sink is a no-op" into "enemy sink records per-victim intake" (unit-level, exact amounts via the `__testTapApplyOutgoingToEnemy` seam), and rewrite the now-false header (`:1-42`).
 
 No new files. No type changes (the `ActorIntake` type and `perActorIncoming` map already exist; `enemySink` already conforms to `DamageAccountingSink`).
 
@@ -125,10 +128,57 @@ Replace the comment block (`:2433-2441`) and the no-op object (`:2442-2446`) wit
 Run: `npx vitest run twoTeamBattle -t "symmetric incoming surface"`
 Expected: PASS — enemy victims now get `intakeFor(enemyId)` buckets with `incoming > 0`.
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 3: Convert the now-false no-op test in `applyOutgoingToEnemy.test.ts`**
+
+This test's behavior #6 asserts the enemy sink is a no-op — now false. Replace the `it('enemy-side sink is a no-op: ...')` block (`:229-252`) with a positive per-victim-intake assertion. Note the exact sink semantics from `applyVictimDamage` (`engine.ts:2294`): `addIncoming` gets the **total** `damage`; `addShieldAbsorbed` gets `min(shield, damage)`; a Barrier carrier gets `addBarrierAbsorbed(damage)` and returns early (no shield/HP). So for the three mid-run hits: `e1` (3000 dmg vs 1000 shield) → incoming 3000, shieldAbsorbed 1000; `barrierEnemy` (4000, Barrier) → incoming 4000, barrierAbsorbed 4000; `e2` (2000 plain) → incoming 2000.
+
+```typescript
+    it('enemy-side sink records per-victim intake: mid-run wrapper calls populate each enemy victim bucket', () => {
+        // Drive several enemy-victim intakes through the REAL wrapper DURING the round (inside the
+        // tap), so the per-actor buckets are still live and get snapshotted afterwards. A shield
+        // hit (overflow), a Barrier full block, and a plain HP hit each exercise a different sink
+        // hook (addShieldAbsorbed / addBarrierAbsorbed / addIncoming).
+        const { result } = captureWrapper(
+            { enemyAttackers: [enemyAttacker('barrierEnemy', selfBuffSkills('Barrier'))] },
+            (fn) => {
+                const shielded = enemyVictim('e1', 10_000);
+                shielded.shieldPool = 1000; // 3000 dmg → 1000 absorbed by shield, 2000 overflow to HP
+                fn(3000, shielded);
+                fn(4000, enemyVictim('barrierEnemy', 10_000)); // fully Barrier-blocked
+                fn(2000, enemyVictim('e2', 10_000)); // plain HP hit
+            }
+        );
+        const rounds = result.healing!.rounds;
+        // E1: the enemy-side sink now records each victim's intake into its OWN per-actor bucket
+        // (keyed by the enemy victim id), exactly like the player sink. `addIncoming` carries the
+        // TOTAL damage; shield/barrier absorbs are tracked separately.
+        const shieldBucket = rounds[0].perActorIncoming.get('e1');
+        expect(shieldBucket?.incoming).toBe(3000);
+        expect(shieldBucket?.shieldAbsorbed).toBe(1000);
+        expect(shieldBucket?.barrierAbsorbed ?? 0).toBe(0);
+        const barrierBucket = rounds[0].perActorIncoming.get('barrierEnemy');
+        expect(barrierBucket?.incoming).toBe(4000);
+        expect(barrierBucket?.barrierAbsorbed).toBe(4000);
+        expect(barrierBucket?.shieldAbsorbed ?? 0).toBe(0);
+        const hpBucket = rounds[0].perActorIncoming.get('e2');
+        expect(hpBucket?.incoming).toBe(2000);
+        // The heal target's own scalar totals stay 0 — the tank was never attacked this round; the
+        // scalars read ONLY the heal target's bucket (engine.ts:4210), not the enemy victims'.
+        expect(rounds[0].incomingDamage).toBe(0);
+    });
+```
+
+Also rewrite the file header (`:1-42`) so it no longer claims the enemy sink is a no-op: state that the enemy sink now records per-victim intake into `perActorIncoming` (keyed by the enemy victim id), and that the round *scalars* still read only the heal target's bucket. Remove the stale "no-ops for PR 1" / "REACHABILITY: no production call site" framing (the positional path now calls it) and the now-false non-vacuity paragraph about inverting the sink.
+
+- [ ] **Step 4: Run the converted test**
+
+Run: `npx vitest run applyOutgoingToEnemy`
+Expected: PASS — all 6 behaviors green, behavior #6 now asserting real per-victim enemy buckets.
+
+- [ ] **Step 5: Commit**
 
 ```bash
-git add src/utils/combat/engine.ts
+git add src/utils/combat/engine.ts src/utils/combat/__tests__/applyOutgoingToEnemy.test.ts
 git commit --no-verify -m "feat(combat): E1 — symmetric incoming surface (enemy victims record intake)"
 ```
 
@@ -157,7 +207,7 @@ Expected: all tests green; **no `.snap` file modified** (the load-bearing invari
 - [ ] **Step 4: Lint + typecheck + skill audit**
 
 Run: `npm run lint && npx tsc --noEmit && npm run audit:skills`
-Expected: lint 0 warnings, tsc clean, audit 0 findings / 141 ships.
+Expected: lint 0 warnings, tsc clean, `audit:skills` green (0 findings — the ship count it reports should be unchanged from baseline; don't treat a specific count as a hard expectation).
 
 (No commit — verification only. If anything fails, fix under the same task before proceeding.)
 

--- a/docs/superpowers/plans/2026-06-19-per-victim-aoe-E1-symmetric-incoming-surface.md
+++ b/docs/superpowers/plans/2026-06-19-per-victim-aoe-E1-symmetric-incoming-surface.md
@@ -1,0 +1,191 @@
+# E1 — Symmetric incoming surface Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the player→enemy damage direction record per-victim intake (incoming / shieldAbsorbed / barrierAbsorbed) into the same `perActorIncoming` map the enemy→player direction already uses, so every victim — on either side — has a real damage-intake surface. This is the keystone foundation for E2 (per-victim leech).
+
+**Architecture:** The engine already has a direction-agnostic per-victim intake map `perActorIncoming` (keyed by actor id, ids globally unique across sides) and a `DamageAccountingSink` abstraction. The enemy→player wrapper (`applyIncomingToTarget`) uses `playerSink`, which writes `intakeFor(victimId)`. The player→enemy wrapper (`applyOutgoingToEnemy`) uses `enemySink`, whose three hooks are currently **no-ops** (`engine.ts:2442-2446`). E1 replaces those no-ops with the exact `playerSink` bodies. `applyOutgoingToEnemy`'s only production caller is the **positional** apply path (`drivePositionalApply`, `engine.ts:2619`); all existing non-positional fixtures never call it, so they add no enemy key and stay byte-identical.
+
+**Tech Stack:** TypeScript, Vitest. Combat engine in `src/utils/combat/`.
+
+---
+
+## Byte-identical analysis (READ FIRST — the load-bearing invariant)
+
+- `applyOutgoingToEnemy` (`engine.ts:2447`) is wired **only** at the positional binding `drivePositionalApply` (`engine.ts:2619`: `applyToVictim: (victim, damage) => applyOutgoingToEnemy(damage, victim)`). It is NOT called on any non-positional path. (`__testTapApplyOutgoingToEnemy` at `:2459` is test-only.)
+- The two tests that assert on `perActorIncoming` — `perActorIncoming.test.ts` and `destroyedRoundUnification.test.ts` — use **only manual (non-positional) enemies** (no `position` field; see `perActorIncoming.test.ts:12-13`, `destroyedRoundUnification.test.ts:26-27`). After E1, `applyOutgoingToEnemy` is still never called in those fixtures → no `'enemy'` key is ever added → their `expect(rd.perActorIncoming.has('enemy')).toBe(false)` assertions remain true.
+- The adapter (`healingEngineAdapter.ts`) and `battleSimulator.ts` do **not** surface `perActorIncoming` into their result types — so no `.snap` golden serializes it. DPS/healing snapshot goldens cannot move.
+- `twoTeamBattle.test.ts` IS positional and WILL now populate enemy intake buckets, but it does **not** assert on `perActorIncoming` (it reads `perTargetDamage` = damage *dealt*, unchanged) → its assertions stay green.
+
+**Conclusion: E1 is FULLY byte-identical (zero `.snap` movement, every existing test green).** The new enemy intake buckets are observable only through the NEW test added in Task 1. If ANY existing golden or test moves, STOP — the invariant leaked; investigate, do not `vitest -u`.
+
+---
+
+## File Structure
+
+- **Modify:** `src/utils/combat/engine.ts` — replace the three no-op `enemySink` hooks (`:2442-2446`) with the `playerSink` bodies; update the stale `enemySink` comment (`:2433-2441`).
+- **Modify (test):** `src/utils/combat/__tests__/twoTeamBattle.test.ts` — add one `describe` block reusing the file's existing `battle()` / `run()` / `ENEMY_IDS` harness to prove the enemy victim now gets a per-actor intake bucket.
+
+No new files. No type changes (the `ActorIntake` type and `perActorIncoming` map already exist; `enemySink` already conforms to `DamageAccountingSink`).
+
+---
+
+## Task 1: Failing test — player→enemy hit records enemy intake
+
+**Files:**
+- Test: `src/utils/combat/__tests__/twoTeamBattle.test.ts` (add a new `describe` at the end, reusing existing helpers)
+
+- [ ] **Step 1: Write the failing test**
+
+Add at the end of `twoTeamBattle.test.ts` (reuses the existing `battle`, `run`, `ENEMY_IDS`, `PLAYER_IDS` helpers already in this file). The round accessor mirrors `perActorIncoming.test.ts:112` (`result.healing!.rounds`).
+
+```typescript
+describe('E1 — symmetric incoming surface: player→enemy hits record per-victim intake', () => {
+    it('an enemy struck by a player attack gets a perActorIncoming bucket with incoming > 0 (non-vacuous)', () => {
+        idc = 0;
+        // Players immortal so the battle runs; enemies tanky enough to survive and keep being hit.
+        const { result } = run(
+            battle({
+                playerHp: 1_000_000_000,
+                enemyHp: 1_000_000_000,
+                playerAttack: 5000,
+                enemyAttack: 5000,
+            })
+        );
+
+        const rounds = result.healing!.rounds;
+
+        // At least one enemy victim has an intake bucket with positive incoming.
+        const enemyBucketRounds = rounds.filter((rd) =>
+            [...ENEMY_IDS].some((id) => (rd.perActorIncoming.get(id)?.incoming ?? 0) > 0)
+        );
+        expect(enemyBucketRounds.length).toBeGreaterThan(0);
+
+        // The player side is still tracked too (symmetry — enemy→player intake unaffected).
+        const playerBucketRounds = rounds.filter((rd) =>
+            [...PLAYER_IDS].some((id) => rd.perActorIncoming.has(id))
+        );
+        expect(playerBucketRounds.length).toBeGreaterThan(0);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it FAILS**
+
+Run: `npx vitest run twoTeamBattle -t "symmetric incoming surface"`
+Expected: FAIL — `enemyBucketRounds.length` is `0` because `enemySink`'s hooks are no-ops, so `intakeFor(enemyId)` is never created and `perActorIncoming.get(enemyId)` is `undefined`.
+
+(If it does NOT fail, STOP — the harness/accessor is wrong. Confirm `result.healing!.rounds` is the right surface and `battle()` produces a positional run that calls `applyOutgoingToEnemy`.)
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add src/utils/combat/__tests__/twoTeamBattle.test.ts
+git commit --no-verify -m "test(combat): E1 — failing test for symmetric enemy intake surface"
+```
+
+---
+
+## Task 2: Make the enemySink hooks real
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts:2433-2446`
+
+- [ ] **Step 1: Replace the no-op enemySink with the real intake writes**
+
+Replace the comment block (`:2433-2441`) and the no-op object (`:2442-2446`) with:
+
+```typescript
+        // Player→enemy intake (E1 — symmetric incoming surface). The symmetric THIN wrapper over
+        // applyVictimDamage for the direction where a PLAYER attacks an ENEMY victim. The enemy
+        // victim runs the FULL HP/shield/Barrier/Cheat-Death/recordDestroyed path AND now records
+        // its incoming / shield-absorbed / barrier-absorbed into the same per-actor `intakeFor`
+        // bucket the playerSink uses — keyed by the ENEMY victim's id (ids are globally unique
+        // across sides, so one map serves both directions). `applyOutgoingToEnemy` is only invoked
+        // on the positional apply path (drivePositionalApply), so non-positional fixtures never add
+        // an enemy key → byte-identical. The enemy victim is never the heal target, so no
+        // heal-target death-round bookkeeping applies. E2 (per-victim leech) reads this surface.
+        const enemySink: DamageAccountingSink = {
+            addIncoming: (amount, victimId) => {
+                intakeFor(victimId).incoming += amount;
+            },
+            addShieldAbsorbed: (amount, victimId) => {
+                intakeFor(victimId).shieldAbsorbed += amount;
+            },
+            addBarrierAbsorbed: (amount, victimId) => {
+                intakeFor(victimId).barrierAbsorbed += amount;
+            },
+        };
+```
+
+(The bodies are intentionally identical to `playerSink` (`:2410-2420`). They are kept as a separate named const so E2/future work can let the two directions diverge without churning the player path.)
+
+- [ ] **Step 2: Run the Task 1 test to verify it PASSES**
+
+Run: `npx vitest run twoTeamBattle -t "symmetric incoming surface"`
+Expected: PASS — enemy victims now get `intakeFor(enemyId)` buckets with `incoming > 0`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/combat/engine.ts
+git commit --no-verify -m "feat(combat): E1 — symmetric incoming surface (enemy victims record intake)"
+```
+
+---
+
+## Task 3: Byte-identical verification sweep
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the two perActorIncoming-asserting tests**
+
+Run: `npx vitest run perActorIncoming destroyedRoundUnification`
+Expected: PASS — both use non-positional manual enemies; their `has('enemy') === false` assertions stay true (no `applyOutgoingToEnemy` call → no enemy key).
+
+- [ ] **Step 2: Run the full positional + two-team suite**
+
+Run: `npx vitest run twoTeamBattle positionalDamage dpsSimulator`
+Expected: PASS, no assertion changes.
+
+- [ ] **Step 3: Run the full test suite + confirm ZERO golden movement**
+
+Run: `npx vitest run`
+Then: `git status --porcelain` and `git diff --stat -- '*.snap'`
+Expected: all tests green; **no `.snap` file modified** (the load-bearing invariant). If any `.snap` moved, STOP and investigate — do NOT `vitest -u`.
+
+- [ ] **Step 4: Lint + typecheck + skill audit**
+
+Run: `npm run lint && npx tsc --noEmit && npm run audit:skills`
+Expected: lint 0 warnings, tsc clean, audit 0 findings / 141 ships.
+
+(No commit — verification only. If anything fails, fix under the same task before proceeding.)
+
+---
+
+## Task 4: Doc closeout
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md` (mark E1 shipped)
+
+- [ ] **Step 1: Append an E1-shipped note to the spec**
+
+Add a short "E1 SHIPPED" line under §4 (commit, byte-identical confirmation, that the enemy intake surface is now live and unread until E2).
+
+- [ ] **Step 2: Commit (docs are gitignored → force-add, skip hook)**
+
+```bash
+git add -f docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md
+git commit --no-verify -m "docs(spec): E1 shipped — symmetric incoming surface"
+```
+
+**No changelog entry:** E1 is internal-only plumbing (no user-facing behavior change; enemy intake is unread until E2). Per CLAUDE.md, skip the changelog.
+
+---
+
+## Done criteria
+
+- New Task 1 test passes (enemy victims get intake buckets on the positional path).
+- `perActorIncoming.test.ts` + `destroyedRoundUnification.test.ts` green (no enemy key on non-positional fixtures).
+- Full suite green; **zero `.snap` movement**; lint 0; tsc clean; audit 0/141.
+- E2 can now read per-victim enemy intake off `perActorIncoming`.

--- a/docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md
+++ b/docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md
@@ -1,0 +1,131 @@
+# Sub-project E — Per-victim AoE accounting (design)
+
+**Status:** Design approved (brainstorm, 2026-06-19). Supersedes the "old PR7" sketch in the combat-realism epic roadmap; PR7b already shipped as B1.
+
+**Branch:** `feat/combat-sim-per-victim-aoe-E` (off `main` post-#117).
+
+## 1. Context & reframing
+
+The combat-realism epic deferred "per-victim AoE accounting" (the old PR7) to its tail. Since that
+deferral, the **positional combat** work (merged in PR #117) already made two of PR7's four pieces
+real:
+
+- **AoE damage** is already per-victim. `positionalApply.ts` (`footprintVictims` +
+  `applyPositionalDamage`) re-resolves the anchor and re-expands the footprint **per hit** against the
+  live opposing roster, and calls `victimHitDamage` for each victim with its own `roleScale` (origin
+  1.0, covered 0.5). `victimHitDamage` (`victimDamage.ts:71-107`) re-solves per-victim defence,
+  affinity, and the incoming-damage debuff override from the victim's own store.
+- **Death / retargeting** is already per-victim on the positional path. `resolvePositionalTarget`
+  filters to living actors (`currentHp > 0`) and re-resolves per hit; a whiff (all targets dead) skips
+  the hit. `recordDestroyed` (`state.ts:173-187`) is idempotent.
+
+PR7b (per-victim debuff *modifier sourcing* — `victimEnemyModifiers`) shipped as B1.
+
+What **remains** in E splits into two largely-independent threads:
+
+- **Thread 1 — Accounting (numbers correctness):** the per-victim damage *outcome* (shield/barrier
+  absorb, hp loss) is computed but discarded for the player→enemy direction, so leech and per-victim
+  intake cannot read it.
+- **Thread 2 — Status removal (gameplay correctness):** purge/cleanse still apply to a single anchor
+  victim, not every victim an AoE hits.
+
+## 2. Current-state gaps (the work)
+
+| # | Mechanic | Current state | File:line |
+|---|----------|---------------|-----------|
+| 4 | Incoming surface | **Asymmetric.** enemy→player buckets per-actor into `perActorIncoming`; player→enemy uses a **no-op `enemySink`** (all three accounting hooks discard). | `engine.ts:2410-2455`, `2433-2439` |
+| 2 | Leech | **Aggregate / single-anchor.** Standing leech procs off aggregate damage at the credit point; taken-leech is **gated out of the positional path** (`!enemyPositional`) because it needs the symmetric surface. | `engine.ts:2014-2044`, `3809-3946` (gate `3913`) |
+| 5 | AoE purge/cleanse | **Single-anchor.** On-cast purge removes only the selected `targetId`; "all-enemies" collapses to one victim. | `playerTurn.ts:1002-1015` (comment `:1012`) |
+| 7 | Amartya | **Single-anchor, count 1.** "purges 1 buff from all enemies for every 50% crit power" fires single-victim, no crit-power scaling. | spec `2026-06-19-purge-ecosystem-c2b-design.md §7` |
+| 6 | Per-victim repair | **Per-victim-capable but single-`healTarget`-limited.** `repairedThisRound` is a per-actor Set; only the heal target is ever healed in current modes, so player-Nayra-vs-enemy never fires. | `engine.ts:1895-1897`, `1912-1927` |
+
+(Items 1 = AoE damage and 3 = death/retargeting are already per-victim — see §1 — so they are NOT
+work in E.)
+
+## 3. Architecture — the symmetric victim-outcome surface (keystone)
+
+The keystone is E1: make the incoming/intake surface **direction-agnostic**.
+
+- A single per-actor `ActorIntake` accounting map keyed by actor id (ids are globally unique across
+  sides, so one map serves both directions).
+- The `enemySink` accounting hooks (`addIncoming` / `addShieldAbsorbed` / `addBarrierAbsorbed`),
+  currently no-ops, become **real writes** into that map.
+- The positional apply path already computes per-victim damage; E1 captures the **full per-victim
+  outcome** (`{shieldBefore, hpDamage, barriered, shieldAbsorbed, barrierAbsorbed}`) for enemy victims
+  too, instead of discarding it.
+
+**Why this is byte-identical to existing goldens:** today's goldens assert *player-side* accounting
+and `perTargetDamage` (damage **dealt**, already per-victim). The enemy-victim intake buckets are a
+**new, currently-unread surface** — purely additive. Nothing existing reads them, so DPS / healing /
+two-team-sim goldens stay byte-identical. (Enemy surfacing in the simulator UI is **out of scope** —
+see §5 decision; it waits for the shield system, sub-project H.)
+
+## 4. Decomposition (sequential PRs)
+
+| PR | Scope | Depends on |
+|----|-------|-----------|
+| **E1** | Symmetric incoming surface — unify `ActorIntake` keyed by actor id; replace the no-op `enemySink` hooks with real writes; capture the full per-victim outcome for enemy victims. **Internal only** (no UI). | — (foundation) |
+| **E2** | Per-victim leech — standing + taken leech re-derived per footprint victim; un-gate the positional leech blocks. | E1 |
+| **E3** | AoE purge/cleanse — apply status removal to **all** footprint victims, not just the anchor. Rides the existing footprint resolver. | — (independent of E1/E2) |
+| **E4** | Amartya — multi-victim purge + **faithful crit-power scaling** `count = floor(casterCritDamage / 50)` read live each cast. | E3 |
+| **E5** | Credit/intake unification + death-fallback cleanup — collapse the now-redundant dual accounting paths. **Per-victim repair (Nayra) lights up here as a consequence.** | E1, E2 |
+
+Thread 1 = E1 → E2 → E5. Thread 2 = E3 → E4 (independent; may run first if gameplay-visible fixes are
+wanted sooner). Each PR gets its own plan and ships under the established gate.
+
+### Per-PR mechanics
+
+**E1 — symmetric incoming surface.** One `perActorIncoming`-style map for all actors. `enemySink`
+hooks write into it keyed by the enemy victim's id. `victimHitDamage` / the positional apply callback
+returns/records the full outcome (shield-before, hp-damage, barriered, absorb amounts) for enemy
+victims, mirroring the player sink. No consumer reads the new enemy buckets yet → additive.
+
+**E2 — per-victim leech.**
+- *Standing leech* (heal/shield off damage **dealt**): sums over footprint victims; covered cells
+  contribute their reduced (50%) damage, since leech is computed off **real damage dealt**.
+- *Taken leech* (reactive heal/shield off damage **taken**): each player victim procs its **own**
+  reactive off the damage **it** took. Un-gates the `!enemyPositional` blocks (`engine.ts:3913`,
+  `3902-3912`).
+- Reads E1's per-victim outcome surface (the shield/hp split each victim needs to leech from).
+
+**E3 — AoE purge/cleanse.** Replace the single-`targetId` removal at `playerTurn.ts:1011` with a loop
+over the footprint victims for "all-enemies"-style targets. The footprint resolver already enumerates
+victims per hit; E3 routes `statusEngine.purge` / `cleanse` to each. Reactive purge/cleanse follow the
+same per-victim routing where an AoE reaction applies.
+
+**E4 — Amartya.** `count = floor(casterCritDamage / 50)` (crit power = the `critDamage` stat),
+computed from the caster's **live** crit power at cast time, applied to **every** footprint victim.
+Builds on E3's multi-victim loop. Removes the C2a single-anchor count-1 under-approximation flag.
+
+**E5 — unification + Nayra consequence.** With the no-op sink gone (E1), collapse the dual
+accounting/credit paths and tidy death-fallback. **Per-victim repair tracking** then lights up:
+`repairedThisRound` is already a per-actor Set, so once the symmetric surface lets any actor be
+healed/tracked per-victim, the documented Nayra limitation
+(player-Nayra-vs-enemy always false because "engine never heals enemy ships") resolves with no new
+mechanism.
+
+## 5. Locked decisions
+
+- **Amartya count = `floor(critDamage / 50)`** — faithful crit-power scaling, read live each cast.
+- **E1 is internal only** — no simulator-UI surfacing of enemy per-victim absorb/HP. Surfacing waits
+  for the shield system (sub-project H), where it is no longer moot.
+- **Full E, sequential PRs** (B/C-series cadence).
+- **Nayra per-victim repair lands in E5** as a consequence of the symmetric surface, not its own PR.
+- **Thread 2 (E3/E4) is independent of Thread 1 (E1/E2)** and may be sequenced first.
+
+## 6. Out of scope / deferred elsewhere
+
+- Enemy shield/barrier per-victim **UI** → sub-project H (shield system).
+- New shield **sources** (gear-set, overheal-to-shield implant) → sub-project D.
+- Lodolite p3 (shield-removal-on-purge) → sub-project H.
+
+## 7. Testing / gate (unchanged from B/C)
+
+- **Byte-identical goldens are the default gate.** Audited churn ONLY on two-team-sim fixtures
+  (twoTeamBattle / dpsSimulator multi-actor / positionalDamage.integration) where a behavior
+  legitimately becomes per-victim — e.g. a leech now firing per footprint victim, or a debuff now
+  stripped from multiple enemies. Explain every golden delta line-by-line. **Never blind `vitest -u`.**
+- DPS single-enemy + healing goldens MUST stay byte-identical (the dummy/single-target guards hold).
+- `audit:skills` 0/141, `npm run lint` (max-warnings 0), `npx tsc --noEmit` clean every PR.
+- Subagent-driven; per-task spec+quality + final holistic (opus) review.
+- Run tests via `npx vitest run <name>` (bare `npm test` = watch mode, hangs agents).

--- a/docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md
+++ b/docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md
@@ -92,6 +92,14 @@ outcome (shield-before, hp-damage, barriered, absorb amounts) is captured from t
 bare number). Mirrors the player sink. Because `applyOutgoingToEnemy` only runs on the positional
 path, existing non-positional fixtures add no enemy keys → byte-identical (see §3).
 
+> **E1 SHIPPED** (2026-06-19, commit `caad6805`). The `enemySink` hooks now write incoming /
+> shield-absorbed / barrier-absorbed into the shared `perActorIncoming` map keyed by the enemy
+> victim's id, mirroring `playerSink`. Production byte-identical: **zero `.snap` movement**, full
+> suite green (2665 tests), lint 0 / tsc clean / audit 0/141. The only test change was converting
+> `applyOutgoingToEnemy.test.ts` behavior #6 from a (now-false) "enemy sink is a no-op" assertion to
+> a positive per-victim-intake assertion. The enemy intake surface is live but **unread until E2**
+> (per-victim leech).
+
 **E2 — per-victim leech.**
 - *Standing leech* (heal/shield off damage **dealt**): today `procStandingLeeches` (`engine.ts:2086`)
   fires once at the credit point off the **aggregate** `amount` (~`engine.ts:2200`). E2 moves this to a

--- a/docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md
+++ b/docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md
@@ -12,9 +12,12 @@ real:
 
 - **AoE damage** is already per-victim. `positionalApply.ts` (`footprintVictims` +
   `applyPositionalDamage`) re-resolves the anchor and re-expands the footprint **per hit** against the
-  live opposing roster, and calls `victimHitDamage` for each victim with its own `roleScale` (origin
-  1.0, covered 0.5). `victimHitDamage` (`victimDamage.ts:71-107`) re-solves per-victim defence,
-  affinity, and the incoming-damage debuff override from the victim's own store.
+  live opposing roster, and computes each victim's damage with its own `roleScale` (origin 1.0,
+  covered 0.5). The per-victim **damage number** comes from `victimHitDamage`
+  (`victimDamage.ts:71-107`), which re-solves per-victim defence, affinity, and the incoming-damage
+  debuff override from the victim's own store. The full damage **outcome**
+  (`{shieldBefore, hpDamage, barriered, shieldAbsorbed, barrierAbsorbed}`) is produced one level up by
+  the engine wrappers `applyVictimDamage` / `applyOutgoingToEnemy` (`engine.ts`, returns ~`:2402`).
 - **Death / retargeting** is already per-victim on the positional path. `resolvePositionalTarget`
   filters to living actors (`currentHp > 0`) and re-resolves per hit; a whiff (all targets dead) skips
   the hit. `recordDestroyed` (`state.ts:173-187`) is idempotent.
@@ -33,11 +36,11 @@ What **remains** in E splits into two largely-independent threads:
 
 | # | Mechanic | Current state | File:line |
 |---|----------|---------------|-----------|
-| 4 | Incoming surface | **Asymmetric.** enemy→player buckets per-actor into `perActorIncoming`; player→enemy uses a **no-op `enemySink`** (all three accounting hooks discard). | `engine.ts:2410-2455`, `2433-2439` |
-| 2 | Leech | **Aggregate / single-anchor.** Standing leech procs off aggregate damage at the credit point; taken-leech is **gated out of the positional path** (`!enemyPositional`) because it needs the symmetric surface. | `engine.ts:2014-2044`, `3809-3946` (gate `3913`) |
-| 5 | AoE purge/cleanse | **Single-anchor.** On-cast purge removes only the selected `targetId`; "all-enemies" collapses to one victim. | `playerTurn.ts:1002-1015` (comment `:1012`) |
+| 4 | Incoming surface | **Asymmetric.** enemy→player buckets per-actor into `perActorIncoming`; player→enemy uses a **no-op `enemySink`** (all three accounting hooks discard). | `engine.ts:2410-2455` (no-op object `2442-2446`) |
+| 2 | Leech | **Aggregate / single-anchor.** Standing leech procs off aggregate damage: `procStandingLeeches` (`engine.ts:2086`) fired at the single damage-credit point (~`:2200`) off the aggregate `amount`. Taken-leech is **gated out of the positional path** (`!enemyPositional`) because it needs the symmetric surface. | `engine.ts:2086`/`~2200`, `3902-3946` (gate `3913-3918`) |
+| 5 | AoE purge/cleanse | **Single-anchor (on-cast purge + reactive purge).** On-cast purge removes only the selected `targetId`; "all-enemies" collapses to one victim. Cleanse already loops recipients; purge does not. | on-cast purge `playerTurn.ts:1392-1401` (comment `:1399-1400`); reactive purge `triggers.ts:1243` |
 | 7 | Amartya | **Single-anchor, count 1.** "purges 1 buff from all enemies for every 50% crit power" fires single-victim, no crit-power scaling. | spec `2026-06-19-purge-ecosystem-c2b-design.md §7` |
-| 6 | Per-victim repair | **Per-victim-capable but single-`healTarget`-limited.** `repairedThisRound` is a per-actor Set; only the heal target is ever healed in current modes, so player-Nayra-vs-enemy never fires. | `engine.ts:1895-1897`, `1912-1927` |
+| 6 | Per-victim repair | **Per-victim-capable but single-`healTarget`-limited.** `repairedThisRound` is a per-actor Set (`engine.ts:1897`, written `:1925`); only the heal target is ever healed in current modes, so player-Nayra-vs-enemy never fires. | `engine.ts:1897`, `1912-1927` |
 
 (Items 1 = AoE damage and 3 = death/retargeting are already per-victim — see §1 — so they are NOT
 work in E.)
@@ -52,13 +55,20 @@ The keystone is E1: make the incoming/intake surface **direction-agnostic**.
   currently no-ops, become **real writes** into that map.
 - The positional apply path already computes per-victim damage; E1 captures the **full per-victim
   outcome** (`{shieldBefore, hpDamage, barriered, shieldAbsorbed, barrierAbsorbed}`) for enemy victims
-  too, instead of discarding it.
+  too (via `applyVictimDamage` / `applyOutgoingToEnemy`), instead of discarding it.
 
-**Why this is byte-identical to existing goldens:** today's goldens assert *player-side* accounting
-and `perTargetDamage` (damage **dealt**, already per-victim). The enemy-victim intake buckets are a
-**new, currently-unread surface** — purely additive. Nothing existing reads them, so DPS / healing /
-two-team-sim goldens stay byte-identical. (Enemy surfacing in the simulator UI is **out of scope** —
-see §5 decision; it waits for the shield system, sub-project H.)
+**Why this is byte-identical to existing goldens — the precise invariant.** The `perActorIncoming`
+map (`engine.ts:2220`) is NOT unread — it is exported wholesale every healing round
+(`row.perActorIncoming`, `engine.ts:4218`) and `perActorIncoming.test.ts` explicitly asserts there is
+no `'enemy'` key. So the real invariant is narrower: E1's new writes flow through
+`applyOutgoingToEnemy` (`engine.ts:2447`), which is **only invoked on the positional apply path**
+(`drivePositionalApply`, wired ~`engine.ts:2619`). **Every existing golden/fixture uses
+non-positional / manual enemies**, so `applyOutgoingToEnemy` is never called and no enemy key is ever
+added → the populated keys don't change → byte-identical. The planner must protect THIS invariant (no
+new enemy keys in existing non-positional fixtures), not "nothing reads the map." A future
+positional-healing-mode fixture would legitimately add an enemy key — that is **audited churn, not a
+regression**. (Enemy surfacing in the simulator UI is **out of scope** — see §5; it waits for the
+shield system, sub-project H.)
 
 ## 4. Decomposition (sequential PRs)
 
@@ -75,23 +85,31 @@ wanted sooner). Each PR gets its own plan and ships under the established gate.
 
 ### Per-PR mechanics
 
-**E1 — symmetric incoming surface.** One `perActorIncoming`-style map for all actors. `enemySink`
-hooks write into it keyed by the enemy victim's id. `victimHitDamage` / the positional apply callback
-returns/records the full outcome (shield-before, hp-damage, barriered, absorb amounts) for enemy
-victims, mirroring the player sink. No consumer reads the new enemy buckets yet → additive.
+**E1 — symmetric incoming surface.** One `perActorIncoming`-style map for all actors. The `enemySink`
+hooks (no-op object `engine.ts:2442-2446`) write into it keyed by the enemy victim's id. The full
+outcome (shield-before, hp-damage, barriered, absorb amounts) is captured from the engine wrapper
+`applyOutgoingToEnemy` (`engine.ts:2447`, returns ~`:2402`) — NOT `victimHitDamage` (which returns a
+bare number). Mirrors the player sink. Because `applyOutgoingToEnemy` only runs on the positional
+path, existing non-positional fixtures add no enemy keys → byte-identical (see §3).
 
 **E2 — per-victim leech.**
-- *Standing leech* (heal/shield off damage **dealt**): sums over footprint victims; covered cells
-  contribute their reduced (50%) damage, since leech is computed off **real damage dealt**.
+- *Standing leech* (heal/shield off damage **dealt**): today `procStandingLeeches` (`engine.ts:2086`)
+  fires once at the credit point off the **aggregate** `amount` (~`engine.ts:2200`). E2 moves this to a
+  per-victim sum over footprint victims; covered cells contribute their reduced (50%) damage, since
+  leech is computed off **real damage dealt**.
 - *Taken leech* (reactive heal/shield off damage **taken**): each player victim procs its **own**
   reactive off the damage **it** took. Un-gates the `!enemyPositional` blocks (`engine.ts:3913`,
   `3902-3912`).
 - Reads E1's per-victim outcome surface (the shield/hp split each victim needs to leech from).
 
-**E3 — AoE purge/cleanse.** Replace the single-`targetId` removal at `playerTurn.ts:1011` with a loop
-over the footprint victims for "all-enemies"-style targets. The footprint resolver already enumerates
-victims per hit; E3 routes `statusEngine.purge` / `cleanse` to each. Reactive purge/cleanse follow the
-same per-victim routing where an AoE reaction applies.
+**E3 — AoE purge/cleanse.** Replace the single-`targetId` removal with a loop over the footprint
+victims for "all-enemies"-style targets. There are **two single-anchor purge sites** to fix (cleanse
+already loops recipients): the **on-cast purge** at `playerTurn.ts:1392-1401` (the literal
+`"single-anchor; multi-victim AoE → sub-project E"` comment is `:1399-1400`), and the **reactive
+purge** at `triggers.ts:1243` (single `targetId`). The footprint resolver already enumerates victims
+per hit; E3 routes `statusEngine.purge` to each. For reference, the already-looping sites are on-cast
+cleanse (`playerTurn.ts:1624`) and reactive cleanse (`triggers.ts:1190`); end-of-round reactive purge
+(Rhodium) lives at `engine.ts:4136` and should be checked for the same per-victim treatment.
 
 **E4 — Amartya.** `count = floor(casterCritDamage / 50)` (crit power = the `critDamage` stat),
 computed from the caster's **live** crit power at cast time, applied to **every** footprint victim.

--- a/src/utils/combat/__tests__/applyOutgoingToEnemy.test.ts
+++ b/src/utils/combat/__tests__/applyOutgoingToEnemy.test.ts
@@ -1,22 +1,25 @@
 /**
  * Tests for the engine's player→enemy victim-intake wrapper (`applyOutgoingToEnemy` in
- * `engine.ts`). This is the second thin wrapper over the shared `applyVictimDamage` core
- * (Task 2), carrying an ENEMY-SIDE sink whose accounting hooks are no-ops for PR 1 (the
- * tank-incoming round accumulators must NOT move when a player attacks an enemy) and which
- * omits `onHealTargetDestroyed`. The wrapper still runs the FULL HP/shield/Barrier/
- * Cheat-Death/recordDestroyed path on the enemy victim, so enemies actually take damage and
- * can die.
+ * `engine.ts`). This is the second thin wrapper over the shared `applyVictimDamage` core,
+ * carrying an ENEMY-SIDE sink. As of E1 (symmetric incoming surface) that sink RECORDS each
+ * enemy victim's intake (incoming / shield-absorbed / barrier-absorbed) into the same per-actor
+ * `perActorIncoming` map the player-side sink uses, keyed by the ENEMY victim's id (ids are
+ * globally unique across sides). The wrapper still runs the FULL HP/shield/Barrier/Cheat-Death/
+ * recordDestroyed path on the enemy victim, so enemies actually take damage and can die, and it
+ * still omits `onHealTargetDestroyed` (the enemy victim is never the heal target).
  *
- * REACHABILITY: there is NO production call site for `applyOutgoingToEnemy` yet — Task 8 wires
- * it into the player→enemy damage sites. So it cannot be exercised through normal `runCombat`
- * flow today. To test the REAL closure (not a mock), `runCombat` accepts a narrow test-only tap
+ * The round-level SCALARS (`incomingDamage`/`shieldAbsorbed`/`barrierAbsorbed` on RoundData)
+ * read ONLY the heal target's own bucket (engine.ts:4210), so an enemy victim's intake never
+ * moves those scalars — it lives solely in that victim's own per-actor bucket. E2 (per-victim
+ * leech) reads this surface.
+ *
+ * The wrapper's only production call site is the positional apply path (drivePositionalApply);
+ * to test the REAL closure (not a mock), `runCombat` also accepts a narrow test-only tap
  * `__testTapApplyOutgoingToEnemy` that hands the genuine closure out once on the first round it
  * is built. Each test runs a healing-mode `runCombat` (the cheapest way to spin up the engine's
  * statusEngine/bus/recordDestroyed/recipientMaxHp context the closure captures), captures the
  * real wrapper through the tap, then invokes it against a hand-built enemy `CombatActor` victim
- * and observes the genuine mutations/emissions. The enemy-side accounting is verified to be a
- * no-op by checking the tank-incoming round accumulators (incomingDamage/shieldAbsorbed/
- * barrierAbsorbed) are untouched by the wrapper's calls.
+ * and observes the genuine mutations/emissions.
  *
  * Behaviors verified against a hand-built enemy victim:
  *   1. plain HP damage (shield 0) — currentHp drops by exactly the damage;
@@ -24,21 +27,15 @@
  *   3. enemy carrying Barrier → full block, HP unchanged, barriered:true;
  *   4. lethal damage, no Cheat Death → currentHp 0 + ship-destroyed emitted once;
  *   5. lethal damage on an enemy Cheat-Death carrier → survives at 1 HP;
- *   6. enemy-side sink is a no-op: invoking the wrapper DURING the run does not bump the tank's
- *      round-incoming accumulators (incomingDamage/shieldAbsorbed/barrierAbsorbed) that are
- *      snapshotted into the round result AFTER the wrapper runs.
+ *   6. enemy-side sink records per-victim intake: invoking the wrapper MID-RUN populates each
+ *      enemy victim's OWN per-actor bucket (incoming / shieldAbsorbed / barrierAbsorbed), while
+ *      the heal target's round scalars stay 0 (they read only the heal target's bucket).
  *
- * NON-VACUITY (behaviour #6): the round accumulators (roundIncomingDamage/…) are CLOSURE
- * variables reset at the top of each round and folded into `rounds[r]` only at post-round
- * assembly. Invoking the wrapper post-`runCombat` (as the other 5 behaviours do) can never move
- * those already-finalized numbers, so a post-run assertion on them would be VACUOUS — it would
- * pass even if the enemy sink bumped the accumulators. To make #6 genuinely catch a regression we
- * invoke the captured wrapper MID-RUN (inside the test tap, after the accumulators are reset to 0
- * for the round but before they are snapshotted). The same closure variables back both the
- * enemy-side sink (no-op) and the player-side sink (which DOES bump them), so if the enemy sink
- * ever started crediting incoming/shield/barrier, the bump would land in `rounds[0]` and the
- * assertion below would FAIL. Proven by inverting the sink locally (addIncoming → += amount) which
- * flips rounds[0].incomingDamage to non-zero and reds the test.
+ * NON-VACUITY (behaviour #6): the per-actor buckets are CLOSURE state reset/snapshotted per
+ * round. The wrapper is invoked MID-RUN (inside the test tap, after the buckets are reset for
+ * the round but before they are snapshotted into the round result), so the recorded intake
+ * surfaces in `result.healing.rounds[0].perActorIncoming`. If the enemy sink ever stopped
+ * recording, those buckets would be absent/zero and the assertions would FAIL.
  */
 import { describe, it, expect } from 'vitest';
 import { runCombat, CombatEngineInput } from '../engine';
@@ -226,11 +223,11 @@ describe('applyOutgoingToEnemy (player→enemy per-victim damage apply wrapper)'
         expect(destroyed.filter((d) => d.actorId === 'cdEnemy')).toHaveLength(0);
     });
 
-    it('enemy-side sink is a no-op: invoking the wrapper MID-RUN does not bump the round accumulators', () => {
+    it('enemy-side sink records per-victim intake: mid-run wrapper calls populate each enemy victim bucket', () => {
         // Drive several enemy-victim intakes through the REAL wrapper DURING the round (inside the
-        // tap), so the accumulators are still live and will be snapshotted afterwards. A shield
+        // tap), so the per-actor buckets are still live and get snapshotted afterwards. A shield
         // hit (overflow), a Barrier full block, and a plain HP hit each exercise a different sink
-        // hook (addShieldAbsorbed / addBarrierAbsorbed / addIncoming) — all no-ops here.
+        // hook (addShieldAbsorbed / addBarrierAbsorbed / addIncoming).
         const { result } = captureWrapper(
             { enemyAttackers: [enemyAttacker('barrierEnemy', selfBuffSkills('Barrier'))] },
             (fn) => {
@@ -242,12 +239,21 @@ describe('applyOutgoingToEnemy (player→enemy per-victim damage apply wrapper)'
             }
         );
         const rounds = result.healing!.rounds;
-        // No enemy attacked the TANK this round, so the tank-incoming buckets start at 0. The
-        // mid-run wrapper calls above route through the enemy-side no-op sink, so the buckets must
-        // STILL read 0 in the finalized round — if the enemy sink ever credited these, the bumps
-        // would have landed here (the player-side sink, sharing these same closure vars, would).
+        // E1: the enemy-side sink now records each victim's intake into its OWN per-actor bucket
+        // (keyed by the enemy victim id), exactly like the player sink. `addIncoming` carries the
+        // TOTAL damage; shield/barrier absorbs are tracked separately.
+        const shieldBucket = rounds[0].perActorIncoming.get('e1');
+        expect(shieldBucket?.incoming).toBe(3000);
+        expect(shieldBucket?.shieldAbsorbed).toBe(1000);
+        expect(shieldBucket?.barrierAbsorbed ?? 0).toBe(0);
+        const barrierBucket = rounds[0].perActorIncoming.get('barrierEnemy');
+        expect(barrierBucket?.incoming).toBe(4000);
+        expect(barrierBucket?.barrierAbsorbed).toBe(4000);
+        expect(barrierBucket?.shieldAbsorbed ?? 0).toBe(0);
+        const hpBucket = rounds[0].perActorIncoming.get('e2');
+        expect(hpBucket?.incoming).toBe(2000);
+        // The heal target's own scalar totals stay 0 — the tank was never attacked this round; the
+        // scalars read ONLY the heal target's bucket (engine.ts:4210), not the enemy victims'.
         expect(rounds[0].incomingDamage).toBe(0);
-        expect(rounds[0].shieldAbsorbed).toBe(0);
-        expect(rounds[0].barrierAbsorbed).toBe(0);
     });
 });

--- a/src/utils/combat/__tests__/twoTeamBattle.test.ts
+++ b/src/utils/combat/__tests__/twoTeamBattle.test.ts
@@ -1098,3 +1098,32 @@ describe('Two-team battle — per-target debuff landing resolves against the ACT
         expect(landed).toBe(3);
     });
 });
+
+describe('E1 — symmetric incoming surface: player→enemy hits record per-victim intake', () => {
+    it('an enemy struck by a player attack gets a perActorIncoming bucket with incoming > 0 (non-vacuous)', () => {
+        idc = 0;
+        // Players immortal so the battle runs; enemies tanky enough to survive and keep being hit.
+        const { result } = run(
+            battle({
+                playerHp: 1_000_000_000,
+                enemyHp: 1_000_000_000,
+                playerAttack: 5000,
+                enemyAttack: 5000,
+            })
+        );
+
+        const rounds = result.healing!.rounds;
+
+        // At least one enemy victim has an intake bucket with positive incoming.
+        const enemyBucketRounds = rounds.filter((rd) =>
+            [...ENEMY_IDS].some((id) => (rd.perActorIncoming.get(id)?.incoming ?? 0) > 0)
+        );
+        expect(enemyBucketRounds.length).toBeGreaterThan(0);
+
+        // The player side is still tracked too (symmetry — enemy→player intake unaffected).
+        const playerBucketRounds = rounds.filter((rd) =>
+            [...PLAYER_IDS].some((id) => rd.perActorIncoming.has(id))
+        );
+        expect(playerBucketRounds.length).toBeGreaterThan(0);
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -1055,9 +1055,11 @@ export interface HealingRoundEngine {
 /**
  * Side-specific accounting hooks for {@link applyVictimDamage}. Everything keyed off the
  * `victim` (Barrier/shield/HP/Cheat-Death/recordDestroyed/hp-changed) lives in the shared
- * core; the four bits that differ between the healing-mode player intake and (future)
- * other intakes are injected here so the core stays caller-agnostic. The legacy player
- * wrapper supplies a sink that performs exactly the original closure's mutations.
+ * core; the per-direction intake accounting is injected here so the core stays
+ * caller-agnostic. Both directions now record into the per-actor `perActorIncoming` map keyed
+ * by the victim's id — `playerSink` for enemy→player (tank intake) and `enemySink` for
+ * player→enemy (E1 symmetric surface). The two bodies are identical today but kept separate so
+ * E2 (per-victim leech) can diverge the enemy side without touching the player path.
  */
 interface DamageAccountingSink {
     /** today: intakeFor(victimId).incoming += amount */

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2430,19 +2430,25 @@ export function runCombat(input: CombatEngineInput): {
             }
         ): { shieldBefore: number; hpDamage: number; barriered: boolean } =>
             applyVictimDamage(damage, victim, playerSink, cause);
-        // Player→enemy intake (Phase 4 PR1, Task 3) — the symmetric THIN wrapper over
+        // Player→enemy intake (E1 — symmetric incoming surface). The symmetric THIN wrapper over
         // applyVictimDamage for the direction where a PLAYER attacks an ENEMY victim. The enemy
-        // victim still runs the FULL HP/shield/Barrier/Cheat-Death/recordDestroyed path (enemies
-        // actually take damage and can die), but the per-actor intake buckets here are the TANK's
-        // incoming accounting — they must NOT move when a player hits an enemy. So this sink's
-        // accounting hooks are no-ops for PR 1
-        // (enemy-incoming accounting is the deferred Phase-5 symmetric surface). The enemy victim
-        // is never the heal target, so no heal-target death-round bookkeeping applies. Task 8
-        // wires a caller.
+        // victim runs the FULL HP/shield/Barrier/Cheat-Death/recordDestroyed path AND now records
+        // its incoming / shield-absorbed / barrier-absorbed into the same per-actor `intakeFor`
+        // bucket the playerSink uses — keyed by the ENEMY victim's id (ids are globally unique
+        // across sides, so one map serves both directions). `applyOutgoingToEnemy` is only invoked
+        // on the positional apply path (drivePositionalApply), so non-positional fixtures never add
+        // an enemy key → byte-identical. The enemy victim is never the heal target, so no
+        // heal-target death-round bookkeeping applies. E2 (per-victim leech) reads this surface.
         const enemySink: DamageAccountingSink = {
-            addIncoming: (_amount, _victimId) => {},
-            addShieldAbsorbed: (_amount, _victimId) => {},
-            addBarrierAbsorbed: (_amount, _victimId) => {},
+            addIncoming: (amount, victimId) => {
+                intakeFor(victimId).incoming += amount;
+            },
+            addShieldAbsorbed: (amount, victimId) => {
+                intakeFor(victimId).shieldAbsorbed += amount;
+            },
+            addBarrierAbsorbed: (amount, victimId) => {
+                intakeFor(victimId).barrierAbsorbed += amount;
+            },
         };
         const applyOutgoingToEnemy = (
             damage: number,


### PR DESCRIPTION
First PR of sub-project **E (per-victim AoE accounting)**. Foundation only — internal plumbing, no user-facing change.

## What
Makes the player→enemy damage direction record per-victim intake (incoming / shieldAbsorbed / barrierAbsorbed) into the same `perActorIncoming` map the enemy→player direction already uses. The `enemySink` accounting hooks in `applyVictimDamage` were no-ops; they now mirror `playerSink`, keyed by the enemy victim's id (ids are globally unique across sides).

This is the keystone foundation for E2 (per-victim leech), which will read this surface. The surface is **live but unread** until E2.

## Why byte-identical
`applyOutgoingToEnemy` has a single production caller — the positional apply path (`drivePositionalApply`, gated by `isPositional`). Every existing fixture uses non-positional/manual enemies, so it's never called there and no enemy key is added. The round scalar `incomingDamage` reads only the heal target's bucket, so enemy keys can't pollute it.

- Production **byte-identical**: zero `.snap` movement.
- 2665 tests green, lint 0, tsc clean, `audit:skills` 0/141.
- The one deliberate test change: `applyOutgoingToEnemy.test.ts` behavior #6 converted from a (now-false) "enemy sink is a no-op" assertion into a positive per-victim-intake assertion.

## Reviews
Subagent-driven: per-task spec-compliance + opus code-quality review, both APPROVED.

Spec: `docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md`
Plan: `docs/superpowers/plans/2026-06-19-per-victim-aoe-E1-symmetric-incoming-surface.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)