### PR TITLE
feat(combat): E2 — per-victim leech (lifesteal) on the positional path

### DIFF
--- a/docs/superpowers/plans/2026-06-19-per-victim-aoe-E2-leech.md
+++ b/docs/superpowers/plans/2026-06-19-per-victim-aoe-E2-leech.md
@@ -23,15 +23,17 @@ The risky part is the pool-closure parametrization (Task 1): it touches code eve
 ## File Structure
 
 - **Modify:** `src/utils/combat/engine.ts`
-  - Task 1: parametrize `applyHealToTarget`/`grantShieldToTarget` by `victim: CombatActor = healTarget` (`:1914-1938`); add an id→actor resolver if one isn't already in scope.
-  - Task 3: per-victim standing-leech proc on the positional firing-hit hook (`drivePositionalApply` per-victim callback `~:2574`; standing-leech data `~2027`/`procStandingLeeches` `~2088`).
-  - Task 4: expand `takenLeeches` registration (`~2061`) to a `Map<ownerId, TakenLeech[]>` over all player runtimes (mirror `standingLeeches` `~2029`).
-  - Task 5: per-victim taken-leech proc on the positional enemy branch (`~3852-3876`), reading each victim's outcome.
-- **Modify:** `src/utils/combat/positionalApply.ts` — surface `applyToVictim`'s return `{shieldBefore,hpDamage,barriered}` to the per-victim hook (Task 2; `~:90`,`:132-134`).
+  - Task 1: parametrize `applyHealToTarget`/`grantShieldToTarget` by `victim: CombatActor = healTarget` (`:1914-1938`). Resolver already exists: `allActorsById` (`engine.ts:1667`, both sides) and `runtimesById.get(id)?.actor` — **no new mechanism**.
+  - Task 2: add an optional per-call `onVictimResolved?(victim, damage, outcome, didCrit)` callback arg to `drivePositionalApply` (`~:2525-2581`) and surface `applyToVictim`'s return into it. `drivePositionalApply` is ONE shared helper used by all three sites (focus `~:3329`, team `~:3508`, enemy `~:3866`), so per-direction leech is supplied per-call, NOT branched inside the shared inline `emitHit`.
+  - Task 3: focus + team call sites pass a STANDING-leech callback (player→enemy); a NEW positional-only standing-leech proc (reuses the fold, own-pool apply) — `procStandingLeeches` (`~:2088`) is NOT modified. Standing-leech data `~:2027`.
+  - Task 4: expand `takenLeeches` registration (`~:2061`) to a `Map<ownerId, TakenLeech[]>` over all player runtimes (mirror `standingLeeches` `~:2029`).
+  - Task 5: enemy call site passes a TAKEN-leech callback (enemy→player) reading each victim's outcome.
+- **Modify:** `src/utils/combat/playerTurn.ts` — `HealingRuntimeCtx` interface (`~:81-101`) carries the `applyHealToTarget`/`grantShieldToTarget` signatures; widen them with the optional `victim` param (Task 1). ~8 test files implement `HealingRuntimeCtx` doubles (triggers.test.ts, enemyActions.test.ts, salvationDeadRecipient.test.ts, …) — an OPTIONAL param keeps them compiling untouched.
+- **Modify:** `src/utils/combat/positionalApply.ts` — change `applyToVictim`'s typed return from `void` so its `{shieldBefore,hpDamage,barriered}` reaches the new `onVictimResolved` callback (Task 2; `~:90`,`:132-134`).
 - **Create (test):** `src/utils/combat/__tests__/perVictimLeech.test.ts` — positional standing + taken leech, covered-cell 50%, Barrier/`requiresHpDamage` per victim, own-pool application.
 - **Modify (changelog):** `src/constants/changelog.ts` — E2 is user-facing (leech now works in the battle sim).
 
-No type changes beyond the closure signatures and `takenLeeches` becoming a map.
+No type changes beyond the closure signatures, the `onVictimResolved` callback, and `takenLeeches` becoming a map.
 
 ---
 
@@ -39,13 +41,13 @@ No type changes beyond the closure signatures and `takenLeeches` becoming a map.
 
 **Files:** Modify `src/utils/combat/engine.ts:1914-1938`
 
-- [ ] **Step 1: Write the characterization test (must already PASS — proves the refactor is byte-identical)**
+- [ ] **Step 1: No RED test — this is a byte-identical refactor**
 
-Add to `perActorIncoming.test.ts` or a small new test: a non-positional healing run with a cast heal, asserting the heal target's HP/heal totals are unchanged. (This is a guard, not RED. If there's already healing coverage that exercises `applyHealToTarget`, note it and skip adding a redundant one — `leech.test.ts` + `healingGoldenParity` already cover it.)
+`leech.test.ts` + `healingGoldenParity` already exercise `applyHealToTarget`/`grantShieldToTarget` thoroughly and serve as the guard. Skip adding a redundant characterization test; the byte-identical check in Step 3 is the gate.
 
 - [ ] **Step 2: Parametrize the closures**
 
-Change `applyHealToTarget` and `grantShieldToTarget` to accept an optional `victim: CombatActor = healTarget` (or `victimId` + a resolver — pick whichever matches the surrounding code; `recipientMaxHp` already resolves by id). Inside, replace every `healTarget.currentHp`/`healTarget.shieldPool`/`recipientMaxHp(healTarget.id)`/`repairedThisRound.add(healTarget.id)` with the `victim` equivalent. Keep the default = `healTarget` so all existing call sites are unchanged. Example shape:
+Change `applyHealToTarget` and `grantShieldToTarget` (`engine.ts:1914-1938`) to accept an optional `victim: CombatActor = healTarget`. Inside, replace every `healTarget.currentHp`/`healTarget.shieldPool`/`recipientMaxHp(healTarget.id)`/`repairedThisRound.add(healTarget.id)` with the `victim` equivalent. Keep the default = `healTarget` so all existing call sites (verified: playerTurn.ts:1520/1596/1614, triggers.ts:1166/1172, engine.ts:2113/2119/3942/3951 — all pass a single arg) are unchanged. **Also widen the matching signatures in the `HealingRuntimeCtx` interface in `playerTurn.ts:~81-101`** (the optional param keeps the ~8 test-double implementers compiling untouched). Example shape:
 
 ```typescript
 applyHealToTarget: (raw, victim = healTarget) => {
@@ -74,27 +76,29 @@ Expected: all green, **zero `.snap` movement** (the default param means every cu
 
 Run: `npm run lint && npx tsc --noEmit`
 ```bash
-git add src/utils/combat/engine.ts && git commit --no-verify -m "refactor(combat): E2 T1 — parametrize heal/shield pool closures by victim (byte-identical)"
+git add src/utils/combat/engine.ts src/utils/combat/playerTurn.ts && git commit --no-verify -m "refactor(combat): E2 T1 — parametrize heal/shield pool closures by victim (byte-identical)"
 ```
 
 ---
 
-## Task 2: Surface the per-victim damage outcome on the positional apply path (byte-identical)
+## Task 2: Add a per-call `onVictimResolved` callback to `drivePositionalApply` (byte-identical)
 
-**Files:** Modify `src/utils/combat/positionalApply.ts` (`~:90`, `:132-134`), `src/utils/combat/engine.ts` (`drivePositionalApply` `~:2536`, `emitHit` `~:2574`)
+**Files:** Modify `src/utils/combat/positionalApply.ts` (`~:90`, `:132-134`), `src/utils/combat/engine.ts` (`drivePositionalApply` `~:2525-2581`)
 
-- [ ] **Step 1: Capture `applyToVictim`'s return**
+This is the SHARED hook that Tasks 3 and 5 supply per-direction leech logic to. It is intentionally a guard-only (no-RED) plumbing step — additive and unread until Tasks 3/5 wire callbacks, consistent with the E1 precedent.
 
-`applyToVictim` (= `applyIncomingToTarget`/`applyOutgoingToEnemy`) returns `{shieldBefore, hpDamage, barriered}` but `applyPositionalDamage` drops it (`positionalApply.ts:133`). Widen the per-victim hook so the engine's `emitHit`/per-victim callback receives that outcome alongside `(victim, damage, didCrit)`. Either change `applyToVictim`'s declared return type from `void` and pass it into `emitHit`, or have `emitHit` take an extra `outcome` arg. Keep it OPTIONAL/additive so no behavior changes.
+- [ ] **Step 1: Capture `applyToVictim`'s return and expose it via an optional callback**
+
+`applyToVictim` (= `applyIncomingToTarget`/`applyOutgoingToEnemy`) returns `{shieldBefore, hpDamage, barriered}` but `applyPositionalDamage` drops it (`positionalApply.ts:133`, typed `void` at `:90`). (a) Change `applyToVictim`'s declared return type so the outcome flows back. (b) Add an OPTIONAL param to `drivePositionalApply` — `onVictimResolved?(victim: CombatActor, damage: number, outcome: {shieldBefore;hpDamage;barriered}, didCrit: boolean)` — invoked per footprint victim after the hit resolves. `drivePositionalApply` is ONE helper shared by all three call sites (focus `~:3329`, team `~:3508`, enemy `~:3866`); since standing (player→enemy) and taken (enemy→player) leech need opposite logic, each call site supplies its own callback (Tasks 3/5) rather than branching inside the shared inline `emitHit`. No site supplies it in this task → fully inert.
 
 - [ ] **Step 2: Verify byte-identical**
 
 Run: `npx vitest run positionalDamage twoTeamBattle perActorIncoming && npx vitest run` then `git diff --stat -- '*.snap'`
-Expected: green, zero `.snap` movement (new data, unread).
+Expected: green, zero `.snap` movement (new optional callback, unsupplied).
 
 - [ ] **Step 3: lint + tsc + commit**
 ```bash
