### PR TITLE
feat(combat): D-PR2 — conditional outgoing-damage implants (Intrusion / Arcane Siege / Warpstrike)

### DIFF
--- a/docs/superpowers/plans/2026-06-20-implant-gearset-abilities-D-pr1.md
+++ b/docs/superpowers/plans/2026-06-20-implant-gearset-abilities-D-pr1.md
@@ -1,0 +1,392 @@
+# Implant + Gear-Set Abilities — D-PR1 (Foundation) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up the source-and-chance foundation that lets the combat sim consume implant + gear-set special effects, proven end-to-end by two effects on existing engine machinery: the **Leech** gear set (standing leech) and the **Bloodthirst** implant (on-crit, 12% chance, self-heal off damage dealt).
+
+**Architecture:** A new sibling module `buildEquipmentAbilities(ship, getGearPiece)` resolves a ship's active gear sets (count by `setBonus`) and equipped implants (id → name + rarity → variant `description`) into `Ability[]`. Gear-set special effects are produced by a tiny explicit per-set builder (their text is terse/non-prose); implant effects are parsed by reusing `abilitiesFromText`, then stamped with a `procChance` extracted from the description. The result is merged into the passive slot via a thin wrapper that leaves `buildShipAbilities` untouched (so every existing test stays byte-identical). Probabilistic procs ride a combat-lifetime `Map<string, RateGate>` keyed `${ownerId}:${abilityId}`, mirroring the existing `oncePerCombatFired` set; the reactive-heal executor rolls the gate before firing.
+
+**Tech Stack:** React 18 + TypeScript, Vitest. Combat engine in `src/utils/combat/`, ability building in `src/utils/abilities/`, parser in `src/utils/skillTextParser.ts`, types in `src/types/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-design.md`.
+
+**Branch:** `feat/combat-d-implant-gearset` (stacked on the E5 branch tip `73e10097`; rebase onto main later).
+
+---
+
+## Critical conventions (read before starting)
+
+- **Test runner:** `npm test` runs Vitest in WATCH mode and hangs agents. ALWAYS use `npx vitest run <path-or-name>`.
+- **Goldens:** NEVER run `vitest -u`. The load-bearing invariant for this PR is that all existing DPS / healing / battle-sim goldens stay **byte-identical** — the new builder only emits abilities when equipment resolves, and no existing fixture carries effect-bearing gear (verified in Task 0). If a `.snap` moves, the gate leaked — fix the gate, don't regenerate.
+- **Lint:** `npm run lint` enforces `--max-warnings 0`. Run it in EVERY task gate, not just the last.
+- **docs/ is gitignored:** commit plan/spec edits with `git add -f` and `git commit --no-verify` (the pre-commit hook runs the full suite; skip it for docs-only commits).
+- **Stat-only portions are already in combat stats** — this PR adds ONLY special-effect abilities, never stats.
+- REQUIRED SUB-SKILLS while implementing: @superpowers:test-driven-development, @superpowers:verification-before-completion.
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/types/abilities.ts` | Ability model | Add `procChance?: number` to `Ability`. |
+| `src/utils/combat/triggers.ts` | Reactive intent execution | Add `procChanceGates?: Map<string, RateGate>` to `IntentExecContext`; roll the gate in the reactive heal/shield executor. |
+| `src/utils/combat/engine.ts` | Combat setup + drain context | Create the combat-lifetime `procChanceGates` map (next to `oncePerCombatFired`) and thread it into every `IntentExecContext` build site. |
+| `src/utils/abilities/buildEquipmentAbilities.ts` | NEW — resolve equipped sets/implants → `Ability[]` | Create. Set registry + implant-via-parser + `procChance` stamping + graceful skip. |
+| `src/utils/abilities/buildShipAbilitiesWithEquipment.ts` | NEW — thin merge wrapper | Create. `buildShipAbilities(ship)` + merge equipment abilities into the passive slot. |
+| `src/utils/calculators/battleSimulator.ts` | Battle sim entry | `simulateBattle` gains optional `getGearPiece?`; `planPlacement` threads it; uses the wrapper when present. |
+| `src/pages/SimulatorPage.tsx` | Sim page | Pass `getGearPiece` into `simulateBattle`. |
+| `src/pages/calculators/HealingCalculatorPage.tsx` | Healing page | Route the 4 `buildShipAbilities(ship)` sites through the wrapper with `getGearPiece`. |
+| `src/constants/changelog.ts` | Changelog | `UNRELEASED_CHANGES` entry. |
+| `src/pages/DocumentationPage.tsx` | In-app docs | Note implant/gear-set effects now apply in the sim. |
+
+---
+
+## Task 0: Baseline + fixture audit
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Confirm branch + green baseline**
+
+Run: `git branch --show-current` → expect `feat/combat-d-implant-gearset`.
+Run: `npx vitest run src/utils/combat src/utils/abilities src/utils/calculators 2>&1 | tail -20`
+Expected: all pass.
+
+- [ ] **Step 2: Confirm no combat fixture carries effect-bearing gear (byte-identical premise)**
+
+Run: `grep -rn "equipment:\s*{[^}]" src/utils/combat/__tests__ src/utils/calculators/__tests__ 2>/dev/null; grep -rn "implants:\s*{[^}]" src/utils/combat/__tests__ src/utils/calculators/__tests__ 2>/dev/null`
+Expected: no matches with non-empty equipment/implants (fixtures use `{}` or omit). If any match resolves to an effect-bearing set/implant, STOP and surface it — the merge is not byte-identical and the plan needs a fixture-neutralization step.
+
+- [ ] **Step 3: Record the baseline test count**
+
+Run: `npx vitest run 2>&1 | tail -5` and note the passing count for later comparison.
+
+---
+
+## Task 1: `procChance` field + per-proc rate gate in the reactive heal executor
+
+The foundational chance machinery. Unreachable until an ability carries `procChance`, so existing behavior is byte-identical; tested in isolation with a synthetic ability.
+
+**Files:**
+- Modify: `src/types/abilities.ts` (the `Ability` interface, ~:280-299)
+- Modify: `src/utils/combat/triggers.ts` (`IntentExecContext` ~:480-554; reactive heal/shield executor ~:1101-1187)
+- Modify: `src/utils/combat/engine.ts` (combat-lifetime state next to `oncePerCombatFired`; every `IntentExecContext` literal)
+- Test: `src/utils/combat/__tests__/procChanceGate.test.ts` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/utils/combat/__tests__/procChanceGate.test.ts`. Use the existing healing-mode engine harness (mirror the setup in `src/utils/combat/__tests__/enemyActions.test.ts` or `healing.test.ts`). Build a player attacker that crits every turn and carries a passive reactive heal ability:
+
+```ts
+// ability under test (hand-built into the actor's passive slot via the test's ShipSkills):
+{
+  id: 'test-proc-heal',
+  type: 'heal', target: 'self', trigger: 'on-crit', conditions: [],
+  procChance: 0.5,
+  config: { type: 'heal', pct: 50, basis: 'damage-dealt', noCrit: true },
+}
+```
+
+Run the engine for 10 rounds where the attacker lands exactly one critting hit per round, in healing mode, and assert the self-heal is credited on exactly 5 of the 10 crits (deterministic accumulator: 0.5 over 10 calls fires 5 times). Assert a second control ability with `procChance` absent fires on all 10. (Assert the COUNT of fires, not which specific rounds — the accumulator is back-loaded, so the exact firing rounds depend on `rateAccumulator.ts:17`; confirm the pattern there when writing the assertion.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/utils/combat/__tests__/procChanceGate.test.ts`
+Expected: FAIL — `procChance` not a known property (tsc) or the heal fires on all 10 (no gate yet).
+
+- [ ] **Step 3: Add `procChance` to the `Ability` type**
+
+In `src/types/abilities.ts`, add to `interface Ability` (top-level, alongside `triggerCritFilter`):
+
+```ts
+    /** Probabilistic proc gate for equipment-sourced reactive abilities ("N% chance to …").
+     *  A value in (0,1) means the ability fires at that rate via a combat-lifetime per-(owner,
+     *  ability) RateGate (deterministic accumulator, like crit/landing). Absent or out of (0,1)
+     *  → fires on every qualifying trigger. */
+    procChance?: number;
+```
+
+- [ ] **Step 4: Add the gate map to `IntentExecContext` and roll it in the heal/shield executor**
+
+In `src/utils/combat/triggers.ts`:
+
+Add to `IntentExecContext` (mirror the `oncePerCombatFired` doc comment):
+```ts
+    /** Combat-lifetime per-ability proc-chance gates (e.g. Bloodthirst's 12% chance).
+     *  Keyed `${ownerId}:${abilityId}`; the RateGate accumulates across all rounds and all
+     *  reactive fires of the same ability so the proc lands at its true frequency. */
+    procChanceGates?: Map<string, RateGate>;
+```
+
+In the reactive heal/shield executor, immediately AFTER the existing `oncePerCombat` guard (~:1107), add:
+```ts
+    const pc = intent.ability.procChance;
+    if (pc !== undefined && pc > 0 && pc < 1) {
+        const gateKey = `${intent.ownerId}:${intent.ability.id}`;
+        let gate = ctx.procChanceGates?.get(gateKey);
+        if (ctx.procChanceGates && !gate) {
+            gate = makeRateGate();
+            ctx.procChanceGates.set(gateKey, gate);
+        }
+        if (gate && !gate(pc)) return;
+    }
+```
+Ensure `makeRateGate` and the `RateGate` type are imported in `triggers.ts` (import `makeRateGate` from `../calculators/rateAccumulator`; `RateGate` from `./playerTurn`).
+
+- [ ] **Step 5: Create and thread the combat-lifetime map in the engine**
+
+In `src/utils/combat/engine.ts`, find where `oncePerCombatFired` (a `Set<string>`) is created OUTSIDE the round loop (combat-lifetime, near `cheatDeathConsumed`). Add next to it:
+```ts
+    const procChanceGates = new Map<string, RateGate>();
+```
+Then add `procChanceGates,` to EVERY `IntentExecContext` object literal that already passes `oncePerCombatFired` (search for `oncePerCombatFired` in engine.ts — pass `procChanceGates` at each of the same sites). Import `RateGate` if not already imported.
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `npx vitest run src/utils/combat/__tests__/procChanceGate.test.ts`
+Expected: PASS (5/10 gated, 10/10 control).
+
+- [ ] **Step 7: Verify byte-identical goldens + lint + types**
+
+Run: `npx vitest run 2>&1 | tail -5` (expect baseline count + the new test; ZERO `.snap` changes — `git status --short` shows no modified `.snap`).
+Run: `npm run lint && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/types/abilities.ts src/utils/combat/triggers.ts src/utils/combat/engine.ts src/utils/combat/__tests__/procChanceGate.test.ts
+git commit -m "feat(combat): D-PR1 — per-proc rate gate for equipment reactive procs"
+```
+
+---
+
+## Task 2: `buildEquipmentAbilities` module
+
+Pure resolution + emission. Not wired into any engine path yet → byte-identical. Unit-tested in isolation.
+
+**Files:**
+- Create: `src/utils/abilities/buildEquipmentAbilities.ts`
+- Test: `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts` (NEW)
+- Reference (read, don't modify): `src/utils/ship/statsCalculator.ts:140-178` (`countSetPieces`), `src/constants/gearSets.ts`, `src/constants/implants.ts`, `src/utils/abilities/buildShipAbilities.ts:644` (`abilitiesFromText`).
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Create `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`. A `makeGetGearPiece(map)` helper returns a `(id)=>GearPiece|undefined`. Cases:
+
+1. **Leech set active (≥2 pieces):** a ship with 2 equipment ids whose pieces have `setBonus:'LEECH'` → returns exactly one ability: `{type:'heal', target:'self', trigger:'on-cast', config:{type:'heal', pct:15, basis:'damage-dealt', leechScope:'all', noCrit:true}}` with a stable id (`equip-set-LEECH`). (`noCrit:true` — a derived-from-damage leech doesn't roll its own heal-crit; flag as a modeling choice in the PR for reviewer confirmation.)
+2. **Leech set inactive (1 piece):** → `[]`.
+3. **Bloodthirst implant (legendary):** `ship.implants.implant_major` → a piece with `setBonus:'BLOODTHIRST', rarity:'legendary'` → returns an ability `{type:'heal', target:'self', trigger:'on-crit', procChance:0.20, config:{type:'heal', pct:20, basis:'damage-dealt'}}` (legendary = 20% chance / 20% heal per the implant data). Assert `procChance` and `config.pct`.
+4. **Missing piece:** an implant id with no entry in the map → skipped, no throw.
+5. **Stat-only implant (e.g. STRIKE / a minor with no description):** → `[]`.
+6. **Unparseable description:** a fake implant whose description is gibberish → skipped, no throw, `[]`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the module**
+
+Create `src/utils/abilities/buildEquipmentAbilities.ts`:
+
+- Export `interface EquipmentAbility extends Ability { source: 'implant' | 'gear-set'; }` OR return plain `Ability[]` and carry the source in a comment — prefer NOT extending `Ability` (the engine consumes plain `Ability`); instead tag via a stable id prefix (`equip-set-*` / `equip-implant-*`) and skip a separate `source` field. (Resolve in the test accordingly.)
+- `export function buildEquipmentAbilities(ship: Ship, getGearPiece: (id: string) => GearPiece | undefined): Ability[]`.
+- **Active sets:** mirror `countSetPieces` — iterate `ship.equipment`, `getGearPiece(id)?.setBonus`, tally; a set is active when `count >= (GEAR_SETS[name]?.minPieces ?? 2)`. For each active set with an entry in the set-ability registry, emit its ability.
+- **Set-ability registry** (only Leech for D-PR1):
+  ```ts
+  const GEAR_SET_ABILITIES: Partial<Record<string, () => AbilityConfig>> = {
+      LEECH: () => ({ type: 'heal', pct: 15, basis: 'damage-dealt', leechScope: 'all', noCrit: true }),
+  };
+  ```
+  Wrap each config in a full `Ability` (`id: 'equip-set-LEECH'`, `type:'heal'`, `target:'self'`, `trigger:'on-cast'`, `conditions:[]`, `autoFilled:true`).
+- **Implants:** for each id in `ship.implants`, resolve `getGearPiece(id)` → `{ setBonus, rarity }`. `setBonus` is the implant name (a `GearSetName ∪ ImplantName`). Look up `IMPLANTS[setBonus]` (guard undefined); find the variant with matching `rarity`; read `variant.description`. If no description → skip. Feed `description` through `abilitiesFromText(description, 'passive', ship.type)`; for each produced `PositionedAbility`, stamp `procChance` (see helper) and a stable id (`equip-implant-<name>-<i>`); collect `.ability`.
+- **`procChance` helper:** `extractProcChance(text): number | undefined` = match `/(\d+)\s*%\s*chance/i`; return `Number(m[1]) / 100` or `undefined`. Stamp onto each ability produced from that description.
+- **Graceful skip everywhere:** wrap per-piece resolution so a missing piece / missing implant data / empty parser output / thrown error yields no ability (never throws out of the function).
+
+Note for the implementer: Bloodthirst's description ("On a critical hit, there is a 12% chance for this unit to repair itself for 12% of the damage dealt") is expected to parse into a `heal` ability with `trigger:'on-crit'` + `config.basis:'damage-dealt'` + `config.pct` (the heal %); the `procChance` comes from the stamping helper (the "% chance" number, NOT the heal %). If `abilitiesFromText` does NOT yield an on-crit damage-dealt heal for this exact string, characterize what it yields and either (a) add a minimal targeted extension to the heal/leech parser, or (b) fall back to a per-implant builder for BLOODTHIRST mirroring the set registry — document which and why in the commit.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + types + byte-identical**
+
+Run: `npm run lint && npx tsc --noEmit && npx vitest run 2>&1 | tail -5`
+Expected: clean; no `.snap` changes (module unwired).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+git commit -m "feat(combat): D-PR1 — buildEquipmentAbilities (Leech set + implant resolution)"
+```
+
+---
+
+## Task 3: Merge wrapper + call-site plumbing
+
+Wires equipment abilities into the engine. Byte-identical because fixtures carry no effect-bearing gear (Task 0).
+
+**Files:**
+- Create: `src/utils/abilities/buildShipAbilitiesWithEquipment.ts`
+- Modify: `src/utils/calculators/battleSimulator.ts` (`simulateBattle` signature ~:560; `planPlacement` ~:520-535)
+- Modify: `src/pages/SimulatorPage.tsx` (call to `simulateBattle`)
+- Modify: `src/pages/calculators/HealingCalculatorPage.tsx` (5 sites: ~:121, 235, 252, 307, 356 — find ALL `buildShipAbilities(ship)` in the file; a missed site is silent because the wrapper deep-equals `buildShipAbilities` when equipment is empty)
+- Test: `src/utils/abilities/__tests__/buildShipAbilitiesWithEquipment.test.ts` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/utils/abilities/__tests__/buildShipAbilitiesWithEquipment.test.ts`. A ship with Leech set (2 pieces) + Bloodthirst implant, plus a normal skill, run through `buildShipAbilitiesWithEquipment(ship, getGearPiece)`:
+- The passive slot contains BOTH the ship's own passive abilities AND the two equipment abilities.
+- A ship with empty equipment/implants produces output identical to `buildShipAbilities(ship)` (deep-equal).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/utils/abilities/__tests__/buildShipAbilitiesWithEquipment.test.ts`
+Expected: FAIL — wrapper does not exist.
+
+- [ ] **Step 3: Implement the wrapper**
+
+Create `src/utils/abilities/buildShipAbilitiesWithEquipment.ts`:
+```ts
+export function buildShipAbilitiesWithEquipment(
+    ship: Ship,
+    getGearPiece: (id: string) => GearPiece | undefined,
+): ShipSkills {
+    const skills = buildShipAbilities(ship);
+    const equip = buildEquipmentAbilities(ship, getGearPiece);
+    if (!equip.length) return skills;
+    const passive = skills.slots.find((s) => s.slot === 'passive');
+    if (passive) passive.abilities.push(...equip);
+    else skills.slots.push({ slot: 'passive', abilities: equip });
+    return skills;
+}
+```
+`buildShipAbilities` is left untouched (single-arg, byte-identical for all existing callers/tests).
+
+- [ ] **Step 4: Thread `getGearPiece` into the battle simulator**
+
+In `src/utils/calculators/battleSimulator.ts`:
+- Add an optional param to the public entry: `export function simulateBattle(input: BattleSimulationInput, getGearPiece?: (id: string) => GearPiece | undefined): BattleResult`.
+- Thread `getGearPiece` into `planPlacement` (add a param). In `planPlacement`, set `shipSkills: getGearPiece ? buildShipAbilitiesWithEquipment(p.ship, getGearPiece) : buildShipAbilities(p.ship)`.
+- When `getGearPiece` is absent (every existing test), behavior is identical → goldens byte-identical.
+
+- [ ] **Step 5: Pass `getGearPiece` from the pages**
+
+- `SimulatorPage.tsx`: it already has `const { getGearPiece } = useInventory()` — pass it as the 2nd arg to `simulateBattle(input, getGearPiece)`.
+- `HealingCalculatorPage.tsx`: it already has `getGearPiece` from `useInventory()`. Replace ALL `buildShipAbilities(ship)` calls — there are 5 (~:121, 235, 252, 307, 356) — with `buildShipAbilitiesWithEquipment(ship, getGearPiece)`. Grep the file to confirm none are missed (a missed site silently drops equipment for that path; no test will fail because the wrapper is byte-identical when equipment is empty).
+
+- [ ] **Step 6: Run the wrapper test + full suite (byte-identical)**
+
+Run: `npx vitest run src/utils/abilities/__tests__/buildShipAbilitiesWithEquipment.test.ts`
+Expected: PASS.
+Run: `npx vitest run 2>&1 | tail -5` and `git status --short`
+Expected: baseline + new tests pass; ZERO `.snap` modifications.
+
+- [ ] **Step 7: Lint + types**
+
+Run: `npm run lint && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/utils/abilities/buildShipAbilitiesWithEquipment.ts src/utils/abilities/__tests__/buildShipAbilitiesWithEquipment.test.ts src/utils/calculators/battleSimulator.ts src/pages/SimulatorPage.tsx src/pages/calculators/HealingCalculatorPage.tsx
+git commit -m "feat(combat): D-PR1 — merge equipment abilities into the passive slot at sim call sites"
+```
+
+---
+
+## Task 4: End-to-end engine integration (Leech standing + Bloodthirst frequency)
+
+Proves the full pipeline: resolution → merge → engine consumption (standing leech) and the gated reactive proc.
+
+**Files:**
+- Test: `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts` (NEW)
+- Reference: `engine.ts:2033-2053` (standing-leech registration), `engine.ts:2096-2131` (`procStandingLeeches`), the healing-mode harness used by `healing.test.ts`.
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Create `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts`, in healing mode (so `healingCtx`/`healTarget` exist and standing leech + reactive heals are exercised):
+
+1. **Leech set standing leech:** a player attacker whose `ShipSkills` (built via `buildShipAbilitiesWithEquipment` with a stub `getGearPiece` returning Leech-set pieces) deals a known direct-damage amount D in a round → the attacker is credited a self-heal of `0.15 * D` (the standing-leech path). Assert via the heal credit surface the healing engine exposes. NOTE: `procStandingLeeches` (engine.ts:~2106) folds the owner's `healModifier` (`raw *= 1 + healModifier/100`) and may crit — set the attacker's `healModifier` to 0 and `noCrit:true` on the Leech ability (already set) so the expected value is exactly `0.15 * D`; otherwise assert against the folded value.
+2. **Bloodthirst gated proc:** an attacker with the Bloodthirst implant resolved, landing exactly one critting hit per round for 10 rounds → the self-heal fires `floor(10 * procChance)` times, each `pct%` of the crit's damage. (For legendary: `procChance 0.20` → 2 fires.) Assert both frequency and amount.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/utils/combat/__tests__/equipmentAbilities.integration.test.ts`
+Expected: FAIL initially (set up the harness until it compiles, then it should drive the asserts).
+
+- [ ] **Step 3: Make them pass**
+
+No new production code is expected here — Tasks 1-3 supply the machinery. If a test fails on a real gap (e.g. the standing-leech registration doesn't see the merged ability because `ShipSkills` → `runtime.castSkills` drops it), debug with @superpowers:systematic-debugging and fix the smallest cause. Document any production change in the commit.
+
+- [ ] **Step 4: Run + full suite + lint + types**
+
+Run: `npx vitest run src/utils/combat/__tests__/equipmentAbilities.integration.test.ts`
+Expected: PASS.
+Run: `npx vitest run 2>&1 | tail -5 && npm run lint && npx tsc --noEmit && git status --short`
+Expected: clean; no `.snap` changes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+git commit -m "test(combat): D-PR1 — end-to-end Leech standing + Bloodthirst proc frequency"
+```
+
+---
+
+## Task 5: Coverage harness + docs + changelog + closeout
+
+**Files:**
+- Test: `src/utils/abilities/__tests__/equipmentCoverage.test.ts` (NEW — lightweight coverage tracker)
+- Modify: `src/constants/changelog.ts` (`UNRELEASED_CHANGES`)
+- Modify: `src/pages/DocumentationPage.tsx`
+
+- [ ] **Step 1: Coverage tracker test**
+
+Create `src/utils/abilities/__tests__/equipmentCoverage.test.ts`: iterate the full `IMPLANTS` + `GEAR_SETS` corpus, run each effect description through the same resolution path `buildEquipmentAbilities` uses, and assert a CURRENT snapshot of which produce ≥1 ability vs. none. For D-PR1 this documents that exactly Leech (set) and the Bloodthirst variants (implant) produce abilities, everything else is `0` (not yet implemented). This makes later-PR coverage growth visible and prevents silent regressions. (Plain `expect` on counts — NOT a `.snap` file.)
+
+- [ ] **Step 2: Run it**
+
+Run: `npx vitest run src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Changelog**
+
+Add to `UNRELEASED_CHANGES` in `src/constants/changelog.ts` a plain-English entry, e.g.: "Combat sim now applies the Leech gear set and the Bloodthirst implant (more implant and gear-set effects coming)."
+
+- [ ] **Step 4: Documentation**
+
+In `src/pages/DocumentationPage.tsx`, note in the combat/sim section that equipped implant and gear-set special effects are beginning to apply in the simulator (Leech, Bloodthirst), with chance-based procs modeled at their true frequency.
+
+- [ ] **Step 5: Final gate**
+
+Run: `npx vitest run 2>&1 | tail -5`
+Run: `npm run lint && npx tsc --noEmit`
+Run: `npm run audit:skills` (expect unchanged 0/141 — equipment parsing is separate from ship-skill audit).
+Run: `git status --short` (expect no `.snap` changes).
+Expected: all clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/abilities/__tests__/equipmentCoverage.test.ts src/constants/changelog.ts src/pages/DocumentationPage.tsx
+git commit -m "docs(combat): D-PR1 — equipment-effect coverage tracker + changelog + docs"
+```
+
+---
+
+## Done-when
+
+- `buildEquipmentAbilities` resolves active sets + equipped implants; Leech set + Bloodthirst implant produce correct abilities; unknown/stat-only/unparseable inputs skip gracefully.
+- The merge wrapper injects equipment abilities into the passive slot at the sim call sites; `buildShipAbilities` is unchanged and all existing goldens are byte-identical (no `.snap` movement).
+- A reactive proc fires at its true frequency via the combat-lifetime per-proc rate gate; the standing Leech credits 15% of damage dealt.
+- Suite green, lint 0, tsc clean, `audit:skills` 0/141.
+
+## Deferred (next D PRs — do NOT do here)
+
+- **D-PR2:** conditional outgoing-damage bucket — the passive conditional-scaling damage fold + Intrusion, Arcane Siege, Warpstrike.
+- **D-PR2+ / later:** in-flight reactive damage amplification + `target-higher-attack` condition (Menace, Giant Slayer); incoming-reduction conditions; the remaining reactive triggers (end-of-round-if-not-hit, on-debuffed, on-resist, on-shield-applied, on-heal-cast, periodic, big-hit); on-death (Battlecry/Last Wish/Martyrdom); charge/DoT/cleanse; net-new mechanics (Boost, Cloaking); CF/Provoke appliers.
+- **Other subprojects:** shield grants → H, reflect → G, start-of-combat stat conversion → F.

--- a/docs/superpowers/plans/2026-06-20-implant-gearset-abilities-D-pr2.md
+++ b/docs/superpowers/plans/2026-06-20-implant-gearset-abilities-D-pr2.md
@@ -1,0 +1,522 @@
+# D-PR2: Conditional Outgoing-Damage Implants — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Light up three conditional outgoing-damage implants (Intrusion, Arcane Siege, Warpstrike) in the combat engine by modeling them as passive `modifier` abilities on channel `outgoingDamage`, and wire the DPS calculator page to consume equipment abilities.
+
+**Architecture:** These effects ride the *existing* modifier fold — `modifierTotalsFromAbilities` already iterates the passive slot, gates by `conditionsMet`, and sums flat `value` + per-count `scaling` into the multiplicative `outgoingDamage` factor. No `conditionalBonusPct`/`playerTurn` damage-fold surgery. The single new engine primitive is a `self-shield` condition subject for Arcane Siege. Effects are added to the D-PR1 `IMPLANT_ABILITIES` registry (values baked per-rarity; `description` used only as a presence gate).
+
+**Tech Stack:** React 18, TypeScript, Vite, Vitest. Combat engine under `src/utils/combat/` + `src/utils/abilities/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-pr2-design.md`
+**Branch:** `feat/combat-d-pr2-conditional-damage` (stacked on D-PR1 tip `cfbafb76`).
+
+---
+
+## Workflow gotchas (read before starting)
+
+- **Test runner:** bare `npm test` runs Vitest in WATCH mode and hangs. Always use `npx vitest run <path-or-name>`. Full suite: `npx vitest run`.
+- **Never** run `vitest -u` (would silently rewrite golden `.snap` files). Goldens must stay byte-identical here.
+- **Lint:** `npm run lint` enforces `--max-warnings 0`. Run it in EVERY task gate, not just the last (a stray `as any` fails the build).
+- **Type check:** `npx tsc --noEmit`.
+- **Skill audit (unchanged-guard):** `npm run audit:skills` should stay 141 ships / 0 findings (this PR doesn't touch the skill-text parser).
+- **`docs/` is gitignored** but `docs/superpowers/**` is force-tracked — commit plan/spec edits with `git add -f`.
+- Commit message footer:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+
+---
+
+## Task 1: Fixture audit — confirm the byte-identical invariant is empty
+
+**Goal:** Before any wiring, prove no existing DPS / battle-sim / healing fixture builds a ship carrying Intrusion / Arcane Siege / Warpstrike. If none do, the goldens are guaranteed byte-identical after Task 4 wires the DPS page. No code change — this is a verification gate.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Grep the test corpus for the three implants**
+
+Run:
+```bash
+grep -rniE "intrusion|arcane[_ ]?siege|warpstrike" src/ --include=*.test.ts --include=*.test.tsx
+grep -rniE "INTRUSION|ARCANE_SIEGE|WARPSTRIKE" src/ --include=*.ts --include=*.tsx | grep -iE "fixture|setBonus|implant" | grep -v "buildEquipmentAbilities\|implants.ts\|equipmentCoverage\|arcaneSiegeUtils"
+```
+Expected: no hits that wire one of these implants onto a ship used by a DPS/battle/healing golden. (Hits in `implants.ts`, `arcaneSiegeUtils.ts` (autogear), and the equipment-ability test files are expected and fine.)
+
+- [ ] **Step 2: Record the result**
+
+If clean (expected): note in the Task 4 commit body that the fixture audit was empty. If a fixture DOES carry one of these, STOP and surface it — either neutralize the fixture's equipment or deliberately audit the resulting churn (never `vitest -u`). Do not proceed to Task 4 with an un-audited fixture.
+
+---
+
+## Task 2: Add the `self-shield` condition primitive
+
+**Goal:** A binary, derivable condition that is met when the acting unit currently has a shield (`shieldPool > 0`). Purely additive — no existing ability uses it, `selfShielded` defaults falsy.
+
+**Files:**
+- Modify: `src/types/abilities.ts` (ConditionSubject union)
+- Modify: `src/utils/abilities/evaluateConditions.ts` (ConditionContext + evaluateCondition)
+- Modify: `src/utils/abilities/roundContext.ts` (buildRoundContext input + output)
+- Modify: `src/utils/combat/playerTurn.ts` (thread `actor.shieldPool > 0` into modifierCtx)
+- Test: `src/utils/abilities/__tests__/evaluateConditions.test.ts` (create if absent — otherwise the nearest existing conditions test; confirm at impl time)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the conditions test file (verify the existing import/helper shape first — mirror a sibling `evaluateCondition` test):
+
+```ts
+import { evaluateCondition, ConditionContext } from '../evaluateConditions';
+
+function baseCtx(over: Partial<ConditionContext> = {}): ConditionContext {
+    return {
+        selfBuffNames: [], selfDebuffNames: [], enemyBuffNames: [], enemyDebuffCount: 0,
+        effectiveCritRate: 0, adjacentAllyCount: 0, enemyAdjacentCount: 0,
+        enemyDestroyedCount: 0, selfHpPct: 100, enemyHpPct: 100, ...over,
+    };
+}
+
+describe('self-shield condition', () => {
+    it('evaluates to 1 when selfShielded is true', () => {
+        expect(evaluateCondition({ subject: 'self-shield', derivable: true }, baseCtx({ selfShielded: true }))).toBe(1);
+    });
+    it('evaluates to 0 when selfShielded is false/absent', () => {
+        expect(evaluateCondition({ subject: 'self-shield', derivable: true }, baseCtx())).toBe(0);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `npx vitest run src/utils/abilities/__tests__/evaluateConditions.test.ts`
+Expected: FAIL — `'self-shield'` not assignable to `ConditionSubject` (tsc) / case not handled.
+
+- [ ] **Step 3: Add `'self-shield'` to the ConditionSubject union**
+
+In `src/types/abilities.ts`, add to the `ConditionSubject` union (place near the other self-* subjects with a short comment):
+
+```ts
+    // Binary gate: the condition owner currently has a shield (CombatActor.shieldPool > 0).
+    // Live-derived (ConditionContext.selfShielded); defaults false (no shield / DPS mode).
+    // Dormant until sub-project H grants shields in the sim. Used by the Arcane Siege implant.
+    | 'self-shield';
+```
+(If `self-shield` is added mid-union, keep the trailing `;` on the final member intact.)
+
+- [ ] **Step 4: Extend ConditionContext + evaluateCondition**
+
+In `src/utils/abilities/evaluateConditions.ts`:
+
+Add to the `ConditionContext` interface (near `targetRepairedThisRound`):
+```ts
+    /** True when the condition owner currently has a shield (shieldPool > 0). Live-derived
+     *  by the engine; defaults false (no shield / DPS mode). Used by the Arcane Siege implant. */
+    selfShielded?: boolean;
+```
+
+Add a case in the `evaluateCondition` switch (near `self-debuff`):
+```ts
+        case 'self-shield':
+            return ctx.selfShielded ? 1 : 0;
+```
+
+- [ ] **Step 5: Thread through buildRoundContext**
+
+In `src/utils/abilities/roundContext.ts`, add to the `state` input type (near `targetRepairedThisRound`):
+```ts
+    /** True when the acting unit has a shield (shieldPool > 0). Default false. */
+    selfShielded?: boolean;
+```
+And to the returned object (near `targetRepairedThisRound: state.targetRepairedThisRound ?? false,`):
+```ts
+        selfShielded: state.selfShielded ?? false,
+```
+
+- [ ] **Step 6: Run the unit test, verify it passes**
+
+Run: `npx vitest run src/utils/abilities/__tests__/evaluateConditions.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Thread the live shield state in playerTurn (modifierCtx site only)**
+
+In `src/utils/combat/playerTurn.ts`, the `buildRoundContext({...})` call that builds `modifierCtx` (~line 1078): add the field, reading the acting actor's live shield:
+```ts
+        selfDebuffNames: selfDebuffNamesArg,
+        selfShielded: actor.shieldPool > 0,
+```
+Verify `actor` is the acting `CombatActor` in scope at that site and `shieldPool` is live there (it is — `state.ts:108`, used elsewhere in the engine). Do NOT thread into other `buildRoundContext` calls — only the modifier fold needs it (spec §4 / open question #2); they default falsy.
+
+- [ ] **Step 8: Verify byte-identical — full suite + lint + tsc**
+
+Run:
+```bash
+npx vitest run
+npm run lint
+npx tsc --noEmit
+```
+Expected: all green; ZERO `.snap` changes in `git status` (additive change — no ability uses `self-shield` yet, `selfShielded` defaults falsy).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/types/abilities.ts src/utils/abilities/evaluateConditions.ts src/utils/abilities/roundContext.ts src/utils/combat/playerTurn.ts src/utils/abilities/__tests__/evaluateConditions.test.ts
+git commit -m "feat(combat): D-PR2 — self-shield condition primitive (Arcane Siege gate)"
+```
+
+---
+
+## Task 3: Add Intrusion / Arcane Siege / Warpstrike to the registry
+
+**Goal:** Three `IMPLANT_ABILITIES` entries emitting passive `modifier`/`outgoingDamage` abilities with the per-rarity values from `implants.ts`.
+
+**Files:**
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts`
+- Test: `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`
+
+Per-rarity values (common / uncommon / rare / epic / legendary), verified against `implants.ts`:
+- **Intrusion** (per enemy debuff): 1 / 2 / 3 / 4 / 5
+- **Arcane Siege** (while shielded): 3 / 6 / 10 / 15 / 20
+- **Warpstrike** (while self-debuffed): 1 / 2 / 3 / 4 / 5
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `buildEquipmentAbilities.test.ts` (mirror the existing Bloodthirst test helpers — reuse the file's `makeShip`/`makePiece` style):
+
+```ts
+describe('Intrusion implant', () => {
+    it('emits a passive outgoingDamage modifier scaling per enemy debuff (legendary = 5/debuff)', () => {
+        const abilities = buildForImplant('INTRUSION', 'legendary');
+        expect(abilities).toHaveLength(1);
+        const a = abilities[0];
+        expect(a.type).toBe('modifier');
+        expect(a.trigger).toBe('passive');
+        expect(a.config).toMatchObject({ type: 'modifier', channel: 'outgoingDamage', value: 0 });
+        expect(a.scaling).toEqual({ conditionIndex: 0, perUnit: 5 });
+        expect(a.conditions).toEqual([{ subject: 'enemy-debuff', derivable: true }]);
+    });
+    it('bakes the uncommon per-debuff value (2)', () => {
+        expect(buildForImplant('INTRUSION', 'uncommon')[0].scaling).toEqual({ conditionIndex: 0, perUnit: 2 });
+    });
+});
+
+describe('Arcane Siege implant', () => {
+    it('emits a flat outgoingDamage modifier gated on self-shield (epic = 15)', () => {
+        const a = buildForImplant('ARCANE_SIEGE', 'epic')[0];
+        expect(a.config).toMatchObject({ type: 'modifier', channel: 'outgoingDamage', value: 15 });
+        expect(a.scaling).toBeUndefined();
+        expect(a.conditions).toEqual([{ subject: 'self-shield', derivable: true }]);
+    });
+});
+
+describe('Warpstrike implant', () => {
+    it('emits a flat outgoingDamage modifier gated on >=1 self-debuff (legendary = 5)', () => {
+        const a = buildForImplant('WARPSTRIKE', 'legendary')[0];
+        expect(a.config).toMatchObject({ type: 'modifier', channel: 'outgoingDamage', value: 5 });
+        expect(a.scaling).toBeUndefined();
+        expect(a.conditions).toEqual([
+            { subject: 'self-debuff', derivable: true, countComparator: 'gte', countThreshold: 1 },
+        ]);
+    });
+});
+```
+
+`buildForImplant(name, rarity)` = a small helper (add if not present) that builds a ship with one implant of that name+rarity and calls `buildEquipmentAbilities(ship, getGearPiece)` — mirror `implantAbilityCount` in `equipmentCoverage.test.ts`.
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+Run: `npx vitest run src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`
+Expected: FAIL — registry has no entries; `buildForImplant(...)` returns `[]`.
+
+- [ ] **Step 3: Add the registry entries**
+
+In `src/utils/abilities/buildEquipmentAbilities.ts`, add per-rarity value maps and three `IMPLANT_ABILITIES` entries. Follow the existing `BLOODTHIRST` builder shape (returns `Omit<Ability,'id'> | undefined`):
+
+```ts
+const INTRUSION_PER_DEBUFF: Record<string, number> = {
+    common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5,
+};
+const ARCANE_SIEGE_PCT: Record<string, number> = {
+    common: 3, uncommon: 6, rare: 10, epic: 15, legendary: 20,
+};
+const WARPSTRIKE_PCT: Record<string, number> = {
+    common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5,
+};
+```
+
+Add to `IMPLANT_ABILITIES`:
+```ts
+    // Intrusion: +N% outgoing direct damage per debuff on the target. Rides the
+    // modifier fold as a pure scaling modifier (value 0 + scaling); the enemy-debuff
+    // condition is a bare scaling source (no countComparator) so it scales, never gates.
+    INTRUSION: (rarity) => {
+        const perUnit = INTRUSION_PER_DEBUFF[rarity];
+        if (perUnit === undefined) return undefined;
+        return {
+            type: 'modifier',
+            target: 'self',
+            trigger: 'passive',
+            conditions: [{ subject: 'enemy-debuff', derivable: true }],
+            scaling: { conditionIndex: 0, perUnit },
+            config: { type: 'modifier', channel: 'outgoingDamage', value: 0, isMultiplicative: false },
+            autoFilled: true,
+        };
+    },
+    // Arcane Siege: +X% outgoing direct damage while shielded. Flat value gated on the
+    // new self-shield condition; dormant until sub-project H grants shields in the sim.
+    ARCANE_SIEGE: (rarity) => {
+        const value = ARCANE_SIEGE_PCT[rarity];
+        if (value === undefined) return undefined;
+        return {
+            type: 'modifier',
+            target: 'self',
+            trigger: 'passive',
+            conditions: [{ subject: 'self-shield', derivable: true }],
+            config: { type: 'modifier', channel: 'outgoingDamage', value, isMultiplicative: false },
+            autoFilled: true,
+        };
+    },
+    // Warpstrike (damage half only): +X% outgoing direct damage while self-debuffed.
+    // Flat value + a >=1 self-debuff gate (NOT scaling — scaledBonus uses the raw debuff
+    // count and would over-apply for multiple debuffs). The "reduce a random debuff's
+    // duration by 1 turn" half is DEFERRED (self-debuff-mitigation / cleanse-family).
+    WARPSTRIKE: (rarity) => {
+        const value = WARPSTRIKE_PCT[rarity];
+        if (value === undefined) return undefined;
+        return {
+            type: 'modifier',
+            target: 'self',
+            trigger: 'passive',
+            conditions: [
+                { subject: 'self-debuff', derivable: true, countComparator: 'gte', countThreshold: 1 },
+            ],
+            config: { type: 'modifier', channel: 'outgoingDamage', value, isMultiplicative: false },
+            autoFilled: true,
+        };
+    },
+```
+
+(Confirm the `Ability`/`Condition` types accept these literals; `trigger: 'passive'` must be a valid `AbilityTrigger` — verify and use the engine's passive-trigger value at impl time.)
+
+- [ ] **Step 4: Run the tests, verify they pass**
+
+Run: `npx vitest run src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + tsc**
+
+Run: `npm run lint && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+git commit -m "feat(combat): D-PR2 — Intrusion/Arcane Siege/Warpstrike outgoingDamage modifiers"
+```
+
+---
+
+## Task 4: Wire the DPS calculator page
+
+**Goal:** Make the DPS page consume equipment abilities so Intrusion/Warpstrike actually affect a DPS run. (`battleSimulator` already routes them since D-PR1.)
+
+**Files:**
+- Modify: `src/pages/calculators/DPSCalculatorPage.tsx` (3 sites: ~lines 73, 384, 440)
+
+- [ ] **Step 1: Add the import**
+
+In `DPSCalculatorPage.tsx`, add (mirror HealingCalculatorPage's import):
+```ts
+import { buildShipAbilitiesWithEquipment } from '../../utils/abilities/buildShipAbilitiesWithEquipment';
+```
+
+- [ ] **Step 2: Replace the three call sites**
+
+Change each `shipSkills: buildShipAbilities(ship),` (lines ~73, 384, 440) to:
+```ts
+shipSkills: buildShipAbilitiesWithEquipment(ship, getGearPiece),
+```
+`getGearPiece` is already in scope (`const { getGearPiece } = useInventory();`, line 39). Remove the now-unused `buildShipAbilities` import only if no other site uses it (grep first).
+
+- [ ] **Step 3: Verify byte-identical — full suite + lint + tsc**
+
+Run:
+```bash
+npx vitest run
+npm run lint
+npx tsc --noEmit
+```
+Expected: all green; ZERO `.snap` changes (fixture audit in Task 1 confirmed no golden ship carries these implants).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/calculators/DPSCalculatorPage.tsx
+git commit -m "feat(combat): D-PR2 — wire DPS calculator page to equipment abilities
+
+Fixture audit (Task 1) confirmed no DPS/battle/healing golden ship carries
+Intrusion/Arcane Siege/Warpstrike, so goldens stay byte-identical."
+```
+
+---
+
+## Task 5: Update the equipment coverage tracker
+
+**Goal:** Reflect the three newly-implemented implants in the living coverage regression guard.
+
+**Files:**
+- Modify: `src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+
+- [ ] **Step 1: Update the implemented-implants assertion**
+
+Change the `implementedImplants` expectation (currently `['BLOODTHIRST']`) to the `IMPLANTS` declaration order of the implemented set:
+```ts
+expect(implementedImplants).toEqual(['ARCANE_SIEGE', 'INTRUSION', 'WARPSTRIKE', 'BLOODTHIRST']);
+```
+(Declaration order in `implants.ts`: ARCANE_SIEGE, INTRUSION, WARPSTRIKE, … BLOODTHIRST. `implementedImplants` is `Object.keys(IMPLANTS).filter(...)`, so order follows declaration.)
+
+- [ ] **Step 2: Move the three implants out of the "produces 0 abilities" loop**
+
+The `nonBloodthirstImplants` loop asserts every non-Bloodthirst implant produces 0 abilities — Intrusion/Arcane Siege/Warpstrike will now break it. Update the exclusion filter and add positive per-implant assertions:
+```ts
+const IMPLEMENTED = ['BLOODTHIRST', 'INTRUSION', 'ARCANE_SIEGE', 'WARPSTRIKE'];
+const unimplementedImplants = Object.keys(IMPLANTS).filter((k) => !IMPLEMENTED.includes(k));
+for (const implantKey of unimplementedImplants) { /* ...existing "produces 0" assertion... */ }
+
+it('INTRUSION (legendary) produces 1 ability', () => {
+    expect(implantAbilityCount('INTRUSION', 'legendary')).toBe(1);
+});
+it('ARCANE_SIEGE (epic) produces 1 ability', () => {
+    expect(implantAbilityCount('ARCANE_SIEGE', 'epic')).toBe(1);
+});
+it('WARPSTRIKE (legendary) produces 1 ability', () => {
+    expect(implantAbilityCount('WARPSTRIKE', 'legendary')).toBe(1);
+});
+```
+Also update the header comment in the file ("when D-PR2 adds new effects …") to note the set now includes these three.
+
+- [ ] **Step 3: Run the coverage test, verify it passes**
+
+Run: `npx vitest run src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/abilities/__tests__/equipmentCoverage.test.ts
+git commit -m "test(combat): D-PR2 — coverage tracker includes Intrusion/Arcane Siege/Warpstrike"
+```
+
+---
+
+## Task 6: Integration tests — the effects actually amplify direct damage
+
+**Goal:** Prove the end-to-end fold: a passive Intrusion/Warpstrike/Arcane Siege modifier amplifies a unit's outgoing direct damage under its condition, via the real engine path (not just the registry shape).
+
+**Files:**
+- Test: `src/utils/abilities/__tests__/conditionalDamageImplants.integration.test.ts` (new), OR extend the D-PR1 end-to-end test file — confirm the existing harness at impl time (D-PR1 added an end-to-end Leech/Bloodthirst test; mirror it).
+
+- [ ] **Step 1: Write a modifier-fold-level integration test**
+
+Assert the fold directly (fast, deterministic), using the registry output + `modifierTotalsFromAbilities`:
+```ts
+import { buildEquipmentAbilities } from '../buildEquipmentAbilities';
+import { modifierTotalsFromAbilities } from '../applyAbilities';
+// ...build a ship with INTRUSION legendary, get the ability, then:
+const [intrusion] = buildEquipmentAbilities(shipWithIntrusion, getGearPiece);
+expect(modifierTotalsFromAbilities([intrusion], ctx({ enemyDebuffCount: 3 })).outgoingDamage).toBe(15); // 5 × 3
+expect(modifierTotalsFromAbilities([intrusion], ctx({ enemyDebuffCount: 0 })).outgoingDamage).toBe(0);
+
+const [warp] = buildEquipmentAbilities(shipWithWarpstrike, getGearPiece);
+expect(modifierTotalsFromAbilities([warp], ctx({ selfDebuffNames: ['Burn'] })).outgoingDamage).toBe(5);
+expect(modifierTotalsFromAbilities([warp], ctx({ selfDebuffNames: [] })).outgoingDamage).toBe(0);
+expect(modifierTotalsFromAbilities([warp], ctx({ selfDebuffNames: ['A', 'B'] })).outgoingDamage).toBe(5); // flat, not 10
+
+const [siege] = buildEquipmentAbilities(shipWithArcaneSiege, getGearPiece);
+expect(modifierTotalsFromAbilities([siege], ctx({ selfShielded: true })).outgoingDamage).toBe(15);
+expect(modifierTotalsFromAbilities([siege], ctx({ selfShielded: false })).outgoingDamage).toBe(0);
+```
+`ctx(over)` = a `ConditionContext` helper (reuse the Task 2 `baseCtx`).
+
+- [ ] **Step 2: Write an engine-level integration test (Intrusion)**
+
+Mirror the D-PR1 end-to-end harness: run a single attacker (equipped with Intrusion) through the engine against an enemy carrying N debuffs, and assert its direct damage is `× (1 + perUnit·N/100)` of the same attacker with no implant. Keep N and the debuff source deterministic. If the existing harness makes a full engine assertion heavy, the modifier-fold-level test in Step 1 + the registry tests in Task 3 are the load-bearing coverage; the engine-level test is a thin confirmation that the passive modifier reaches the fold. Confirm scope at impl time.
+
+- [ ] **Step 3: Run the integration tests, verify they pass**
+
+Run: `npx vitest run <new test path>`
+Expected: PASS.
+
+- [ ] **Step 4: Lint + tsc + commit**
+
+```bash
+npm run lint && npx tsc --noEmit
+git add <new test path>
+git commit -m "test(combat): D-PR2 — integration: conditional outgoing-damage implants amplify direct damage"
+```
+
+---
+
+## Task 7: Changelog + in-app docs
+
+**Goal:** User-facing entry + keep combat docs in sync.
+
+**Files:**
+- Modify: `src/constants/changelog.ts` (`UNRELEASED_CHANGES`)
+- Modify: `src/pages/DocumentationPage.tsx` (if it documents which implant/gear effects the sim models)
+
+- [ ] **Step 1: Add an UNRELEASED_CHANGES entry**
+
+Plain-English, e.g.:
+```
+The combat & DPS simulators now model the Intrusion, Arcane Siege, and Warpstrike implants — your outgoing damage scales with debuffs on the target, your own shield, and your own debuffs respectively. The DPS calculator now accounts for equipped implant and gear-set effects.
+```
+
+- [ ] **Step 2: Update DocumentationPage if it lists modeled equipment effects**
+
+Grep `DocumentationPage.tsx` for the D-PR1 equipment-effects mention (Leech/Bloodthirst). If present, extend it with the three new implants. If no such section exists, skip.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/constants/changelog.ts src/pages/DocumentationPage.tsx
+git commit -m "docs(combat): D-PR2 — changelog + docs for conditional outgoing-damage implants"
+```
+
+---
+
+## Task 8: Final verification gate
+
+**Goal:** Whole-PR green + byte-identical confirmation before review/merge.
+
+- [ ] **Step 1: Full suite**
+
+Run: `npx vitest run`
+Expected: all green; test count = D-PR1 baseline + the new tests; ZERO unexplained failures.
+
+- [ ] **Step 2: Lint + type check + skill audit**
+
+Run:
+```bash
+npm run lint
+npx tsc --noEmit
+npm run audit:skills
+```
+Expected: lint 0 warnings; tsc clean; audit 141 ships / 0 findings (unchanged).
+
+- [ ] **Step 3: Confirm zero golden movement**
+
+Run: `git status --porcelain && git diff --stat HEAD~7 -- '*.snap'`
+Expected: no `.snap` files modified across the PR.
+
+- [ ] **Step 4: Update project memory**
+
+Append D-PR2 shipped facts to the combat-realism epic memory node (`project_combat_realism_epic.md`): effects, the modifier-fold approach (overriding the earlier conditionalBonusPct framing), the new `self-shield` condition, DPS-page wiring, and "what's next in D" (Giant Slayer/Menace/Insidiousness/Voidfire; Warpstrike duration-reduction half; incoming-reduction bucket).
+
+---
+
+## Done criteria
+
+- Intrusion / Arcane Siege / Warpstrike emit passive `outgoingDamage` modifiers from the registry; the engine folds them (gated + scaled) into direct damage.
+- `self-shield` condition added and unit-tested; threaded from `actor.shieldPool`.
+- DPS calculator page consumes equipment abilities.
+- Coverage tracker + integration tests green.
+- All DPS / battle-sim / healing goldens byte-identical.
+- Changelog + docs updated.

--- a/docs/superpowers/plans/2026-06-20-implant-gearset-abilities-D-pr2.md
+++ b/docs/superpowers/plans/2026-06-20-implant-gearset-abilities-D-pr2.md
@@ -186,7 +186,7 @@ describe('Intrusion implant', () => {
         expect(abilities).toHaveLength(1);
         const a = abilities[0];
         expect(a.type).toBe('modifier');
-        expect(a.trigger).toBe('passive');
+        expect(a.trigger).toBe('on-cast');
         expect(a.config).toMatchObject({ type: 'modifier', channel: 'outgoingDamage', value: 0 });
         expect(a.scaling).toEqual({ conditionIndex: 0, perUnit: 5 });
         expect(a.conditions).toEqual([{ subject: 'enemy-debuff', derivable: true }]);
@@ -251,7 +251,7 @@ Add to `IMPLANT_ABILITIES`:
         return {
             type: 'modifier',
             target: 'self',
-            trigger: 'passive',
+            trigger: 'on-cast',
             conditions: [{ subject: 'enemy-debuff', derivable: true }],
             scaling: { conditionIndex: 0, perUnit },
             config: { type: 'modifier', channel: 'outgoingDamage', value: 0, isMultiplicative: false },
@@ -266,7 +266,7 @@ Add to `IMPLANT_ABILITIES`:
         return {
             type: 'modifier',
             target: 'self',
-            trigger: 'passive',
+            trigger: 'on-cast',
             conditions: [{ subject: 'self-shield', derivable: true }],
             config: { type: 'modifier', channel: 'outgoingDamage', value, isMultiplicative: false },
             autoFilled: true,
@@ -282,7 +282,7 @@ Add to `IMPLANT_ABILITIES`:
         return {
             type: 'modifier',
             target: 'self',
-            trigger: 'passive',
+            trigger: 'on-cast',
             conditions: [
                 { subject: 'self-debuff', derivable: true, countComparator: 'gte', countThreshold: 1 },
             ],
@@ -292,7 +292,7 @@ Add to `IMPLANT_ABILITIES`:
     },
 ```
 
-(Confirm the `Ability`/`Condition` types accept these literals; `trigger: 'passive'` must be a valid `AbilityTrigger` — verify and use the engine's passive-trigger value at impl time.)
+(Note: `'passive'` is NOT a valid `AbilityTrigger`. Use `trigger: 'on-cast'` — the same value `buildShipAbilities` assigns to parser-emitted passive-slot `outgoingDamage` modifiers. The trigger is inert for these: `modifierTotalsFromAbilities` filters only on `type === 'modifier'`, never on trigger.)
 
 - [ ] **Step 4: Run the tests, verify they pass**
 

--- a/docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-design.md
+++ b/docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-design.md
@@ -1,0 +1,223 @@
+# Combat Realism Epic — Sub-project D: Implant + Gear-Set Abilities (Design)
+
+**Date:** 2026-06-20
+**Sub-project:** D (new ability sources: implants + gear-set skills).
+**Parent:** `docs/superpowers/specs/2026-06-17-combat-realism-epic-roadmap.md`.
+**Status:** design (brainstorm complete, user-approved through coverage + testing sections).
+
+## 1. Context
+
+The combat engine derives a ship's abilities **only** from its skill text. `buildShipAbilities(ship)`
+(`src/utils/abilities/buildShipAbilities.ts:1368`) iterates `getShipSkillRows(ship)` and never reads
+`ship.equipment` or `ship.implants`, even though both are present on the `Ship` it receives. As a
+result, **implant and gear-set special effects are entirely absent from the combat engine** (a grep
+across `src/utils/combat/` finds nothing).
+
+The effect data already exists, as `description` strings analogous to `ship-skills.csv` text:
+
+- **Implants** — `src/constants/implants.ts`. Each `ImplantData` has `variants[]` keyed by rarity;
+  each variant carries optional `stats[]` and an optional `description` (the special effect, e.g.
+  Bloodthirst: "On a critical hit, there is a 12% chance for this unit to repair itself for 12% of
+  the damage dealt"). Minor implants (alpha/gamma/sigma) are stat-only (no `description`).
+- **Gear sets** — `src/constants/gearSets.ts`. `GearSetBonus` carries `stats[]` and an optional
+  `description` for special-effect sets (Boost, Burner, Decimation, Leech, Reflect, Shield, Cloaking,
+  Hardened). Most sets are stat-only.
+
+**Stat-only portions are already handled.** The combat simulators read pre-resolved combat stats
+(`battleSimulator.resolveStats` reads `ship.baseStats`/`statOverrides`; `calculateTotalStats` folds
+gear + set + implant + engineering stats). D therefore adds **only the special-effect abilities** —
+it never re-adds stats.
+
+**Precedent:** `src/utils/autogear/arcaneSiegeUtils.ts` already models one implant effect (Arcane
+Siege +damage while shielded), but only inside autogear scoring — not the combat engine.
+
+This is the first node of sub-project D. The epic roadmap scopes D as "data model → parse →
+`buildShipAbilities` → ride A/B/C machinery"; effects needing genuinely new machinery belong to other
+sub-projects (shields → H, reflect → G, pre-fight stat conversion → F).
+
+## 2. Goals / non-goals
+
+**Goals**
+
+- A reusable **source layer** that resolves a ship's equipped implants + active gear sets into parsed
+  abilities, merged into the engine's ability pipeline at the call sites that already have inventory.
+- A **probability model** for procs consistent with the engine's existing deterministic resolution.
+- Light up the **category-1** effects (those that ride existing engine machinery) over a sequence of
+  reviewable PRs, starting with a thin vertical slice.
+
+**Non-goals (deferred, with their owning sub-project)**
+
+- Shield grants (Abundant Renewal, Lifeline, Adaptive Plating, Shield set) → **H**.
+- Reflect (Reflect set) → **G**.
+- Start-of-combat stat conversion (Code Guard, Cipher Link) → **F**.
+- Concentrate-Fire / Provoke **appliers** (Doomsayer, Bulwark) — Phase 3 flagged forced-targeting
+  appliers as future work; deferred within D (own slice, likely with adjacency).
+- No autogear/scoring changes — D is combat-engine-only. (`arcaneSiegeUtils` stays as is.)
+- No UI for toggling the chance model in this sub-project (possible later enhancement).
+
+## 3. Chance model (cross-cutting decision — LOCKED)
+
+The engine resolves **all** probabilistic events (crit, debuff-landing, DoT-extension) with a
+**deterministic fractional accumulator**, `makeRateGate()` (`src/utils/calculators/rateAccumulator.ts`):
+a 70% rate over 10 calls fires exactly 7 times, reproducible, no `Math.random`. Each distinct
+event gets its own gate instance (state persists across calls).
+
+**Decision:** implant/gear-set procs ride the **same mechanism**. Each proc gets its own
+`makeRateGate()` instance (per owner-proc), fired at the proc's chance each time its trigger fires.
+This is faithful to expected frequency, deterministic, reproducible, and consistent with how crit and
+landing already behave in this engine. (Always-fire and user-toggle were considered and rejected;
+always-fire overstates value and diverges from the "close to the game" goal.)
+
+The parser must therefore extract a generic **`procChance`** from the description ("N% chance to …")
+and thread it onto the ability; the engine allocates and feeds a per-proc gate.
+
+## 4. Architecture
+
+### 4.1 New module: `buildEquipmentAbilities`
+
+A sibling to `buildShipAbilities` (not a modification of it — keeps skill-text parsing focused and the
+new concern independently testable). It mirrors the inventory-access pattern of `calculateTotalStats`
+(which takes a `getGearPiece: (id) => GearPiece | undefined` closure rather than importing a context):
+
+```
+buildEquipmentAbilities(
+  ship: Ship,
+  getGearPiece: (id: string) => GearPiece | undefined,
+): PositionedAbility[]
+```
+
+Responsibilities:
+
+1. **Resolve active gear sets** — count `ship.equipment` pieces by `setBonus` via `getGearPiece`; keep
+   sets meeting their threshold (≥2, or `minPieces: 4`). Filter to sets with a `description`
+   (special-effect); stat-only sets are skipped.
+2. **Resolve equipped implants** — `ship.implants` (slot → inventory id) → `getGearPiece` →
+   `setBonus` (= implant name) + `rarity` → `IMPLANTS` variant `description`. Skip variants with no
+   `description` (stat-only minors).
+3. **Parse each description** → abilities, tagged with a `source: 'implant' | 'gear-set'` marker for
+   display/debugging.
+
+There is no committed set-count helper today (autogear and `statsCalculator` each count inline); this
+module owns a small "active sets for a ship" resolver.
+
+### 4.2 Parsing layer (reuse + two new primitives)
+
+Reuse `abilitiesFromText` / `skillTextParser` on the description strings — the effect *bodies* ("gain
+Speed Up 3 for 2 turns", "inflicts Disable", "repair X% of allies' max HP") are exactly what the
+existing parser handles. Extend it with:
+
+- **`procChance` extractor** — a generic "N% chance to …" detector (§3). The leading chance clause is
+  stripped/recorded so the remaining body parses normally; the chance is threaded onto the ability.
+- **Generalized `oncePerRound` / `oncePerCombat`** — the cap infrastructure exists but is scoped to the
+  cheat-death / extra-action paths today (`buildShipAbilities.ts:994`, `skillTextParser.ts:1319`).
+  Generalize so equipment effects ("limited to once per round", "once per battle") set the cap.
+
+Isolation requirement: feeding equipment text through the shared parser must not change ship-skill
+parsing. The new primitives are additive and only engage on the equipment text path.
+
+### 4.3 Merge point
+
+Merge the abilities returned by `buildEquipmentAbilities` into the `ShipSkills` from
+`buildShipAbilities`, into the **passive slot**. Equipment effects are all passive/reactive/
+conditional-aura, so they ride the same machinery the engine already runs over passive abilities
+(round-1 timed-status seeding + reactive registration). `buildShipAbilities`'s single-arg signature is
+untouched → every existing test that calls it stays byte-identical.
+
+**Inventory access is NOT free at the merge sites — it must be plumbed (D-PR1 foundation work).**
+The two `buildShipAbilities(ship)` call sites differ:
+
+- **`battleSimulator` (`planPlacement`, ~`:530`)** does **not** hold a `getGearPiece` resolver today.
+  `planPlacement` receives only a `BattlePlacement` (ship + position); `resolveStats` reads
+  pre-resolved `statOverrides`/`baseStats` (the page layer resolves gear and passes stats in). Only the
+  raw equipment/implant ids are on `p.ship` — not the resolver closure. So D-PR1 must **thread a
+  `getGearPiece`-style resolver into `simulateBattle`'s input contract / `planPlacement`'s signature**.
+  This plumbing is non-trivial and is explicitly part of the foundation, not an afterthought.
+- **`HealingCalculatorPage`** is a React page with inventory context in scope and is the more likely of
+  the two to already have a resolver. Verify and reuse it.
+
+(Plan-time verification: (a) which sites already have a resolver vs. need plumbing — see Open
+Question #4; (b) confirm the passive slot is the correct merge target for reactive-triggered and
+conditional-aura abilities, and that round-1 seeding + reactive registration pick them up.)
+
+### 4.4 Error handling — graceful skip, never throw
+
+Equipment is user-imported and noisy (descriptions contain typos: "icnreawse", "grans", "sheild").
+Unlike the targeting parser (which throws on unknown tokens), equipment-effect parsing must degrade
+gracefully: a missing gear piece, an unparseable description, or an unrecognized implant yields **no
+ability** and never breaks a ship's combat.
+
+## 5. Effect coverage
+
+### 5.1 Deferred to other sub-projects (category 2)
+
+- Shield grants → **H**: Abundant Renewal, Lifeline, Adaptive Plating, Shield set.
+- Reflect → **G**: Reflect set.
+- Start-of-combat stat conversion → **F**: Code Guard, Cipher Link.
+
+### 5.2 In scope (category 1), bucketed by engine mechanism
+
+| Bucket | Implants / sets | New triggers/conditions needed |
+|---|---|---|
+| **Conditional outgoing dmg** | Intrusion, Arcane Siege, Giant Slayer, Menace, Insidiousness, Warpstrike, Voidfire Catalyst | self-shielded, target-higher-attack; detonation modifier |
+| **Conditional incoming reduction** | Voidshade, Nebula Nullifier, Hyperion Gaze, Vortex Veil, Shadowguard, Ironclad, Hardened set | self-stealthed/stasised, crit-hit-by-stealthed, DoT-source, nth-hit |
+| **Reactive self/ally buffs** | Alacrity, Ambush, Smokescreen, Firewall, Last Stand, Lockdown, Resonating Fury, Font of Power, Spearhead, Fortifying Shroud, Tenacity | end-of-round-if-not-hit, on-debuffed, on-resist, on-shield-applied, on-heal-cast, periodic, big-hit; adjacency |
+| **Reactive heal/leech** | Bloodthirst, Second Wind, Exuberance, Nourishment, Vivacious Repair, Leech set | on-crit-hit-received; heal-received / heal-cast modifiers |
+| **On-death** | Battlecry, Last Wish, Martyrdom | killer-identity (Martyrdom) |
+| **Charge / DoT / cleanse** | Chrono Reaver, Burner set, Decimation set, Reactive Ward | periodic charge; DoT applier/modifier; reactive cleanse |
+| **Net-new mechanics (cat-3)** | Boost set (buffs last +1 turn), Cloaking set (grant Stealth) | new duration / stealth-grant primitives |
+| **Forced-targeting appliers (deferred within D)** | Doomsayer (CF), Bulwark (Provoke), Synaptic Resonance (on-enemy-repaired) | CF/Provoke appliers (Phase-3 future work) |
+
+Minor stat-only implants (Citadel, Haste, Onslaught, Precision, Sentry, Strike, Barrier, Override,
+Bastion, Devastation, Guardian) are out of scope — already in combat stats.
+
+### 5.3 Subtleties to carry into plans
+
+- **Martyrdom** needs killer-identity tracking (which enemy dealt the killing blow).
+- **Adjacency** (Bulwark, Fortifying Shroud) needs positional adjacency — board geometry exists from
+  Phase 1 (`src/utils/targeting/board.ts` `neighbors()`).
+- Several effects scale or gate on **crit** (Menace, Reactive Ward, Second Wind) or self/target status
+  (stealth, shielded, debuffed) — reuse existing condition machinery where it exists.
+
+## 6. Phasing (PRs within sub-project D)
+
+- **D-PR1 — Foundation + thinnest vertical slice.** The whole source pipeline
+  (`buildEquipmentAbilities` + inventory-resolver plumbing into the merge sites per §4.3 +
+  passive-slot merge) + the two parse primitives (`procChance`, generalized once-per) + a handful of
+  effects that reuse triggers/conditions that **already exist**: Menace & Giant Slayer (on-crit /
+  conditional-damage), Bloodthirst (on-crit leech), Leech set, Intrusion (per-debuff-on-target
+  scaling). Proves plumbing + chance end-to-end with near-zero new engine machinery. Note: threading
+  `getGearPiece` into `simulateBattle`/`planPlacement` (§4.3) is a real part of this PR's scope.
+- **D-PR2…N — one trigger/condition family per PR**, each pulling in its implants (incoming-reduction
+  conditions; new reactive triggers; on-death; periodic/charge; DoT; net-new mechanics).
+- **Deferred slice within D:** CF/Provoke appliers (Doomsayer, Bulwark), aligned with the forced-
+  targeting applier work Phase 3 flagged (likely with adjacency).
+
+## 7. Testing & invariants
+
+- **Unit — `buildEquipmentAbilities`:** set-count thresholds (≥2 / `minPieces`), implant
+  id→name+rarity→description resolution, stat-only variants skipped, `source` tagging, graceful skip on
+  missing/unparseable input.
+- **Unit — parse primitives:** `procChance` extraction across the corpus phrasings; generalized
+  once-per.
+- **Integration — D-PR1 effects:** assert the rate accumulator fires at expected frequency (a 50% proc
+  over N triggers fires N/2 times) and the conditional damage / leech lands.
+- **Coverage harness** analogous to `audit:skills` for the implant/set corpus, tracking parse coverage
+  as later PRs add effects. (The corpus is committed TS constants, always available — no gitignored-CSV
+  skip needed.)
+- **Load-bearing invariant:** existing DPS / healing / battle-sim goldens stay **byte-identical** — the
+  new builder only runs where inventory is threaded, and `buildShipAbilities` is unchanged.
+  **Plan-time risk to verify (do this FIRST, before any merge wiring):** if any existing
+  `battleSimulator`/healing fixture builds a ship that carries equipped implants or active sets with
+  special-effect descriptions, those goldens **will** churn once the merge is wired. The plan's first
+  step should be the fixture audit (grep battle-sim/healing fixtures for effect-bearing implants/sets)
+  so the byte-identical invariant is confirmed empty before it can silently break; then neutralize the
+  fixture or deliberately audit the churn (never `vitest -u`).
+
+## 8. Open questions for the plan
+
+1. Exact `procChance` regex shape and the set of "once per …" phrasings in the corpus.
+2. Whether the passive-slot merge needs a dedicated source slot or rides the existing passive slot.
+3. The precise list of conditions/triggers that already exist vs. must be added for the D-PR1 set
+   (characterize before writing the plan).
+4. Inventory-threading mechanics at each call site (does each site already hold a `getGearPiece`-style
+   resolver, or does one need plumbing?).

--- a/docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-pr2-design.md
+++ b/docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-pr2-design.md
@@ -85,6 +85,11 @@ the D-PR1 per-rarity-builder pattern. Each returns a single `Ability` (minus `id
 `channel: 'outgoingDamage'`, `target: 'self'`, `trigger: 'passive'`, `autoFilled: true`. Per-rarity
 values are baked from `implants.ts`; a rarity absent from the value map yields `undefined` (skip).
 
+Values are **baked into the registry** (not text-parsed) precisely because the source `description`
+strings are inconsistent ("Direct Damage" vs "direct damage", inconsistent trailing periods, one
+Intrusion variant missing its period) — the registry path sidesteps that fragility, matching D-PR1.
+The `description` is still used only as a presence gate, never parsed.
+
 ### 3.1 Intrusion — per-count scaling
 
 ```
@@ -154,7 +159,7 @@ The minimal additive change required for Arcane Siege:
 4. **`buildRoundContext`** — accept a `selfShielded` input and set it on the context it builds.
 5. **`playerTurn.ts`** — thread `selfShielded: actor.shieldPool > 0` into the `buildRoundContext` call
    that produces `modifierCtx` (`~line 1078`). `actor` is the acting `CombatActor`; `shieldPool` exists
-   on it (`state.ts:104`, init 0) and reflects the live remaining shield at attack time.
+   on it (`state.ts:108`, init 0) and reflects the live remaining shield at attack time.
 
 Emitted conditions use `derivable: true` — a `derivable: false` condition is treated as always-met
 (`evaluateConditions.ts`), which would defeat the gate. (Mirrors the `target-repaired-this-round`

--- a/docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-pr2-design.md
+++ b/docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-pr2-design.md
@@ -1,0 +1,209 @@
+# Combat Realism Epic — Sub-project D, PR2: Conditional Outgoing-Damage Implants (Design)
+
+**Date:** 2026-06-20
+**Sub-project:** D (new ability sources: implants + gear-set skills), second PR.
+**Parent spec:** `docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-design.md`.
+**Builds on:** D-PR1 (`feat/combat-d-implant-gearset`) — `buildEquipmentAbilities` registry,
+`buildShipAbilitiesWithEquipment` passive-slot merge, `procChance` machinery, equipment coverage tracker.
+**Branch:** `feat/combat-d-pr2-conditional-damage`, stacked on the D-PR1 tip.
+**Status:** design (brainstorm complete, user-approved through all sections).
+
+## 1. Context
+
+D-PR1 shipped the equipment-ability **source layer** (a registry-based `buildEquipmentAbilities` merged
+into the passive slot via `buildShipAbilitiesWithEquipment`) plus the `procChance` proc-gate machinery,
+and lit up the first two effects (Leech gear set + Bloodthirst implant — both heals). The DPS calculator
+page was deliberately **not** wired in D-PR1 because those effects are heals that don't affect DPS.
+
+D-PR2 lights up the **conditional outgoing-damage** bucket from the parent spec (§5.2) — the implants
+that increase a unit's outgoing direct damage under a condition:
+
+- **Intrusion** (`src/constants/implants.ts`) — "Increases damage dealt by X% for **each debuff on the
+  target** when directly damaging them." X = 1/2/3/4/5 by rarity (common/uncommon/rare/epic/legendary).
+- **Arcane Siege** — "Increases outgoing Direct Damage by X% **while shielded**." X = 3/6/10/15/20.
+- **Warpstrike** — "Increases damage by X% when directly damaging an enemy **while debuffed**, and
+  reduces a random active debuff's duration by 1 turn." X = 1/2/3/4/5. (Only the damage half is in
+  scope; see §6.)
+
+Because these are outgoing damage, D-PR2 also **wires the DPS calculator page** to consume equipment
+abilities (the wiring D-PR1 skipped).
+
+### 1.1 Key finding that reshaped this PR
+
+The sub-project-D spec and the prior working assumption framed the core work as *"wire passive
+conditional-scaling into `conditionalBonusPct`"* — i.e. extend the additive multiplier-points fold in
+`playerTurn.ts` (`conditionalBonusPct`, ~line 1210) to read passive-slot scaling, which today it does
+not (it reads only the firing skill's damage ability).
+
+A code-read showed a **simpler and more faithful** path already exists. `modifierTotalsFromAbilities`
+(`src/utils/abilities/applyAbilities.ts:22-76`):
+
+- already iterates **all** abilities passed to it, and `playerTurn.ts:1094-1097` already passes the
+  **passive slot** (`modifierAbilities = [...firing, ...passive]`);
+- already **gates** each ability by `conditionsMet(gateConditions(ability), ctx)` (line 41);
+- already supports **both** a flat `config.value` **and** per-count `scaling` via
+  `value + (scaling ? scaledBonus(ability, ctx) : 0)` (line 49);
+- routes channel `outgoingDamage` into `dmgStats.totals.outgoingDamageBuff`, which
+  `playerTurn.ts` applies as the **multiplicative** factor `(1 + outgoingDamageBuff/100)` inside
+  `nonCritFactor` — and that factor scopes naturally to **direct** damage (DoT damage is computed on a
+  separate path).
+
+So these three effects can be modeled as passive `modifier` abilities on channel `outgoingDamage`, and
+the engine **already folds them** — no `conditionalBonusPct` surgery. This is also more faithful: the
+implants literally say "increase outgoing/dealt damage by X%" (multiplicative), whereas
+`conditionalBonusPct` adds flat percentage-points onto the skill multiplier.
+
+The **only** genuinely-new engine primitive is a `self-shield` condition subject for Arcane Siege (§4).
+
+## 2. Goals / non-goals
+
+**Goals**
+
+- Add Intrusion, Arcane Siege, and Warpstrike (damage half) as `buildEquipmentAbilities` registry
+  entries that ride the existing `outgoingDamage` modifier fold.
+- Add the one new condition primitive (`self-shield`) Arcane Siege requires.
+- Wire the DPS calculator page to consume equipment abilities.
+- Keep all existing DPS / battle-sim / healing goldens **byte-identical**.
+
+**Non-goals (deferred, with owner)**
+
+- Warpstrike's "reduce a random active debuff's duration by 1 turn" half → **deferred** (self-debuff-
+  mitigation / cleanse-family; not in this PR's machinery). See §6.
+- Giant Slayer / Menace / Insidiousness / Voidfire Catalyst (the rest of the parent spec's
+  "conditional outgoing dmg" row) → **later D PRs**. Menace + Giant Slayer need in-flight reactive
+  damage amplification + a `target-higher-attack` condition (noted in D-PR1) and don't fit the passive
+  modifier fold.
+- Making shields actually *appear* in DPS/battle-sim (shield grants) → **sub-project H**. Arcane Siege
+  is therefore dormant in integration until H lands; it is unit-tested in isolation now (§5).
+- No autogear/scoring changes (`arcaneSiegeUtils` stays as is — that models the same implant only inside
+  autogear scoring, independent of the combat engine).
+
+## 3. Effect models (registry entries)
+
+All three are added to `IMPLANT_ABILITIES` in `src/utils/abilities/buildEquipmentAbilities.ts`, mirroring
+the D-PR1 per-rarity-builder pattern. Each returns a single `Ability` (minus `id`) of `type: 'modifier'`,
+`channel: 'outgoingDamage'`, `target: 'self'`, `trigger: 'passive'`, `autoFilled: true`. Per-rarity
+values are baked from `implants.ts`; a rarity absent from the value map yields `undefined` (skip).
+
+### 3.1 Intrusion — per-count scaling
+
+```
+{
+  type: 'modifier',
+  target: 'self',
+  trigger: 'passive',
+  conditions: [{ subject: 'enemy-debuff', derivable: true }],
+  scaling: { conditionIndex: 0, perUnit: X },   // X = 1/2/3/4/5
+  config: { type: 'modifier', channel: 'outgoingDamage', value: 0, isMultiplicative: false },
+  autoFilled: true,
+}
+```
+
+- `enemy-debuff` is a bare scaling-source condition (no `countComparator`) → `gateConditions` removes it
+  from the gate (it scales, never gates), so the modifier always folds and contributes
+  `scaledBonus = perUnit × enemyDebuffCount`. Zero debuffs → +0%. `enemyDebuffCount` is already in
+  `modifierCtx` (`landedEnemyDebuffCount`, `playerTurn.ts:1080`).
+- `isMultiplicative: false` matches the channel convention — `modifierTotalsFromAbilities` ignores the
+  flag and sums into the additive `outgoingDamageBuff` total, which is then applied multiplicatively as
+  `(1 + outgoingDamageBuff/100)`. (This is the same treatment every existing `outgoingDamage` modifier
+  already gets.)
+
+### 3.2 Arcane Siege — flat, gated on self-shield
+
+```
+{
+  type: 'modifier',
+  target: 'self',
+  trigger: 'passive',
+  conditions: [{ subject: 'self-shield', derivable: true }],
+  config: { type: 'modifier', channel: 'outgoingDamage', value: X, isMultiplicative: false },
+  autoFilled: true,
+}
+```
+
+- X = 3/6/10/15/20. No `scaling`; a flat `value` gated by the self-shield condition.
+- `self-shield` is **not** a bare scaling source → `gateConditions` keeps it → the +X% applies only when
+  `conditionsMet` (the unit is shielded). Dormant until shields exist in the path (§2).
+
+### 3.3 Warpstrike (damage half) — flat, gated on self-debuff
+
+```
+{
+  type: 'modifier',
+  target: 'self',
+  trigger: 'passive',
+  conditions: [{ subject: 'self-debuff', derivable: true, countComparator: 'gte', countThreshold: 1 }],
+  config: { type: 'modifier', channel: 'outgoingDamage', value: X, isMultiplicative: false },
+  autoFilled: true,
+}
+```
+
+- X = 1/2/3/4/5. A flat `value` gated on the unit having ≥1 debuff. Using a flat value + a `gte 1` gate
+  (rather than `scaling` on `self-debuff`) is deliberate: `scaledBonus` always uses the **raw** count,
+  so scaling on `self-debuff` would over-apply for a unit carrying multiple debuffs. The flat-value +
+  gate gives a single +X% whenever debuffed. `selfDebuffNames` is already in `modifierCtx`
+  (`playerTurn.ts:1091`).
+
+## 4. New engine primitive — `self-shield` condition
+
+The minimal additive change required for Arcane Siege:
+
+1. **`ConditionSubject` union** (`src/types/abilities.ts`) — add `'self-shield'`.
+2. **`ConditionContext`** (`src/utils/abilities/evaluateConditions.ts`) — add `selfShielded?: boolean`.
+3. **`evaluateCondition`** — `case 'self-shield': return ctx.selfShielded ? 1 : 0;` (binary, derivable).
+4. **`buildRoundContext`** — accept a `selfShielded` input and set it on the context it builds.
+5. **`playerTurn.ts`** — thread `selfShielded: actor.shieldPool > 0` into the `buildRoundContext` call
+   that produces `modifierCtx` (`~line 1078`). `actor` is the acting `CombatActor`; `shieldPool` exists
+   on it (`state.ts:104`, init 0) and reflects the live remaining shield at attack time.
+
+Emitted conditions use `derivable: true` — a `derivable: false` condition is treated as always-met
+(`evaluateConditions.ts`), which would defeat the gate. (Mirrors the `target-repaired-this-round`
+pattern.)
+
+This is purely additive: no existing ability carries `subject: 'self-shield'`, and `selfShielded`
+defaults falsy, so every existing fold is unchanged.
+
+## 5. DPS calculator page wiring
+
+`DPSCalculatorPage.tsx` already holds `getGearPiece` from `useInventory()` (line 39). Swap its three
+`buildShipAbilities(ship)` call sites (lines 73, 384, 440) to
+`buildShipAbilitiesWithEquipment(ship, getGearPiece)`, exactly mirroring the HealingCalculatorPage sites
+D-PR1 wired. This is what makes Intrusion/Warpstrike actually affect a DPS run. (`battleSimulator`
+already routes equipment abilities since D-PR1.)
+
+## 6. Deferred: Warpstrike's debuff-duration reduction
+
+Warpstrike also "reduces a random active debuff's duration by 1 turn" on the wielder. This is a
+self-debuff-mitigation effect (cleanse-family), not an outgoing-damage modifier, and would pull in
+machinery this PR otherwise doesn't touch (selecting/decrementing a random standing self-debuff at
+attack time). It is **deferred** and noted in-code on the Warpstrike registry entry so the omission is
+explicit. The damage half is the faithful, high-value part for a DPS/combat model.
+
+## 7. Testing & invariants
+
+- **Unit — registry entries** (`buildEquipmentAbilities.test.ts`): each implant at each rarity emits a
+  single `modifier`/`outgoingDamage` ability with the expected `value`, `scaling`, and `conditions`;
+  unsupported rarity → none; graceful skip on missing pieces (already covered by the D-PR1 harness).
+- **Unit — `self-shield`** (`evaluateConditions` test): returns 1 when `selfShielded` true, 0 otherwise;
+  an Arcane Siege modifier folds +X% only when the context is shielded.
+- **Integration**: a ship with Intrusion attacking an enemy carrying N debuffs deals
+  `× (1 + X·N/100)` of its no-implant direct damage; a ship with Warpstrike deals `× (1 + X/100)` only
+  while itself debuffed, and unmodified otherwise.
+- **Coverage tracker** (`equipmentCoverage.test.ts`): implemented implants set updated to
+  `BLOODTHIRST, INTRUSION, ARCANE_SIEGE, WARPSTRIKE` (in `IMPLANTS` declaration order), and the
+  per-implant "produces 0 abilities" guard for those three is replaced with positive assertions.
+- **Load-bearing byte-identical invariant:** existing DPS / battle-sim / healing goldens stay
+  **byte-identical**. The `self-shield` subject + `selfShielded` ctx field are additive, and equipment
+  abilities only run where `getGearPiece` is threaded. **First plan step (do before any wiring):** grep
+  the DPS/battle-sim/healing fixtures for ships carrying Intrusion / Arcane Siege / Warpstrike implants
+  (expected: none). Confirm the invariant is empty before it can silently break; if a fixture *does*
+  carry one, neutralize it or deliberately audit the churn (never `vitest -u`).
+
+## 8. Open questions for the plan
+
+1. Exact `IMPLANTS` declaration order for the coverage-tracker `implementedImplants` assertion (read it
+   at plan time; the test filters `Object.keys(IMPLANTS)`).
+2. Whether `buildRoundContext` is called in more than one place that should carry `selfShielded` (only
+   the `modifierCtx` site needs it for these effects; thread minimally, default falsy elsewhere).
+3. Confirm `actor.shieldPool` is in scope and live at the `modifierCtx` build site in every `runPlayerTurn`
+   entry (player/team/enemy) — it is the same team-agnostic function, but verify the param plumbing.

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -11,6 +11,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat simulator: Amartya's charge purge now scales with crit power — it removes 1 buff for every 50% crit power (so higher crit power purges more buffs), applied to every enemy hit.",
     'Combat simulator: enemy ships now actually heal — their HP recovers from repair skills instead of being stuck, so enemy teams survive more realistically. Skills that trigger off a target being healed this round (such as Nayra) now also fire against healed enemies.',
     'Combat simulator now applies the Leech gear set and the Bloodthirst implant, with chance-based procs modeled at their true average frequency. More implant and gear-set effects are coming.',
+    'Combat & DPS simulators now model three conditional damage implants: Intrusion (more outgoing damage per debuff on the target), Arcane Siege (more outgoing damage while your ship is shielded), and Warpstrike (more outgoing damage while your ship is debuffed). The DPS calculator now also accounts for equipped implant and gear-set effects.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -9,6 +9,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator: lifesteal/leech (heal or shield from damage dealt or taken) now works per ship — each ship heals or shields itself off its own damage, and AoE splash leeches off the reduced (covered-cell) splash damage.',
     'Combat simulator: area-of-effect purge skills now remove buffs from every enemy they hit, not just the primary target.',
     "Combat simulator: Amartya's charge purge now scales with crit power — it removes 1 buff for every 50% crit power (so higher crit power purges more buffs), applied to every enemy hit.",
+    'Combat simulator: enemy ships now actually heal — their HP recovers from repair skills instead of being stuck, so enemy teams survive more realistically. Skills that trigger off a target being healed this round (such as Nayra) now also fire against healed enemies.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -10,6 +10,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator: area-of-effect purge skills now remove buffs from every enemy they hit, not just the primary target.',
     "Combat simulator: Amartya's charge purge now scales with crit power — it removes 1 buff for every 50% crit power (so higher crit power purges more buffs), applied to every enemy hit.",
     'Combat simulator: enemy ships now actually heal — their HP recovers from repair skills instead of being stuck, so enemy teams survive more realistically. Skills that trigger off a target being healed this round (such as Nayra) now also fire against healed enemies.',
+    'Combat simulator now applies the Leech gear set and the Bloodthirst implant, with chance-based procs modeled at their true average frequency. More implant and gear-set effects are coming.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3063,14 +3063,19 @@ const DocumentationPage: React.FC = () => {
                                 </h4>
                                 <p className="text-theme-text">
                                     Equipped implant and gear-set special effects are beginning to
-                                    apply in the simulator. Currently supported:{' '}
-                                    <strong>Leech</strong> gear set (heals the ship for 15% of all
-                                    damage it deals each turn) and the <strong>Bloodthirst</strong>{' '}
-                                    implant (on-crit heal for 12%, 17%, or 20% of damage dealt,
-                                    depending on rarity). Chance-based procs such as Bloodthirst are
-                                    modeled at
-                                    their expected average frequency. More implant and gear-set
-                                    effects will be added in future updates.
+                                    apply in the simulator (and now in the DPS calculator too).
+                                    Currently supported: <strong>Leech</strong> gear set (heals the
+                                    ship for 15% of all damage it deals each turn) and the{' '}
+                                    <strong>Bloodthirst</strong> implant (on-crit heal for 12%, 17%,
+                                    or 20% of damage dealt, depending on rarity). Chance-based procs
+                                    such as Bloodthirst are modeled at their expected average
+                                    frequency. Three conditional damage implants also apply:{' '}
+                                    <strong>Intrusion</strong> (more outgoing damage for each debuff
+                                    on the target), <strong>Arcane Siege</strong> (more outgoing
+                                    damage while the ship is shielded), and{' '}
+                                    <strong>Warpstrike</strong> (more outgoing damage while the ship
+                                    is debuffed). More implant and gear-set effects will be added in
+                                    future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3056,6 +3056,23 @@ const DocumentationPage: React.FC = () => {
                                     </li>
                                 </ul>
                             </div>
+
+                            <div className="p-4 bg-dark-lighter">
+                                <h4 className="font-semibold text-primary mb-2">
+                                    Gear Set and Implant Effects
+                                </h4>
+                                <p className="text-theme-text">
+                                    Equipped implant and gear-set special effects are beginning to
+                                    apply in the simulator. Currently supported:{' '}
+                                    <strong>Leech</strong> gear set (heals the ship for 15% of all
+                                    damage it deals each turn) and the <strong>Bloodthirst</strong>{' '}
+                                    implant (on-crit heal for 12%, 17%, or 20% of damage dealt,
+                                    depending on rarity). Chance-based procs such as Bloodthirst are
+                                    modeled at
+                                    their expected average frequency. More implant and gear-set
+                                    effects will be added in future updates.
+                                </p>
+                            </div>
                         </div>
                     </section>
 

--- a/src/pages/SimulatorPage.tsx
+++ b/src/pages/SimulatorPage.tsx
@@ -122,10 +122,13 @@ const SimulatorPage: React.FC = () => {
         if (!canRun) return;
         setRunError(null);
         try {
-            const result = simulateBattle({
-                playerTeam: buildTeam(playerBoard),
-                enemyTeam: buildTeam(enemyBoard),
-            });
+            const result = simulateBattle(
+                {
+                    playerTeam: buildTeam(playerBoard),
+                    enemyTeam: buildTeam(enemyBoard),
+                },
+                getGearPiece
+            );
             setBattleResult(result);
         } catch (err) {
             setBattleResult(null);

--- a/src/pages/calculators/DPSCalculatorPage.tsx
+++ b/src/pages/calculators/DPSCalculatorPage.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../types/calculator';
 import { ShipSkills } from '../../types/abilities';
 import { detectFullyCharged } from '../../utils/skillTextParser';
-import { buildShipAbilities } from '../../utils/abilities/buildShipAbilities';
+import { buildShipAbilitiesWithEquipment } from '../../utils/abilities/buildShipAbilitiesWithEquipment';
 import {
     buildDefaultShipSkills,
     configShipSkillsToSimInputs,
@@ -70,7 +70,7 @@ const DPSCalculatorPage: React.FC = () => {
                                 ship.secondPassiveSkillText,
                                 ship.thirdPassiveSkillText,
                             ]),
-                            shipSkills: buildShipAbilities(ship),
+                            shipSkills: buildShipAbilitiesWithEquipment(ship, getGearPiece),
                         },
                     ],
                     nextId: 2,
@@ -381,7 +381,7 @@ const DPSCalculatorPage: React.FC = () => {
                         ship.thirdPassiveSkillText,
                     ]),
                     affinity: ship.affinity,
-                    shipSkills: buildShipAbilities(ship),
+                    shipSkills: buildShipAbilitiesWithEquipment(ship, getGearPiece),
                 };
             })
         );
@@ -437,7 +437,7 @@ const DPSCalculatorPage: React.FC = () => {
                     startCharged,
                     speed,
                     chargeCount: ship.chargeSkillCharge ?? 0,
-                    shipSkills: buildShipAbilities(ship),
+                    shipSkills: buildShipAbilitiesWithEquipment(ship, getGearPiece),
                     stats: combatStats,
                     affinity: ship.affinity,
                     // Walked skills supersede auto-fill stamping; clear any prior auto-filled

--- a/src/pages/calculators/HealingCalculatorPage.tsx
+++ b/src/pages/calculators/HealingCalculatorPage.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../types/calculator';
 import { ShipSkills } from '../../types/abilities';
 import { detectFullyCharged } from '../../utils/skillTextParser';
-import { buildShipAbilities } from '../../utils/abilities/buildShipAbilities';
+import { buildShipAbilitiesWithEquipment } from '../../utils/abilities/buildShipAbilitiesWithEquipment';
 import { buildDefaultShipSkills } from '../../utils/abilities/configToSimInputs';
 import { calculateTotalStats } from '../../utils/ship/statsCalculator';
 import {
@@ -118,7 +118,7 @@ const HealingCalculatorPage: React.FC = () => {
                             ...healerStatsFromShip(shipFinalStats(ship)),
                             chargeCount: ship.chargeSkillCharge ?? 0,
                             startCharged: detectShipCharged(ship),
-                            shipSkills: buildShipAbilities(ship),
+                            shipSkills: buildShipAbilitiesWithEquipment(ship, getGearPiece),
                         },
                     ],
                     nextId: 2,
@@ -232,7 +232,7 @@ const HealingCalculatorPage: React.FC = () => {
                     ...stats,
                     chargeCount: ship.chargeSkillCharge ?? 0,
                     startCharged: detectShipCharged(ship),
-                    shipSkills: buildShipAbilities(ship),
+                    shipSkills: buildShipAbilitiesWithEquipment(ship, getGearPiece),
                 };
             })
         );
@@ -249,7 +249,7 @@ const HealingCalculatorPage: React.FC = () => {
             speed: Math.round(final.speed ?? 100),
             security: Math.round(final.security ?? 0),
         }));
-        setTargetShipSkills(buildShipAbilities(ship));
+        setTargetShipSkills(buildShipAbilitiesWithEquipment(ship, getGearPiece));
         setTargetChargeCount(ship.chargeSkillCharge ?? 0);
         setTargetStartCharged(detectShipCharged(ship));
         setTargetAffinity(ship.affinity);
@@ -304,7 +304,7 @@ const HealingCalculatorPage: React.FC = () => {
                     hacking: Math.round(final.hacking ?? 200),
                     chargeCount: ship.chargeSkillCharge ?? 0,
                     startCharged: detectShipCharged(ship),
-                    shipSkills: buildShipAbilities(ship),
+                    shipSkills: buildShipAbilitiesWithEquipment(ship, getGearPiece),
                     affinity: ship.affinity,
                 };
             })
@@ -353,7 +353,7 @@ const HealingCalculatorPage: React.FC = () => {
                     startCharged: detectShipCharged(ship),
                     speed: Math.round(final.speed ?? 100),
                     chargeCount: ship.chargeSkillCharge ?? 0,
-                    shipSkills: buildShipAbilities(ship),
+                    shipSkills: buildShipAbilitiesWithEquipment(ship, getGearPiece),
                     stats: {
                         attack: Math.round(final.attack ?? 0),
                         crit: Math.round(final.crit ?? 0),

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -293,6 +293,11 @@ export interface Ability {
      *  ShipTypeName — 'DEBUFFER' matches every DEBUFFER_* variant). Absent → any
      *  ally. A filter with an UNKNOWN ally role never matches (conservative). */
     roleFilter?: ShipRoleCategory[];
+    /** Probabilistic proc gate for equipment-sourced reactive abilities ("N% chance to …").
+     *  A value in (0,1) means the ability fires at that rate via a combat-lifetime per-(owner,
+     *  ability) RateGate (deterministic accumulator, like crit/landing). Absent or out of (0,1)
+     *  → fires on every qualifying trigger. */
+    procChance?: number;
     scaling?: ScalingRule;
     config: AbilityConfig;
     autoFilled?: boolean;

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -135,7 +135,11 @@ export type ConditionSubject =
     // defaults false (DPS mode / un-repaired target). Nayra's charged purge + Stasis/
     // Exposed inflicts. derivable:true — a derivable:false condition would always be met
     // (evaluateConditions.ts:30), defeating the gate.
-    | 'target-repaired-this-round';
+    | 'target-repaired-this-round'
+    // Binary gate: the condition owner currently has a shield (CombatActor.shieldPool > 0).
+    // Live-derived (ConditionContext.selfShielded); defaults false (no shield / DPS mode).
+    // Dormant until sub-project H grants shields in the sim. Used by the Arcane Siege implant.
+    | 'self-shield';
 
 export interface Condition {
     subject: ConditionSubject;

--- a/src/utils/abilities/__tests__/applyAbilities.test.ts
+++ b/src/utils/abilities/__tests__/applyAbilities.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../applyAbilities';
 import { Ability, Condition, ModifierChannel, ShipSkills, Skill } from '../../../types/abilities';
 import { ConditionContext } from '../evaluateConditions';
+import { makeConditionContext } from './conditionContextFixture';
 
 function damage(id: string, multiplier: number, hits?: number): Ability {
     return {
@@ -79,22 +80,6 @@ function modifier(
     };
 }
 
-function makeCtx(overrides: Partial<ConditionContext> = {}): ConditionContext {
-    return {
-        selfBuffNames: [],
-        selfDebuffNames: [],
-        enemyBuffNames: [],
-        enemyDebuffCount: 0,
-        effectiveCritRate: 0,
-        adjacentAllyCount: 0,
-        enemyAdjacentCount: 0,
-        enemyDestroyedCount: 0,
-        selfHpPct: 100,
-        enemyHpPct: 100,
-        ...overrides,
-    };
-}
-
 describe('modifierTotalsFromAbilities', () => {
     const zero = {
         attack: 0,
@@ -109,7 +94,7 @@ describe('modifierTotalsFromAbilities', () => {
     it('sums a single outgoingDamage modifier', () => {
         const result = modifierTotalsFromAbilities(
             [modifier('m', 'outgoingDamage', 40)],
-            makeCtx()
+            makeConditionContext()
         );
         expect(result).toEqual({ ...zero, outgoingDamage: 40 });
     });
@@ -121,7 +106,7 @@ describe('modifierTotalsFromAbilities', () => {
                     { subject: 'enemy-type', derivable: true, requiredEnemyType: 'Defender' },
                 ]),
             ],
-            makeCtx({ enemyType: 'Attacker' })
+            makeConditionContext({ enemyType: 'Attacker' })
         );
         expect(result).toEqual(zero);
     });
@@ -133,20 +118,23 @@ describe('modifierTotalsFromAbilities', () => {
                     { subject: 'enemy-type', derivable: true, requiredEnemyType: 'Defender' },
                 ]),
             ],
-            makeCtx({ enemyType: 'Defender' })
+            makeConditionContext({ enemyType: 'Defender' })
         );
         expect(result).toEqual({ ...zero, attack: 50 });
     });
 
     it('maps the "defense" channel to the defence bucket', () => {
-        const result = modifierTotalsFromAbilities([modifier('m', 'defense', 30)], makeCtx());
+        const result = modifierTotalsFromAbilities(
+            [modifier('m', 'defense', 30)],
+            makeConditionContext()
+        );
         expect(result).toEqual({ ...zero, defence: 30 });
     });
 
     it('stacks two modifiers', () => {
         const result = modifierTotalsFromAbilities(
             [modifier('m1', 'attack', 20), modifier('m2', 'attack', 15)],
-            makeCtx()
+            makeConditionContext()
         );
         expect(result).toEqual({ ...zero, attack: 35 });
     });
@@ -154,13 +142,13 @@ describe('modifierTotalsFromAbilities', () => {
     it('ignores channels with no DPS bucket (outgoingHeal, incomingDamage)', () => {
         const result = modifierTotalsFromAbilities(
             [modifier('m1', 'outgoingHeal', 50), modifier('m2', 'incomingDamage', 25)],
-            makeCtx()
+            makeConditionContext()
         );
         expect(result).toEqual(zero);
     });
 
     it('returns all zero with no abilities', () => {
-        expect(modifierTotalsFromAbilities([], makeCtx())).toEqual(zero);
+        expect(modifierTotalsFromAbilities([], makeConditionContext())).toEqual(zero);
     });
 
     it('applies a scaling defense-penetration modifier (per self-buff, capped)', () => {
@@ -183,14 +171,16 @@ describe('modifierTotalsFromAbilities', () => {
         expect(
             modifierTotalsFromAbilities(
                 [scalingDefPen],
-                makeCtx({ selfBuffNames: ['a', 'b', 'c'] })
+                makeConditionContext({ selfBuffNames: ['a', 'b', 'c'] })
             )
         ).toEqual({ ...zero, defensePenetration: 22.5 });
         // 10 self-buffs → capped at 45%
         expect(
             modifierTotalsFromAbilities(
                 [scalingDefPen],
-                makeCtx({ selfBuffNames: Array.from({ length: 10 }, (_, i) => `b${i}`) })
+                makeConditionContext({
+                    selfBuffNames: Array.from({ length: 10 }, (_, i) => `b${i}`),
+                })
             )
         ).toEqual({ ...zero, defensePenetration: 45 });
     });
@@ -571,11 +561,11 @@ describe('extraActionsFromSkill', () => {
         };
         const rawSkill: Skill = { slot: 'active', abilities: [conditionedExtraAction] };
         // Stealth not present → gateFiringAbilities drops the ability
-        const { gatedSkill } = gateFiringAbilities(rawSkill, makeCtx());
+        const { gatedSkill } = gateFiringAbilities(rawSkill, makeConditionContext());
         expect(extraActionsFromSkill(gatedSkill)).toEqual([]);
         // Stealth present → ability passes the gate → grant surfaces
         const { gatedSkill: gatedSkillWith } = gateFiringAbilities(rawSkill, {
-            ...makeCtx(),
+            ...makeConditionContext(),
             selfBuffNames: ['Stealth'],
         });
         expect(extraActionsFromSkill(gatedSkillWith)).toEqual([

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import { buildEquipmentAbilities } from '../buildEquipmentAbilities';
+import { Ship } from '../../../types/ship';
+import { GearPiece } from '../../../types/gear';
+
+/** Build a minimal Ship for test purposes. */
+function makeShip(over: Partial<Ship>): Ship {
+    return {
+        id: 'test-ship',
+        name: 'Test Ship',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'ATTACKER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        ...over,
+    } as Ship;
+}
+
+/** Build a minimal GearPiece for test purposes. */
+function makePiece(over: Partial<GearPiece>): GearPiece {
+    return {
+        id: 'piece-1',
+        slot: 'weapon',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: null,
+        ...over,
+    } as GearPiece;
+}
+
+/** Factory that returns a getGearPiece function backed by the given id→GearPiece map. */
+function makeGetGearPiece(map: Record<string, GearPiece>): (id: string) => GearPiece | undefined {
+    return (id) => map[id];
+}
+
+// ---------------------------------------------------------------------------
+// Case 1: Leech set active (≥2 pieces)
+// ---------------------------------------------------------------------------
+describe('buildEquipmentAbilities — Leech set', () => {
+    it('emits the Leech ability when ≥2 LEECH pieces are equipped', () => {
+        const pieceA = makePiece({ id: 'leech-1', setBonus: 'LEECH' });
+        const pieceB = makePiece({ id: 'leech-2', slot: 'hull', setBonus: 'LEECH' });
+        const ship = makeShip({
+            equipment: { weapon: 'leech-1', hull: 'leech-2' },
+        });
+        const getGearPiece = makeGetGearPiece({ 'leech-1': pieceA, 'leech-2': pieceB });
+
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+
+        expect(abilities).toHaveLength(1);
+        const [ab] = abilities;
+        expect(ab.id).toBe('equip-set-LEECH');
+        expect(ab.type).toBe('heal');
+        expect(ab.target).toBe('self');
+        expect(ab.trigger).toBe('on-cast');
+        expect(ab.config).toEqual({
+            type: 'heal',
+            pct: 15,
+            basis: 'damage-dealt',
+            leechScope: 'all',
+            noCrit: true,
+        });
+    });
+
+    // Case 2: Leech set inactive (1 piece)
+    it('emits nothing when only 1 LEECH piece is equipped', () => {
+        const pieceA = makePiece({ id: 'leech-1', setBonus: 'LEECH' });
+        const ship = makeShip({
+            equipment: { weapon: 'leech-1' },
+        });
+        const getGearPiece = makeGetGearPiece({ 'leech-1': pieceA });
+
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+
+        expect(abilities).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Case 3: Bloodthirst implant (legendary)
+// ---------------------------------------------------------------------------
+describe('buildEquipmentAbilities — Bloodthirst implant', () => {
+    it('emits on-crit heal with procChance 0.20 and pct 20 for legendary Bloodthirst', () => {
+        const implantPiece = makePiece({
+            id: 'bt-implant',
+            slot: 'implant_major',
+            rarity: 'legendary',
+            setBonus: 'BLOODTHIRST',
+        });
+        const ship = makeShip({
+            implants: { implant_major: 'bt-implant' },
+        });
+        const getGearPiece = makeGetGearPiece({ 'bt-implant': implantPiece });
+
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+
+        expect(abilities.length).toBeGreaterThanOrEqual(1);
+        const ab = abilities.find((a) => a.trigger === 'on-crit');
+        expect(ab).toBeDefined();
+        expect(ab!.procChance).toBeCloseTo(0.2);
+        expect(ab!.config.type).toBe('heal');
+        if (ab!.config.type === 'heal') {
+            expect(ab!.config.pct).toBe(20);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Case 4: Missing piece — no entry in map
+// ---------------------------------------------------------------------------
+describe('buildEquipmentAbilities — missing piece', () => {
+    it('skips gracefully when an implant id has no entry in the map', () => {
+        const ship = makeShip({
+            implants: { implant_major: 'nonexistent-id' },
+        });
+        const getGearPiece = makeGetGearPiece({});
+
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        expect(abilities).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Case 5: Stat-only implant (e.g. STRIKE minor with no description)
+// ---------------------------------------------------------------------------
+describe('buildEquipmentAbilities — stat-only implant', () => {
+    it('emits nothing for a stat-only implant with no description', () => {
+        const implantPiece = makePiece({
+            id: 'strike-implant',
+            slot: 'implant_minor_sigma',
+            rarity: 'legendary',
+            setBonus: 'STRIKE',
+        });
+        const ship = makeShip({
+            implants: { implant_minor_sigma: 'strike-implant' },
+        });
+        const getGearPiece = makeGetGearPiece({ 'strike-implant': implantPiece });
+
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+
+        expect(abilities).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Case 6: Unknown implant key — not in IMPLANTS registry
+// ---------------------------------------------------------------------------
+describe('buildEquipmentAbilities — unknown implant key', () => {
+    it('skips gracefully when the implant setBonus key is unknown (not in IMPLANTS)', () => {
+        // The piece has a setBonus that doesn't exist in IMPLANTS at all, so it is
+        // skipped before any description is read — this is an unknown-key guard, not a
+        // parse failure.
+        const implantPiece = makePiece({
+            id: 'fake-implant',
+            slot: 'implant_major',
+            rarity: 'legendary',
+            setBonus: 'FAKE_NONEXISTENT_IMPLANT' as never,
+        });
+        const ship = makeShip({
+            implants: { implant_major: 'fake-implant' },
+        });
+        const getGearPiece = makeGetGearPiece({ 'fake-implant': implantPiece });
+
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        expect(abilities).toHaveLength(0);
+    });
+});

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -171,3 +171,72 @@ describe('buildEquipmentAbilities — unknown implant key', () => {
         expect(abilities).toHaveLength(0);
     });
 });
+
+// ---------------------------------------------------------------------------
+// Helpers for implant-only tests
+// ---------------------------------------------------------------------------
+
+/** Build a ship with a single implant piece in implant_major and call buildEquipmentAbilities. */
+function buildForImplant(name: string, rarity: string) {
+    const implantPiece = makePiece({
+        id: `${name.toLowerCase()}-implant`,
+        slot: 'implant_major',
+        rarity: rarity as unknown as GearPiece['rarity'],
+        setBonus: name as GearPiece['setBonus'],
+    });
+    const ship = makeShip({
+        implants: { implant_major: `${name.toLowerCase()}-implant` },
+    });
+    const getGearPiece = makeGetGearPiece({
+        [`${name.toLowerCase()}-implant`]: implantPiece,
+    });
+    return buildEquipmentAbilities(ship, getGearPiece);
+}
+
+// ---------------------------------------------------------------------------
+// Case 7: Intrusion implant
+// ---------------------------------------------------------------------------
+describe('Intrusion implant', () => {
+    it('emits a passive outgoingDamage modifier scaling per enemy debuff (legendary = 5/debuff)', () => {
+        const abilities = buildForImplant('INTRUSION', 'legendary');
+        expect(abilities).toHaveLength(1);
+        const a = abilities[0];
+        expect(a.type).toBe('modifier');
+        expect(a.trigger).toBe('on-cast');
+        expect(a.config).toMatchObject({ type: 'modifier', channel: 'outgoingDamage', value: 0 });
+        expect(a.scaling).toEqual({ conditionIndex: 0, perUnit: 5 });
+        expect(a.conditions).toEqual([{ subject: 'enemy-debuff', derivable: true }]);
+    });
+    it('bakes the uncommon per-debuff value (2)', () => {
+        expect(buildForImplant('INTRUSION', 'uncommon')[0].scaling).toEqual({
+            conditionIndex: 0,
+            perUnit: 2,
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Case 8: Arcane Siege implant
+// ---------------------------------------------------------------------------
+describe('Arcane Siege implant', () => {
+    it('emits a flat outgoingDamage modifier gated on self-shield (epic = 15)', () => {
+        const a = buildForImplant('ARCANE_SIEGE', 'epic')[0];
+        expect(a.config).toMatchObject({ type: 'modifier', channel: 'outgoingDamage', value: 15 });
+        expect(a.scaling).toBeUndefined();
+        expect(a.conditions).toEqual([{ subject: 'self-shield', derivable: true }]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Case 9: Warpstrike implant
+// ---------------------------------------------------------------------------
+describe('Warpstrike implant', () => {
+    it('emits a flat outgoingDamage modifier gated on >=1 self-debuff (legendary = 5)', () => {
+        const a = buildForImplant('WARPSTRIKE', 'legendary')[0];
+        expect(a.config).toMatchObject({ type: 'modifier', channel: 'outgoingDamage', value: 5 });
+        expect(a.scaling).toBeUndefined();
+        expect(a.conditions).toEqual([
+            { subject: 'self-debuff', derivable: true, countComparator: 'gte', countThreshold: 1 },
+        ]);
+    });
+});

--- a/src/utils/abilities/__tests__/buildShipAbilitiesWithEquipment.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilitiesWithEquipment.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilitiesWithEquipment } from '../buildShipAbilitiesWithEquipment';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { GearPiece } from '../../../types/gear';
+
+/** Build a minimal Ship for test purposes. */
+function makeShip(over: Partial<Ship>): Ship {
+    return {
+        id: 'test-ship',
+        name: 'Test Ship',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'ATTACKER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        ...over,
+    } as Ship;
+}
+
+/** Build a minimal GearPiece for test purposes. */
+function makePiece(over: Partial<GearPiece>): GearPiece {
+    return {
+        id: 'piece-1',
+        slot: 'weapon',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: null,
+        ...over,
+    } as GearPiece;
+}
+
+/** Factory that returns a getGearPiece function backed by the given id→GearPiece map. */
+function makeGetGearPiece(map: Record<string, GearPiece>): (id: string) => GearPiece | undefined {
+    return (id) => map[id];
+}
+
+// ---------------------------------------------------------------------------
+// Ship fixture with NO equipment (baseline)
+// ---------------------------------------------------------------------------
+const bareShip = makeShip({});
+
+// ---------------------------------------------------------------------------
+// Case 1: Ship with Leech set + Bloodthirst implant
+// ---------------------------------------------------------------------------
+describe('buildShipAbilitiesWithEquipment — equipment-bearing ship', () => {
+    const leechA = makePiece({ id: 'leech-1', setBonus: 'LEECH' });
+    const leechB = makePiece({ id: 'leech-2', slot: 'hull', setBonus: 'LEECH' });
+    const bloodthirst = makePiece({
+        id: 'bt-implant',
+        slot: 'implant_major',
+        rarity: 'legendary',
+        setBonus: 'BLOODTHIRST',
+    });
+
+    const ship = makeShip({
+        equipment: { weapon: 'leech-1', hull: 'leech-2' },
+        implants: { implant_major: 'bt-implant' },
+    });
+
+    const getGearPiece = makeGetGearPiece({
+        'leech-1': leechA,
+        'leech-2': leechB,
+        'bt-implant': bloodthirst,
+    });
+
+    it('passive slot contains the ship own passive abilities PLUS the two equipment abilities', () => {
+        const result = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+
+        const passive = result.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+
+        // Two equipment abilities: Leech set + Bloodthirst implant
+        const equipIds = passive!.abilities
+            .filter((a) => a.id.startsWith('equip-'))
+            .map((a) => a.id);
+        expect(equipIds).toContain('equip-set-LEECH');
+        expect(equipIds).toContain('equip-implant-BLOODTHIRST');
+    });
+
+    it('equipment abilities are appended after ship own passive abilities', () => {
+        const basePassive = buildShipAbilities(ship).slots.find((s) => s.slot === 'passive');
+        const baseCount = basePassive?.abilities.length ?? 0;
+
+        const result = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+        const passive = result.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        // Two equip abilities appended
+        expect(passive!.abilities.length).toBe(baseCount + 2);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Case 2: Ship with empty equipment — output deep-equals buildShipAbilities
+// ---------------------------------------------------------------------------
+describe('buildShipAbilitiesWithEquipment — empty equipment', () => {
+    it('returns output deep-equal to buildShipAbilities when no equipment resolves', () => {
+        const getGearPiece = makeGetGearPiece({});
+        const base = buildShipAbilities(bareShip);
+        const result = buildShipAbilitiesWithEquipment(bareShip, getGearPiece);
+        expect(result).toEqual(base);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Case 3: else-branch — ship whose base ShipSkills has NO passive slot, but
+// has Leech-set equipment → wrapper must CREATE a new passive slot.
+//
+// Construction: a ship with only `activeSkillText` (no firstPassiveSkillText /
+// secondPassiveSkillText / thirdPassiveSkillText) has no passive-row in
+// getShipSkillRows, so buildShipAbilities never pushes to the passive bucket
+// and returns a ShipSkills with no passive Skill entry. We assert that
+// invariant in the test before exercising the wrapper.
+// ---------------------------------------------------------------------------
+describe('buildShipAbilitiesWithEquipment — else-branch (no base passive slot)', () => {
+    // Ship with an active skill only; all passive text fields are absent.
+    const activeOnlyShip = makeShip({
+        activeSkillText: 'Fires a basic attack at an enemy.',
+        // no firstPassiveSkillText / secondPassiveSkillText / thirdPassiveSkillText
+    });
+
+    const leechA = makePiece({ id: 'leech-no-passive-1', setBonus: 'LEECH' });
+    const leechB = makePiece({ id: 'leech-no-passive-2', slot: 'hull', setBonus: 'LEECH' });
+
+    const shipWithLeech = makeShip({
+        activeSkillText: 'Fires a basic attack at an enemy.',
+        equipment: { weapon: 'leech-no-passive-1', hull: 'leech-no-passive-2' },
+    });
+
+    const getGearPiece = makeGetGearPiece({
+        'leech-no-passive-1': leechA,
+        'leech-no-passive-2': leechB,
+    });
+
+    it('base buildShipAbilities output has NO passive slot (precondition)', () => {
+        const base = buildShipAbilities(activeOnlyShip);
+        const passive = base.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeUndefined();
+    });
+
+    it('wrapper creates a new passive slot containing the Leech set ability', () => {
+        const result = buildShipAbilitiesWithEquipment(shipWithLeech, getGearPiece);
+        const passive = result.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        expect(passive!.abilities.map((a) => a.id)).toContain('equip-set-LEECH');
+    });
+
+    it('the new passive slot contains ONLY the equipment abilities (no ship-own abilities)', () => {
+        const result = buildShipAbilitiesWithEquipment(shipWithLeech, getGearPiece);
+        const passive = result.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        expect(passive!.abilities).toHaveLength(1);
+        expect(passive!.abilities[0].id).toBe('equip-set-LEECH');
+    });
+});

--- a/src/utils/abilities/__tests__/conditionContextFixture.ts
+++ b/src/utils/abilities/__tests__/conditionContextFixture.ts
@@ -1,0 +1,26 @@
+import { ConditionContext } from '../evaluateConditions';
+
+/**
+ * Test fixture: a ConditionContext with all required fields defaulted, plus overrides.
+ * Single source of truth so a new ConditionContext field is updated in ONE place.
+ *
+ * Optional fields (enemyType, roundCrit, targetHpPct, isLowestSpeedAlly,
+ * targetRepairedThisRound, selfShielded) are NOT defaulted here — TypeScript optional
+ * fields are undefined by default, which is the correct baseline for tests that do not
+ * exercise those paths. Pass them via `over` when a test depends on them.
+ */
+export function makeConditionContext(over: Partial<ConditionContext> = {}): ConditionContext {
+    return {
+        selfBuffNames: [],
+        selfDebuffNames: [],
+        enemyBuffNames: [],
+        enemyDebuffCount: 0,
+        effectiveCritRate: 0,
+        adjacentAllyCount: 0,
+        enemyAdjacentCount: 0,
+        enemyDestroyedCount: 0,
+        selfHpPct: 100,
+        enemyHpPct: 100,
+        ...over,
+    };
+}

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -1,0 +1,155 @@
+/**
+ * equipmentCoverage.test.ts
+ *
+ * Documents CURRENT buildEquipmentAbilities coverage across the full IMPLANTS +
+ * GEAR_SETS corpus.  The intent is a living regression guard: when D-PR2 adds new
+ * effects, this file is updated deliberately so reviewers can see coverage grow.
+ *
+ * Assertions are plain `expect` calls — no snapshot files.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildEquipmentAbilities } from '../buildEquipmentAbilities';
+import { GEAR_SETS } from '../../../constants/gearSets';
+import { IMPLANTS } from '../../../constants/implants';
+import { Ship } from '../../../types/ship';
+import { GearPiece } from '../../../types/gear';
+
+// ---------------------------------------------------------------------------
+// Minimal fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeShip(over: Partial<Ship>): Ship {
+    return {
+        id: 'coverage-ship',
+        name: 'Coverage Ship',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'ATTACKER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        ...over,
+    } as Ship;
+}
+
+function makePiece(over: Partial<GearPiece>): GearPiece {
+    return {
+        id: 'piece',
+        slot: 'weapon',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: null,
+        ...over,
+    } as GearPiece;
+}
+
+/**
+ * Build a minimal ship equipping enough pieces of a gear set (≥ its minPieces)
+ * and return the ability count produced by buildEquipmentAbilities.
+ */
+function gearSetAbilityCount(setKey: string): number {
+    const setDef = GEAR_SETS[setKey];
+    const minPieces = setDef?.minPieces ?? 2;
+
+    // Gear slot names used in the test — just need enough distinct slots.
+    const slots = ['weapon', 'hull', 'sensor', 'engine', 'shield', 'computer'] as const;
+    const equipment: Record<string, string> = {};
+    const pieceMap: Record<string, GearPiece> = {};
+
+    for (let i = 0; i < minPieces; i++) {
+        const id = `${setKey}-piece-${i}`;
+        const slot = slots[i % slots.length];
+        equipment[slot] = id;
+        pieceMap[id] = makePiece({ id, slot, setBonus: setKey });
+    }
+
+    const ship = makeShip({ equipment });
+    return buildEquipmentAbilities(ship, (id) => pieceMap[id]).length;
+}
+
+/**
+ * Build a minimal ship equipping one implant piece (at the given rarity) and
+ * return the ability count produced by buildEquipmentAbilities.
+ */
+function implantAbilityCount(implantKey: string, rarity: GearPiece['rarity']): number {
+    const id = `${implantKey}-piece`;
+    const pieceMap: Record<string, GearPiece> = {
+        [id]: makePiece({ id, slot: 'implant_major', rarity, setBonus: implantKey }),
+    };
+    const ship = makeShip({ implants: { implant_major: id } });
+    return buildEquipmentAbilities(ship, (gearId) => pieceMap[gearId]).length;
+}
+
+// ---------------------------------------------------------------------------
+// Regression guard: implemented effect names must equal exactly this set.
+// Update deliberately when D-PR2 adds more.
+// ---------------------------------------------------------------------------
+
+describe('equipmentCoverage — implemented effects registry', () => {
+    it('exactly { LEECH (gear set), BLOODTHIRST (implant) } are currently implemented', () => {
+        // Gear sets with an ability builder
+        const implementedSets = Object.keys(GEAR_SETS).filter(
+            (key) => gearSetAbilityCount(key) > 0
+        );
+        expect(implementedSets).toEqual(['LEECH']);
+
+        // Implants with an ability builder (check each implant with a rarity that exists)
+        const implementedImplants = Object.keys(IMPLANTS).filter((key) => {
+            const variants = IMPLANTS[key].variants;
+            // Try the first available rarity for each implant.
+            return variants.some((v) => implantAbilityCount(key, v.rarity) > 0);
+        });
+        expect(implementedImplants).toEqual(['BLOODTHIRST']);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Gear-set coverage: one assertion per set
+// ---------------------------------------------------------------------------
+
+describe('equipmentCoverage — gear sets', () => {
+    it('LEECH produces exactly 1 ability (the standing leech)', () => {
+        expect(gearSetAbilityCount('LEECH')).toBe(1);
+    });
+
+    const nonLeechSets = Object.keys(GEAR_SETS).filter((k) => k !== 'LEECH');
+    for (const setKey of nonLeechSets) {
+        it(`${setKey} produces 0 abilities (not yet implemented)`, () => {
+            expect(gearSetAbilityCount(setKey)).toBe(0);
+        });
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Implant coverage: one assertion per implant
+// ---------------------------------------------------------------------------
+
+describe('equipmentCoverage — implants', () => {
+    it('BLOODTHIRST (uncommon) produces >= 1 ability (on-crit heal)', () => {
+        expect(implantAbilityCount('BLOODTHIRST', 'uncommon')).toBeGreaterThanOrEqual(1);
+    });
+
+    it('BLOODTHIRST (epic) produces >= 1 ability (on-crit heal)', () => {
+        expect(implantAbilityCount('BLOODTHIRST', 'epic')).toBeGreaterThanOrEqual(1);
+    });
+
+    it('BLOODTHIRST (legendary) produces >= 1 ability (on-crit heal)', () => {
+        expect(implantAbilityCount('BLOODTHIRST', 'legendary')).toBeGreaterThanOrEqual(1);
+    });
+
+    const nonBloodthirstImplants = Object.keys(IMPLANTS).filter((k) => k !== 'BLOODTHIRST');
+    for (const implantKey of nonBloodthirstImplants) {
+        it(`${implantKey} produces 0 abilities (not yet implemented)`, () => {
+            const variants = IMPLANTS[implantKey].variants;
+            // Check all available rarities — none should produce abilities yet.
+            for (const v of variants) {
+                expect(implantAbilityCount(implantKey, v.rarity)).toBe(0);
+            }
+        });
+    }
+});

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -91,7 +91,7 @@ function implantAbilityCount(implantKey: string, rarity: GearPiece['rarity']): n
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { LEECH (gear set), BLOODTHIRST (implant) } are currently implemented', () => {
+    it('exactly { LEECH (gear set), BLOODTHIRST + INTRUSION + ARCANE_SIEGE + WARPSTRIKE (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -104,7 +104,12 @@ describe('equipmentCoverage — implemented effects registry', () => {
             // Try the first available rarity for each implant.
             return variants.some((v) => implantAbilityCount(key, v.rarity) > 0);
         });
-        expect(implementedImplants).toEqual(['BLOODTHIRST']);
+        expect(implementedImplants).toEqual([
+            'ARCANE_SIEGE',
+            'INTRUSION',
+            'WARPSTRIKE',
+            'BLOODTHIRST',
+        ]);
     });
 });
 
@@ -142,8 +147,32 @@ describe('equipmentCoverage — implants', () => {
         expect(implantAbilityCount('BLOODTHIRST', 'legendary')).toBeGreaterThanOrEqual(1);
     });
 
-    const nonBloodthirstImplants = Object.keys(IMPLANTS).filter((k) => k !== 'BLOODTHIRST');
-    for (const implantKey of nonBloodthirstImplants) {
+    // D-PR2: INTRUSION, ARCANE_SIEGE, WARPSTRIKE now produce 1 ability each.
+    const implementedImplants = new Set(['BLOODTHIRST', 'INTRUSION', 'ARCANE_SIEGE', 'WARPSTRIKE']);
+
+    it('INTRUSION produces 1 ability per rarity (outgoingDamage modifier with scaling)', () => {
+        const variants = IMPLANTS['INTRUSION'].variants;
+        for (const v of variants) {
+            expect(implantAbilityCount('INTRUSION', v.rarity)).toBe(1);
+        }
+    });
+
+    it('ARCANE_SIEGE produces 1 ability per rarity (outgoingDamage modifier gated on self-shield)', () => {
+        const variants = IMPLANTS['ARCANE_SIEGE'].variants;
+        for (const v of variants) {
+            expect(implantAbilityCount('ARCANE_SIEGE', v.rarity)).toBe(1);
+        }
+    });
+
+    it('WARPSTRIKE produces 1 ability per rarity (outgoingDamage modifier gated on self-debuff)', () => {
+        const variants = IMPLANTS['WARPSTRIKE'].variants;
+        for (const v of variants) {
+            expect(implantAbilityCount('WARPSTRIKE', v.rarity)).toBe(1);
+        }
+    });
+
+    const unimplementedImplants = Object.keys(IMPLANTS).filter((k) => !implementedImplants.has(k));
+    for (const implantKey of unimplementedImplants) {
         it(`${implantKey} produces 0 abilities (not yet implemented)`, () => {
             const variants = IMPLANTS[implantKey].variants;
             // Check all available rarities — none should produce abilities yet.

--- a/src/utils/abilities/__tests__/evaluateConditions.test.ts
+++ b/src/utils/abilities/__tests__/evaluateConditions.test.ts
@@ -1,28 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import {
-    ConditionContext,
-    evaluateCondition,
-    conditionMet,
-    conditionsMet,
-    scaledBonus,
-} from '../evaluateConditions';
+import { evaluateCondition, conditionMet, conditionsMet, scaledBonus } from '../evaluateConditions';
 import { buildRoundContext } from '../roundContext';
 import { Ability, Condition } from '../../../types/abilities';
-
-const ctx = (over: Partial<ConditionContext> = {}): ConditionContext => ({
-    selfBuffNames: [],
-    selfDebuffNames: [],
-    enemyBuffNames: [],
-    enemyDebuffCount: 0,
-    enemyType: undefined,
-    effectiveCritRate: 0,
-    adjacentAllyCount: 0,
-    enemyAdjacentCount: 0,
-    enemyDestroyedCount: 0,
-    selfHpPct: 100,
-    enemyHpPct: 100,
-    ...over,
-});
+import { makeConditionContext } from './conditionContextFixture';
 
 const cond = (over: Partial<Condition>): Condition => ({
     subject: 'always',
@@ -32,11 +12,11 @@ const cond = (over: Partial<Condition>): Condition => ({
 
 describe('evaluateCondition', () => {
     it("'always' is 1", () => {
-        expect(evaluateCondition(cond({ subject: 'always' }), ctx())).toBe(1);
+        expect(evaluateCondition(cond({ subject: 'always' }), makeConditionContext())).toBe(1);
     });
 
     it("derivable 'self-buff' counts active self buffs (all, or by name)", () => {
-        const c = ctx({ selfBuffNames: ['Attack Up II', 'Defense Up II'] });
+        const c = makeConditionContext({ selfBuffNames: ['Attack Up II', 'Defense Up II'] });
         expect(evaluateCondition(cond({ subject: 'self-buff', derivable: true }), c)).toBe(2);
         expect(
             evaluateCondition(
@@ -50,7 +30,7 @@ describe('evaluateCondition', () => {
         expect(
             evaluateCondition(
                 cond({ subject: 'enemy-debuff', derivable: true }),
-                ctx({ enemyDebuffCount: 3 })
+                makeConditionContext({ enemyDebuffCount: 3 })
             )
         ).toBe(3);
     });
@@ -59,13 +39,13 @@ describe('evaluateCondition', () => {
         expect(
             evaluateCondition(
                 cond({ subject: 'enemy-buff', derivable: true, buffName: 'Stealth' }),
-                ctx({ enemyBuffNames: ['Stealth'] })
+                makeConditionContext({ enemyBuffNames: ['Stealth'] })
             )
         ).toBe(1);
         expect(
             evaluateCondition(
                 cond({ subject: 'enemy-buff', derivable: true, buffName: 'Stealth' }),
-                ctx()
+                makeConditionContext()
             )
         ).toBe(0);
     });
@@ -74,21 +54,21 @@ describe('evaluateCondition', () => {
         expect(
             evaluateCondition(
                 cond({ subject: 'self-crit', derivable: true }),
-                ctx({ effectiveCritRate: 100 })
+                makeConditionContext({ effectiveCritRate: 100 })
             )
         ).toBe(1);
         expect(
             evaluateCondition(
                 cond({ subject: 'self-crit', derivable: true }),
-                ctx({ effectiveCritRate: 50 })
+                makeConditionContext({ effectiveCritRate: 50 })
             )
         ).toBe(0.5);
     });
 
     it("'enemy-type' is 1 on match else 0", () => {
         const c = cond({ subject: 'enemy-type', derivable: true, requiredEnemyType: 'Defender' });
-        expect(evaluateCondition(c, ctx({ enemyType: 'Defender' }))).toBe(1);
-        expect(evaluateCondition(c, ctx({ enemyType: 'Attacker' }))).toBe(0);
+        expect(evaluateCondition(c, makeConditionContext({ enemyType: 'Defender' }))).toBe(1);
+        expect(evaluateCondition(c, makeConditionContext({ enemyType: 'Attacker' }))).toBe(0);
     });
 
     it("negated 'enemy-type' is 1 when the enemy is NOT the type (non-Defenders)", () => {
@@ -98,10 +78,10 @@ describe('evaluateCondition', () => {
             requiredEnemyType: 'Defender',
             negate: true,
         });
-        expect(evaluateCondition(c, ctx({ enemyType: 'Attacker' }))).toBe(1);
-        expect(evaluateCondition(c, ctx({ enemyType: 'Defender' }))).toBe(0);
+        expect(evaluateCondition(c, makeConditionContext({ enemyType: 'Attacker' }))).toBe(1);
+        expect(evaluateCondition(c, makeConditionContext({ enemyType: 'Defender' }))).toBe(0);
         // Unknown enemy type → cannot confirm "not a Defender" → 0.
-        expect(evaluateCondition(c, ctx({ enemyType: undefined }))).toBe(0);
+        expect(evaluateCondition(c, makeConditionContext({ enemyType: undefined }))).toBe(0);
     });
 
     it("'hp-threshold' below/above resolves against context HP", () => {
@@ -111,8 +91,8 @@ describe('evaluateCondition', () => {
             hpComparator: 'below',
             hpPercent: 50,
         });
-        expect(evaluateCondition(below, ctx({ enemyHpPct: 40 }))).toBe(1);
-        expect(evaluateCondition(below, ctx({ enemyHpPct: 60 }))).toBe(0);
+        expect(evaluateCondition(below, makeConditionContext({ enemyHpPct: 40 }))).toBe(1);
+        expect(evaluateCondition(below, makeConditionContext({ enemyHpPct: 60 }))).toBe(0);
     });
 
     it("'hp-threshold' with hpSubject 'self' resolves against the unit's own HP", () => {
@@ -123,22 +103,37 @@ describe('evaluateCondition', () => {
             hpPercent: 99,
             hpSubject: 'self',
         });
-        expect(evaluateCondition(selfAboveFull, ctx({ selfHpPct: 100, enemyHpPct: 10 }))).toBe(1);
-        expect(evaluateCondition(selfAboveFull, ctx({ selfHpPct: 50, enemyHpPct: 100 }))).toBe(0);
+        expect(
+            evaluateCondition(
+                selfAboveFull,
+                makeConditionContext({ selfHpPct: 100, enemyHpPct: 10 })
+            )
+        ).toBe(1);
+        expect(
+            evaluateCondition(
+                selfAboveFull,
+                makeConditionContext({ selfHpPct: 50, enemyHpPct: 100 })
+            )
+        ).toBe(0);
     });
 
     it('non-derivable uses manualCount (default 1)', () => {
-        expect(evaluateCondition(cond({ subject: 'enemy-buff', derivable: false }), ctx())).toBe(1);
+        expect(
+            evaluateCondition(
+                cond({ subject: 'enemy-buff', derivable: false }),
+                makeConditionContext()
+            )
+        ).toBe(1);
         expect(
             evaluateCondition(
                 cond({ subject: 'enemy-buff', derivable: false, manualCount: 3 }),
-                ctx()
+                makeConditionContext()
             )
         ).toBe(3);
         expect(
             evaluateCondition(
                 cond({ subject: 'enemy-buff', derivable: false, manualCount: 0 }),
-                ctx()
+                makeConditionContext()
             )
         ).toBe(0);
     });
@@ -146,7 +141,7 @@ describe('evaluateCondition', () => {
 
 describe('conditionsMet (AND of OR-groups)', () => {
     it('empty conditions → always met', () => {
-        expect(conditionsMet([], ctx())).toBe(true);
+        expect(conditionsMet([], makeConditionContext())).toBe(true);
     });
 
     it('AND: all groups must have count > 0', () => {
@@ -154,12 +149,18 @@ describe('conditionsMet (AND of OR-groups)', () => {
             cond({ subject: 'enemy-type', requiredEnemyType: 'Defender' }),
             cond({ subject: 'self-crit' }),
         ];
-        expect(conditionsMet(conds, ctx({ enemyType: 'Defender', effectiveCritRate: 100 }))).toBe(
-            true
-        );
-        expect(conditionsMet(conds, ctx({ enemyType: 'Defender', effectiveCritRate: 0 }))).toBe(
-            false
-        );
+        expect(
+            conditionsMet(
+                conds,
+                makeConditionContext({ enemyType: 'Defender', effectiveCritRate: 100 })
+            )
+        ).toBe(true);
+        expect(
+            conditionsMet(
+                conds,
+                makeConditionContext({ enemyType: 'Defender', effectiveCritRate: 0 })
+            )
+        ).toBe(false);
     });
 
     it('OR-group (anyOf): any member > 0 satisfies the group', () => {
@@ -173,8 +174,8 @@ describe('conditionsMet (AND of OR-groups)', () => {
                 buffName: 'Stealth',
             }),
         ];
-        expect(conditionsMet(conds, ctx({ enemyType: 'Defender' }))).toBe(true);
-        expect(conditionsMet(conds, ctx({ enemyType: 'Attacker' }))).toBe(false);
+        expect(conditionsMet(conds, makeConditionContext({ enemyType: 'Defender' }))).toBe(true);
+        expect(conditionsMet(conds, makeConditionContext({ enemyType: 'Attacker' }))).toBe(false);
     });
 
     it('non-adjacent anyOf conditions do NOT merge across a plain condition', () => {
@@ -191,49 +192,58 @@ describe('conditionsMet (AND of OR-groups)', () => {
             }),
         ];
         // type true + buff true, but the plain self-crit group is false (crit 0) → overall false
-        expect(conditionsMet(conds, ctx({ enemyType: 'Defender' }))).toBe(false);
+        expect(conditionsMet(conds, makeConditionContext({ enemyType: 'Defender' }))).toBe(false);
         // all three groups satisfied
-        expect(conditionsMet(conds, ctx({ enemyType: 'Defender', effectiveCritRate: 100 }))).toBe(
-            true
-        );
+        expect(
+            conditionsMet(
+                conds,
+                makeConditionContext({ enemyType: 'Defender', effectiveCritRate: 100 })
+            )
+        ).toBe(true);
     });
 });
 
 describe('conditionMet (count comparator gating)', () => {
     it('no comparator → presence rule (count > 0)', () => {
-        expect(conditionMet(cond({ subject: 'enemy-debuff' }), ctx({ enemyDebuffCount: 1 }))).toBe(
-            true
-        );
-        expect(conditionMet(cond({ subject: 'enemy-debuff' }), ctx({ enemyDebuffCount: 0 }))).toBe(
-            false
-        );
+        expect(
+            conditionMet(
+                cond({ subject: 'enemy-debuff' }),
+                makeConditionContext({ enemyDebuffCount: 1 })
+            )
+        ).toBe(true);
+        expect(
+            conditionMet(
+                cond({ subject: 'enemy-debuff' }),
+                makeConditionContext({ enemyDebuffCount: 0 })
+            )
+        ).toBe(false);
     });
 
     it('gte threshold: met only at/above the count (Crocus "more than 3" → gte 4)', () => {
         const c = cond({ subject: 'enemy-debuff', countComparator: 'gte', countThreshold: 4 });
-        expect(conditionMet(c, ctx({ enemyDebuffCount: 3 }))).toBe(false);
-        expect(conditionMet(c, ctx({ enemyDebuffCount: 4 }))).toBe(true);
-        expect(conditionMet(c, ctx({ enemyDebuffCount: 9 }))).toBe(true);
+        expect(conditionMet(c, makeConditionContext({ enemyDebuffCount: 3 }))).toBe(false);
+        expect(conditionMet(c, makeConditionContext({ enemyDebuffCount: 4 }))).toBe(true);
+        expect(conditionMet(c, makeConditionContext({ enemyDebuffCount: 9 }))).toBe(true);
     });
 
     it('eq 0: met only when the count is exactly zero (Sustainer "no debuffs")', () => {
         const c = cond({ subject: 'self-debuff', countComparator: 'eq', countThreshold: 0 });
-        expect(conditionMet(c, ctx({ selfDebuffNames: [] }))).toBe(true);
-        expect(conditionMet(c, ctx({ selfDebuffNames: ['Burn'] }))).toBe(false);
+        expect(conditionMet(c, makeConditionContext({ selfDebuffNames: [] }))).toBe(true);
+        expect(conditionMet(c, makeConditionContext({ selfDebuffNames: ['Burn'] }))).toBe(false);
     });
 
     it('lte threshold: met at/below the count', () => {
         const c = cond({ subject: 'enemy-debuff', countComparator: 'lte', countThreshold: 2 });
-        expect(conditionMet(c, ctx({ enemyDebuffCount: 2 }))).toBe(true);
-        expect(conditionMet(c, ctx({ enemyDebuffCount: 3 }))).toBe(false);
+        expect(conditionMet(c, makeConditionContext({ enemyDebuffCount: 2 }))).toBe(true);
+        expect(conditionMet(c, makeConditionContext({ enemyDebuffCount: 3 }))).toBe(false);
     });
 
     it('comparator flows through conditionsMet as a gate', () => {
         const conds = [
             cond({ subject: 'enemy-debuff', countComparator: 'gte', countThreshold: 3 }),
         ];
-        expect(conditionsMet(conds, ctx({ enemyDebuffCount: 3 }))).toBe(true);
-        expect(conditionsMet(conds, ctx({ enemyDebuffCount: 2 }))).toBe(false);
+        expect(conditionsMet(conds, makeConditionContext({ enemyDebuffCount: 3 }))).toBe(true);
+        expect(conditionsMet(conds, makeConditionContext({ enemyDebuffCount: 2 }))).toBe(false);
     });
 
     it('comparator does NOT affect scaledBonus (scaling always uses the raw count)', () => {
@@ -249,7 +259,7 @@ describe('conditionMet (count comparator gating)', () => {
             config: { type: 'damage', multiplier: 200 },
         };
         // count 2 < threshold 4 (gate would fail), but scaling still uses raw count 2 → 20.
-        expect(scaledBonus(a, ctx({ enemyDebuffCount: 2 }))).toBe(20);
+        expect(scaledBonus(a, makeConditionContext({ enemyDebuffCount: 2 }))).toBe(20);
     });
 });
 
@@ -270,12 +280,12 @@ describe('scaledBonus', () => {
             perUnit: 10,
             cap: 30,
         });
-        expect(scaledBonus(a, ctx({ enemyDebuffCount: 2 }))).toBe(20);
-        expect(scaledBonus(a, ctx({ enemyDebuffCount: 5 }))).toBe(30);
+        expect(scaledBonus(a, makeConditionContext({ enemyDebuffCount: 2 }))).toBe(20);
+        expect(scaledBonus(a, makeConditionContext({ enemyDebuffCount: 5 }))).toBe(30);
     });
 
     it('returns 0 when no scaling rule', () => {
-        expect(scaledBonus(dmg([], undefined), ctx())).toBe(0);
+        expect(scaledBonus(dmg([], undefined), makeConditionContext())).toBe(0);
     });
 
     it('scaling reads only the indexed condition, even inside an anyOf OR-group', () => {
@@ -289,39 +299,49 @@ describe('scaledBonus', () => {
             ],
             { conditionIndex: 0, perUnit: 10, cap: 30 }
         );
-        expect(scaledBonus(a, ctx({ enemyDebuffCount: 2 }))).toBe(20);
-        expect(scaledBonus(a, ctx({ enemyDebuffCount: 5 }))).toBe(30); // capped
+        expect(scaledBonus(a, makeConditionContext({ enemyDebuffCount: 2 }))).toBe(20);
+        expect(scaledBonus(a, makeConditionContext({ enemyDebuffCount: 5 }))).toBe(30); // capped
         // self-buffs alone satisfy the OR-gate but contribute nothing to scaling
-        expect(scaledBonus(a, ctx({ selfBuffNames: ['Stealth'] }))).toBe(0);
+        expect(scaledBonus(a, makeConditionContext({ selfBuffNames: ['Stealth'] }))).toBe(0);
     });
 });
 
 describe('binary roundCrit', () => {
     it('self-crit returns 1 when roundCrit is true, 0 when false', () => {
         const cond = { subject: 'self-crit' as const, derivable: true };
-        expect(evaluateCondition(cond, ctx({ effectiveCritRate: 70, roundCrit: true }))).toBe(1);
-        expect(evaluateCondition(cond, ctx({ effectiveCritRate: 70, roundCrit: false }))).toBe(0);
+        expect(
+            evaluateCondition(
+                cond,
+                makeConditionContext({ effectiveCritRate: 70, roundCrit: true })
+            )
+        ).toBe(1);
+        expect(
+            evaluateCondition(
+                cond,
+                makeConditionContext({ effectiveCritRate: 70, roundCrit: false })
+            )
+        ).toBe(0);
     });
 
     it('self-crit falls back to probability when roundCrit is undefined', () => {
         const cond = { subject: 'self-crit' as const, derivable: true };
-        expect(evaluateCondition(cond, ctx({ effectiveCritRate: 70 }))).toBe(0.7);
+        expect(evaluateCondition(cond, makeConditionContext({ effectiveCritRate: 70 }))).toBe(0.7);
     });
 });
 
 describe('HP-percentage count subjects', () => {
     it('enemy-hp-pct counts the enemy HP percentage', () => {
         const c = cond({ subject: 'enemy-hp-pct' });
-        expect(evaluateCondition(c, ctx({ enemyHpPct: 100 }))).toBe(100);
-        expect(evaluateCondition(c, ctx({ enemyHpPct: 42 }))).toBe(42);
-        expect(evaluateCondition(c, ctx({ enemyHpPct: 0 }))).toBe(0);
+        expect(evaluateCondition(c, makeConditionContext({ enemyHpPct: 100 }))).toBe(100);
+        expect(evaluateCondition(c, makeConditionContext({ enemyHpPct: 42 }))).toBe(42);
+        expect(evaluateCondition(c, makeConditionContext({ enemyHpPct: 0 }))).toBe(0);
     });
 
     it('enemy-hp-missing-pct counts the missing percentage', () => {
         const c = cond({ subject: 'enemy-hp-missing-pct' });
-        expect(evaluateCondition(c, ctx({ enemyHpPct: 100 }))).toBe(0);
-        expect(evaluateCondition(c, ctx({ enemyHpPct: 30 }))).toBe(70);
-        expect(evaluateCondition(c, ctx({ enemyHpPct: 0 }))).toBe(100);
+        expect(evaluateCondition(c, makeConditionContext({ enemyHpPct: 100 }))).toBe(0);
+        expect(evaluateCondition(c, makeConditionContext({ enemyHpPct: 30 }))).toBe(70);
+        expect(evaluateCondition(c, makeConditionContext({ enemyHpPct: 0 }))).toBe(100);
     });
 });
 
@@ -334,8 +354,8 @@ describe('hp-threshold hpSubject target', () => {
             hpPercent: 40,
             hpSubject: 'target',
         };
-        expect(evaluateCondition(c, ctx({ targetHpPct: 35 }))).toBe(1);
-        expect(evaluateCondition(c, ctx({ targetHpPct: 60 }))).toBe(0);
+        expect(evaluateCondition(c, makeConditionContext({ targetHpPct: 35 }))).toBe(1);
+        expect(evaluateCondition(c, makeConditionContext({ targetHpPct: 60 }))).toBe(0);
     });
 
     it('hp-threshold target defaults to 100 when targetHpPct absent (DPS-mode inert)', () => {
@@ -346,7 +366,7 @@ describe('hp-threshold hpSubject target', () => {
             hpPercent: 40,
             hpSubject: 'target',
         };
-        expect(evaluateCondition(c, ctx())).toBe(0);
+        expect(evaluateCondition(c, makeConditionContext())).toBe(0);
     });
 });
 
@@ -354,14 +374,20 @@ describe('target-repaired-this-round condition', () => {
     const cond = { subject: 'target-repaired-this-round' as const, derivable: true };
 
     it('is met when the target was repaired this round', () => {
-        expect(evaluateCondition(cond, ctx({ targetRepairedThisRound: true }))).toBe(1);
-        expect(conditionsMet([cond], ctx({ targetRepairedThisRound: true }))).toBe(true);
+        expect(
+            evaluateCondition(cond, makeConditionContext({ targetRepairedThisRound: true }))
+        ).toBe(1);
+        expect(conditionsMet([cond], makeConditionContext({ targetRepairedThisRound: true }))).toBe(
+            true
+        );
     });
 
     it('is NOT met when the target was not repaired (false or undefined)', () => {
-        expect(evaluateCondition(cond, ctx({ targetRepairedThisRound: false }))).toBe(0);
-        expect(evaluateCondition(cond, ctx())).toBe(0);
-        expect(conditionsMet([cond], ctx())).toBe(false);
+        expect(
+            evaluateCondition(cond, makeConditionContext({ targetRepairedThisRound: false }))
+        ).toBe(0);
+        expect(evaluateCondition(cond, makeConditionContext())).toBe(0);
+        expect(conditionsMet([cond], makeConditionContext())).toBe(false);
     });
 });
 
@@ -370,12 +396,14 @@ describe('self-shield condition', () => {
         expect(
             evaluateCondition(
                 { subject: 'self-shield', derivable: true },
-                ctx({ selfShielded: true })
+                makeConditionContext({ selfShielded: true })
             )
         ).toBe(1);
     });
     it('evaluates to 0 when selfShielded is false/absent', () => {
-        expect(evaluateCondition({ subject: 'self-shield', derivable: true }, ctx())).toBe(0);
+        expect(
+            evaluateCondition({ subject: 'self-shield', derivable: true }, makeConditionContext())
+        ).toBe(0);
     });
 });
 

--- a/src/utils/abilities/__tests__/evaluateConditions.test.ts
+++ b/src/utils/abilities/__tests__/evaluateConditions.test.ts
@@ -365,6 +365,20 @@ describe('target-repaired-this-round condition', () => {
     });
 });
 
+describe('self-shield condition', () => {
+    it('evaluates to 1 when selfShielded is true', () => {
+        expect(
+            evaluateCondition(
+                { subject: 'self-shield', derivable: true },
+                ctx({ selfShielded: true })
+            )
+        ).toBe(1);
+    });
+    it('evaluates to 0 when selfShielded is false/absent', () => {
+        expect(evaluateCondition({ subject: 'self-shield', derivable: true }, ctx())).toBe(0);
+    });
+});
+
 describe('lowest-speed-ally', () => {
     it('returns 1 when isLowestSpeedAlly is true', () => {
         const ctx = buildRoundContext({

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -7,7 +7,13 @@
  * Gear-set abilities are resolved via GEAR_SET_ABILITIES (currently: Leech).
  * Implant abilities are resolved via IMPLANT_ABILITIES (currently: Bloodthirst).
  *
- * This module is NOT wired into any engine path yet (Task 3 does that).
+ * D-PR1 approach (registry, not text-parsing): effect values are baked from the
+ * source data in implants.ts / gearSets.ts per the registries above. A variant's
+ * `description` is used only as a PRESENCE gate (stat-only variants have none and are
+ * skipped) — its text is NOT parsed. A future PR may add a text-parse path for
+ * implants whose phrasing the skill parser can handle; until then, new effects need a
+ * registry entry. Merged into the passive slot by buildShipAbilitiesWithEquipment.
+ *
  * It is pure: no side effects, no throws out of the function.
  *
  * Modeling note: noCrit:true on the Leech set heal — a derived-from-damage leech

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -5,7 +5,8 @@
  * that the combat engine can consume.
  *
  * Gear-set abilities are resolved via GEAR_SET_ABILITIES (currently: Leech).
- * Implant abilities are resolved via IMPLANT_ABILITIES (currently: Bloodthirst).
+ * Implant abilities are resolved via IMPLANT_ABILITIES (currently: Bloodthirst,
+ * Intrusion, Arcane Siege, Warpstrike).
  *
  * D-PR1 approach (registry, not text-parsing): effect values are baked from the
  * source data in implants.ts / gearSets.ts per the registries above. A variant's
@@ -42,7 +43,7 @@ const GEAR_SET_ABILITIES: Partial<Record<string, () => Omit<Ability, 'id'>>> = {
 };
 
 // ---------------------------------------------------------------------------
-// Implant ability registry (D-PR1: Bloodthirst only)
+// Implant ability registry (D-PR1: Bloodthirst; D-PR2: Intrusion, Arcane Siege, Warpstrike)
 // ---------------------------------------------------------------------------
 //
 // Each entry maps an implant name to a per-rarity builder.  A builder returns

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -1,0 +1,158 @@
+/**
+ * buildEquipmentAbilities
+ *
+ * Turns a ship's equipped gear sets + implants into a list of Ability objects
+ * that the combat engine can consume.
+ *
+ * Gear-set abilities are resolved via GEAR_SET_ABILITIES (currently: Leech).
+ * Implant abilities are resolved via IMPLANT_ABILITIES (currently: Bloodthirst).
+ *
+ * This module is NOT wired into any engine path yet (Task 3 does that).
+ * It is pure: no side effects, no throws out of the function.
+ *
+ * Modeling note: noCrit:true on the Leech set heal — a derived-from-damage leech
+ * doesn't roll its own heal-crit; flagged as a modeling choice for reviewer confirmation.
+ */
+
+import { GEAR_SETS } from '../../constants/gearSets';
+import { IMPLANTS } from '../../constants/implants';
+import { GearPiece } from '../../types/gear';
+import { Ability } from '../../types/abilities';
+import { Ship } from '../../types/ship';
+
+// ---------------------------------------------------------------------------
+// Gear-set ability registry (D-PR1: Leech only)
+// ---------------------------------------------------------------------------
+
+const GEAR_SET_ABILITIES: Partial<Record<string, () => Omit<Ability, 'id'>>> = {
+    LEECH: () => ({
+        type: 'heal',
+        target: 'self',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'heal', pct: 15, basis: 'damage-dealt', leechScope: 'all', noCrit: true },
+        autoFilled: true,
+    }),
+};
+
+// ---------------------------------------------------------------------------
+// Implant ability registry (D-PR1: Bloodthirst only)
+// ---------------------------------------------------------------------------
+//
+// Each entry maps an implant name to a per-rarity builder.  A builder returns
+// an Ability (minus `id`) or undefined when the rarity is unsupported.
+
+type ImplantAbilityBuilder = (rarity: string) => Omit<Ability, 'id'> | undefined;
+
+const BLOODTHIRST_HEAL_PCT: Record<string, number> = {
+    uncommon: 12,
+    epic: 17,
+    legendary: 20,
+};
+
+const BLOODTHIRST_PROC_CHANCE: Record<string, number> = {
+    uncommon: 0.12,
+    epic: 0.17,
+    legendary: 0.2,
+};
+
+const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
+    BLOODTHIRST: (rarity) => {
+        const pct = BLOODTHIRST_HEAL_PCT[rarity];
+        const procChance = BLOODTHIRST_PROC_CHANCE[rarity];
+        if (pct === undefined) return undefined;
+        return {
+            type: 'heal',
+            target: 'self',
+            trigger: 'on-crit',
+            conditions: [],
+            procChance,
+            config: {
+                type: 'heal',
+                pct,
+                basis: 'damage-dealt',
+            },
+            autoFilled: true,
+        };
+    },
+};
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a ship's active gear-set effects + implant effects into Ability[].
+ *
+ * @param ship          The ship whose equipment and implants to inspect.
+ * @param getGearPiece  Inventory lookup — maps a gear id to a GearPiece (or undefined).
+ */
+export function buildEquipmentAbilities(
+    ship: Ship,
+    getGearPiece: (id: string) => GearPiece | undefined
+): Ability[] {
+    const abilities: Ability[] = [];
+
+    // ------------------------------------------------------------------
+    // 1. Active gear sets
+    // ------------------------------------------------------------------
+    // GEAR_SETS is a static constant — no runtime throws expected, so no per-set guard.
+    const setCounts: Record<string, number> = {};
+    for (const gearId of Object.values(ship.equipment ?? {})) {
+        if (!gearId) continue;
+        const piece = getGearPiece(gearId);
+        if (!piece?.setBonus) continue;
+        setCounts[piece.setBonus] = (setCounts[piece.setBonus] ?? 0) + 1;
+    }
+
+    for (const [setName, count] of Object.entries(setCounts)) {
+        const minPieces = GEAR_SETS[setName]?.minPieces ?? 2;
+        if (count < minPieces) continue;
+
+        const builder = GEAR_SET_ABILITIES[setName];
+        if (!builder) continue;
+
+        const partial = builder();
+        abilities.push({ id: `equip-set-${setName}`, ...partial });
+    }
+
+    // ------------------------------------------------------------------
+    // 2. Implants
+    // ------------------------------------------------------------------
+    for (const gearId of Object.values(ship.implants ?? {})) {
+        if (!gearId) continue;
+
+        try {
+            const piece = getGearPiece(gearId);
+            if (!piece?.setBonus) continue;
+
+            const implantName = piece.setBonus;
+            const implantData = IMPLANTS[implantName];
+            if (!implantData) continue;
+
+            const variant = implantData.variants.find((v) => v.rarity === piece.rarity);
+            if (!variant?.description) continue;
+
+            // Try the per-implant builder first (handles cases the text parser can't).
+            const builder = IMPLANT_ABILITIES[implantName];
+            if (builder) {
+                const partial = builder(piece.rarity);
+                if (!partial) continue;
+                abilities.push({
+                    ...partial,
+                    id: `equip-implant-${implantName}`,
+                });
+                continue;
+            }
+
+            // For implants not in the registry: the description text could not be
+            // reliably parsed for D-PR1 (the text parser lacks the "N% chance" proc-gate
+            // stamping path for reactive triggers). Skip gracefully — no ability emitted,
+            // no throw.
+        } catch {
+            // Per-piece errors never surface out of this function.
+        }
+    }
+
+    return abilities;
+}

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -62,6 +62,30 @@ const BLOODTHIRST_PROC_CHANCE: Record<string, number> = {
     legendary: 0.2,
 };
 
+const INTRUSION_PER_DEBUFF: Record<string, number> = {
+    common: 1,
+    uncommon: 2,
+    rare: 3,
+    epic: 4,
+    legendary: 5,
+};
+
+const ARCANE_SIEGE_PCT: Record<string, number> = {
+    common: 3,
+    uncommon: 6,
+    rare: 10,
+    epic: 15,
+    legendary: 20,
+};
+
+const WARPSTRIKE_PCT: Record<string, number> = {
+    common: 1,
+    uncommon: 2,
+    rare: 3,
+    epic: 4,
+    legendary: 5,
+};
+
 const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
     BLOODTHIRST: (rarity) => {
         const pct = BLOODTHIRST_HEAL_PCT[rarity];
@@ -78,6 +102,64 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
                 pct,
                 basis: 'damage-dealt',
             },
+            autoFilled: true,
+        };
+    },
+    // Intrusion: +N% outgoing direct damage per debuff on the target. Rides the modifier
+    // fold as a pure scaling modifier (value 0 + scaling); the enemy-debuff condition is a
+    // bare scaling source (no countComparator) so it scales, never gates.
+    INTRUSION: (rarity) => {
+        const perUnit = INTRUSION_PER_DEBUFF[rarity];
+        if (perUnit === undefined) return undefined;
+        return {
+            type: 'modifier',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [{ subject: 'enemy-debuff', derivable: true }],
+            scaling: { conditionIndex: 0, perUnit },
+            config: {
+                type: 'modifier',
+                channel: 'outgoingDamage',
+                value: 0,
+                isMultiplicative: false,
+            },
+            autoFilled: true,
+        };
+    },
+    // Arcane Siege: +X% outgoing direct damage while shielded. Flat value gated on the new
+    // self-shield condition; dormant until sub-project H grants shields in the sim.
+    ARCANE_SIEGE: (rarity) => {
+        const value = ARCANE_SIEGE_PCT[rarity];
+        if (value === undefined) return undefined;
+        return {
+            type: 'modifier',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [{ subject: 'self-shield', derivable: true }],
+            config: { type: 'modifier', channel: 'outgoingDamage', value, isMultiplicative: false },
+            autoFilled: true,
+        };
+    },
+    // Warpstrike (damage half only): +X% outgoing direct damage while self-debuffed. Flat
+    // value + a >=1 self-debuff gate (NOT scaling — scaledBonus uses the raw debuff count and
+    // would over-apply for multiple debuffs). The "reduce a random debuff's duration by 1
+    // turn" half is DEFERRED (self-debuff-mitigation / cleanse-family).
+    WARPSTRIKE: (rarity) => {
+        const value = WARPSTRIKE_PCT[rarity];
+        if (value === undefined) return undefined;
+        return {
+            type: 'modifier',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [
+                {
+                    subject: 'self-debuff',
+                    derivable: true,
+                    countComparator: 'gte',
+                    countThreshold: 1,
+                },
+            ],
+            config: { type: 'modifier', channel: 'outgoingDamage', value, isMultiplicative: false },
             autoFilled: true,
         };
     },

--- a/src/utils/abilities/buildShipAbilitiesWithEquipment.ts
+++ b/src/utils/abilities/buildShipAbilitiesWithEquipment.ts
@@ -1,0 +1,42 @@
+/**
+ * buildShipAbilitiesWithEquipment
+ *
+ * Thin wrapper around `buildShipAbilities` that merges equipment-derived abilities
+ * (gear-set bonuses + implant effects) into the passive skill slot.
+ *
+ * `buildShipAbilities` is left single-arg / untouched (Task 3 invariant).
+ * When `buildEquipmentAbilities` returns an empty list (no active gear sets, no
+ * ability-bearing implants, or a ship with no equipment at all) the result is
+ * byte-identical to calling `buildShipAbilities` directly — existing goldens are
+ * unaffected.
+ */
+
+import { Ship } from '../../types/ship';
+import { GearPiece } from '../../types/gear';
+import { ShipSkills } from '../../types/abilities';
+import { buildShipAbilities } from './buildShipAbilities';
+import { buildEquipmentAbilities } from './buildEquipmentAbilities';
+
+/**
+ * Build the full ability roster for a ship, including equipment-sourced abilities.
+ *
+ * @param ship          The ship to resolve abilities for.
+ * @param getGearPiece  Inventory lookup — maps a gear id to a GearPiece (or undefined).
+ * @returns             A ShipSkills object with equipment abilities appended to the passive slot.
+ */
+// Returns the same ShipSkills reference in both paths; in-place mutation is safe because buildShipAbilities allocates a fresh object per call.
+export function buildShipAbilitiesWithEquipment(
+    ship: Ship,
+    getGearPiece: (id: string) => GearPiece | undefined
+): ShipSkills {
+    const skills = buildShipAbilities(ship);
+    const equip = buildEquipmentAbilities(ship, getGearPiece);
+    if (!equip.length) return skills;
+    const passive = skills.slots.find((s) => s.slot === 'passive');
+    if (passive) {
+        passive.abilities.push(...equip);
+    } else {
+        skills.slots.push({ slot: 'passive', abilities: equip });
+    }
+    return skills;
+}

--- a/src/utils/abilities/evaluateConditions.ts
+++ b/src/utils/abilities/evaluateConditions.ts
@@ -26,6 +26,9 @@ export interface ConditionContext {
     /** True when the acting attacker's target was repaired (HP healed) earlier this
      *  round. Live-derived by the engine; defaults false (DPS / un-repaired). */
     targetRepairedThisRound?: boolean;
+    /** True when the condition owner currently has a shield (shieldPool > 0). Live-derived
+     *  by the engine; defaults false (no shield / DPS mode). Used by the Arcane Siege implant. */
+    selfShielded?: boolean;
 }
 
 /** Resolve one condition to a count (>= 0). 0 means "not met". */
@@ -75,6 +78,8 @@ export function evaluateCondition(cond: Condition, ctx: ConditionContext): numbe
             return ctx.isLowestSpeedAlly ? 1 : 0;
         case 'target-repaired-this-round':
             return ctx.targetRepairedThisRound ? 1 : 0;
+        case 'self-shield':
+            return ctx.selfShielded ? 1 : 0;
         default:
             return 0;
     }

--- a/src/utils/abilities/roundContext.ts
+++ b/src/utils/abilities/roundContext.ts
@@ -36,6 +36,8 @@ export function buildRoundContext(state: {
     isLowestSpeedAlly?: boolean;
     /** The acting attacker's target was repaired this round. Default false. */
     targetRepairedThisRound?: boolean;
+    /** True when the acting unit has a shield (shieldPool > 0). Default false. */
+    selfShielded?: boolean;
 }): ConditionContext {
     return {
         selfBuffNames: state.selfBuffNames,
@@ -57,6 +59,7 @@ export function buildRoundContext(state: {
         enemyHpPct: state.enemyHpPct ?? 100,
         isLowestSpeedAlly: state.isLowestSpeedAlly ?? true,
         targetRepairedThisRound: state.targetRepairedThisRound ?? false,
+        selfShielded: state.selfShielded ?? false,
         ...(state.roundCrit !== undefined ? { roundCrit: state.roundCrit } : {}),
     };
 }

--- a/src/utils/calculators/battleSimulator.ts
+++ b/src/utils/calculators/battleSimulator.ts
@@ -40,6 +40,9 @@ import type { CombatStatBlock } from '../../types/calculator';
 import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../combat/engine';
 import { createEventBus } from '../combat/events';
 import { buildShipAbilities } from '../abilities/buildShipAbilities';
+import { buildShipAbilitiesWithEquipment } from '../abilities/buildShipAbilitiesWithEquipment';
+import type { ShipSkills } from '../../types/abilities';
+import type { GearPiece } from '../../types/gear';
 import { selectFiringSkill } from '../abilities/applyAbilities';
 import { parseShipTargeting, SkillTargeting } from '../targetingParser';
 import { computeAffinityModifiers } from './affinityUtils';
@@ -510,14 +513,18 @@ interface PlacementPlan {
     name: string;
     position: Position;
     stats: DerivedCombatStats;
-    shipSkills: ReturnType<typeof buildShipAbilities>;
+    shipSkills: ShipSkills;
     affinity: AffinityName | undefined;
     /** Parsed ACTIVE targeting ({ target, pattern }); undefined if the ship has no targeting data. */
     targeting: SkillTargeting | undefined;
     chargeCount: number;
 }
 
-function planPlacement(p: BattlePlacement, id: string): PlacementPlan {
+function planPlacement(
+    p: BattlePlacement,
+    id: string,
+    getGearPiece?: (id: string) => GearPiece | undefined
+): PlacementPlan {
     const targeting = parseShipTargeting(p.ship);
     // Use the ACTIVE targeting (target + pattern). The engine input takes ONE target/pattern
     // per actor, so charged-skill targeting is a follow-up (PR2) — when a ship's charged
@@ -527,7 +534,9 @@ function planPlacement(p: BattlePlacement, id: string): PlacementPlan {
         name: p.ship.name,
         position: p.position,
         stats: resolveStats(p),
-        shipSkills: buildShipAbilities(p.ship),
+        shipSkills: getGearPiece
+            ? buildShipAbilitiesWithEquipment(p.ship, getGearPiece)
+            : buildShipAbilities(p.ship),
         affinity: p.ship.affinity,
         targeting: targeting.active,
         chargeCount: p.ship.chargeSkillCharge ?? 0,
@@ -557,7 +566,10 @@ function planPlacement(p: BattlePlacement, id: string): PlacementPlan {
  * Actor ids are minted globally-unique across both squads (`p:<shipId>:<idx>` / `e:<shipId>:<idx>`),
  * avoiding the reserved `'attacker'`/`'enemy'` ids and any duplicate (runCombat throws on either).
  */
-export function simulateBattle(input: BattleSimulationInput): BattleResult {
+export function simulateBattle(
+    input: BattleSimulationInput,
+    getGearPiece?: (id: string) => GearPiece | undefined
+): BattleResult {
     // Validate inputs up front (trust boundary): empty teams or a bad round count
     // would otherwise flow through and produce misleading draw/empty outcomes.
     if (input.playerTeam.length === 0) {
@@ -577,9 +589,11 @@ export function simulateBattle(input: BattleSimulationInput): BattleResult {
     // team + every enemy get minted globally-unique ids that avoid `'attacker'`/`'enemy'`.
     const FOCUS_ID = 'attacker';
     const playerPlans = input.playerTeam.map((p, i) =>
-        planPlacement(p, i === 0 ? FOCUS_ID : `p:${p.ship.id}:${i}`)
+        planPlacement(p, i === 0 ? FOCUS_ID : `p:${p.ship.id}:${i}`, getGearPiece)
     );
-    const enemyPlans = input.enemyTeam.map((p, i) => planPlacement(p, `e:${p.ship.id}:${i}`));
+    const enemyPlans = input.enemyTeam.map((p, i) =>
+        planPlacement(p, `e:${p.ship.id}:${i}`, getGearPiece)
+    );
 
     // Representative opposing affinity for each side's matchup resolution (first opponent).
     const enemyRepAffinity = enemyPlans[0]?.affinity;

--- a/src/utils/combat/__tests__/enemyActions.test.ts
+++ b/src/utils/combat/__tests__/enemyActions.test.ts
@@ -266,15 +266,25 @@ describe('Phase 4c PR 4 Task 5a: event-only enemy heal/cleanse emission', () => 
             },
             grantShieldToTarget: (raw) => shields.push(raw),
             playerIds: ['enemy1', 'tank'],
+            // E5: an enemy single-'ally' heal routes to the lowest-HP living enemy ally; here the
+            // sole enemy ally is the caster itself ('enemy1'), a living stand-in (currentHp > 0).
+            enemyIds: ['enemy1'],
+            recipientActor: (id) =>
+                id === 'enemy1' ? ({ id, currentHp: 10000 } as CombatActor) : undefined,
         };
         return { healing, credits, applied, shields };
     };
 
     // An enemy-side runtime whose ACTIVE cast skill heals an ally and cleanses.
-    const makeRuntime = (skills: ShipSkills): PlayerActorRuntime => {
+    // `side` mirrors the real engine: an ENEMY caster (event-only path) carries side:'enemy'
+    // so E5's side-aware recipient routing fires; the normal-mode (player) test uses 'player'.
+    const makeRuntime = (
+        skills: ShipSkills,
+        side: CombatActor['side'] = 'player'
+    ): PlayerActorRuntime => {
         const actor = createActor({
             id: 'enemy1',
-            side: 'player', // runPlayerTurn is side-agnostic; the engine flags enemy via healEventOnly
+            side,
             kind: 'attacker',
             stats: {
                 attack: 5000,
@@ -388,10 +398,12 @@ describe('Phase 4c PR 4 Task 5a: event-only enemy heal/cleanse emission', () => 
         ],
     });
 
-    it('emits heal-performed + cleanse-performed with the actor id and mutates NOTHING', () => {
+    it('E5: enemy heal RESTORES HP + emits a real heal-performed amount, still NO player credit', () => {
         const events: CombatEvent[] = [];
         const spy = makeHealingSpy();
-        const args = makeArgs(makeRuntime(healCleanseSkills()), spy.healing, true);
+        // side:'enemy' → E5 side-aware routing: the 'ally' heal targets the lowest-HP enemy ally
+        // (the caster itself here), and applyHealToTarget runs on the enemy path.
+        const args = makeArgs(makeRuntime(healCleanseSkills(), 'enemy'), spy.healing, true);
         args.bus.on('heal-performed', (e) => events.push(e));
         args.bus.on('cleanse-performed', (e) => events.push(e));
 
@@ -406,13 +418,15 @@ describe('Phase 4c PR 4 Task 5a: event-only enemy heal/cleanse emission', () => 
         expect(cleanse!.count).toBe(2);
         expect(heal).toBeDefined();
         expect(heal!.casterId).toBe('enemy1');
-        // Event-only heal carries NO numeric (amount 0, no crit info).
-        expect(heal!.amount).toBe(0);
+        // E5: heal-performed now carries the REAL amount (effectiveHp 10000 × 20% basis 'hp');
+        // no crit (noGate → false) so critHits stays absent.
+        expect(heal!.amount).toBe(2000);
         expect(heal!.critHits).toBeUndefined();
 
-        // CRITICAL: not a single healing.* mutation ran in event-only mode.
+        // E5: the heal IS applied to the enemy's own pool (applied received the raw)...
+        expect(spy.applied).toEqual([2000]);
+        // ...but NOTHING is credited to the player healing buckets, and no shield was granted.
         expect(spy.credits).toHaveLength(0);
-        expect(spy.applied).toHaveLength(0);
         expect(spy.shields).toHaveLength(0);
     });
 
@@ -486,6 +500,9 @@ describe('Phase 4c PR 4 Task 5 fix: HoT ticking is gated behind healEventOnly', 
             },
             grantShieldToTarget: (raw) => shields.push(raw),
             playerIds: ['attacker', 'tank'],
+            // E5 fields (unused by the HoT-ticking path — present for type-correctness).
+            enemyIds: ['attacker'],
+            recipientActor: (id) => ({ id, currentHp: 10000 }) as CombatActor,
         };
         return { healing, credits, applied, shields };
     };

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -1,0 +1,301 @@
+/**
+ * D-PR1: end-to-end engine integration — Leech standing leech + Bloodthirst proc frequency.
+ *
+ * Both tests use `buildShipAbilitiesWithEquipment` with a stub `getGearPiece`, exercising the
+ * real resolution→merge→engine path (Tasks 2+3+engine pickup), not just ability injection.
+ *
+ * Leech (standing leech):
+ *   The Leech set ability has trigger 'on-cast', so it stays in castSkills after the
+ *   reactive partition and is picked up by the standing-leech scan (engine.ts ~2037-2057).
+ *   With attackerHealModifier=0, noCrit:true on the ability, and 1 round of damage D,
+ *   the credited directHeal is exactly 0.15 × D.
+ *
+ * Bloodthirst (reactive on-crit heal):
+ *   The Bloodthirst ability has trigger 'on-crit', so it routes to reactiveAbilities →
+ *   registered as a listener that fires once per critting hit. procChance 0.20 over 10
+ *   rounds (1 crit/round) → floor(10 × 0.20) = 2 fires (accumulator back-loaded: rounds
+ *   5 and 10 — acc accumulates 0.20 per crit and first crosses 1.0 on the 5th call).
+ *   basis 'damage-dealt' resolves in the reactive executor as the owner's max HP (the
+ *   fallthrough branch — not damage-dealt scaling off the attack amount). With hp=10000
+ *   and pct=20: each fire credits directHeal of 10000 × 0.20 × healModifier(0) = 2000.
+ *   2 fires → 4000 total.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { ShipSkills } from '../../../types/abilities';
+import { Ship } from '../../../types/ship';
+import { GearPiece } from '../../../types/gear';
+import { buildShipAbilitiesWithEquipment } from '../../abilities/buildShipAbilitiesWithEquipment';
+
+// ---------------------------------------------------------------------------
+// Shared test harness helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal Ship stub. Equipment and implants are provided by overrides. */
+function makeShip(over: Partial<Ship>): Ship {
+    return {
+        id: 'test-ship',
+        name: 'Test Ship',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'ATTACKER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        ...over,
+    } as Ship;
+}
+
+/** Minimal GearPiece stub. */
+function makePiece(over: Partial<GearPiece>): GearPiece {
+    return {
+        id: 'piece-1',
+        slot: 'weapon',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: null,
+        ...over,
+    } as GearPiece;
+}
+
+/** getGearPiece factory backed by an id→GearPiece map. */
+function makeGetGearPiece(map: Record<string, GearPiece>): (id: string) => GearPiece | undefined {
+    return (id) => map[id];
+}
+
+/** Sum a heal bucket over all rounds for the given actor (default: 'attacker'). */
+function sumHeal(
+    result: ReturnType<typeof runCombat>,
+    bucket: 'directHeal' | 'effectiveHeal' | 'overheal',
+    actorId = 'attacker'
+): number {
+    return (result.healing?.rounds ?? []).reduce(
+        (sum, rd) => sum + (rd.perActor.get(actorId)?.[bucket] ?? 0),
+        0
+    );
+}
+
+/** Base engine input: neutral stats, enemy never dies, healing mode on (focus is target). */
+const BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 5000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [] },
+    enemyDefense: 0,
+    enemyHp: 10_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 2000,
+    hp: 10_000,
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Gear stubs shared across tests
+// ---------------------------------------------------------------------------
+
+const leechPieceA = makePiece({ id: 'leech-1', slot: 'weapon', setBonus: 'LEECH' });
+const leechPieceB = makePiece({ id: 'leech-2', slot: 'hull', setBonus: 'LEECH' });
+const bloodthirstPiece = makePiece({
+    id: 'bt-legendary',
+    slot: 'implant_major',
+    rarity: 'legendary',
+    setBonus: 'BLOODTHIRST',
+});
+
+// ---------------------------------------------------------------------------
+// Test 1: Leech set standing leech — full end-to-end
+// ---------------------------------------------------------------------------
+
+describe('D-PR1 integration — Leech set standing leech', () => {
+    /**
+     * Setup:
+     *   - Ship equipped with 2 LEECH-set pieces (activates the Leech set ability via buildEquipmentAbilities).
+     *   - buildShipAbilitiesWithEquipment merges the Leech ability into the passive slot.
+     *   - Active slot: a single-hit damage ability with multiplier 100 (attack 5000 → damage 5000).
+     *   - healModifier: 0 (so raw = pct × damage, no further folds).
+     *   - Leech ability config: pct 15, basis 'damage-dealt', noCrit:true.
+     *   - Expected directHeal = 0.15 × 5000 = 750.
+     *
+     * The standing-leech scan (engine.ts ~2037) reads from the attacker's castSkills passive slot.
+     * Because the Leech ability has trigger 'on-cast' (NOT in LIVE_TRIGGERS), it stays in castSkills
+     * after the reactive partition and IS picked up. This test exercises that full path.
+     */
+    it('Leech set: standing leech credits directHeal = 0.15 × damage (full build→merge→engine path)', () => {
+        const ship = makeShip({
+            equipment: { weapon: 'leech-1', hull: 'leech-2' },
+        });
+        const getGearPiece = makeGetGearPiece({
+            'leech-1': leechPieceA,
+            'leech-2': leechPieceB,
+        });
+
+        // Real resolution+merge path: tasks 2+3.
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+
+        // Verify the Leech ability landed in the passive slot (pre-condition).
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        const leechAbility = passive!.abilities.find((a) => a.id === 'equip-set-LEECH');
+        expect(leechAbility).toBeDefined();
+
+        // Append a damage active so the attacker deals damage that the standing leech can latch onto.
+        const shipSkills: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'dmg-active',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 100, hits: 1 },
+                        },
+                    ],
+                },
+                // Carry over the full passive slot (Leech + any ship own passives).
+                ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+            ],
+        };
+
+        // attack 5000, mult 100, enemyDefense 0 → direct damage = 5000.
+        // Leech: 15% of 5000 = 750. healModifier 0, noCrit:true → directHeal = 750.
+        const D = 5000;
+        const result = runCombat(
+            BASE({
+                attack: D,
+                crit: 0,
+                critDamage: 0,
+                healModifier: 0,
+                numRounds: 1,
+                hp: 10_000,
+                shipSkills,
+            })
+        );
+
+        expect(result.healing).toBeDefined();
+        // directHeal must equal 15% of direct damage dealt.
+        expect(sumHeal(result, 'directHeal')).toBeCloseTo(0.15 * D, 6);
+        // Full HP → all overheal, no effectiveHeal.
+        expect(sumHeal(result, 'effectiveHeal')).toBeCloseTo(0, 6);
+        expect(sumHeal(result, 'overheal')).toBeCloseTo(0.15 * D, 6);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: Bloodthirst implant (legendary) — proc frequency + per-fire amount
+// ---------------------------------------------------------------------------
+
+describe('D-PR1 integration — Bloodthirst implant proc frequency', () => {
+    /**
+     * Setup:
+     *   - Ship equipped with legendary Bloodthirst implant (procChance 0.20, pct 20).
+     *   - buildShipAbilitiesWithEquipment merges the on-crit reactive ability into the passive slot.
+     *   - Active slot: 1-hit damage ability. crit 100 → 1 crit per round for 10 rounds.
+     *   - procChance 0.20 → accumulator fires floor(10×0.20)=2 times (back-loaded: rounds 5, 10).
+     *     The rateAccumulator starts at 0 and accumulates +0.20 per qualifying crit. It fires
+     *     when acc >= 1: first fire at call 5 (acc 0.2→0.4→0.6→0.8→1.0), second at call 10.
+     *   - Each fire: basis 'damage-dealt' resolves in the reactive executor as the owner's max HP
+     *     (fallthrough branch — same as 'hp'). hp=10000, pct=20 → raw = 10000 × 0.20 = 2000.
+     *     healModifier 0, no outgoing/incoming buffs → directHeal per fire = 2000.
+     *   - Total directHeal over 10 rounds = 2 × 2000 = 4000.
+     *
+     * Two assertions:
+     *   (a) fire count = 2 and fires on rounds 5 and 10 (back-loaded accumulator schedule).
+     *   (b) summed directHeal = 4000.
+     */
+    it('Bloodthirst legendary: fires floor(10 × 0.20)=2 times over 10 crits; total directHeal = 2×2000', () => {
+        const ship = makeShip({
+            implants: { implant_major: 'bt-legendary' },
+        });
+        const getGearPiece = makeGetGearPiece({ 'bt-legendary': bloodthirstPiece });
+
+        // Real resolution+merge path: tasks 2+3.
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+
+        // Verify the Bloodthirst ability landed in the passive slot (pre-condition).
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        const btAbility = passive!.abilities.find((a) => a.id === 'equip-implant-BLOODTHIRST');
+        expect(btAbility).toBeDefined();
+        expect(btAbility!.procChance).toBeCloseTo(0.2);
+
+        // Append a damage active. crit 100 → every hit crits → on-crit listener fires once/round.
+        const shipSkills: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'dmg-active',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 100, hits: 1 },
+                        },
+                    ],
+                },
+                ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+            ],
+        };
+
+        // Each reactive-heal fire: basis 'damage-dealt' → owner hp fallthrough = 10000.
+        // pct 20 → raw = 10000 × 0.20 = 2000. procChance 0.20 over 10 crits → 2 fires.
+        const perFireAmount = 10_000 * (20 / 100); // = 2000
+        const expectedFires = Math.floor(10 * 0.2); // = 2
+        const expectedTotal = expectedFires * perFireAmount; // = 4000
+
+        const result = runCombat(
+            BASE({
+                attack: 5000,
+                crit: 100,
+                critDamage: 0,
+                healModifier: 0,
+                numRounds: 10,
+                hp: 10_000,
+                shipSkills,
+            })
+        );
+
+        expect(result.healing).toBeDefined();
+        expect(result.healing!.rounds).toHaveLength(10);
+
+        // (b) total direct heal = 4000.
+        expect(sumHeal(result, 'directHeal')).toBeCloseTo(expectedTotal, 6);
+
+        // (a) fire count: back-loaded accumulator fires on rounds 2 and 10.
+        const firedRounds = result
+            .healing!.rounds.map((rd, i) => ({
+                round: i + 1,
+                heal: rd.perActor.get('attacker')?.directHeal ?? 0,
+            }))
+            .filter((r) => r.heal > 0);
+        expect(firedRounds).toHaveLength(expectedFires);
+        // Back-loaded accumulator: with rate 0.20, the gate crosses 1 at call 5 and call 10.
+        // Fires on rounds 5 and 10 (not 2 and 10 — that is the 0.5 schedule).
+        expect(firedRounds[0].round).toBe(5);
+        expect(firedRounds[1].round).toBe(10);
+        // Each fire credits exactly perFireAmount.
+        for (const r of firedRounds) {
+            expect(r.heal).toBeCloseTo(perFireAmount, 6);
+        }
+    });
+});

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -15,10 +15,11 @@
  *   registered as a listener that fires once per critting hit. procChance 0.20 over 10
  *   rounds (1 crit/round) → floor(10 × 0.20) = 2 fires (accumulator back-loaded: rounds
  *   5 and 10 — acc accumulates 0.20 per crit and first crosses 1.0 on the 5th call).
- *   basis 'damage-dealt' resolves in the reactive executor as the owner's max HP (the
- *   fallthrough branch — not damage-dealt scaling off the attack amount). With hp=10000
- *   and pct=20: each fire credits directHeal of 10000 × 0.20 × healModifier(0) = 2000.
- *   2 fires → 4000 total.
+ *   basis 'damage-dealt': the reactive executor now resolves this as the triggering hit's
+ *   damage (eventCtx.triggerDamage), captured from ability-performed.damage on the on-crit
+ *   listener. Crit damage computation: attack=5000, multiplier=100%, critDamage=0,
+ *   enemyDefense=0 → directDamage = 5000 * 1.0 * 1.0 = 5000. Each fire: pct=20 →
+ *   directHeal = 5000 × 0.20 = 1000. 2 fires → 2000 total.
  */
 import { describe, it, expect } from 'vitest';
 import { runCombat, CombatEngineInput } from '../engine';
@@ -212,16 +213,17 @@ describe('D-PR1 integration — Bloodthirst implant proc frequency', () => {
      *   - procChance 0.20 → accumulator fires floor(10×0.20)=2 times (back-loaded: rounds 5, 10).
      *     The rateAccumulator starts at 0 and accumulates +0.20 per qualifying crit. It fires
      *     when acc >= 1: first fire at call 5 (acc 0.2→0.4→0.6→0.8→1.0), second at call 10.
-     *   - Each fire: basis 'damage-dealt' resolves in the reactive executor as the owner's max HP
-     *     (fallthrough branch — same as 'hp'). hp=10000, pct=20 → raw = 10000 × 0.20 = 2000.
-     *     healModifier 0, no outgoing/incoming buffs → directHeal per fire = 2000.
-     *   - Total directHeal over 10 rounds = 2 × 2000 = 4000.
+     *   - Each fire: basis 'damage-dealt' now resolves as the triggering hit's damage
+     *     (eventCtx.triggerDamage, captured from ability-performed.damage). Crit damage:
+     *     attack=5000, multiplier=100%, critDamage=0, enemyDefense=0 → directDamage=5000.
+     *     pct=20 → raw = 5000 × 0.20 = 1000. healModifier 0 → directHeal per fire = 1000.
+     *   - Total directHeal over 10 rounds = 2 × 1000 = 2000.
      *
      * Two assertions:
      *   (a) fire count = 2 and fires on rounds 5 and 10 (back-loaded accumulator schedule).
-     *   (b) summed directHeal = 4000.
+     *   (b) summed directHeal = 2000.
      */
-    it('Bloodthirst legendary: fires floor(10 × 0.20)=2 times over 10 crits; total directHeal = 2×2000', () => {
+    it('Bloodthirst legendary: fires floor(10 × 0.20)=2 times over 10 crits; total directHeal = 2×1000', () => {
         const ship = makeShip({
             implants: { implant_major: 'bt-legendary' },
         });
@@ -257,11 +259,13 @@ describe('D-PR1 integration — Bloodthirst implant proc frequency', () => {
             ],
         };
 
-        // Each reactive-heal fire: basis 'damage-dealt' → owner hp fallthrough = 10000.
-        // pct 20 → raw = 10000 × 0.20 = 2000. procChance 0.20 over 10 crits → 2 fires.
-        const perFireAmount = 10_000 * (20 / 100); // = 2000
+        // Each reactive-heal fire: basis 'damage-dealt' → eventCtx.triggerDamage = directDamage.
+        // attack=5000, multiplier=100%, critDamage=0, enemyDefense=0 → directDamage=5000.
+        // pct 20 → raw = 5000 × 0.20 = 1000. procChance 0.20 over 10 crits → 2 fires.
+        const critDamage = 5000; // attack 5000 × mult 1.0 × critMult 1.0 (critDamage=0) × noDefense
+        const perFireAmount = critDamage * (20 / 100); // = 1000
         const expectedFires = Math.floor(10 * 0.2); // = 2
-        const expectedTotal = expectedFires * perFireAmount; // = 4000
+        const expectedTotal = expectedFires * perFireAmount; // = 2000
 
         const result = runCombat(
             BASE({
@@ -278,10 +282,10 @@ describe('D-PR1 integration — Bloodthirst implant proc frequency', () => {
         expect(result.healing).toBeDefined();
         expect(result.healing!.rounds).toHaveLength(10);
 
-        // (b) total direct heal = 4000.
+        // (b) total direct heal = 2000 (2 fires × 1000 per fire).
         expect(sumHeal(result, 'directHeal')).toBeCloseTo(expectedTotal, 6);
 
-        // (a) fire count: back-loaded accumulator fires on rounds 2 and 10.
+        // (a) fire count: back-loaded accumulator fires on rounds 5 and 10.
         const firedRounds = result
             .healing!.rounds.map((rd, i) => ({
                 round: i + 1,

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -27,6 +27,10 @@ import { ShipSkills } from '../../../types/abilities';
 import { Ship } from '../../../types/ship';
 import { GearPiece } from '../../../types/gear';
 import { buildShipAbilitiesWithEquipment } from '../../abilities/buildShipAbilitiesWithEquipment';
+import { buildEquipmentAbilities } from '../../abilities/buildEquipmentAbilities';
+import { modifierTotalsFromAbilities } from '../../abilities/applyAbilities';
+import { ConditionContext } from '../../abilities/evaluateConditions';
+import { SelectedGameBuff } from '../../../types/calculator';
 
 // ---------------------------------------------------------------------------
 // Shared test harness helpers
@@ -302,4 +306,334 @@ describe('D-PR1 integration — Bloodthirst implant proc frequency', () => {
             expect(r.heal).toBeCloseTo(perFireAmount, 6);
         }
     });
+});
+
+// ---------------------------------------------------------------------------
+// D-PR2 — conditional outgoing-damage implants
+// ---------------------------------------------------------------------------
+//
+// Three implants now live in the equipment-ability registry as passive `modifier`
+// abilities with channel 'outgoingDamage'. These tests exercise the REAL fold path:
+//   buildEquipmentAbilities → Ability[] → modifierTotalsFromAbilities(abilities, ctx)
+// which is identical to the path the engine walks inside effectiveDamageStatsOf.
+//
+// Step 1 tests are FOLD-LEVEL (fast, deterministic): they prove the correct
+// value is accumulated into totals.outgoingDamage for each implant.
+// Step 2 is an ENGINE-LEVEL smoke-test for INTRUSION (the scaling implant):
+// it runs the full runCombat pipeline and asserts directDamage amplification.
+
+/** Minimal ConditionContext with the same required fields as evaluateConditions.test.ts. */
+const makeCtx = (over: Partial<ConditionContext> = {}): ConditionContext => ({
+    selfBuffNames: [],
+    selfDebuffNames: [],
+    enemyBuffNames: [],
+    enemyDebuffCount: 0,
+    effectiveCritRate: 0,
+    adjacentAllyCount: 0,
+    enemyAdjacentCount: 0,
+    enemyDestroyedCount: 0,
+    selfHpPct: 100,
+    enemyHpPct: 100,
+    ...over,
+});
+
+// ---------------------------------------------------------------------------
+// Gear-piece stubs for the three D-PR2 implants
+// ---------------------------------------------------------------------------
+
+/** INTRUSION legendary: +5% outgoing damage per enemy debuff (value 0, perUnit 5). */
+const intrusionPiece = makePiece({
+    id: 'intrusion-legendary',
+    slot: 'implant_major',
+    rarity: 'legendary',
+    setBonus: 'INTRUSION',
+});
+
+/** ARCANE_SIEGE epic: +15% outgoing damage while shielded (flat value 15). */
+const arcaneSiegePiece = makePiece({
+    id: 'arcane-siege-epic',
+    slot: 'implant_minor',
+    rarity: 'epic',
+    setBonus: 'ARCANE_SIEGE',
+});
+
+/** WARPSTRIKE legendary: +5% outgoing damage while self-debuffed (flat, >=1 gate). */
+const warpstrikePiece = makePiece({
+    id: 'warpstrike-legendary',
+    slot: 'implant_major',
+    rarity: 'legendary',
+    setBonus: 'WARPSTRIKE',
+});
+
+// ---------------------------------------------------------------------------
+// Step 1: modifier-fold-level integration tests
+// ---------------------------------------------------------------------------
+
+describe('D-PR2 integration — INTRUSION fold (modifier-level)', () => {
+    /**
+     * INTRUSION legendary: value:0, scaling:{conditionIndex:0, perUnit:5}, condition: enemy-debuff.
+     * The scaling condition has no countComparator → it is a BARE scaling source (gateConditions
+     * strips it), so the ability folds unconditionally with bonus = enemyDebuffCount × perUnit.
+     *
+     * At enemyDebuffCount:3 → 0 + 3×5 = 15.
+     * At enemyDebuffCount:0 → 0 + 0×5 = 0.
+     */
+    it('outgoingDamage === 15 when enemyDebuffCount:3 (legendary, 3×5%)', () => {
+        const ship = makeShip({ implants: { implant_major: 'intrusion-legendary' } });
+        const getGearPiece = makeGetGearPiece({ 'intrusion-legendary': intrusionPiece });
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+
+        const intrusion = abilities.find((a) => a.id === 'equip-implant-INTRUSION');
+        expect(intrusion).toBeDefined();
+
+        const totals = modifierTotalsFromAbilities([intrusion!], makeCtx({ enemyDebuffCount: 3 }));
+        expect(totals.outgoingDamage).toBe(15); // 3 × 5
+    });
+
+    it('outgoingDamage === 0 when enemyDebuffCount:0 (no debuffs → zero bonus)', () => {
+        const ship = makeShip({ implants: { implant_major: 'intrusion-legendary' } });
+        const getGearPiece = makeGetGearPiece({ 'intrusion-legendary': intrusionPiece });
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        const intrusion = abilities.find((a) => a.id === 'equip-implant-INTRUSION');
+
+        const totals = modifierTotalsFromAbilities([intrusion!], makeCtx({ enemyDebuffCount: 0 }));
+        expect(totals.outgoingDamage).toBe(0);
+    });
+});
+
+describe('D-PR2 integration — WARPSTRIKE fold (modifier-level)', () => {
+    /**
+     * WARPSTRIKE legendary: flat value:5, condition: self-debuff >=1 (countComparator:'gte',
+     * countThreshold:1). This condition HAS a countComparator, so gateConditions keeps it as
+     * a GATE (not just a scaler). The flat value fires once (not per-debuff).
+     *
+     * Load-bearing assertion: with selfDebuffNames:['A','B'] (2 debuffs) → still === 5,
+     * NOT 10. This proves the flat-value+gate choice (the value does NOT scale with count).
+     */
+    it('outgoingDamage === 5 when selfDebuffNames:["Burn"] (legendary, 1 debuff → flat value)', () => {
+        const ship = makeShip({ implants: { implant_major: 'warpstrike-legendary' } });
+        const getGearPiece = makeGetGearPiece({ 'warpstrike-legendary': warpstrikePiece });
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        const warpstrike = abilities.find((a) => a.id === 'equip-implant-WARPSTRIKE');
+        expect(warpstrike).toBeDefined();
+
+        const totals = modifierTotalsFromAbilities(
+            [warpstrike!],
+            makeCtx({ selfDebuffNames: ['Burn'] })
+        );
+        expect(totals.outgoingDamage).toBe(5);
+    });
+
+    it('outgoingDamage === 0 when selfDebuffNames:[] (no self-debuffs → gate fails)', () => {
+        const ship = makeShip({ implants: { implant_major: 'warpstrike-legendary' } });
+        const getGearPiece = makeGetGearPiece({ 'warpstrike-legendary': warpstrikePiece });
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        const warpstrike = abilities.find((a) => a.id === 'equip-implant-WARPSTRIKE');
+
+        const totals = modifierTotalsFromAbilities([warpstrike!], makeCtx({ selfDebuffNames: [] }));
+        expect(totals.outgoingDamage).toBe(0);
+    });
+
+    it(
+        'outgoingDamage === 5 (NOT 10) when selfDebuffNames:["A","B"] — ' +
+            'flat value, not per-count (load-bearing: proves gate-not-scaler)',
+        () => {
+            const ship = makeShip({ implants: { implant_major: 'warpstrike-legendary' } });
+            const getGearPiece = makeGetGearPiece({ 'warpstrike-legendary': warpstrikePiece });
+            const abilities = buildEquipmentAbilities(ship, getGearPiece);
+            const warpstrike = abilities.find((a) => a.id === 'equip-implant-WARPSTRIKE');
+
+            const totals = modifierTotalsFromAbilities(
+                [warpstrike!],
+                makeCtx({ selfDebuffNames: ['A', 'B'] })
+            );
+            // Flat value gates once — does NOT scale with debuff count.
+            expect(totals.outgoingDamage).toBe(5);
+        }
+    );
+});
+
+describe('D-PR2 integration — ARCANE_SIEGE fold (modifier-level)', () => {
+    /**
+     * ARCANE_SIEGE epic: flat value:15, condition: self-shield (derivable). The self-shield
+     * condition returns selfShielded ? 1 : 0. With countComparator absent it gates on count > 0.
+     */
+    it('outgoingDamage === 15 when selfShielded:true (epic, +15% while shielded)', () => {
+        const ship = makeShip({ implants: { implant_minor: 'arcane-siege-epic' } });
+        const getGearPiece = makeGetGearPiece({ 'arcane-siege-epic': arcaneSiegePiece });
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        const arcaneSiege = abilities.find((a) => a.id === 'equip-implant-ARCANE_SIEGE');
+        expect(arcaneSiege).toBeDefined();
+
+        const totals = modifierTotalsFromAbilities([arcaneSiege!], makeCtx({ selfShielded: true }));
+        expect(totals.outgoingDamage).toBe(15);
+    });
+
+    it('outgoingDamage === 0 when selfShielded:false (gate fails — dormant without shield)', () => {
+        const ship = makeShip({ implants: { implant_minor: 'arcane-siege-epic' } });
+        const getGearPiece = makeGetGearPiece({ 'arcane-siege-epic': arcaneSiegePiece });
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        const arcaneSiege = abilities.find((a) => a.id === 'equip-implant-ARCANE_SIEGE');
+
+        const totals = modifierTotalsFromAbilities(
+            [arcaneSiege!],
+            makeCtx({ selfShielded: false })
+        );
+        expect(totals.outgoingDamage).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Step 2: engine-level smoke test — INTRUSION amplifies direct damage end-to-end
+// ---------------------------------------------------------------------------
+//
+// Assertion form used: QUALITATIVE (strictly more / exactly equal) rather than
+// exact ratio. Reason: the exact per-round debuff count reaching modifierCtx
+// depends on how many scheduled SelectedGameBuff entries resolve as "landed"
+// active buffs on that specific round, which involves the status engine's
+// application timing (recurring vs timed) and the landedEnemyDebuffs array
+// accumulation. Computing the exact expected ratio would require reimplementing
+// that pipeline here. The qualitative assertion is sufficient to confirm that
+// (a) the INTRUSION passive ability is picked up by the engine's modifier fold,
+// (b) non-zero enemyDebuffCount produces a positive outgoingDamage boost, and
+// (c) the boost is absent when there are no debuffs.
+// The Step 1 fold-level tests provide the exact quantitative coverage.
+
+describe('D-PR2 integration — INTRUSION engine-level (outgoing damage amplified)', () => {
+    /**
+     * Minimal SelectedGameBuff stub for an enemy debuff. The parsedEffects only need
+     * to be non-null (the debuff contribution that matters here is PRESENCE in the
+     * landed-debuff count, not the buff's own numeric effects on damage).
+     * skillDuration:'recurring' → the debuff is active every round without needing
+     * a charge schedule (mirrors the "recurring" scheduling in the status engine).
+     */
+    function makeEnemyDebuff(name: string): SelectedGameBuff {
+        return {
+            id: `test-debuff-${name}`,
+            buffName: name,
+            stacks: 1,
+            parsedEffects: {},
+            isStackable: false,
+            skillDuration: 'recurring',
+            autoFilled: false,
+        };
+    }
+
+    /** Ship with legendary INTRUSION implant. Passive slot injected from buildShipAbilitiesWithEquipment. */
+    function buildIntrusionShipSkills(): ShipSkills {
+        const ship = makeShip({ implants: { implant_major: 'intrusion-legendary' } });
+        const getGearPiece = makeGetGearPiece({ 'intrusion-legendary': intrusionPiece });
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+
+        return {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'dmg-active',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 100, hits: 1 },
+                        },
+                    ],
+                },
+                ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+            ],
+        };
+    }
+
+    /** Ship with NO implant — bare damage active only. */
+    const bareShipSkills: ShipSkills = {
+        slots: [
+            {
+                slot: 'active',
+                abilities: [
+                    {
+                        id: 'dmg-active',
+                        type: 'damage',
+                        target: 'enemy',
+                        trigger: 'on-cast',
+                        conditions: [],
+                        config: { type: 'damage', multiplier: 100, hits: 1 },
+                    },
+                ],
+            },
+        ],
+    };
+
+    it(
+        'INTRUSION legendary: directDamage > bare when 3 enemy debuffs are active; ' +
+            'directDamage === bare with no debuffs',
+        () => {
+            const ATTACK = 10_000;
+            // Three recurring enemy debuffs — all land every round.
+            const threeDebuffs = [
+                makeEnemyDebuff('Corrosion'),
+                makeEnemyDebuff('Inferno'),
+                makeEnemyDebuff('Armor Break'),
+            ];
+
+            // Intrusion + debuffs present → modifier should boost outgoingDamage.
+            const withIntrusionWithDebuffs = runCombat(
+                BASE({
+                    attack: ATTACK,
+                    crit: 0,
+                    critDamage: 0,
+                    numRounds: 1,
+                    enemyDebuffs: threeDebuffs,
+                    shipSkills: buildIntrusionShipSkills(),
+                })
+            );
+
+            // Bare (no Intrusion) + same debuffs → no modifier.
+            const bareWithDebuffs = runCombat(
+                BASE({
+                    attack: ATTACK,
+                    crit: 0,
+                    critDamage: 0,
+                    numRounds: 1,
+                    enemyDebuffs: threeDebuffs,
+                    shipSkills: bareShipSkills,
+                })
+            );
+
+            // Intrusion + no debuffs → modifier is 0, same as bare.
+            const withIntrusionNoDebuffs = runCombat(
+                BASE({
+                    attack: ATTACK,
+                    crit: 0,
+                    critDamage: 0,
+                    numRounds: 1,
+                    enemyDebuffs: [],
+                    shipSkills: buildIntrusionShipSkills(),
+                })
+            );
+
+            // Bare + no debuffs → baseline.
+            const bareNoDebuffs = runCombat(
+                BASE({
+                    attack: ATTACK,
+                    crit: 0,
+                    critDamage: 0,
+                    numRounds: 1,
+                    enemyDebuffs: [],
+                    shipSkills: bareShipSkills,
+                })
+            );
+
+            // Qualitative assertion A: INTRUSION fires when debuffs are present.
+            // Intrusion-equipped attacker MUST deal strictly more direct damage than bare.
+            expect(withIntrusionWithDebuffs.rawTotals.direct).toBeGreaterThan(
+                bareWithDebuffs.rawTotals.direct
+            );
+
+            // Qualitative assertion B: INTRUSION is dormant when no debuffs are present.
+            // Direct damage must equal the bare baseline.
+            expect(withIntrusionNoDebuffs.rawTotals.direct).toBe(bareNoDebuffs.rawTotals.direct);
+        }
+    );
 });

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -23,13 +23,13 @@
  */
 import { describe, it, expect } from 'vitest';
 import { runCombat, CombatEngineInput } from '../engine';
-import { ShipSkills } from '../../../types/abilities';
+import { Ability, ShipSkills } from '../../../types/abilities';
 import { Ship } from '../../../types/ship';
 import { GearPiece } from '../../../types/gear';
 import { buildShipAbilitiesWithEquipment } from '../../abilities/buildShipAbilitiesWithEquipment';
 import { buildEquipmentAbilities } from '../../abilities/buildEquipmentAbilities';
 import { modifierTotalsFromAbilities } from '../../abilities/applyAbilities';
-import { ConditionContext } from '../../abilities/evaluateConditions';
+import { makeConditionContext } from '../../abilities/__tests__/conditionContextFixture';
 import { SelectedGameBuff } from '../../../types/calculator';
 
 // ---------------------------------------------------------------------------
@@ -322,21 +322,6 @@ describe('D-PR1 integration — Bloodthirst implant proc frequency', () => {
 // Step 2 is an ENGINE-LEVEL smoke-test for INTRUSION (the scaling implant):
 // it runs the full runCombat pipeline and asserts directDamage amplification.
 
-/** Minimal ConditionContext with the same required fields as evaluateConditions.test.ts. */
-const makeCtx = (over: Partial<ConditionContext> = {}): ConditionContext => ({
-    selfBuffNames: [],
-    selfDebuffNames: [],
-    enemyBuffNames: [],
-    enemyDebuffCount: 0,
-    effectiveCritRate: 0,
-    adjacentAllyCount: 0,
-    enemyAdjacentCount: 0,
-    enemyDestroyedCount: 0,
-    selfHpPct: 100,
-    enemyHpPct: 100,
-    ...over,
-});
-
 // ---------------------------------------------------------------------------
 // Gear-piece stubs for the three D-PR2 implants
 // ---------------------------------------------------------------------------
@@ -386,7 +371,10 @@ describe('D-PR2 integration — INTRUSION fold (modifier-level)', () => {
         const intrusion = abilities.find((a) => a.id === 'equip-implant-INTRUSION');
         expect(intrusion).toBeDefined();
 
-        const totals = modifierTotalsFromAbilities([intrusion!], makeCtx({ enemyDebuffCount: 3 }));
+        const totals = modifierTotalsFromAbilities(
+            [intrusion!],
+            makeConditionContext({ enemyDebuffCount: 3 })
+        );
         expect(totals.outgoingDamage).toBe(15); // 3 × 5
     });
 
@@ -396,7 +384,10 @@ describe('D-PR2 integration — INTRUSION fold (modifier-level)', () => {
         const abilities = buildEquipmentAbilities(ship, getGearPiece);
         const intrusion = abilities.find((a) => a.id === 'equip-implant-INTRUSION');
 
-        const totals = modifierTotalsFromAbilities([intrusion!], makeCtx({ enemyDebuffCount: 0 }));
+        const totals = modifierTotalsFromAbilities(
+            [intrusion!],
+            makeConditionContext({ enemyDebuffCount: 0 })
+        );
         expect(totals.outgoingDamage).toBe(0);
     });
 });
@@ -419,7 +410,7 @@ describe('D-PR2 integration — WARPSTRIKE fold (modifier-level)', () => {
 
         const totals = modifierTotalsFromAbilities(
             [warpstrike!],
-            makeCtx({ selfDebuffNames: ['Burn'] })
+            makeConditionContext({ selfDebuffNames: ['Burn'] })
         );
         expect(totals.outgoingDamage).toBe(5);
     });
@@ -430,7 +421,10 @@ describe('D-PR2 integration — WARPSTRIKE fold (modifier-level)', () => {
         const abilities = buildEquipmentAbilities(ship, getGearPiece);
         const warpstrike = abilities.find((a) => a.id === 'equip-implant-WARPSTRIKE');
 
-        const totals = modifierTotalsFromAbilities([warpstrike!], makeCtx({ selfDebuffNames: [] }));
+        const totals = modifierTotalsFromAbilities(
+            [warpstrike!],
+            makeConditionContext({ selfDebuffNames: [] })
+        );
         expect(totals.outgoingDamage).toBe(0);
     });
 
@@ -445,7 +439,7 @@ describe('D-PR2 integration — WARPSTRIKE fold (modifier-level)', () => {
 
             const totals = modifierTotalsFromAbilities(
                 [warpstrike!],
-                makeCtx({ selfDebuffNames: ['A', 'B'] })
+                makeConditionContext({ selfDebuffNames: ['A', 'B'] })
             );
             // Flat value gates once — does NOT scale with debuff count.
             expect(totals.outgoingDamage).toBe(5);
@@ -465,7 +459,10 @@ describe('D-PR2 integration — ARCANE_SIEGE fold (modifier-level)', () => {
         const arcaneSiege = abilities.find((a) => a.id === 'equip-implant-ARCANE_SIEGE');
         expect(arcaneSiege).toBeDefined();
 
-        const totals = modifierTotalsFromAbilities([arcaneSiege!], makeCtx({ selfShielded: true }));
+        const totals = modifierTotalsFromAbilities(
+            [arcaneSiege!],
+            makeConditionContext({ selfShielded: true })
+        );
         expect(totals.outgoingDamage).toBe(15);
     });
 
@@ -477,7 +474,7 @@ describe('D-PR2 integration — ARCANE_SIEGE fold (modifier-level)', () => {
 
         const totals = modifierTotalsFromAbilities(
             [arcaneSiege!],
-            makeCtx({ selfShielded: false })
+            makeConditionContext({ selfShielded: false })
         );
         expect(totals.outgoingDamage).toBe(0);
     });
@@ -519,6 +516,16 @@ describe('D-PR2 integration — INTRUSION engine-level (outgoing damage amplifie
         };
     }
 
+    /** Single-hit 100% damage active shared between the Intrusion and bare ship-skills builders. */
+    const dmgActiveAbility: Ability = {
+        id: 'dmg-active',
+        type: 'damage',
+        target: 'enemy',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'damage', multiplier: 100, hits: 1 },
+    };
+
     /** Ship with legendary INTRUSION implant. Passive slot injected from buildShipAbilitiesWithEquipment. */
     function buildIntrusionShipSkills(): ShipSkills {
         const ship = makeShip({ implants: { implant_major: 'intrusion-legendary' } });
@@ -530,16 +537,7 @@ describe('D-PR2 integration — INTRUSION engine-level (outgoing damage amplifie
             slots: [
                 {
                     slot: 'active',
-                    abilities: [
-                        {
-                            id: 'dmg-active',
-                            type: 'damage',
-                            target: 'enemy',
-                            trigger: 'on-cast',
-                            conditions: [],
-                            config: { type: 'damage', multiplier: 100, hits: 1 },
-                        },
-                    ],
+                    abilities: [dmgActiveAbility],
                 },
                 ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
             ],
@@ -551,16 +549,7 @@ describe('D-PR2 integration — INTRUSION engine-level (outgoing damage amplifie
         slots: [
             {
                 slot: 'active',
-                abilities: [
-                    {
-                        id: 'dmg-active',
-                        type: 'damage',
-                        target: 'enemy',
-                        trigger: 'on-cast',
-                        conditions: [],
-                        config: { type: 'damage', multiplier: 100, hits: 1 },
-                    },
-                ],
+                abilities: [dmgActiveAbility],
             },
         ],
     };

--- a/src/utils/combat/__tests__/nayraEnemyRepairedPurge.test.ts
+++ b/src/utils/combat/__tests__/nayraEnemyRepairedPurge.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { StatusEngine } from '../statusEngine';
+
+// ---------------------------------------------------------------------------
+// E5 Task 2: the SIDES-SWAPPED consequence of symmetric healing
+// (nayraRepairedPurge.test.ts is the MIRROR — there the player focus is repaired
+// and an enemy Nayra purges it). Here the PLAYER focus IS the Nayra: its on-cast
+// purge is GATED on whether its struck target was REPAIRED (HP-healed) this round
+// (subject 'target-repaired-this-round'). The repaired target is an ENEMY ally.
+//
+// Before E5, enemy heals never restored HP, so an enemy could never enter the
+// engine's per-round repaired set → a player Nayra attacking an enemy never saw
+// targetRepairedThisRound === true. Task 1 made enemy heals symmetric. This test
+// proves the consequence: a player Nayra now purges a *repaired enemy*.
+//
+// Positional two-team battle-sim harness. Turn order by speed desc within a round:
+//   EnemyAlly(200)   → self-heals (consumes any HP deficit → flagged repaired) and
+//                      applies a removable "Attack Up" self-buff.
+//   Nayra-focus(100) → hits the enemy ally (creating/refreshing the deficit) AND
+//                      fires its on-cast purge gated on target-repaired-this-round.
+//
+// The deficit→heal→purge sequence completes across rounds:
+//   Round 1: enemy ally self-heals at full HP (consumes 0 → NOT repaired this
+//            round) → focus purge gate false. Then the focus hits the enemy ally,
+//            opening a deficit.
+//   Round 2: enemy ally self-heals consuming the round-1 deficit (> 0 → REPAIRED
+//            this round). Then the focus acts → targetRepairedThisRound(enemyAlly)
+//            = true → its on-cast purge fires → strips "Attack Up".
+//
+// Two runs (non-vacuous contrast):
+//   1. Repaired:     enemy-ally self-heal present → it enters repairedThisRound →
+//                    Attack Up GONE.
+//   2. Not repaired: enemy-ally self-heal removed → never repaired → the player
+//                    Nayra's gate is false → purge does NOT fire → Attack Up REMAINS.
+//
+// Observed off the ENEMY ALLY's self-buff store via
+// statusEngine.timedAbilityStatuses('self', ENEMY_ALLY_ID) read through the
+// __testTapStatusEngine tap (the same store nayraRepairedPurge.test.ts reads for
+// the focus, keyed here by the enemy ally's id).
+// ---------------------------------------------------------------------------
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `ner${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+const FOCUS_ID = 'attacker';
+const ENEMY_ALLY_ID = 'enemy-ally';
+
+describe('E5 Task 2: player-Nayra purge gated on target-repaired-this-round vs a repaired enemy', () => {
+    // The enemy ally's removable self-buff, applied on its active each round.
+    const attackUp = (): Ability =>
+        ab({
+            type: 'buff',
+            target: 'self',
+            config: {
+                type: 'buff',
+                buffName: 'Attack Up',
+                parsedEffects: { attack: 30 },
+                stacks: 1,
+                isStackable: false,
+                duration: 99,
+            },
+        });
+
+    // A self-heal: 10% of the enemy ally's own max HP. With an HP deficit from the
+    // focus's prior-round hit, consumed > 0 → the enemy ally is flagged repaired.
+    const selfHeal = (): Ability =>
+        ab({
+            type: 'heal',
+            target: 'self',
+            config: { type: 'heal', pct: 10, basis: 'target-hp' },
+        });
+
+    const hit = (): Ability =>
+        ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } });
+
+    // The enemy ally (speed 200, acts FIRST): applies Attack Up to itself, optionally
+    // self-heals, and fires a basic hit so its turn resolves normally. NO purge.
+    const enemyAlly = (heal: boolean) => ({
+        id: ENEMY_ALLY_ID,
+        stats: { attack: 1000, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000, speed: 200 },
+        chargeCount: 0,
+        startCharged: false,
+        position: 'M1' as Position,
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active' as const,
+                    abilities: heal ? [attackUp(), selfHeal(), hit()] : [attackUp(), hit()],
+                },
+            ],
+        },
+    });
+
+    // The player focus IS the Nayra (speed 100, acts LAST): an on-cast purge GATED
+    // on target-repaired-this-round, plus a basic hit so targetId resolves to the
+    // enemy ally and (in the prior round) dents it to open the deficit.
+    const nayraFocusSkills = (): ShipSkills => ({
+        slots: [
+            {
+                slot: 'active',
+                abilities: [
+                    ab({
+                        type: 'purge',
+                        target: 'enemy',
+                        trigger: 'on-cast',
+                        conditions: [{ subject: 'target-repaired-this-round', derivable: true }],
+                        config: { type: 'purge', count: 'all' },
+                    }),
+                    hit(),
+                ],
+            },
+        ],
+    });
+
+    const BASE = (heal: boolean): CombatEngineInput => ({
+        // Modest attack: a non-lethal dent each round, leaving a deficit for the
+        // enemy ally's self-heal to consume without out-healing it to full.
+        attack: 5000,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: nayraFocusSkills(),
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 3,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        // The player focus is the Nayra. It is also the (formal) heal target — required
+        // because enemyAttackers demand a healTargetId — but it is never healed.
+        hp: 1_000_000,
+        // Focus acts LAST (speed 100 < enemy ally 200), so it sees the enemy ally's
+        // same-round self-heal before its purge gate is evaluated.
+        speed: 100,
+        healTargetId: FOCUS_ID,
+        position: 'M4',
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        enemyAttackers: [enemyAlly(heal)],
+    });
+
+    const finalEnemyAllySelfBuffs = (heal: boolean): string[] => {
+        idc = 0;
+        let engine: StatusEngine | undefined;
+        runCombat({
+            ...BASE(heal),
+            __testTapStatusEngine: (e) => {
+                engine = e;
+            },
+        });
+        return engine!.timedAbilityStatuses('self', ENEMY_ALLY_ID).map((b) => b.active.buffName);
+    };
+
+    it('REPAIRED (enemy ally self-heals after taking damage): player-Nayra purge fires → Attack Up removed', () => {
+        expect(finalEnemyAllySelfBuffs(true)).toEqual([]);
+    });
+
+    it('NOT REPAIRED (enemy ally never self-heals): player-Nayra gate false → purge inert → Attack Up remains', () => {
+        expect(finalEnemyAllySelfBuffs(false)).toEqual(['Attack Up']);
+    });
+});

--- a/src/utils/combat/__tests__/procChanceGate.test.ts
+++ b/src/utils/combat/__tests__/procChanceGate.test.ts
@@ -1,0 +1,147 @@
+/**
+ * D-PR1: procChance gate — deterministic accumulator for equipment reactive procs.
+ *
+ * A passive on-crit reactive heal with procChance 0.5 over 10 rounds fires exactly 5 times
+ * (back-loaded: rounds 2, 4, 6, 8, 10). A control ability without procChance fires all 10.
+ *
+ * The rateAccumulator fires when acc >= 1. With rate 0.5 per call:
+ *   call 1: acc=0.5 → no fire
+ *   call 2: acc=1.0 → fire (acc→0)
+ *   call 3: acc=0.5 → no fire
+ *   call 4: acc=1.0 → fire (acc→0)
+ *   ... → fires on even-numbered calls: 2,4,6,8,10 → exactly 5 of 10.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { Ability, ShipSkills } from '../../../types/abilities';
+
+let idCounter = 0;
+const nextId = (): string => `proc-test-${++idCounter}`;
+
+const makeHealAbility = (procChance?: number): Ability => ({
+    id: nextId(),
+    type: 'heal',
+    target: 'self',
+    trigger: 'on-crit',
+    conditions: [],
+    ...(procChance !== undefined ? { procChance } : {}),
+    config: { type: 'heal', pct: 50, basis: 'hp', noCrit: true },
+});
+
+const BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 5000,
+    crit: 100, // every hit crits → on-crit fires once per round
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [] },
+    enemyDefense: 0,
+    enemyHp: 10_000_000, // enemy never dies
+    numRounds: 10,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 2000,
+    hp: 10000,
+    healTargetId: 'attacker', // enable healing mode, self is target
+    ...overrides,
+});
+
+/** Build a ShipSkills with a single-hit damage active (so on-crit fires once per round)
+ *  and the given reactive heal abilities on the passive slot. */
+const makeSkills = (abilities: Ability[]): ShipSkills => ({
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                {
+                    id: nextId(),
+                    type: 'damage',
+                    target: 'enemy',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config: { type: 'damage', multiplier: 100, hits: 1 },
+                },
+            ],
+        },
+        {
+            slot: 'passive',
+            abilities,
+        },
+    ],
+});
+
+/** Sum a heal bucket over all rounds for the focus actor ('attacker'). */
+const sumHeal = (
+    result: ReturnType<typeof runCombat>,
+    bucket: 'directHeal' | 'effectiveHeal' | 'overheal'
+): number =>
+    (result.healing?.rounds ?? []).reduce(
+        (sum, rd) => sum + (rd.perActor.get('attacker')?.[bucket] ?? 0),
+        0
+    );
+
+describe('D-PR1: procChance gate — per-proc rate gate for equipment reactive procs', () => {
+    it('procChance 0.5 over 10 on-crit triggers fires the reactive heal exactly 5 times (deterministic accumulator)', () => {
+        idCounter = 0;
+        // Each fire credits directHeal = 10000 (hp) × 50% = 5000.
+        // 5 fires → 25000 total; 10 fires (no gate) → 50000 total.
+        const gatedAbility = makeHealAbility(0.5);
+        const result = runCombat(
+            BASE({
+                shipSkills: makeSkills([gatedAbility]),
+            })
+        );
+
+        expect(result.healing).toBeDefined();
+        expect(result.healing!.rounds).toHaveLength(10);
+
+        // 5 fires × 5000 = 25000
+        expect(sumHeal(result, 'directHeal')).toBe(25000);
+    });
+
+    it('control: reactive heal without procChance fires on all 10 on-crit triggers (no gate)', () => {
+        idCounter = 0;
+        const controlAbility = makeHealAbility(/* no procChance */);
+        const result = runCombat(
+            BASE({
+                shipSkills: makeSkills([controlAbility]),
+            })
+        );
+
+        expect(result.healing).toBeDefined();
+        expect(result.healing!.rounds).toHaveLength(10);
+
+        // 10 fires × 5000 = 50000
+        expect(sumHeal(result, 'directHeal')).toBe(50000);
+    });
+
+    it('procChance exactly 1: fires on every trigger (no skip)', () => {
+        idCounter = 0;
+        const result = runCombat(
+            BASE({
+                shipSkills: makeSkills([makeHealAbility(1)]),
+            })
+        );
+        // procChance=1 is outside (0,1) so the gate is bypassed → 10 fires × 5000 = 50000
+        expect(sumHeal(result, 'directHeal')).toBe(50000);
+    });
+
+    it('procChance exactly 0: gate bypassed, fires on every trigger (treated as absent)', () => {
+        idCounter = 0;
+        const result = runCombat(
+            BASE({
+                shipSkills: makeSkills([makeHealAbility(0)]),
+            })
+        );
+        // procChance=0 is outside (0,1) so gate is bypassed → 10 fires × 5000 = 50000
+        // (procChance=0 means always fire, same as absent — the guard is pc > 0 && pc < 1)
+        expect(sumHeal(result, 'directHeal')).toBe(50000);
+    });
+});

--- a/src/utils/combat/__tests__/salvationDeadRecipient.test.ts
+++ b/src/utils/combat/__tests__/salvationDeadRecipient.test.ts
@@ -58,6 +58,9 @@ const makeHealing = (
         },
         grantShieldToTarget: () => {},
         playerIds,
+        // E5 fields (unused on this player-path double — present for type-correctness).
+        enemyIds: [],
+        recipientActor: () => undefined,
     };
     return { healing, credits };
 };

