### PR TITLE
feat(combat): E4 — Amartya crit-power-scaled purge

### DIFF
--- a/docs/superpowers/plans/2026-06-20-combat-realism-E4-amartya-crit-purge.md
+++ b/docs/superpowers/plans/2026-06-20-combat-realism-E4-amartya-crit-purge.md
@@ -1,0 +1,377 @@
+# E4 — Amartya Crit-Power-Scaled Purge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Amartya's charge purge count scale with the caster's live crit power — `count = configCount × floor(effectiveCritDamage / per)` — applied to every footprint victim, instead of the static parsed count of 1.
+
+**Architecture:** Add an optional `countScaling` descriptor to the purge ability config. The parser (`parsePurge`) detects "for every N% crit power" in the purge sentence and attaches `{ stat: 'critDamage', per: N }`. `buildShipAbilities` threads it onto the config. The on-cast purge apply site (`playerTurn.ts:1421`) computes the live count from `effectiveCritDamage` (already in scope) when the descriptor is present, else uses the static count.
+
+**Tech Stack:** TypeScript, Vitest. Combat engine in `src/utils/combat/`, skill parser in `src/utils/skillTextParser.ts`, ability builder in `src/utils/abilities/buildShipAbilities.ts`.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-combat-realism-E-tail-design.md` §3.
+
+**Gameplay reference:** Amartya charge skill text — "This Unit deals 210% damage and purges 1 buff from all enemies for every 50% crit power this Unit has." `critDamage` is a percentage-only stat stored as an integer (base 50; e.g. 150 = 150%), so 150 crit power → 3 purges, 100 → 2, 50 → 1, <50 → 0.
+
+**Faithful formula:** total purged = `count × floor(effectiveCritDamage / per)`. For Amartya, `count = 1` (the per-tier buff amount) and `per = 50`, so total = `floor(critDamage / 50)`. The `count ×` factor generalizes to a hypothetical "purges 2 buffs for every 50% crit power"; it is 1× for the only corpus match.
+
+---
+
+## Workflow notes (binding)
+
+- `gh auth switch --hostname github.com --user TheSusort` before any PR ops; dev server on :3000.
+- Run tests with `npx vitest run <path-or-name>` — **bare `npm test` is Vitest watch and hangs**.
+- Run `npx tsc --noEmit` independently after each implementation step — esbuild-based Vitest does **not** typecheck, so a green test run can hide a type error.
+- `npm run lint` enforces `--max-warnings 0`; run it in every task gate, not just the last.
+- Goldens are synthetic → any `.snap` movement is a bug here (Amartya has no golden fixture). Never `vitest -u`.
+- Branch off current `main`: `git checkout -b feat/combat-E4-amartya-crit-purge`.
+
+---
+
+## File structure
+
+- `src/types/abilities.ts` — add optional `countScaling` to the cleanse/purge config union member (~line 261).
+- `src/utils/skillTextParser.ts` — `parsePurge` (~2135) detects the crit-power phrase and returns `countScaling`; add a `CRIT_POWER_SCALING_RE`.
+- `src/utils/abilities/buildShipAbilities.ts` — thread `p.countScaling` into the emitted purge config (~1100).
+- `src/utils/combat/playerTurn.ts` — compute the live count at the on-cast purge apply site (~1421).
+- `src/utils/__tests__/skillTextParser.test.ts` — parser test for the scaling extraction.
+- `src/utils/combat/__tests__/amartyaCritPurge.test.ts` (new) — apply-side integration: count scales with live crit power, 0-count edge, per-victim in AoE.
+- `src/constants/changelog.ts` — `UNRELEASED_CHANGES` entry.
+
+---
+
+## Task 0: Baseline
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Branch + confirm green baseline**
+
+Run:
+```bash
+git checkout main && git pull --ff-only
+git checkout -b feat/combat-E4-amartya-crit-purge
+npx tsc --noEmit && npm run lint
+npm run audit:skills
+```
+Expected: tsc clean, lint clean, `audit:skills` → `Audited 141 ships → 0 findings.`
+
+- [ ] **Step 2: Confirm Amartya parses as an all-enemies on-cast purge (the per-victim claim depends on it)**
+
+Add a temporary scratch assertion or use an existing test harness. Quickest: a throwaway parser test (delete after).
+
+Run:
+```bash
+npx vitest run skillTextParser -t "purge"
+```
+Then confirm by reading: Amartya's charge text "purges 1 buff from all enemies" → `parsePurge` returns `{ count: 1, target: 'all-enemies', explicitTarget: true }` (the `all enemies` clause → `'all-enemies'`). The charged slot makes `trigger: 'on-cast'` in `buildShipAbilities`. No code change — this is a read/confirm step; record the finding in the commit message of Task 2.
+
+---
+
+## Task 1: Add `countScaling` to the purge config type
+
+**Files:**
+- Modify: `src/types/abilities.ts:261`
+
+- [ ] **Step 1: Extend the union member**
+
+Change:
+```ts
+    | { type: 'cleanse' | 'purge'; count: number | 'all' }
+```
+to:
+```ts
+    | {
+          type: 'cleanse' | 'purge';
+          count: number | 'all';
+          /** E4: purge count scales with a caster stat — total purged =
+           *  count × floor(effectiveStat / per). Only `critDamage` (crit power) is
+           *  used today (Amartya: "purges 1 buff … for every 50% crit power").
+           *  Absent → static `count`. cleanse never sets this. */
+          countScaling?: { stat: 'critDamage'; per: number };
+      }
+```
+
+- [ ] **Step 2: Verify it compiles (field is optional → no consumer breaks)**
+
+Run: `npx tsc --noEmit`
+Expected: clean (optional field, no existing consumer references it).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types/abilities.ts
+git commit -m "feat(combat): E4 — add countScaling to purge ability config (unwired)"
+```
+
+---
+
+## Task 2: Parser — extract "for every N% crit power"
+
+**Files:**
+- Modify: `src/utils/skillTextParser.ts` (`parsePurge` ~2135; add `CRIT_POWER_SCALING_RE` near `PURGE_RE` ~2119)
+- Test: `src/utils/__tests__/skillTextParser.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `skillTextParser.test.ts` (near the existing purge tests):
+```ts
+describe('parsePurge — E4 crit-power scaling', () => {
+    it('extracts countScaling from "for every 50% crit power"', () => {
+        const text =
+            'This Unit deals 210% damage and purges 1 buff from all enemies for every 50% crit power this Unit has.';
+        const [p] = parsePurge(text);
+        expect(p).toMatchObject({
+            count: 1,
+            target: 'all-enemies',
+            countScaling: { stat: 'critDamage', per: 50 },
+        });
+    });
+
+    it('leaves countScaling undefined for a plain purge', () => {
+        const [p] = parsePurge('This Unit purges 2 buffs from the enemy.');
+        expect(p.count).toBe(2);
+        expect(p.countScaling).toBeUndefined();
+    });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run skillTextParser -t "crit-power scaling"`
+Expected: FAIL — `countScaling` is `undefined` (not yet returned).
+
+- [ ] **Step 3: Implement**
+
+Near `PURGE_RE` (~2119) add:
+```ts
+// E4: "for every N% crit power" — purge-count scaling on crit power (Amartya).
+// Sentence-scoped (applied to the purge's own sentence). Matches "for every 50% crit power".
+const CRIT_POWER_SCALING_RE = /for\s+every\s+(\d+)\s*%?\s*crit\s+power/i;
+```
+
+In `parsePurge`, widen the return type and attach the descriptor. Change the return-type annotation and the `results` array element type to include the optional field:
+```ts
+): {
+    count: number | 'all';
+    target: 'enemy' | 'all-enemies';
+    explicitTarget: boolean;
+    countScaling?: { stat: 'critDamage'; per: number };
+}[] {
+```
+(apply the same addition to the local `results` declaration).
+
+Then inside the loop, after computing `sentence` (~2160), before `results.push`:
+```ts
+        const scaleMatch = CRIT_POWER_SCALING_RE.exec(sentence);
+        const countScaling =
+            scaleMatch && typeof count === 'number'
+                ? ({ stat: 'critDamage' as const, per: parseInt(scaleMatch[1], 10) })
+                : undefined;
+        results.push({ count, target, explicitTarget: true, ...(countScaling ? { countScaling } : {}) });
+```
+(`sentence` is already lower-cased at ~2160; `CRIT_POWER_SCALING_RE` is case-insensitive regardless. Guard `typeof count === 'number'` so a nonsensical "purges all … per 50% crit power" never carries scaling.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run skillTextParser -t "crit-power scaling"`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Full parser suite + tsc**
+
+Run: `npx vitest run skillTextParser && npx tsc --noEmit`
+Expected: all green, tsc clean (no other parsePurge consumer broke — `buildShipAbilities` reads `p.count`/`p.target` only, both unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/skillTextParser.ts src/utils/__tests__/skillTextParser.test.ts
+git commit -m "feat(combat): E4 — parse 'for every N% crit power' purge scaling
+
+Amartya charge confirmed to parse as on-cast all-enemies purge, count 1."
+```
+
+---
+
+## Task 3: Thread `countScaling` into the built ability
+
+**Files:**
+- Modify: `src/utils/abilities/buildShipAbilities.ts:1100`
+- Test: extend `src/utils/__tests__/skillTextParser.test.ts` OR a buildShipAbilities test if one exists for purge (check `src/utils/abilities/__tests__/`).
+
+- [ ] **Step 1: Write the failing test**
+
+Locate the existing build test for Amartya/purge (grep `buildShipAbilities` test dir for `purge`). If one exists, add a case; otherwise add to the parser test file a build-level assertion:
+```ts
+import { buildShipAbilities } from '../abilities/buildShipAbilities';
+// ...
+it('E4: built Amartya charge purge carries countScaling', () => {
+    const abilities = buildShipAbilities(/* Amartya rows — mirror an existing build test's fixture */);
+    const purge = abilities.find(
+        (a) => a.config.type === 'purge' && a.trigger === 'on-cast'
+    );
+    expect(purge?.config).toMatchObject({
+        type: 'purge',
+        count: 1,
+        countScaling: { stat: 'critDamage', per: 50 },
+    });
+});
+```
+NOTE: match the exact `buildShipAbilities` call signature used by existing tests in the repo (do not invent fixture shape — copy a working call).
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run buildShipAbilities -t "countScaling"` (or the parser file if co-located)
+Expected: FAIL — `countScaling` absent from the built config.
+
+- [ ] **Step 3: Implement**
+
+At `buildShipAbilities.ts:1100`, change:
+```ts
+                config: { type: 'purge', count: p.count },
+```
+to:
+```ts
+                config: {
+                    type: 'purge',
+                    count: p.count,
+                    ...(p.countScaling ? { countScaling: p.countScaling } : {}),
+                },
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run buildShipAbilities -t "countScaling" && npx tsc --noEmit`
+Expected: PASS, tsc clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/abilities/buildShipAbilities.ts src/utils/__tests__/skillTextParser.test.ts
+git commit -m "feat(combat): E4 — thread purge countScaling into the built ability"
+```
+
+---
+
+## Task 4: Apply — live count at the on-cast purge site
+
+**Files:**
+- Modify: `src/utils/combat/playerTurn.ts:1421`
+- Test: `src/utils/combat/__tests__/amartyaCritPurge.test.ts` (new)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `src/utils/combat/__tests__/amartyaCritPurge.test.ts`. Mirror the harness in the existing `aoePurge.test.ts` (E3) — copy its `runCombat`/positional setup and adapt. Assert:
+  1. A caster with `critDamage: 150` purging an enemy carrying ≥3 removable buffs removes **3**.
+  2. `critDamage: 100` → removes **2**.
+  3. `critDamage: 40` → removes **0** (no `purge-performed` event for that victim).
+  4. In an `all-enemies` AoE over 2 footprint victims each with ≥3 buffs, **each** victim loses 3 (per-victim count independence).
+
+Use a synthetic caster ability `{ type: 'purge', target: 'all-enemies', trigger: 'on-cast', config: { type: 'purge', count: 1, countScaling: { stat: 'critDamage', per: 50 } } }` (build via the same path the E3 test uses, or inject through the ship-skills fixture). Set the caster's effective crit power via its stats (no buffs → base critDamage).
+
+```ts
+// Sketch — adapt exact construction to aoePurge.test.ts's harness:
+it('purges floor(critDamage/50) buffs per victim (150 → 3)', () => {
+    const result = runScenario({ casterCritDamage: 150, victimBuffs: 4 });
+    expect(buffsRemovedFor(result, 'enemy-1')).toBe(3);
+});
+it('0 crit power tiers → no purge, no event (40 → 0)', () => {
+    const result = runScenario({ casterCritDamage: 40, victimBuffs: 4 });
+    expect(purgeEvents(result)).toHaveLength(0);
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run amartyaCritPurge`
+Expected: FAIL — counts come back as 1 (static `ab.config.count`), 0-case removes 1, etc.
+
+- [ ] **Step 3: Implement**
+
+At `playerTurn.ts:1420-1421`, replace:
+```ts
+                for (const vid of recipients) {
+                    const removed = statusEngine.purge(vid, ab.config.count);
+```
+with:
+```ts
+                // E4: when the purge scales on crit power, total purged per victim =
+                // count × floor(live effectiveCritDamage / per). effectiveCritDamage (declared
+                // ~line 1104 = dmgStats.critDamage) is the caster's LIVE crit power (buffs/debuffs
+                // folded), integer percent (e.g. 150). Else the static parsed count.
+                const scaling = ab.config.countScaling;
+                const purgeCount: number | 'all' =
+                    scaling && typeof ab.config.count === 'number'
+                        ? ab.config.count * Math.floor(effectiveCritDamage / scaling.per)
+                        : ab.config.count;
+                for (const vid of recipients) {
+                    const removed = statusEngine.purge(vid, purgeCount);
+```
+(`purgeCount` is hoisted out of the victim loop — same value for every footprint victim; the caster's crit power is constant within the cast.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run amartyaCritPurge`
+Expected: PASS (150→3, 100→2, 40→0/no event, per-victim 3 each).
+
+- [ ] **Step 5: tsc + lint**
+
+Run: `npx tsc --noEmit && npm run lint`
+Expected: clean. (`ab.config` is narrowed to the purge member by the `ab.config.type === 'purge'` guard at ~1408, so `.countScaling` and `.count` are accessible.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/combat/playerTurn.ts src/utils/combat/__tests__/amartyaCritPurge.test.ts
+git commit -m "feat(combat): E4 — purge count scales with live crit power, per footprint victim"
+```
+
+---
+
+## Task 5: Changelog + full-suite gate
+
+**Files:**
+- Modify: `src/constants/changelog.ts` (`UNRELEASED_CHANGES`)
+
+- [ ] **Step 1: Add the changelog entry**
+
+Add to `UNRELEASED_CHANGES` (plain English, user-facing):
+```
+"Amartya's charge purge now removes more buffs the higher its crit power (1 buff per 50% crit power), matching the in-game scaling, applied to every enemy hit."
+```
+(Match the existing array's quoting/format exactly.)
+
+- [ ] **Step 2: Full gate**
+
+Run:
+```bash
+npx vitest run
+npx tsc --noEmit
+npm run lint
+npm run audit:skills
+```
+Expected: all tests green (new tests included), **zero `.snap` movement** (`git status` shows no modified `.snap`), tsc clean, lint clean, `audit:skills` → `0 findings` over 141 ships.
+
+- [ ] **Step 3: Confirm no golden churn explicitly**
+
+Run: `git status --porcelain | grep -E '\.snap$'`
+Expected: **no output** (Amartya has no golden fixture; the change is gated behind `countScaling`, absent on every existing purge).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/constants/changelog.ts
+git commit -m "feat(combat): E4 — changelog (Amartya crit-power purge scaling)"
+```
+
+---
+
+## Done criteria
+
+- Amartya's charge purge removes `floor(critDamage / 50)` buffs per enemy, live each cast.
+- 0-count edge emits no `purge-performed`.
+- Per-victim independence in AoE preserved (each footprint victim purged at the same count).
+- All goldens byte-identical (zero `.snap` movement); 141/141 skill audit clean; tsc + lint clean.
+- New parser test + apply-side integration test green.
+
+## Out of scope (→ E5, separate plan)
+
+Symmetric enemy healing, the Nayra repaired-this-round light-up, the `baseHpById` enemy seed, detonation per-victim intake, death-fallback DRY. None are touched here.

--- a/docs/superpowers/plans/2026-06-20-combat-realism-E4-amartya-crit-purge.md
+++ b/docs/superpowers/plans/2026-06-20-combat-realism-E4-amartya-crit-purge.md
@@ -328,7 +328,7 @@ git commit -m "feat(combat): E4 — purge count scales with live crit power, per
 - [ ] **Step 1: Add the changelog entry**
 
 Add to `UNRELEASED_CHANGES` (plain English, user-facing):
-```
+```text
 "Amartya's charge purge now removes more buffs the higher its crit power (1 buff per 50% crit power), matching the in-game scaling, applied to every enemy hit."
 ```
 (Match the existing array's quoting/format exactly.)

--- a/docs/superpowers/plans/2026-06-20-combat-realism-E4-amartya-crit-purge.md
+++ b/docs/superpowers/plans/2026-06-20-combat-realism-E4-amartya-crit-purge.md
@@ -43,26 +43,20 @@
 
 **Files:** none (verification only).
 
-- [ ] **Step 1: Branch + confirm green baseline**
+- [ ] **Step 1: Branch off local main + confirm green baseline**
 
+Branch off the current local `main` as-is (do NOT `git pull` mid-task — remote ops need `gh auth switch` first and docs are gitignored; local main is already current from the start of this session).
 Run:
 ```bash
-git checkout main && git pull --ff-only
 git checkout -b feat/combat-E4-amartya-crit-purge
 npx tsc --noEmit && npm run lint
 npm run audit:skills
 ```
 Expected: tsc clean, lint clean, `audit:skills` → `Audited 141 ships → 0 findings.`
 
-- [ ] **Step 2: Confirm Amartya parses as an all-enemies on-cast purge (the per-victim claim depends on it)**
+- [ ] **Step 2: Read-confirm Amartya's parse (no code, no scratch test)**
 
-Add a temporary scratch assertion or use an existing test harness. Quickest: a throwaway parser test (delete after).
-
-Run:
-```bash
-npx vitest run skillTextParser -t "purge"
-```
-Then confirm by reading: Amartya's charge text "purges 1 buff from all enemies" → `parsePurge` returns `{ count: 1, target: 'all-enemies', explicitTarget: true }` (the `all enemies` clause → `'all-enemies'`). The charged slot makes `trigger: 'on-cast'` in `buildShipAbilities`. No code change — this is a read/confirm step; record the finding in the commit message of Task 2.
+Pure read-confirm (the permanent assertion lives in Task 2's test). Amartya's charge text "purges 1 buff from all enemies for every 50% crit power this Unit has" → `parsePurge` returns `{ count: 1, target: 'all-enemies', explicitTarget: true }` (the `all enemies` clause → `'all-enemies'`), and the charged slot sets `trigger: 'on-cast'` in `buildShipAbilities` (buildShipAbilities.ts:1084-1085: `slot === 'charged' → 'on-cast'`). The per-victim AoE claim depends on `target === 'all-enemies'`. No change here.
 
 ---
 
@@ -199,7 +193,7 @@ Amartya charge confirmed to parse as on-cast all-enemies purge, count 1."
 
 - [ ] **Step 1: Write the failing test**
 
-Locate the existing build test for Amartya/purge (grep `buildShipAbilities` test dir for `purge`). If one exists, add a case; otherwise add to the parser test file a build-level assertion:
+Build the ability from Amartya's charged-slot text and assert the config carries `countScaling`. `abilitiesIntegration.test.ts` exercises `type: 'purge'` and shows the `ShipSkills`/`slots` fixture shape to copy; the charged slot MUST carry Amartya's exact charge text so `buildShipAbilities` sets `trigger: 'on-cast'` (buildShipAbilities.ts:1084-1085). Add a case there or in the parser test file:
 ```ts
 import { buildShipAbilities } from '../abilities/buildShipAbilities';
 // ...

--- a/docs/superpowers/specs/2026-06-20-combat-realism-E-tail-design.md
+++ b/docs/superpowers/specs/2026-06-20-combat-realism-E-tail-design.md
@@ -70,34 +70,76 @@ every 50% crit power this Unit has." → `count = floor(critDamage / 50)`.
 
 **Removes** the C2a single-anchor count-1 under-approximation flag/note left for E4.
 
+**Edge cases:**
+
+- `count === 0` (crit power < `per`) → no purge, no `purge-performed` emit (the emit is already
+  gated on `removed > 0` at playerTurn.ts:1422, so this falls out for free). Amartya's base crit
+  power is 50 → count 1, so this is only reachable with a crit-power debuff.
+- **Confirm Amartya's charge parses as `target: 'all-enemies'`** so it enters the `aoeVictimIds`
+  footprint branch (playerTurn.ts ~1419) rather than the single-anchor fallback — the per-victim
+  claim depends on it (verify in the plan's baseline task).
+
 **Gate:** byte-identical goldens (Amartya has no golden fixture). New unit test: count scales with
-live crit power (e.g. 150 → 3, 100 → 2, buffed crit power → higher), applied per footprint victim.
+live crit power (e.g. 150 → 3, 100 → 2, buffed crit power → higher; 0-count edge), applied per
+footprint victim.
 
 ## 4. E5 — symmetric healing + Nayra + accounting tidy
 
 ### 4.1 Symmetric healing (the core)
 
-`healEventOnly` was introduced (Phase 4c PR4) so enemy heals **emit** heal events without **polluting
-the player healing buckets** (`healFor` / `credit`). It currently also blocks the HP-restore mutation,
+`healEventOnly` (set only on `enemyTurnBindings`, engine.ts ~2790, never on `playerTurnBindings`)
+was introduced (Phase 4c PR4) so enemy heals **emit** heal events without **polluting the player
+healing buckets** (`healFor` / `healing.credit`). It currently also blocks the HP-restore mutation,
 which is why enemy HP never recovers and `repairedThisRound` never sees an enemy id.
 
-Split `healEventOnly`'s two concerns:
+**The pool mechanism is already fully general** — `applyHealToTarget(raw, victim = healTarget)`
+(engine.ts ~1912) and `grantShieldToTarget(raw, victim = healTarget)` (~1928) heal **any** actor's
+own `currentHp` / `shieldPool`, clamp against per-victim `recipientMaxHp(victim.id)` (~1789, resolves
+any id via `lastTurnCtxByActor ?? baseHpFor`), and already call `repairedThisRound.add(victim.id)`.
+**No pool change is needed.** Three player-centric *routing* facts are what block enemy heals:
 
-- **(a) HP-restore mutation** — `applyHealToTarget(raw, victim)` adding `victim.currentHp` and
-  `repairedThisRound.add(victim.id)`, plus `grantShieldToTarget` adding to `victim.shieldPool`:
-  **ENABLE** for enemy-side heals, routed to the healed enemy ally's **own** pool via E2's
-  parametrized closures (pass the resolved enemy recipient as `victim`, not the player `healTarget`).
-- **(b) Player-bucket credit** — the `healFor` / `healing.credit` writes that build the player healing
-  result: keep **SUPPRESSED** for enemy heals (no enemy result surface until sub-project H).
+1. `recipientsFor(target)` (playerTurn.ts:1457–1462) is hardcoded player-side:
+   `self → [actor.id]`, `all-allies → healing.playerIds`, `ally → [healing.targetId]` (the player
+   heal-target). For an enemy caster these resolve onto **player** ids.
+2. The HP-apply is gated `if (rid === healing.targetId)` (playerTurn.ts:1613/1631), so even on the
+   non-event path only the **player heal-target** gets HP/shield (other recipients get
+   `directHeal`/`shield` credit only). The enemy recipient never reaches `applyHealToTarget`.
+3. In `healEventOnly` mode the heal branch `continue`s (playerTurn.ts:1598) and the shield branch
+   `continue`s (1624) **before computing the numeric `raw`** at all.
 
-So after E5 the enemy heal **restores enemy HP** but its numbers **do not appear** in the player
-healing result. Recipient resolution reuses the existing enemy-team ally routing (enemy-team support
-PRs #102–#104) for `ally` / `all-allies` heal targets; positional heals ride E2's per-victim pools.
+**Mechanism (confined entirely to the `healEventOnly === true` branch → player path byte-identical):**
+Replace the event-only early-`continue` with an enemy-side apply path:
 
-**Affected sites (from the scope map; plan confirms exact lines):** the four `healEventOnly` guards in
-`playerTurn.ts` (~1544 HoT, ~1594/1624 cast heal, ~1639 shield) — separate the HP-mutation call from
-the bucket-credit call so each can be gated independently; the enemy heal recipient resolution; and
-the `applyHealToTarget`/`grantShieldToTarget` call sites that currently pass no `victim` arg.
+- **Compute the heal numeric in enemy mode.** Draw `healCritGate` (1601) and compute `raw`
+  (1605–1611) exactly as the player path does. *(This adds RNG draws on the enemy turn — see the
+  gate note in §6: deterministic-but-new draws, audited two-team-sim churn.)*
+- **Route to the recipient's own pool, NOT the player heal-target.** Resolve each enemy recipient id
+  to its `CombatActor` (via the engine's `allActorsById` / a `victimOf(id)` helper) and call
+  `applyHealToTarget(raw, recipientActor)` / `grantShieldToTarget(raw, recipientActor)`. This heals
+  the enemy's own `currentHp` and fires `repairedThisRound.add(recipientId)`.
+- **Suppress player-bucket credit.** Do **not** call `healing.credit(...)` on the enemy path (no
+  enemy result surface until sub-project H). Still push recipients to `healTargets` so the
+  `heal-performed` event fires (as today).
+
+**Enemy recipient resolution.** Make `recipientsFor` side-aware off the acting actor's side:
+
+- `self → [actor.id]` (already side-agnostic; covers the common case — most enemy repairs are
+  self-targeted, e.g. Isha "when directly damaged, this Unit repairs 3% of its max HP").
+- `all-allies →` the acting side's ally id list. Thread an `enemyIds` list into `HealingRuntimeCtx`
+  (mirror of the existing `playerIds` field, ~1937), sourced like the enemy-team routing of
+  PRs #102–#104 (`enemyRecipientIds`).
+- `ally` (single-target) on the enemy side: **DECISION (plan-level, default proposed):** resolve to
+  the **lowest-HP living enemy ally** (deterministic, mirrors typical healer targeting). If the plan
+  finds no single-target `ally` enemy heal in the corpus that matters for Nayra, this may be deferred
+  with a logged note rather than implemented speculatively.
+
+**healingCtx existence.** `healingCtx` is built only when a player `healTarget` exists (~1901). It is
+present in **healing-calc** mode and in the **two-team battle-sim** (battleSimulator sets
+`healTargetId: focus.id`, the vestigial workaround C1 relies on). In **pure DPS** there is no
+`healingCtx` and the enemy is the indestructible dummy with no heal abilities → enemy heals are moot.
+So every mode that can host an enemy healer already has the ctx. The plan must still confirm
+`baseHpFor` resolves enemy ids (walked enemies populate `lastTurnCtxByActor` after their first turn;
+pre-first-turn falls back to `baseHpFor`).
 
 ### 4.2 Nayra lights up (consequence, no new code beyond 4.1)
 
@@ -138,17 +180,27 @@ them; it documents this (a comment at the two declarations) so the framing is cl
 - **Nayra requires no Nayra-specific code** beyond 4.1 — its condition + repair tracking already ship.
 - **One spec, two sequential PRs:** E4 first (small, gameplay-visible), then E5.
 - **E5 is one PR** (symmetric healing → Nayra → detonation → DRY → doc); user ratified not peeling
-  detonation/DRY into a separate follow-up.
+  detonation/DRY into a separate follow-up. **Known risk / pressure valve:** §4.1 (healing routing)
+  is the riskiest change in the epic and is bundled with two unrelated cleanups (§4.3 detonation
+  intake, §4.4 DRY). If, during planning or implementation, §4.1 proves larger than estimated, peel
+  §4.3/§4.4 into a thin follow-up PR rather than ballooning the symmetric-healing PR's review surface.
 - **Internal only** — no `/simulator` UI surfacing of enemy heal/HP (→ H).
 
 ## 6. Testing / gate
 
 - **DPS goldens: byte-identical** (indestructible dummy enemy has no heal abilities).
-- **Healing-calc goldens: byte-identical** — audit that no healing-calc fixture has an enemy that
-  heals an enemy ally (expected none; if one exists, that churn is audited, not blind `-u`).
+- **Healing-calc goldens: byte-identical** — guaranteed *structurally*, not just by fixture audit:
+  the entire change is confined to the `healEventOnly === true` branch, and `healEventOnly` is set
+  only on `enemyTurnBindings` (never on `playerTurnBindings`). Player-side healing-calc turns never
+  enter the changed code. (Still spot-audit that no healing-calc fixture's *enemy* attacker has a
+  heal/shield ability whose new HP-restore moves a tank-survival trajectory.)
 - **Two-team-sim goldens** (`twoTeamBattle`, `dpsSimulator` multi-actor, `positionalDamage.integration`):
-  **AUDITED churn** only where (a) an enemy ship now heals an enemy ally, or (b) player-Nayra now fires
-  its repaired-this-round purge/Stasis vs a repaired enemy. Every diff explained; never `vitest -u`.
+  **AUDITED churn** where (a) an enemy ship now heals an enemy ally (HP trajectory + survival), (b)
+  player-Nayra now fires its repaired-this-round purge/Stasis vs a repaired enemy, or (c) the new
+  enemy-side `healCritGate` draws shift a deterministic RNG sequence. Every diff explained; never
+  `vitest -u`. **RNG note:** drawing the heal crit gate on the enemy turn is a *new* consumption of
+  the gate; if any two-team fixture shares an RNG stream across turns, downstream draws can shift —
+  audit and explain, do not regenerate blindly.
 - **New tests:**
   - E4: purge count scales with live crit power, per footprint victim.
   - E5: enemy heal restores enemy ally HP into its own pool + populates `repairedThisRound`; enemy

--- a/docs/superpowers/specs/2026-06-20-combat-realism-E-tail-design.md
+++ b/docs/superpowers/specs/2026-06-20-combat-realism-E-tail-design.md
@@ -114,9 +114,13 @@ Replace the event-only early-`continue` with an enemy-side apply path:
   (1605–1611) exactly as the player path does. *(This adds RNG draws on the enemy turn — see the
   gate note in §6: deterministic-but-new draws, audited two-team-sim churn.)*
 - **Route to the recipient's own pool, NOT the player heal-target.** Resolve each enemy recipient id
-  to its `CombatActor` (via the engine's `allActorsById` / a `victimOf(id)` helper) and call
-  `applyHealToTarget(raw, recipientActor)` / `grantShieldToTarget(raw, recipientActor)`. This heals
-  the enemy's own `currentHp` and fires `repairedThisRound.add(recipientId)`.
+  to its `CombatActor` and call `applyHealToTarget(raw, recipientActor)` (heals enemy `currentHp`,
+  fires `repairedThisRound.add(recipientId)`). **Id→actor resolution (pin):** `allActorsById`
+  (engine.ts ~1665) already includes enemy actors; since `HealingRuntimeCtx` is built in engine.ts
+  but consumed in playerTurn.ts, the enemy apply path must either close over `allActorsById` or gain
+  an explicit `recipientActor(id) => CombatActor` resolver on the ctx (plan picks one — prefer the
+  ctx resolver to keep the closure boundary clean, consistent with how prior routing fixes were
+  threaded).
 - **Suppress player-bucket credit.** Do **not** call `healing.credit(...)` on the enemy path (no
   enemy result surface until sub-project H). Still push recipients to `healTargets` so the
   `heal-performed` event fires (as today).
@@ -137,9 +141,18 @@ Replace the event-only early-`continue` with an enemy-side apply path:
 present in **healing-calc** mode and in the **two-team battle-sim** (battleSimulator sets
 `healTargetId: focus.id`, the vestigial workaround C1 relies on). In **pure DPS** there is no
 `healingCtx` and the enemy is the indestructible dummy with no heal abilities → enemy heals are moot.
-So every mode that can host an enemy healer already has the ctx. The plan must still confirm
-`baseHpFor` resolves enemy ids (walked enemies populate `lastTurnCtxByActor` after their first turn;
-pre-first-turn falls back to `baseHpFor`).
+So every mode that can host an enemy healer already has the ctx.
+
+**REQUIRED CHANGE — enemy max-HP seed (not just a confirm).** `recipientMaxHp(id)` (~1789) is
+`lastTurnCtxByActor.get(id)?.effectiveMaxHp ?? baseHpFor(id)`, and `baseHpById` (~1689) **excludes
+enemy ids** (explicit comment ~1688 "Enemy ids are never queried as recipients"), so `baseHpFor`
+returns `?? 0` for an enemy. For an enemy recipient healed **before its first turn** (no
+`lastTurnCtxByActor` entry yet), `recipientMaxHp` → 0 → the deficit `Math.max(0, min(raw, 0 -
+currentHp))` → `consumed === 0` → the heal is all overheal **and `repairedThisRound.add` never fires**
+(gated on `consumed > 0`, ~1925), silently breaking the Nayra consequence for that case. E5 **must
+extend `baseHpById` to seed enemy attacker base HP** (from `enemyAttackerInputs` / `enemyRecipientIds`)
+so enemy recipients have a real pre-first-turn cap. The same `recipientMaxHp` cap governs
+`grantShieldToTarget` (~1930), so a future enemy-shield lift (sub-project H) inherits this fix for free.
 
 ### 4.2 Nayra lights up (consequence, no new code beyond 4.1)
 

--- a/docs/superpowers/specs/2026-06-20-combat-realism-E-tail-design.md
+++ b/docs/superpowers/specs/2026-06-20-combat-realism-E-tail-design.md
@@ -64,9 +64,10 @@ every 50% crit power this Unit has." → `count = floor(critDamage / 50)`.
    descriptor — shape TBD in the plan, e.g. `countScaling?: { stat: 'critDamage'; per: 50 }` on the
    purge ability config. Only Amartya matches in the corpus today.
 2. **Apply** at `playerTurn.ts:1421` (the E3 footprint loop): when `countScaling` is present,
-   compute `count = floor(effectiveStatsOf(caster).critDamage / per)` and pass that to
-   `statusEngine.purge(vid, count)` for **every** footprint victim; otherwise use `ab.config.count`
-   unchanged.
+   compute `purgeCount = ab.config.count × floor(effectiveStatsOf(caster).critDamage / per)` (the
+   base `count` multiplier preserves faithfulness for any future base-count > 1; 1× for Amartya) and
+   pass that to `statusEngine.purge(vid, purgeCount)` for **every** footprint victim; otherwise use
+   `ab.config.count` unchanged. Guard `per > 0 && finite` before dividing (defensive).
 
 **Removes** the C2a single-anchor count-1 under-approximation flag/note left for E4.
 

--- a/docs/superpowers/specs/2026-06-20-combat-realism-E-tail-design.md
+++ b/docs/superpowers/specs/2026-06-20-combat-realism-E-tail-design.md
@@ -1,0 +1,167 @@
+# Combat Realism Epic — E tail (E4 + E5) Design
+
+**Date:** 2026-06-20
+**Sub-project:** E (per-victim AoE accounting, old PR7), tail.
+**Parent:** `docs/superpowers/specs/2026-06-17-combat-realism-epic-roadmap.md`,
+`docs/superpowers/specs/2026-06-19-per-victim-aoe-accounting-E-design.md` (E1–E3 shipped).
+
+## 1. Context
+
+E1/E2/E3 shipped to `main` (PRs #122/#123/#124):
+
+- **E1** — symmetric incoming surface: `enemySink` now writes per-victim intake into the
+  shared `perActorIncoming` map keyed by victim id (internal; unread by UI).
+- **E2** — per-victim leech, **and** the per-victim heal/shield **pool generalization** pulled
+  forward: `applyHealToTarget(raw, victim = healTarget)` / `grantShieldToTarget(raw, victim = healTarget)`
+  are now parametrized by victim (engine.ts ~1912/1928), defaulting to `healTarget` so non-positional
+  callers stay byte-identical.
+- **E3** — AoE on-cast purge over **all** footprint victims (the loop at `playerTurn.ts:1421`,
+  `statusEngine.purge(vid, ab.config.count)`), at the parsed count of 1.
+
+This spec covers the remaining two sub-parts: **E4** (Amartya crit-power-scaled purge count) and
+**E5** (symmetric healing + the Nayra consequence + accounting tidy). After E5, sub-project E — and
+the last remnant of the bySide-unification campaign — is closed.
+
+### Correction to the umbrella E spec's E5 assumption
+
+The umbrella E spec's E5 sketch claimed the documented Nayra limitation ("engine never heals enemy
+ships") would resolve "with the Nayra condition + the now-general pools — **no new pool mechanism
+needed**." That is **inaccurate**. The pools are parametrized, but enemy-side heals never reach them
+because **`healEventOnly` actively skips the HP-restore mutation** for enemy actors
+(`playerTurn.ts:1544/1594/1624/1639`: `if (!healEventOnly) { ... apply heal ... }`). So lighting up
+Nayra requires a real (carefully-scoped) change: **lift the HP-restore half of `healEventOnly`**.
+This is captured below and supersedes that sketch.
+
+## 2. Goals / non-goals
+
+**Goals**
+
+- E4: Amartya's charge purge count scales with live crit power, applied to every footprint victim.
+- E5: enemy ships actually heal (symmetric per-side healing), which lights up player-Nayra's
+  already-parsed "target was repaired this round" purge/Stasis condition; plus close the deferred
+  detonation per-victim intake caveat and the death-fallback DRY duplication.
+
+**Non-goals (deferred elsewhere)**
+
+- Surfacing enemy per-victim HP / heal / shield-absorb in the `/simulator` UI → sub-project **H**
+  (shield system). E5 stays internal.
+- New shield/leech/reflect **sources** (gear-set, implants) → sub-project **D**.
+- Any change to player-side healing result accounting (the `healFor` buckets / healing-calc result
+  surface) — enemy heals must NOT pollute those.
+
+## 3. E4 — Amartya crit-power-scaled purge
+
+**Game text (Amartya charge):** "This Unit deals 210% damage and purges 1 buff from all enemies for
+every 50% crit power this Unit has." → `count = floor(critDamage / 50)`.
+
+**Units:** `critDamage` is a `PERCENTAGE_ONLY_STAT` stored as an integer (e.g. `150` = 150%), so
+`floor(critDamage / 50)` reads directly (150 crit power → 3 purges). Read the **live** value via
+`effectiveStatsOf(caster).critDamage` (effectiveStats.ts ~98/205) at cast time, not the base stat.
+
+**Mechanism**
+
+1. **Parse** the "for every 50% crit power" phrasing on a purge ability into a count-scaling
+   descriptor — shape TBD in the plan, e.g. `countScaling?: { stat: 'critDamage'; per: 50 }` on the
+   purge ability config. Only Amartya matches in the corpus today.
+2. **Apply** at `playerTurn.ts:1421` (the E3 footprint loop): when `countScaling` is present,
+   compute `count = floor(effectiveStatsOf(caster).critDamage / per)` and pass that to
+   `statusEngine.purge(vid, count)` for **every** footprint victim; otherwise use `ab.config.count`
+   unchanged.
+
+**Removes** the C2a single-anchor count-1 under-approximation flag/note left for E4.
+
+**Gate:** byte-identical goldens (Amartya has no golden fixture). New unit test: count scales with
+live crit power (e.g. 150 → 3, 100 → 2, buffed crit power → higher), applied per footprint victim.
+
+## 4. E5 — symmetric healing + Nayra + accounting tidy
+
+### 4.1 Symmetric healing (the core)
+
+`healEventOnly` was introduced (Phase 4c PR4) so enemy heals **emit** heal events without **polluting
+the player healing buckets** (`healFor` / `credit`). It currently also blocks the HP-restore mutation,
+which is why enemy HP never recovers and `repairedThisRound` never sees an enemy id.
+
+Split `healEventOnly`'s two concerns:
+
+- **(a) HP-restore mutation** — `applyHealToTarget(raw, victim)` adding `victim.currentHp` and
+  `repairedThisRound.add(victim.id)`, plus `grantShieldToTarget` adding to `victim.shieldPool`:
+  **ENABLE** for enemy-side heals, routed to the healed enemy ally's **own** pool via E2's
+  parametrized closures (pass the resolved enemy recipient as `victim`, not the player `healTarget`).
+- **(b) Player-bucket credit** — the `healFor` / `healing.credit` writes that build the player healing
+  result: keep **SUPPRESSED** for enemy heals (no enemy result surface until sub-project H).
+
+So after E5 the enemy heal **restores enemy HP** but its numbers **do not appear** in the player
+healing result. Recipient resolution reuses the existing enemy-team ally routing (enemy-team support
+PRs #102–#104) for `ally` / `all-allies` heal targets; positional heals ride E2's per-victim pools.
+
+**Affected sites (from the scope map; plan confirms exact lines):** the four `healEventOnly` guards in
+`playerTurn.ts` (~1544 HoT, ~1594/1624 cast heal, ~1639 shield) — separate the HP-mutation call from
+the bucket-credit call so each can be gated independently; the enemy heal recipient resolution; and
+the `applyHealToTarget`/`grantShieldToTarget` call sites that currently pass no `victim` arg.
+
+### 4.2 Nayra lights up (consequence, no new code beyond 4.1)
+
+Nayra's condition is **already parsed and gated** (C2b-3): active "if the target was repaired this
+round → inflict Stasis 1 turn"; charge "if the target was repaired this round → inflict Exposed 1 turn
+and purge all buffs." The engine already tracks `repairedThisRound` per victim id (engine.ts ~1897,
+add at ~1925, clear at ~2275, read at ~2881 `targetRepairedThisRound: repairedThisRound.has(tgt.id)`).
+Once 4.1 lets an enemy ally be healed by its enemy healer, that enemy's id enters `repairedThisRound`,
+and player-Nayra attacking it sees `targetRepairedThisRound === true` → fires the purge/Stasis. No
+Nayra-specific code beyond 4.1; verified by an end-to-end test.
+
+### 4.3 Detonation per-victim intake (deferred caveat)
+
+Close the E5-tagged caveat at engine.ts ~4000–4052: non-positional enemy attack **detonations** are
+not yet recorded per-victim into `perActorIncoming` (only the positional path reads per-victim
+outcomes). Record detonation intake symmetrically per victim, matching E1's incoming surface.
+
+### 4.4 Death-fallback DRY
+
+Extract the synthesized no-action `PlayerTurnResult` shape duplicated between `handleDeadTargetSkip`
+(engine.ts ~2937–2962) and the Stasis turn-skip (~3582–3605) into one helper
+(`synthesizeSkippedTurn()` or similar). Pure DRY; `tsc` catches drift.
+
+### 4.5 Credit≠intake closeout (documentation)
+
+The "collapse the dual credit/intake paths" framing in the umbrella spec overstates the redundancy:
+the **credit** path (`roundDamage` / `creditDamage`, damage *dealt* per source, feeds row totals +
+damage-dealt leeches) and the **intake** path (`perActorIncoming` / `intakeFor`, damage *taken* per
+victim, feeds healing-mode rows) record **complementary** facts, not duplicate ones. E5 does not merge
+them; it documents this (a comment at the two declarations) so the framing is closed honestly.
+
+## 5. Locked decisions
+
+- **E4 count** = `floor(effectiveStatsOf(caster).critDamage / 50)`, live each cast, all footprint
+  victims.
+- **E5 lifts the HP-restore half of `healEventOnly`** for enemy heals; **keeps player-bucket credit
+  suppressed**. (Corrects the umbrella spec's "no new pool mechanism needed" assumption.)
+- **Nayra requires no Nayra-specific code** beyond 4.1 — its condition + repair tracking already ship.
+- **One spec, two sequential PRs:** E4 first (small, gameplay-visible), then E5.
+- **E5 is one PR** (symmetric healing → Nayra → detonation → DRY → doc); user ratified not peeling
+  detonation/DRY into a separate follow-up.
+- **Internal only** — no `/simulator` UI surfacing of enemy heal/HP (→ H).
+
+## 6. Testing / gate
+
+- **DPS goldens: byte-identical** (indestructible dummy enemy has no heal abilities).
+- **Healing-calc goldens: byte-identical** — audit that no healing-calc fixture has an enemy that
+  heals an enemy ally (expected none; if one exists, that churn is audited, not blind `-u`).
+- **Two-team-sim goldens** (`twoTeamBattle`, `dpsSimulator` multi-actor, `positionalDamage.integration`):
+  **AUDITED churn** only where (a) an enemy ship now heals an enemy ally, or (b) player-Nayra now fires
+  its repaired-this-round purge/Stasis vs a repaired enemy. Every diff explained; never `vitest -u`.
+- **New tests:**
+  - E4: purge count scales with live crit power, per footprint victim.
+  - E5: enemy heal restores enemy ally HP into its own pool + populates `repairedThisRound`; enemy
+    heal does **not** appear in the player healing result (bucket-credit still suppressed);
+    player-Nayra purge + Stasis fires vs a repaired enemy and does NOT fire vs an un-repaired enemy
+    (non-vacuous contrast); non-positional detonation records per-victim intake.
+- `npm run audit:skills` stays 0/141; `tsc --noEmit` + `npm run lint` (max-warnings 0) clean.
+  Always run `npx tsc --noEmit` independently after subagent work (esbuild-based vitest does not
+  typecheck).
+
+## 7. Workflow (inherited from the B/C series)
+
+- `gh auth switch --hostname github.com --user TheSusort` before PR ops; dev server on :3000.
+- Use `npx vitest run <name>` — bare `npm test` is Vitest **watch** and hangs agents.
+- docs/ is gitignored → `git add -f`, `--no-verify` for docs-only commits.
+- Subagent-driven implementation; per-task spec+quality reviews + a final holistic (opus) review.

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -8,6 +8,7 @@ export const CURRENT_VERSION = '1.64.0';
 export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator: lifesteal/leech (heal or shield from damage dealt or taken) now works per ship — each ship heals or shields itself off its own damage, and AoE splash leeches off the reduced (covered-cell) splash damage.',
     'Combat simulator: area-of-effect purge skills now remove buffs from every enemy they hit, not just the primary target.',
+    "Combat simulator: Amartya's charge purge now scales with crit power — it removes 1 buff for every 50% crit power (so higher crit power purges more buffs), applied to every enemy hit.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -258,7 +258,15 @@ export type AbilityConfig =
            *  Absent → unbounded (fires on every qualifying trigger). */
           oncePerCombat?: boolean;
       }
-    | { type: 'cleanse' | 'purge'; count: number | 'all' }
+    | {
+          type: 'cleanse' | 'purge';
+          count: number | 'all';
+          /** E4: purge count scales with a caster stat — total purged =
+           *  count × floor(effectiveStat / per). Only `critDamage` (crit power) is
+           *  used today (Amartya: "purges 1 buff … for every 50% crit power").
+           *  Absent → static `count`. cleanse never sets this. */
+          countScaling?: { stat: 'critDamage'; per: number };
+      }
     | {
           type: 'control';
           effect: ControlEffect;

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -3195,7 +3195,7 @@ describe('parsePurge', () => {
     });
     it('parses "purges 1 buff from all enemies" (Amartya)', () => {
         expect(parsePurge('purges 1 buff from all enemies for every 50% crit power')).toEqual([
-            { count: 1, target: 'all-enemies', explicitTarget: true },
+            { count: 1, target: 'all-enemies', explicitTarget: true, countScaling: { stat: 'critDamage', per: 50 } },
         ]);
     });
     it('parses "purges a buff from an enemy" (Sefuba p2 / Lodolite p3)', () => {
@@ -3219,6 +3219,25 @@ describe('parsePurge', () => {
         expect(result).toHaveLength(2);
         expect(result[0]).toEqual({ count: 1, target: 'enemy', explicitTarget: true });
         expect(result[1]).toEqual({ count: 1, target: 'enemy', explicitTarget: true });
+    });
+});
+
+describe('parsePurge — E4 crit-power scaling', () => {
+    it('extracts countScaling from "for every 50% crit power"', () => {
+        const text =
+            'This Unit deals 210% damage and purges 1 buff from all enemies for every 50% crit power this Unit has.';
+        const [p] = parsePurge(text);
+        expect(p).toMatchObject({
+            count: 1,
+            target: 'all-enemies',
+            countScaling: { stat: 'critDamage', per: 50 },
+        });
+    });
+
+    it('leaves countScaling undefined for a plain purge', () => {
+        const [p] = parsePurge('This Unit purges 2 buffs from the enemy.');
+        expect(p.count).toBe(2);
+        expect(p.countScaling).toBeUndefined();
     });
 });
 

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -3139,3 +3139,27 @@ describe('buildShipAbilities — Nayra target-repaired-this-round purge (C2b-3)'
         ]);
     });
 });
+
+// E4: Amartya — crit-power-scaled purge count threaded through the built ability.
+describe('buildShipAbilities — E4 Amartya crit-power-scaled purge (countScaling)', () => {
+    const amartya = () =>
+        ship({
+            chargeSkillText:
+                'This Unit deals 210% damage and purges 1 buff from all enemies for every 50% crit power this Unit has.',
+            chargeSkillCharge: 4,
+        });
+
+    it('emits exactly ONE purge ability from the charged slot with countScaling { stat: critDamage, per: 50 }', () => {
+        const charged = slot(buildShipAbilities(amartya()).slots, 'charged')!;
+        const purges = charged.abilities.filter((a) => a.type === 'purge');
+        expect(purges).toHaveLength(1);
+        const purge = purges[0];
+        expect(purge.trigger).toBe('on-cast');
+        expect(purge.target).toBe('all-enemies');
+        expect(purge.config).toMatchObject({
+            type: 'purge',
+            count: 1,
+            countScaling: { stat: 'critDamage', per: 50 },
+        });
+    });
+});

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -1097,7 +1097,11 @@ function abilitiesFromText(
                 target,
                 trigger,
                 conditions: repairedCond ? [repairedCond] : [],
-                config: { type: 'purge', count: p.count },
+                config: {
+                    type: 'purge',
+                    count: p.count,
+                    ...(p.countScaling ? { countScaling: p.countScaling } : {}),
+                },
                 autoFilled: true,
             },
             pos: purgePos >= 0 ? purgePos : MAX_POS,

--- a/src/utils/combat/__tests__/amartyaCritPurge.test.ts
+++ b/src/utils/combat/__tests__/amartyaCritPurge.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { StatusEngine } from '../statusEngine';
+import { createEventBus } from '../events';
+import type { CombatEvent } from '../events';
+
+// ---------------------------------------------------------------------------
+// E4: an on-cast 'all-enemies' purge whose config carries
+//   countScaling: { stat: 'critDamage', per: 50 }
+// removes, PER victim, count × floor(effectiveCritDamage / per) buffs.
+//
+// Amartya's charge: "purges 1 buff from all enemies for every 50% crit power"
+//   → count: 1, countScaling: { stat: 'critDamage', per: 50 }
+//   → per victim: floor(critDamage / 50)  (150→3, 100→2, 50→1, 40→0).
+//
+// Harness mirrors aoePurge.test.ts (positional two-team battle-sim): the focus
+// fires an 'all'-pattern active so the footprint covers EVERY living enemy; the
+// purge ability is injected directly with the scaling config.
+// ---------------------------------------------------------------------------
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `e4p${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+const allPattern = (): ParsedPattern => ({ raw: 'all', shape: 'all', range: 'all', modifiers: {} });
+
+const hit = (): Ability =>
+    ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } });
+
+// A removable self-buff with a distinct name so the victim carries several.
+const namedBuff = (name: string): Ability =>
+    ab({
+        type: 'buff',
+        target: 'self',
+        config: {
+            type: 'buff',
+            buffName: name,
+            parsedEffects: { attack: 10 },
+            stacks: 1,
+            isStackable: false,
+            duration: 99,
+        },
+    });
+
+// An enemy that applies FOUR distinct removable self-buffs each round, then hits.
+const fourBuffEnemy = (id: string, position: Position) => ({
+    id,
+    stats: { attack: 1000, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 200 },
+    chargeCount: 0,
+    startCharged: false,
+    position,
+    target: parsedTarget('front'),
+    pattern: allPattern(),
+    shipSkills: {
+        slots: [
+            {
+                slot: 'active' as const,
+                abilities: [
+                    namedBuff('Buff A'),
+                    namedBuff('Buff B'),
+                    namedBuff('Buff C'),
+                    namedBuff('Buff D'),
+                    hit(),
+                ],
+            },
+        ],
+    },
+});
+
+// Focus fires a scaling all-enemies purge (count 1, per 50) + a hit so the
+// positional harness resolves a real anchor.
+const scalingPurgeSkills = (): ShipSkills => ({
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                ab({
+                    type: 'purge',
+                    target: 'all-enemies',
+                    config: {
+                        type: 'purge',
+                        count: 1,
+                        countScaling: { stat: 'critDamage', per: 50 },
+                    },
+                }),
+                hit(),
+            ],
+        },
+    ],
+});
+
+const BASE = (
+    critDamage: number,
+    enemies: ReturnType<typeof fourBuffEnemy>[]
+): CombatEngineInput => ({
+    attack: 5000,
+    crit: 0,
+    critDamage,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: scalingPurgeSkills(),
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedTarget('front'),
+    pattern: allPattern(),
+    enemyAttackers: enemies,
+});
+
+// Run a single round (enemies act first — speed 200 > focus 100 — applying their
+// four buffs; the focus then purges) and report the surviving buff count per
+// victim plus the purge-performed events.
+const run = (
+    critDamage: number,
+    enemyIds: string[]
+): { remaining: Record<string, number>; purgeEvents: CombatEvent[] } => {
+    idc = 0;
+    let engine: StatusEngine | undefined;
+    const purgeEvents: CombatEvent[] = [];
+    const bus = createEventBus();
+    bus.on('purge-performed', (e) => purgeEvents.push(e));
+    const enemies = enemyIds.map((id, i) => fourBuffEnemy(id, i === 0 ? 'M4' : 'M3'));
+    runCombat({
+        ...BASE(critDamage, enemies),
+        bus,
+        __testTapStatusEngine: (e) => {
+            engine = e;
+        },
+    });
+    const remaining: Record<string, number> = {};
+    for (const id of enemyIds) {
+        remaining[id] = engine!.timedAbilityStatuses('self', id).length;
+    }
+    return { remaining, purgeEvents };
+};
+
+describe('E4: all-enemies purge count scales with live crit power, per footprint victim', () => {
+    it('critDamage 150 → each victim loses exactly 3 buffs (4 - 3 = 1 remaining)', () => {
+        const { remaining } = run(150, ['enemy-front']);
+        expect(remaining['enemy-front']).toBe(1);
+    });
+
+    it('critDamage 100 → each victim loses exactly 2 buffs (4 - 2 = 2 remaining)', () => {
+        const { remaining } = run(100, ['enemy-front']);
+        expect(remaining['enemy-front']).toBe(2);
+    });
+
+    it('critDamage 40 → 0 removed, all 4 buffs survive, and NO purge-performed event fires', () => {
+        const { remaining, purgeEvents } = run(40, ['enemy-front']);
+        expect(remaining['enemy-front']).toBe(4);
+        expect(
+            purgeEvents.filter((e) => e.type === 'purge-performed' && e.targetId === 'enemy-front')
+        ).toHaveLength(0);
+    });
+
+    it('AoE over two footprint victims at critDamage 150 → EACH loses 3 (per-victim count independence)', () => {
+        const { remaining } = run(150, ['enemy-front', 'enemy-back']);
+        expect(remaining['enemy-front']).toBe(1);
+        expect(remaining['enemy-back']).toBe(1);
+    });
+});

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1422,10 +1422,18 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 // dmgStats.critDamage) is the caster's LIVE crit power (buffs/debuffs folded),
                 // integer percent (e.g. 150). Hoisted out of the victim loop — constant within a cast.
                 const scaling = ab.config.countScaling;
-                const purgeCount: number | 'all' =
-                    scaling && typeof ab.config.count === 'number'
-                        ? ab.config.count * Math.floor(effectiveCritDamage / scaling.per)
-                        : ab.config.count;
+                // Guard `per` (defensive: the parser only emits per≥1 from `\d+`, but a
+                // hand-built config with per<=0/non-finite would make floor(x/per) Infinity/NaN).
+                let purgeCount: number | 'all' = ab.config.count;
+                if (
+                    scaling &&
+                    typeof ab.config.count === 'number' &&
+                    Number.isFinite(scaling.per) &&
+                    scaling.per > 0
+                ) {
+                    purgeCount =
+                        ab.config.count * Math.max(0, Math.floor(effectiveCritDamage / scaling.per));
+                }
                 for (const vid of recipients) {
                     const removed = statusEngine.purge(vid, purgeCount);
                     if (removed > 0) {

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1417,8 +1417,17 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 // parsed count.)
                 const recipients =
                     ab.target === 'all-enemies' && aoeVictimIds ? aoeVictimIds : [targetId];
+                // E4: when the purge scales on crit power, total purged per victim =
+                // count × floor(live effectiveCritDamage / per). effectiveCritDamage (~line 1104 =
+                // dmgStats.critDamage) is the caster's LIVE crit power (buffs/debuffs folded),
+                // integer percent (e.g. 150). Hoisted out of the victim loop — constant within a cast.
+                const scaling = ab.config.countScaling;
+                const purgeCount: number | 'all' =
+                    scaling && typeof ab.config.count === 'number'
+                        ? ab.config.count * Math.floor(effectiveCritDamage / scaling.per)
+                        : ab.config.count;
                 for (const vid of recipients) {
-                    const removed = statusEngine.purge(vid, ab.config.count);
+                    const removed = statusEngine.purge(vid, purgeCount);
                     if (removed > 0) {
                         bus.emit({
                             type: 'purge-performed',

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -2118,6 +2118,10 @@ export function parseHealAbilities(text: string | null | undefined): ParsedHealA
 // (no "purges" token). Must NOT match "cleanses".
 const PURGE_RE = /\bpurges?\s+(?:(\d+|all)|an?\b)/gi;
 
+// E4: "for every N% crit power" — purge-count scaling on crit power (Amartya).
+// Sentence-scoped (applied to the purge's own sentence). Matches "for every 50% crit power".
+const CRIT_POWER_SCALING_RE = /for\s+every\s+(\d+)\s*%?\s*crit\s+power/i;
+
 // "cleanses N" — must NOT match "purges". Trailing clause names the recipient.
 const CLEANSE_RE = /\bcleanses?\s+(\d+|all)\b/gi;
 
@@ -2134,13 +2138,19 @@ const CLEANSE_RE = /\bcleanses?\s+(\d+|all)\b/gi;
  */
 export function parsePurge(
     text: string | null | undefined
-): { count: number | 'all'; target: 'enemy' | 'all-enemies'; explicitTarget: boolean }[] {
+): {
+    count: number | 'all';
+    target: 'enemy' | 'all-enemies';
+    explicitTarget: boolean;
+    countScaling?: { stat: 'critDamage'; per: number };
+}[] {
     if (!text) return [];
     const plain = stripUnitTags(text).replace(/<br\s*\/?>/gi, '. ');
     const results: {
         count: number | 'all';
         target: 'enemy' | 'all-enemies';
         explicitTarget: boolean;
+        countScaling?: { stat: 'critDamage'; per: number };
     }[] = [];
     PURGE_RE.lastIndex = 0;
     let m: RegExpExecArray | null;
@@ -2161,7 +2171,12 @@ export function parsePurge(
         const target: 'enemy' | 'all-enemies' = /all\s+enemies/.test(sentence)
             ? 'all-enemies'
             : 'enemy';
-        results.push({ count, target, explicitTarget: true });
+        const scaleMatch = CRIT_POWER_SCALING_RE.exec(sentence);
+        const countScaling =
+            scaleMatch && typeof count === 'number'
+                ? { stat: 'critDamage' as const, per: parseInt(scaleMatch[1], 10) }
+                : undefined;
+        results.push({ count, target, explicitTarget: true, ...(countScaling ? { countScaling } : {}) });
     }
     return results;
 }


### PR DESCRIPTION
## Summary

Sub-project **E** tail (PR1 of 2) of the combat-realism epic. Makes Amartya's charge purge faithful to the game: **"purges 1 buff from all enemies for every 50% crit power"** now removes `floor(critDamage / 50)` buffs per enemy hit, computed from **live** crit power each cast, instead of the static parsed count of 1.

- Optional `countScaling?: { stat: 'critDamage'; per: number }` on the purge ability config (`abilities.ts`).
- Parser (`parsePurge`) detects "for every N% crit power" → `{ stat: 'critDamage', per: 50 }` (sentence-scoped, guarded to numeric counts).
- Threaded through `buildShipAbilities`.
- Engine on-cast purge apply site computes `count × floor(effectiveCritDamage / per)` once per cast, applied to **every footprint victim** (rides E3's AoE loop). `effectiveCritDamage` is the buff/debuff-folded live value, so a Crit Power Down on Amartya correctly reduces the count. Count 0 → no purge, no `purge-performed` event.

## Test Plan

- [x] New parser tests: Amartya text → `countScaling {stat:'critDamage', per:50}`; plain purge → undefined.
- [x] New build test: Amartya charge builds an on-cast all-enemies purge carrying `countScaling`.
- [x] New engine integration (`amartyaCritPurge.test.ts`): 150→3, 100→2, 40→0 (+ no event), AoE per-victim independence (each of 2 victims loses 3). Verified to fail pre-change.
- [x] Byte-identical: **zero `.snap` movement** (Amartya has no golden; change gated behind the new flag).
- [x] Full suite 2685/2685 green; `tsc --noEmit` clean; `npm run lint` clean; `audit:skills` 0/141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)