-git add src/utils/combat/positionalApply.ts src/utils/combat/engine.ts && git commit --no-verify -m "feat(combat): E2 T2 — surface per-victim damage outcome on positional apply (unread)"
+git add src/utils/combat/positionalApply.ts src/utils/combat/engine.ts && git commit --no-verify -m "feat(combat): E2 T2 — add per-victim onVictimResolved hook to drivePositionalApply (inert)"
 ```
 
 ---
@@ -111,7 +115,7 @@ Run: `npx vitest run perVictimLeech -t "standing"` → Expected: FAIL.
 
 - [ ] **Step 2: Implement the per-victim standing-leech proc**
 
-In the positional per-victim hook (where each footprint victim's damage is known), proc the ACTING attacker's standing leeches off THAT victim's dealt damage, applying to the leeching owner's own pool. Reuse the existing fold (`procStandingLeeches`) but route the pool application through the Task-1 parametrized closures so a `self`/owner recipient heals its OWN pool (resolve recipient id → actor). Do NOT write the cumulative `dmg()` accumulator (no double-count); leave the `if (!positional)` aggregate suppression and the non-positional `procStandingLeeches` apply behavior intact. Honor `scope` (detonation-scoped leeches do not fire on the per-victim `direct` channel — the existing `e.scope` guard handles this). Decide and document the heal-crit-gate cadence: per-victim procs draw the owner's `activeHealCritGate` once per victim (state it in a comment; the new test pins the resulting numbers).
+Wire an `onVictimResolved` callback at the focus + team call sites (player→enemy). In it, proc the ACTING attacker's standing leeches off THAT victim's dealt damage. **Write a NEW positional-only proc — do NOT modify `procStandingLeeches`** (its `rid === healTarget.id` pool-gating is load-bearing for the non-positional all-allies case, leech.test.ts:355-404, where teammates are credited but NOT pool-applied — changing it would alter non-positional behavior). The new proc may reuse the FOLD math (pct, healModifier, heal-crit draw) but does its OWN pool application: for each recipient id (`self` → the attacker/owner; `ally`/`all-allies` → resolve), look up the actor via **`runtimesById.get(rid)?.actor`** (the focus is keyed `'attacker'`, not its real id — use `runtimesById`, not `allActorsById`, for recipient resolution) and call the Task-1 parametrized `applyHealToTarget(raw, actor)` / `grantShieldToTarget(raw, actor)`. Do NOT write the cumulative `dmg()` accumulator (no double-count); leave the `if (!positional)` aggregate suppression AND `procStandingLeeches` itself untouched. Honor `scope` (detonation-scoped leeches don't fire on the per-victim `direct` channel). Document the heal-crit-gate cadence: per-victim procs draw the owner's `activeHealCritGate` once per victim (comment it; the new test pins the numbers).
 
 Run: `npx vitest run perVictimLeech -t "standing"` → Expected: PASS.
 
@@ -157,7 +161,7 @@ Run: `npx vitest run perVictimLeech -t "taken"` → Expected: FAIL.
 
 - [ ] **Step 2: Implement per-victim taken leech**
 
-In the positional enemy branch, for each player victim hit (with its per-hit `{shieldBefore, hpDamage, barriered}` from Task 2), proc that victim's own taken-leeches (`takenLeechesByOwner.get(victim.id)`) off the damage it took, applying to the victim's OWN pool via the Task-1 closures. The Barrier carve-out (`!barriered`) and `requiresHpDamage` (`shieldBefore > 0 && hpDamage > 0`) must be evaluated **per victim**. Leave the `!enemyPositional` non-positional block fully intact (it stays the path for non-positional fixtures). The positional branch's per-victim leech is the new behavior.
+Wire an `onVictimResolved` callback at the enemy call site (enemy→player). For each player victim hit (with its per-hit `{shieldBefore, hpDamage, barriered}` from Task 2's callback), proc that victim's own taken-leeches (`takenLeechesByOwner.get(victim.id)`) off the damage it took, applying to the victim's OWN pool via the Task-1 closures (`applyHealToTarget(raw, victim)` / `grantShieldToTarget(raw, victim)`). The Barrier carve-out (skip if `barriered`) and `requiresHpDamage` (`shieldBefore > 0 && hpDamage > 0`) are evaluated **per victim** — matching the non-positional block's semantics (`engine.ts:3925`/`3929`). Leave the `!enemyPositional` non-positional block fully intact (it stays the path for non-positional fixtures). The positional branch's per-victim leech is the new behavior.
 
 Run: `npx vitest run perVictimLeech -t "taken"` → Expected: PASS.
 

--- a/docs/superpowers/plans/2026-06-19-per-victim-aoe-E2-leech.md
+++ b/docs/superpowers/plans/2026-06-19-per-victim-aoe-E2-leech.md
@@ -1,0 +1,200 @@
+# E2 — Per-victim leech Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make leech (lifesteal) per-victim: on the positional path, each leeching ship heals/shields its OWN pool off the damage it dealt (standing leech) or took (taken leech), with covered AoE cells contributing their reduced (50%) damage. Generalize the heal/shield pool-application closures to be per-victim (the machinery E5's per-victim repair also needs).
+
+**Architecture:** Today `applyHealToTarget`/`grantShieldToTarget` (`engine.ts:1914`/`1930`) are hardcoded to the single `healTarget`; standing leech is *entirely suppressed* on the positional path (the `direct` credit is skipped per-victim to avoid double-counting); taken leech is *gated out* of the positional path (`!enemyPositional`). E2 (1) parametrizes the pool closures by victim — **default `healTarget`, so every non-positional call stays byte-identical**; (2) adds NEW per-victim leech procs on the positional path, applying to each leeching owner's own pool; and (3) leaves the non-positional leech paths (`procStandingLeeches` off aggregate, the `!enemyPositional` taken-leech block) **completely untouched**. Builds on E1's `perActorIncoming` surface + the per-hit `{shieldBefore,hpDamage,barriered}` outcome (surfaced through the positional apply hook).
+
+**Tech Stack:** TypeScript, Vitest. Combat engine `src/utils/combat/engine.ts` + `positionalApply.ts`.
+
+---
+
+## Byte-identical strategy (READ FIRST)
+
+E2's new per-victim leech runs **ONLY on the positional path**, where leech does not fire today (standing leech suppressed; taken leech gated). The legacy non-positional leech code (`procStandingLeeches` off the aggregate `direct` credit; the `if (!enemyPositional)` taken-leech block at `engine.ts:3921-3953`) is **NOT modified** — so `leech.test.ts` and the `healingGoldenParity` leech scenarios (all non-positional, all single-`healTarget`) stay byte-identical.
+
+The risky part is the pool-closure parametrization (Task 1): it touches code every heal/shield path uses. The default-parameter (`victim = healTarget`) makes it a pure refactor — verify byte-identical after Task 1 before building on it.
+
+**There is no existing test that exercises leech positionally** (confirmed: twoTeamBattle/positionalDamage/dpsSimulator have zero real leech configs). So E2's per-victim behavior is locked by NEW tests; expected golden churn against existing fixtures = **zero**. If any existing `.snap` moves or `leech.test.ts`/`healingGoldenParity` changes, STOP — the non-positional path leaked. Never `vitest -u`.
+
+---
+
+## File Structure
+
+- **Modify:** `src/utils/combat/engine.ts`
+  - Task 1: parametrize `applyHealToTarget`/`grantShieldToTarget` by `victim: CombatActor = healTarget` (`:1914-1938`); add an id→actor resolver if one isn't already in scope.
+  - Task 3: per-victim standing-leech proc on the positional firing-hit hook (`drivePositionalApply` per-victim callback `~:2574`; standing-leech data `~2027`/`procStandingLeeches` `~2088`).
+  - Task 4: expand `takenLeeches` registration (`~2061`) to a `Map<ownerId, TakenLeech[]>` over all player runtimes (mirror `standingLeeches` `~2029`).
+  - Task 5: per-victim taken-leech proc on the positional enemy branch (`~3852-3876`), reading each victim's outcome.
+- **Modify:** `src/utils/combat/positionalApply.ts` — surface `applyToVictim`'s return `{shieldBefore,hpDamage,barriered}` to the per-victim hook (Task 2; `~:90`,`:132-134`).
+- **Create (test):** `src/utils/combat/__tests__/perVictimLeech.test.ts` — positional standing + taken leech, covered-cell 50%, Barrier/`requiresHpDamage` per victim, own-pool application.
+- **Modify (changelog):** `src/constants/changelog.ts` — E2 is user-facing (leech now works in the battle sim).
+
+No type changes beyond the closure signatures and `takenLeeches` becoming a map.
+
+---
+
+## Task 1: Parametrize the heal/shield pool closures by victim (byte-identical)
+
+**Files:** Modify `src/utils/combat/engine.ts:1914-1938`
+
+- [ ] **Step 1: Write the characterization test (must already PASS — proves the refactor is byte-identical)**
+
+Add to `perActorIncoming.test.ts` or a small new test: a non-positional healing run with a cast heal, asserting the heal target's HP/heal totals are unchanged. (This is a guard, not RED. If there's already healing coverage that exercises `applyHealToTarget`, note it and skip adding a redundant one — `leech.test.ts` + `healingGoldenParity` already cover it.)
+
+- [ ] **Step 2: Parametrize the closures**
+
+Change `applyHealToTarget` and `grantShieldToTarget` to accept an optional `victim: CombatActor = healTarget` (or `victimId` + a resolver — pick whichever matches the surrounding code; `recipientMaxHp` already resolves by id). Inside, replace every `healTarget.currentHp`/`healTarget.shieldPool`/`recipientMaxHp(healTarget.id)`/`repairedThisRound.add(healTarget.id)` with the `victim` equivalent. Keep the default = `healTarget` so all existing call sites are unchanged. Example shape:
+
+```typescript
+applyHealToTarget: (raw, victim = healTarget) => {
+    if (victim.currentHp <= 0) return { consumed: 0, overheal: raw };
+    const targetMaxHp = recipientMaxHp(victim.id);
+    const consumed = Math.max(0, Math.min(raw, targetMaxHp - victim.currentHp));
+    victim.currentHp += consumed;
+    if (consumed > 0) repairedThisRound.add(victim.id);
+    return { consumed, overheal: raw - consumed };
+},
+grantShieldToTarget: (raw, victim = healTarget) => {
+    if (victim.currentHp <= 0) return;
+    const targetMaxHp = recipientMaxHp(victim.id);
+    victim.shieldPool = Math.min(victim.shieldPool + raw, targetMaxHp);
+},
+```
+
+Update the `HealingRuntimeCtx` type for the two closures' new optional param.
+
+- [ ] **Step 3: Run the full suite — verify byte-identical**
+
+Run: `npx vitest run` then `git diff --stat -- '*.snap'`
+Expected: all green, **zero `.snap` movement** (the default param means every current caller behaves identically).
+
+- [ ] **Step 4: lint + tsc + commit**
+
+Run: `npm run lint && npx tsc --noEmit`
+```bash
+git add src/utils/combat/engine.ts && git commit --no-verify -m "refactor(combat): E2 T1 — parametrize heal/shield pool closures by victim (byte-identical)"
+```
+
+---
+
+## Task 2: Surface the per-victim damage outcome on the positional apply path (byte-identical)
+
+**Files:** Modify `src/utils/combat/positionalApply.ts` (`~:90`, `:132-134`), `src/utils/combat/engine.ts` (`drivePositionalApply` `~:2536`, `emitHit` `~:2574`)
+
+- [ ] **Step 1: Capture `applyToVictim`'s return**
+
+`applyToVictim` (= `applyIncomingToTarget`/`applyOutgoingToEnemy`) returns `{shieldBefore, hpDamage, barriered}` but `applyPositionalDamage` drops it (`positionalApply.ts:133`). Widen the per-victim hook so the engine's `emitHit`/per-victim callback receives that outcome alongside `(victim, damage, didCrit)`. Either change `applyToVictim`'s declared return type from `void` and pass it into `emitHit`, or have `emitHit` take an extra `outcome` arg. Keep it OPTIONAL/additive so no behavior changes.
+
+- [ ] **Step 2: Verify byte-identical**
+
+Run: `npx vitest run positionalDamage twoTeamBattle perActorIncoming && npx vitest run` then `git diff --stat -- '*.snap'`
+Expected: green, zero `.snap` movement (new data, unread).
+
+- [ ] **Step 3: lint + tsc + commit**
+```bash
+git add src/utils/combat/positionalApply.ts src/utils/combat/engine.ts && git commit --no-verify -m "feat(combat): E2 T2 — surface per-victim damage outcome on positional apply (unread)"
+```
+
+---
+
+## Task 3: Per-victim standing leech on the positional path
+
+**Files:** Modify `src/utils/combat/engine.ts` (per-victim hook in `drivePositionalApply` `~:2574`; reuse `standingLeeches`/`procStandingLeeches` `~:2027`/`:2088`)
+
+- [ ] **Step 1: Write the failing test** (`src/utils/combat/__tests__/perVictimLeech.test.ts`)
+
+A positional healing-mode two-team run where the player attacker has a passive `damage-dealt` heal leech (standing) and its AoE hits an origin + a covered enemy. Assert the attacker's own HP/heal-credit reflects leech off (origin dealt + 0.5×covered dealt). Mirror the harness from `twoTeamBattle.test.ts` (positioned actors, `healTargetId`). Currently FAILS — standing leech is suppressed on the positional path (no proc).
+
+Run: `npx vitest run perVictimLeech -t "standing"` → Expected: FAIL.
+
+- [ ] **Step 2: Implement the per-victim standing-leech proc**
+
+In the positional per-victim hook (where each footprint victim's damage is known), proc the ACTING attacker's standing leeches off THAT victim's dealt damage, applying to the leeching owner's own pool. Reuse the existing fold (`procStandingLeeches`) but route the pool application through the Task-1 parametrized closures so a `self`/owner recipient heals its OWN pool (resolve recipient id → actor). Do NOT write the cumulative `dmg()` accumulator (no double-count); leave the `if (!positional)` aggregate suppression and the non-positional `procStandingLeeches` apply behavior intact. Honor `scope` (detonation-scoped leeches do not fire on the per-victim `direct` channel — the existing `e.scope` guard handles this). Decide and document the heal-crit-gate cadence: per-victim procs draw the owner's `activeHealCritGate` once per victim (state it in a comment; the new test pins the resulting numbers).
+
+Run: `npx vitest run perVictimLeech -t "standing"` → Expected: PASS.
+
+- [ ] **Step 3: Byte-identical guard + commit**
+
+Run: `npx vitest run leech healingGoldenParity && npx vitest run` then `git diff --stat -- '*.snap'`
+Expected: green, zero `.snap` movement (non-positional leech untouched).
+```bash
+git add -A && git commit --no-verify -m "feat(combat): E2 T3 — per-victim standing leech on the positional path"
+```
+
+---
+
+## Task 4: Expand taken-leech registration to all player runtimes (byte-identical)
+
+**Files:** Modify `src/utils/combat/engine.ts:2060-2079`
+
+- [ ] **Step 1: Make `takenLeeches` a `Map<ownerId, TakenLeech[]>`**
+
+Mirror `standingLeeches` (`:2029`): loop all `runtimesById`, collect each owner's passive `damage-taken` heal/shield abilities keyed by owner id. The existing non-positional taken-leech block (`:3921-3953`) currently reads the heal target's list — update it to read `takenLeechesByOwner.get(healTarget.id) ?? []` so its behavior is unchanged.
+
+- [ ] **Step 2: Verify byte-identical**
+
+Run: `npx vitest run leech healingGoldenParity && npx vitest run` then `git diff --stat -- '*.snap'`
+Expected: green, zero `.snap` (only the heal target had taken-leeches in non-positional fixtures → same list read).
+
+- [ ] **Step 3: lint + tsc + commit**
+```bash
+git add src/utils/combat/engine.ts && git commit --no-verify -m "refactor(combat): E2 T4 — taken-leech registration per owner (byte-identical)"
+```
+
+---
+
+## Task 5: Per-victim taken leech on the positional enemy branch
+
+**Files:** Modify `src/utils/combat/engine.ts` (positional enemy branch `~:3852-3876`; the gate `~:3921-3926`)
+
+- [ ] **Step 1: Write the failing test** (`perVictimLeech.test.ts`)
+
+A positional run where an enemy AoE hits two player victims, ONE of which has a `damage-taken` heal-leech passive. Assert that victim heals its OWN pool off the damage IT took, the other does not. Add a case where the leeching victim has an active Barrier (full block) → its taken leech reads 0 (per-victim Barrier carve-out), and a `requiresHpDamage` (Quixilver-style) case. Currently FAILS — taken leech is gated out of the positional path.
+
+Run: `npx vitest run perVictimLeech -t "taken"` → Expected: FAIL.
+
+- [ ] **Step 2: Implement per-victim taken leech**
+
+In the positional enemy branch, for each player victim hit (with its per-hit `{shieldBefore, hpDamage, barriered}` from Task 2), proc that victim's own taken-leeches (`takenLeechesByOwner.get(victim.id)`) off the damage it took, applying to the victim's OWN pool via the Task-1 closures. The Barrier carve-out (`!barriered`) and `requiresHpDamage` (`shieldBefore > 0 && hpDamage > 0`) must be evaluated **per victim**. Leave the `!enemyPositional` non-positional block fully intact (it stays the path for non-positional fixtures). The positional branch's per-victim leech is the new behavior.
+
+Run: `npx vitest run perVictimLeech -t "taken"` → Expected: PASS.
+
+- [ ] **Step 3: Byte-identical guard + commit**
+
+Run: `npx vitest run leech healingGoldenParity twoTeamBattle && npx vitest run` then `git diff --stat -- '*.snap'`
+Expected: green, zero `.snap` movement.
+```bash
+git add -A && git commit --no-verify -m "feat(combat): E2 T5 — per-victim taken leech on the positional path"
+```
+
+---
+
+## Task 6: Verification sweep + changelog + doc closeout
+
+- [ ] **Step 1: Full gate**
+
+Run: `npx vitest run && npm run lint && npx tsc --noEmit && npm run audit:skills`
+Expected: all green, lint 0, tsc clean, audit 0 findings. Confirm `git diff --stat -- '*.snap'` empty across the whole PR.
+
+- [ ] **Step 2: Changelog (E2 IS user-facing)**
+
+Add to `UNRELEASED_CHANGES` in `src/constants/changelog.ts` a plain-English entry: lifesteal/leech (heal or shield from damage dealt/taken) now works per-ship in the combat simulator — each ship heals itself off its own damage, and AoE splash leeches off the reduced splash damage.
+
+- [ ] **Step 3: Spec closeout + commit**
+
+Append an "E2 SHIPPED" note to the E-design spec §4 (pool generalization done, per-victim standing + taken leech live, E5 now thin).
+```bash
+git add -A && git add -f docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md
+git commit --no-verify -m "feat(combat): E2 — changelog + spec closeout (per-victim leech)"
+```
+
+---
+
+## Done criteria
+
+- Per-victim standing + taken leech work on the positional path (own-pool, covered-cell 50%, Barrier/`requiresHpDamage` per victim) — locked by `perVictimLeech.test.ts`.
+- Pool closures parametrized by victim (E5's per-victim repair can now reuse them).
+- Non-positional leech byte-identical: `leech.test.ts` + `healingGoldenParity` green, zero `.snap` movement across the PR.
+- Full suite green, lint 0, tsc clean, audit 0 findings.

--- a/docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md
+++ b/docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md
@@ -123,6 +123,20 @@ path, existing non-positional fixtures add no enemy keys → byte-identical (see
   per victim but currently discards — E2 surfaces `applyToVictim`'s return through the per-victim hook in
   `applyPositionalDamage` / `drivePositionalApply`).
 
+> **E2 SHIPPED** (2026-06-19, commits `bff66b74`→`680957fb`). Per-victim leech is live on the positional path.
+> **T1** parametrized `applyHealToTarget` / `grantShieldToTarget` by victim (defaulting to `healTarget`) so the
+> pool-application closures now heal/shield any owner's OWN pool — byte-identical for every non-positional call.
+> **T2** added the inert `onVictimResolved` hook to `drivePositionalApply` carrying each victim's per-hit damage
+> outcome. **T3** procs standing leech (heal/shield off damage dealt) per footprint victim off that victim's own
+> dealt damage (covered cells already at reduced 50%), crediting the leeching owner's pool via the parametrized
+> closures, bypassing the cumulative `dmg()` accumulator (no double-count). **T4** expanded `takenLeeches`
+> registration from heal-target-only to per-owner (all player runtimes, mirroring `standingLeeches`) —
+> byte-identical. **T5** un-gated the `!enemyPositional` taken-leech block so each victim procs its own reactive
+> off the damage IT took into its OWN pool, with the per-victim Barrier carve-out (fully-blocked round reads 0)
+> and `requiresHpDamage` (Quixilver) holding per victim. Production byte-identical: **zero `.snap` movement**
+> across the whole PR (working-tree and `main...HEAD`), full suite green (2673 tests), lint 0 / tsc clean /
+> audit 0/141. E5's per-victim repair (Nayra) can now reuse the T1 parametrized closures, so **E5 is now thin**.
+
 **E3 — AoE purge/cleanse.** Replace the single-`targetId` removal with a loop over the footprint
 victims for "all-enemies"-style targets. There are **two single-anchor purge sites** to fix (cleanse
 already loops recipients): the **on-cast purge** at `playerTurn.ts:1392-1401` (the literal

--- a/docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md
+++ b/docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md
@@ -100,15 +100,28 @@ path, existing non-positional fixtures add no enemy keys → byte-identical (see
 > a positive per-victim-intake assertion. The enemy intake surface is live but **unread until E2**
 > (per-victim leech).
 
-**E2 — per-victim leech.**
-- *Standing leech* (heal/shield off damage **dealt**): today `procStandingLeeches` (`engine.ts:2086`)
-  fires once at the credit point off the **aggregate** `amount` (~`engine.ts:2200`). E2 moves this to a
-  per-victim sum over footprint victims; covered cells contribute their reduced (50%) damage, since
-  leech is computed off **real damage dealt**.
-- *Taken leech* (reactive heal/shield off damage **taken**): each player victim procs its **own**
-  reactive off the damage **it** took. Un-gates the `!enemyPositional` blocks (`engine.ts:3913`,
-  `3902-3912`).
-- Reads E1's per-victim outcome surface (the shield/hp split each victim needs to leech from).
+**E2 — per-victim leech (now includes per-victim heal/shield POOL generalization — scope decision 2026-06-19).**
+- **Per-victim pool foundation (pulled forward from E5).** Today `applyHealToTarget` / `grantShieldToTarget`
+  (`engine.ts:~1914`/`~1930`) are hardcoded to the single `healTarget` (they close over it and mutate
+  `healTarget.currentHp` / `.shieldPool`). E2 parametrizes them by victim, **defaulting to `healTarget`** so
+  every non-positional call stays byte-identical. This is the machinery that makes a leeching ship heal its
+  OWN pool — and it is exactly what E5's per-victim repair needs, so it lands here (E5 shrinks accordingly).
+- *Standing leech* (heal/shield off damage **dealt**): today `procStandingLeeches` (`engine.ts:2086`) is
+  **entirely suppressed on the positional path** (the `direct` credit is skipped per-victim to avoid
+  double-counting cumulative damage, so the leech never procs). E2 procs it **per footprint victim** off that
+  victim's own dealt damage (covered cells contribute their reduced 50% — already baked into the per-victim
+  `damage`), crediting/applying to the **leeching owner's own pool** via the parametrized closures. Must NOT
+  route through the cumulative `dmg()` accumulator (no double-count); DoT/bomb/detonation-channel leech stays
+  aggregate and untouched.
+- *Taken leech* (reactive heal/shield off damage **taken**): each player victim procs its **own** reactive
+  off the damage **it** took, into its **own** pool. Un-gates the `!enemyPositional` block (`engine.ts:3921-3926`).
+  Requires expanding `takenLeeches` registration (`engine.ts:~2061`, today heal-target-only) to **all player
+  runtimes** (mirror `standingLeeches` at `~2029`), and reading each victim's per-hit outcome
+  (`{shieldBefore, hpDamage, barriered}`) — the Barrier carve-out (a `damage-taken` leech reads 0 in a
+  fully-blocked round) and `requiresHpDamage` (Quixilver) must hold **per victim**.
+- Reads E1's per-victim intake surface + the per-hit damage outcome (which the positional apply path computes
+  per victim but currently discards — E2 surfaces `applyToVictim`'s return through the per-victim hook in
+  `applyPositionalDamage` / `drivePositionalApply`).
 
 **E3 — AoE purge/cleanse.** Replace the single-`targetId` removal with a loop over the footprint
 victims for "all-enemies"-style targets. There are **two single-anchor purge sites** to fix (cleanse
@@ -123,12 +136,12 @@ cleanse (`playerTurn.ts:1624`) and reactive cleanse (`triggers.ts:1190`); end-of
 computed from the caster's **live** crit power at cast time, applied to **every** footprint victim.
 Builds on E3's multi-victim loop. Removes the C2a single-anchor count-1 under-approximation flag.
 
-**E5 — unification + Nayra consequence.** With the no-op sink gone (E1), collapse the dual
-accounting/credit paths and tidy death-fallback. **Per-victim repair tracking** then lights up:
-`repairedThisRound` is already a per-actor Set, so once the symmetric surface lets any actor be
-healed/tracked per-victim, the documented Nayra limitation
-(player-Nayra-vs-enemy always false because "engine never heals enemy ships") resolves with no new
-mechanism.
+**E5 — unification + Nayra consequence (SHRUNK after E2 pulled the pool generalization forward).** With the
+no-op sink gone (E1) and the per-victim heal/shield pools done (E2), E5 collapses the dual accounting/credit
+paths and tidies death-fallback. **Per-victim repair tracking** then lights up: `repairedThisRound` is
+already a per-actor Set, and once any actor can be healed into its own pool (E2's parametrized closures), the
+documented Nayra limitation (player-Nayra-vs-enemy always false because "engine never heals enemy ships")
+resolves with the Nayra condition + the now-general pools — no new pool mechanism needed.
 
 ## 5. Locked decisions
 
@@ -136,7 +149,10 @@ mechanism.
 - **E1 is internal only** — no simulator-UI surfacing of enemy per-victim absorb/HP. Surfacing waits
   for the shield system (sub-project H), where it is no longer moot.
 - **Full E, sequential PRs** (B/C-series cadence).
-- **Nayra per-victim repair lands in E5** as a consequence of the symmetric surface, not its own PR.
+- **Per-victim heal/shield POOL generalization lands in E2** (scope decision 2026-06-19), not E5 — E2's
+  leech must heal each leeching ship's own pool to be correct in the multi-actor sim, and that machinery is
+  shared with E5's per-victim repair. Closures default to `healTarget` → non-positional byte-identical.
+- **Nayra per-victim repair lands in E5** (condition + credit unification), now riding E2's general pools.
 - **Thread 2 (E3/E4) is independent of Thread 1 (E1/E2)** and may be sequenced first.
 
 ## 6. Out of scope / deferred elsewhere

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -5,7 +5,9 @@ export const CURRENT_VERSION = '1.64.0';
 // RELEASE CHECKLIST: move these strings into a new ChangelogEntry at the top of
 // CHANGELOG (with the new version + today's date), clear this array back to [],
 // and bump CURRENT_VERSION. All three steps must happen together.
-export const UNRELEASED_CHANGES: string[] = [];
+export const UNRELEASED_CHANGES: string[] = [
+    'Combat simulator: lifesteal/leech (heal or shield from damage dealt or taken) now works per ship — each ship heals or shields itself off its own damage, and AoE splash leeches off the reduced (covered-cell) splash damage.',
+];
 
 export const CHANGELOG: ChangelogEntry[] = [
     {

--- a/src/utils/combat/__tests__/perVictimLeech.test.ts
+++ b/src/utils/combat/__tests__/perVictimLeech.test.ts
@@ -1,0 +1,183 @@
+/**
+ * E2 Task 3 — PER-VICTIM standing leech on the positional apply path.
+ *
+ * Before E2, standing damage-dealt leeches were suppressed on the positional path: the
+ * firing-hit damage lands per-victim via `applyPositionalDamage`, but the aggregate
+ * `creditDamage(... 'direct' ...)` (which is what `procStandingLeeches` rides) is SKIPPED
+ * for the positional case (no double-count). So a positional AoE attacker's own
+ * standing leech never fired.
+ *
+ * E2 wires an `onVictimResolved` callback at the player→enemy positional sites that procs
+ * the ACTING attacker's standing leeches off EACH footprint victim's dealt damage. Because
+ * the per-victim `damage` is already role-scaled (origin full, covered half), leeching off
+ * `damage` per victim yields exactly `origin dealt + 0.5×covered dealt`.
+ *
+ * Harness mirrors twoTeamBattle.test.ts / positionalDamage.integration.test.ts: positioned
+ * actors, `healTargetId` to unlock the enemy roster, a passive damage-dealt heal leech on
+ * the focus. Crit 0 keeps every credited value an exact integer; the heal-crit test pins the
+ * per-victim heal-crit-gate cadence explicitly.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `pvl${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+// Single-hit basic attack: multiplier 100% (1x), 1 hit, no passive payload — so the firing
+// hit's per-victim damage is attack × roleScale vs defence 0 (origin full, covered half).
+const basicAttack = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } }),
+    ],
+});
+
+// A passive-slot damage-dealt heal leech (STANDING). `target` defaults to 'self' → the
+// acting attacker is the recipient.
+const leechHeal = (
+    pct: number,
+    extra: { leechScope?: 'all' | 'detonation'; noCrit?: boolean } = {},
+    target: Ability['target'] = 'self'
+): Ability =>
+    ab({
+        type: 'heal',
+        target,
+        config: { type: 'heal', pct, basis: 'damage-dealt', leechScope: 'all', ...extra },
+    });
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+// AoE pattern: origin + one covered cell one step toward back (Pattern-Line-Range-1).
+// Anchored at the FRONT enemy (M4) it covers M3 — origin full, covered half.
+const lineRange1Pattern = (): ParsedPattern => ({
+    raw: 'line-range-1',
+    shape: 'line',
+    range: 1,
+    modifiers: {},
+});
+
+// A positioned, finite-HP enemy with zero offense (a stationary, damageable target).
+const enemyAt = (id: string, position: Position, hp: number): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        shipSkills: { slots: [] } as ShipSkills,
+    }) as EnemyAttacker;
+
+/** Sum a healing bucket over every round for `actorId` (defaults to the focus). */
+const sumHeal = (
+    result: ReturnType<typeof runCombat>,
+    bucket: 'directHeal' | 'effectiveHeal' | 'overheal',
+    actorId = 'attacker'
+): number =>
+    (result.healing?.rounds ?? []).reduce(
+        (sum, rd) => sum + (rd.perActor.get(actorId)?.[bucket] ?? 0),
+        0
+    );
+
+// Focus attacker positioned at M4 firing Line-Range-1 at `front`. attack 5000 × 100% × 1 hit
+// vs defence-0 victims. Origin (front enemy at M4) takes 5000, covered (mid enemy at M3) 2500.
+// The focus carries a passive 20% damage-dealt self heal leech.
+const BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 5000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: {
+        slots: [
+            basicAttack(),
+            { slot: 'passive', abilities: [leechHeal(20, { leechScope: 'all' })] },
+        ],
+    },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    // Below max HP so the heal has deficit to consume (effectiveHeal observable).
+    hp: 1_000_000,
+    healModifier: 0,
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedTarget('front'),
+    pattern: lineRange1Pattern(),
+    enemyAttackers: [
+        enemyAt('enemy-front', 'M4', 1_000_000_000),
+        enemyAt('enemy-mid', 'M3', 1_000_000_000),
+    ],
+    ...overrides,
+});
+
+describe('E2 T3 — per-victim standing leech on the positional path', () => {
+    it('standing leech credits origin dealt + 0.5×covered dealt (20% of 5000 + 2500 = 1500)', () => {
+        idc = 0;
+        // Origin 5000 + covered 2500 = 7500 dealt; 20% leech → directHeal 1500. crit 0 → no fold.
+        const result = runCombat(BASE());
+        expect(sumHeal(result, 'directHeal')).toBeCloseTo(1500, 6);
+    });
+
+    it('standing leech with healModifier 50 folds × 1.5 per victim → 2250', () => {
+        idc = 0;
+        // (5000 + 2500) × 0.20 × 1.5 = 2250. healModifier folds into a heal-kind leech.
+        const result = runCombat(BASE({ healModifier: 50 }));
+        expect(sumHeal(result, 'directHeal')).toBeCloseTo(2250, 6);
+    });
+
+    it('standing leech heal-crit gate draws ONCE PER VICTIM (crit 100 → both victims double)', () => {
+        idc = 0;
+        // crit 100 → the FIRING damage crits (× 2 via critDamage 100), so the per-victim dealt
+        // damage is origin 10000 / covered 5000. crit 100 also makes activeHealCritGate(1.0)
+        // always crit, and the per-victim proc draws the gate ONCE PER VICTIM → both leeches
+        // double via critDamage 100.
+        // origin: 10000 × 0.20 × 2 = 4000; covered: 5000 × 0.20 × 2 = 2000 → total 6000.
+        const result = runCombat(BASE({ crit: 100, critDamage: 100 }));
+        expect(sumHeal(result, 'directHeal')).toBeCloseTo(6000, 6);
+    });
+
+    it('detonation-scoped leech does NOT fire on the per-victim direct channel', () => {
+        idc = 0;
+        // A detonation-scoped leech must be inert on the positional `direct` per-victim path
+        // (no bomb in this run) → zero directHeal.
+        const result = runCombat(
+            BASE({
+                shipSkills: {
+                    slots: [
+                        basicAttack(),
+                        {
+                            slot: 'passive',
+                            abilities: [leechHeal(20, { leechScope: 'detonation' })],
+                        },
+                    ],
+                },
+            })
+        );
+        expect(sumHeal(result, 'directHeal')).toBe(0);
+    });
+});

