### PR TITLE
feat(combat): E5 — symmetric enemy healing + Nayra + accounting tidy

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -9,6 +9,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator: lifesteal/leech (heal or shield from damage dealt or taken) now works per ship — each ship heals or shields itself off its own damage, and AoE splash leeches off the reduced (covered-cell) splash damage.',
     'Combat simulator: area-of-effect purge skills now remove buffs from every enemy they hit, not just the primary target.',
     "Combat simulator: Amartya's charge purge now scales with crit power — it removes 1 buff for every 50% crit power (so higher crit power purges more buffs), applied to every enemy hit.",
+    'Combat simulator: enemy ships now actually heal — their HP recovers from repair skills instead of being stuck, so enemy teams survive more realistically. Skills that trigger off a target being healed this round (such as Nayra) now also fire against healed enemies.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/combat/__tests__/enemyActions.test.ts
+++ b/src/utils/combat/__tests__/enemyActions.test.ts
@@ -266,15 +266,25 @@ describe('Phase 4c PR 4 Task 5a: event-only enemy heal/cleanse emission', () => 
             },
             grantShieldToTarget: (raw) => shields.push(raw),
             playerIds: ['enemy1', 'tank'],
+            // E5: an enemy single-'ally' heal routes to the lowest-HP living enemy ally; here the
+            // sole enemy ally is the caster itself ('enemy1'), a living stand-in (currentHp > 0).
+            enemyIds: ['enemy1'],
+            recipientActor: (id) =>
+                id === 'enemy1' ? ({ id, currentHp: 10000 } as CombatActor) : undefined,
         };
         return { healing, credits, applied, shields };
     };
 
     // An enemy-side runtime whose ACTIVE cast skill heals an ally and cleanses.
