### PR TITLE
Combat sim: implant + gear-set abilities — D-PR1 foundation (Leech + Bloodthirst)

### DIFF
--- a/docs/superpowers/plans/2026-06-20-implant-gearset-abilities-D-pr1.md
+++ b/docs/superpowers/plans/2026-06-20-implant-gearset-abilities-D-pr1.md
@@ -1,0 +1,392 @@
+# Implant + Gear-Set Abilities — D-PR1 (Foundation) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up the source-and-chance foundation that lets the combat sim consume implant + gear-set special effects, proven end-to-end by two effects on existing engine machinery: the **Leech** gear set (standing leech) and the **Bloodthirst** implant (on-crit, 12% chance, self-heal off damage dealt).
+
+**Architecture:** A new sibling module `buildEquipmentAbilities(ship, getGearPiece)` resolves a ship's active gear sets (count by `setBonus`) and equipped implants (id → name + rarity → variant `description`) into `Ability[]`. Gear-set special effects are produced by a tiny explicit per-set builder (their text is terse/non-prose); implant effects are parsed by reusing `abilitiesFromText`, then stamped with a `procChance` extracted from the description. The result is merged into the passive slot via a thin wrapper that leaves `buildShipAbilities` untouched (so every existing test stays byte-identical). Probabilistic procs ride a combat-lifetime `Map<string, RateGate>` keyed `${ownerId}:${abilityId}`, mirroring the existing `oncePerCombatFired` set; the reactive-heal executor rolls the gate before firing.
+
+**Tech Stack:** React 18 + TypeScript, Vitest. Combat engine in `src/utils/combat/`, ability building in `src/utils/abilities/`, parser in `src/utils/skillTextParser.ts`, types in `src/types/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-design.md`.
+
+**Branch:** `feat/combat-d-implant-gearset` (stacked on the E5 branch tip `73e10097`; rebase onto main later).
+
+---
+
+## Critical conventions (read before starting)
+
+- **Test runner:** `npm test` runs Vitest in WATCH mode and hangs agents. ALWAYS use `npx vitest run <path-or-name>`.
+- **Goldens:** NEVER run `vitest -u`. The load-bearing invariant for this PR is that all existing DPS / healing / battle-sim goldens stay **byte-identical** — the new builder only emits abilities when equipment resolves, and no existing fixture carries effect-bearing gear (verified in Task 0). If a `.snap` moves, the gate leaked — fix the gate, don't regenerate.
+- **Lint:** `npm run lint` enforces `--max-warnings 0`. Run it in EVERY task gate, not just the last.
+- **docs/ is gitignored:** commit plan/spec edits with `git add -f` and `git commit --no-verify` (the pre-commit hook runs the full suite; skip it for docs-only commits).
+- **Stat-only portions are already in combat stats** — this PR adds ONLY special-effect abilities, never stats.
+- REQUIRED SUB-SKILLS while implementing: @superpowers:test-driven-development, @superpowers:verification-before-completion.
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/types/abilities.ts` | Ability model | Add `procChance?: number` to `Ability`. |
+| `src/utils/combat/triggers.ts` | Reactive intent execution | Add `procChanceGates?: Map<string, RateGate>` to `IntentExecContext`; roll the gate in the reactive heal/shield executor. |
+| `src/utils/combat/engine.ts` | Combat setup + drain context | Create the combat-lifetime `procChanceGates` map (next to `oncePerCombatFired`) and thread it into every `IntentExecContext` build site. |
+| `src/utils/abilities/buildEquipmentAbilities.ts` | NEW — resolve equipped sets/implants → `Ability[]` | Create. Set registry + implant-via-parser + `procChance` stamping + graceful skip. |
+| `src/utils/abilities/buildShipAbilitiesWithEquipment.ts` | NEW — thin merge wrapper | Create. `buildShipAbilities(ship)` + merge equipment abilities into the passive slot. |
+| `src/utils/calculators/battleSimulator.ts` | Battle sim entry | `simulateBattle` gains optional `getGearPiece?`; `planPlacement` threads it; uses the wrapper when present. |
+| `src/pages/SimulatorPage.tsx` | Sim page | Pass `getGearPiece` into `simulateBattle`. |
+| `src/pages/calculators/HealingCalculatorPage.tsx` | Healing page | Route the 4 `buildShipAbilities(ship)` sites through the wrapper with `getGearPiece`. |
+| `src/constants/changelog.ts` | Changelog | `UNRELEASED_CHANGES` entry. |
+| `src/pages/DocumentationPage.tsx` | In-app docs | Note implant/gear-set effects now apply in the sim. |
+
+---
+
+## Task 0: Baseline + fixture audit
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Confirm branch + green baseline**
+
+Run: `git branch --show-current` → expect `feat/combat-d-implant-gearset`.
+Run: `npx vitest run src/utils/combat src/utils/abilities src/utils/calculators 2>&1 | tail -20`
+Expected: all pass.
+
+- [ ] **Step 2: Confirm no combat fixture carries effect-bearing gear (byte-identical premise)**
+
+Run: `grep -rn "equipment:\s*{[^}]" src/utils/combat/__tests__ src/utils/calculators/__tests__ 2>/dev/null; grep -rn "implants:\s*{[^}]" src/utils/combat/__tests__ src/utils/calculators/__tests__ 2>/dev/null`
+Expected: no matches with non-empty equipment/implants (fixtures use `{}` or omit). If any match resolves to an effect-bearing set/implant, STOP and surface it — the merge is not byte-identical and the plan needs a fixture-neutralization step.
+
+- [ ] **Step 3: Record the baseline test count**
+
+Run: `npx vitest run 2>&1 | tail -5` and note the passing count for later comparison.
+
+---
+
+## Task 1: `procChance` field + per-proc rate gate in the reactive heal executor
+
+The foundational chance machinery. Unreachable until an ability carries `procChance`, so existing behavior is byte-identical; tested in isolation with a synthetic ability.
+
+**Files:**
+- Modify: `src/types/abilities.ts` (the `Ability` interface, ~:280-299)
+- Modify: `src/utils/combat/triggers.ts` (`IntentExecContext` ~:480-554; reactive heal/shield executor ~:1101-1187)
+- Modify: `src/utils/combat/engine.ts` (combat-lifetime state next to `oncePerCombatFired`; every `IntentExecContext` literal)
+- Test: `src/utils/combat/__tests__/procChanceGate.test.ts` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/utils/combat/__tests__/procChanceGate.test.ts`. Use the existing healing-mode engine harness (mirror the setup in `src/utils/combat/__tests__/enemyActions.test.ts` or `healing.test.ts`). Build a player attacker that crits every turn and carries a passive reactive heal ability:
+
+```ts
+// ability under test (hand-built into the actor's passive slot via the test's ShipSkills):
+{
+  id: 'test-proc-heal',
+  type: 'heal', target: 'self', trigger: 'on-crit', conditions: [],
+  procChance: 0.5,
+  config: { type: 'heal', pct: 50, basis: 'damage-dealt', noCrit: true },
+}
+```
+
+Run the engine for 10 rounds where the attacker lands exactly one critting hit per round, in healing mode, and assert the self-heal is credited on exactly 5 of the 10 crits (deterministic accumulator: 0.5 over 10 calls fires 5 times). Assert a second control ability with `procChance` absent fires on all 10. (Assert the COUNT of fires, not which specific rounds — the accumulator is back-loaded, so the exact firing rounds depend on `rateAccumulator.ts:17`; confirm the pattern there when writing the assertion.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/utils/combat/__tests__/procChanceGate.test.ts`
+Expected: FAIL — `procChance` not a known property (tsc) or the heal fires on all 10 (no gate yet).
+
+- [ ] **Step 3: Add `procChance` to the `Ability` type**
+
+In `src/types/abilities.ts`, add to `interface Ability` (top-level, alongside `triggerCritFilter`):
+
+```ts
+    /** Probabilistic proc gate for equipment-sourced reactive abilities ("N% chance to …").
+     *  A value in (0,1) means the ability fires at that rate via a combat-lifetime per-(owner,
+     *  ability) RateGate (deterministic accumulator, like crit/landing). Absent or out of (0,1)
+     *  → fires on every qualifying trigger. */
+    procChance?: number;
+```
+
+- [ ] **Step 4: Add the gate map to `IntentExecContext` and roll it in the heal/shield executor**
+
+In `src/utils/combat/triggers.ts`:
+
+Add to `IntentExecContext` (mirror the `oncePerCombatFired` doc comment):
+```ts
+    /** Combat-lifetime per-ability proc-chance gates (e.g. Bloodthirst's 12% chance).
+     *  Keyed `${ownerId}:${abilityId}`; the RateGate accumulates across all rounds and all
+     *  reactive fires of the same ability so the proc lands at its true frequency. */
+    procChanceGates?: Map<string, RateGate>;
+```
+
+In the reactive heal/shield executor, immediately AFTER the existing `oncePerCombat` guard (~:1107), add:
+```ts
+    const pc = intent.ability.procChance;
+    if (pc !== undefined && pc > 0 && pc < 1) {
+        const gateKey = `${intent.ownerId}:${intent.ability.id}`;
+        let gate = ctx.procChanceGates?.get(gateKey);
+        if (ctx.procChanceGates && !gate) {
+            gate = makeRateGate();
+            ctx.procChanceGates.set(gateKey, gate);
+        }
+        if (gate && !gate(pc)) return;
+    }
+```
+Ensure `makeRateGate` and the `RateGate` type are imported in `triggers.ts` (import `makeRateGate` from `../calculators/rateAccumulator`; `RateGate` from `./playerTurn`).
+
+- [ ] **Step 5: Create and thread the combat-lifetime map in the engine**
+
+In `src/utils/combat/engine.ts`, find where `oncePerCombatFired` (a `Set<string>`) is created OUTSIDE the round loop (combat-lifetime, near `cheatDeathConsumed`). Add next to it:
+```ts
+    const procChanceGates = new Map<string, RateGate>();
+```
+Then add `procChanceGates,` to EVERY `IntentExecContext` object literal that already passes `oncePerCombatFired` (search for `oncePerCombatFired` in engine.ts — pass `procChanceGates` at each of the same sites). Import `RateGate` if not already imported.
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `npx vitest run src/utils/combat/__tests__/procChanceGate.test.ts`
+Expected: PASS (5/10 gated, 10/10 control).
+
+- [ ] **Step 7: Verify byte-identical goldens + lint + types**
+
+Run: `npx vitest run 2>&1 | tail -5` (expect baseline count + the new test; ZERO `.snap` changes — `git status --short` shows no modified `.snap`).
+Run: `npm run lint && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/types/abilities.ts src/utils/combat/triggers.ts src/utils/combat/engine.ts src/utils/combat/__tests__/procChanceGate.test.ts
+git commit -m "feat(combat): D-PR1 — per-proc rate gate for equipment reactive procs"
+```
+
+---
+
+## Task 2: `buildEquipmentAbilities` module
+
+Pure resolution + emission. Not wired into any engine path yet → byte-identical. Unit-tested in isolation.
+
+**Files:**
+- Create: `src/utils/abilities/buildEquipmentAbilities.ts`
+- Test: `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts` (NEW)
+- Reference (read, don't modify): `src/utils/ship/statsCalculator.ts:140-178` (`countSetPieces`), `src/constants/gearSets.ts`, `src/constants/implants.ts`, `src/utils/abilities/buildShipAbilities.ts:644` (`abilitiesFromText`).
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Create `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`. A `makeGetGearPiece(map)` helper returns a `(id)=>GearPiece|undefined`. Cases:
+
+1. **Leech set active (≥2 pieces):** a ship with 2 equipment ids whose pieces have `setBonus:'LEECH'` → returns exactly one ability: `{type:'heal', target:'self', trigger:'on-cast', config:{type:'heal', pct:15, basis:'damage-dealt', leechScope:'all', noCrit:true}}` with a stable id (`equip-set-LEECH`). (`noCrit:true` — a derived-from-damage leech doesn't roll its own heal-crit; flag as a modeling choice in the PR for reviewer confirmation.)
+2. **Leech set inactive (1 piece):** → `[]`.
+3. **Bloodthirst implant (legendary):** `ship.implants.implant_major` → a piece with `setBonus:'BLOODTHIRST', rarity:'legendary'` → returns an ability `{type:'heal', target:'self', trigger:'on-crit', procChance:0.20, config:{type:'heal', pct:20, basis:'damage-dealt'}}` (legendary = 20% chance / 20% heal per the implant data). Assert `procChance` and `config.pct`.
+4. **Missing piece:** an implant id with no entry in the map → skipped, no throw.
+5. **Stat-only implant (e.g. STRIKE / a minor with no description):** → `[]`.
+6. **Unparseable description:** a fake implant whose description is gibberish → skipped, no throw, `[]`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the module**
+
+Create `src/utils/abilities/buildEquipmentAbilities.ts`:
+
+- Export `interface EquipmentAbility extends Ability { source: 'implant' | 'gear-set'; }` OR return plain `Ability[]` and carry the source in a comment — prefer NOT extending `Ability` (the engine consumes plain `Ability`); instead tag via a stable id prefix (`equip-set-*` / `equip-implant-*`) and skip a separate `source` field. (Resolve in the test accordingly.)
+- `export function buildEquipmentAbilities(ship: Ship, getGearPiece: (id: string) => GearPiece | undefined): Ability[]`.
+- **Active sets:** mirror `countSetPieces` — iterate `ship.equipment`, `getGearPiece(id)?.setBonus`, tally; a set is active when `count >= (GEAR_SETS[name]?.minPieces ?? 2)`. For each active set with an entry in the set-ability registry, emit its ability.
+- **Set-ability registry** (only Leech for D-PR1):
+  ```ts
+  const GEAR_SET_ABILITIES: Partial<Record<string, () => AbilityConfig>> = {
+      LEECH: () => ({ type: 'heal', pct: 15, basis: 'damage-dealt', leechScope: 'all', noCrit: true }),
+  };
+  ```
+  Wrap each config in a full `Ability` (`id: 'equip-set-LEECH'`, `type:'heal'`, `target:'self'`, `trigger:'on-cast'`, `conditions:[]`, `autoFilled:true`).
+- **Implants:** for each id in `ship.implants`, resolve `getGearPiece(id)` → `{ setBonus, rarity }`. `setBonus` is the implant name (a `GearSetName ∪ ImplantName`). Look up `IMPLANTS[setBonus]` (guard undefined); find the variant with matching `rarity`; read `variant.description`. If no description → skip. Feed `description` through `abilitiesFromText(description, 'passive', ship.type)`; for each produced `PositionedAbility`, stamp `procChance` (see helper) and a stable id (`equip-implant-<name>-<i>`); collect `.ability`.
+- **`procChance` helper:** `extractProcChance(text): number | undefined` = match `/(\d+)\s*%\s*chance/i`; return `Number(m[1]) / 100` or `undefined`. Stamp onto each ability produced from that description.
+- **Graceful skip everywhere:** wrap per-piece resolution so a missing piece / missing implant data / empty parser output / thrown error yields no ability (never throws out of the function).
+
+Note for the implementer: Bloodthirst's description ("On a critical hit, there is a 12% chance for this unit to repair itself for 12% of the damage dealt") is expected to parse into a `heal` ability with `trigger:'on-crit'` + `config.basis:'damage-dealt'` + `config.pct` (the heal %); the `procChance` comes from the stamping helper (the "% chance" number, NOT the heal %). If `abilitiesFromText` does NOT yield an on-crit damage-dealt heal for this exact string, characterize what it yields and either (a) add a minimal targeted extension to the heal/leech parser, or (b) fall back to a per-implant builder for BLOODTHIRST mirroring the set registry — document which and why in the commit.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + types + byte-identical**
+
+Run: `npm run lint && npx tsc --noEmit && npx vitest run 2>&1 | tail -5`
+Expected: clean; no `.snap` changes (module unwired).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+git commit -m "feat(combat): D-PR1 — buildEquipmentAbilities (Leech set + implant resolution)"
+```
+
+---
+
+## Task 3: Merge wrapper + call-site plumbing
+
+Wires equipment abilities into the engine. Byte-identical because fixtures carry no effect-bearing gear (Task 0).
+
+**Files:**
+- Create: `src/utils/abilities/buildShipAbilitiesWithEquipment.ts`
+- Modify: `src/utils/calculators/battleSimulator.ts` (`simulateBattle` signature ~:560; `planPlacement` ~:520-535)
+- Modify: `src/pages/SimulatorPage.tsx` (call to `simulateBattle`)
+- Modify: `src/pages/calculators/HealingCalculatorPage.tsx` (5 sites: ~:121, 235, 252, 307, 356 — find ALL `buildShipAbilities(ship)` in the file; a missed site is silent because the wrapper deep-equals `buildShipAbilities` when equipment is empty)
+- Test: `src/utils/abilities/__tests__/buildShipAbilitiesWithEquipment.test.ts` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/utils/abilities/__tests__/buildShipAbilitiesWithEquipment.test.ts`. A ship with Leech set (2 pieces) + Bloodthirst implant, plus a normal skill, run through `buildShipAbilitiesWithEquipment(ship, getGearPiece)`:
+- The passive slot contains BOTH the ship's own passive abilities AND the two equipment abilities.
+- A ship with empty equipment/implants produces output identical to `buildShipAbilities(ship)` (deep-equal).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/utils/abilities/__tests__/buildShipAbilitiesWithEquipment.test.ts`
+Expected: FAIL — wrapper does not exist.
+
+- [ ] **Step 3: Implement the wrapper**
+
+Create `src/utils/abilities/buildShipAbilitiesWithEquipment.ts`:
+```ts
+export function buildShipAbilitiesWithEquipment(
+    ship: Ship,
+    getGearPiece: (id: string) => GearPiece | undefined,
+): ShipSkills {
+    const skills = buildShipAbilities(ship);
+    const equip = buildEquipmentAbilities(ship, getGearPiece);
+    if (!equip.length) return skills;
+    const passive = skills.slots.find((s) => s.slot === 'passive');
+    if (passive) passive.abilities.push(...equip);
+    else skills.slots.push({ slot: 'passive', abilities: equip });
+    return skills;
+}
+```
+`buildShipAbilities` is left untouched (single-arg, byte-identical for all existing callers/tests).
+
+- [ ] **Step 4: Thread `getGearPiece` into the battle simulator**
+
+In `src/utils/calculators/battleSimulator.ts`:
+- Add an optional param to the public entry: `export function simulateBattle(input: BattleSimulationInput, getGearPiece?: (id: string) => GearPiece | undefined): BattleResult`.
+- Thread `getGearPiece` into `planPlacement` (add a param). In `planPlacement`, set `shipSkills: getGearPiece ? buildShipAbilitiesWithEquipment(p.ship, getGearPiece) : buildShipAbilities(p.ship)`.
+- When `getGearPiece` is absent (every existing test), behavior is identical → goldens byte-identical.
+
+- [ ] **Step 5: Pass `getGearPiece` from the pages**
+
+- `SimulatorPage.tsx`: it already has `const { getGearPiece } = useInventory()` — pass it as the 2nd arg to `simulateBattle(input, getGearPiece)`.
+- `HealingCalculatorPage.tsx`: it already has `getGearPiece` from `useInventory()`. Replace ALL `buildShipAbilities(ship)` calls — there are 5 (~:121, 235, 252, 307, 356) — with `buildShipAbilitiesWithEquipment(ship, getGearPiece)`. Grep the file to confirm none are missed (a missed site silently drops equipment for that path; no test will fail because the wrapper is byte-identical when equipment is empty).
+
+- [ ] **Step 6: Run the wrapper test + full suite (byte-identical)**
+
+Run: `npx vitest run src/utils/abilities/__tests__/buildShipAbilitiesWithEquipment.test.ts`
+Expected: PASS.
+Run: `npx vitest run 2>&1 | tail -5` and `git status --short`
+Expected: baseline + new tests pass; ZERO `.snap` modifications.
+
+- [ ] **Step 7: Lint + types**
+
+Run: `npm run lint && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/utils/abilities/buildShipAbilitiesWithEquipment.ts src/utils/abilities/__tests__/buildShipAbilitiesWithEquipment.test.ts src/utils/calculators/battleSimulator.ts src/pages/SimulatorPage.tsx src/pages/calculators/HealingCalculatorPage.tsx
+git commit -m "feat(combat): D-PR1 — merge equipment abilities into the passive slot at sim call sites"
+```
+
+---
+
+## Task 4: End-to-end engine integration (Leech standing + Bloodthirst frequency)
+
+Proves the full pipeline: resolution → merge → engine consumption (standing leech) and the gated reactive proc.
+
+**Files:**
+- Test: `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts` (NEW)
+- Reference: `engine.ts:2033-2053` (standing-leech registration), `engine.ts:2096-2131` (`procStandingLeeches`), the healing-mode harness used by `healing.test.ts`.
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Create `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts`, in healing mode (so `healingCtx`/`healTarget` exist and standing leech + reactive heals are exercised):
+
+1. **Leech set standing leech:** a player attacker whose `ShipSkills` (built via `buildShipAbilitiesWithEquipment` with a stub `getGearPiece` returning Leech-set pieces) deals a known direct-damage amount D in a round → the attacker is credited a self-heal of `0.15 * D` (the standing-leech path). Assert via the heal credit surface the healing engine exposes. NOTE: `procStandingLeeches` (engine.ts:~2106) folds the owner's `healModifier` (`raw *= 1 + healModifier/100`) and may crit — set the attacker's `healModifier` to 0 and `noCrit:true` on the Leech ability (already set) so the expected value is exactly `0.15 * D`; otherwise assert against the folded value.
+2. **Bloodthirst gated proc:** an attacker with the Bloodthirst implant resolved, landing exactly one critting hit per round for 10 rounds → the self-heal fires `floor(10 * procChance)` times, each `pct%` of the crit's damage. (For legendary: `procChance 0.20` → 2 fires.) Assert both frequency and amount.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/utils/combat/__tests__/equipmentAbilities.integration.test.ts`
+Expected: FAIL initially (set up the harness until it compiles, then it should drive the asserts).
+
+- [ ] **Step 3: Make them pass**
+
+No new production code is expected here — Tasks 1-3 supply the machinery. If a test fails on a real gap (e.g. the standing-leech registration doesn't see the merged ability because `ShipSkills` → `runtime.castSkills` drops it), debug with @superpowers:systematic-debugging and fix the smallest cause. Document any production change in the commit.
+
+- [ ] **Step 4: Run + full suite + lint + types**
+
+Run: `npx vitest run src/utils/combat/__tests__/equipmentAbilities.integration.test.ts`
+Expected: PASS.
+Run: `npx vitest run 2>&1 | tail -5 && npm run lint && npx tsc --noEmit && git status --short`
+Expected: clean; no `.snap` changes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+git commit -m "test(combat): D-PR1 — end-to-end Leech standing + Bloodthirst proc frequency"
+```
+
+---
+
+## Task 5: Coverage harness + docs + changelog + closeout
+
+**Files:**
+- Test: `src/utils/abilities/__tests__/equipmentCoverage.test.ts` (NEW — lightweight coverage tracker)
+- Modify: `src/constants/changelog.ts` (`UNRELEASED_CHANGES`)
+- Modify: `src/pages/DocumentationPage.tsx`
+
+- [ ] **Step 1: Coverage tracker test**
+
+Create `src/utils/abilities/__tests__/equipmentCoverage.test.ts`: iterate the full `IMPLANTS` + `GEAR_SETS` corpus, run each effect description through the same resolution path `buildEquipmentAbilities` uses, and assert a CURRENT snapshot of which produce ≥1 ability vs. none. For D-PR1 this documents that exactly Leech (set) and the Bloodthirst variants (implant) produce abilities, everything else is `0` (not yet implemented). This makes later-PR coverage growth visible and prevents silent regressions. (Plain `expect` on counts — NOT a `.snap` file.)
+
+- [ ] **Step 2: Run it**
+
+Run: `npx vitest run src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Changelog**
+
+Add to `UNRELEASED_CHANGES` in `src/constants/changelog.ts` a plain-English entry, e.g.: "Combat sim now applies the Leech gear set and the Bloodthirst implant (more implant and gear-set effects coming)."
+
+- [ ] **Step 4: Documentation**
+
+In `src/pages/DocumentationPage.tsx`, note in the combat/sim section that equipped implant and gear-set special effects are beginning to apply in the simulator (Leech, Bloodthirst), with chance-based procs modeled at their true frequency.
+
+- [ ] **Step 5: Final gate**
+
+Run: `npx vitest run 2>&1 | tail -5`
+Run: `npm run lint && npx tsc --noEmit`
+Run: `npm run audit:skills` (expect unchanged 0/141 — equipment parsing is separate from ship-skill audit).
+Run: `git status --short` (expect no `.snap` changes).
+Expected: all clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/abilities/__tests__/equipmentCoverage.test.ts src/constants/changelog.ts src/pages/DocumentationPage.tsx
+git commit -m "docs(combat): D-PR1 — equipment-effect coverage tracker + changelog + docs"
+```
+
+---
+
+## Done-when
+
+- `buildEquipmentAbilities` resolves active sets + equipped implants; Leech set + Bloodthirst implant produce correct abilities; unknown/stat-only/unparseable inputs skip gracefully.
+- The merge wrapper injects equipment abilities into the passive slot at the sim call sites; `buildShipAbilities` is unchanged and all existing goldens are byte-identical (no `.snap` movement).
+- A reactive proc fires at its true frequency via the combat-lifetime per-proc rate gate; the standing Leech credits 15% of damage dealt.
+- Suite green, lint 0, tsc clean, `audit:skills` 0/141.
+
+## Deferred (next D PRs — do NOT do here)
+
+- **D-PR2:** conditional outgoing-damage bucket — the passive conditional-scaling damage fold + Intrusion, Arcane Siege, Warpstrike.
+- **D-PR2+ / later:** in-flight reactive damage amplification + `target-higher-attack` condition (Menace, Giant Slayer); incoming-reduction conditions; the remaining reactive triggers (end-of-round-if-not-hit, on-debuffed, on-resist, on-shield-applied, on-heal-cast, periodic, big-hit); on-death (Battlecry/Last Wish/Martyrdom); charge/DoT/cleanse; net-new mechanics (Boost, Cloaking); CF/Provoke appliers.
+- **Other subprojects:** shield grants → H, reflect → G, start-of-combat stat conversion → F.

--- a/docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-design.md
+++ b/docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-design.md
@@ -1,0 +1,223 @@
+# Combat Realism Epic — Sub-project D: Implant + Gear-Set Abilities (Design)
+
+**Date:** 2026-06-20
+**Sub-project:** D (new ability sources: implants + gear-set skills).
+**Parent:** `docs/superpowers/specs/2026-06-17-combat-realism-epic-roadmap.md`.
+**Status:** design (brainstorm complete, user-approved through coverage + testing sections).
+
+## 1. Context
+
+The combat engine derives a ship's abilities **only** from its skill text. `buildShipAbilities(ship)`
+(`src/utils/abilities/buildShipAbilities.ts:1368`) iterates `getShipSkillRows(ship)` and never reads
+`ship.equipment` or `ship.implants`, even though both are present on the `Ship` it receives. As a
+result, **implant and gear-set special effects are entirely absent from the combat engine** (a grep
+across `src/utils/combat/` finds nothing).
+
+The effect data already exists, as `description` strings analogous to `ship-skills.csv` text:
+
+- **Implants** — `src/constants/implants.ts`. Each `ImplantData` has `variants[]` keyed by rarity;
+  each variant carries optional `stats[]` and an optional `description` (the special effect, e.g.
+  Bloodthirst: "On a critical hit, there is a 12% chance for this unit to repair itself for 12% of
+  the damage dealt"). Minor implants (alpha/gamma/sigma) are stat-only (no `description`).
+- **Gear sets** — `src/constants/gearSets.ts`. `GearSetBonus` carries `stats[]` and an optional
+  `description` for special-effect sets (Boost, Burner, Decimation, Leech, Reflect, Shield, Cloaking,
+  Hardened). Most sets are stat-only.
+
+**Stat-only portions are already handled.** The combat simulators read pre-resolved combat stats
+(`battleSimulator.resolveStats` reads `ship.baseStats`/`statOverrides`; `calculateTotalStats` folds
+gear + set + implant + engineering stats). D therefore adds **only the special-effect abilities** —
+it never re-adds stats.
+
+**Precedent:** `src/utils/autogear/arcaneSiegeUtils.ts` already models one implant effect (Arcane
+Siege +damage while shielded), but only inside autogear scoring — not the combat engine.
+
+This is the first node of sub-project D. The epic roadmap scopes D as "data model → parse →
+`buildShipAbilities` → ride A/B/C machinery"; effects needing genuinely new machinery belong to other
+sub-projects (shields → H, reflect → G, pre-fight stat conversion → F).
+
+## 2. Goals / non-goals
+
+**Goals**
+
+- A reusable **source layer** that resolves a ship's equipped implants + active gear sets into parsed
+  abilities, merged into the engine's ability pipeline at the call sites that already have inventory.
+- A **probability model** for procs consistent with the engine's existing deterministic resolution.
+- Light up the **category-1** effects (those that ride existing engine machinery) over a sequence of
+  reviewable PRs, starting with a thin vertical slice.
+
+**Non-goals (deferred, with their owning sub-project)**
+
+- Shield grants (Abundant Renewal, Lifeline, Adaptive Plating, Shield set) → **H**.
+- Reflect (Reflect set) → **G**.
+- Start-of-combat stat conversion (Code Guard, Cipher Link) → **F**.
+- Concentrate-Fire / Provoke **appliers** (Doomsayer, Bulwark) — Phase 3 flagged forced-targeting
+  appliers as future work; deferred within D (own slice, likely with adjacency).
+- No autogear/scoring changes — D is combat-engine-only. (`arcaneSiegeUtils` stays as is.)
+- No UI for toggling the chance model in this sub-project (possible later enhancement).
+
+## 3. Chance model (cross-cutting decision — LOCKED)
+
+The engine resolves **all** probabilistic events (crit, debuff-landing, DoT-extension) with a
+**deterministic fractional accumulator**, `makeRateGate()` (`src/utils/calculators/rateAccumulator.ts`):
+a 70% rate over 10 calls fires exactly 7 times, reproducible, no `Math.random`. Each distinct
+event gets its own gate instance (state persists across calls).
+
+**Decision:** implant/gear-set procs ride the **same mechanism**. Each proc gets its own
+`makeRateGate()` instance (per owner-proc), fired at the proc's chance each time its trigger fires.
+This is faithful to expected frequency, deterministic, reproducible, and consistent with how crit and
+landing already behave in this engine. (Always-fire and user-toggle were considered and rejected;
+always-fire overstates value and diverges from the "close to the game" goal.)
+
+The parser must therefore extract a generic **`procChance`** from the description ("N% chance to …")
+and thread it onto the ability; the engine allocates and feeds a per-proc gate.
+
+## 4. Architecture
+
+### 4.1 New module: `buildEquipmentAbilities`
+
+A sibling to `buildShipAbilities` (not a modification of it — keeps skill-text parsing focused and the
+new concern independently testable). It mirrors the inventory-access pattern of `calculateTotalStats`
+(which takes a `getGearPiece: (id) => GearPiece | undefined` closure rather than importing a context):
+
+```
+buildEquipmentAbilities(
+  ship: Ship,
+  getGearPiece: (id: string) => GearPiece | undefined,
+): PositionedAbility[]
+```
+
+Responsibilities:
+
+1. **Resolve active gear sets** — count `ship.equipment` pieces by `setBonus` via `getGearPiece`; keep
+   sets meeting their threshold (≥2, or `minPieces: 4`). Filter to sets with a `description`
+   (special-effect); stat-only sets are skipped.
+2. **Resolve equipped implants** — `ship.implants` (slot → inventory id) → `getGearPiece` →
+   `setBonus` (= implant name) + `rarity` → `IMPLANTS` variant `description`. Skip variants with no
+   `description` (stat-only minors).
+3. **Parse each description** → abilities, tagged with a `source: 'implant' | 'gear-set'` marker for
+   display/debugging.
+
+There is no committed set-count helper today (autogear and `statsCalculator` each count inline); this
+module owns a small "active sets for a ship" resolver.
+
+### 4.2 Parsing layer (reuse + two new primitives)
+
+Reuse `abilitiesFromText` / `skillTextParser` on the description strings — the effect *bodies* ("gain
+Speed Up 3 for 2 turns", "inflicts Disable", "repair X% of allies' max HP") are exactly what the
+existing parser handles. Extend it with:
+
+- **`procChance` extractor** — a generic "N% chance to …" detector (§3). The leading chance clause is
+  stripped/recorded so the remaining body parses normally; the chance is threaded onto the ability.
+- **Generalized `oncePerRound` / `oncePerCombat`** — the cap infrastructure exists but is scoped to the
+  cheat-death / extra-action paths today (`buildShipAbilities.ts:994`, `skillTextParser.ts:1319`).
+  Generalize so equipment effects ("limited to once per round", "once per battle") set the cap.
+
+Isolation requirement: feeding equipment text through the shared parser must not change ship-skill
+parsing. The new primitives are additive and only engage on the equipment text path.
+
+### 4.3 Merge point
+
+Merge the abilities returned by `buildEquipmentAbilities` into the `ShipSkills` from
+`buildShipAbilities`, into the **passive slot**. Equipment effects are all passive/reactive/
+conditional-aura, so they ride the same machinery the engine already runs over passive abilities
+(round-1 timed-status seeding + reactive registration). `buildShipAbilities`'s single-arg signature is
+untouched → every existing test that calls it stays byte-identical.
+
+**Inventory access is NOT free at the merge sites — it must be plumbed (D-PR1 foundation work).**
+The two `buildShipAbilities(ship)` call sites differ:
+
+- **`battleSimulator` (`planPlacement`, ~`:530`)** does **not** hold a `getGearPiece` resolver today.
+  `planPlacement` receives only a `BattlePlacement` (ship + position); `resolveStats` reads
+  pre-resolved `statOverrides`/`baseStats` (the page layer resolves gear and passes stats in). Only the
+  raw equipment/implant ids are on `p.ship` — not the resolver closure. So D-PR1 must **thread a
+  `getGearPiece`-style resolver into `simulateBattle`'s input contract / `planPlacement`'s signature**.
+  This plumbing is non-trivial and is explicitly part of the foundation, not an afterthought.
+- **`HealingCalculatorPage`** is a React page with inventory context in scope and is the more likely of
+  the two to already have a resolver. Verify and reuse it.
+
+(Plan-time verification: (a) which sites already have a resolver vs. need plumbing — see Open
+Question #4; (b) confirm the passive slot is the correct merge target for reactive-triggered and
+conditional-aura abilities, and that round-1 seeding + reactive registration pick them up.)
+
+### 4.4 Error handling — graceful skip, never throw
+
+Equipment is user-imported and noisy (descriptions contain typos: "icnreawse", "grans", "sheild").
+Unlike the targeting parser (which throws on unknown tokens), equipment-effect parsing must degrade
+gracefully: a missing gear piece, an unparseable description, or an unrecognized implant yields **no
+ability** and never breaks a ship's combat.
+
+## 5. Effect coverage
+
+### 5.1 Deferred to other sub-projects (category 2)
+
+- Shield grants → **H**: Abundant Renewal, Lifeline, Adaptive Plating, Shield set.
+- Reflect → **G**: Reflect set.
+- Start-of-combat stat conversion → **F**: Code Guard, Cipher Link.
+
+### 5.2 In scope (category 1), bucketed by engine mechanism
+
+| Bucket | Implants / sets | New triggers/conditions needed |
+|---|---|---|
+| **Conditional outgoing dmg** | Intrusion, Arcane Siege, Giant Slayer, Menace, Insidiousness, Warpstrike, Voidfire Catalyst | self-shielded, target-higher-attack; detonation modifier |
+| **Conditional incoming reduction** | Voidshade, Nebula Nullifier, Hyperion Gaze, Vortex Veil, Shadowguard, Ironclad, Hardened set | self-stealthed/stasised, crit-hit-by-stealthed, DoT-source, nth-hit |
+| **Reactive self/ally buffs** | Alacrity, Ambush, Smokescreen, Firewall, Last Stand, Lockdown, Resonating Fury, Font of Power, Spearhead, Fortifying Shroud, Tenacity | end-of-round-if-not-hit, on-debuffed, on-resist, on-shield-applied, on-heal-cast, periodic, big-hit; adjacency |
+| **Reactive heal/leech** | Bloodthirst, Second Wind, Exuberance, Nourishment, Vivacious Repair, Leech set | on-crit-hit-received; heal-received / heal-cast modifiers |
+| **On-death** | Battlecry, Last Wish, Martyrdom | killer-identity (Martyrdom) |
+| **Charge / DoT / cleanse** | Chrono Reaver, Burner set, Decimation set, Reactive Ward | periodic charge; DoT applier/modifier; reactive cleanse |
+| **Net-new mechanics (cat-3)** | Boost set (buffs last +1 turn), Cloaking set (grant Stealth) | new duration / stealth-grant primitives |
+| **Forced-targeting appliers (deferred within D)** | Doomsayer (CF), Bulwark (Provoke), Synaptic Resonance (on-enemy-repaired) | CF/Provoke appliers (Phase-3 future work) |
+
+Minor stat-only implants (Citadel, Haste, Onslaught, Precision, Sentry, Strike, Barrier, Override,
+Bastion, Devastation, Guardian) are out of scope — already in combat stats.
+
+### 5.3 Subtleties to carry into plans
+
+- **Martyrdom** needs killer-identity tracking (which enemy dealt the killing blow).
+- **Adjacency** (Bulwark, Fortifying Shroud) needs positional adjacency — board geometry exists from
+  Phase 1 (`src/utils/targeting/board.ts` `neighbors()`).
+- Several effects scale or gate on **crit** (Menace, Reactive Ward, Second Wind) or self/target status
+  (stealth, shielded, debuffed) — reuse existing condition machinery where it exists.
+
+## 6. Phasing (PRs within sub-project D)
+
+- **D-PR1 — Foundation + thinnest vertical slice.** The whole source pipeline
+  (`buildEquipmentAbilities` + inventory-resolver plumbing into the merge sites per §4.3 +
+  passive-slot merge) + the two parse primitives (`procChance`, generalized once-per) + a handful of
+  effects that reuse triggers/conditions that **already exist**: Menace & Giant Slayer (on-crit /
+  conditional-damage), Bloodthirst (on-crit leech), Leech set, Intrusion (per-debuff-on-target
+  scaling). Proves plumbing + chance end-to-end with near-zero new engine machinery. Note: threading
+  `getGearPiece` into `simulateBattle`/`planPlacement` (§4.3) is a real part of this PR's scope.
+- **D-PR2…N — one trigger/condition family per PR**, each pulling in its implants (incoming-reduction
+  conditions; new reactive triggers; on-death; periodic/charge; DoT; net-new mechanics).
+- **Deferred slice within D:** CF/Provoke appliers (Doomsayer, Bulwark), aligned with the forced-
+  targeting applier work Phase 3 flagged (likely with adjacency).
+
+## 7. Testing & invariants
+
+- **Unit — `buildEquipmentAbilities`:** set-count thresholds (≥2 / `minPieces`), implant
+  id→name+rarity→description resolution, stat-only variants skipped, `source` tagging, graceful skip on
+  missing/unparseable input.
+- **Unit — parse primitives:** `procChance` extraction across the corpus phrasings; generalized
+  once-per.
+- **Integration — D-PR1 effects:** assert the rate accumulator fires at expected frequency (a 50% proc
+  over N triggers fires N/2 times) and the conditional damage / leech lands.
+- **Coverage harness** analogous to `audit:skills` for the implant/set corpus, tracking parse coverage
+  as later PRs add effects. (The corpus is committed TS constants, always available — no gitignored-CSV
+  skip needed.)
+- **Load-bearing invariant:** existing DPS / healing / battle-sim goldens stay **byte-identical** — the
+  new builder only runs where inventory is threaded, and `buildShipAbilities` is unchanged.
+  **Plan-time risk to verify (do this FIRST, before any merge wiring):** if any existing
+  `battleSimulator`/healing fixture builds a ship that carries equipped implants or active sets with
+  special-effect descriptions, those goldens **will** churn once the merge is wired. The plan's first
+  step should be the fixture audit (grep battle-sim/healing fixtures for effect-bearing implants/sets)
+  so the byte-identical invariant is confirmed empty before it can silently break; then neutralize the
+  fixture or deliberately audit the churn (never `vitest -u`).
+
+## 8. Open questions for the plan
+
+1. Exact `procChance` regex shape and the set of "once per …" phrasings in the corpus.
+2. Whether the passive-slot merge needs a dedicated source slot or rides the existing passive slot.
+3. The precise list of conditions/triggers that already exist vs. must be added for the D-PR1 set
+   (characterize before writing the plan).
+4. Inventory-threading mechanics at each call site (does each site already hold a `getGearPiece`-style
+   resolver, or does one need plumbing?).

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -10,6 +10,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator: area-of-effect purge skills now remove buffs from every enemy they hit, not just the primary target.',
     "Combat simulator: Amartya's charge purge now scales with crit power — it removes 1 buff for every 50% crit power (so higher crit power purges more buffs), applied to every enemy hit.",
     'Combat simulator: enemy ships now actually heal — their HP recovers from repair skills instead of being stuck, so enemy teams survive more realistically. Skills that trigger off a target being healed this round (such as Nayra) now also fire against healed enemies.',
+    'Combat simulator now applies the Leech gear set and the Bloodthirst implant, with chance-based procs modeled at their true average frequency. More implant and gear-set effects are coming.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3056,6 +3056,23 @@ const DocumentationPage: React.FC = () => {
                                     </li>
                                 </ul>
                             </div>
+
+                            <div className="p-4 bg-dark-lighter">
+                                <h4 className="font-semibold text-primary mb-2">
+                                    Gear Set and Implant Effects
+                                </h4>
+                                <p className="text-theme-text">
+                                    Equipped implant and gear-set special effects are beginning to
+                                    apply in the simulator. Currently supported:{' '}
+                                    <strong>Leech</strong> gear set (heals the ship for 15% of all
+                                    damage it deals each turn) and the <strong>Bloodthirst</strong>{' '}
+                                    implant (on-crit heal for 12%, 17%, or 20% of damage dealt,
+                                    depending on rarity). Chance-based procs such as Bloodthirst are
+                                    modeled at
+                                    their expected average frequency. More implant and gear-set
+                                    effects will be added in future updates.
+                                </p>
+                            </div>
                         </div>
                     </section>
 

--- a/src/pages/SimulatorPage.tsx
+++ b/src/pages/SimulatorPage.tsx
@@ -122,10 +122,13 @@ const SimulatorPage: React.FC = () => {
         if (!canRun) return;
         setRunError(null);
         try {
-            const result = simulateBattle({
-                playerTeam: buildTeam(playerBoard),
-                enemyTeam: buildTeam(enemyBoard),
-            });
+            const result = simulateBattle(
+                {
+                    playerTeam: buildTeam(playerBoard),
+                    enemyTeam: buildTeam(enemyBoard),
+                },
+                getGearPiece
+            );
             setBattleResult(result);
         } catch (err) {
             setBattleResult(null);

--- a/src/pages/calculators/HealingCalculatorPage.tsx
+++ b/src/pages/calculators/HealingCalculatorPage.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../types/calculator';
 import { ShipSkills } from '../../types/abilities';
 import { detectFullyCharged } from '../../utils/skillTextParser';
-import { buildShipAbilities } from '../../utils/abilities/buildShipAbilities';
+import { buildShipAbilitiesWithEquipment } from '../../utils/abilities/buildShipAbilitiesWithEquipment';
 import { buildDefaultShipSkills } from '../../utils/abilities/configToSimInputs';
 import { calculateTotalStats } from '../../utils/ship/statsCalculator';
 import {
@@ -118,7 +118,7 @@ const HealingCalculatorPage: React.FC = () => {
                             ...healerStatsFromShip(shipFinalStats(ship)),
                             chargeCount: ship.chargeSkillCharge ?? 0,
                             startCharged: detectShipCharged(ship),
-                            shipSkills: buildShipAbilities(ship),
+                            shipSkills: buildShipAbilitiesWithEquipment(ship, getGearPiece),
                         },
                     ],
                     nextId: 2,
@@ -232,7 +232,7 @@ const HealingCalculatorPage: React.FC = () => {
                     ...stats,
                     chargeCount: ship.chargeSkillCharge ?? 0,
                     startCharged: detectShipCharged(ship),
-                    shipSkills: buildShipAbilities(ship),
+                    shipSkills: buildShipAbilitiesWithEquipment(ship, getGearPiece),
                 };
             })
         );
@@ -249,7 +249,7 @@ const HealingCalculatorPage: React.FC = () => {
             speed: Math.round(final.speed ?? 100),
             security: Math.round(final.security ?? 0),
         }));
-        setTargetShipSkills(buildShipAbilities(ship));
+        setTargetShipSkills(buildShipAbilitiesWithEquipment(ship, getGearPiece));
         setTargetChargeCount(ship.chargeSkillCharge ?? 0);
         setTargetStartCharged(detectShipCharged(ship));
         setTargetAffinity(ship.affinity);
@@ -304,7 +304,7 @@ const HealingCalculatorPage: React.FC = () => {
                     hacking: Math.round(final.hacking ?? 200),
                     chargeCount: ship.chargeSkillCharge ?? 0,
                     startCharged: detectShipCharged(ship),
-                    shipSkills: buildShipAbilities(ship),
+                    shipSkills: buildShipAbilitiesWithEquipment(ship, getGearPiece),
                     affinity: ship.affinity,
                 };
             })
@@ -353,7 +353,7 @@ const HealingCalculatorPage: React.FC = () => {
                     startCharged: detectShipCharged(ship),
                     speed: Math.round(final.speed ?? 100),
                     chargeCount: ship.chargeSkillCharge ?? 0,
-                    shipSkills: buildShipAbilities(ship),
+                    shipSkills: buildShipAbilitiesWithEquipment(ship, getGearPiece),
                     stats: {
                         attack: Math.round(final.attack ?? 0),
                         crit: Math.round(final.crit ?? 0),

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -293,6 +293,11 @@ export interface Ability {
      *  ShipTypeName — 'DEBUFFER' matches every DEBUFFER_* variant). Absent → any
      *  ally. A filter with an UNKNOWN ally role never matches (conservative). */
     roleFilter?: ShipRoleCategory[];
+    /** Probabilistic proc gate for equipment-sourced reactive abilities ("N% chance to …").
+     *  A value in (0,1) means the ability fires at that rate via a combat-lifetime per-(owner,
+     *  ability) RateGate (deterministic accumulator, like crit/landing). Absent or out of (0,1)
+     *  → fires on every qualifying trigger. */
+    procChance?: number;
     scaling?: ScalingRule;
     config: AbilityConfig;
     autoFilled?: boolean;

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import { buildEquipmentAbilities } from '../buildEquipmentAbilities';
+import { Ship } from '../../../types/ship';
+import { GearPiece } from '../../../types/gear';
+
+/** Build a minimal Ship for test purposes. */
+function makeShip(over: Partial<Ship>): Ship {
+    return {
+        id: 'test-ship',
+        name: 'Test Ship',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'ATTACKER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        ...over,
+    } as Ship;
+}
+
+/** Build a minimal GearPiece for test purposes. */
+function makePiece(over: Partial<GearPiece>): GearPiece {
+    return {
+        id: 'piece-1',
+        slot: 'weapon',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: null,
+        ...over,
+    } as GearPiece;
+}
+
+/** Factory that returns a getGearPiece function backed by the given id→GearPiece map. */
+function makeGetGearPiece(map: Record<string, GearPiece>): (id: string) => GearPiece | undefined {
+    return (id) => map[id];
+}
+
+// ---------------------------------------------------------------------------
+// Case 1: Leech set active (≥2 pieces)
+// ---------------------------------------------------------------------------
+describe('buildEquipmentAbilities — Leech set', () => {
+    it('emits the Leech ability when ≥2 LEECH pieces are equipped', () => {
+        const pieceA = makePiece({ id: 'leech-1', setBonus: 'LEECH' });
+        const pieceB = makePiece({ id: 'leech-2', slot: 'hull', setBonus: 'LEECH' });
+        const ship = makeShip({
+            equipment: { weapon: 'leech-1', hull: 'leech-2' },
+        });
+        const getGearPiece = makeGetGearPiece({ 'leech-1': pieceA, 'leech-2': pieceB });
+
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+
+        expect(abilities).toHaveLength(1);
+        const [ab] = abilities;
+        expect(ab.id).toBe('equip-set-LEECH');
+        expect(ab.type).toBe('heal');
+        expect(ab.target).toBe('self');
+        expect(ab.trigger).toBe('on-cast');
+        expect(ab.config).toEqual({
+            type: 'heal',
+            pct: 15,
+            basis: 'damage-dealt',
+            leechScope: 'all',
+            noCrit: true,
+        });
+    });
+
+    // Case 2: Leech set inactive (1 piece)
+    it('emits nothing when only 1 LEECH piece is equipped', () => {
+        const pieceA = makePiece({ id: 'leech-1', setBonus: 'LEECH' });
+        const ship = makeShip({
+            equipment: { weapon: 'leech-1' },
+        });
+        const getGearPiece = makeGetGearPiece({ 'leech-1': pieceA });
+
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+
+        expect(abilities).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Case 3: Bloodthirst implant (legendary)
+// ---------------------------------------------------------------------------
+describe('buildEquipmentAbilities — Bloodthirst implant', () => {
+    it('emits on-crit heal with procChance 0.20 and pct 20 for legendary Bloodthirst', () => {
+        const implantPiece = makePiece({
+            id: 'bt-implant',
+            slot: 'implant_major',
+            rarity: 'legendary',
+            setBonus: 'BLOODTHIRST',
+        });
+        const ship = makeShip({
+            implants: { implant_major: 'bt-implant' },
+        });
+        const getGearPiece = makeGetGearPiece({ 'bt-implant': implantPiece });
+
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+
+        expect(abilities.length).toBeGreaterThanOrEqual(1);
+        const ab = abilities.find((a) => a.trigger === 'on-crit');
+        expect(ab).toBeDefined();
+        expect(ab!.procChance).toBeCloseTo(0.2);
+        expect(ab!.config.type).toBe('heal');
+        if (ab!.config.type === 'heal') {
+            expect(ab!.config.pct).toBe(20);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Case 4: Missing piece — no entry in map
+// ---------------------------------------------------------------------------
+describe('buildEquipmentAbilities — missing piece', () => {
+    it('skips gracefully when an implant id has no entry in the map', () => {
+        const ship = makeShip({
+            implants: { implant_major: 'nonexistent-id' },
+        });
+        const getGearPiece = makeGetGearPiece({});
+
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        expect(abilities).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Case 5: Stat-only implant (e.g. STRIKE minor with no description)
+// ---------------------------------------------------------------------------
+describe('buildEquipmentAbilities — stat-only implant', () => {
+    it('emits nothing for a stat-only implant with no description', () => {
+        const implantPiece = makePiece({
+            id: 'strike-implant',
+            slot: 'implant_minor_sigma',
+            rarity: 'legendary',
+            setBonus: 'STRIKE',
+        });
+        const ship = makeShip({
+            implants: { implant_minor_sigma: 'strike-implant' },
+        });
+        const getGearPiece = makeGetGearPiece({ 'strike-implant': implantPiece });
+
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+
+        expect(abilities).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Case 6: Unknown implant key — not in IMPLANTS registry
+// ---------------------------------------------------------------------------
+describe('buildEquipmentAbilities — unknown implant key', () => {
+    it('skips gracefully when the implant setBonus key is unknown (not in IMPLANTS)', () => {
+        // The piece has a setBonus that doesn't exist in IMPLANTS at all, so it is
+        // skipped before any description is read — this is an unknown-key guard, not a
+        // parse failure.
+        const implantPiece = makePiece({
+            id: 'fake-implant',
+            slot: 'implant_major',
+            rarity: 'legendary',
+            setBonus: 'FAKE_NONEXISTENT_IMPLANT' as never,
+        });
+        const ship = makeShip({
+            implants: { implant_major: 'fake-implant' },
+        });
+        const getGearPiece = makeGetGearPiece({ 'fake-implant': implantPiece });
+
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        expect(abilities).toHaveLength(0);
+    });
+});

--- a/src/utils/abilities/__tests__/buildShipAbilitiesWithEquipment.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilitiesWithEquipment.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilitiesWithEquipment } from '../buildShipAbilitiesWithEquipment';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { GearPiece } from '../../../types/gear';
+
+/** Build a minimal Ship for test purposes. */
+function makeShip(over: Partial<Ship>): Ship {
+    return {
+        id: 'test-ship',
+        name: 'Test Ship',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'ATTACKER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        ...over,
+    } as Ship;
+}
+
+/** Build a minimal GearPiece for test purposes. */
+function makePiece(over: Partial<GearPiece>): GearPiece {
+    return {
+        id: 'piece-1',
+        slot: 'weapon',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: null,
+        ...over,
+    } as GearPiece;
+}
+
+/** Factory that returns a getGearPiece function backed by the given id→GearPiece map. */
+function makeGetGearPiece(map: Record<string, GearPiece>): (id: string) => GearPiece | undefined {
+    return (id) => map[id];
+}
+
+// ---------------------------------------------------------------------------
+// Ship fixture with NO equipment (baseline)
+// ---------------------------------------------------------------------------
+const bareShip = makeShip({});
+
+// ---------------------------------------------------------------------------
+// Case 1: Ship with Leech set + Bloodthirst implant
+// ---------------------------------------------------------------------------
+describe('buildShipAbilitiesWithEquipment — equipment-bearing ship', () => {
+    const leechA = makePiece({ id: 'leech-1', setBonus: 'LEECH' });
+    const leechB = makePiece({ id: 'leech-2', slot: 'hull', setBonus: 'LEECH' });
+    const bloodthirst = makePiece({
+        id: 'bt-implant',
+        slot: 'implant_major',
+        rarity: 'legendary',
+        setBonus: 'BLOODTHIRST',
+    });
+
+    const ship = makeShip({
+        equipment: { weapon: 'leech-1', hull: 'leech-2' },
+        implants: { implant_major: 'bt-implant' },
+    });
+
+    const getGearPiece = makeGetGearPiece({
+        'leech-1': leechA,
+        'leech-2': leechB,
+        'bt-implant': bloodthirst,
+    });
+
+    it('passive slot contains the ship own passive abilities PLUS the two equipment abilities', () => {
+        const result = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+
+        const passive = result.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+
+        // Two equipment abilities: Leech set + Bloodthirst implant
+        const equipIds = passive!.abilities
+            .filter((a) => a.id.startsWith('equip-'))
+            .map((a) => a.id);
+        expect(equipIds).toContain('equip-set-LEECH');
+        expect(equipIds).toContain('equip-implant-BLOODTHIRST');
+    });
+
+    it('equipment abilities are appended after ship own passive abilities', () => {
+        const basePassive = buildShipAbilities(ship).slots.find((s) => s.slot === 'passive');
+        const baseCount = basePassive?.abilities.length ?? 0;
+
+        const result = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+        const passive = result.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        // Two equip abilities appended
+        expect(passive!.abilities.length).toBe(baseCount + 2);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Case 2: Ship with empty equipment — output deep-equals buildShipAbilities
+// ---------------------------------------------------------------------------
+describe('buildShipAbilitiesWithEquipment — empty equipment', () => {
+    it('returns output deep-equal to buildShipAbilities when no equipment resolves', () => {
+        const getGearPiece = makeGetGearPiece({});
+        const base = buildShipAbilities(bareShip);
+        const result = buildShipAbilitiesWithEquipment(bareShip, getGearPiece);
+        expect(result).toEqual(base);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Case 3: else-branch — ship whose base ShipSkills has NO passive slot, but
+// has Leech-set equipment → wrapper must CREATE a new passive slot.
+//
+// Construction: a ship with only `activeSkillText` (no firstPassiveSkillText /
+// secondPassiveSkillText / thirdPassiveSkillText) has no passive-row in
+// getShipSkillRows, so buildShipAbilities never pushes to the passive bucket
+// and returns a ShipSkills with no passive Skill entry. We assert that
+// invariant in the test before exercising the wrapper.
+// ---------------------------------------------------------------------------
+describe('buildShipAbilitiesWithEquipment — else-branch (no base passive slot)', () => {
+    // Ship with an active skill only; all passive text fields are absent.
+    const activeOnlyShip = makeShip({
+        activeSkillText: 'Fires a basic attack at an enemy.',
+        // no firstPassiveSkillText / secondPassiveSkillText / thirdPassiveSkillText
+    });
+
+    const leechA = makePiece({ id: 'leech-no-passive-1', setBonus: 'LEECH' });
+    const leechB = makePiece({ id: 'leech-no-passive-2', slot: 'hull', setBonus: 'LEECH' });
+
+    const shipWithLeech = makeShip({
+        activeSkillText: 'Fires a basic attack at an enemy.',
+        equipment: { weapon: 'leech-no-passive-1', hull: 'leech-no-passive-2' },
+    });
+
+    const getGearPiece = makeGetGearPiece({
+        'leech-no-passive-1': leechA,
+        'leech-no-passive-2': leechB,
+    });
+
+    it('base buildShipAbilities output has NO passive slot (precondition)', () => {
+        const base = buildShipAbilities(activeOnlyShip);
+        const passive = base.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeUndefined();
+    });
+
+    it('wrapper creates a new passive slot containing the Leech set ability', () => {
+        const result = buildShipAbilitiesWithEquipment(shipWithLeech, getGearPiece);
+        const passive = result.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        expect(passive!.abilities.map((a) => a.id)).toContain('equip-set-LEECH');
+    });
+
+    it('the new passive slot contains ONLY the equipment abilities (no ship-own abilities)', () => {
+        const result = buildShipAbilitiesWithEquipment(shipWithLeech, getGearPiece);
+        const passive = result.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        expect(passive!.abilities).toHaveLength(1);
+        expect(passive!.abilities[0].id).toBe('equip-set-LEECH');
+    });
+});

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -1,0 +1,155 @@
+/**
+ * equipmentCoverage.test.ts
+ *
+ * Documents CURRENT buildEquipmentAbilities coverage across the full IMPLANTS +
+ * GEAR_SETS corpus.  The intent is a living regression guard: when D-PR2 adds new
+ * effects, this file is updated deliberately so reviewers can see coverage grow.
+ *
+ * Assertions are plain `expect` calls — no snapshot files.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildEquipmentAbilities } from '../buildEquipmentAbilities';
+import { GEAR_SETS } from '../../../constants/gearSets';
+import { IMPLANTS } from '../../../constants/implants';
+import { Ship } from '../../../types/ship';
+import { GearPiece } from '../../../types/gear';
+
+// ---------------------------------------------------------------------------
+// Minimal fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeShip(over: Partial<Ship>): Ship {
+    return {
+        id: 'coverage-ship',
+        name: 'Coverage Ship',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'ATTACKER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        ...over,
+    } as Ship;
+}
+
+function makePiece(over: Partial<GearPiece>): GearPiece {
+    return {
+        id: 'piece',
+        slot: 'weapon',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: null,
+        ...over,
+    } as GearPiece;
+}
+
+/**
+ * Build a minimal ship equipping enough pieces of a gear set (≥ its minPieces)
+ * and return the ability count produced by buildEquipmentAbilities.
+ */
+function gearSetAbilityCount(setKey: string): number {
+    const setDef = GEAR_SETS[setKey];
+    const minPieces = setDef?.minPieces ?? 2;
+
+    // Gear slot names used in the test — just need enough distinct slots.
+    const slots = ['weapon', 'hull', 'sensor', 'engine', 'shield', 'computer'] as const;
+    const equipment: Record<string, string> = {};
+    const pieceMap: Record<string, GearPiece> = {};
+
+    for (let i = 0; i < minPieces; i++) {
+        const id = `${setKey}-piece-${i}`;
+        const slot = slots[i % slots.length];
+        equipment[slot] = id;
+        pieceMap[id] = makePiece({ id, slot, setBonus: setKey });
+    }
+
+    const ship = makeShip({ equipment });
+    return buildEquipmentAbilities(ship, (id) => pieceMap[id]).length;
+}
+
+/**
+ * Build a minimal ship equipping one implant piece (at the given rarity) and
+ * return the ability count produced by buildEquipmentAbilities.
+ */
+function implantAbilityCount(implantKey: string, rarity: GearPiece['rarity']): number {
+    const id = `${implantKey}-piece`;
+    const pieceMap: Record<string, GearPiece> = {
+        [id]: makePiece({ id, slot: 'implant_major', rarity, setBonus: implantKey }),
+    };
+    const ship = makeShip({ implants: { implant_major: id } });
+    return buildEquipmentAbilities(ship, (gearId) => pieceMap[gearId]).length;
+}
+
+// ---------------------------------------------------------------------------
+// Regression guard: implemented effect names must equal exactly this set.
+// Update deliberately when D-PR2 adds more.
+// ---------------------------------------------------------------------------
+
+describe('equipmentCoverage — implemented effects registry', () => {
+    it('exactly { LEECH (gear set), BLOODTHIRST (implant) } are currently implemented', () => {
+        // Gear sets with an ability builder
+        const implementedSets = Object.keys(GEAR_SETS).filter(
+            (key) => gearSetAbilityCount(key) > 0
+        );
+        expect(implementedSets).toEqual(['LEECH']);
+
+        // Implants with an ability builder (check each implant with a rarity that exists)
+        const implementedImplants = Object.keys(IMPLANTS).filter((key) => {
+            const variants = IMPLANTS[key].variants;
+            // Try the first available rarity for each implant.
+            return variants.some((v) => implantAbilityCount(key, v.rarity) > 0);
+        });
+        expect(implementedImplants).toEqual(['BLOODTHIRST']);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Gear-set coverage: one assertion per set
+// ---------------------------------------------------------------------------
+
+describe('equipmentCoverage — gear sets', () => {
+    it('LEECH produces exactly 1 ability (the standing leech)', () => {
+        expect(gearSetAbilityCount('LEECH')).toBe(1);
+    });
+
+    const nonLeechSets = Object.keys(GEAR_SETS).filter((k) => k !== 'LEECH');
+    for (const setKey of nonLeechSets) {
+        it(`${setKey} produces 0 abilities (not yet implemented)`, () => {
+            expect(gearSetAbilityCount(setKey)).toBe(0);
+        });
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Implant coverage: one assertion per implant
+// ---------------------------------------------------------------------------
+
+describe('equipmentCoverage — implants', () => {
+    it('BLOODTHIRST (uncommon) produces >= 1 ability (on-crit heal)', () => {
+        expect(implantAbilityCount('BLOODTHIRST', 'uncommon')).toBeGreaterThanOrEqual(1);
+    });
+
+    it('BLOODTHIRST (epic) produces >= 1 ability (on-crit heal)', () => {
+        expect(implantAbilityCount('BLOODTHIRST', 'epic')).toBeGreaterThanOrEqual(1);
+    });
+
+    it('BLOODTHIRST (legendary) produces >= 1 ability (on-crit heal)', () => {
+        expect(implantAbilityCount('BLOODTHIRST', 'legendary')).toBeGreaterThanOrEqual(1);
+    });
+
+    const nonBloodthirstImplants = Object.keys(IMPLANTS).filter((k) => k !== 'BLOODTHIRST');
+    for (const implantKey of nonBloodthirstImplants) {
+        it(`${implantKey} produces 0 abilities (not yet implemented)`, () => {
+            const variants = IMPLANTS[implantKey].variants;
+            // Check all available rarities — none should produce abilities yet.
+            for (const v of variants) {
+                expect(implantAbilityCount(implantKey, v.rarity)).toBe(0);
+            }
+        });
+    }
+});

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -7,7 +7,13 @@
  * Gear-set abilities are resolved via GEAR_SET_ABILITIES (currently: Leech).
  * Implant abilities are resolved via IMPLANT_ABILITIES (currently: Bloodthirst).
  *
- * This module is NOT wired into any engine path yet (Task 3 does that).
+ * D-PR1 approach (registry, not text-parsing): effect values are baked from the
+ * source data in implants.ts / gearSets.ts per the registries above. A variant's
+ * `description` is used only as a PRESENCE gate (stat-only variants have none and are
+ * skipped) — its text is NOT parsed. A future PR may add a text-parse path for
+ * implants whose phrasing the skill parser can handle; until then, new effects need a
+ * registry entry. Merged into the passive slot by buildShipAbilitiesWithEquipment.
+ *
  * It is pure: no side effects, no throws out of the function.
  *
  * Modeling note: noCrit:true on the Leech set heal — a derived-from-damage leech

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -1,0 +1,158 @@
+/**
+ * buildEquipmentAbilities
+ *
+ * Turns a ship's equipped gear sets + implants into a list of Ability objects
+ * that the combat engine can consume.
+ *
+ * Gear-set abilities are resolved via GEAR_SET_ABILITIES (currently: Leech).
+ * Implant abilities are resolved via IMPLANT_ABILITIES (currently: Bloodthirst).
+ *
+ * This module is NOT wired into any engine path yet (Task 3 does that).
+ * It is pure: no side effects, no throws out of the function.
+ *
+ * Modeling note: noCrit:true on the Leech set heal — a derived-from-damage leech
+ * doesn't roll its own heal-crit; flagged as a modeling choice for reviewer confirmation.
+ */
+
+import { GEAR_SETS } from '../../constants/gearSets';
+import { IMPLANTS } from '../../constants/implants';
+import { GearPiece } from '../../types/gear';
+import { Ability } from '../../types/abilities';
+import { Ship } from '../../types/ship';
+
+// ---------------------------------------------------------------------------
+// Gear-set ability registry (D-PR1: Leech only)
+// ---------------------------------------------------------------------------
+
+const GEAR_SET_ABILITIES: Partial<Record<string, () => Omit<Ability, 'id'>>> = {
+    LEECH: () => ({
+        type: 'heal',
+        target: 'self',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'heal', pct: 15, basis: 'damage-dealt', leechScope: 'all', noCrit: true },
+        autoFilled: true,
+    }),
+};
+
+// ---------------------------------------------------------------------------
+// Implant ability registry (D-PR1: Bloodthirst only)
+// ---------------------------------------------------------------------------
+//
+// Each entry maps an implant name to a per-rarity builder.  A builder returns
+// an Ability (minus `id`) or undefined when the rarity is unsupported.
+
+type ImplantAbilityBuilder = (rarity: string) => Omit<Ability, 'id'> | undefined;
+
+const BLOODTHIRST_HEAL_PCT: Record<string, number> = {
+    uncommon: 12,
+    epic: 17,
+    legendary: 20,
+};
+
+const BLOODTHIRST_PROC_CHANCE: Record<string, number> = {
+    uncommon: 0.12,
+    epic: 0.17,
+    legendary: 0.2,
+};
+
+const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
+    BLOODTHIRST: (rarity) => {
+        const pct = BLOODTHIRST_HEAL_PCT[rarity];
+        const procChance = BLOODTHIRST_PROC_CHANCE[rarity];
+        if (pct === undefined) return undefined;
+        return {
+            type: 'heal',
+            target: 'self',
+            trigger: 'on-crit',
+            conditions: [],
+            procChance,
+            config: {
+                type: 'heal',
+                pct,
+                basis: 'damage-dealt',
+            },
+            autoFilled: true,
+        };
+    },
+};
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a ship's active gear-set effects + implant effects into Ability[].
+ *
+ * @param ship          The ship whose equipment and implants to inspect.
+ * @param getGearPiece  Inventory lookup — maps a gear id to a GearPiece (or undefined).
+ */
+export function buildEquipmentAbilities(
+    ship: Ship,
+    getGearPiece: (id: string) => GearPiece | undefined
+): Ability[] {
+    const abilities: Ability[] = [];
+
+    // ------------------------------------------------------------------
+    // 1. Active gear sets
+    // ------------------------------------------------------------------
+    // GEAR_SETS is a static constant — no runtime throws expected, so no per-set guard.
+    const setCounts: Record<string, number> = {};
+    for (const gearId of Object.values(ship.equipment ?? {})) {
+        if (!gearId) continue;
+        const piece = getGearPiece(gearId);
+        if (!piece?.setBonus) continue;
+        setCounts[piece.setBonus] = (setCounts[piece.setBonus] ?? 0) + 1;
+    }
+
+    for (const [setName, count] of Object.entries(setCounts)) {
+        const minPieces = GEAR_SETS[setName]?.minPieces ?? 2;
+        if (count < minPieces) continue;
+
+        const builder = GEAR_SET_ABILITIES[setName];
+        if (!builder) continue;
+
+        const partial = builder();
+        abilities.push({ id: `equip-set-${setName}`, ...partial });
+    }
+
+    // ------------------------------------------------------------------
+    // 2. Implants
+    // ------------------------------------------------------------------
+    for (const gearId of Object.values(ship.implants ?? {})) {
+        if (!gearId) continue;
+
+        try {
+            const piece = getGearPiece(gearId);
+            if (!piece?.setBonus) continue;
+
+            const implantName = piece.setBonus;
+            const implantData = IMPLANTS[implantName];
+            if (!implantData) continue;
+
+            const variant = implantData.variants.find((v) => v.rarity === piece.rarity);
+            if (!variant?.description) continue;
+
+            // Try the per-implant builder first (handles cases the text parser can't).
+            const builder = IMPLANT_ABILITIES[implantName];
+            if (builder) {
+                const partial = builder(piece.rarity);
+                if (!partial) continue;
+                abilities.push({
+                    ...partial,
+                    id: `equip-implant-${implantName}`,
+                });
+                continue;
+            }
+
+            // For implants not in the registry: the description text could not be
+            // reliably parsed for D-PR1 (the text parser lacks the "N% chance" proc-gate
+            // stamping path for reactive triggers). Skip gracefully — no ability emitted,
+            // no throw.
+        } catch {
+            // Per-piece errors never surface out of this function.
+        }
+    }
+
+    return abilities;
+}

--- a/src/utils/abilities/buildShipAbilitiesWithEquipment.ts
+++ b/src/utils/abilities/buildShipAbilitiesWithEquipment.ts
@@ -1,0 +1,42 @@
+/**
+ * buildShipAbilitiesWithEquipment
+ *
+ * Thin wrapper around `buildShipAbilities` that merges equipment-derived abilities
+ * (gear-set bonuses + implant effects) into the passive skill slot.
+ *
+ * `buildShipAbilities` is left single-arg / untouched (Task 3 invariant).
+ * When `buildEquipmentAbilities` returns an empty list (no active gear sets, no
+ * ability-bearing implants, or a ship with no equipment at all) the result is
+ * byte-identical to calling `buildShipAbilities` directly — existing goldens are
+ * unaffected.
+ */
+
+import { Ship } from '../../types/ship';
+import { GearPiece } from '../../types/gear';
+import { ShipSkills } from '../../types/abilities';
+import { buildShipAbilities } from './buildShipAbilities';
+import { buildEquipmentAbilities } from './buildEquipmentAbilities';
+
+/**
+ * Build the full ability roster for a ship, including equipment-sourced abilities.
+ *
+ * @param ship          The ship to resolve abilities for.
+ * @param getGearPiece  Inventory lookup — maps a gear id to a GearPiece (or undefined).
+ * @returns             A ShipSkills object with equipment abilities appended to the passive slot.
+ */
+// Returns the same ShipSkills reference in both paths; in-place mutation is safe because buildShipAbilities allocates a fresh object per call.
+export function buildShipAbilitiesWithEquipment(
+    ship: Ship,
+    getGearPiece: (id: string) => GearPiece | undefined
+): ShipSkills {
+    const skills = buildShipAbilities(ship);
+    const equip = buildEquipmentAbilities(ship, getGearPiece);
+    if (!equip.length) return skills;
+    const passive = skills.slots.find((s) => s.slot === 'passive');
+    if (passive) {
+        passive.abilities.push(...equip);
+    } else {
+        skills.slots.push({ slot: 'passive', abilities: equip });
+    }
+    return skills;
+}

--- a/src/utils/calculators/battleSimulator.ts
+++ b/src/utils/calculators/battleSimulator.ts
@@ -40,6 +40,9 @@ import type { CombatStatBlock } from '../../types/calculator';
 import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../combat/engine';
 import { createEventBus } from '../combat/events';
 import { buildShipAbilities } from '../abilities/buildShipAbilities';
+import { buildShipAbilitiesWithEquipment } from '../abilities/buildShipAbilitiesWithEquipment';
+import type { ShipSkills } from '../../types/abilities';
+import type { GearPiece } from '../../types/gear';
 import { selectFiringSkill } from '../abilities/applyAbilities';
 import { parseShipTargeting, SkillTargeting } from '../targetingParser';
 import { computeAffinityModifiers } from './affinityUtils';
@@ -510,14 +513,18 @@ interface PlacementPlan {
     name: string;
     position: Position;
     stats: DerivedCombatStats;
-    shipSkills: ReturnType<typeof buildShipAbilities>;
+    shipSkills: ShipSkills;
     affinity: AffinityName | undefined;
     /** Parsed ACTIVE targeting ({ target, pattern }); undefined if the ship has no targeting data. */
     targeting: SkillTargeting | undefined;
     chargeCount: number;
 }
 
-function planPlacement(p: BattlePlacement, id: string): PlacementPlan {
+function planPlacement(
+    p: BattlePlacement,
+    id: string,
+    getGearPiece?: (id: string) => GearPiece | undefined
+): PlacementPlan {
     const targeting = parseShipTargeting(p.ship);
     // Use the ACTIVE targeting (target + pattern). The engine input takes ONE target/pattern
     // per actor, so charged-skill targeting is a follow-up (PR2) — when a ship's charged
@@ -527,7 +534,9 @@ function planPlacement(p: BattlePlacement, id: string): PlacementPlan {
         name: p.ship.name,
         position: p.position,
         stats: resolveStats(p),
-        shipSkills: buildShipAbilities(p.ship),
+        shipSkills: getGearPiece
+            ? buildShipAbilitiesWithEquipment(p.ship, getGearPiece)
+            : buildShipAbilities(p.ship),
         affinity: p.ship.affinity,
         targeting: targeting.active,
         chargeCount: p.ship.chargeSkillCharge ?? 0,
@@ -557,7 +566,10 @@ function planPlacement(p: BattlePlacement, id: string): PlacementPlan {
  * Actor ids are minted globally-unique across both squads (`p:<shipId>:<idx>` / `e:<shipId>:<idx>`),
  * avoiding the reserved `'attacker'`/`'enemy'` ids and any duplicate (runCombat throws on either).
  */
-export function simulateBattle(input: BattleSimulationInput): BattleResult {
+export function simulateBattle(
+    input: BattleSimulationInput,
+    getGearPiece?: (id: string) => GearPiece | undefined
+): BattleResult {
     // Validate inputs up front (trust boundary): empty teams or a bad round count
     // would otherwise flow through and produce misleading draw/empty outcomes.
     if (input.playerTeam.length === 0) {
@@ -577,9 +589,11 @@ export function simulateBattle(input: BattleSimulationInput): BattleResult {
     // team + every enemy get minted globally-unique ids that avoid `'attacker'`/`'enemy'`.
     const FOCUS_ID = 'attacker';
     const playerPlans = input.playerTeam.map((p, i) =>
-        planPlacement(p, i === 0 ? FOCUS_ID : `p:${p.ship.id}:${i}`)
+        planPlacement(p, i === 0 ? FOCUS_ID : `p:${p.ship.id}:${i}`, getGearPiece)
     );
-    const enemyPlans = input.enemyTeam.map((p, i) => planPlacement(p, `e:${p.ship.id}:${i}`));
+    const enemyPlans = input.enemyTeam.map((p, i) =>
+        planPlacement(p, `e:${p.ship.id}:${i}`, getGearPiece)
+    );
 
     // Representative opposing affinity for each side's matchup resolution (first opponent).
     const enemyRepAffinity = enemyPlans[0]?.affinity;

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -1,0 +1,301 @@
+/**
+ * D-PR1: end-to-end engine integration — Leech standing leech + Bloodthirst proc frequency.
+ *
+ * Both tests use `buildShipAbilitiesWithEquipment` with a stub `getGearPiece`, exercising the
+ * real resolution→merge→engine path (Tasks 2+3+engine pickup), not just ability injection.
+ *
+ * Leech (standing leech):
+ *   The Leech set ability has trigger 'on-cast', so it stays in castSkills after the
+ *   reactive partition and is picked up by the standing-leech scan (engine.ts ~2037-2057).
+ *   With attackerHealModifier=0, noCrit:true on the ability, and 1 round of damage D,
+ *   the credited directHeal is exactly 0.15 × D.
+ *
+ * Bloodthirst (reactive on-crit heal):
+ *   The Bloodthirst ability has trigger 'on-crit', so it routes to reactiveAbilities →
+ *   registered as a listener that fires once per critting hit. procChance 0.20 over 10
+ *   rounds (1 crit/round) → floor(10 × 0.20) = 2 fires (accumulator back-loaded: rounds
+ *   5 and 10 — acc accumulates 0.20 per crit and first crosses 1.0 on the 5th call).
+ *   basis 'damage-dealt' resolves in the reactive executor as the owner's max HP (the
+ *   fallthrough branch — not damage-dealt scaling off the attack amount). With hp=10000
+ *   and pct=20: each fire credits directHeal of 10000 × 0.20 × healModifier(0) = 2000.
+ *   2 fires → 4000 total.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { ShipSkills } from '../../../types/abilities';
+import { Ship } from '../../../types/ship';
+import { GearPiece } from '../../../types/gear';
+import { buildShipAbilitiesWithEquipment } from '../../abilities/buildShipAbilitiesWithEquipment';
+
+// ---------------------------------------------------------------------------
+// Shared test harness helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal Ship stub. Equipment and implants are provided by overrides. */
+function makeShip(over: Partial<Ship>): Ship {
+    return {
+        id: 'test-ship',
+        name: 'Test Ship',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'ATTACKER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        ...over,
+    } as Ship;
+}
+
+/** Minimal GearPiece stub. */
+function makePiece(over: Partial<GearPiece>): GearPiece {
+    return {
+        id: 'piece-1',
+        slot: 'weapon',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: null,
+        ...over,
+    } as GearPiece;
+}
+
+/** getGearPiece factory backed by an id→GearPiece map. */
+function makeGetGearPiece(map: Record<string, GearPiece>): (id: string) => GearPiece | undefined {
+    return (id) => map[id];
+}
+
+/** Sum a heal bucket over all rounds for the given actor (default: 'attacker'). */
+function sumHeal(
+    result: ReturnType<typeof runCombat>,
+    bucket: 'directHeal' | 'effectiveHeal' | 'overheal',
+    actorId = 'attacker'
+): number {
+    return (result.healing?.rounds ?? []).reduce(
+        (sum, rd) => sum + (rd.perActor.get(actorId)?.[bucket] ?? 0),
+        0
+    );
+}
+
+/** Base engine input: neutral stats, enemy never dies, healing mode on (focus is target). */
+const BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 5000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [] },
+    enemyDefense: 0,
+    enemyHp: 10_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 2000,
+    hp: 10_000,
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Gear stubs shared across tests
+// ---------------------------------------------------------------------------
+
+const leechPieceA = makePiece({ id: 'leech-1', slot: 'weapon', setBonus: 'LEECH' });
+const leechPieceB = makePiece({ id: 'leech-2', slot: 'hull', setBonus: 'LEECH' });
+const bloodthirstPiece = makePiece({
+    id: 'bt-legendary',
+    slot: 'implant_major',
+    rarity: 'legendary',
+    setBonus: 'BLOODTHIRST',
+});
+
+// ---------------------------------------------------------------------------
+// Test 1: Leech set standing leech — full end-to-end
+// ---------------------------------------------------------------------------
+
+describe('D-PR1 integration — Leech set standing leech', () => {
+    /**
+     * Setup:
+     *   - Ship equipped with 2 LEECH-set pieces (activates the Leech set ability via buildEquipmentAbilities).
+     *   - buildShipAbilitiesWithEquipment merges the Leech ability into the passive slot.
+     *   - Active slot: a single-hit damage ability with multiplier 100 (attack 5000 → damage 5000).
+     *   - healModifier: 0 (so raw = pct × damage, no further folds).
+     *   - Leech ability config: pct 15, basis 'damage-dealt', noCrit:true.
+     *   - Expected directHeal = 0.15 × 5000 = 750.
+     *
+     * The standing-leech scan (engine.ts ~2037) reads from the attacker's castSkills passive slot.
+     * Because the Leech ability has trigger 'on-cast' (NOT in LIVE_TRIGGERS), it stays in castSkills
+     * after the reactive partition and IS picked up. This test exercises that full path.
+     */
+    it('Leech set: standing leech credits directHeal = 0.15 × damage (full build→merge→engine path)', () => {
+        const ship = makeShip({
+            equipment: { weapon: 'leech-1', hull: 'leech-2' },
+        });
+        const getGearPiece = makeGetGearPiece({
+            'leech-1': leechPieceA,
+            'leech-2': leechPieceB,
+        });
+
+        // Real resolution+merge path: tasks 2+3.
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+
+        // Verify the Leech ability landed in the passive slot (pre-condition).
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        const leechAbility = passive!.abilities.find((a) => a.id === 'equip-set-LEECH');
+        expect(leechAbility).toBeDefined();
+
+        // Append a damage active so the attacker deals damage that the standing leech can latch onto.
+        const shipSkills: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'dmg-active',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 100, hits: 1 },
+                        },
+                    ],
+                },
+                // Carry over the full passive slot (Leech + any ship own passives).
+                ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+            ],
+        };
+
+        // attack 5000, mult 100, enemyDefense 0 → direct damage = 5000.
+        // Leech: 15% of 5000 = 750. healModifier 0, noCrit:true → directHeal = 750.
+        const D = 5000;
+        const result = runCombat(
+            BASE({
+                attack: D,
+                crit: 0,
+                critDamage: 0,
+                healModifier: 0,
+                numRounds: 1,
+                hp: 10_000,
+                shipSkills,
+            })
+        );
+
+        expect(result.healing).toBeDefined();
+        // directHeal must equal 15% of direct damage dealt.
+        expect(sumHeal(result, 'directHeal')).toBeCloseTo(0.15 * D, 6);
+        // Full HP → all overheal, no effectiveHeal.
+        expect(sumHeal(result, 'effectiveHeal')).toBeCloseTo(0, 6);
+        expect(sumHeal(result, 'overheal')).toBeCloseTo(0.15 * D, 6);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: Bloodthirst implant (legendary) — proc frequency + per-fire amount
+// ---------------------------------------------------------------------------
+
+describe('D-PR1 integration — Bloodthirst implant proc frequency', () => {
+    /**
+     * Setup:
+     *   - Ship equipped with legendary Bloodthirst implant (procChance 0.20, pct 20).
+     *   - buildShipAbilitiesWithEquipment merges the on-crit reactive ability into the passive slot.
+     *   - Active slot: 1-hit damage ability. crit 100 → 1 crit per round for 10 rounds.
+     *   - procChance 0.20 → accumulator fires floor(10×0.20)=2 times (back-loaded: rounds 5, 10).
+     *     The rateAccumulator starts at 0 and accumulates +0.20 per qualifying crit. It fires
+     *     when acc >= 1: first fire at call 5 (acc 0.2→0.4→0.6→0.8→1.0), second at call 10.
+     *   - Each fire: basis 'damage-dealt' resolves in the reactive executor as the owner's max HP
+     *     (fallthrough branch — same as 'hp'). hp=10000, pct=20 → raw = 10000 × 0.20 = 2000.
+     *     healModifier 0, no outgoing/incoming buffs → directHeal per fire = 2000.
+     *   - Total directHeal over 10 rounds = 2 × 2000 = 4000.
+     *
+     * Two assertions:
+     *   (a) fire count = 2 and fires on rounds 5 and 10 (back-loaded accumulator schedule).
+     *   (b) summed directHeal = 4000.
+     */
+    it('Bloodthirst legendary: fires floor(10 × 0.20)=2 times over 10 crits; total directHeal = 2×2000', () => {
+        const ship = makeShip({
+            implants: { implant_major: 'bt-legendary' },
+        });
+        const getGearPiece = makeGetGearPiece({ 'bt-legendary': bloodthirstPiece });
+
+        // Real resolution+merge path: tasks 2+3.
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+
+        // Verify the Bloodthirst ability landed in the passive slot (pre-condition).
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        const btAbility = passive!.abilities.find((a) => a.id === 'equip-implant-BLOODTHIRST');
+        expect(btAbility).toBeDefined();
+        expect(btAbility!.procChance).toBeCloseTo(0.2);
+
+        // Append a damage active. crit 100 → every hit crits → on-crit listener fires once/round.
+        const shipSkills: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'dmg-active',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 100, hits: 1 },
+                        },
+                    ],
+                },
+                ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+            ],
+        };
+
+        // Each reactive-heal fire: basis 'damage-dealt' → owner hp fallthrough = 10000.
+        // pct 20 → raw = 10000 × 0.20 = 2000. procChance 0.20 over 10 crits → 2 fires.
+        const perFireAmount = 10_000 * (20 / 100); // = 2000
+        const expectedFires = Math.floor(10 * 0.2); // = 2
+        const expectedTotal = expectedFires * perFireAmount; // = 4000
+
+        const result = runCombat(
+            BASE({
+                attack: 5000,
+                crit: 100,
+                critDamage: 0,
+                healModifier: 0,
+                numRounds: 10,
+                hp: 10_000,
+                shipSkills,
+            })
+        );
+
+        expect(result.healing).toBeDefined();
+        expect(result.healing!.rounds).toHaveLength(10);
+
+        // (b) total direct heal = 4000.
+        expect(sumHeal(result, 'directHeal')).toBeCloseTo(expectedTotal, 6);
+
+        // (a) fire count: back-loaded accumulator fires on rounds 2 and 10.
+        const firedRounds = result
+            .healing!.rounds.map((rd, i) => ({
+                round: i + 1,
+                heal: rd.perActor.get('attacker')?.directHeal ?? 0,
+            }))
+            .filter((r) => r.heal > 0);
+        expect(firedRounds).toHaveLength(expectedFires);
+        // Back-loaded accumulator: with rate 0.20, the gate crosses 1 at call 5 and call 10.
+        // Fires on rounds 5 and 10 (not 2 and 10 — that is the 0.5 schedule).
+        expect(firedRounds[0].round).toBe(5);
+        expect(firedRounds[1].round).toBe(10);
+        // Each fire credits exactly perFireAmount.
+        for (const r of firedRounds) {
+            expect(r.heal).toBeCloseTo(perFireAmount, 6);
+        }
+    });
+});

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -15,10 +15,11 @@
  *   registered as a listener that fires once per critting hit. procChance 0.20 over 10
  *   rounds (1 crit/round) → floor(10 × 0.20) = 2 fires (accumulator back-loaded: rounds
  *   5 and 10 — acc accumulates 0.20 per crit and first crosses 1.0 on the 5th call).
- *   basis 'damage-dealt' resolves in the reactive executor as the owner's max HP (the
- *   fallthrough branch — not damage-dealt scaling off the attack amount). With hp=10000
- *   and pct=20: each fire credits directHeal of 10000 × 0.20 × healModifier(0) = 2000.
- *   2 fires → 4000 total.
+ *   basis 'damage-dealt': the reactive executor now resolves this as the triggering hit's
+ *   damage (eventCtx.triggerDamage), captured from ability-performed.damage on the on-crit
+ *   listener. Crit damage computation: attack=5000, multiplier=100%, critDamage=0,
+ *   enemyDefense=0 → directDamage = 5000 * 1.0 * 1.0 = 5000. Each fire: pct=20 →
+ *   directHeal = 5000 × 0.20 = 1000. 2 fires → 2000 total.
  */
 import { describe, it, expect } from 'vitest';
 import { runCombat, CombatEngineInput } from '../engine';
@@ -212,16 +213,17 @@ describe('D-PR1 integration — Bloodthirst implant proc frequency', () => {
      *   - procChance 0.20 → accumulator fires floor(10×0.20)=2 times (back-loaded: rounds 5, 10).
      *     The rateAccumulator starts at 0 and accumulates +0.20 per qualifying crit. It fires
      *     when acc >= 1: first fire at call 5 (acc 0.2→0.4→0.6→0.8→1.0), second at call 10.
-     *   - Each fire: basis 'damage-dealt' resolves in the reactive executor as the owner's max HP
-     *     (fallthrough branch — same as 'hp'). hp=10000, pct=20 → raw = 10000 × 0.20 = 2000.
-     *     healModifier 0, no outgoing/incoming buffs → directHeal per fire = 2000.
-     *   - Total directHeal over 10 rounds = 2 × 2000 = 4000.
+     *   - Each fire: basis 'damage-dealt' now resolves as the triggering hit's damage
+     *     (eventCtx.triggerDamage, captured from ability-performed.damage). Crit damage:
+     *     attack=5000, multiplier=100%, critDamage=0, enemyDefense=0 → directDamage=5000.
+     *     pct=20 → raw = 5000 × 0.20 = 1000. healModifier 0 → directHeal per fire = 1000.
+     *   - Total directHeal over 10 rounds = 2 × 1000 = 2000.
      *
      * Two assertions:
      *   (a) fire count = 2 and fires on rounds 5 and 10 (back-loaded accumulator schedule).
-     *   (b) summed directHeal = 4000.
+     *   (b) summed directHeal = 2000.
      */
-    it('Bloodthirst legendary: fires floor(10 × 0.20)=2 times over 10 crits; total directHeal = 2×2000', () => {
+    it('Bloodthirst legendary: fires floor(10 × 0.20)=2 times over 10 crits; total directHeal = 2×1000', () => {
         const ship = makeShip({
             implants: { implant_major: 'bt-legendary' },
         });
@@ -257,11 +259,13 @@ describe('D-PR1 integration — Bloodthirst implant proc frequency', () => {
             ],
         };
 
-        // Each reactive-heal fire: basis 'damage-dealt' → owner hp fallthrough = 10000.
-        // pct 20 → raw = 10000 × 0.20 = 2000. procChance 0.20 over 10 crits → 2 fires.
-        const perFireAmount = 10_000 * (20 / 100); // = 2000
+        // Each reactive-heal fire: basis 'damage-dealt' → eventCtx.triggerDamage = directDamage.
+        // attack=5000, multiplier=100%, critDamage=0, enemyDefense=0 → directDamage=5000.
+        // pct 20 → raw = 5000 × 0.20 = 1000. procChance 0.20 over 10 crits → 2 fires.
+        const critDamage = 5000; // attack 5000 × mult 1.0 × critMult 1.0 (critDamage=0) × noDefense
+        const perFireAmount = critDamage * (20 / 100); // = 1000
         const expectedFires = Math.floor(10 * 0.2); // = 2
-        const expectedTotal = expectedFires * perFireAmount; // = 4000
+        const expectedTotal = expectedFires * perFireAmount; // = 2000
 
         const result = runCombat(
             BASE({
@@ -278,10 +282,10 @@ describe('D-PR1 integration — Bloodthirst implant proc frequency', () => {
         expect(result.healing).toBeDefined();
         expect(result.healing!.rounds).toHaveLength(10);
 
-        // (b) total direct heal = 4000.
+        // (b) total direct heal = 2000 (2 fires × 1000 per fire).
         expect(sumHeal(result, 'directHeal')).toBeCloseTo(expectedTotal, 6);
 
-        // (a) fire count: back-loaded accumulator fires on rounds 2 and 10.
+        // (a) fire count: back-loaded accumulator fires on rounds 5 and 10.
         const firedRounds = result
             .healing!.rounds.map((rd, i) => ({
                 round: i + 1,

--- a/src/utils/combat/__tests__/procChanceGate.test.ts
+++ b/src/utils/combat/__tests__/procChanceGate.test.ts
@@ -1,0 +1,147 @@
+/**
+ * D-PR1: procChance gate — deterministic accumulator for equipment reactive procs.
+ *
+ * A passive on-crit reactive heal with procChance 0.5 over 10 rounds fires exactly 5 times
+ * (back-loaded: rounds 2, 4, 6, 8, 10). A control ability without procChance fires all 10.
+ *
+ * The rateAccumulator fires when acc >= 1. With rate 0.5 per call:
+ *   call 1: acc=0.5 → no fire
+ *   call 2: acc=1.0 → fire (acc→0)
+ *   call 3: acc=0.5 → no fire
+ *   call 4: acc=1.0 → fire (acc→0)
+ *   ... → fires on even-numbered calls: 2,4,6,8,10 → exactly 5 of 10.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { Ability, ShipSkills } from '../../../types/abilities';
+
+let idCounter = 0;
+const nextId = (): string => `proc-test-${++idCounter}`;
+
+const makeHealAbility = (procChance?: number): Ability => ({
+    id: nextId(),
+    type: 'heal',
+    target: 'self',
+    trigger: 'on-crit',
+    conditions: [],
+    ...(procChance !== undefined ? { procChance } : {}),
+    config: { type: 'heal', pct: 50, basis: 'hp', noCrit: true },
+});
+
+const BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 5000,
+    crit: 100, // every hit crits → on-crit fires once per round
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [] },
+    enemyDefense: 0,
+    enemyHp: 10_000_000, // enemy never dies
+    numRounds: 10,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 2000,
+    hp: 10000,
+    healTargetId: 'attacker', // enable healing mode, self is target
+    ...overrides,
+});
+
+/** Build a ShipSkills with a single-hit damage active (so on-crit fires once per round)
+ *  and the given reactive heal abilities on the passive slot. */
+const makeSkills = (abilities: Ability[]): ShipSkills => ({
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                {
+                    id: nextId(),
+                    type: 'damage',
+                    target: 'enemy',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config: { type: 'damage', multiplier: 100, hits: 1 },
+                },
+            ],
+        },
+        {
+            slot: 'passive',
+            abilities,
+        },
+    ],
+});
+
+/** Sum a heal bucket over all rounds for the focus actor ('attacker'). */
+const sumHeal = (
+    result: ReturnType<typeof runCombat>,
+    bucket: 'directHeal' | 'effectiveHeal' | 'overheal'
+): number =>
+    (result.healing?.rounds ?? []).reduce(
+        (sum, rd) => sum + (rd.perActor.get('attacker')?.[bucket] ?? 0),
+        0
+    );
+
+describe('D-PR1: procChance gate — per-proc rate gate for equipment reactive procs', () => {
+    it('procChance 0.5 over 10 on-crit triggers fires the reactive heal exactly 5 times (deterministic accumulator)', () => {
+        idCounter = 0;
+        // Each fire credits directHeal = 10000 (hp) × 50% = 5000.
+        // 5 fires → 25000 total; 10 fires (no gate) → 50000 total.
+        const gatedAbility = makeHealAbility(0.5);
+        const result = runCombat(
+            BASE({
+                shipSkills: makeSkills([gatedAbility]),
+            })
+        );
+
+        expect(result.healing).toBeDefined();
+        expect(result.healing!.rounds).toHaveLength(10);
+
+        // 5 fires × 5000 = 25000
+        expect(sumHeal(result, 'directHeal')).toBe(25000);
+    });
+
+    it('control: reactive heal without procChance fires on all 10 on-crit triggers (no gate)', () => {
+        idCounter = 0;
+        const controlAbility = makeHealAbility(/* no procChance */);
+        const result = runCombat(
+            BASE({
+                shipSkills: makeSkills([controlAbility]),
+            })
+        );
+
+        expect(result.healing).toBeDefined();
+        expect(result.healing!.rounds).toHaveLength(10);
+
+        // 10 fires × 5000 = 50000
+        expect(sumHeal(result, 'directHeal')).toBe(50000);
+    });
+
+    it('procChance exactly 1: fires on every trigger (no skip)', () => {
+        idCounter = 0;
+        const result = runCombat(
+            BASE({
+                shipSkills: makeSkills([makeHealAbility(1)]),
+            })
+        );
+        // procChance=1 is outside (0,1) so the gate is bypassed → 10 fires × 5000 = 50000
+        expect(sumHeal(result, 'directHeal')).toBe(50000);
+    });
+
+    it('procChance exactly 0: gate bypassed, fires on every trigger (treated as absent)', () => {
+        idCounter = 0;
+        const result = runCombat(
+            BASE({
+                shipSkills: makeSkills([makeHealAbility(0)]),
+            })
+        );
+        // procChance=0 is outside (0,1) so gate is bypassed → 10 fires × 5000 = 50000
+        // (procChance=0 means always fire, same as absent — the guard is pc > 0 && pc < 1)
+        expect(sumHeal(result, 'directHeal')).toBe(50000);
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -59,6 +59,7 @@ import {
     PlayerActorRuntime,
     PlayerRoundCtx,
     PlayerTurnResult,
+    RateGate,
     runPlayerTurn,
 } from './playerTurn';
 import {
@@ -1853,6 +1854,10 @@ export function runCombat(input: CombatEngineInput): {
     // repair — Yazid's on-cheat-death-activated 60% repair — fires at most once per battle even
     // across rounds. Threaded into executeIntent's ctx; the executor checks/sets it.
     const oncePerCombatFired = new Set<string>();
+    // Combat-lifetime proc-chance gates for equipment reactive procs (D-PR1). Keyed
+    // `${ownerId}:${abilityId}`; each gate is a RateGate accumulator that fires at the
+    // ability's procChance rate across all rounds, deterministically (like crit/landing gates).
+    const procChanceGates = new Map<string, RateGate>();
 
     // ═══════════════════════════════════════════════════════════════════════════════════════
     // Reactive extra-action timing analysis (Phase 4b Task 10). Two death paths land an
@@ -3146,6 +3151,9 @@ export function runCombat(input: CombatEngineInput): {
                         // Combat-lifetime once-per-battle guard (Task 8): a flagged reactive
                         // repair (Yazid) fires at most once across the whole combat.
                         oncePerCombatFired,
+                        // Combat-lifetime proc-chance gates (D-PR1): equipment reactive procs
+                        // that carry a procChance fire at their stated rate via this accumulator.
+                        procChanceGates,
                         // Phase 4c PR 6: live lowest-speed-ally gate. UNCONDITIONAL (unlike the
                         // healing-only selfHpPctFor spread) — in DPS mode the set is {attacker}, so
                         // the lone attacker resolves true and DPS gating stays byte-identical.

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -94,7 +94,15 @@ export interface Intent {
      *  (Cultivator's repair, Refine/Graphite's grants) instead of the default.
      *  `fromPurgeEvent`: depth-1 purge chain guard — a purge triggered by a
      *  purge-performed event does not re-emit purge-performed, preventing infinite chains. */
-    eventCtx?: { counterTargetId?: string; damagedAllyId?: string; fromPurgeEvent?: boolean };
+    eventCtx?: {
+        counterTargetId?: string;
+        damagedAllyId?: string;
+        fromPurgeEvent?: boolean;
+        /** The damage dealt by the triggering event (ability-performed.damage), used by a
+         *  reactive `basis:'damage-dealt'` heal/shield (e.g. Bloodthirst) to scale off the
+         *  triggering hit's damage rather than the owner's max HP. */
+        triggerDamage?: number;
+    };
 }
 
 /** Whether an ability is reactive (routed through the trigger machinery): a
@@ -229,7 +237,19 @@ export function registerReactiveListeners(args: {
                         // follow-up fires twice. Events without critHits fall back
                         // to the didCrit binary (one enqueue).
                         const n = e.critHits ?? (e.didCrit ? 1 : 0);
-                        for (let i = 0; i < n; i++) enqueue(intent);
+                        // Per-event copy: carry e.damage (total damage for this ability-performed
+                        // event) into eventCtx.triggerDamage so that a reactive basis:'damage-dealt'
+                        // heal (e.g. Bloodthirst) scales off the triggering hit's damage.
+                        // KNOWN APPROXIMATION: for a multi-hit ability, each critting hit enqueues
+                        // with the same event-total damage (not per-hit damage), so the heal is
+                        // proportionally over-counted per fire when critHits > 1. Per-hit attribution
+                        // is not supported in the event model today; document and accept.
+                        for (let i = 0; i < n; i++) {
+                            enqueue({
+                                ...intent,
+                                eventCtx: { ...intent.eventCtx, triggerDamage: e.damage },
+                            });
+                        }
                     });
                     break;
                 case 'on-debuff-inflicted':
@@ -1153,7 +1173,13 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
                 ? (ownerCtx?.effectiveAttack ?? owner.attack)
                 : cfg.basis === 'defense'
                   ? (ownerCtx?.effectiveDefence ?? owner.defence)
-                  : (ownerCtx?.effectiveMaxHp ?? owner.hp);
+                  : cfg.basis === 'damage-dealt'
+                    ? // Reactive damage-dealt (e.g. Bloodthirst on-crit): scale off the triggering
+                      // hit's damage captured in eventCtx.triggerDamage. Falls back to 0 when no
+                      // triggering damage is present (non-crit path or missing context) — a
+                      // damage-dealt reactive heal with no damage context heals nothing.
+                      (intent.eventCtx?.triggerDamage ?? 0)
+                    : (ownerCtx?.effectiveMaxHp ?? owner.hp);
         // Recipients: an 'ally'-target heal prefers eventCtx.damagedAllyId (an ally-damage
         // reaction repairs THAT ally) over the healing target. Identical today — the engine
         // only ever attacks the heal target, so damagedAllyId === healing.targetId in every

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -5,6 +5,7 @@ import { EnemyBaseClass, ParsedBuffEffects, SelectedGameBuff } from '../../types
 import { PERSISTENT_STACKING_BUFFS } from '../../constants/persistentStackingBuffs';
 import { conditionsMet } from '../abilities/evaluateConditions';
 import { buildRoundContext } from '../abilities/roundContext';
+import { makeRateGate } from '../calculators/rateAccumulator';
 import { expandEnemyDebuffs, payloadToSelectedBuff } from './buffTotals';
 import { liveGateConditions } from './abilityStatusGating';
 import { CombatEventBus } from './events';
@@ -18,7 +19,7 @@ import {
 } from './statusEngine';
 // Type-only import (erased at runtime) → no circular-import cycle even though playerTurn.ts
 // imports buildActorConditionContext/ReactiveAbility from this module.
-import type { PlayerActorRuntime, PlayerRoundCtx, HealingRuntimeCtx } from './playerTurn';
+import type { PlayerActorRuntime, PlayerRoundCtx, HealingRuntimeCtx, RateGate } from './playerTurn';
 import type { ActorTargetingStatus } from './positionalBinding';
 
 /** The trigger values the engine consumes — defined next to AbilityTrigger in
@@ -533,6 +534,10 @@ export interface IntentExecContext {
      *  fire and is skipped on every later fire — Yazid's on-cheat-death-activated 60% repair
      *  fires at most ONCE per combat. Absent in unit tests that exercise unbounded follow-ups. */
     oncePerCombatFired?: Set<string>;
+    /** Combat-lifetime per-ability proc-chance gates (e.g. Bloodthirst's 12% chance).
+     *  Keyed `${ownerId}:${abilityId}`; the RateGate accumulates across all rounds and all
+     *  reactive fires of the same ability so the proc lands at its true frequency. */
+    procChanceGates?: Map<string, RateGate>;
     /** Live self-HP% per owner (0..100) for drain-time hp-threshold gates (Phase 4c
      *  PR 1). The engine closes over the heal target's current/max HP (healing mode);
      *  every other owner — and DPS mode entirely — reports 100 (the pre-4c default),
@@ -1108,6 +1113,17 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
             const key = `${intent.ownerId}:${intent.ability.id}`;
             if (ctx.oncePerCombatFired?.has(key)) return;
             ctx.oncePerCombatFired?.add(key);
+        }
+        const pc = intent.ability.procChance;
+        if (pc !== undefined && pc > 0 && pc < 1) {
+            const gateKey = `${intent.ownerId}:${intent.ability.id}`;
+            let gate = ctx.procChanceGates?.get(gateKey);
+            if (ctx.procChanceGates && !gate) {
+                gate = makeRateGate();
+                ctx.procChanceGates.set(gateKey, gate);
+            }
+            // absent map (unit-test contexts) → gate stays undefined → pass through
+            if (gate && !gate(pc)) return;
         }
         // Reactive heals NEVER crit (no draw at drain time — deterministic, documented
         // approximation) and use the OWNER's last-turn ctx stats; before the owner's first


### PR DESCRIPTION
## Summary

First PR of sub-project **D** (implant + gear-set abilities) in the combat-realism epic. Lays the **foundation** for the combat sim to consume implant/gear-set special effects, proven end-to-end by two effects on existing engine machinery.

- **`buildEquipmentAbilities(ship, getGearPiece)`** — resolves a ship's active gear sets + equipped implants into `Ability[]` (graceful skip on missing/stat-only/bad data; never throws). Gear sets via a small registry; implants via a per-implant registry baking values from `implants.ts` (the skill parser can't yield `on-crit` for a leech-basis heal — documented).
- **Per-proc chance model** — new `procChance?` on `Ability` + a combat-lifetime per-`(owner, ability)` rate gate in the reactive heal executor (deterministic accumulator, mirroring crit/landing — a proc fires at its true average frequency).
- **Merge wrapper** `buildShipAbilitiesWithEquipment` injects equipment abilities into the passive slot; `simulateBattle` gains an optional `getGearPiece` threaded to both teams; the Simulator and Healing pages route through it. `buildShipAbilities` itself is untouched.
- **Reactive `damage-dealt` heal basis** — the reactive heal executor now scales a `damage-dealt` heal off the triggering hit's damage (via `Intent.eventCtx.triggerDamage`), so Bloodthirst heals 20% of the crit's damage, not max HP.

**Effects shipped:** Leech gear set (standing leech, 15% of damage dealt) and the Bloodthirst implant (on-crit, rarity proc chance, heal rarity% of the crit's damage).

**Deferred (next PRs):** conditional outgoing-damage bucket incl. Intrusion + the passive-scaling damage fold (D-PR2); Menace/Giant Slayer in-flight amplification; shields→H, reflect→G, stat-conversion→F.

Stacked on the E5 branch (PR #126); retarget to `main` after E5 merges.

## Test Plan

- [x] `npx vitest run` — 2794 pass (new: per-proc-gate, buildEquipmentAbilities, wrapper, integration, coverage)
- [x] Existing DPS/healing/battle-sim goldens **byte-identical** (zero `.snap` drift — no fixture carries effect-bearing gear)
- [x] `npm run lint` clean, `npx tsc --noEmit` clean
- [x] `npm run audit:skills` 0 findings / 141 ships (unchanged)
- [x] Coverage tracker pins the implemented set to `{LEECH, BLOODTHIRST}` (forces a deliberate update in D-PR2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)