--- a/src/utils/combat/__tests__/perVictimLeech.test.ts
+++ b/src/utils/combat/__tests__/perVictimLeech.test.ts
@@ -24,6 +24,7 @@ import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
 import type { Position } from '../../../types/encounters';
 
 type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
 
 let idc = 0;
 const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
@@ -179,5 +180,266 @@ describe('E2 T3 — per-victim standing leech on the positional path', () => {
             })
         );
         expect(sumHeal(result, 'directHeal')).toBe(0);
+    });
+});
+
+/**
+ * E2 Task 5 — PER-VICTIM TAKEN leech on the positional ENEMY branch (enemy→player).
+ *
+ * Before E2 the damage-taken HEAL/SHIELD leech was gated to the NON-positional path: on the
+ * positional path the enemy's firing hit lands per-victim via drivePositionalApply, but the
+ * leech block only credited the single heal target off the aggregate `damage` (gated out by
+ * `!enemyPositional`). So a player victim's "when damaged, heal/shield" reactive never fired
+ * when the enemy used a positional AoE.
+ *
+ * E2 wires an `onVictimResolved` callback at the ENEMY positional site that procs EACH player
+ * victim's OWN taken-leeches (takenLeechesByOwner.get(victim.id)) off the per-victim
+ * `{shieldBefore, hpDamage, barriered}` outcome, applying to the victim's OWN pool via the
+ * Task-1 closures. The Barrier carve-out and requiresHpDamage gate are evaluated PER VICTIM,
+ * mirroring the non-positional block.
+ *
+ * Harness: a positioned, OFFENSIVE enemy at M1 firing `front` with a Line-Range-1 AoE. The
+ * front-most player (focus 'attacker' at M4) is the origin victim (full damage); the M3 team
+ * player ('player-team') is the covered victim (half damage). ONE player carries a passive
+ * damage-taken heal leech; the other does not. Crit 0 / healModifier 0 keeps every value an
+ * exact integer.
+ */
+describe('E2 T5 — per-victim taken leech on the positional enemy branch', () => {
+    // A passive-slot damage-taken HEAL leech (taken-leech). `target` is 'self' → the victim
+    // heals its OWN pool off the damage IT took.
+    const takenHeal = (pct: number, extra: { requiresHpDamage?: boolean; noCrit?: boolean } = {}): Ability =>
+        ab({
+            type: 'heal',
+            target: 'self',
+            config: { type: 'heal', pct, basis: 'damage-taken', ...extra },
+        });
+
+    // A no-payload, always-active Barrier self-buff (full damage immunity). A victim carrying
+    // this fully BLOCKS the incoming hit → no damage taken → the per-victim Barrier carve-out
+    // skips its taken leech. Same shape barrier.test.ts uses.
+    const barrierBuff = () => ({
+        id: 'pvl-barrier',
+        buffName: 'Barrier',
+        stacks: 1,
+        isStackable: false,
+        parsedEffects: {},
+    });
+
+    // A walked team player at a board position. Optional shipSkills slots (else a bare basic
+    // attack so it has a damage skill / position is meaningful). HP huge so it never dies.
+    const playerAt = (
+        id: string,
+        position: Position,
+        slots: ShipSkills['slots'] = [basicAttack()],
+        hp = 1_000_000,
+        selfBuffs: TeamActor['selfBuffs'] = []
+    ): TeamActor => ({
+        id,
+        speed: 1, // order is irrelevant: the enemy AoE lands on a fixed footprint regardless.
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs,
+        enemyDebuffs: [],
+        position,
+        target: parsedTarget('front'),
+        pattern: lineRange1Pattern(),
+        walk: {
+            shipSkills: { slots },
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+            healModifier: 0,
+        },
+    });
+
+    // An OFFENSIVE enemy at M1 firing a Line-Range-1 AoE at `front`. Anchored at the front-most
+    // player (focus at M4) it covers the M3 player — origin full, covered half.
+    const offensiveEnemyAt = (id: string, position: Position, attack: number, hp = 1_000_000_000): EnemyAttacker =>
+        ({
+            id,
+            stats: { attack, crit: 0, critDamage: 0, defence: 0, hp, speed: 10 },
+            chargeCount: 0,
+            startCharged: false,
+            position,
+            target: parsedTarget('front'),
+            pattern: lineRange1Pattern(),
+            shipSkills: { slots: [basicAttack()] },
+        }) as EnemyAttacker;
+
+    // 1v(focus+team): the enemy AoE hits BOTH players. The focus ('attacker', M4) is the origin
+    // victim (full damage); the M3 team player is the covered victim (half). HP huge so nobody
+    // dies; the focus has a HP deficit so its own taken leech (when present) has room to consume.
+    const TAKEN_BASE = (overrides: {
+        focusSlots?: ShipSkills['slots'];
+        teamSlots?: ShipSkills['slots'];
+        enemyAttack?: number;
+        focusHp?: number;
+        teamSelfBuffs?: TeamActor['selfBuffs'];
+        focusSelfBuffs?: CombatEngineInput['selfBuffs'];
+    } = {}): CombatEngineInput => ({
+        attack: 0,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: { slots: overrides.focusSlots ?? [basicAttack()] },
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: overrides.focusSelfBuffs ?? [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: overrides.focusHp ?? 1_000_000,
+        healModifier: 0,
+        healTargetId: 'attacker',
+        position: 'M4',
+        target: parsedTarget('front'),
+        pattern: lineRange1Pattern(),
+        teamActors: [
+            playerAt('player-team', 'M3', overrides.teamSlots, 1_000_000, overrides.teamSelfBuffs),
+        ],
+        enemyAttackers: [offensiveEnemyAt('enemy-atk', 'M1', overrides.enemyAttack ?? 5000)],
+    });
+
+    it('taken leech: the COVERED victim heals its OWN pool off the half damage it took; the origin victim does not', () => {
+        idc = 0;
+        // Enemy attack 5000 → origin (focus M4) takes 5000, covered (team M3) takes 2500.
+        // Only the covered team player carries a 20% damage-taken heal leech.
+        // covered directHeal = 2500 × 0.20 = 500; origin gets no leech → 0.
+        const result = runCombat(
+            TAKEN_BASE({
+                teamSlots: [basicAttack(), { slot: 'passive', abilities: [takenHeal(20)] }],
+            })
+        );
+        expect(sumHeal(result, 'directHeal', 'player-team')).toBeCloseTo(500, 6);
+        expect(sumHeal(result, 'directHeal', 'attacker')).toBe(0);
+        // The leech consumed against the deficit the SAME attack created (2500 taken) → all 500
+        // effective, zero overheal. Proves the leech applied to the victim's OWN pool.
+        expect(sumHeal(result, 'effectiveHeal', 'player-team')).toBeCloseTo(500, 6);
+        expect(sumHeal(result, 'overheal', 'player-team')).toBe(0);
+    });
+
+    it('taken leech: the ORIGIN victim heals its OWN pool off the FULL damage it took', () => {
+        idc = 0;
+        // The focus (origin, full 5000) carries the 20% damage-taken heal leech.
+        // origin directHeal = 5000 × 0.20 = 1000; covered (no leech) → 0.
+        const result = runCombat(
+            TAKEN_BASE({
+                focusSlots: [basicAttack(), { slot: 'passive', abilities: [takenHeal(20)] }],
+            })
+        );
+        expect(sumHeal(result, 'directHeal', 'attacker')).toBeCloseTo(1000, 6);
+        expect(sumHeal(result, 'directHeal', 'player-team')).toBe(0);
+    });
+
+    it('taken leech: a victim under a full Barrier reads 0 (per-victim Barrier carve-out)', () => {
+        idc = 0;
+        // The ORIGIN focus carries an always-active Barrier → the enemy's origin hit is FULLY
+        // BLOCKED (barriered, no damage taken) → its taken leech is skipped entirely. The covered
+        // team player (no Barrier) still leeches off its half damage (2500 → 500) — proving the
+        // Barrier carve-out is evaluated PER VICTIM, not globally.
+        const result = runCombat(
+            TAKEN_BASE({
+                focusSlots: [basicAttack(), { slot: 'passive', abilities: [takenHeal(20)] }],
+                focusSelfBuffs: [barrierBuff()],
+                teamSlots: [basicAttack(), { slot: 'passive', abilities: [takenHeal(20)] }],
+            })
+        );
+        // Barriered origin → 0 leech; covered (2500 taken) → 500.
+        expect(sumHeal(result, 'directHeal', 'attacker')).toBe(0);
+        expect(sumHeal(result, 'directHeal', 'player-team')).toBeCloseTo(500, 6);
+    });
+
+    it('taken leech requiresHpDamage: fires only when the hit deals HP damage past shield', () => {
+        idc = 0;
+        // No shield anywhere → the attack hits HP directly, but shieldBefore is 0, so a
+        // requiresHpDamage (Quixilver-style) gate FAILS (needs shieldBefore > 0 AND hpDamage > 0).
+        // Both victims carry the gated leech → neither fires.
+        const noShield = runCombat(
+            TAKEN_BASE({
+                focusSlots: [basicAttack(), { slot: 'passive', abilities: [takenHeal(20, { requiresHpDamage: true })] }],
+                teamSlots: [basicAttack(), { slot: 'passive', abilities: [takenHeal(20, { requiresHpDamage: true })] }],
+            })
+        );
+        expect(sumHeal(noShield, 'directHeal', 'attacker')).toBe(0);
+        expect(sumHeal(noShield, 'directHeal', 'player-team')).toBe(0);
+
+        idc = 0;
+        // Now the origin focus seeds a pre-existing Barrier-free SHIELD (HP-basis) on its own
+        // turn (before the enemy at speed 10): 10% of 1,000,000 = 100,000. The enemy's 5000 hit
+        // is FULLY absorbed by the shield (shieldBefore 100000, hpDamage 0) → the gate still
+        // fails (no HP damage). So even WITH shield, a fully-absorbed hit does not fire the gate.
+        const fullyAbsorbed = runCombat(
+            TAKEN_BASE({
+                focusSlots: [
+                    {
+                        slot: 'active',
+                        abilities: [
+                            ab({
+                                type: 'damage',
+                                target: 'enemy',
+                                config: { type: 'damage', multiplier: 100 },
+                            }),
+                            ab({
+                                type: 'shield',
+                                target: 'self',
+                                config: { type: 'shield', pct: 10, basis: 'hp' },
+                            }),
+                        ],
+                    },
+                    { slot: 'passive', abilities: [takenHeal(20, { requiresHpDamage: true })] },
+                ],
+            })
+        );
+        expect(sumHeal(fullyAbsorbed, 'directHeal', 'attacker')).toBe(0);
+
+        idc = 0;
+        // Finally: a SMALL shield (1% of 1,000,000 = 10,000) that the 50,000 hit punches
+        // through — shieldBefore 10000 > 0 AND hpDamage 40000 > 0 → the gate PASSES. The leech
+        // fires off the FULL damage taken (50,000), not the HP portion: 50000 × 0.20 = 10000.
+        const punchThrough = runCombat(
+            TAKEN_BASE({
+                enemyAttack: 50_000,
+                focusHp: 1_000_000,
+                focusSlots: [
+                    {
+                        slot: 'active',
+                        abilities: [
+                            ab({
+                                type: 'damage',
+                                target: 'enemy',
+                                config: { type: 'damage', multiplier: 100 },
+                            }),
+                            ab({
+                                type: 'shield',
+                                target: 'self',
+                                config: { type: 'shield', pct: 1, basis: 'hp' },
+                            }),
+                        ],
+                    },
+                    { slot: 'passive', abilities: [takenHeal(20, { requiresHpDamage: true })] },
+                ],
+            })
+        );
+        expect(sumHeal(punchThrough, 'directHeal', 'attacker')).toBeCloseTo(10000, 6);
     });
 });

--- a/src/utils/combat/__tests__/positionalApply.test.ts
+++ b/src/utils/combat/__tests__/positionalApply.test.ts
@@ -105,6 +105,7 @@ describe('applyPositionalDamage', () => {
             applyToVictim: (victim, damage) => {
                 applyCalls.push({ id: victim.id, damage, didCrit: false });
                 victim.currentHp -= damage;
+                return { shieldBefore: 0, hpDamage: damage, barriered: false };
             },
             emitHit: (victim, damage, didCrit) => {
                 emitCalls.push({ id: victim.id, damage, didCrit });
@@ -138,6 +139,7 @@ describe('applyPositionalDamage', () => {
             applyToVictim: (victim, damage) => {
                 applyCalls.push({ id: victim.id, damage, didCrit: false });
                 victim.currentHp = 0;
+                return { shieldBefore: 0, hpDamage: damage, barriered: false };
             },
             emitHit: (victim, damage, didCrit) => {
                 emitCalls.push({ id: victim.id, damage, didCrit });
@@ -171,6 +173,7 @@ describe('applyPositionalDamage', () => {
             // High HP, real damage decrement — nobody dies, so footprint stays stable.
             applyToVictim: (victim, damage) => {
                 victim.currentHp -= damage;
+                return { shieldBefore: 0, hpDamage: damage, barriered: false };
             },
             emitHit: (victim, damage, didCrit) => {
                 emitCalls.push({ id: victim.id, damage, didCrit });
@@ -207,6 +210,7 @@ describe('applyPositionalDamage', () => {
                 defenseProfileOf: profile,
                 applyToVictim: (victim, damage) => {
                     victim.currentHp -= damage;
+                    return { shieldBefore: 0, hpDamage: damage, barriered: false };
                 },
                 emitHit: (victim, damage, didCrit) => {
                     emitCalls.push({ id: victim.id, damage, didCrit });

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -43,7 +43,7 @@ import {
 } from './statusEngine';
 import { liveGateConditions } from './abilityStatusGating';
 import { isPositional, resolvePositionalTarget } from './positionalBinding';
-import { applyPositionalDamage } from './positionalApply';
+import { applyPositionalDamage, type VictimDamageOutcome } from './positionalApply';
 import type { AttackerDamageScalars } from './victimDamage';
 import { CHEAT_DEATH_BUFFS } from './cheatDeathBuffs';
 import { BARRIER_BUFFS } from './barrierBuffs';
@@ -2533,7 +2533,18 @@ export function runCombat(input: CombatEngineInput): {
             ignoresForcedTargeting?: boolean;
             actingId: string;
             opposingLiving: CombatActor[];
-            applyToVictim: (victim: CombatActor, damage: number) => void;
+            applyToVictim: (victim: CombatActor, damage: number) => VictimDamageOutcome;
+            // E2 (per-victim leech): OPTIONAL per-direction hook. drivePositionalApply is ONE
+            // helper shared by all three sites (focus / team / enemy); since standing (player→
+            // enemy) and taken (enemy→player) leech need opposite logic, each site supplies its
+            // own callback (Tasks 3/5) rather than branching inside the shared inline path.
+            // Unsupplied by every current caller → fully inert.
+            onVictimResolved?: (
+                victim: CombatActor,
+                damage: number,
+                outcome: VictimDamageOutcome,
+                didCrit: boolean
+            ) => void;
         }): void => {
             applyPositionalDamage({
                 hitCrits: args.hitCrits ?? [],
@@ -2577,6 +2588,8 @@ export function runCombat(input: CombatEngineInput): {
                         (roundPerTargetDamage.get(victim.id) ?? 0) + damage
                     );
                 },
+                // E2: forward the per-direction leech hook (unsupplied by all current callers).
+                onVictimResolved: args.onVictimResolved,
             });
         };
 
@@ -2613,8 +2626,10 @@ export function runCombat(input: CombatEngineInput): {
             enemyTypeArg: EnemyBaseClass | undefined;
             enemyBuffNamesUnion: () => string[];
             healEventOnly: boolean;
-            // Matches drivePositionalApply's applyToVictim param type exactly: (victim, damage) => void.
-            applyToVictim: (victim: CombatActor, damage: number) => void;
+            // Matches drivePositionalApply's applyToVictim param type exactly. E2: returns the
+            // resolved VictimDamageOutcome (both impls wrap applyOutgoingToEnemy /
+            // applyIncomingToTarget, which already surface it from E1).
+            applyToVictim: (victim: CombatActor, damage: number) => VictimDamageOutcome;
         }
         const playerTurnBindings: TurnBindings = {
             opposingRoster: enemyAttackerActors,

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2201,6 +2201,65 @@ export function runCombat(input: CombatEngineInput): {
         }
     };
 
+    // E2 Task 5: PER-VICTIM damage-TAKEN leech proc for the POSITIONAL enemy branch
+    // (enemy→player). The non-positional consumption block (~:4025) credits ONLY the heal
+    // target off the aggregate `damage`, gated by `!enemyPositional` — so on the positional
+    // path NO taken leech fired before E2 (each player victim took only its OWN per-victim AoE
+    // share, and the heal-target-only single-row credit would have been wrong). This proc
+    // restores it by running once per FOOTPRINT VICTIM (wired via drivePositionalApply's
+    // `onVictimResolved` at the enemy site), procing THAT victim's OWN taken-leeches
+    // (takenLeechesByOwner.get(victim.id)) off the per-victim `damage` it took, applying to the
+    // victim's OWN pool via the Task-1 closures.
+    //
+    // SEMANTICS — mirror the non-positional block (~:4025-4060) PER VICTIM:
+    //   - Barrier carve-out: skip entirely if the victim was `barriered` (its hit was fully
+    //     blocked — no damage taken, nothing to leech). Per victim via `outcome.barriered`.
+    //   - requiresHpDamage (Quixilver): only fire an entry with requiresHpDamage when the hit
+    //     dealt HP damage PAST shield — per victim via `outcome.shieldBefore > 0 &&
+    //     outcome.hpDamage > 0`.
+    //   - The leech is off `damage` (the FULL per-victim damage taken — already covered-cell
+    //     reduced), NOT the HP portion — matching the non-positional `damage * (e.pct/100)`.
+    //   - Same heal/shield fold (pct → raw, healModifier, heal-crit gate/noCrit) and the same
+    //     directHeal/effectiveHeal/overheal vs shield bucket split, credited to the victim.
+    //
+    // HEAL-CRIT-GATE CADENCE: this fires once per victim, so a heal-kind leech draws the
+    // victim's `activeHealCritGate` ONCE PER VICTIM (matching procStandingLeechesPerVictim).
+    const procTakenLeechesPerVictim = (
+        victim: CombatActor,
+        damage: number,
+        outcome: VictimDamageOutcome
+    ): void => {
+        if (!healingCtx || damage <= 0) return;
+        // Barrier carve-out (per victim): a fully-blocked hit deals no damage taken.
+        if (outcome.barriered) return;
+        const entries = takenLeechesByOwner.get(victim.id);
+        if (!entries) return;
+        const rt = runtimesById.get(victim.id);
+        for (const e of entries) {
+            // requiresHpDamage gate (per victim): shield present at hit start AND HP damage dealt.
+            if (e.requiresHpDamage && !(outcome.shieldBefore > 0 && outcome.hpDamage > 0)) {
+                continue;
+            }
+            let raw = damage * (e.pct / 100);
+            if (e.kind === 'heal' && rt) {
+                raw *= 1 + rt.healModifier / 100;
+                // One heal-crit draw PER VICTIM (this proc runs per footprint victim).
+                if (!e.noCrit && rt.activeHealCritGate(rt.crit / 100)) {
+                    raw *= 1 + rt.critDamage / 100;
+                }
+            }
+            if (e.kind === 'heal') {
+                healingCtx.credit(victim.id, 'directHeal', raw);
+                const { consumed, overheal } = healingCtx.applyHealToTarget(raw, victim);
+                healingCtx.credit(victim.id, 'effectiveHeal', consumed);
+                healingCtx.credit(victim.id, 'overheal', overheal);
+            } else {
+                healingCtx.credit(victim.id, 'shield', raw);
+                healingCtx.grantShieldToTarget(raw, victim);
+            }
+        }
+    };
+
     // C2b-2 T5: the id of the actor whose turn is CURRENTLY executing. Set once at the top of
     // each actor's turn (after the dead-actor skips, before any damage is applied), so the
     // DIRECT-damage wrappers can stamp the lethal attacker onto ship-destroyed (Faust reads it
@@ -3917,12 +3976,14 @@ export function runCombat(input: CombatEngineInput): {
                             processExtraActionGrants(actor, enemyTurn.extraActionGrants);
                         }
                         if (damage > 0) {
-                            // Phase-5 per-victim accounting TODOs (see detailed notes below): (1)
-                            // takenLeeches gated to non-positional — per-victim leech needs the symmetric
-                            // heal surface; (2) since PR5b playerSink.addIncoming keys each victim's AoE
-                            // share into ITS OWN per-actor bucket (the heal-target row is no longer
-                            // inflated) — surfacing those other per-actor buckets as result rows is the
-                            // still-deferred symmetric-accounting surface.
+                            // Phase-5 per-victim accounting notes (see detailed notes below): (1) the
+                            // damage-taken leech now fires PER VICTIM on the positional path too (E2 T5,
+                            // procTakenLeechesPerVictim at the enemy site); the non-positional block below
+                            // stays gated to `!enemyPositional` and heal-target-only; (2) since PR5b
+                            // playerSink.addIncoming keys each victim's AoE share into ITS OWN per-actor
+                            // bucket (the heal-target row is no longer inflated) — surfacing those other
+                            // per-actor buckets as result rows is the still-deferred symmetric-accounting
+                            // surface.
                             //
                             // Shield-first drain → HP → ship-destroyed → the victim's per-actor bucket. The
                             // shieldBefore/hpDamage are captured for the punch-through gate (Quixilver) below.
@@ -3977,6 +4038,13 @@ export function runCombat(input: CombatEngineInput): {
                                     actingId: actor.id,
                                     opposingLiving: tb.opposingRoster,
                                     applyToVictim: tb.applyToVictim,
+                                    // E2 Task 5: per-victim taken leech (enemy→player). Each
+                                    // player victim procs its OWN damage-taken heal/shield leech
+                                    // off the damage IT took, with the per-victim Barrier /
+                                    // requiresHpDamage gates — mirroring the non-positional block
+                                    // below, per victim.
+                                    onVictimResolved: (victim, dmg, outcome) =>
+                                        procTakenLeechesPerVictim(victim, dmg, outcome),
                                 });
                             } else {
                                 ({ shieldBefore, hpDamage, barriered } = applyIncomingToTarget(
@@ -4011,17 +4079,17 @@ export function runCombat(input: CombatEngineInput): {
                             // nothing to leech from. (Distinct from a shield absorb, where the convention
                             // still leeches off the full attack: a shield takes the hit, Barrier nullifies it.)
                             //
-                            // POSITIONAL DEFERRAL (Task 9, Step C — Phase-5 follow-up): this damage-taken
-                            // leech is single-target heal-target infrastructure (takenLeeches is collected
-                            // ONLY for the heal target; the healing-accounting model has one row, the heal
-                            // target's). On the positional path the heal target took only its OWN per-victim
-                            // AoE share (origin full / covered half), and shieldBefore/hpDamage are not
-                            // surfaced per victim — crediting off the aggregate `damage` here would be wrong.
-                            // So the leech is gated to the NON-positional path: the legacy heal-target leech
-                            // stays byte-identical, and full per-victim leech symmetry (every player victim
-                            // procing its OWN damage-taken reactive off the damage IT took) is the documented
-                            // Phase-5 follow-up. Inert today either way (no fixture runs a damage-taken
-                            // reactive in healing mode → takenLeeches is empty).
+                            // POSITIONAL SPLIT (E2 T4/T5): taken-leeches are now collected PER OWNER
+                            // (takenLeechesByOwner, keyed by each owner's id), but the NON-positional
+                            // consumption HERE reads only the heal target's slice — the legacy single-row
+                            // healing-accounting model lands every enemy attack on the heal target, so its
+                            // values stay byte-identical. The POSITIONAL path no longer defers: each player
+                            // victim procs its OWN taken-leech off the damage IT took via
+                            // procTakenLeechesPerVictim (wired at the enemy drivePositionalApply site, with
+                            // the per-victim Barrier carve-out + requiresHpDamage gate). This block is
+                            // gated to `!enemyPositional` so the two paths never double-count. Inert on the
+                            // non-positional path unless a player runs a damage-taken reactive in healing
+                            // mode (no current fixture does → the heal target's slice is empty).
                             const healTargetTakenLeeches =
                                 takenLeechesByOwner.get(healTarget!.id) ?? [];
                             if (

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -1911,30 +1911,30 @@ export function runCombat(input: CombatEngineInput): {
               // Foreign HoT applier max HP (Task 7): lastTurnCtxByActor ONLY, NO base-stat
               // fallback (strict corrosion applier-ctx rule — undefined → the holder skips the tick).
               applierMaxHp: (id) => lastTurnCtxByActor.get(id)?.effectiveMaxHp,
-              applyHealToTarget: (raw) => {
+              applyHealToTarget: (raw, victim = healTarget) => {
                   // Dead target → all overheal. Otherwise consume up to the deficit against
                   // the target's CURRENT effective max HP (live ctx via recipientMaxHp).
-                  if (healTarget.currentHp <= 0) {
+                  if (victim.currentHp <= 0) {
                       return { consumed: 0, overheal: raw };
                   }
-                  const targetMaxHp = recipientMaxHp(healTarget.id);
+                  const targetMaxHp = recipientMaxHp(victim.id);
                   // Clamp the deficit at 0: a max-HP buff expiring can shrink effectiveMaxHp
                   // below currentHp, making (targetMaxHp - currentHp) negative — without the
                   // Math.max a heal would REDUCE the target's HP. Floor at 0 → consumed 0,
                   // overheal = raw (the whole heal is wasted, which is correct in that state).
-                  const consumed = Math.max(0, Math.min(raw, targetMaxHp - healTarget.currentHp));
-                  healTarget.currentHp += consumed;
-                  if (consumed > 0) repairedThisRound.add(healTarget.id);
+                  const consumed = Math.max(0, Math.min(raw, targetMaxHp - victim.currentHp));
+                  victim.currentHp += consumed;
+                  if (consumed > 0) repairedThisRound.add(victim.id);
                   return { consumed, overheal: raw - consumed };
               },
-              grantShieldToTarget: (raw) => {
-                  if (healTarget.currentHp <= 0) return; // dead → no-op
-                  const targetMaxHp = recipientMaxHp(healTarget.id);
+              grantShieldToTarget: (raw, victim = healTarget) => {
+                  if (victim.currentHp <= 0) return; // dead → no-op
+                  const targetMaxHp = recipientMaxHp(victim.id);
                   // Capped at the CURRENT effective max HP. Note: if a max-HP buff later expires
                   // and shrinks targetMaxHp below an already-granted pool, the larger pool simply
                   // persists (we never shrink an existing shield) — acceptable, as the cap is only
                   // enforced at grant time and a shield is additive, never HP-reducing.
-                  healTarget.shieldPool = Math.min(healTarget.shieldPool + raw, targetMaxHp);
+                  victim.shieldPool = Math.min(victim.shieldPool + raw, targetMaxHp);
               },
               playerIds,
           }

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -922,14 +922,12 @@ export interface CombatEngineInput {
      *  wrapper against a hand-built enemy actor. Never set by production code; the closure runs the
      *  real applyVictimDamage path (no mocks).
      *  KEPT (not removed once Task 8/9 wired production callers): `applyOutgoingToEnemy.test.ts`
-     *  behaviour #6 — the enemy-side sink is a no-op (tank accumulators stay 0) — is unique coverage
-     *  the positionalDamage integration test cannot observe (it only sees `ship-destroyed`). Inert
-     *  (optional, never set in production). Revisit if that no-op contract gains an observable seam. */
+     *  behaviour #6 — the enemy-side sink now records per-victim intake (incoming / shield-absorbed /
+     *  barrier-absorbed into the victim's own bucket, since E1) — is unique coverage the
+     *  positionalDamage integration test cannot observe (it only sees `ship-destroyed`). Inert
+     *  (optional, never set in production). */
     __testTapApplyOutgoingToEnemy?: (
-        fn: (
-            damage: number,
-            enemyVictim: CombatActor
-        ) => VictimDamageOutcome
+        fn: (damage: number, enemyVictim: CombatActor) => VictimDamageOutcome
     ) => void;
     /** TEST-ONLY tap (A2 Task 2): receives the full `allActors` roster once, right after actors
      *  are constructed, so unit tests can assert the plumbed base hacking/security on each actor
@@ -4026,6 +4024,15 @@ export function runCombat(input: CombatEngineInput): {
                                 // Phase-5 symmetric-accounting surface (the result still exposes a single
                                 // heal-target row today). Inert here regardless (no production caller
                                 // threads enemy position+pattern).
+                                // DETONATION CAVEAT (deferred → E5 accounting unification): only the firing
+                                // hit (enemyScalars, the DIRECT channel) lands per-victim here. The
+                                // aggregate `damage` also folds enemyTurn.detonationDamage, which the
+                                // NON-positional branch drains via applyIncomingToTarget(damage, tgt) but
+                                // which is NOT routed to any player victim on the positional path — routing
+                                // it needs per-victim bomb attribution the engine does not track yet
+                                // (detonation is a single turn-scalar, not per-target). Byte-identical today
+                                // (no fixture threads enemy position+pattern WITH detonation); a positional
+                                // enemy-detonation model lands with E5.
                                 const tb = turnBindings(actor.side);
                                 drivePositionalApply({
                                     scalars: enemyScalars!,

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -929,7 +929,7 @@ export interface CombatEngineInput {
         fn: (
             damage: number,
             enemyVictim: CombatActor
-        ) => { shieldBefore: number; hpDamage: number; barriered: boolean }
+        ) => VictimDamageOutcome
     ) => void;
     /** TEST-ONLY tap (A2 Task 2): receives the full `allActors` roster once, right after actors
      *  are constructed, so unit tests can assert the plumbed base hacking/security on each actor
@@ -2122,6 +2122,82 @@ export function runCombat(input: CombatEngineInput): {
         }
     };
 
+    // E2 Task 3: PER-VICTIM standing-leech proc for the POSITIONAL apply path.
+    //
+    // The non-positional `procStandingLeeches` above rides the aggregate `creditDamage(...
+    // 'direct' ...)` write — but that write is SUPPRESSED for the positional case (the firing-hit
+    // damage lands per-victim via applyPositionalDamage, so crediting it again would double-count).
+    // So on the positional path NO standing leech fired before E2. This proc restores it by
+    // running once per FOOTPRINT VICTIM (wired via drivePositionalApply's `onVictimResolved`),
+    // leeching off THAT victim's already-role-scaled dealt damage — so origin victims contribute
+    // full damage and covered victims contribute half automatically (the caller passes the
+    // per-victim `damage`).
+    //
+    // It REUSES procStandingLeeches's fold math (pct → raw, healModifier, heal-crit draw) but does
+    // its OWN pool application via the Task-1 parametrized closures (applyHealToTarget(raw, actor) /
+    // grantShieldToTarget(raw, actor)), resolving each recipient's actor — so a covered enemy's
+    // leech can repair the right ally, not just the heal target. procStandingLeeches is left
+    // UNTOUCHED (its `rid === healTarget.id` pool-gating is load-bearing for the non-positional
+    // all-allies case, leech.test.ts:355-404).
+    //
+    // RECIPIENT RESOLUTION: via `runtimesById` (NOT allActorsById) — the focus attacker is keyed
+    // 'attacker', not its real id. `self` → the acting owner; `ally` → the heal target; `all-allies`
+    // → every player id. A recipient with no resolvable runtime actor is credited but not
+    // pool-applied (mirrors procStandingLeeches's effect for the all-allies non-target case).
+    //
+    // HEAL-CRIT-GATE CADENCE: this fires once per victim, so a heal-kind leech draws the owner's
+    // `activeHealCritGate` ONCE PER VICTIM (an N-victim AoE makes N draws, in footprint order).
+    // The perVictimLeech test pins the exact numbers.
+    //
+    // NO `dmg()`/cumulative accumulator write here (the per-victim apply already landed the HP
+    // damage; the aggregate direct credit stays suppressed) → no double-count. Honors `scope`:
+    // a detonation-scoped leech is skipped on the per-victim `direct` channel.
+    const procStandingLeechesPerVictim = (sourceId: string, amount: number): void => {
+        if (!healingCtx || amount <= 0) return;
+        const entries = standingLeeches.get(sourceId);
+        if (!entries) return;
+        const owner = runtimesById.get(sourceId);
+        if (!owner) return;
+        for (const e of entries) {
+            // Per-victim damage rides the `direct` channel only; detonation-scoped leeches
+            // never fire here (bombs credit through the aggregate detonation path instead).
+            if (e.scope === 'detonation') continue;
+            let raw = amount * (e.pct / 100);
+            if (e.kind === 'heal') {
+                raw *= 1 + owner.healModifier / 100;
+                // One heal-crit draw PER VICTIM (this proc runs per footprint victim).
+                if (!e.noCrit && owner.activeHealCritGate(owner.crit / 100)) {
+                    raw *= 1 + owner.critDamage / 100;
+                }
+            }
+            const recipients =
+                e.target === 'ally'
+                    ? [healTarget!.id]
+                    : e.target === 'all-allies'
+                      ? healingCtx.playerIds
+                      : [sourceId];
+            for (const rid of recipients) {
+                // Resolve the recipient's live actor for the pool application (Task-1 closures
+                // take an explicit victim). runtimesById, not allActorsById: the focus is 'attacker'.
+                const recipientActor = runtimesById.get(rid)?.actor;
+                if (e.kind === 'heal') {
+                    healingCtx.credit(sourceId, 'directHeal', raw);
+                    if (recipientActor) {
+                        const { consumed, overheal } = healingCtx.applyHealToTarget(
+                            raw,
+                            recipientActor
+                        );
+                        healingCtx.credit(sourceId, 'effectiveHeal', consumed);
+                        healingCtx.credit(sourceId, 'overheal', overheal);
+                    }
+                } else {
+                    healingCtx.credit(sourceId, 'shield', raw);
+                    if (recipientActor) healingCtx.grantShieldToTarget(raw, recipientActor);
+                }
+            }
+        }
+    };
+
     // C2b-2 T5: the id of the actor whose turn is CURRENTLY executing. Set once at the top of
     // each actor's turn (after the dead-actor skips, before any damage is applied), so the
     // DIRECT-damage wrappers can stamp the lethal attacker onto ship-destroyed (Faust reads it
@@ -2292,7 +2368,7 @@ export function runCombat(input: CombatEngineInput): {
             // passes { byDirectDamage: false } (no single killer). No consumer reads these yet
             // (Faust, Task 6), so production stays byte-identical.
             cause?: { killerId?: string; byDirectDamage?: boolean }
-        ): { shieldBefore: number; hpDamage: number; barriered: boolean } => {
+        ): VictimDamageOutcome => {
             sink.addIncoming(damage, victim.id);
             // Capture the pre-drain HP + the target's current effective max HP for the
             // tank-side hp-changed emission below (Phase 4c PR 3). Read BEFORE the drain
@@ -2430,8 +2506,7 @@ export function runCombat(input: CombatEngineInput): {
                 killerId: actingActorId,
                 byDirectDamage: true,
             }
-        ): { shieldBefore: number; hpDamage: number; barriered: boolean } =>
-            applyVictimDamage(damage, victim, playerSink, cause);
+        ): VictimDamageOutcome => applyVictimDamage(damage, victim, playerSink, cause);
         // Player→enemy intake (E1 — symmetric incoming surface). The symmetric THIN wrapper over
         // applyVictimDamage for the direction where a PLAYER attacks an ENEMY victim. The enemy
         // victim runs the FULL HP/shield/Barrier/Cheat-Death/recordDestroyed path AND now records
@@ -2455,7 +2530,7 @@ export function runCombat(input: CombatEngineInput): {
         const applyOutgoingToEnemy = (
             damage: number,
             enemyVictim: CombatActor
-        ): { shieldBefore: number; hpDamage: number; barriered: boolean } =>
+        ): VictimDamageOutcome =>
             // C2b-2 T5: a player→enemy hit is always DIRECT damage from the acting attacker.
             applyVictimDamage(damage, enemyVictim, enemySink, {
                 killerId: actingActorId,
@@ -3351,6 +3426,12 @@ export function runCombat(input: CombatEngineInput): {
                                 actingId: actor.id,
                                 opposingLiving: tb.opposingRoster,
                                 applyToVictim: tb.applyToVictim,
+                                // E2 Task 3: per-victim standing leech (player→enemy). The ACTING
+                                // attacker's standing leeches proc off EACH footprint victim's
+                                // role-scaled dealt damage (origin full, covered half) → restoring
+                                // the leech the positional credit-suppression had silenced.
+                                onVictimResolved: (_victim, damage) =>
+                                    procStandingLeechesPerVictim(actor.id, damage),
                             });
                         }
 
@@ -3530,6 +3611,11 @@ export function runCombat(input: CombatEngineInput): {
                                 actingId: actor.id,
                                 opposingLiving: tb.opposingRoster,
                                 applyToVictim: tb.applyToVictim,
+                                // E2 Task 3: per-victim standing leech (player→enemy), keyed to
+                                // THIS walked team actor as the acting attacker. Same per-victim
+                                // proc as the focus site.
+                                onVictimResolved: (_victim, damage) =>
+                                    procStandingLeechesPerVictim(actor.id, damage),
                             });
                         }
 

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -4004,13 +4004,12 @@ export function runCombat(input: CombatEngineInput): {
                             //    victim would be double-hit: once by the AoE loop, once by the single
                             //    apply). enemyPattern is non-null via the enemyPositional gate.
                             //
-                            // DEFERRED (Phase-5, documented in Step C): on the positional path the per-
-                            // victim shield/HP outcomes are not surfaced, so shieldBefore/hpDamage/barriered
-                            // fall back to neutral defaults — the heal-target damage-taken HEAL/SHIELD leech
-                            // (takenLeeches) is NOT re-derived from the anchor victim's AoE hit. Inert today
-                            // (no fixture runs a "when damaged" reactive in healing mode), so the legacy
-                            // single-target leech path stays byte-identical; per-victim leech symmetry is the
-                            // Phase-5 follow-up. The non-positional path keeps the exact legacy leech values.
+                            // These aggregate locals feed ONLY the non-positional damage-taken leech
+                            // block below; on the positional path they stay at neutral defaults. Per-victim
+                            // taken leech on the positional path is now handled by procTakenLeechesPerVictim
+                            // (E2 T5), which reads each player victim's OWN {shieldBefore,hpDamage,barriered}
+                            // outcome via the onVictimResolved hook — not these heal-target aggregates. The
+                            // non-positional path keeps the exact legacy single-target leech values.
                             let shieldBefore = 0;
                             let hpDamage = 0;
                             let barriered = false;
@@ -4070,8 +4069,9 @@ export function runCombat(input: CombatEngineInput): {
                             // positional selection (Task C3) the enemy's HP/shield drain re-routes to the
                             // selected player (`tgt`, above), but these damage-taken HEAL/SHIELD leech
                             // procs still credit the heal target's accounting. Inert unless a player runs
-                            // a "when damaged, heal/shield" reactive (takenLeeches non-empty) — no current
-                            // fixture does — so the legacy path stays byte-identical. Retargeting the
+                            // a "when damaged, heal/shield" reactive (the heal target's takenLeechesByOwner
+                            // slice non-empty) — no current fixture does — so the legacy path stays
+                            // byte-identical. Retargeting the
                             // single-target healing accounting to an arbitrary victim is out of scope for
                             // Phase 2 (incoming-damage routing).
                             // Barrier carve-out (decision #7): an attack FULLY BLOCKED by Barrier deals no

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2047,26 +2047,28 @@ export function runCombat(input: CombatEngineInput): {
         }
     }
 
-    // The heal target's passive damage-taken abilities (damage-leech spec §5): each enemy
-    // ATTACK on the target procs these AFTER the attack's shield-first drain. Sibling shape
-    // to the standing leeches above. Enemy attacks only ever hit the heal target in this
-    // model, so only the heal target's runtime is scanned. Healing mode only.
+    // Passive damage-taken abilities per owner (damage-leech spec §5): each enemy ATTACK on a
+    // victim procs that victim's own abilities AFTER the attack's shield-first drain. Sibling
+    // shape to the standing leeches above — scanned once at setup from every runtime, keyed by
+    // owner id. The non-positional consumption site reads only the heal target's list (enemy
+    // attacks land on the heal target in that model), so its behavior is unchanged; the
+    // per-owner map prepares the per-victim positional path (Phase-5 follow-up). Healing mode only.
     interface TakenLeech {
         kind: 'heal' | 'shield';
         pct: number;
         noCrit: boolean;
         requiresHpDamage: boolean;
     }
-    const takenLeeches: TakenLeech[] = [];
+    const takenLeechesByOwner = new Map<string, TakenLeech[]>();
     if (healTarget) {
-        const rt = runtimesById.get(healTarget.id);
-        if (rt) {
+        for (const [ownerId, rt] of runtimesById) {
+            const entries: TakenLeech[] = [];
             for (const slot of rt.castSkills.slots) {
                 if (slot.slot !== 'passive') continue;
                 for (const a of slot.abilities) {
                     const c = a.config;
                     if ((c.type === 'heal' || c.type === 'shield') && c.basis === 'damage-taken') {
-                        takenLeeches.push({
+                        entries.push({
                             kind: c.type,
                             pct: c.pct,
                             noCrit: c.type === 'heal' ? (c.noCrit ?? false) : true,
@@ -2075,6 +2077,7 @@ export function runCombat(input: CombatEngineInput): {
                     }
                 }
             }
+            if (entries.length > 0) takenLeechesByOwner.set(ownerId, entries);
         }
     }
 
@@ -4019,14 +4022,16 @@ export function runCombat(input: CombatEngineInput): {
                             // procing its OWN damage-taken reactive off the damage IT took) is the documented
                             // Phase-5 follow-up. Inert today either way (no fixture runs a damage-taken
                             // reactive in healing mode → takenLeeches is empty).
+                            const healTargetTakenLeeches =
+                                takenLeechesByOwner.get(healTarget!.id) ?? [];
                             if (
                                 !enemyPositional &&
-                                takenLeeches.length > 0 &&
+                                healTargetTakenLeeches.length > 0 &&
                                 healingCtx &&
                                 !barriered
                             ) {
                                 const rt = runtimesById.get(healTarget!.id);
-                                for (const e of takenLeeches) {
+                                for (const e of healTargetTakenLeeches) {
                                     if (e.requiresHpDamage && !(shieldBefore > 0 && hpDamage > 0)) {
                                         continue;
                                     }

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -91,11 +91,16 @@ export interface HealingRuntimeCtx {
      *  local effectiveHp directly, never this accessor.) */
     applierMaxHp: (actorId: string) => number | undefined;
     /** Target-routed heal: consumed = min(raw, maxHp − currentHp); dead target → all overheal.
-     *  Mutates target.currentHp. Returns the split. */
-    applyHealToTarget: (raw: number) => { consumed: number; overheal: number };
-    /** Additive pool capped at the target's max HP; drains before HP (enemy attacks, Task 8).
-     *  Dead target → no-op. */
-    grantShieldToTarget: (raw: number) => void;
+     *  Mutates the victim's currentHp. Returns the split. `victim` defaults to the heal target
+     *  (E2 T1: optional per-victim override for positional AoE leech). */
+    applyHealToTarget: (
+        raw: number,
+        victim?: CombatActor
+    ) => { consumed: number; overheal: number };
+    /** Additive pool capped at the victim's max HP; drains before HP (enemy attacks, Task 8).
+     *  Dead victim → no-op. `victim` defaults to the heal target (E2 T1: optional per-victim
+     *  override for positional AoE leech). */
+    grantShieldToTarget: (raw: number, victim?: CombatActor) => void;
     /** Fixed player-id order for all-allies recipient routing. */
     playerIds: string[];
 }

--- a/src/utils/combat/positionalApply.ts
+++ b/src/utils/combat/positionalApply.ts
@@ -20,6 +20,19 @@ export interface FootprintHit {
     roleScale: number;
 }
 
+/**
+ * The per-hit damage resolution outcome surfaced by the engine's victim-apply wrappers
+ * (`applyIncomingToTarget` / `applyOutgoingToEnemy`, E1 — symmetric incoming surface):
+ * the victim's shield pool BEFORE the hit, the HP damage that actually landed after
+ * shield/Barrier absorption, and whether a Barrier fully absorbed the hit. E2 plumbs this
+ * through `applyPositionalDamage` so per-direction leech can read it per footprint victim.
+ */
+export interface VictimDamageOutcome {
+    shieldBefore: number;
+    hpDamage: number;
+    barriered: boolean;
+}
+
 /** Per-cell damage scale keyed off the resolved CellRole. */
 const roleScaleFor = (role: CellRole): number => (role === 'origin' ? 1.0 : 0.5);
 
@@ -86,9 +99,24 @@ export function applyPositionalDamage(args: {
     statusOf?: (id: string) => ActorTargetingStatus | undefined;
     acting?: { ignoresForcedTargeting?: boolean; provokedBy?: string };
     defenseProfileOf: (v: CombatActor) => VictimDefenseProfile;
-    /** Engine wrapper — decrements the victim's currentHp (Task 8 passes applyOutgoingToEnemy). */
-    applyToVictim: (victim: CombatActor, damage: number) => void;
+    /**
+     * Engine wrapper — decrements the victim's currentHp (Task 8 passes applyOutgoingToEnemy)
+     * and returns the resolved {@link VictimDamageOutcome} (shield-before / HP-damage / barriered).
+     */
+    applyToVictim: (victim: CombatActor, damage: number) => VictimDamageOutcome;
     emitHit?: (victim: CombatActor, damage: number, didCrit: boolean) => void;
+    /**
+     * OPTIONAL per-victim hook (E2 — per-victim leech). Invoked once per footprint victim AFTER
+     * the hit resolves, with the resolved {@link VictimDamageOutcome}. Direction-specific leech
+     * logic is supplied per call site (standing vs taken) rather than branched inline. Unsupplied
+     * → fully inert.
+     */
+    onVictimResolved?: (
+        victim: CombatActor,
+        damage: number,
+        outcome: VictimDamageOutcome,
+        didCrit: boolean
+    ) => void;
 }): void {
     const {
         hitCrits,
@@ -102,6 +130,7 @@ export function applyPositionalDamage(args: {
         defenseProfileOf,
         applyToVictim,
         emitHit,
+        onVictimResolved,
     } = args;
 
     // Canonical hit count: derive the loop count from `scalars.hits` (the single source of
@@ -130,8 +159,9 @@ export function applyPositionalDamage(args: {
             opposingLiving
         )) {
             const dmg = victimHitDamage(scalars, defenseProfileOf(victim), didCrit, roleScale);
-            applyToVictim(victim, dmg);
+            const outcome = applyToVictim(victim, dmg);
             emitHit?.(victim, dmg, didCrit);
+            onVictimResolved?.(victim, dmg, outcome, didCrit);
         }
     }
 }


### PR DESCRIPTION
## Summary

Makes leech (lifesteal — heal or shield from damage) **per-victim** on the positional combat path. Previously standing leech was suppressed and taken leech was gated out of the positional path; now each leeching ship heals/shields its OWN pool off the damage it dealt (standing) or took (taken), with covered AoE cells contributing their reduced (50%) damage.

The legacy non-positional leech path is left **completely untouched** — verified byte-identical (zero `.snap` movement across the whole PR).

### Tasks (each shipped via spec-compliance + code-quality review)
- **T1** — parametrized the `applyHealToTarget`/`grantShieldToTarget` pool closures by an optional `victim = healTarget` (byte-identical; E5's per-victim repair can now reuse these).
- **T2** — added an inert per-victim `onVictimResolved(victim, damage, outcome, didCrit)` hook to `drivePositionalApply`, surfacing the per-hit `{shieldBefore, hpDamage, barriered}` outcome.
- **T3** — per-victim **standing** leech via a new positional-only proc wired at the focus + team (player→enemy) sites; own-pool application, covered-cell 50%, scope-honored, heal-crit gate drawn once per victim. `procStandingLeeches` left unmodified.
- **T4** — taken-leech registration generalized to `Map<ownerId, TakenLeech[]>` over all player runtimes (byte-identical).
- **T5** — per-victim **taken** leech via a new proc wired at the enemy (enemy→player) site; per-victim Barrier carve-out + `requiresHpDamage` gate, mirroring non-positional semantics per victim.
- **T6** — changelog + spec closeout.

### Integration guarantees (final whole-feature review)
- Positional vs non-positional paths are strictly mutually exclusive (gated on `positional`/`teamPositional`/`enemyPositional`) — no path double-counts a single hit. Detonation-scoped leech is carved out of the per-victim direct channel.
- Directions not crossed: standing leeches off damage **dealt** to each victim; taken leeches off damage each victim **took**.

## Test Plan
- [x] `npx vitest run` — full suite green (2673 tests / 180 files)
- [x] `git diff --stat main...HEAD -- '*.snap'` — **empty** (non-positional leech byte-identical)
- [x] `leech.test.ts` + `healingGoldenParity` green
- [x] New `perVictimLeech.test.ts` — positional standing + taken, covered-cell 50%, per-victim Barrier carve-out, `requiresHpDamage`, own-pool application (TDD RED→GREEN)
- [x] `npm run lint` (0), `npx tsc --noEmit` (clean), `npm run audit:skills` (0/141)

🤖 Generated with [Claude Code](https://claude.com/claude-code)