-    const makeRuntime = (skills: ShipSkills): PlayerActorRuntime => {
+    // `side` mirrors the real engine: an ENEMY caster (event-only path) carries side:'enemy'
+    // so E5's side-aware recipient routing fires; the normal-mode (player) test uses 'player'.
+    const makeRuntime = (
+        skills: ShipSkills,
+        side: CombatActor['side'] = 'player'
+    ): PlayerActorRuntime => {
         const actor = createActor({
             id: 'enemy1',
-            side: 'player', // runPlayerTurn is side-agnostic; the engine flags enemy via healEventOnly
+            side,
             kind: 'attacker',
             stats: {
                 attack: 5000,
@@ -388,10 +398,12 @@ describe('Phase 4c PR 4 Task 5a: event-only enemy heal/cleanse emission', () => 
         ],
     });
 
-    it('emits heal-performed + cleanse-performed with the actor id and mutates NOTHING', () => {
+    it('E5: enemy heal RESTORES HP + emits a real heal-performed amount, still NO player credit', () => {
         const events: CombatEvent[] = [];
         const spy = makeHealingSpy();
-        const args = makeArgs(makeRuntime(healCleanseSkills()), spy.healing, true);
+        // side:'enemy' → E5 side-aware routing: the 'ally' heal targets the lowest-HP enemy ally
+        // (the caster itself here), and applyHealToTarget runs on the enemy path.
+        const args = makeArgs(makeRuntime(healCleanseSkills(), 'enemy'), spy.healing, true);
         args.bus.on('heal-performed', (e) => events.push(e));
         args.bus.on('cleanse-performed', (e) => events.push(e));
 
@@ -406,13 +418,15 @@ describe('Phase 4c PR 4 Task 5a: event-only enemy heal/cleanse emission', () => 
         expect(cleanse!.count).toBe(2);
         expect(heal).toBeDefined();
         expect(heal!.casterId).toBe('enemy1');
-        // Event-only heal carries NO numeric (amount 0, no crit info).
-        expect(heal!.amount).toBe(0);
+        // E5: heal-performed now carries the REAL amount (effectiveHp 10000 × 20% basis 'hp');
+        // no crit (noGate → false) so critHits stays absent.
+        expect(heal!.amount).toBe(2000);
         expect(heal!.critHits).toBeUndefined();
 
-        // CRITICAL: not a single healing.* mutation ran in event-only mode.
+        // E5: the heal IS applied to the enemy's own pool (applied received the raw)...
+        expect(spy.applied).toEqual([2000]);
+        // ...but NOTHING is credited to the player healing buckets, and no shield was granted.
         expect(spy.credits).toHaveLength(0);
-        expect(spy.applied).toHaveLength(0);
         expect(spy.shields).toHaveLength(0);
     });
 
@@ -486,6 +500,9 @@ describe('Phase 4c PR 4 Task 5 fix: HoT ticking is gated behind healEventOnly', 
             },
             grantShieldToTarget: (raw) => shields.push(raw),
             playerIds: ['attacker', 'tank'],
+            // E5 fields (unused by the HoT-ticking path — present for type-correctness).
+            enemyIds: ['attacker'],
+            recipientActor: (id) => ({ id, currentHp: 10000 }) as CombatActor,
         };
         return { healing, credits, applied, shields };
     };

--- a/src/utils/combat/__tests__/nayraEnemyRepairedPurge.test.ts
+++ b/src/utils/combat/__tests__/nayraEnemyRepairedPurge.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { StatusEngine } from '../statusEngine';
+
+// ---------------------------------------------------------------------------
+// E5 Task 2: the SIDES-SWAPPED consequence of symmetric healing
+// (nayraRepairedPurge.test.ts is the MIRROR — there the player focus is repaired
+// and an enemy Nayra purges it). Here the PLAYER focus IS the Nayra: its on-cast
+// purge is GATED on whether its struck target was REPAIRED (HP-healed) this round
+// (subject 'target-repaired-this-round'). The repaired target is an ENEMY ally.
+//
+// Before E5, enemy heals never restored HP, so an enemy could never enter the
+// engine's per-round repaired set → a player Nayra attacking an enemy never saw
+// targetRepairedThisRound === true. Task 1 made enemy heals symmetric. This test
+// proves the consequence: a player Nayra now purges a *repaired enemy*.
+//
+// Positional two-team battle-sim harness. Turn order by speed desc within a round:
+//   EnemyAlly(200)   → self-heals (consumes any HP deficit → flagged repaired) and
+//                      applies a removable "Attack Up" self-buff.
+//   Nayra-focus(100) → hits the enemy ally (creating/refreshing the deficit) AND
+//                      fires its on-cast purge gated on target-repaired-this-round.
+//
+// The deficit→heal→purge sequence completes across rounds:
+//   Round 1: enemy ally self-heals at full HP (consumes 0 → NOT repaired this
+//            round) → focus purge gate false. Then the focus hits the enemy ally,
+//            opening a deficit.
+//   Round 2: enemy ally self-heals consuming the round-1 deficit (> 0 → REPAIRED
+//            this round). Then the focus acts → targetRepairedThisRound(enemyAlly)
+//            = true → its on-cast purge fires → strips "Attack Up".
+//
+// Two runs (non-vacuous contrast):
+//   1. Repaired:     enemy-ally self-heal present → it enters repairedThisRound →
+//                    Attack Up GONE.
+//   2. Not repaired: enemy-ally self-heal removed → never repaired → the player
+//                    Nayra's gate is false → purge does NOT fire → Attack Up REMAINS.
+//
+// Observed off the ENEMY ALLY's self-buff store via
+// statusEngine.timedAbilityStatuses('self', ENEMY_ALLY_ID) read through the
+// __testTapStatusEngine tap (the same store nayraRepairedPurge.test.ts reads for
+// the focus, keyed here by the enemy ally's id).
+// ---------------------------------------------------------------------------
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `ner${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+const FOCUS_ID = 'attacker';
+const ENEMY_ALLY_ID = 'enemy-ally';
+
+describe('E5 Task 2: player-Nayra purge gated on target-repaired-this-round vs a repaired enemy', () => {
+    // The enemy ally's removable self-buff, applied on its active each round.
+    const attackUp = (): Ability =>
+        ab({
+            type: 'buff',
+            target: 'self',
+            config: {
+                type: 'buff',
+                buffName: 'Attack Up',
+                parsedEffects: { attack: 30 },
+                stacks: 1,
+                isStackable: false,
+                duration: 99,
+            },
+        });
+
+    // A self-heal: 10% of the enemy ally's own max HP. With an HP deficit from the
+    // focus's prior-round hit, consumed > 0 → the enemy ally is flagged repaired.
+    const selfHeal = (): Ability =>
+        ab({
+            type: 'heal',
+            target: 'self',
+            config: { type: 'heal', pct: 10, basis: 'target-hp' },
+        });
+
+    const hit = (): Ability =>
+        ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } });
+
+    // The enemy ally (speed 200, acts FIRST): applies Attack Up to itself, optionally
+    // self-heals, and fires a basic hit so its turn resolves normally. NO purge.
+    const enemyAlly = (heal: boolean) => ({
+        id: ENEMY_ALLY_ID,
+        stats: { attack: 1000, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000, speed: 200 },
+        chargeCount: 0,
+        startCharged: false,
+        position: 'M1' as Position,
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active' as const,
+                    abilities: heal ? [attackUp(), selfHeal(), hit()] : [attackUp(), hit()],
+                },
+            ],
+        },
+    });
+
+    // The player focus IS the Nayra (speed 100, acts LAST): an on-cast purge GATED
+    // on target-repaired-this-round, plus a basic hit so targetId resolves to the
+    // enemy ally and (in the prior round) dents it to open the deficit.
+    const nayraFocusSkills = (): ShipSkills => ({
+        slots: [
+            {
+                slot: 'active',
+                abilities: [
+                    ab({
+                        type: 'purge',
+                        target: 'enemy',
+                        trigger: 'on-cast',
+                        conditions: [{ subject: 'target-repaired-this-round', derivable: true }],
+                        config: { type: 'purge', count: 'all' },
+                    }),
+                    hit(),
+                ],
+            },
+        ],
+    });
+
+    const BASE = (heal: boolean): CombatEngineInput => ({
+        // Modest attack: a non-lethal dent each round, leaving a deficit for the
+        // enemy ally's self-heal to consume without out-healing it to full.
+        attack: 5000,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: nayraFocusSkills(),
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 3,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        // The player focus is the Nayra. It is also the (formal) heal target — required
+        // because enemyAttackers demand a healTargetId — but it is never healed.
+        hp: 1_000_000,
+        // Focus acts LAST (speed 100 < enemy ally 200), so it sees the enemy ally's
+        // same-round self-heal before its purge gate is evaluated.
+        speed: 100,
+        healTargetId: FOCUS_ID,
+        position: 'M4',
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        enemyAttackers: [enemyAlly(heal)],
+    });
+
+    const finalEnemyAllySelfBuffs = (heal: boolean): string[] => {
+        idc = 0;
+        let engine: StatusEngine | undefined;
+        runCombat({
+            ...BASE(heal),
+            __testTapStatusEngine: (e) => {
+                engine = e;
+            },
+        });
+        return engine!.timedAbilityStatuses('self', ENEMY_ALLY_ID).map((b) => b.active.buffName);
+    };
+
+    it('REPAIRED (enemy ally self-heals after taking damage): player-Nayra purge fires → Attack Up removed', () => {
+        expect(finalEnemyAllySelfBuffs(true)).toEqual([]);
+    });
+
+    it('NOT REPAIRED (enemy ally never self-heals): player-Nayra gate false → purge inert → Attack Up remains', () => {
+        expect(finalEnemyAllySelfBuffs(false)).toEqual(['Attack Up']);
+    });
+});

--- a/src/utils/combat/__tests__/salvationDeadRecipient.test.ts
+++ b/src/utils/combat/__tests__/salvationDeadRecipient.test.ts
@@ -58,6 +58,9 @@ const makeHealing = (
         },
         grantShieldToTarget: () => {},
         playerIds,
+        // E5 fields (unused on this player-path double — present for type-correctness).
+        enemyIds: [],
+        recipientActor: () => undefined,
     };
     return { healing, credits };
 };

--- a/src/utils/combat/__tests__/symmetricHealing.test.ts
+++ b/src/utils/combat/__tests__/symmetricHealing.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { CombatActor } from '../state';
+
+// ---------------------------------------------------------------------------
+// E5 §4.1: Symmetric enemy healing (the core). An ENEMY healer takes damage from
+// the player focus, then self-heals into its OWN currentHp via the per-victim
+// pool. Roles are INVERTED vs nayraRepairedPurge.test.ts: the player focus just
+// attacks; the enemy ship does the healing.
+//
+// Two assertions:
+//   1. The enemy healer's currentHp recovers (was HP-restore-blocked before E5).
+//   2. The player healing result does NOT contain the enemy id (no player-bucket
+//      credit / surface leak on the enemy path).
+// ---------------------------------------------------------------------------
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `e5_${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+const hit = (): Ability =>
+    ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } });
+const FOCUS_ID = 'attacker';
+const selfHeal = (): Ability =>
+    ab({ type: 'heal', target: 'self', config: { type: 'heal', pct: 2, basis: 'target-hp' } });
+const enemyHealer = () => ({
+    id: 'enemy-healer',
+    stats: { attack: 1, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000, speed: 100 },
+    chargeCount: 0,
+    startCharged: false,
+    position: 'M4' as Position,
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    shipSkills: { slots: [{ slot: 'active' as const, abilities: [selfHeal(), hit()] }] },
+});
+const focusSkills = (): ShipSkills => ({ slots: [{ slot: 'active', abilities: [hit()] }] });
+const BASE = (): CombatEngineInput => ({
+    attack: 50_000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: focusSkills(),
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 3,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000,
+    speed: 300,
+    healTargetId: FOCUS_ID,
+    position: 'M1',
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    enemyAttackers: [enemyHealer()],
+});
+
+describe('E5 §4.1: enemy heals restore enemy HP into its own pool', () => {
+    it('enemy healer recovers HP after taking damage', () => {
+        idc = 0;
+        let healer: CombatActor | undefined;
+        runCombat({
+            ...BASE(),
+            __testTapActors: (actors) => {
+                healer = actors.find((a) => a.id === 'enemy-healer');
+            },
+        });
+        expect(healer).toBeDefined();
+        // Per-round (player speed 300 acts first, enemy speed 100 last):
+        //   hit −50,000 (attack 50k, defence 0, ×1.0 multiplier), then self-heal
+        //   +20,000 (2% of the 1,000,000 max-HP basis). Net −30,000/round over 3 rounds.
+        //   Without E5 the floor would be 1,000,000 − 3×50,000 = 850,000 (no restore).
+        // Non-vacuous: above the no-heal floor (heals landed) AND below max (damage landed).
+        expect(healer!.currentHp).toBe(910_000);
+        expect(healer!.currentHp).toBeGreaterThan(850_000);
+        expect(healer!.currentHp).toBeLessThan(1_000_000);
+    });
+
+    it('enemy heal does NOT pollute the player healing result', () => {
+        idc = 0;
+        const result = runCombat(BASE());
+        // Scope to the HEALING surface: the player focus attacks the enemy healer, so the
+        // enemy id legitimately appears in the DAMAGE perTargetDamage — that's not pollution.
+        // The enemy heal must contribute NOTHING to the player healing buckets (no credit).
+        expect(JSON.stringify(result.healing)).not.toContain('enemy-healer');
+    });
+});

--- a/src/utils/combat/__tests__/symmetricHealing.test.ts
+++ b/src/utils/combat/__tests__/symmetricHealing.test.ts
@@ -102,6 +102,10 @@ describe('E5 §4.1: enemy heals restore enemy HP into its own pool', () => {
         // Scope to the HEALING surface: the player focus attacks the enemy healer, so the
         // enemy id legitimately appears in the DAMAGE perTargetDamage — that's not pollution.
         // The enemy heal must contribute NOTHING to the player healing buckets (no credit).
-        expect(JSON.stringify(result.healing)).not.toContain('enemy-healer');
+        // perActor is a Map, so JSON.stringify would serialize it to {} — check membership directly.
+        const hasEnemyHealingCredits = result.healing?.rounds.some((round) =>
+            round.perActor.has('enemy-healer')
+        );
+        expect(hasEnemyHealingCredits).toBe(false);
     });
 });