--- a/src/utils/combat/__tests__/symmetricHealing.test.ts
+++ b/src/utils/combat/__tests__/symmetricHealing.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { CombatActor } from '../state';
+
+// ---------------------------------------------------------------------------
+// E5 §4.1: Symmetric enemy healing (the core). An ENEMY healer takes damage from
+// the player focus, then self-heals into its OWN currentHp via the per-victim
+// pool. Roles are INVERTED vs nayraRepairedPurge.test.ts: the player focus just
+// attacks; the enemy ship does the healing.
+//
+// Two assertions:
+//   1. The enemy healer's currentHp recovers (was HP-restore-blocked before E5).
+//   2. The player healing result does NOT contain the enemy id (no player-bucket
+//      credit / surface leak on the enemy path).
+// ---------------------------------------------------------------------------
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `e5_${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+const hit = (): Ability =>
+    ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } });
+const FOCUS_ID = 'attacker';
+const selfHeal = (): Ability =>
+    ab({ type: 'heal', target: 'self', config: { type: 'heal', pct: 2, basis: 'target-hp' } });
+const enemyHealer = () => ({
+    id: 'enemy-healer',
+    stats: { attack: 1, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000, speed: 100 },
+    chargeCount: 0,
+    startCharged: false,
+    position: 'M4' as Position,
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    shipSkills: { slots: [{ slot: 'active' as const, abilities: [selfHeal(), hit()] }] },
+});
+const focusSkills = (): ShipSkills => ({ slots: [{ slot: 'active', abilities: [hit()] }] });
+const BASE = (): CombatEngineInput => ({
+    attack: 50_000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: focusSkills(),
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 3,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000,
+    speed: 300,
+    healTargetId: FOCUS_ID,
+    position: 'M1',
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    enemyAttackers: [enemyHealer()],
+});
+
+describe('E5 §4.1: enemy heals restore enemy HP into its own pool', () => {
+    it('enemy healer recovers HP after taking damage', () => {
+        idc = 0;
+        let healer: CombatActor | undefined;
+        runCombat({
+            ...BASE(),
+            __testTapActors: (actors) => {
+                healer = actors.find((a) => a.id === 'enemy-healer');
+            },
+        });
+        expect(healer).toBeDefined();
+        // Per-round (player speed 300 acts first, enemy speed 100 last):
+        //   hit −50,000 (attack 50k, defence 0, ×1.0 multiplier), then self-heal
+        //   +20,000 (2% of the 1,000,000 max-HP basis). Net −30,000/round over 3 rounds.
+        //   Without E5 the floor would be 1,000,000 − 3×50,000 = 850,000 (no restore).
+        // Non-vacuous: above the no-heal floor (heals landed) AND below max (damage landed).
+        expect(healer!.currentHp).toBe(910_000);
+        expect(healer!.currentHp).toBeGreaterThan(850_000);
+        expect(healer!.currentHp).toBeLessThan(1_000_000);
+    });
+
+    it('enemy heal does NOT pollute the player healing result', () => {
+        idc = 0;
+        const result = runCombat(BASE());
+        // Scope to the HEALING surface: the player focus attacks the enemy healer, so the
+        // enemy id legitimately appears in the DAMAGE perTargetDamage — that's not pollution.
+        // The enemy heal must contribute NOTHING to the player healing buckets (no credit).
+        expect(JSON.stringify(result.healing)).not.toContain('enemy-healer');
+    });
+});

--- a/src/utils/combat/__tests__/triggers.test.ts
+++ b/src/utils/combat/__tests__/triggers.test.ts
@@ -2213,6 +2213,8 @@ describe('once-per-combat repair cap in executeIntent (Task 8)', () => {
             },
             grantShieldToTarget: () => {},
             playerIds: ['A'],
+            enemyIds: [],
+            recipientActor: () => undefined,
         };
         const ctx: IntentExecContext = {
             round: 1,
@@ -2728,6 +2730,8 @@ describe('Phase 4c Task 6: live drain-time selfHpPct', () => {
             },
             grantShieldToTarget: () => {},
             playerIds: ['A'],
+            enemyIds: [],
+            recipientActor: () => undefined,
         };
         const ctx: IntentExecContext = {
             round: 1,
@@ -2985,6 +2989,8 @@ describe('Phase 4c PR 2 Task 4: damagedAllyId recipient routing', () => {
             },
             grantShieldToTarget: () => {},
             playerIds: PLAYER_IDS,
+            enemyIds: [],
+            recipientActor: () => undefined,
         };
         const ctx: IntentExecContext = {
             ...buildBuffCtx(),

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2937,38 +2937,45 @@ export function runCombat(input: CombatEngineInput): {
             if (actor.id === focusActorId) {
                 // PR6b: read the dummy sink's live currentHp instead of the scalar (identical
                 // value — the sink update at ~3771 keeps enemy.currentHp == enemyHp - cumulative).
-                const enemyHpDecline = Math.max(0, enemyHp - enemy.currentHp);
-                const enemyHpPct =
-                    enemyHp > 0 ? Math.max(0, 100 * (1 - enemyHpDecline / enemyHp)) : 100;
-                const lastKnownCtx = lastTurnCtxByActor.get(actor.id);
-                focusTurns.push({
-                    action: 'active',
-                    roundCrit: false,
-                    hitCrits: [],
-                    enemyHpPct,
-                    dotsConfig: [],
-                    dotsLanded: true,
-                    activeSelfBuffs: [],
-                    landedEnemyDebuffs: [],
-                    inflictedEnemyDebuffs: [],
-                    resistedEnemyDebuffs: [],
-                    directDamage: 0,
-                    secondaryDamage: 0,
-                    conditionalDamage: 0,
-                    detonationDamage: 0,
-                    extraActionGrants: [],
-                    turnCtx: lastKnownCtx ?? {
-                        effectiveAttack: 0,
-                        dotMult: 1,
-                        affinityMult: 1,
-                        effectiveDefence: 0,
-                        effectiveMaxHp: 0,
-                        outgoingHealPct: 0,
-                        incomingHealPct: 0,
-                    },
-                });
+                pushSynthesizedFocusSkipTurn();
             }
             return true;
+        };
+
+        // E5 §4.4: the synthesized no-action focus turn pushed when the focus skips its
+        // turn (dead heal-target OR stasised). Extracted from the two byte-identical sites
+        // (handleDeadTargetSkip + the stasis gate) so the shape cannot drift.
+        const pushSynthesizedFocusSkipTurn = (): void => {
+            const enemyHpDecline = Math.max(0, enemyHp - enemy.currentHp);
+            const enemyHpPct =
+                enemyHp > 0 ? Math.max(0, 100 * (1 - enemyHpDecline / enemyHp)) : 100;
+            const lastKnownCtx = lastTurnCtxByActor.get(focusActorId);
+            focusTurns.push({
+                action: 'active',
+                roundCrit: false,
+                hitCrits: [],
+                enemyHpPct,
+                dotsConfig: [],
+                dotsLanded: true,
+                activeSelfBuffs: [],
+                landedEnemyDebuffs: [],
+                inflictedEnemyDebuffs: [],
+                resistedEnemyDebuffs: [],
+                directDamage: 0,
+                secondaryDamage: 0,
+                conditionalDamage: 0,
+                detonationDamage: 0,
+                extraActionGrants: [],
+                turnCtx: lastKnownCtx ?? {
+                    effectiveAttack: 0,
+                    dotMult: 1,
+                    affinityMult: 1,
+                    effectiveDefence: 0,
+                    effectiveMaxHp: 0,
+                    outgoingHealPct: 0,
+                    incomingHealPct: 0,
+                },
+            });
         };
 
         // Per-round extra-action bookkeeping: oncePerRound abilities fire at most once
@@ -3578,40 +3585,9 @@ export function runCombat(input: CombatEngineInput): {
                         // Synthesize a minimal no-action result so the post-round
                         // `focusTurns.length` guard does not throw (the focus actor
                         // was stasised — it did not act, but the round must still assemble).
-                        // Shape copied verbatim from handleDeadTargetSkip's focusTurns.push(…).
+                        // Delegated to pushSynthesizedFocusSkipTurn (E5 §4.4 DRY helper).
                         if (actor.id === focusActorId) {
-                            const enemyHpDecline = Math.max(0, enemyHp - enemy.currentHp);
-                            const enemyHpPct =
-                                enemyHp > 0
-                                    ? Math.max(0, 100 * (1 - enemyHpDecline / enemyHp))
-                                    : 100;
-                            const lastKnownCtx = lastTurnCtxByActor.get(actor.id);
-                            focusTurns.push({
-                                action: 'active',
-                                roundCrit: false,
-                                hitCrits: [],
-                                enemyHpPct,
-                                dotsConfig: [],
-                                dotsLanded: true,
-                                activeSelfBuffs: [],
-                                landedEnemyDebuffs: [],
-                                inflictedEnemyDebuffs: [],
-                                resistedEnemyDebuffs: [],
-                                directDamage: 0,
-                                secondaryDamage: 0,
-                                conditionalDamage: 0,
-                                detonationDamage: 0,
-                                extraActionGrants: [],
-                                turnCtx: lastKnownCtx ?? {
-                                    effectiveAttack: 0,
-                                    dotMult: 1,
-                                    affinityMult: 1,
-                                    effectiveDefence: 0,
-                                    effectiveMaxHp: 0,
-                                    outgoingHealPct: 0,
-                                    incomingHealPct: 0,
-                                },
-                            });
+                            pushSynthesizedFocusSkipTurn();
                         }
                     } // end stasis gate (attacker branch)
                 } else if (actor.kind === 'team' && teamRuntimeById.has(actor.id)) {

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -43,7 +43,11 @@ import {
 } from './statusEngine';
 import { liveGateConditions } from './abilityStatusGating';
 import { isPositional, resolvePositionalTarget } from './positionalBinding';
-import { applyPositionalDamage, footprintVictims, type VictimDamageOutcome } from './positionalApply';
+import {
+    applyPositionalDamage,
+    footprintVictims,
+    type VictimDamageOutcome,
+} from './positionalApply';
 import type { AttackerDamageScalars } from './victimDamage';
 import { CHEAT_DEATH_BUFFS } from './cheatDeathBuffs';
 import { BARRIER_BUFFS } from './barrierBuffs';
@@ -1684,11 +1688,12 @@ export function runCombat(input: CombatEngineInput): {
     const isStasised = (actorId: string): boolean => ownerDebuffNames(actorId).some(isStasis);
 
     // Base-HP fallback for recipientMaxHp before an actor has taken its first turn (no ctx yet):
-    // attacker → input.hp; walked team → walk stats hp; legacy team → its combat-actor hp (1).
-    // Enemy ids are never queried as recipients.
+    // attacker → input.hp; walked team → walk stats hp; enemy attackers → their CombatActor hp
+    // (E5: enemy ids ARE now queried as recipients once enemy heals restore HP).
     const baseHpById = new Map<string, number>([
         [attacker.id, hp],
         ...teamActors.map((t) => [t.id, t.walk!.stats.hp] as const),
+        ...enemyAttackerActors.map((a) => [a.id, a.stats.hp] as const),
     ]);
     const baseHpFor = (id: string): number => baseHpById.get(id) ?? 0;
 
@@ -1935,6 +1940,8 @@ export function runCombat(input: CombatEngineInput): {
                   victim.shieldPool = Math.min(victim.shieldPool + raw, targetMaxHp);
               },
               playerIds,
+              enemyIds: enemyRecipientIds,
+              recipientActor: (id) => allActorsById.get(id),
           }
         : undefined;
 

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2328,6 +2328,13 @@ export function runCombat(input: CombatEngineInput): {
         // its own entry; the post-round assembly derives row fields from the focus entry.
         // The helper `dmg(id)` lazily creates entries on first write — actors that never
         // produce damage in a round simply have no entry, keeping the map sparse.
+        //
+        // E5 §4.5 — CREDIT vs INTAKE are COMPLEMENTARY, not redundant (closing the umbrella
+        // spec's "collapse the dual paths" framing). This `roundDamage`/`creditDamage` path is
+        // the CREDIT side: damage *dealt*, keyed by SOURCE id, feeding row totals + damage-dealt
+        // leeches. The `perActorIncoming`/`intakeFor` path below (~2365) is the INTAKE side:
+        // damage *taken*, keyed by VICTIM id, feeding healing-mode rows. They record different
+        // facts about the same hit (who dealt it vs who took it); E5 does NOT merge them.
         const roundDamage = new Map<string, ActorDamage>();
         // Per-round per-victim positional damage accumulator (victim actor id → summed damage
         // dealt to it this round). Populated ONLY by the positional apply path's emitHit
@@ -2362,6 +2369,10 @@ export function runCombat(input: CombatEngineInput): {
         // Barrier (full damage immunity), kept SEPARATE from shieldAbsorbed (Barrier does NOT drain
         // the shield pool) so the UI can attribute the blocked total to the Barrier, not the shield.
         // Fresh map each round; intakeFor() get-or-creates on first write.
+        //
+        // E5 §4.5 — this is the INTAKE side (damage *taken*, keyed by VICTIM id); the
+        // complementary CREDIT side is `roundDamage`/`creditDamage` (~2331, damage *dealt*,
+        // keyed by SOURCE id). Complementary facts, not duplicates — see the note there.
         const perActorIncoming = new Map<string, ActorIntake>();
         const intakeFor = (id: string): ActorIntake => {
             let entry = perActorIncoming.get(id);
@@ -4024,15 +4035,19 @@ export function runCombat(input: CombatEngineInput): {
                                 // Phase-5 symmetric-accounting surface (the result still exposes a single
                                 // heal-target row today). Inert here regardless (no production caller
                                 // threads enemy position+pattern).
-                                // DETONATION CAVEAT (deferred → E5 accounting unification): only the firing
-                                // hit (enemyScalars, the DIRECT channel) lands per-victim here. The
+                                // DETONATION CAVEAT (E5 §4.3 — PEELED to a dedicated follow-up): only the
+                                // firing hit (enemyScalars, the DIRECT channel) lands per-victim here. The
                                 // aggregate `damage` also folds enemyTurn.detonationDamage, which the
-                                // NON-positional branch drains via applyIncomingToTarget(damage, tgt) but
-                                // which is NOT routed to any player victim on the positional path — routing
-                                // it needs per-victim bomb attribution the engine does not track yet
-                                // (detonation is a single turn-scalar, not per-target). Byte-identical today
-                                // (no fixture threads enemy position+pattern WITH detonation); a positional
-                                // enemy-detonation model lands with E5.
+                                // NON-positional branch already drains per-victim via
+                                // applyIncomingToTarget(damage, tgt) → perActorIncoming (so non-positional
+                                // detonation intake is ALREADY recorded). Only the POSITIONAL path leaves it
+                                // unrouted — and routing it per-victim needs per-victim bomb attribution the
+                                // engine does not track yet (detonation is a single turn-scalar, not
+                                // per-target). E5 PEELED this per the spec's §5 pressure valve: it requires
+                                // NEW tracking and has zero observable cost to defer (perActorIncoming is
+                                // internal/unread by the UI, and no fixture threads enemy position+pattern
+                                // WITH detonation → byte-identical today). A positional enemy-detonation
+                                // model lands in the follow-up.
                                 const tb = turnBindings(actor.side);
                                 drivePositionalApply({
                                     scalars: enemyScalars!,

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -59,6 +59,7 @@ import {
     PlayerActorRuntime,
     PlayerRoundCtx,
     PlayerTurnResult,
+    RateGate,
     runPlayerTurn,
 } from './playerTurn';
 import {
@@ -1853,6 +1854,10 @@ export function runCombat(input: CombatEngineInput): {
     // repair — Yazid's on-cheat-death-activated 60% repair — fires at most once per battle even
     // across rounds. Threaded into executeIntent's ctx; the executor checks/sets it.
     const oncePerCombatFired = new Set<string>();
+    // Combat-lifetime proc-chance gates for equipment reactive procs (D-PR1). Keyed
+    // `${ownerId}:${abilityId}`; each gate is a RateGate accumulator that fires at the
+    // ability's procChance rate across all rounds, deterministically (like crit/landing gates).
+    const procChanceGates = new Map<string, RateGate>();
 
     // ═══════════════════════════════════════════════════════════════════════════════════════
     // Reactive extra-action timing analysis (Phase 4b Task 10). Two death paths land an
@@ -3146,6 +3151,9 @@ export function runCombat(input: CombatEngineInput): {
                         // Combat-lifetime once-per-battle guard (Task 8): a flagged reactive
                         // repair (Yazid) fires at most once across the whole combat.
                         oncePerCombatFired,
+                        // Combat-lifetime proc-chance gates (D-PR1): equipment reactive procs
+                        // that carry a procChance fire at their stated rate via this accumulator.
+                        procChanceGates,
                         // Phase 4c PR 6: live lowest-speed-ally gate. UNCONDITIONAL (unlike the
                         // healing-only selfHpPctFor spread) — in DPS mode the set is {attacker}, so
                         // the lone attacker resolves true and DPS gating stays byte-identical.

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -103,6 +103,10 @@ export interface HealingRuntimeCtx {
     grantShieldToTarget: (raw: number, victim?: CombatActor) => void;
     /** Fixed player-id order for all-allies recipient routing. */
     playerIds: string[];
+    /** Fixed enemy-attacker-id order for an ENEMY caster's all-allies routing (E5). */
+    enemyIds: string[];
+    /** Resolve a recipient id to its CombatActor (E5 enemy-heal apply). undefined if absent. */
+    recipientActor: (id: string) => CombatActor | undefined;
 }
 
 /** Everything one player actor's turn contributes to the round's RoundData row. */
@@ -1432,7 +1436,8 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                     scaling.per > 0
                 ) {
                     purgeCount =
-                        ab.config.count * Math.max(0, Math.floor(effectiveCritDamage / scaling.per));
+                        ab.config.count *
+                        Math.max(0, Math.floor(effectiveCritDamage / scaling.per));
                 }
                 for (const vid of recipients) {
                     const removed = statusEngine.purge(vid, purgeCount);
@@ -1471,12 +1476,35 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 : healing.recipientIncomingHealPct(rid);
         // Recipient routing (user-confirmed): self → caster; ally → the bombarded target;
         // all-allies → every player in fixed source order. Shared by the heal + shield branches.
-        const recipientsFor = (target: Ability['target']): string[] =>
-            target === 'self'
-                ? [actor.id]
-                : target === 'all-allies'
-                  ? healing.playerIds
-                  : [healing.targetId];
+        const isEnemyCaster = actor.side === 'enemy';
+        // Lowest-HP-fraction living enemy ally for an enemy single-'ally' heal (E5).
+        // Deterministic: ties broken by enemyIds source order. Falls back to the caster
+        // when no other living ally exists. NEVER routes to the player heal target.
+        const lowestHpEnemyAllyId = (): string | undefined => {
+            let best: string | undefined;
+            let bestFrac = Infinity;
+            for (const id of healing.enemyIds) {
+                const a = healing.recipientActor(id);
+                if (!a || a.currentHp <= 0) continue;
+                const maxHp = healing.recipientMaxHp(id);
+                const frac = maxHp > 0 ? a.currentHp / maxHp : 0;
+                if (frac < bestFrac) {
+                    bestFrac = frac;
+                    best = id;
+                }
+            }
+            return best ?? actor.id;
+        };
+        const recipientsFor = (target: Ability['target']): string[] => {
+            if (target === 'self') return [actor.id];
+            if (target === 'all-allies')
+                return isEnemyCaster ? healing.enemyIds : healing.playerIds;
+            if (isEnemyCaster) {
+                const rid = lowestHpEnemyAllyId();
+                return rid ? [rid] : [];
+            }
+            return [healing.targetId];
+        };
         // Basis value for a heal/shield ability against recipient `rid`.
         const basisValue = (
             basis: 'hp' | 'attack' | 'defense' | 'target-hp' | 'damage-dealt' | 'damage-taken',
@@ -1609,9 +1637,25 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
             if (cfg.type === 'heal') {
                 const recipients = recipientsFor(ability.target);
                 if (healEventOnly) {
-                    // Event-only: NO numeric at all — do NOT draw the heal crit gate, do NOT
-                    // credit or apply. Just register recipients so heal-performed fires (amount 0).
-                    for (const rid of recipients) healTargets.push(rid);
+                    // E5 §4.1: enemy heals restore each recipient's OWN currentHp (via the
+                    // per-victim pool), fire repairedThisRound, and emit heal-performed — but
+                    // contribute NOTHING to the player healing buckets (no healing.credit).
+                    const didCrit = cfg.noCrit ? false : healCritGate(effectiveCrit / 100);
+                    if (didCrit) healCritCount += 1;
+                    for (const rid of recipients) {
+                        const basis = basisValue(cfg.basis, rid);
+                        const raw =
+                            basis *
+                            (cfg.pct / 100) *
+                            (didCrit ? 1 + effectiveCritDamage / 100 : 1) *
+                            (1 + healModifier / 100) *
+                            (1 + dmgStats.totals.outgoingHealBuff / 100) *
+                            (1 + incomingPctFor(rid) / 100);
+                        const recipientActor = healing.recipientActor(rid);
+                        if (recipientActor) healing.applyHealToTarget(raw, recipientActor);
+                        healTargets.push(rid);
+                        healRawSum += raw;
+                    }
                     continue;
                 }
                 // ONE crit draw per heal ability (not per recipient).

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1089,6 +1089,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         targetRepairedThisRound: targetRepairedThisRoundArg,
         enemyBuffNames: enemyBuffNamesArg,
         selfDebuffNames: selfDebuffNamesArg,
+        selfShielded: actor.shieldPool > 0,
     });
     const passiveSkill = shipSkills.slots.find((s) => s.slot === 'passive');
     const modifierAbilities = [

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1719,8 +1719,9 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         }
 
         // ONE heal-performed per cast that healed at least one recipient. critHits is the
-        // number of heal abilities that crit (present-only-when-positive). In event-only mode
-        // amount is 0 and critHits is absent (no numeric was computed).
+        // number of heal abilities that crit (present-only-when-positive). In event-only
+        // (enemy) mode E5 §4.1 now computes the numeric, so amount/critHits reflect the real
+        // enemy heal (the player healing buckets stay uncredited — see the healEventOnly note above).
         if (healTargets.length > 0) {
             bus.emit({
                 type: 'heal-performed',

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -234,11 +234,14 @@ export interface PlayerTurnArgs {
      *  Absent for DPS-mode turns — the heal block is fully gated on this, keeping the DPS
      *  goldens byte-identical. */
     healing?: HealingRuntimeCtx;
-    /** Event-only heal/cleanse emission (Phase 4c PR 4 Task 5): when true (the enemy walk),
-     *  the heal block EMITS `heal-performed`/`cleanse-performed` carrying THIS actor's id but
-     *  credits NO player healing bucket and mutates NO target — the shared player `healing` ctx
-     *  must never see an enemy-id mutation. Scopes emission to the CAST skill (gatedSkill) only,
-     *  never the passive. Defaults falsy (player/team turns credit + mutate as before). */
+    /** Event-only heal/cleanse emission (Phase 4c PR 4 Task 5; HP-restore lifted in E5 §4.1):
+     *  when true (the enemy walk), the heal block EMITS `heal-performed`/`cleanse-performed`
+     *  carrying THIS actor's id and (E5) restores each heal recipient's OWN currentHp via the
+     *  per-victim pool — but credits NO player healing bucket and never mutates the player
+     *  heal-target (the shared player `healing` ctx never sees an enemy-id BUCKET credit).
+     *  Shields/cleanse still mutate nothing on this path. Scopes emission to the CAST skill
+     *  (gatedSkill) only, never the passive. Defaults falsy (player/team turns credit + mutate
+     *  as before). */
     healEventOnly?: boolean;
     /** Acting actor's live HP% (0..100) for self-HP-threshold gates. Defaults to 100 so
      *  callers that do not supply it (e.g. standalone tests, un-updated call sites) behave
@@ -1618,9 +1621,12 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
             if (c.basis === 'damage-taken') return true;
             return c.basis === 'damage-dealt' && fromPassive;
         };
-        // Event-only mode (enemy walk, Task 5): EMIT heal/cleanse events but credit/mutate
-        // NOTHING — and scope to the CAST skill only (the spec: "the cast skill carries"),
-        // never the passive. Normal (player/team) mode keeps both slots and credits/mutates.
+        // Event-only mode (enemy walk, Task 5; HP-restore lifted in E5 §4.1): EMIT heal/cleanse
+        // events and (E5) restore each heal recipient's OWN currentHp via the per-victim pool,
+        // but credit NO player healing bucket and never mutate the player heal-target. Shields
+        // and cleanse still mutate NOTHING on the enemy path (deferred to sub-projects H / enemy
+        // cleanse). Scope to the CAST skill only (the spec: "the cast skill carries"), never the
+        // passive. Normal (player/team) mode keeps both slots and credits/mutates as before.
         const healAbilities = healEventOnly
             ? (gatedSkill?.abilities ?? []).filter((a) => !isHookOwned(a, false))
             : [

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -94,7 +94,15 @@ export interface Intent {
      *  (Cultivator's repair, Refine/Graphite's grants) instead of the default.
      *  `fromPurgeEvent`: depth-1 purge chain guard — a purge triggered by a
      *  purge-performed event does not re-emit purge-performed, preventing infinite chains. */
-    eventCtx?: { counterTargetId?: string; damagedAllyId?: string; fromPurgeEvent?: boolean };
+    eventCtx?: {
+        counterTargetId?: string;
+        damagedAllyId?: string;
+        fromPurgeEvent?: boolean;
+        /** The damage dealt by the triggering event (ability-performed.damage), used by a
+         *  reactive `basis:'damage-dealt'` heal/shield (e.g. Bloodthirst) to scale off the
+         *  triggering hit's damage rather than the owner's max HP. */
+        triggerDamage?: number;
+    };
 }
 
 /** Whether an ability is reactive (routed through the trigger machinery): a
@@ -229,7 +237,19 @@ export function registerReactiveListeners(args: {
                         // follow-up fires twice. Events without critHits fall back
                         // to the didCrit binary (one enqueue).
                         const n = e.critHits ?? (e.didCrit ? 1 : 0);
-                        for (let i = 0; i < n; i++) enqueue(intent);
+                        // Per-event copy: carry e.damage (total damage for this ability-performed
+                        // event) into eventCtx.triggerDamage so that a reactive basis:'damage-dealt'
+                        // heal (e.g. Bloodthirst) scales off the triggering hit's damage.
+                        // KNOWN APPROXIMATION: for a multi-hit ability, each critting hit enqueues
+                        // with the same event-total damage (not per-hit damage), so the heal is
+                        // proportionally over-counted per fire when critHits > 1. Per-hit attribution
+                        // is not supported in the event model today; document and accept.
+                        for (let i = 0; i < n; i++) {
+                            enqueue({
+                                ...intent,
+                                eventCtx: { ...intent.eventCtx, triggerDamage: e.damage },
+                            });
+                        }
                     });
                     break;
                 case 'on-debuff-inflicted':
@@ -1153,7 +1173,13 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
                 ? (ownerCtx?.effectiveAttack ?? owner.attack)
                 : cfg.basis === 'defense'
                   ? (ownerCtx?.effectiveDefence ?? owner.defence)
-                  : (ownerCtx?.effectiveMaxHp ?? owner.hp);
+                  : cfg.basis === 'damage-dealt'
+                    ? // Reactive damage-dealt (e.g. Bloodthirst on-crit): scale off the triggering
+                      // hit's damage captured in eventCtx.triggerDamage. Falls back to 0 when no
+                      // triggering damage is present (non-crit path or missing context) — a
+                      // damage-dealt reactive heal with no damage context heals nothing.
+                      (intent.eventCtx?.triggerDamage ?? 0)
+                    : (ownerCtx?.effectiveMaxHp ?? owner.hp);
         // Recipients: an 'ally'-target heal prefers eventCtx.damagedAllyId (an ally-damage
         // reaction repairs THAT ally) over the healing target. Identical today — the engine
         // only ever attacks the heal target, so damagedAllyId === healing.targetId in every

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -5,6 +5,7 @@ import { EnemyBaseClass, ParsedBuffEffects, SelectedGameBuff } from '../../types
 import { PERSISTENT_STACKING_BUFFS } from '../../constants/persistentStackingBuffs';
 import { conditionsMet } from '../abilities/evaluateConditions';
 import { buildRoundContext } from '../abilities/roundContext';
+import { makeRateGate } from '../calculators/rateAccumulator';
 import { expandEnemyDebuffs, payloadToSelectedBuff } from './buffTotals';
 import { liveGateConditions } from './abilityStatusGating';
 import { CombatEventBus } from './events';
@@ -18,7 +19,7 @@ import {
 } from './statusEngine';
 // Type-only import (erased at runtime) → no circular-import cycle even though playerTurn.ts
 // imports buildActorConditionContext/ReactiveAbility from this module.
-import type { PlayerActorRuntime, PlayerRoundCtx, HealingRuntimeCtx } from './playerTurn';
+import type { PlayerActorRuntime, PlayerRoundCtx, HealingRuntimeCtx, RateGate } from './playerTurn';
 import type { ActorTargetingStatus } from './positionalBinding';
 
 /** The trigger values the engine consumes — defined next to AbilityTrigger in
@@ -533,6 +534,10 @@ export interface IntentExecContext {
      *  fire and is skipped on every later fire — Yazid's on-cheat-death-activated 60% repair
      *  fires at most ONCE per combat. Absent in unit tests that exercise unbounded follow-ups. */
     oncePerCombatFired?: Set<string>;
+    /** Combat-lifetime per-ability proc-chance gates (e.g. Bloodthirst's 12% chance).
+     *  Keyed `${ownerId}:${abilityId}`; the RateGate accumulates across all rounds and all
+     *  reactive fires of the same ability so the proc lands at its true frequency. */
+    procChanceGates?: Map<string, RateGate>;
     /** Live self-HP% per owner (0..100) for drain-time hp-threshold gates (Phase 4c
      *  PR 1). The engine closes over the heal target's current/max HP (healing mode);
      *  every other owner — and DPS mode entirely — reports 100 (the pre-4c default),
@@ -1108,6 +1113,17 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
             const key = `${intent.ownerId}:${intent.ability.id}`;
             if (ctx.oncePerCombatFired?.has(key)) return;
             ctx.oncePerCombatFired?.add(key);
+        }
+        const pc = intent.ability.procChance;
+        if (pc !== undefined && pc > 0 && pc < 1) {
+            const gateKey = `${intent.ownerId}:${intent.ability.id}`;
+            let gate = ctx.procChanceGates?.get(gateKey);
+            if (ctx.procChanceGates && !gate) {
+                gate = makeRateGate();
+                ctx.procChanceGates.set(gateKey, gate);
+            }
+            // absent map (unit-test contexts) → gate stays undefined → pass through
+            if (gate && !gate(pc)) return;
         }
         // Reactive heals NEVER crit (no draw at drain time — deterministic, documented
         // approximation) and use the OWNER's last-turn ctx stats; before the owner's first


### PR DESCRIPTION
## Summary

Second PR of sub-project D (implants + gear-set abilities) in the combat-realism epic. **Stacked on D-PR1 (#127)** — retarget to `main` once D-PR1 merges.

Lights up the **conditional outgoing-damage** implant bucket, modeling all three as passive `modifier` abilities on channel `outgoingDamage` that ride the engine's **existing** modifier fold (`modifierTotalsFromAbilities` already iterates the passive slot, gates on conditions, and sums flat `value` + per-count `scaling` into the multiplicative `(1 + outgoingDamageBuff/100)` factor — direct-damage-scoped). No `conditionalBonusPct`/damage-path surgery; this is also the more faithful model ("increase outgoing damage by X%" = multiplicative).

- **Intrusion** — +X% outgoing damage per debuff on the target (per-count scaling; X = 1/2/3/4/5 by rarity).
- **Arcane Siege** — +X% outgoing damage while shielded (flat, gated on the new `self-shield` condition; X = 3/6/10/15/20). Dormant in the sim until sub-project H grants shields; unit-tested now.
- **Warpstrike** — +X% outgoing damage while self-debuffed (flat + `>=1` self-debuff gate, so it doesn't over-apply per debuff; X = 1/2/3/4/5). Its "reduce a random debuff's duration" half is deferred (cleanse-family).

Also: new `self-shield` condition primitive (the only new engine code); DPS calculator page wired to `buildShipAbilitiesWithEquipment` (the wiring D-PR1 skipped since its effects were heals); coverage tracker + integration tests; shared `makeConditionContext` test fixture; changelog + docs.

## Test Plan

- [x] Full suite green — 2808 passing (+14 over D-PR1)
- [x] `npm run lint` clean (max-warnings 0), `npx tsc --noEmit` clean
- [x] `npm run audit:skills` 141 ships / 0 findings (unchanged)
- [x] **ZERO golden `.snap` movement** across the PR (no fixture carries these implants — fixture audit was the first step)
- [x] Per-task spec + code-quality review + final holistic review — all approved

Spec: `docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-pr2-design.md`
Plan: `docs/superpowers/plans/2026-06-20-implant-gearset-abilities-D-pr2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)