### PR TITLE
feat(combat): E3 — AoE on-cast purge over footprint victims (per-victim AoE accounting)

### DIFF
--- a/docs/superpowers/plans/2026-06-19-per-victim-aoe-E3-aoe-purge.md
+++ b/docs/superpowers/plans/2026-06-19-per-victim-aoe-E3-aoe-purge.md
@@ -1,0 +1,435 @@
+# E3 — AoE on-cast purge over footprint victims — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make an on-cast purge whose ability `target` is `'all-enemies'` remove buffs from **every footprint victim** of the firing skill's pattern, instead of only the single resolved anchor victim.
+
+**Architecture:** The on-cast purge in `playerTurn.ts` removes buffs from the single resolved anchor `targetId`. E3 threads an optional `aoeVictimIds: string[]` (the firing skill's footprint victim ids) into `runPlayerTurn` via `buildTurnArgs` (engine.ts) — which is spread into all three `runPlayerTurn` call sites (focus / team / enemy), so one change covers every direction. `buildTurnArgs` computes the footprint with the existing pure helper `footprintVictims(pattern, anchor, opposingRoster)` (already the authority for AoE *damage*) **only when positional** (`pattern`, `target` present AND the resolved target is a positioned actor); otherwise it stays `undefined`. The on-cast purge loop then routes `ab.target === 'all-enemies' && aoeVictimIds ? aoeVictimIds : [targetId]`, purging and emitting `purge-performed` **per victim**. Single-target (`'enemy'`) purges and all non-positional callers keep the single-anchor behaviour → **production byte-identical**.
+
+**Tech Stack:** TypeScript, Vitest. Combat engine (`src/utils/combat/`).
+
+**Spec:** `docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md` (§4 row E3, §"E3 — AoE purge/cleanse").
+
+**Branch:** `feat/combat-sim-aoe-purge-E3` (off `main` post-#117; E3 is Thread-2, independent of E1/E2 — see spec §4).
+
+---
+
+## Grounding facts (verified on this branch, 2026-06-19)
+
+- **The only AoE purge in the corpus is Amartya** ("purges 1 buff from all enemies for every 50% crit power"). `parsePurge` (`skillTextParser.ts:2135`) already emits `target: 'all-enemies'` for "from all enemies"; every other purge emits `target: 'enemy'` (single). Amartya's **crit-power count scaling** is **deferred to E4** — E3 builds the multi-victim routing that E4 rides, and ships at Amartya's parsed count (`1`). **No existing fixture/golden carries an `'all-enemies'` purge**, so this PR is production byte-identical.
+- **On-cast purge site:** `src/utils/combat/playerTurn.ts:1386-1416`. Loops `gatedSkill?.abilities`, fires on `ab.config.type === 'purge' && ab.trigger === 'on-cast' && conditionsMet(...)`, calls `statusEngine.purge(targetId, ab.config.count)`, emits `purge-performed` when `removed > 0`. **Side-symmetric** (keyed off `targetId`, no `healEventOnly` gate → fires for player AND enemy casters). `ab.target` is a top-level `Ability` field (e.g. `'all-enemies' | 'enemy' | 'enemy-most-buffs'`).
+- **Ability shape** (`buildShipAbilities.ts:1093-1104`): `{ id, type:'purge', target, trigger, conditions, config:{type:'purge', count}, autoFilled }`. So the loop reads `ab.config.type`, `ab.config.count`, `ab.trigger`, `ab.conditions`, and `ab.target`.
+- **`buildTurnArgs`** (`src/utils/combat/engine.ts:2670-2711`) builds the full `runPlayerTurn` arg object for any side, folding per-side divergence via `turnBindings(a.side)`. It is spread (`...buildTurnArgs(actor, tgt)`) into all three `runPlayerTurn` sites: **focus 3262, team 3463, enemy 3712**. In scope: `parsedPatternFor(a)` (2589), `parsedTargetFor(a)` (2584), `tb.opposingRoster`, and (after T2) `footprintVictims`.
+- **`selectTurnTarget`** (engine.ts:2645) returns `{ tgt: selected ?? tb.legacyVictim }`. When **positional**, `tgt` is the resolved positioned enemy (`tgt.position != null`). When **non-positional** (DPS/healing-single), `tgt` is the legacy dummy/heal-target (`tgt.position == null`). So **`tgt.position != null` is the positional discriminator** → guarantees `aoeVictimIds === undefined` for every existing fixture.
+- **`footprintVictims(pattern, anchor, opposingLiving)`** (`src/utils/combat/positionalApply.ts:37`) → `FootprintHit[]` (`{ victim, roleScale }`), living positioned actors ≤1/cell, includes the origin (anchor) cell. **Pure** geometry+roster; already the per-hit authority inside `applyPositionalDamage`. `roleScale` is irrelevant to status removal (covered cells are 50% *damage only*; purge/buff/debuff is **uniform** across the footprint — board-geometry resolver locked rule). Currently imported into engine.ts as: `import { applyPositionalDamage } from './positionalApply';` (engine.ts:46) — **must add `footprintVictims`**.
+- **`statusEngine.purge(actorId, count)`** (`src/utils/combat/statusEngine.ts`) removes ≤`count` removable buffs newest-first (skips `UNREMOVABLE_STATUSES`/`'permanent'`), returns count removed, unknown id → `0`.
+- **NO change** needed at the other status-removal sites (verified, documented in T4):
+  - *Reactive purge* (`triggers.ts`, executor `cfg.type==='purge'`): targets are `'enemy-most-buffs'` (Rhodium) or `counterTargetId ?? enemyId` (Iridium counter-attacker / Faust killer) — **inherently single-target**; no `'all-enemies'` reactive purge exists in the corpus, and the footprint (pattern + opposing roster) is **not reachable at drain time**.
+  - *End-of-round purge* (Rhodium, engine round tail): drains the reactive queue; same single-`enemy-most-buffs` target.
+  - *Cleanse* (on-cast `playerTurn.ts`, reactive `triggers.ts`): already loops `recipientsFor(ability.target)` / `reactiveRecipients(...)`. Cleanse targets **allies**; `'all-allies'` = the whole team (not a footprint) — already correct.
+
+---
+
+## File structure
+
+- **Modify** `src/utils/combat/playerTurn.ts` — add optional `aoeVictimIds?: string[]` to `PlayerTurnArgs`; route the on-cast purge over it for `'all-enemies'` targets.
+- **Modify** `src/utils/combat/engine.ts` — add `footprintVictims` to the `positionalApply` import; compute + return `aoeVictimIds` in `buildTurnArgs`.
+- **Create** `src/utils/combat/__tests__/aoePurge.test.ts` — integration coverage (mirrors `purgeCastPath.test.ts`).
+- **Modify** `docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md` — E3 closeout note.
+- **Modify** `src/constants/changelog.ts` — `UNRELEASED_CHANGES` entry.
+
+---
+
+## Gate (every task, before any "done"/commit)
+
+- `npx vitest run <file>` for the touched test(s) — **bare `npm test` is watch mode and hangs**.
+- Production **byte-identical**: `git status` shows **zero `.snap` movement**; if any golden moves, the positional gate leaked — fix it, **never `vitest -u`**.
+- Final task only: full suite `npx vitest run`, `npm run lint` (max-warnings 0), `npx tsc --noEmit` clean, `npm run audit:skills` (0 findings / 141 ships).
+- **ALWAYS run `npx tsc --noEmit` independently** after subagent work — vitest/esbuild does not typecheck.
+
+---
+
+### Task 0: Baseline
+
+**Files:** none.
+
+- [ ] **Step 1: Confirm the branch + clean tree**
+
+Run: `git branch --show-current && git status --porcelain`
+Expected: `feat/combat-sim-aoe-purge-E3`, empty status.
+
+- [ ] **Step 2: Confirm the suite is green at baseline**
+
+Run: `npx vitest run src/utils/combat/__tests__/purgeCastPath.test.ts`
+Expected: PASS (5 tests). This is the harness Task 1 mirrors.
+
+---
+
+### Task 1: Failing integration test — AoE purge hits all footprint enemies
+
+**Files:**
+- Create: `src/utils/combat/__tests__/aoePurge.test.ts`
+
+This mirrors `purgeCastPath.test.ts` but uses **two** positioned enemies and an **`all`-shape pattern** on the player focus so the footprint covers both, and an `'all-enemies'` purge ability. On current code the purge hits only the single anchor → the "both purged" assertion FAILS.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { StatusEngine } from '../statusEngine';
+
+// ---------------------------------------------------------------------------
+// E3: an on-cast purge with ability target 'all-enemies' removes buffs from
+// EVERY footprint victim, not just the single resolved anchor.
+//
+// Harness mirrors purgeCastPath.test.ts (positional two-team battle-sim:
+// healTargetId set unlocks the enemy roster; the focus needs position + parsed
+// target so selectTurnTarget resolves a REAL enemy as the anchor `targetId`).
+// TWO enemies (M4 front + M3) each self-buff "Attack Up" every round. The focus
+// fires an 'all'-shape pattern (footprint = all living enemies), so the footprint
+// covers BOTH. The control uses a single-'enemy' purge (anchor only).
+// ---------------------------------------------------------------------------
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `e3p${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+// 'all'-shape pattern → resolveCells returns all 12 cells as origin (board-geometry
+// resolver: "`all` shape returns all 12 as origin ignoring anchor") → footprintVictims
+// returns every living enemy.
+const allPattern = (): ParsedPattern => ({ raw: 'all', shape: 'all', range: 'all', modifiers: {} });
+
+const attackUp = (): Ability =>
+    ab({
+        type: 'buff',
+        target: 'self',
+        config: {
+            type: 'buff',
+            buffName: 'Attack Up',
+            parsedEffects: { attack: 30 },
+            stacks: 1,
+            isStackable: false,
+            duration: 99,
+        },
+    });
+
+const hit = (): Ability =>
+    ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } });
+
+// An enemy that self-buffs "Attack Up" each round then hits. speed 200 > focus 100 so
+// the enemies act FIRST (apply their buffs) before the focus purges this round.
+const buffingEnemy = (id: string, position: Position) => ({
+    id,
+    stats: { attack: 1000, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 200 },
+    chargeCount: 0,
+    startCharged: false,
+    position,
+    target: parsedTarget('front'),
+    pattern: allPattern(),
+    shipSkills: { slots: [{ slot: 'active' as const, abilities: [attackUp(), hit()] }] },
+});
+
+// Player focus: an 'all-enemies' (AoE) or single-'enemy' purge active + a basic hit so it
+// fires positionally.
+const focusSkills = (aoe: boolean): ShipSkills => ({
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                ab({
+                    type: 'purge',
+                    target: aoe ? 'all-enemies' : 'enemy',
+                    config: { type: 'purge', count: 5 },
+                }),
+                hit(),
+            ],
+        },
+    ],
+});
+
+const BASE = (aoe: boolean): CombatEngineInput => ({
+    attack: 5000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: focusSkills(aoe),
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 3,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000, // focus immortal so the battle runs all rounds
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedTarget('front'),
+    pattern: allPattern(), // focus AoE pattern → footprint = all living enemies
+    enemyAttackers: [buffingEnemy('enemy-front', 'M4'), buffingEnemy('enemy-back', 'M3')],
+});
+
+const finalSelfBuffs = (aoe: boolean, enemyId: string): string[] => {
+    idc = 0;
+    let engine: StatusEngine | undefined;
+    runCombat({
+        ...BASE(aoe),
+        __testTapStatusEngine: (e) => {
+            engine = e;
+        },
+    });
+    return engine!.timedAbilityStatuses('self', enemyId).map((b) => b.active.buffName);
+};
+
+describe('E3: on-cast all-enemies purge removes buffs from every footprint victim', () => {
+    it('an all-enemies purge strips the self-buff from BOTH enemies', () => {
+        expect(finalSelfBuffs(true, 'enemy-front')).toEqual([]);
+        expect(finalSelfBuffs(true, 'enemy-back')).toEqual([]);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails on the multi-victim assertion**
+
+Run: `npx vitest run src/utils/combat/__tests__/aoePurge.test.ts`
+Expected: FAIL — `enemy-front` is purged (`[]`) but `enemy-back` keeps `['Attack Up']` (single-anchor today). Confirm the failure is the `enemy-back` expectation, NOT a harness/setup error (if `enemy-front` is also non-empty, the positional anchor resolution is wrong — fix the test before proceeding).
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+git add -f docs/superpowers/plans/2026-06-19-per-victim-aoe-E3-aoe-purge.md
+git add src/utils/combat/__tests__/aoePurge.test.ts
+git commit -m "test(combat): E3 — failing AoE-purge multi-victim test (red)"
+```
+(Plan is gitignored under `docs/` → `git add -f`; commit with `--no-verify` only if the pre-commit hook blocks on the not-yet-passing test — but prefer keeping the red commit local; if the hook runs the full suite and fails, use `git commit --no-verify`.)
+
+---
+
+### Task 2: Thread `aoeVictimIds` and route the all-enemies purge over it (green)
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts:46` (import), `:2670-2711` (`buildTurnArgs`)
+- Modify: `src/utils/combat/playerTurn.ts:~252` (`PlayerTurnArgs`), `:~609` (destructure), `:1386-1416` (purge loop)
+
+- [ ] **Step 1: Add `footprintVictims` to the engine import**
+
+`src/utils/combat/engine.ts:46` — change:
+```typescript
+import { applyPositionalDamage } from './positionalApply';
+```
+to:
+```typescript
+import { applyPositionalDamage, footprintVictims } from './positionalApply';
+```
+
+- [ ] **Step 2: Compute + return `aoeVictimIds` in `buildTurnArgs`**
+
+`src/utils/combat/engine.ts` — inside `buildTurnArgs` (just after `const maxHp = rt.hp;` at ~2673), add:
+```typescript
+            // E3 (AoE purge): footprint victim ids for an 'all-enemies' on-cast purge.
+            // Computed ONLY when positional — `tgt.position != null` is the positional
+            // discriminator (selectTurnTarget returns the dummy/heal-target sink, which has
+            // no position, in DPS/healing-single mode). footprintVictims is the same pure
+            // resolver the AoE damage path uses; covered cells are included (status removal is
+            // uniform across the footprint, unlike the 50% damage scale). Non-positional →
+            // undefined → the playerTurn purge loop falls back to the single anchor →
+            // byte-identical. The purge ability gates on `target === 'all-enemies'`, so single-
+            // 'enemy' purges ignore this regardless.
+            const aoePattern = parsedPatternFor(a);
+            const aoeTarget = parsedTargetFor(a);
+            const aoeVictimIds =
+                aoePattern != null && aoeTarget != null && tgt.position != null
+                    ? footprintVictims(aoePattern, tgt.position, tb.opposingRoster).map(
+                          (h) => h.victim.id
+                      )
+                    : undefined;
+```
+Then add to the returned object literal (alongside the other conditional spreads, e.g. after the `targetId` spread at ~2684):
+```typescript
+                ...(aoeVictimIds ? { aoeVictimIds } : {}),
+```
+
+- [ ] **Step 3: Add `aoeVictimIds` to `PlayerTurnArgs` and destructure it**
+
+`src/utils/combat/playerTurn.ts` — in `interface PlayerTurnArgs` (near `targetId?: string;` at ~252), add:
+```typescript
+    /**
+     * E3 (AoE purge): the firing skill's footprint victim ids, supplied by the engine in
+     * positional mode. The on-cast purge fans an 'all-enemies' purge over these instead of the
+     * single `targetId`. Absent for non-positional callers → single-anchor (byte-identical).
+     */
+    aoeVictimIds?: string[];
+```
+And add `aoeVictimIds` to the args destructure (near `targetId,` at ~609):
+```typescript
+        aoeVictimIds,
+```
+
+- [ ] **Step 4: Route the on-cast purge over the footprint victims**
+
+`src/utils/combat/playerTurn.ts:1392-1416` — replace the purge block body. New version:
+```typescript
+    if (targetId !== undefined) {
+        for (const ab of gatedSkill?.abilities ?? []) {
+            if (
+                ab.config.type === 'purge' &&
+                ab.trigger === 'on-cast' &&
+                conditionsMet(ab.conditions, ctx)
+            ) {
+                // E3: an 'all-enemies' purge fans out to EVERY footprint victim (aoeVictimIds,
+                // supplied by the engine in positional mode). Single-'enemy' purges — and any
+                // caller without a footprint (non-positional) — stay on the single anchor
+                // `targetId`. Each victim emits its own purge-performed (Salvation/Sefuba are
+                // victim-scoped). (Amartya's per-victim COUNT scaling is E4; this ships at the
+                // parsed count.)
+                const recipients =
+                    ab.target === 'all-enemies' && aoeVictimIds ? aoeVictimIds : [targetId];
+                for (const vid of recipients) {
+                    const removed = statusEngine.purge(vid, ab.config.count);
+                    if (removed > 0) {
+                        bus.emit({
+                            type: 'purge-performed',
+                            casterId: actor.id,
+                            targetId: vid,
+                            count: removed,
+                            round: r,
+                        });
+                    }
+                }
+            }
+        }
+    }
+```
+
+- [ ] **Step 5: Run the Task-1 test — verify it passes**
+
+Run: `npx vitest run src/utils/combat/__tests__/aoePurge.test.ts`
+Expected: PASS (both enemies `[]`).
+
+- [ ] **Step 6: Verify production byte-identical + typecheck**
+
+Run: `npx vitest run src/utils/combat/__tests__/purgeCastPath.test.ts src/utils/combat/__tests__/twoTeamBattle.test.ts src/utils/combat/__tests__/positionalDamage.integration.test.ts && git status --porcelain | grep '\.snap' || echo "NO SNAP MOVEMENT"`
+Expected: all PASS, `NO SNAP MOVEMENT`.
+
+Run: `npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/utils/combat/engine.ts src/utils/combat/playerTurn.ts
+git commit -m "feat(combat): E3 — route on-cast all-enemies purge over footprint victims"
+```
+
+---
+
+### Task 3: Broaden coverage — control, side-symmetry, per-victim count, single-target safety
+
+**Files:**
+- Modify: `src/utils/combat/__tests__/aoePurge.test.ts`
+
+Add these `it` blocks / a side-symmetry `describe` using the same harness. Each is one assertion of an independent guarantee.
+
+- [ ] **Step 1: CONTROL — a single-'enemy' purge hits only the anchor**
+
+```typescript
+    it('CONTROL: a single-enemy purge strips only the anchor (front-most), not the back enemy', () => {
+        expect(finalSelfBuffs(false, 'enemy-front')).toEqual([]); // anchor purged
+        expect(finalSelfBuffs(false, 'enemy-back')).toEqual(['Attack Up']); // untouched
+    });
+```
+
+- [ ] **Step 2: Per-victim count is honoured independently**
+
+Add a variant where each enemy carries TWO removable buffs and the purge count is 1 → each enemy loses exactly one (newest-first), proving the count applies per victim (not pooled). (Extend `buffingEnemy` with a second self-buff via a small local helper, or add a second `describe` block modelled on the `count:'all'` suite in `purgeCastPath.test.ts`.) Assert both enemies retain exactly one buff after a `count:1` all-enemies purge.
+
+- [ ] **Step 3: SIDE-SYMMETRY — an enemy all-enemies purge strips both players**
+
+Add a `describe` mirroring the side-symmetry suite in `purgeCastPath.test.ts`: TWO player actors (the focus `attacker` at M4 + a team actor at M3) each self-buff "Attack Up"; a single ENEMY at M4 fires an `'all-enemies'` purge with an `all`-shape pattern (speed < players so it purges after they buff). Assert BOTH players' self-buff stores are emptied. Read player team-actor stores via `timedAbilityStatuses('self', <teamActorId>)`. (If wiring a second player team actor is heavy, this can instead assert the focus alone is purged via the enemy path — but prefer the two-player form to actually exercise multi-victim on the enemy side.)
+
+- [ ] **Step 4: Run the file — all green**
+
+Run: `npx vitest run src/utils/combat/__tests__/aoePurge.test.ts`
+Expected: PASS (all blocks).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/__tests__/aoePurge.test.ts
+git commit -m "test(combat): E3 — control, per-victim count, side-symmetry coverage"
+```
+
+---
+
+### Task 4: Documentation, no-change site notes, changelog, spec closeout
+
+**Files:**
+- Modify: `src/utils/combat/playerTurn.ts` (purge comment refresh)
+- Modify: `src/utils/combat/triggers.ts` (reactive purge — one-line "single-target by design" note)
+- Modify: `src/utils/combat/engine.ts` (end-of-round purge — one-line note, optional)
+- Modify: `docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md`
+- Modify: `src/constants/changelog.ts`
+
+- [ ] **Step 1: Refresh the on-cast purge comment**
+
+In `playerTurn.ts` purge block: the stale C2a line `'all-enemies' purges only the single targetId in C2a (single-anchor; multi-victim AoE → sub-project E).` was replaced by the E3 routing comment in Task 2 — confirm no other comment still claims single-anchor AoE. The header comment (`On-cast purge (C2a/C2b-3)...`) can gain "E3: all-enemies fans over the footprint" for accuracy.
+
+- [ ] **Step 2: Annotate the no-change sites**
+
+Add a one-line comment at the **reactive purge** executor (`triggers.ts`, `cfg.type==='purge'` branch) noting it is single-target by design (counter-attacker / killer / most-buffs); no `'all-enemies'` reactive purge exists and the footprint is unreachable at drain time (out of E3 scope). Optionally the same at the end-of-round (Rhodium) drain. Do NOT change behaviour.
+
+- [ ] **Step 3: Spec closeout**
+
+Append to the spec's "E3 — AoE purge/cleanse" section an **`> E3 SHIPPED`** note (mirroring the E1/E2 notes): on-cast `'all-enemies'` purge now fans over the footprint via `footprintVictims` threaded through `buildTurnArgs` → `aoeVictimIds`; single-`enemy` purges, cleanse (already loops all-allies), reactive + end-of-round purges (single-target by design) unchanged; production byte-identical (no `'all-enemies'`-purge fixture); Amartya count-scaling still deferred to E4.
+
+- [ ] **Step 4: Changelog**
+
+Add a plain-English entry to `UNRELEASED_CHANGES` in `src/constants/changelog.ts`, e.g.: *"Combat simulator: area-of-effect purge skills now remove buffs from every enemy they hit, not just the primary target."*
+
+- [ ] **Step 5: Final full gate**
+
+Run: `npx vitest run`
+Expected: full suite green (baseline + the new `aoePurge.test.ts` cases; **zero `.snap` movement**).
+
+Run: `npm run lint && npx tsc --noEmit && npm run audit:skills`
+Expected: lint 0 warnings, tsc clean, audit 0 findings / 141 ships.
+
+Run: `git status --porcelain | grep '\.snap' || echo "NO SNAP MOVEMENT"`
+Expected: `NO SNAP MOVEMENT`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/combat/playerTurn.ts src/utils/combat/triggers.ts src/utils/combat/engine.ts src/constants/changelog.ts
+git add -f docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md
+git commit -m "docs(combat): E3 — changelog, no-change-site notes, spec closeout"
+```
+
+---
+
+## Out of scope (deferred, per spec §4 / §6)
+
+- **Amartya per-victim count scaling** `count = floor(critDamage / 50)` → **E4** (builds on this multi-victim loop).
+- **Reactive / end-of-round AoE purge** — no corpus case; footprint unreachable at drain time.
+- **Per-victim leech / intake accounting** → E1/E2 (shipped, separate PRs #122/#123).
+- **Per-victim repair (Nayra) + credit unification** → E5.

--- a/docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md
+++ b/docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md
@@ -146,6 +146,20 @@ per hit; E3 routes `statusEngine.purge` to each. For reference, the already-loop
 cleanse (`playerTurn.ts:1624`) and reactive cleanse (`triggers.ts:1190`); end-of-round reactive purge
 (Rhodium) lives at `engine.ts:4136` and should be checked for the same per-victim treatment.
 
+> **E3 SHIPPED** (2026-06-19, commits `7f64a2d8`→`9f88fa9c`). On-cast purges whose ability
+> target is `'all-enemies'` now fan over the firing skill's footprint: `buildTurnArgs` computes
+> the footprint victim ids via `footprintVictims(pattern, anchor, opposingRoster)` when positional
+> (`tgt.position != null` discriminator) and threads them as `aoeVictimIds` into all three
+> `runPlayerTurn` sites; the on-cast purge loop routes `ab.target === 'all-enemies' && aoeVictimIds
+> ? aoeVictimIds : [targetId]`, emitting `purge-performed` per victim. Single-`'enemy'` purges,
+> cleanse (already loops all-allies), and the reactive + end-of-round purges (single-target by
+> design — counter-attacker / killer / most-buffs; footprint unreachable at drain) are unchanged.
+> Production byte-identical: **zero `.snap` movement** (no `'all-enemies'`-purge fixture exists —
+> the only one, Amartya, has no golden). New `aoePurge.test.ts` (5 tests: AoE-both / single-anchor
+> control / per-victim count independence / enemy-side side-symmetry + its non-purge control).
+> **Amartya's `count = floor(critDamage/50)` scaling stays deferred to E4** (this ships at the
+> parsed count 1).
+
 **E4 — Amartya.** `count = floor(casterCritDamage / 50)` (crit power = the `critDamage` stat),
 computed from the caster's **live** crit power at cast time, applied to **every** footprint victim.
 Builds on E3's multi-victim loop. Removes the C2a single-anchor count-1 under-approximation flag.

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -7,6 +7,7 @@ export const CURRENT_VERSION = '1.64.0';
 // and bump CURRENT_VERSION. All three steps must happen together.
 export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator: lifesteal/leech (heal or shield from damage dealt or taken) now works per ship — each ship heals or shields itself off its own damage, and AoE splash leeches off the reduced (covered-cell) splash damage.',
+    'Combat simulator: area-of-effect purge skills now remove buffs from every enemy they hit, not just the primary target.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/combat/__tests__/aoePurge.test.ts
+++ b/src/utils/combat/__tests__/aoePurge.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { StatusEngine } from '../statusEngine';
+
+// ---------------------------------------------------------------------------
+// E3: an on-cast purge with ability target 'all-enemies' removes buffs from
+// EVERY footprint victim, not just the single resolved anchor.
+//
+// Harness mirrors purgeCastPath.test.ts (positional two-team battle-sim:
+// healTargetId set unlocks the enemy roster; the focus needs position + parsed
+// target so selectTurnTarget resolves a REAL enemy as the anchor `targetId`).
+// TWO enemies (M4 front + M3) each self-buff "Attack Up" every round. The focus
+// fires an 'all'-shape pattern (footprint = all living enemies), so the footprint
+// covers BOTH. The control uses a single-'enemy' purge (anchor only).
+// ---------------------------------------------------------------------------
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `e3p${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+const allPattern = (): ParsedPattern => ({ raw: 'all', shape: 'all', range: 'all', modifiers: {} });
+
+const attackUp = (): Ability =>
+    ab({
+        type: 'buff',
+        target: 'self',
+        config: {
+            type: 'buff',
+            buffName: 'Attack Up',
+            parsedEffects: { attack: 30 },
+            stacks: 1,
+            isStackable: false,
+            duration: 99,
+        },
+    });
+
+const hit = (): Ability =>
+    ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } });
+
+const buffingEnemy = (id: string, position: Position) => ({
+    id,
+    stats: { attack: 1000, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 200 },
+    chargeCount: 0,
+    startCharged: false,
+    position,
+    target: parsedTarget('front'),
+    pattern: allPattern(),
+    shipSkills: { slots: [{ slot: 'active' as const, abilities: [attackUp(), hit()] }] },
+});
+
+const focusSkills = (aoe: boolean): ShipSkills => ({
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                ab({
+                    type: 'purge',
+                    target: aoe ? 'all-enemies' : 'enemy',
+                    config: { type: 'purge', count: 5 },
+                }),
+                hit(),
+            ],
+        },
+    ],
+});
+
+const BASE = (aoe: boolean): CombatEngineInput => ({
+    attack: 5000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: focusSkills(aoe),
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 3,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedTarget('front'),
+    pattern: allPattern(),
+    enemyAttackers: [buffingEnemy('enemy-front', 'M4'), buffingEnemy('enemy-back', 'M3')],
+});
+
+const finalSelfBuffs = (aoe: boolean, enemyId: string): string[] => {
+    idc = 0;
+    let engine: StatusEngine | undefined;
+    runCombat({
+        ...BASE(aoe),
+        __testTapStatusEngine: (e) => {
+            engine = e;
+        },
+    });
+    return engine!.timedAbilityStatuses('self', enemyId).map((b) => b.active.buffName);
+};
+
+describe('E3: on-cast all-enemies purge removes buffs from every footprint victim', () => {
+    it('an all-enemies purge strips the self-buff from BOTH enemies', () => {
+        expect(finalSelfBuffs(true, 'enemy-front')).toEqual([]);
+        expect(finalSelfBuffs(true, 'enemy-back')).toEqual([]);
+    });
+
+    it('CONTROL: a single-enemy purge strips only the anchor (front-most), not the back enemy', () => {
+        expect(finalSelfBuffs(false, 'enemy-front')).toEqual([]); // anchor purged
+        expect(finalSelfBuffs(false, 'enemy-back')).toEqual(['Attack Up']); // untouched
+    });
+});