--- a/src/utils/combat/__tests__/triggers.test.ts
+++ b/src/utils/combat/__tests__/triggers.test.ts
@@ -2213,6 +2213,8 @@ describe('once-per-combat repair cap in executeIntent (Task 8)', () => {
             },
             grantShieldToTarget: () => {},
             playerIds: ['A'],
+            enemyIds: [],
+            recipientActor: () => undefined,
         };
         const ctx: IntentExecContext = {
             round: 1,
@@ -2728,6 +2730,8 @@ describe('Phase 4c Task 6: live drain-time selfHpPct', () => {
             },
             grantShieldToTarget: () => {},
             playerIds: ['A'],
+            enemyIds: [],
+            recipientActor: () => undefined,
         };
         const ctx: IntentExecContext = {
             round: 1,
@@ -2985,6 +2989,8 @@ describe('Phase 4c PR 2 Task 4: damagedAllyId recipient routing', () => {
             },
             grantShieldToTarget: () => {},
             playerIds: PLAYER_IDS,
+            enemyIds: [],
+            recipientActor: () => undefined,
         };
         const ctx: IntentExecContext = {
             ...buildBuffCtx(),

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2937,38 +2937,45 @@ export function runCombat(input: CombatEngineInput): {
             if (actor.id === focusActorId) {
                 // PR6b: read the dummy sink's live currentHp instead of the scalar (identical
                 // value — the sink update at ~3771 keeps enemy.currentHp == enemyHp - cumulative).
-                const enemyHpDecline = Math.max(0, enemyHp - enemy.currentHp);
-                const enemyHpPct =
-                    enemyHp > 0 ? Math.max(0, 100 * (1 - enemyHpDecline / enemyHp)) : 100;
-                const lastKnownCtx = lastTurnCtxByActor.get(actor.id);
-                focusTurns.push({
-                    action: 'active',
-                    roundCrit: false,
-                    hitCrits: [],
-                    enemyHpPct,
-                    dotsConfig: [],
-                    dotsLanded: true,
-                    activeSelfBuffs: [],
-                    landedEnemyDebuffs: [],
-                    inflictedEnemyDebuffs: [],
-                    resistedEnemyDebuffs: [],
-                    directDamage: 0,
-                    secondaryDamage: 0,
-                    conditionalDamage: 0,
-                    detonationDamage: 0,
-                    extraActionGrants: [],
-                    turnCtx: lastKnownCtx ?? {
-                        effectiveAttack: 0,
-                        dotMult: 1,
-                        affinityMult: 1,
-                        effectiveDefence: 0,
-                        effectiveMaxHp: 0,
-                        outgoingHealPct: 0,
-                        incomingHealPct: 0,
-                    },
-                });
+                pushSynthesizedFocusSkipTurn();
             }
             return true;
+        };
+
+        // E5 §4.4: the synthesized no-action focus turn pushed when the focus skips its
+        // turn (dead heal-target OR stasised). Extracted from the two byte-identical sites
+        // (handleDeadTargetSkip + the stasis gate) so the shape cannot drift.
+        const pushSynthesizedFocusSkipTurn = (): void => {
+            const enemyHpDecline = Math.max(0, enemyHp - enemy.currentHp);
+            const enemyHpPct =
+                enemyHp > 0 ? Math.max(0, 100 * (1 - enemyHpDecline / enemyHp)) : 100;
+            const lastKnownCtx = lastTurnCtxByActor.get(focusActorId);
+            focusTurns.push({
+                action: 'active',
+                roundCrit: false,
+                hitCrits: [],
+                enemyHpPct,
+                dotsConfig: [],
+                dotsLanded: true,
+                activeSelfBuffs: [],
+                landedEnemyDebuffs: [],
+                inflictedEnemyDebuffs: [],
+                resistedEnemyDebuffs: [],
+                directDamage: 0,
+                secondaryDamage: 0,
+                conditionalDamage: 0,
+                detonationDamage: 0,
+                extraActionGrants: [],
+                turnCtx: lastKnownCtx ?? {
+                    effectiveAttack: 0,
+                    dotMult: 1,
+                    affinityMult: 1,
+                    effectiveDefence: 0,
+                    effectiveMaxHp: 0,
+                    outgoingHealPct: 0,
+                    incomingHealPct: 0,
+                },
+            });
         };
 
         // Per-round extra-action bookkeeping: oncePerRound abilities fire at most once
@@ -3578,40 +3585,9 @@ export function runCombat(input: CombatEngineInput): {
                         // Synthesize a minimal no-action result so the post-round
                         // `focusTurns.length` guard does not throw (the focus actor
                         // was stasised — it did not act, but the round must still assemble).
-                        // Shape copied verbatim from handleDeadTargetSkip's focusTurns.push(…).
+                        // Delegated to pushSynthesizedFocusSkipTurn (E5 §4.4 DRY helper).
                         if (actor.id === focusActorId) {
-                            const enemyHpDecline = Math.max(0, enemyHp - enemy.currentHp);
-                            const enemyHpPct =
-                                enemyHp > 0
-                                    ? Math.max(0, 100 * (1 - enemyHpDecline / enemyHp))
-                                    : 100;
-                            const lastKnownCtx = lastTurnCtxByActor.get(actor.id);
-                            focusTurns.push({
-                                action: 'active',
-                                roundCrit: false,
-                                hitCrits: [],
-                                enemyHpPct,
-                                dotsConfig: [],
-                                dotsLanded: true,
-                                activeSelfBuffs: [],
-                                landedEnemyDebuffs: [],
-                                inflictedEnemyDebuffs: [],
-                                resistedEnemyDebuffs: [],
-                                directDamage: 0,
-                                secondaryDamage: 0,
-                                conditionalDamage: 0,
-                                detonationDamage: 0,
-                                extraActionGrants: [],
-                                turnCtx: lastKnownCtx ?? {
-                                    effectiveAttack: 0,
-                                    dotMult: 1,
-                                    affinityMult: 1,
-                                    effectiveDefence: 0,
-                                    effectiveMaxHp: 0,
-                                    outgoingHealPct: 0,
-                                    incomingHealPct: 0,
-                                },
-                            });
+                            pushSynthesizedFocusSkipTurn();
                         }
                     } // end stasis gate (attacker branch)
                 } else if (actor.kind === 'team' && teamRuntimeById.has(actor.id)) {

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -43,7 +43,11 @@ import {
 } from './statusEngine';
 import { liveGateConditions } from './abilityStatusGating';
 import { isPositional, resolvePositionalTarget } from './positionalBinding';
-import { applyPositionalDamage, footprintVictims, type VictimDamageOutcome } from './positionalApply';
+import {
+    applyPositionalDamage,
+    footprintVictims,
+    type VictimDamageOutcome,
+} from './positionalApply';
 import type { AttackerDamageScalars } from './victimDamage';
 import { CHEAT_DEATH_BUFFS } from './cheatDeathBuffs';
 import { BARRIER_BUFFS } from './barrierBuffs';
@@ -1684,11 +1688,12 @@ export function runCombat(input: CombatEngineInput): {
     const isStasised = (actorId: string): boolean => ownerDebuffNames(actorId).some(isStasis);
 
     // Base-HP fallback for recipientMaxHp before an actor has taken its first turn (no ctx yet):
-    // attacker → input.hp; walked team → walk stats hp; legacy team → its combat-actor hp (1).
-    // Enemy ids are never queried as recipients.
+    // attacker → input.hp; walked team → walk stats hp; enemy attackers → their CombatActor hp
+    // (E5: enemy ids ARE now queried as recipients once enemy heals restore HP).
     const baseHpById = new Map<string, number>([
         [attacker.id, hp],
         ...teamActors.map((t) => [t.id, t.walk!.stats.hp] as const),
+        ...enemyAttackerActors.map((a) => [a.id, a.stats.hp] as const),
     ]);
     const baseHpFor = (id: string): number => baseHpById.get(id) ?? 0;
 
@@ -1935,6 +1940,8 @@ export function runCombat(input: CombatEngineInput): {
                   victim.shieldPool = Math.min(victim.shieldPool + raw, targetMaxHp);
               },
               playerIds,
+              enemyIds: enemyRecipientIds,
+              recipientActor: (id) => allActorsById.get(id),
           }
         : undefined;
 

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2328,6 +2328,13 @@ export function runCombat(input: CombatEngineInput): {
         // its own entry; the post-round assembly derives row fields from the focus entry.
         // The helper `dmg(id)` lazily creates entries on first write — actors that never
         // produce damage in a round simply have no entry, keeping the map sparse.
+        //
+        // E5 §4.5 — CREDIT vs INTAKE are COMPLEMENTARY, not redundant (closing the umbrella
+        // spec's "collapse the dual paths" framing). This `roundDamage`/`creditDamage` path is
+        // the CREDIT side: damage *dealt*, keyed by SOURCE id, feeding row totals + damage-dealt
+        // leeches. The `perActorIncoming`/`intakeFor` path below (~2365) is the INTAKE side:
+        // damage *taken*, keyed by VICTIM id, feeding healing-mode rows. They record different
+        // facts about the same hit (who dealt it vs who took it); E5 does NOT merge them.
         const roundDamage = new Map<string, ActorDamage>();
         // Per-round per-victim positional damage accumulator (victim actor id → summed damage
         // dealt to it this round). Populated ONLY by the positional apply path's emitHit
@@ -2362,6 +2369,10 @@ export function runCombat(input: CombatEngineInput): {
         // Barrier (full damage immunity), kept SEPARATE from shieldAbsorbed (Barrier does NOT drain
         // the shield pool) so the UI can attribute the blocked total to the Barrier, not the shield.
         // Fresh map each round; intakeFor() get-or-creates on first write.
+        //
+        // E5 §4.5 — this is the INTAKE side (damage *taken*, keyed by VICTIM id); the
+        // complementary CREDIT side is `roundDamage`/`creditDamage` (~2331, damage *dealt*,
+        // keyed by SOURCE id). Complementary facts, not duplicates — see the note there.
         const perActorIncoming = new Map<string, ActorIntake>();
         const intakeFor = (id: string): ActorIntake => {
             let entry = perActorIncoming.get(id);
@@ -4024,15 +4035,19 @@ export function runCombat(input: CombatEngineInput): {
                                 // Phase-5 symmetric-accounting surface (the result still exposes a single
                                 // heal-target row today). Inert here regardless (no production caller
                                 // threads enemy position+pattern).
-                                // DETONATION CAVEAT (deferred → E5 accounting unification): only the firing
-                                // hit (enemyScalars, the DIRECT channel) lands per-victim here. The
+                                // DETONATION CAVEAT (E5 §4.3 — PEELED to a dedicated follow-up): only the
+                                // firing hit (enemyScalars, the DIRECT channel) lands per-victim here. The
                                 // aggregate `damage` also folds enemyTurn.detonationDamage, which the
-                                // NON-positional branch drains via applyIncomingToTarget(damage, tgt) but
-                                // which is NOT routed to any player victim on the positional path — routing
-                                // it needs per-victim bomb attribution the engine does not track yet
-                                // (detonation is a single turn-scalar, not per-target). Byte-identical today
-                                // (no fixture threads enemy position+pattern WITH detonation); a positional
-                                // enemy-detonation model lands with E5.
+                                // NON-positional branch already drains per-victim via
+                                // applyIncomingToTarget(damage, tgt) → perActorIncoming (so non-positional
+                                // detonation intake is ALREADY recorded). Only the POSITIONAL path leaves it
+                                // unrouted — and routing it per-victim needs per-victim bomb attribution the
+                                // engine does not track yet (detonation is a single turn-scalar, not
+                                // per-target). E5 PEELED this per the spec's §5 pressure valve: it requires
+                                // NEW tracking and has zero observable cost to defer (perActorIncoming is
+                                // internal/unread by the UI, and no fixture threads enemy position+pattern
+                                // WITH detonation → byte-identical today). A positional enemy-detonation
+                                // model lands in the follow-up.
                                 const tb = turnBindings(actor.side);
                                 drivePositionalApply({
                                     scalars: enemyScalars!,

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -103,6 +103,10 @@ export interface HealingRuntimeCtx {
     grantShieldToTarget: (raw: number, victim?: CombatActor) => void;
     /** Fixed player-id order for all-allies recipient routing. */
     playerIds: string[];
+    /** Fixed enemy-attacker-id order for an ENEMY caster's all-allies routing (E5). */
+    enemyIds: string[];
+    /** Resolve a recipient id to its CombatActor (E5 enemy-heal apply). undefined if absent. */
+    recipientActor: (id: string) => CombatActor | undefined;
 }
 
 /** Everything one player actor's turn contributes to the round's RoundData row. */
@@ -1432,7 +1436,8 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                     scaling.per > 0
                 ) {
                     purgeCount =
-                        ab.config.count * Math.max(0, Math.floor(effectiveCritDamage / scaling.per));
+                        ab.config.count *
+                        Math.max(0, Math.floor(effectiveCritDamage / scaling.per));
                 }
                 for (const vid of recipients) {
                     const removed = statusEngine.purge(vid, purgeCount);
@@ -1471,12 +1476,35 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 : healing.recipientIncomingHealPct(rid);
         // Recipient routing (user-confirmed): self → caster; ally → the bombarded target;
         // all-allies → every player in fixed source order. Shared by the heal + shield branches.
-        const recipientsFor = (target: Ability['target']): string[] =>
-            target === 'self'
-                ? [actor.id]
-                : target === 'all-allies'
-                  ? healing.playerIds
-                  : [healing.targetId];
+        const isEnemyCaster = actor.side === 'enemy';
+        // Lowest-HP-fraction living enemy ally for an enemy single-'ally' heal (E5).
+        // Deterministic: ties broken by enemyIds source order. Falls back to the caster
+        // when no other living ally exists. NEVER routes to the player heal target.
+        const lowestHpEnemyAllyId = (): string | undefined => {
+            let best: string | undefined;
+            let bestFrac = Infinity;
+            for (const id of healing.enemyIds) {
+                const a = healing.recipientActor(id);
+                if (!a || a.currentHp <= 0) continue;
+                const maxHp = healing.recipientMaxHp(id);
+                const frac = maxHp > 0 ? a.currentHp / maxHp : 0;
+                if (frac < bestFrac) {
+                    bestFrac = frac;
+                    best = id;
+                }
+            }
+            return best ?? actor.id;
+        };
+        const recipientsFor = (target: Ability['target']): string[] => {
+            if (target === 'self') return [actor.id];
+            if (target === 'all-allies')
+                return isEnemyCaster ? healing.enemyIds : healing.playerIds;
+            if (isEnemyCaster) {
+                const rid = lowestHpEnemyAllyId();
+                return rid ? [rid] : [];
+            }
+            return [healing.targetId];
+        };
         // Basis value for a heal/shield ability against recipient `rid`.
         const basisValue = (
             basis: 'hp' | 'attack' | 'defense' | 'target-hp' | 'damage-dealt' | 'damage-taken',
@@ -1609,9 +1637,25 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
             if (cfg.type === 'heal') {
                 const recipients = recipientsFor(ability.target);
                 if (healEventOnly) {
-                    // Event-only: NO numeric at all — do NOT draw the heal crit gate, do NOT
-                    // credit or apply. Just register recipients so heal-performed fires (amount 0).
-                    for (const rid of recipients) healTargets.push(rid);
+                    // E5 §4.1: enemy heals restore each recipient's OWN currentHp (via the
+                    // per-victim pool), fire repairedThisRound, and emit heal-performed — but
+                    // contribute NOTHING to the player healing buckets (no healing.credit).
+                    const didCrit = cfg.noCrit ? false : healCritGate(effectiveCrit / 100);
+                    if (didCrit) healCritCount += 1;
+                    for (const rid of recipients) {
+                        const basis = basisValue(cfg.basis, rid);
+                        const raw =
+                            basis *
+                            (cfg.pct / 100) *
+                            (didCrit ? 1 + effectiveCritDamage / 100 : 1) *
+                            (1 + healModifier / 100) *
+                            (1 + dmgStats.totals.outgoingHealBuff / 100) *
+                            (1 + incomingPctFor(rid) / 100);
+                        const recipientActor = healing.recipientActor(rid);
+                        if (recipientActor) healing.applyHealToTarget(raw, recipientActor);
+                        healTargets.push(rid);
+                        healRawSum += raw;
+                    }
                     continue;
                 }
                 // ONE crit draw per heal ability (not per recipient).

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1719,8 +1719,9 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         }
 
         // ONE heal-performed per cast that healed at least one recipient. critHits is the
-        // number of heal abilities that crit (present-only-when-positive). In event-only mode
-        // amount is 0 and critHits is absent (no numeric was computed).
+        // number of heal abilities that crit (present-only-when-positive). In event-only
+        // (enemy) mode E5 §4.1 now computes the numeric, so amount/critHits reflect the real
+        // enemy heal (the player healing buckets stay uncredited — see the healEventOnly note above).
         if (healTargets.length > 0) {
             bus.emit({
                 type: 'heal-performed',

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -234,11 +234,14 @@ export interface PlayerTurnArgs {
      *  Absent for DPS-mode turns — the heal block is fully gated on this, keeping the DPS
      *  goldens byte-identical. */
     healing?: HealingRuntimeCtx;
-    /** Event-only heal/cleanse emission (Phase 4c PR 4 Task 5): when true (the enemy walk),
-     *  the heal block EMITS `heal-performed`/`cleanse-performed` carrying THIS actor's id but
-     *  credits NO player healing bucket and mutates NO target — the shared player `healing` ctx
-     *  must never see an enemy-id mutation. Scopes emission to the CAST skill (gatedSkill) only,
-     *  never the passive. Defaults falsy (player/team turns credit + mutate as before). */
+    /** Event-only heal/cleanse emission (Phase 4c PR 4 Task 5; HP-restore lifted in E5 §4.1):
+     *  when true (the enemy walk), the heal block EMITS `heal-performed`/`cleanse-performed`
+     *  carrying THIS actor's id and (E5) restores each heal recipient's OWN currentHp via the
+     *  per-victim pool — but credits NO player healing bucket and never mutates the player
+     *  heal-target (the shared player `healing` ctx never sees an enemy-id BUCKET credit).
+     *  Shields/cleanse still mutate nothing on this path. Scopes emission to the CAST skill
+     *  (gatedSkill) only, never the passive. Defaults falsy (player/team turns credit + mutate
+     *  as before). */
     healEventOnly?: boolean;
     /** Acting actor's live HP% (0..100) for self-HP-threshold gates. Defaults to 100 so
      *  callers that do not supply it (e.g. standalone tests, un-updated call sites) behave
@@ -1618,9 +1621,12 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
             if (c.basis === 'damage-taken') return true;
             return c.basis === 'damage-dealt' && fromPassive;
         };
-        // Event-only mode (enemy walk, Task 5): EMIT heal/cleanse events but credit/mutate
-        // NOTHING — and scope to the CAST skill only (the spec: "the cast skill carries"),
-        // never the passive. Normal (player/team) mode keeps both slots and credits/mutates.
+        // Event-only mode (enemy walk, Task 5; HP-restore lifted in E5 §4.1): EMIT heal/cleanse
+        // events and (E5) restore each heal recipient's OWN currentHp via the per-victim pool,
+        // but credit NO player healing bucket and never mutate the player heal-target. Shields
+        // and cleanse still mutate NOTHING on the enemy path (deferred to sub-projects H / enemy
+        // cleanse). Scope to the CAST skill only (the spec: "the cast skill carries"), never the
+        // passive. Normal (player/team) mode keeps both slots and credits/mutates as before.
         const healAbilities = healEventOnly
             ? (gatedSkill?.abilities ?? []).filter((a) => !isHookOwned(a, false))
             : [

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1487,6 +1487,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
             let best: string | undefined;
             let bestFrac = Infinity;
             for (const id of healing.enemyIds) {
+                if (id === actor.id) continue; // caster is the fallback only, never a primary candidate
                 const a = healing.recipientActor(id);
                 if (!a || a.currentHp <= 0) continue;
                 const maxHp = healing.recipientMaxHp(id);


### PR DESCRIPTION
## Summary

Closes sub-project **E** (per-victim AoE accounting) — and the last remnant of the bySide-unification campaign — by making the battle sim symmetric for healing.

Enemy ships now **actually heal**: they restore their own `currentHp` via the already-general per-victim pool and enter `repairedThisRound`, while player-side healing-result accounting stays untouched. This lights up player-**Nayra**'s already-parsed "if the target was repaired this round" purge/Stasis condition against healed enemies. Plus the death-fallback DRY extraction and the credit≠intake documentation closeout.

Spec: `docs/superpowers/specs/2026-06-20-combat-realism-E-tail-design.md` §4.
Plan: `docs/superpowers/plans/2026-06-20-combat-realism-E5-symmetric-healing.md`.

## What changed (5 functional commits)

- **Symmetric enemy healing (§4.1):** lifts the HP-restore half of `healEventOnly` for enemy heals. The change is confined entirely to the `healEventOnly === true` branch of `runPlayerTurn` (set only on the enemy turn binding), so the player healing-calc path is **structurally byte-identical**. Added `enemyIds` + `recipientActor` to `HealingRuntimeCtx`; seeded enemy attacker base HP into `baseHpById` (so pre-first-turn enemy recipients have a real cap — otherwise `repairedThisRound` silently never fires); made `recipientsFor` side-aware (enemy single-`ally` → lowest-HP living enemy ally, never the player heal target). Player-bucket credit stays suppressed (no enemy result surface until sub-project H). Enemy `heal-performed` events now carry the real amount + critHits.
- **Nayra lights up (§4.2):** no new production code — proved end-to-end by `nayraEnemyRepairedPurge.test.ts` (player-Nayra purge fires vs a repaired enemy, not vs an un-repaired one; non-vacuous contrast).
- **Death-fallback DRY (§4.4):** extracted `pushSynthesizedFocusSkipTurn()` from the two byte-identical synth-turn shapes (dead-heal-target skip + Stasis skip). Byte-identical refactor.
- **Credit≠intake closeout (§4.5):** clarifying comments documenting that `creditDamage` (dealt-per-source) and `perActorIncoming` (taken-per-victim) are complementary, not redundant; plus a stale-comment sweep.

## Deferred (peeled per the spec's §5 pressure valve)

- **Detonation per-victim intake (§4.3) → follow-up.** Non-positional detonation intake is **already recorded** per-victim (the aggregate `damage` folds detonation and drains via `applyIncomingToTarget` → `perActorIncoming`). Only the **positional** per-victim case remains, and it needs new per-victim bomb attribution the engine doesn't track yet — zero observable cost to defer (`perActorIncoming` is internal/unread; no fixture threads enemy position+pattern with detonation). Logged in-code at the caveat site.

## Testing / gate

- **2689 tests pass** (was 2685 at baseline + 4 new). **Zero golden/snapshot movement** — no existing fixture placed a heal ability on an enemy attacker, so there was no enemy heal to newly restore. The one behavioral test update (`enemyActions.test.ts`) corrected a test whose setup (`side:'player'` + `healEventOnly:true`) the engine never produces.
- `tsc --noEmit` clean, `lint` 0 warnings, `audit:skills` 141 ships / 0 findings.
- Per-task spec + code-quality reviews on every commit, plus a final holistic (opus) review — all addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)