--- a/src/utils/combat/__tests__/aoePurge.test.ts
+++ b/src/utils/combat/__tests__/aoePurge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { runCombat, CombatEngineInput } from '../engine';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
 import { Ability, ShipSkills } from '../../../types/abilities';
 import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
 import type { Position } from '../../../types/encounters';
@@ -126,5 +126,237 @@ describe('E3: on-cast all-enemies purge removes buffs from every footprint victi
     it('CONTROL: a single-enemy purge strips only the anchor (front-most), not the back enemy', () => {
         expect(finalSelfBuffs(false, 'enemy-front')).toEqual([]); // anchor purged
         expect(finalSelfBuffs(false, 'enemy-back')).toEqual(['Attack Up']); // untouched
+    });
+});
+
+// ---------------------------------------------------------------------------
+// E3 Test A — per-victim count is NOT pooled across the footprint.
+//
+// Each enemy carries TWO removable self-buffs: "Attack Up" (applied first) and
+// "Defence Up" (applied second, higher appliedSeq). The focus fires an
+// 'all-enemies' purge with count: 1. The engine calls purge(victimId, 1) for
+// EACH victim independently — removing the NEWEST buff (Defence Up) and leaving
+// the oldest (Attack Up). If the count were pooled as a shared budget of 1, only
+// ONE of the two enemies would lose a buff; both losing exactly one proves
+// per-victim application.
+// ---------------------------------------------------------------------------
+describe('E3: per-victim purge count is independent — count:1 removes one buff per victim, not one total', () => {
+    const defenceUp = (): Ability =>
+        ab({
+            type: 'buff',
+            target: 'self',
+            config: {
+                type: 'buff',
+                buffName: 'Defence Up',
+                parsedEffects: { defense: 20 },
+                stacks: 1,
+                isStackable: false,
+                duration: 99,
+            },
+        });
+
+    // A two-buff enemy: applies "Attack Up" THEN "Defence Up" every round, then hits.
+    // appliedSeq for "Defence Up" > appliedSeq for "Attack Up" → "Defence Up" is newest-first,
+    // so a count:1 purge removes "Defence Up" and leaves "Attack Up".
+    const twoBuffEnemy = (id: string, position: Position) => ({
+        id,
+        stats: { attack: 1000, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 200 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget('front'),
+        pattern: allPattern(),
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active' as const,
+                    abilities: [attackUp(), defenceUp(), hit()],
+                },
+            ],
+        },
+    });
+
+    // Focus: count:1 all-enemies purge + a basic hit so the positional harness fires.
+    const countOnePurgeSkills = (): ShipSkills => ({
+        slots: [
+            {
+                slot: 'active',
+                abilities: [
+                    ab({
+                        type: 'purge',
+                        target: 'all-enemies',
+                        config: { type: 'purge', count: 1 },
+                    }),
+                    hit(),
+                ],
+            },
+        ],
+    });
+
+    const run = (): { front: string[]; back: string[] } => {
+        idc = 0;
+        let engine: StatusEngine | undefined;
+        runCombat({
+            ...BASE(false /* aoe flag unused; we override shipSkills below */),
+            shipSkills: countOnePurgeSkills(),
+            enemyAttackers: [twoBuffEnemy('enemy-front', 'M4'), twoBuffEnemy('enemy-back', 'M3')],
+            __testTapStatusEngine: (e) => {
+                engine = e;
+            },
+        });
+        return {
+            front: engine!
+                .timedAbilityStatuses('self', 'enemy-front')
+                .map((b) => b.active.buffName),
+            back: engine!.timedAbilityStatuses('self', 'enemy-back').map((b) => b.active.buffName),
+        };
+    };
+
+    it('count:1 all-enemies purge removes exactly one buff from EACH enemy (newest Defence Up removed, Attack Up survives)', () => {
+        const { front, back } = run();
+        // Each enemy had two buffs; count:1 removes the newest-applied one ("Defence Up"),
+        // leaving exactly one buff on each. The budget is per-victim — if pooled, one enemy
+        // would keep both buffs.
+        expect(front).toHaveLength(1);
+        expect(front).toContain('Attack Up');
+        expect(back).toHaveLength(1);
+        expect(back).toContain('Attack Up');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// E3 Test B — side-symmetry: an ENEMY all-enemies purge strips BOTH player buffs.
+//
+// Mirror of the player→enemy direction: two POSITIONED player actors both
+// self-buff "Attack Up" each round. A single enemy fires an 'all'-pattern
+// 'all-enemies' purge (count 5). Enemy speed is 50 < player speed 100, so the
+// players act FIRST each round (self-buff), then the enemy purges — otherwise
+// the enemy purges an empty store and players re-buff after (turn-order, not a
+// plumbing gap — see purgeCastPath.test.ts side-symmetry comment).
+//
+// The focus ('attacker') carries its own active self-buff + hit. A walked team
+// actor at M3 ('player-team') does the same via its walk bundle. Both players'
+// self-buff stores are read via timedAbilityStatuses('self', id) after the run.
+// ---------------------------------------------------------------------------
+describe('E3: enemy all-enemies purge is side-symmetric — strips BOTH player self-buffs', () => {
+    // Player focus self-buffs then hits — same active as the existing buffingEnemy helper.
+    const selfBuffThenHitSkills = (): ShipSkills => ({
+        slots: [{ slot: 'active', abilities: [attackUp(), hit()] }],
+    });
+
+    // The single enemy: fires 'all-enemies' purge (count 5) + basic hit when purge=true,
+    // or a plain hit-only active when purge=false (the control). Pattern 'all' so the
+    // footprint covers EVERY positioned player. Speed 50 < player speed 100 so the
+    // players self-buff first each round before the enemy acts.
+    const purgeEnemy = (purge: boolean) => ({
+        id: 'enemy-front',
+        stats: { attack: 1000, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 50 },
+        chargeCount: 0,
+        startCharged: false,
+        position: 'M4' as Position,
+        target: parsedTarget('front'),
+        pattern: allPattern(),
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active' as const,
+                    abilities: purge
+                        ? [
+                              ab({
+                                  type: 'purge',
+                                  target: 'all-enemies',
+                                  config: { type: 'purge', count: 5 },
+                              }),
+                              hit(),
+                          ]
+                        : [hit()],
+                },
+            ],
+        },
+    });
+
+    // Walked team actor at M3 — same harness shape as twoTeamBattle.test.ts teamAttackerAt,
+    // but the walk shipSkills self-buff + hit. Speed 100 (default), so acts BEFORE the enemy.
+    const playerTeamActor = (): TeamActorEngineInput => ({
+        id: 'player-team',
+        speed: 100,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position: 'M3',
+        target: parsedTarget('front'),
+        pattern: allPattern(),
+        walk: {
+            shipSkills: selfBuffThenHitSkills(),
+            stats: {
+                attack: 500,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 200,
+                defence: 0,
+                hp: 1_000_000_000,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    });
+
+    const run = (purge: boolean): { focus: string[]; team: string[] } => {
+        idc = 0;
+        let engine: StatusEngine | undefined;
+        runCombat({
+            // Focus actor — self-buffs then hits, speed 100 (acts before the speed-50 enemy).
+            attack: 5000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: selfBuffThenHitSkills(),
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 3,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            healTargetId: 'attacker',
+            position: 'M4',
+            target: parsedTarget('front'),
+            pattern: allPattern(),
+            teamActors: [playerTeamActor()],
+            enemyAttackers: [purgeEnemy(purge)],
+            __testTapStatusEngine: (e) => {
+                engine = e;
+            },
+        });
+        return {
+            focus: engine!.timedAbilityStatuses('self', 'attacker').map((b) => b.active.buffName),
+            team: engine!.timedAbilityStatuses('self', 'player-team').map((b) => b.active.buffName),
+        };
+    };
+
+    it('CONTROL (enemy does not purge): both players KEEP their self-buff', () => {
+        const { focus, team } = run(false);
+        expect(focus).toEqual(['Attack Up']);
+        expect(team).toEqual(['Attack Up']);
+    });
+
+    it('an ENEMY all-enemies purge empties the self-buff store of BOTH positioned players', () => {
+        const { focus, team } = run(true);
+        expect(focus).toEqual([]);
+        expect(team).toEqual([]);
     });
 });

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -43,7 +43,7 @@ import {
 } from './statusEngine';
 import { liveGateConditions } from './abilityStatusGating';
 import { isPositional, resolvePositionalTarget } from './positionalBinding';
-import { applyPositionalDamage, type VictimDamageOutcome } from './positionalApply';
+import { applyPositionalDamage, footprintVictims, type VictimDamageOutcome } from './positionalApply';
 import type { AttackerDamageScalars } from './victimDamage';
 import { CHEAT_DEATH_BUFFS } from './cheatDeathBuffs';
 import { BARRIER_BUFFS } from './barrierBuffs';
@@ -2829,6 +2829,22 @@ export function runCombat(input: CombatEngineInput): {
             const tb = turnBindings(a.side);
             const rt = runtimeFor(a);
             const maxHp = rt.hp; // unified denom (baseHpFor(id) === runtimeFor(id).hp)
+            // E3 (AoE purge): footprint victim ids for an 'all-enemies' on-cast purge.
+            // Computed ONLY when positional — `tgt.position != null` is the positional
+            // discriminator (selectTurnTarget returns the position-less dummy/heal-target sink
+            // in DPS/healing-single mode). footprintVictims is the same pure resolver the AoE
+            // damage path uses; covered cells are included (status removal is uniform across the
+            // footprint). Non-positional → undefined → the playerTurn purge loop falls back to
+            // the single anchor → byte-identical. The purge ability gates on
+            // target === 'all-enemies', so single-'enemy' purges ignore this regardless.
+            const aoePattern = parsedPatternFor(a);
+            const aoeTarget = parsedTargetFor(a); // parse-completeness guard only (not a footprint arg)
+            const aoeVictimIds =
+                aoePattern != null && aoeTarget != null && tgt.position != null
+                    ? footprintVictims(aoePattern, tgt.position, tb.opposingRoster).map(
+                          (h) => h.victim.id
+                      )
+                    : undefined;
             return {
                 runtime: rt,
                 enemy: tgt,
@@ -2865,6 +2881,7 @@ export function runCombat(input: CombatEngineInput): {
                 targetRepairedThisRound: repairedThisRound.has(tgt.id),
                 enemyBuffNames: tb.enemyBuffNamesUnion(),
                 selfDebuffNames: ownerDebuffNames(a.id),
+                ...(aoeVictimIds ? { aoeVictimIds } : {}),
             };
         };
 

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -4342,6 +4342,7 @@ export function runCombat(input: CombatEngineInput): {
         // round-ended (C2b-2): end-of-round reactive purge (Rhodium). Emitted at the round TAIL,
         // after the post-round death drain so the purge sees post-death state, before roundData
         // assembly. Drain BOTH queues (player + enemy), mirroring the round-started emit+drain.
+        // Drains the single-target reactive executor (most-buffs) — single-target by design, out of E3 scope.
         bus.emit({ type: 'round-ended', round: r });
         drainIntents();
         drainEnemyIntents();

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -273,6 +273,12 @@ export interface PlayerTurnArgs {
      *  channel apply boundaries (non-positional and positional via emitHit override); absent for
      *  DPS/standalone callers → inert (byte-identical). */
     onHitBreakStasis?: (targetId: string) => void;
+    /**
+     * E3 (AoE purge): the firing skill's footprint victim ids, supplied by the engine in
+     * positional mode. The on-cast purge fans an 'all-enemies' purge over these instead of the
+     * single `targetId`. Absent for non-positional callers → single-anchor (byte-identical).
+     */
+    aoeVictimIds?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -616,6 +622,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         selfDebuffNames: selfDebuffNamesArg = [],
         healEventOnly = false,
         onHitBreakStasis,
+        aoeVictimIds,
     } = args;
 
     const {
@@ -1401,20 +1408,25 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 ab.trigger === 'on-cast' &&
                 conditionsMet(ab.conditions, ctx)
             ) {
-                // 'all-enemies' purges only the single targetId in C2a (single-anchor;
-                // multi-victim AoE → sub-project E).
-                const removed = statusEngine.purge(targetId, ab.config.count);
-                // Emit purge-performed (C2b-1) — on-cast purges are never depth-guarded,
-                // so they ALWAYS emit (when something was removed), triggering Sefuba/
-                // Salvation. Suppressed at 0 removed (honest metric; mirrors cleanse-performed).
-                if (removed > 0) {
-                    bus.emit({
-                        type: 'purge-performed',
-                        casterId: actor.id,
-                        targetId,
-                        count: removed,
-                        round: r,
-                    });
+                // E3: an 'all-enemies' purge fans out to EVERY footprint victim (aoeVictimIds,
+                // supplied by the engine in positional mode). Single-'enemy' purges — and any
+                // caller without a footprint (non-positional) — stay on the single anchor
+                // `targetId`. Each victim emits its own purge-performed (Salvation/Sefuba are
+                // victim-scoped). (Amartya's per-victim COUNT scaling is E4; this ships at the
+                // parsed count.)
+                const recipients =
+                    ab.target === 'all-enemies' && aoeVictimIds ? aoeVictimIds : [targetId];
+                for (const vid of recipients) {
+                    const removed = statusEngine.purge(vid, ab.config.count);
+                    if (removed > 0) {
+                        bus.emit({
+                            type: 'purge-performed',
+                            casterId: actor.id,
+                            targetId: vid,
+                            count: removed,
+                            round: r,
+                        });
+                    }
                 }
             }
         }

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1401,6 +1401,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     // no buffs) → no-op → byte-identical. NOT inside the args.healing gate.
     // conditionsMet() enforces any ability-level gates (e.g. Nayra's target-repaired-this-round
     // condition) so conditional purges only fire when their precondition holds.
+    // E3: 'all-enemies' purge ability fans over the footprint victims (aoeVictimIds) instead of just targetId.
     if (targetId !== undefined) {
         for (const ab of gatedSkill?.abilities ?? []) {
             if (

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -413,7 +413,11 @@ export function registerReactiveListeners(args: {
                         if (e.casterId === ownerId)
                             enqueue({
                                 ...intent,
-                                eventCtx: { ...intent.eventCtx, counterTargetId: e.targetId, fromPurgeEvent: true },
+                                eventCtx: {
+                                    ...intent.eventCtx,
+                                    counterTargetId: e.targetId,
+                                    fromPurgeEvent: true,
+                                },
                             });
                     });
                     break;
@@ -424,7 +428,11 @@ export function registerReactiveListeners(args: {
                         if (isSameSideAlly(e.targetId, ownerId))
                             enqueue({
                                 ...intent,
-                                eventCtx: { ...intent.eventCtx, damagedAllyId: e.targetId, fromPurgeEvent: true },
+                                eventCtx: {
+                                    ...intent.eventCtx,
+                                    damagedAllyId: e.targetId,
+                                    fromPurgeEvent: true,
+                                },
                             });
                     });
                     break;
@@ -1229,6 +1237,9 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
     }
 
     if (cfg.type === 'purge') {
+        // Single-target BY DESIGN (counter-attacker / killer / most-buffs routing) — out of E3's
+        // AoE scope: no 'all-enemies' reactive purge exists in the corpus and the firing skill's
+        // footprint (pattern + opposing roster) is not reachable at drain time.
         // Reactive purge (C2b): remove buffs from the victim. Target = the routed
         // attacker/killer (counterTargetId — set by on-attacked/on-destroyed in C2b-2,
         // and by on-enemy-purged for Sefuba's chain victim-routing) else the turn's


### PR DESCRIPTION
## Summary

Sub-project **E3** of the per-victim AoE accounting epic (Thread-2 status work, independent of E1/E2).

- On-cast purges whose ability `target === 'all-enemies'` now remove buffs from **every footprint victim** of the firing skill's pattern, instead of only the single resolved anchor.
- Mechanism: `buildTurnArgs` (engine.ts) computes the footprint victim ids via the existing pure `footprintVictims(pattern, anchor, opposingRoster)` resolver **when positional** (`tgt.position != null` discriminator), threading them as `aoeVictimIds` into all three `runPlayerTurn` sites (focus / team / enemy — all spread `...buildTurnArgs`). The on-cast purge loop routes `ab.target === 'all-enemies' && aoeVictimIds ? aoeVictimIds : [targetId]`, emitting `purge-performed` **per victim** (Salvation/Sefuba reactors are victim-scoped).
- **Side-symmetric** (player and enemy casters), **covered cells included** (status removal is uniform across the footprint — not scaled by the 50% damage `roleScale`).

**Unchanged, by design (documented in-code):** single-`'enemy'` purges (single anchor); cleanse (already loops all-allies = whole team); reactive purge (Iridium/Faust/Rhodium) and end-of-round purge — all single-target (counter-attacker / killer / most-buffs), and the footprint is unreachable at drain time. The only AoE purge in the corpus is **Amartya**; its `count = floor(critDamage / 50)` crit-power scaling stays **deferred to E4**, which rides this multi-victim loop (E3 ships at the parsed count 1).

## Test Plan

- [x] New `aoePurge.test.ts` (5 tests, proven non-vacuous by neutering the routing): AoE strips both enemies / single-`'enemy'` control strips only the anchor / per-victim count independence (`count:1` removes one per victim, not pooled) / enemy-side side-symmetry strips both players + its no-purge control (both players provably carry the buff first).
- [x] **Production byte-identical** — zero `.snap` movement (working tree and `main...HEAD`); no existing fixture carries an `'all-enemies'` purge.
- [x] Full suite green (2669 tests), `npm run lint` 0 warnings, `npx tsc --noEmit` clean, `npm run audit:skills` 0 findings / 141 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)