### PR TITLE
feat(combat): D-PR2 — conditional outgoing-damage implants (Intrusion / Arcane Siege / Warpstrike)

### DIFF
--- a/docs/superpowers/plans/2026-06-20-implant-gearset-abilities-D-pr2.md
+++ b/docs/superpowers/plans/2026-06-20-implant-gearset-abilities-D-pr2.md
@@ -1,0 +1,522 @@
+# D-PR2: Conditional Outgoing-Damage Implants — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Light up three conditional outgoing-damage implants (Intrusion, Arcane Siege, Warpstrike) in the combat engine by modeling them as passive `modifier` abilities on channel `outgoingDamage`, and wire the DPS calculator page to consume equipment abilities.
+
+**Architecture:** These effects ride the *existing* modifier fold — `modifierTotalsFromAbilities` already iterates the passive slot, gates by `conditionsMet`, and sums flat `value` + per-count `scaling` into the multiplicative `outgoingDamage` factor. No `conditionalBonusPct`/`playerTurn` damage-fold surgery. The single new engine primitive is a `self-shield` condition subject for Arcane Siege. Effects are added to the D-PR1 `IMPLANT_ABILITIES` registry (values baked per-rarity; `description` used only as a presence gate).
+
+**Tech Stack:** React 18, TypeScript, Vite, Vitest. Combat engine under `src/utils/combat/` + `src/utils/abilities/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-pr2-design.md`
+**Branch:** `feat/combat-d-pr2-conditional-damage` (stacked on D-PR1 tip `cfbafb76`).
+
+---
+
+## Workflow gotchas (read before starting)
+
+- **Test runner:** bare `npm test` runs Vitest in WATCH mode and hangs. Always use `npx vitest run <path-or-name>`. Full suite: `npx vitest run`.
+- **Never** run `vitest -u` (would silently rewrite golden `.snap` files). Goldens must stay byte-identical here.
+- **Lint:** `npm run lint` enforces `--max-warnings 0`. Run it in EVERY task gate, not just the last (a stray `as any` fails the build).
+- **Type check:** `npx tsc --noEmit`.
+- **Skill audit (unchanged-guard):** `npm run audit:skills` should stay 141 ships / 0 findings (this PR doesn't touch the skill-text parser).
+- **`docs/` is gitignored** but `docs/superpowers/**` is force-tracked — commit plan/spec edits with `git add -f`.
+- Commit message footer:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+
+---
+
+## Task 1: Fixture audit — confirm the byte-identical invariant is empty
+
+**Goal:** Before any wiring, prove no existing DPS / battle-sim / healing fixture builds a ship carrying Intrusion / Arcane Siege / Warpstrike. If none do, the goldens are guaranteed byte-identical after Task 4 wires the DPS page. No code change — this is a verification gate.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Grep the test corpus for the three implants**
+
+Run:
+```bash
+grep -rniE "intrusion|arcane[_ ]?siege|warpstrike" src/ --include=*.test.ts --include=*.test.tsx
+grep -rniE "INTRUSION|ARCANE_SIEGE|WARPSTRIKE" src/ --include=*.ts --include=*.tsx | grep -iE "fixture|setBonus|implant" | grep -v "buildEquipmentAbilities\|implants.ts\|equipmentCoverage\|arcaneSiegeUtils"
+```
+Expected: no hits that wire one of these implants onto a ship used by a DPS/battle/healing golden. (Hits in `implants.ts`, `arcaneSiegeUtils.ts` (autogear), and the equipment-ability test files are expected and fine.)
+
+- [ ] **Step 2: Record the result**
+
+If clean (expected): note in the Task 4 commit body that the fixture audit was empty. If a fixture DOES carry one of these, STOP and surface it — either neutralize the fixture's equipment or deliberately audit the resulting churn (never `vitest -u`). Do not proceed to Task 4 with an un-audited fixture.
+
+---
+
+## Task 2: Add the `self-shield` condition primitive
+
+**Goal:** A binary, derivable condition that is met when the acting unit currently has a shield (`shieldPool > 0`). Purely additive — no existing ability uses it, `selfShielded` defaults falsy.
+
+**Files:**
+- Modify: `src/types/abilities.ts` (ConditionSubject union)
+- Modify: `src/utils/abilities/evaluateConditions.ts` (ConditionContext + evaluateCondition)
+- Modify: `src/utils/abilities/roundContext.ts` (buildRoundContext input + output)
+- Modify: `src/utils/combat/playerTurn.ts` (thread `actor.shieldPool > 0` into modifierCtx)
+- Test: `src/utils/abilities/__tests__/evaluateConditions.test.ts` (create if absent — otherwise the nearest existing conditions test; confirm at impl time)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the conditions test file (verify the existing import/helper shape first — mirror a sibling `evaluateCondition` test):
+
+```ts
+import { evaluateCondition, ConditionContext } from '../evaluateConditions';
+
+function baseCtx(over: Partial<ConditionContext> = {}): ConditionContext {
+    return {
+        selfBuffNames: [], selfDebuffNames: [], enemyBuffNames: [], enemyDebuffCount: 0,
+        effectiveCritRate: 0, adjacentAllyCount: 0, enemyAdjacentCount: 0,
+        enemyDestroyedCount: 0, selfHpPct: 100, enemyHpPct: 100, ...over,
+    };
+}
+
+describe('self-shield condition', () => {
+    it('evaluates to 1 when selfShielded is true', () => {
+        expect(evaluateCondition({ subject: 'self-shield', derivable: true }, baseCtx({ selfShielded: true }))).toBe(1);
+    });
+    it('evaluates to 0 when selfShielded is false/absent', () => {
+        expect(evaluateCondition({ subject: 'self-shield', derivable: true }, baseCtx())).toBe(0);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `npx vitest run src/utils/abilities/__tests__/evaluateConditions.test.ts`
+Expected: FAIL — `'self-shield'` not assignable to `ConditionSubject` (tsc) / case not handled.
+
+- [ ] **Step 3: Add `'self-shield'` to the ConditionSubject union**
+
+In `src/types/abilities.ts`, add to the `ConditionSubject` union (place near the other self-* subjects with a short comment):
+
+```ts
+    // Binary gate: the condition owner currently has a shield (CombatActor.shieldPool > 0).
+    // Live-derived (ConditionContext.selfShielded); defaults false (no shield / DPS mode).
+    // Dormant until sub-project H grants shields in the sim. Used by the Arcane Siege implant.
+    | 'self-shield';
+```
+(If `self-shield` is added mid-union, keep the trailing `;` on the final member intact.)
+
+- [ ] **Step 4: Extend ConditionContext + evaluateCondition**
+
+In `src/utils/abilities/evaluateConditions.ts`:
+
+Add to the `ConditionContext` interface (near `targetRepairedThisRound`):
+```ts
+    /** True when the condition owner currently has a shield (shieldPool > 0). Live-derived
+     *  by the engine; defaults false (no shield / DPS mode). Used by the Arcane Siege implant. */
+    selfShielded?: boolean;
+```
+
+Add a case in the `evaluateCondition` switch (near `self-debuff`):
+```ts
+        case 'self-shield':
+            return ctx.selfShielded ? 1 : 0;
+```
+
+- [ ] **Step 5: Thread through buildRoundContext**
+
+In `src/utils/abilities/roundContext.ts`, add to the `state` input type (near `targetRepairedThisRound`):
+```ts
+    /** True when the acting unit has a shield (shieldPool > 0). Default false. */
+    selfShielded?: boolean;
+```
+And to the returned object (near `targetRepairedThisRound: state.targetRepairedThisRound ?? false,`):
+```ts
+        selfShielded: state.selfShielded ?? false,
+```
+
+- [ ] **Step 6: Run the unit test, verify it passes**
+
+Run: `npx vitest run src/utils/abilities/__tests__/evaluateConditions.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Thread the live shield state in playerTurn (modifierCtx site only)**
+
+In `src/utils/combat/playerTurn.ts`, the `buildRoundContext({...})` call that builds `modifierCtx` (~line 1078): add the field, reading the acting actor's live shield:
+```ts
+        selfDebuffNames: selfDebuffNamesArg,
+        selfShielded: actor.shieldPool > 0,
+```
+Verify `actor` is the acting `CombatActor` in scope at that site and `shieldPool` is live there (it is — `state.ts:108`, used elsewhere in the engine). Do NOT thread into other `buildRoundContext` calls — only the modifier fold needs it (spec §4 / open question #2); they default falsy.
+
+- [ ] **Step 8: Verify byte-identical — full suite + lint + tsc**
+
+Run:
+```bash
+npx vitest run
+npm run lint
+npx tsc --noEmit
+```
+Expected: all green; ZERO `.snap` changes in `git status` (additive change — no ability uses `self-shield` yet, `selfShielded` defaults falsy).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/types/abilities.ts src/utils/abilities/evaluateConditions.ts src/utils/abilities/roundContext.ts src/utils/combat/playerTurn.ts src/utils/abilities/__tests__/evaluateConditions.test.ts
+git commit -m "feat(combat): D-PR2 — self-shield condition primitive (Arcane Siege gate)"
+```
+
+---
+
+## Task 3: Add Intrusion / Arcane Siege / Warpstrike to the registry
+
+**Goal:** Three `IMPLANT_ABILITIES` entries emitting passive `modifier`/`outgoingDamage` abilities with the per-rarity values from `implants.ts`.
+
+**Files:**
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts`
+- Test: `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`
+
+Per-rarity values (common / uncommon / rare / epic / legendary), verified against `implants.ts`:
+- **Intrusion** (per enemy debuff): 1 / 2 / 3 / 4 / 5
+- **Arcane Siege** (while shielded): 3 / 6 / 10 / 15 / 20
+- **Warpstrike** (while self-debuffed): 1 / 2 / 3 / 4 / 5
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `buildEquipmentAbilities.test.ts` (mirror the existing Bloodthirst test helpers — reuse the file's `makeShip`/`makePiece` style):
+
+```ts
+describe('Intrusion implant', () => {
+    it('emits a passive outgoingDamage modifier scaling per enemy debuff (legendary = 5/debuff)', () => {
+        const abilities = buildForImplant('INTRUSION', 'legendary');
+        expect(abilities).toHaveLength(1);
+        const a = abilities[0];
+        expect(a.type).toBe('modifier');
+        expect(a.trigger).toBe('passive');
+        expect(a.config).toMatchObject({ type: 'modifier', channel: 'outgoingDamage', value: 0 });
+        expect(a.scaling).toEqual({ conditionIndex: 0, perUnit: 5 });
+        expect(a.conditions).toEqual([{ subject: 'enemy-debuff', derivable: true }]);
+    });
+    it('bakes the uncommon per-debuff value (2)', () => {
+        expect(buildForImplant('INTRUSION', 'uncommon')[0].scaling).toEqual({ conditionIndex: 0, perUnit: 2 });
+    });
+});
+
+describe('Arcane Siege implant', () => {
+    it('emits a flat outgoingDamage modifier gated on self-shield (epic = 15)', () => {
+        const a = buildForImplant('ARCANE_SIEGE', 'epic')[0];
+        expect(a.config).toMatchObject({ type: 'modifier', channel: 'outgoingDamage', value: 15 });
+        expect(a.scaling).toBeUndefined();
+        expect(a.conditions).toEqual([{ subject: 'self-shield', derivable: true }]);
+    });
+});
+
+describe('Warpstrike implant', () => {
+    it('emits a flat outgoingDamage modifier gated on >=1 self-debuff (legendary = 5)', () => {
+        const a = buildForImplant('WARPSTRIKE', 'legendary')[0];
+        expect(a.config).toMatchObject({ type: 'modifier', channel: 'outgoingDamage', value: 5 });
+        expect(a.scaling).toBeUndefined();
+        expect(a.conditions).toEqual([
+            { subject: 'self-debuff', derivable: true, countComparator: 'gte', countThreshold: 1 },
+        ]);
+    });
+});
+```
+
+`buildForImplant(name, rarity)` = a small helper (add if not present) that builds a ship with one implant of that name+rarity and calls `buildEquipmentAbilities(ship, getGearPiece)` — mirror `implantAbilityCount` in `equipmentCoverage.test.ts`.
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+Run: `npx vitest run src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`
+Expected: FAIL — registry has no entries; `buildForImplant(...)` returns `[]`.
+
+- [ ] **Step 3: Add the registry entries**
+
+In `src/utils/abilities/buildEquipmentAbilities.ts`, add per-rarity value maps and three `IMPLANT_ABILITIES` entries. Follow the existing `BLOODTHIRST` builder shape (returns `Omit<Ability,'id'> | undefined`):
+
+```ts
+const INTRUSION_PER_DEBUFF: Record<string, number> = {
+    common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5,
+};
+const ARCANE_SIEGE_PCT: Record<string, number> = {
+    common: 3, uncommon: 6, rare: 10, epic: 15, legendary: 20,
+};
+const WARPSTRIKE_PCT: Record<string, number> = {
+    common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5,
+};
+```
+
+Add to `IMPLANT_ABILITIES`:
+```ts
+    // Intrusion: +N% outgoing direct damage per debuff on the target. Rides the
+    // modifier fold as a pure scaling modifier (value 0 + scaling); the enemy-debuff
+    // condition is a bare scaling source (no countComparator) so it scales, never gates.
+    INTRUSION: (rarity) => {
+        const perUnit = INTRUSION_PER_DEBUFF[rarity];
+        if (perUnit === undefined) return undefined;
+        return {
+            type: 'modifier',
+            target: 'self',
+            trigger: 'passive',
+            conditions: [{ subject: 'enemy-debuff', derivable: true }],
+            scaling: { conditionIndex: 0, perUnit },
+            config: { type: 'modifier', channel: 'outgoingDamage', value: 0, isMultiplicative: false },
+            autoFilled: true,
+        };
+    },
+    // Arcane Siege: +X% outgoing direct damage while shielded. Flat value gated on the
+    // new self-shield condition; dormant until sub-project H grants shields in the sim.
+    ARCANE_SIEGE: (rarity) => {
+        const value = ARCANE_SIEGE_PCT[rarity];
+        if (value === undefined) return undefined;
+        return {
+            type: 'modifier',
+            target: 'self',
+            trigger: 'passive',
+            conditions: [{ subject: 'self-shield', derivable: true }],
+            config: { type: 'modifier', channel: 'outgoingDamage', value, isMultiplicative: false },
+            autoFilled: true,
+        };
+    },
+    // Warpstrike (damage half only): +X% outgoing direct damage while self-debuffed.
+    // Flat value + a >=1 self-debuff gate (NOT scaling — scaledBonus uses the raw debuff
+    // count and would over-apply for multiple debuffs). The "reduce a random debuff's
+    // duration by 1 turn" half is DEFERRED (self-debuff-mitigation / cleanse-family).
+    WARPSTRIKE: (rarity) => {
+        const value = WARPSTRIKE_PCT[rarity];
+        if (value === undefined) return undefined;
+        return {
+            type: 'modifier',
+            target: 'self',
+            trigger: 'passive',
+            conditions: [
+                { subject: 'self-debuff', derivable: true, countComparator: 'gte', countThreshold: 1 },
+            ],
+            config: { type: 'modifier', channel: 'outgoingDamage', value, isMultiplicative: false },
+            autoFilled: true,
+        };
+    },
+```
+
+(Confirm the `Ability`/`Condition` types accept these literals; `trigger: 'passive'` must be a valid `AbilityTrigger` — verify and use the engine's passive-trigger value at impl time.)
+
+- [ ] **Step 4: Run the tests, verify they pass**
+
+Run: `npx vitest run src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + tsc**
+
+Run: `npm run lint && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+git commit -m "feat(combat): D-PR2 — Intrusion/Arcane Siege/Warpstrike outgoingDamage modifiers"
+```
+
+---
+
+## Task 4: Wire the DPS calculator page
+
+**Goal:** Make the DPS page consume equipment abilities so Intrusion/Warpstrike actually affect a DPS run. (`battleSimulator` already routes them since D-PR1.)
+
+**Files:**
+- Modify: `src/pages/calculators/DPSCalculatorPage.tsx` (3 sites: ~lines 73, 384, 440)
+
+- [ ] **Step 1: Add the import**
+
+In `DPSCalculatorPage.tsx`, add (mirror HealingCalculatorPage's import):
+```ts
+import { buildShipAbilitiesWithEquipment } from '../../utils/abilities/buildShipAbilitiesWithEquipment';
+```
+
+- [ ] **Step 2: Replace the three call sites**
+
+Change each `shipSkills: buildShipAbilities(ship),` (lines ~73, 384, 440) to:
+```ts
+shipSkills: buildShipAbilitiesWithEquipment(ship, getGearPiece),
+```
+`getGearPiece` is already in scope (`const { getGearPiece } = useInventory();`, line 39). Remove the now-unused `buildShipAbilities` import only if no other site uses it (grep first).
+
+- [ ] **Step 3: Verify byte-identical — full suite + lint + tsc**
+
+Run:
+```bash
+npx vitest run
+npm run lint
+npx tsc --noEmit
+```
+Expected: all green; ZERO `.snap` changes (fixture audit in Task 1 confirmed no golden ship carries these implants).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/calculators/DPSCalculatorPage.tsx
+git commit -m "feat(combat): D-PR2 — wire DPS calculator page to equipment abilities
+
+Fixture audit (Task 1) confirmed no DPS/battle/healing golden ship carries
+Intrusion/Arcane Siege/Warpstrike, so goldens stay byte-identical."
+```
+
+---
+
+## Task 5: Update the equipment coverage tracker
+
+**Goal:** Reflect the three newly-implemented implants in the living coverage regression guard.
+
+**Files:**
+- Modify: `src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+
+- [ ] **Step 1: Update the implemented-implants assertion**
+
+Change the `implementedImplants` expectation (currently `['BLOODTHIRST']`) to the `IMPLANTS` declaration order of the implemented set:
+```ts
+expect(implementedImplants).toEqual(['ARCANE_SIEGE', 'INTRUSION', 'WARPSTRIKE', 'BLOODTHIRST']);
+```
+(Declaration order in `implants.ts`: ARCANE_SIEGE, INTRUSION, WARPSTRIKE, … BLOODTHIRST. `implementedImplants` is `Object.keys(IMPLANTS).filter(...)`, so order follows declaration.)
+
+- [ ] **Step 2: Move the three implants out of the "produces 0 abilities" loop**
+
+The `nonBloodthirstImplants` loop asserts every non-Bloodthirst implant produces 0 abilities — Intrusion/Arcane Siege/Warpstrike will now break it. Update the exclusion filter and add positive per-implant assertions:
+```ts
+const IMPLEMENTED = ['BLOODTHIRST', 'INTRUSION', 'ARCANE_SIEGE', 'WARPSTRIKE'];
+const unimplementedImplants = Object.keys(IMPLANTS).filter((k) => !IMPLEMENTED.includes(k));
+for (const implantKey of unimplementedImplants) { /* ...existing "produces 0" assertion... */ }
+
+it('INTRUSION (legendary) produces 1 ability', () => {
+    expect(implantAbilityCount('INTRUSION', 'legendary')).toBe(1);
+});
+it('ARCANE_SIEGE (epic) produces 1 ability', () => {
+    expect(implantAbilityCount('ARCANE_SIEGE', 'epic')).toBe(1);
+});
+it('WARPSTRIKE (legendary) produces 1 ability', () => {
+    expect(implantAbilityCount('WARPSTRIKE', 'legendary')).toBe(1);
+});
+```
+Also update the header comment in the file ("when D-PR2 adds new effects …") to note the set now includes these three.
+
+- [ ] **Step 3: Run the coverage test, verify it passes**
+
+Run: `npx vitest run src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/abilities/__tests__/equipmentCoverage.test.ts
+git commit -m "test(combat): D-PR2 — coverage tracker includes Intrusion/Arcane Siege/Warpstrike"
+```
+
+---
+
+## Task 6: Integration tests — the effects actually amplify direct damage
+
+**Goal:** Prove the end-to-end fold: a passive Intrusion/Warpstrike/Arcane Siege modifier amplifies a unit's outgoing direct damage under its condition, via the real engine path (not just the registry shape).
+
+**Files:**
+- Test: `src/utils/abilities/__tests__/conditionalDamageImplants.integration.test.ts` (new), OR extend the D-PR1 end-to-end test file — confirm the existing harness at impl time (D-PR1 added an end-to-end Leech/Bloodthirst test; mirror it).
+
+- [ ] **Step 1: Write a modifier-fold-level integration test**
+
+Assert the fold directly (fast, deterministic), using the registry output + `modifierTotalsFromAbilities`:
+```ts
+import { buildEquipmentAbilities } from '../buildEquipmentAbilities';
+import { modifierTotalsFromAbilities } from '../applyAbilities';
+// ...build a ship with INTRUSION legendary, get the ability, then:
+const [intrusion] = buildEquipmentAbilities(shipWithIntrusion, getGearPiece);
+expect(modifierTotalsFromAbilities([intrusion], ctx({ enemyDebuffCount: 3 })).outgoingDamage).toBe(15); // 5 × 3
+expect(modifierTotalsFromAbilities([intrusion], ctx({ enemyDebuffCount: 0 })).outgoingDamage).toBe(0);
+
+const [warp] = buildEquipmentAbilities(shipWithWarpstrike, getGearPiece);
+expect(modifierTotalsFromAbilities([warp], ctx({ selfDebuffNames: ['Burn'] })).outgoingDamage).toBe(5);
+expect(modifierTotalsFromAbilities([warp], ctx({ selfDebuffNames: [] })).outgoingDamage).toBe(0);
+expect(modifierTotalsFromAbilities([warp], ctx({ selfDebuffNames: ['A', 'B'] })).outgoingDamage).toBe(5); // flat, not 10
+
+const [siege] = buildEquipmentAbilities(shipWithArcaneSiege, getGearPiece);
+expect(modifierTotalsFromAbilities([siege], ctx({ selfShielded: true })).outgoingDamage).toBe(15);
+expect(modifierTotalsFromAbilities([siege], ctx({ selfShielded: false })).outgoingDamage).toBe(0);
+```
+`ctx(over)` = a `ConditionContext` helper (reuse the Task 2 `baseCtx`).
+
+- [ ] **Step 2: Write an engine-level integration test (Intrusion)**
+
+Mirror the D-PR1 end-to-end harness: run a single attacker (equipped with Intrusion) through the engine against an enemy carrying N debuffs, and assert its direct damage is `× (1 + perUnit·N/100)` of the same attacker with no implant. Keep N and the debuff source deterministic. If the existing harness makes a full engine assertion heavy, the modifier-fold-level test in Step 1 + the registry tests in Task 3 are the load-bearing coverage; the engine-level test is a thin confirmation that the passive modifier reaches the fold. Confirm scope at impl time.
+
+- [ ] **Step 3: Run the integration tests, verify they pass**
+
+Run: `npx vitest run <new test path>`
+Expected: PASS.
+
+- [ ] **Step 4: Lint + tsc + commit**
+
+```bash
+npm run lint && npx tsc --noEmit
+git add <new test path>
+git commit -m "test(combat): D-PR2 — integration: conditional outgoing-damage implants amplify direct damage"
+```
+
+---
+
+## Task 7: Changelog + in-app docs
+
+**Goal:** User-facing entry + keep combat docs in sync.
+
+**Files:**
+- Modify: `src/constants/changelog.ts` (`UNRELEASED_CHANGES`)
+- Modify: `src/pages/DocumentationPage.tsx` (if it documents which implant/gear effects the sim models)
+
+- [ ] **Step 1: Add an UNRELEASED_CHANGES entry**
+
+Plain-English, e.g.:
+```
+The combat & DPS simulators now model the Intrusion, Arcane Siege, and Warpstrike implants — your outgoing damage scales with debuffs on the target, your own shield, and your own debuffs respectively. The DPS calculator now accounts for equipped implant and gear-set effects.
+```
+
+- [ ] **Step 2: Update DocumentationPage if it lists modeled equipment effects**
+
+Grep `DocumentationPage.tsx` for the D-PR1 equipment-effects mention (Leech/Bloodthirst). If present, extend it with the three new implants. If no such section exists, skip.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/constants/changelog.ts src/pages/DocumentationPage.tsx
+git commit -m "docs(combat): D-PR2 — changelog + docs for conditional outgoing-damage implants"
+```
+
+---
+
+## Task 8: Final verification gate
+
+**Goal:** Whole-PR green + byte-identical confirmation before review/merge.
+
+- [ ] **Step 1: Full suite**
+
+Run: `npx vitest run`
+Expected: all green; test count = D-PR1 baseline + the new tests; ZERO unexplained failures.
+
+- [ ] **Step 2: Lint + type check + skill audit**
+
+Run:
+```bash
+npm run lint
+npx tsc --noEmit
+npm run audit:skills
+```
+Expected: lint 0 warnings; tsc clean; audit 141 ships / 0 findings (unchanged).
+
+- [ ] **Step 3: Confirm zero golden movement**
+
+Run: `git status --porcelain && git diff --stat HEAD~7 -- '*.snap'`
+Expected: no `.snap` files modified across the PR.
+
+- [ ] **Step 4: Update project memory**
+
+Append D-PR2 shipped facts to the combat-realism epic memory node (`project_combat_realism_epic.md`): effects, the modifier-fold approach (overriding the earlier conditionalBonusPct framing), the new `self-shield` condition, DPS-page wiring, and "what's next in D" (Giant Slayer/Menace/Insidiousness/Voidfire; Warpstrike duration-reduction half; incoming-reduction bucket).
+
+---
+
+## Done criteria
+
+- Intrusion / Arcane Siege / Warpstrike emit passive `outgoingDamage` modifiers from the registry; the engine folds them (gated + scaled) into direct damage.
+- `self-shield` condition added and unit-tested; threaded from `actor.shieldPool`.
+- DPS calculator page consumes equipment abilities.
+- Coverage tracker + integration tests green.
+- All DPS / battle-sim / healing goldens byte-identical.
+- Changelog + docs updated.

--- a/docs/superpowers/plans/2026-06-20-implant-gearset-abilities-D-pr2.md
+++ b/docs/superpowers/plans/2026-06-20-implant-gearset-abilities-D-pr2.md
@@ -186,7 +186,7 @@ describe('Intrusion implant', () => {
         expect(abilities).toHaveLength(1);
         const a = abilities[0];
         expect(a.type).toBe('modifier');
-        expect(a.trigger).toBe('passive');
+        expect(a.trigger).toBe('on-cast');
         expect(a.config).toMatchObject({ type: 'modifier', channel: 'outgoingDamage', value: 0 });
         expect(a.scaling).toEqual({ conditionIndex: 0, perUnit: 5 });
         expect(a.conditions).toEqual([{ subject: 'enemy-debuff', derivable: true }]);
@@ -251,7 +251,7 @@ Add to `IMPLANT_ABILITIES`:
         return {
             type: 'modifier',
             target: 'self',
-            trigger: 'passive',
+            trigger: 'on-cast',
             conditions: [{ subject: 'enemy-debuff', derivable: true }],
             scaling: { conditionIndex: 0, perUnit },
             config: { type: 'modifier', channel: 'outgoingDamage', value: 0, isMultiplicative: false },
@@ -266,7 +266,7 @@ Add to `IMPLANT_ABILITIES`:
         return {
             type: 'modifier',
             target: 'self',
-            trigger: 'passive',
+            trigger: 'on-cast',
             conditions: [{ subject: 'self-shield', derivable: true }],
             config: { type: 'modifier', channel: 'outgoingDamage', value, isMultiplicative: false },
             autoFilled: true,
@@ -282,7 +282,7 @@ Add to `IMPLANT_ABILITIES`:
         return {
             type: 'modifier',
             target: 'self',
-            trigger: 'passive',
+            trigger: 'on-cast',
             conditions: [
                 { subject: 'self-debuff', derivable: true, countComparator: 'gte', countThreshold: 1 },
             ],
@@ -292,7 +292,7 @@ Add to `IMPLANT_ABILITIES`:
     },
 ```
 
-(Confirm the `Ability`/`Condition` types accept these literals; `trigger: 'passive'` must be a valid `AbilityTrigger` — verify and use the engine's passive-trigger value at impl time.)
+(Note: `'passive'` is NOT a valid `AbilityTrigger`. Use `trigger: 'on-cast'` — the same value `buildShipAbilities` assigns to parser-emitted passive-slot `outgoingDamage` modifiers. The trigger is inert for these: `modifierTotalsFromAbilities` filters only on `type === 'modifier'`, never on trigger.)
 
 - [ ] **Step 4: Run the tests, verify they pass**
 

--- a/docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-pr2-design.md
+++ b/docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-pr2-design.md
@@ -85,6 +85,11 @@ the D-PR1 per-rarity-builder pattern. Each returns a single `Ability` (minus `id
 `channel: 'outgoingDamage'`, `target: 'self'`, `trigger: 'passive'`, `autoFilled: true`. Per-rarity
 values are baked from `implants.ts`; a rarity absent from the value map yields `undefined` (skip).
 
+Values are **baked into the registry** (not text-parsed) precisely because the source `description`
+strings are inconsistent ("Direct Damage" vs "direct damage", inconsistent trailing periods, one
+Intrusion variant missing its period) — the registry path sidesteps that fragility, matching D-PR1.
+The `description` is still used only as a presence gate, never parsed.
+
 ### 3.1 Intrusion — per-count scaling
 
 ```
@@ -154,7 +159,7 @@ The minimal additive change required for Arcane Siege:
 4. **`buildRoundContext`** — accept a `selfShielded` input and set it on the context it builds.
 5. **`playerTurn.ts`** — thread `selfShielded: actor.shieldPool > 0` into the `buildRoundContext` call
    that produces `modifierCtx` (`~line 1078`). `actor` is the acting `CombatActor`; `shieldPool` exists
-   on it (`state.ts:104`, init 0) and reflects the live remaining shield at attack time.
+   on it (`state.ts:108`, init 0) and reflects the live remaining shield at attack time.
 
 Emitted conditions use `derivable: true` — a `derivable: false` condition is treated as always-met
 (`evaluateConditions.ts`), which would defeat the gate. (Mirrors the `target-repaired-this-round`

--- a/docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-pr2-design.md
+++ b/docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-pr2-design.md
@@ -1,0 +1,209 @@
+# Combat Realism Epic — Sub-project D, PR2: Conditional Outgoing-Damage Implants (Design)
+
+**Date:** 2026-06-20
+**Sub-project:** D (new ability sources: implants + gear-set skills), second PR.
+**Parent spec:** `docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-design.md`.
+**Builds on:** D-PR1 (`feat/combat-d-implant-gearset`) — `buildEquipmentAbilities` registry,
+`buildShipAbilitiesWithEquipment` passive-slot merge, `procChance` machinery, equipment coverage tracker.
+**Branch:** `feat/combat-d-pr2-conditional-damage`, stacked on the D-PR1 tip.
+**Status:** design (brainstorm complete, user-approved through all sections).
+
+## 1. Context
+
+D-PR1 shipped the equipment-ability **source layer** (a registry-based `buildEquipmentAbilities` merged
+into the passive slot via `buildShipAbilitiesWithEquipment`) plus the `procChance` proc-gate machinery,
+and lit up the first two effects (Leech gear set + Bloodthirst implant — both heals). The DPS calculator
+page was deliberately **not** wired in D-PR1 because those effects are heals that don't affect DPS.
+
+D-PR2 lights up the **conditional outgoing-damage** bucket from the parent spec (§5.2) — the implants
+that increase a unit's outgoing direct damage under a condition:
+
+- **Intrusion** (`src/constants/implants.ts`) — "Increases damage dealt by X% for **each debuff on the
+  target** when directly damaging them." X = 1/2/3/4/5 by rarity (common/uncommon/rare/epic/legendary).
+- **Arcane Siege** — "Increases outgoing Direct Damage by X% **while shielded**." X = 3/6/10/15/20.
+- **Warpstrike** — "Increases damage by X% when directly damaging an enemy **while debuffed**, and
+  reduces a random active debuff's duration by 1 turn." X = 1/2/3/4/5. (Only the damage half is in
+  scope; see §6.)
+
+Because these are outgoing damage, D-PR2 also **wires the DPS calculator page** to consume equipment
+abilities (the wiring D-PR1 skipped).
+
+### 1.1 Key finding that reshaped this PR
+
+The sub-project-D spec and the prior working assumption framed the core work as *"wire passive
+conditional-scaling into `conditionalBonusPct`"* — i.e. extend the additive multiplier-points fold in
+`playerTurn.ts` (`conditionalBonusPct`, ~line 1210) to read passive-slot scaling, which today it does
+not (it reads only the firing skill's damage ability).
+
+A code-read showed a **simpler and more faithful** path already exists. `modifierTotalsFromAbilities`
+(`src/utils/abilities/applyAbilities.ts:22-76`):
+
+- already iterates **all** abilities passed to it, and `playerTurn.ts:1094-1097` already passes the
+  **passive slot** (`modifierAbilities = [...firing, ...passive]`);
+- already **gates** each ability by `conditionsMet(gateConditions(ability), ctx)` (line 41);
+- already supports **both** a flat `config.value` **and** per-count `scaling` via
+  `value + (scaling ? scaledBonus(ability, ctx) : 0)` (line 49);
+- routes channel `outgoingDamage` into `dmgStats.totals.outgoingDamageBuff`, which
+  `playerTurn.ts` applies as the **multiplicative** factor `(1 + outgoingDamageBuff/100)` inside
+  `nonCritFactor` — and that factor scopes naturally to **direct** damage (DoT damage is computed on a
+  separate path).
+
+So these three effects can be modeled as passive `modifier` abilities on channel `outgoingDamage`, and
+the engine **already folds them** — no `conditionalBonusPct` surgery. This is also more faithful: the
+implants literally say "increase outgoing/dealt damage by X%" (multiplicative), whereas
+`conditionalBonusPct` adds flat percentage-points onto the skill multiplier.
+
+The **only** genuinely-new engine primitive is a `self-shield` condition subject for Arcane Siege (§4).
+
+## 2. Goals / non-goals
+
+**Goals**
+
+- Add Intrusion, Arcane Siege, and Warpstrike (damage half) as `buildEquipmentAbilities` registry
+  entries that ride the existing `outgoingDamage` modifier fold.
+- Add the one new condition primitive (`self-shield`) Arcane Siege requires.
+- Wire the DPS calculator page to consume equipment abilities.
+- Keep all existing DPS / battle-sim / healing goldens **byte-identical**.
+
+**Non-goals (deferred, with owner)**
+
+- Warpstrike's "reduce a random active debuff's duration by 1 turn" half → **deferred** (self-debuff-
+  mitigation / cleanse-family; not in this PR's machinery). See §6.
+- Giant Slayer / Menace / Insidiousness / Voidfire Catalyst (the rest of the parent spec's
+  "conditional outgoing dmg" row) → **later D PRs**. Menace + Giant Slayer need in-flight reactive
+  damage amplification + a `target-higher-attack` condition (noted in D-PR1) and don't fit the passive
+  modifier fold.
+- Making shields actually *appear* in DPS/battle-sim (shield grants) → **sub-project H**. Arcane Siege
+  is therefore dormant in integration until H lands; it is unit-tested in isolation now (§5).
+- No autogear/scoring changes (`arcaneSiegeUtils` stays as is — that models the same implant only inside
+  autogear scoring, independent of the combat engine).
+
+## 3. Effect models (registry entries)
+
+All three are added to `IMPLANT_ABILITIES` in `src/utils/abilities/buildEquipmentAbilities.ts`, mirroring
+the D-PR1 per-rarity-builder pattern. Each returns a single `Ability` (minus `id`) of `type: 'modifier'`,
+`channel: 'outgoingDamage'`, `target: 'self'`, `trigger: 'passive'`, `autoFilled: true`. Per-rarity
+values are baked from `implants.ts`; a rarity absent from the value map yields `undefined` (skip).
+
+### 3.1 Intrusion — per-count scaling
+
+```
+{
+  type: 'modifier',
+  target: 'self',
+  trigger: 'passive',
+  conditions: [{ subject: 'enemy-debuff', derivable: true }],
+  scaling: { conditionIndex: 0, perUnit: X },   // X = 1/2/3/4/5
+  config: { type: 'modifier', channel: 'outgoingDamage', value: 0, isMultiplicative: false },
+  autoFilled: true,
+}
+```
+
+- `enemy-debuff` is a bare scaling-source condition (no `countComparator`) → `gateConditions` removes it
+  from the gate (it scales, never gates), so the modifier always folds and contributes
+  `scaledBonus = perUnit × enemyDebuffCount`. Zero debuffs → +0%. `enemyDebuffCount` is already in
+  `modifierCtx` (`landedEnemyDebuffCount`, `playerTurn.ts:1080`).
+- `isMultiplicative: false` matches the channel convention — `modifierTotalsFromAbilities` ignores the
+  flag and sums into the additive `outgoingDamageBuff` total, which is then applied multiplicatively as
+  `(1 + outgoingDamageBuff/100)`. (This is the same treatment every existing `outgoingDamage` modifier
+  already gets.)
+
+### 3.2 Arcane Siege — flat, gated on self-shield
+
+```
+{
+  type: 'modifier',
+  target: 'self',
+  trigger: 'passive',
+  conditions: [{ subject: 'self-shield', derivable: true }],
+  config: { type: 'modifier', channel: 'outgoingDamage', value: X, isMultiplicative: false },
+  autoFilled: true,
+}
+```
+
+- X = 3/6/10/15/20. No `scaling`; a flat `value` gated by the self-shield condition.
+- `self-shield` is **not** a bare scaling source → `gateConditions` keeps it → the +X% applies only when
+  `conditionsMet` (the unit is shielded). Dormant until shields exist in the path (§2).
+
+### 3.3 Warpstrike (damage half) — flat, gated on self-debuff
+
+```
+{
+  type: 'modifier',
+  target: 'self',
+  trigger: 'passive',
+  conditions: [{ subject: 'self-debuff', derivable: true, countComparator: 'gte', countThreshold: 1 }],
+  config: { type: 'modifier', channel: 'outgoingDamage', value: X, isMultiplicative: false },
+  autoFilled: true,
+}
+```
+
+- X = 1/2/3/4/5. A flat `value` gated on the unit having ≥1 debuff. Using a flat value + a `gte 1` gate
+  (rather than `scaling` on `self-debuff`) is deliberate: `scaledBonus` always uses the **raw** count,
+  so scaling on `self-debuff` would over-apply for a unit carrying multiple debuffs. The flat-value +
+  gate gives a single +X% whenever debuffed. `selfDebuffNames` is already in `modifierCtx`
+  (`playerTurn.ts:1091`).
+
+## 4. New engine primitive — `self-shield` condition
+
+The minimal additive change required for Arcane Siege:
+
+1. **`ConditionSubject` union** (`src/types/abilities.ts`) — add `'self-shield'`.
+2. **`ConditionContext`** (`src/utils/abilities/evaluateConditions.ts`) — add `selfShielded?: boolean`.
+3. **`evaluateCondition`** — `case 'self-shield': return ctx.selfShielded ? 1 : 0;` (binary, derivable).
+4. **`buildRoundContext`** — accept a `selfShielded` input and set it on the context it builds.
+5. **`playerTurn.ts`** — thread `selfShielded: actor.shieldPool > 0` into the `buildRoundContext` call
+   that produces `modifierCtx` (`~line 1078`). `actor` is the acting `CombatActor`; `shieldPool` exists
+   on it (`state.ts:104`, init 0) and reflects the live remaining shield at attack time.
+
+Emitted conditions use `derivable: true` — a `derivable: false` condition is treated as always-met
+(`evaluateConditions.ts`), which would defeat the gate. (Mirrors the `target-repaired-this-round`
+pattern.)
+
+This is purely additive: no existing ability carries `subject: 'self-shield'`, and `selfShielded`
+defaults falsy, so every existing fold is unchanged.
+
+## 5. DPS calculator page wiring
+
+`DPSCalculatorPage.tsx` already holds `getGearPiece` from `useInventory()` (line 39). Swap its three
+`buildShipAbilities(ship)` call sites (lines 73, 384, 440) to
+`buildShipAbilitiesWithEquipment(ship, getGearPiece)`, exactly mirroring the HealingCalculatorPage sites
+D-PR1 wired. This is what makes Intrusion/Warpstrike actually affect a DPS run. (`battleSimulator`
+already routes equipment abilities since D-PR1.)
+
+## 6. Deferred: Warpstrike's debuff-duration reduction
+
+Warpstrike also "reduces a random active debuff's duration by 1 turn" on the wielder. This is a
+self-debuff-mitigation effect (cleanse-family), not an outgoing-damage modifier, and would pull in
+machinery this PR otherwise doesn't touch (selecting/decrementing a random standing self-debuff at
+attack time). It is **deferred** and noted in-code on the Warpstrike registry entry so the omission is
+explicit. The damage half is the faithful, high-value part for a DPS/combat model.
+
+## 7. Testing & invariants
+
+- **Unit — registry entries** (`buildEquipmentAbilities.test.ts`): each implant at each rarity emits a
+  single `modifier`/`outgoingDamage` ability with the expected `value`, `scaling`, and `conditions`;
+  unsupported rarity → none; graceful skip on missing pieces (already covered by the D-PR1 harness).
+- **Unit — `self-shield`** (`evaluateConditions` test): returns 1 when `selfShielded` true, 0 otherwise;
+  an Arcane Siege modifier folds +X% only when the context is shielded.
+- **Integration**: a ship with Intrusion attacking an enemy carrying N debuffs deals
+  `× (1 + X·N/100)` of its no-implant direct damage; a ship with Warpstrike deals `× (1 + X/100)` only
+  while itself debuffed, and unmodified otherwise.
+- **Coverage tracker** (`equipmentCoverage.test.ts`): implemented implants set updated to
+  `BLOODTHIRST, INTRUSION, ARCANE_SIEGE, WARPSTRIKE` (in `IMPLANTS` declaration order), and the
+  per-implant "produces 0 abilities" guard for those three is replaced with positive assertions.
+- **Load-bearing byte-identical invariant:** existing DPS / battle-sim / healing goldens stay
+  **byte-identical**. The `self-shield` subject + `selfShielded` ctx field are additive, and equipment
+  abilities only run where `getGearPiece` is threaded. **First plan step (do before any wiring):** grep
+  the DPS/battle-sim/healing fixtures for ships carrying Intrusion / Arcane Siege / Warpstrike implants
+  (expected: none). Confirm the invariant is empty before it can silently break; if a fixture *does*
+  carry one, neutralize it or deliberately audit the churn (never `vitest -u`).
+
+## 8. Open questions for the plan
+
+1. Exact `IMPLANTS` declaration order for the coverage-tracker `implementedImplants` assertion (read it
+   at plan time; the test filters `Object.keys(IMPLANTS)`).
+2. Whether `buildRoundContext` is called in more than one place that should carry `selfShielded` (only
+   the `modifierCtx` site needs it for these effects; thread minimally, default falsy elsewhere).
+3. Confirm `actor.shieldPool` is in scope and live at the `modifierCtx` build site in every `runPlayerTurn`
+   entry (player/team/enemy) — it is the same team-agnostic function, but verify the param plumbing.

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -11,6 +11,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat simulator: Amartya's charge purge now scales with crit power — it removes 1 buff for every 50% crit power (so higher crit power purges more buffs), applied to every enemy hit.",
     'Combat simulator: enemy ships now actually heal — their HP recovers from repair skills instead of being stuck, so enemy teams survive more realistically. Skills that trigger off a target being healed this round (such as Nayra) now also fire against healed enemies.',
     'Combat simulator now applies the Leech gear set and the Bloodthirst implant, with chance-based procs modeled at their true average frequency. More implant and gear-set effects are coming.',
+    'Combat & DPS simulators now model three conditional damage implants: Intrusion (more outgoing damage per debuff on the target), Arcane Siege (more outgoing damage while your ship is shielded), and Warpstrike (more outgoing damage while your ship is debuffed). The DPS calculator now also accounts for equipped implant and gear-set effects.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3063,14 +3063,19 @@ const DocumentationPage: React.FC = () => {
                                 </h4>
                                 <p className="text-theme-text">
                                     Equipped implant and gear-set special effects are beginning to
-                                    apply in the simulator. Currently supported:{' '}
-                                    <strong>Leech</strong> gear set (heals the ship for 15% of all
-                                    damage it deals each turn) and the <strong>Bloodthirst</strong>{' '}
-                                    implant (on-crit heal for 12%, 17%, or 20% of damage dealt,
-                                    depending on rarity). Chance-based procs such as Bloodthirst are
-                                    modeled at
-                                    their expected average frequency. More implant and gear-set
-                                    effects will be added in future updates.
+                                    apply in the simulator (and now in the DPS calculator too).
+                                    Currently supported: <strong>Leech</strong> gear set (heals the
+                                    ship for 15% of all damage it deals each turn) and the{' '}
+                                    <strong>Bloodthirst</strong> implant (on-crit heal for 12%, 17%,
+                                    or 20% of damage dealt, depending on rarity). Chance-based procs
+                                    such as Bloodthirst are modeled at their expected average
+                                    frequency. Three conditional damage implants also apply:{' '}
+                                    <strong>Intrusion</strong> (more outgoing damage for each debuff
+                                    on the target), <strong>Arcane Siege</strong> (more outgoing
+                                    damage while the ship is shielded), and{' '}
+                                    <strong>Warpstrike</strong> (more outgoing damage while the ship
+                                    is debuffed). More implant and gear-set effects will be added in
+                                    future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/pages/calculators/DPSCalculatorPage.tsx
+++ b/src/pages/calculators/DPSCalculatorPage.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../types/calculator';
 import { ShipSkills } from '../../types/abilities';
 import { detectFullyCharged } from '../../utils/skillTextParser';
-import { buildShipAbilities } from '../../utils/abilities/buildShipAbilities';
+import { buildShipAbilitiesWithEquipment } from '../../utils/abilities/buildShipAbilitiesWithEquipment';
 import {
     buildDefaultShipSkills,
     configShipSkillsToSimInputs,
@@ -70,7 +70,7 @@ const DPSCalculatorPage: React.FC = () => {
                                 ship.secondPassiveSkillText,
                                 ship.thirdPassiveSkillText,
                             ]),
-                            shipSkills: buildShipAbilities(ship),
+                            shipSkills: buildShipAbilitiesWithEquipment(ship, getGearPiece),
                         },
                     ],
                     nextId: 2,
@@ -381,7 +381,7 @@ const DPSCalculatorPage: React.FC = () => {
                         ship.thirdPassiveSkillText,
                     ]),
                     affinity: ship.affinity,
-                    shipSkills: buildShipAbilities(ship),
+                    shipSkills: buildShipAbilitiesWithEquipment(ship, getGearPiece),
                 };
             })
         );
@@ -437,7 +437,7 @@ const DPSCalculatorPage: React.FC = () => {
                     startCharged,
                     speed,
                     chargeCount: ship.chargeSkillCharge ?? 0,
-                    shipSkills: buildShipAbilities(ship),
+                    shipSkills: buildShipAbilitiesWithEquipment(ship, getGearPiece),
                     stats: combatStats,
                     affinity: ship.affinity,
                     // Walked skills supersede auto-fill stamping; clear any prior auto-filled

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -135,7 +135,11 @@ export type ConditionSubject =
     // defaults false (DPS mode / un-repaired target). Nayra's charged purge + Stasis/
     // Exposed inflicts. derivable:true — a derivable:false condition would always be met
     // (evaluateConditions.ts:30), defeating the gate.
-    | 'target-repaired-this-round';
+    | 'target-repaired-this-round'
+    // Binary gate: the condition owner currently has a shield (CombatActor.shieldPool > 0).
+    // Live-derived (ConditionContext.selfShielded); defaults false (no shield / DPS mode).
+    // Dormant until sub-project H grants shields in the sim. Used by the Arcane Siege implant.
+    | 'self-shield';
 
 export interface Condition {
     subject: ConditionSubject;

--- a/src/utils/abilities/__tests__/applyAbilities.test.ts
+++ b/src/utils/abilities/__tests__/applyAbilities.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../applyAbilities';
 import { Ability, Condition, ModifierChannel, ShipSkills, Skill } from '../../../types/abilities';
 import { ConditionContext } from '../evaluateConditions';
+import { makeConditionContext } from './conditionContextFixture';
 
 function damage(id: string, multiplier: number, hits?: number): Ability {
     return {
@@ -79,22 +80,6 @@ function modifier(
     };
 }
 
-function makeCtx(overrides: Partial<ConditionContext> = {}): ConditionContext {
-    return {
-        selfBuffNames: [],
-        selfDebuffNames: [],
-        enemyBuffNames: [],
-        enemyDebuffCount: 0,
-        effectiveCritRate: 0,
-        adjacentAllyCount: 0,
-        enemyAdjacentCount: 0,
-        enemyDestroyedCount: 0,
-        selfHpPct: 100,
-        enemyHpPct: 100,
-        ...overrides,
-    };
-}
-
 describe('modifierTotalsFromAbilities', () => {
     const zero = {
         attack: 0,
@@ -109,7 +94,7 @@ describe('modifierTotalsFromAbilities', () => {
     it('sums a single outgoingDamage modifier', () => {
         const result = modifierTotalsFromAbilities(
             [modifier('m', 'outgoingDamage', 40)],
-            makeCtx()
+            makeConditionContext()
         );
         expect(result).toEqual({ ...zero, outgoingDamage: 40 });
     });
@@ -121,7 +106,7 @@ describe('modifierTotalsFromAbilities', () => {
                     { subject: 'enemy-type', derivable: true, requiredEnemyType: 'Defender' },
                 ]),
             ],
-            makeCtx({ enemyType: 'Attacker' })
+            makeConditionContext({ enemyType: 'Attacker' })
         );
         expect(result).toEqual(zero);
     });
@@ -133,20 +118,23 @@ describe('modifierTotalsFromAbilities', () => {
                     { subject: 'enemy-type', derivable: true, requiredEnemyType: 'Defender' },
                 ]),
             ],
-            makeCtx({ enemyType: 'Defender' })
+            makeConditionContext({ enemyType: 'Defender' })
         );
         expect(result).toEqual({ ...zero, attack: 50 });
     });
 
     it('maps the "defense" channel to the defence bucket', () => {
-        const result = modifierTotalsFromAbilities([modifier('m', 'defense', 30)], makeCtx());
+        const result = modifierTotalsFromAbilities(
+            [modifier('m', 'defense', 30)],
+            makeConditionContext()
+        );
         expect(result).toEqual({ ...zero, defence: 30 });
     });
 
     it('stacks two modifiers', () => {
         const result = modifierTotalsFromAbilities(
             [modifier('m1', 'attack', 20), modifier('m2', 'attack', 15)],
-            makeCtx()
+            makeConditionContext()
         );
         expect(result).toEqual({ ...zero, attack: 35 });
     });
@@ -154,13 +142,13 @@ describe('modifierTotalsFromAbilities', () => {
     it('ignores channels with no DPS bucket (outgoingHeal, incomingDamage)', () => {
         const result = modifierTotalsFromAbilities(
             [modifier('m1', 'outgoingHeal', 50), modifier('m2', 'incomingDamage', 25)],
-            makeCtx()
+            makeConditionContext()
         );
         expect(result).toEqual(zero);
     });
 
     it('returns all zero with no abilities', () => {
-        expect(modifierTotalsFromAbilities([], makeCtx())).toEqual(zero);
+        expect(modifierTotalsFromAbilities([], makeConditionContext())).toEqual(zero);
     });
 
     it('applies a scaling defense-penetration modifier (per self-buff, capped)', () => {
@@ -183,14 +171,16 @@ describe('modifierTotalsFromAbilities', () => {
         expect(
             modifierTotalsFromAbilities(
                 [scalingDefPen],
-                makeCtx({ selfBuffNames: ['a', 'b', 'c'] })
+                makeConditionContext({ selfBuffNames: ['a', 'b', 'c'] })
             )
         ).toEqual({ ...zero, defensePenetration: 22.5 });
         // 10 self-buffs → capped at 45%
         expect(
             modifierTotalsFromAbilities(
                 [scalingDefPen],
-                makeCtx({ selfBuffNames: Array.from({ length: 10 }, (_, i) => `b${i}`) })
+                makeConditionContext({
+                    selfBuffNames: Array.from({ length: 10 }, (_, i) => `b${i}`),
+                })
             )
         ).toEqual({ ...zero, defensePenetration: 45 });
     });
@@ -571,11 +561,11 @@ describe('extraActionsFromSkill', () => {
         };
         const rawSkill: Skill = { slot: 'active', abilities: [conditionedExtraAction] };
         // Stealth not present → gateFiringAbilities drops the ability
-        const { gatedSkill } = gateFiringAbilities(rawSkill, makeCtx());
+        const { gatedSkill } = gateFiringAbilities(rawSkill, makeConditionContext());
         expect(extraActionsFromSkill(gatedSkill)).toEqual([]);
         // Stealth present → ability passes the gate → grant surfaces
         const { gatedSkill: gatedSkillWith } = gateFiringAbilities(rawSkill, {
-            ...makeCtx(),
+            ...makeConditionContext(),
             selfBuffNames: ['Stealth'],
         });
         expect(extraActionsFromSkill(gatedSkillWith)).toEqual([

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -171,3 +171,72 @@ describe('buildEquipmentAbilities — unknown implant key', () => {
         expect(abilities).toHaveLength(0);
     });
 });
+
+// ---------------------------------------------------------------------------
+// Helpers for implant-only tests
+// ---------------------------------------------------------------------------
+
+/** Build a ship with a single implant piece in implant_major and call buildEquipmentAbilities. */
+function buildForImplant(name: string, rarity: string) {
+    const implantPiece = makePiece({
+        id: `${name.toLowerCase()}-implant`,
+        slot: 'implant_major',
+        rarity: rarity as unknown as GearPiece['rarity'],
+        setBonus: name as GearPiece['setBonus'],
+    });
+    const ship = makeShip({
+        implants: { implant_major: `${name.toLowerCase()}-implant` },
+    });
+    const getGearPiece = makeGetGearPiece({
+        [`${name.toLowerCase()}-implant`]: implantPiece,
+    });
+    return buildEquipmentAbilities(ship, getGearPiece);
+}
+
+// ---------------------------------------------------------------------------
+// Case 7: Intrusion implant
+// ---------------------------------------------------------------------------
+describe('Intrusion implant', () => {
+    it('emits a passive outgoingDamage modifier scaling per enemy debuff (legendary = 5/debuff)', () => {
+        const abilities = buildForImplant('INTRUSION', 'legendary');
+        expect(abilities).toHaveLength(1);
+        const a = abilities[0];
+        expect(a.type).toBe('modifier');
+        expect(a.trigger).toBe('on-cast');
+        expect(a.config).toMatchObject({ type: 'modifier', channel: 'outgoingDamage', value: 0 });
+        expect(a.scaling).toEqual({ conditionIndex: 0, perUnit: 5 });
+        expect(a.conditions).toEqual([{ subject: 'enemy-debuff', derivable: true }]);
+    });
+    it('bakes the uncommon per-debuff value (2)', () => {
+        expect(buildForImplant('INTRUSION', 'uncommon')[0].scaling).toEqual({
+            conditionIndex: 0,
+            perUnit: 2,
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Case 8: Arcane Siege implant
+// ---------------------------------------------------------------------------
+describe('Arcane Siege implant', () => {
+    it('emits a flat outgoingDamage modifier gated on self-shield (epic = 15)', () => {
+        const a = buildForImplant('ARCANE_SIEGE', 'epic')[0];
+        expect(a.config).toMatchObject({ type: 'modifier', channel: 'outgoingDamage', value: 15 });
+        expect(a.scaling).toBeUndefined();
+        expect(a.conditions).toEqual([{ subject: 'self-shield', derivable: true }]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Case 9: Warpstrike implant
+// ---------------------------------------------------------------------------
+describe('Warpstrike implant', () => {
+    it('emits a flat outgoingDamage modifier gated on >=1 self-debuff (legendary = 5)', () => {
+        const a = buildForImplant('WARPSTRIKE', 'legendary')[0];
+        expect(a.config).toMatchObject({ type: 'modifier', channel: 'outgoingDamage', value: 5 });
+        expect(a.scaling).toBeUndefined();
+        expect(a.conditions).toEqual([
+            { subject: 'self-debuff', derivable: true, countComparator: 'gte', countThreshold: 1 },
+        ]);
+    });
+});

--- a/src/utils/abilities/__tests__/conditionContextFixture.ts
+++ b/src/utils/abilities/__tests__/conditionContextFixture.ts
@@ -1,0 +1,26 @@
+import { ConditionContext } from '../evaluateConditions';
+
+/**
+ * Test fixture: a ConditionContext with all required fields defaulted, plus overrides.
+ * Single source of truth so a new ConditionContext field is updated in ONE place.
+ *
+ * Optional fields (enemyType, roundCrit, targetHpPct, isLowestSpeedAlly,
+ * targetRepairedThisRound, selfShielded) are NOT defaulted here — TypeScript optional
+ * fields are undefined by default, which is the correct baseline for tests that do not
+ * exercise those paths. Pass them via `over` when a test depends on them.
+ */
+export function makeConditionContext(over: Partial<ConditionContext> = {}): ConditionContext {
+    return {
+        selfBuffNames: [],
+        selfDebuffNames: [],
+        enemyBuffNames: [],
+        enemyDebuffCount: 0,
+        effectiveCritRate: 0,
+        adjacentAllyCount: 0,
+        enemyAdjacentCount: 0,
+        enemyDestroyedCount: 0,
+        selfHpPct: 100,
+        enemyHpPct: 100,
+        ...over,
+    };
+}

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -91,7 +91,7 @@ function implantAbilityCount(implantKey: string, rarity: GearPiece['rarity']): n
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { LEECH (gear set), BLOODTHIRST (implant) } are currently implemented', () => {
+    it('exactly { LEECH (gear set), BLOODTHIRST + INTRUSION + ARCANE_SIEGE + WARPSTRIKE (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -104,7 +104,12 @@ describe('equipmentCoverage — implemented effects registry', () => {
             // Try the first available rarity for each implant.
             return variants.some((v) => implantAbilityCount(key, v.rarity) > 0);
         });
-        expect(implementedImplants).toEqual(['BLOODTHIRST']);
+        expect(implementedImplants).toEqual([
+            'ARCANE_SIEGE',
+            'INTRUSION',
+            'WARPSTRIKE',
+            'BLOODTHIRST',
+        ]);
     });
 });
 
@@ -142,8 +147,32 @@ describe('equipmentCoverage — implants', () => {
         expect(implantAbilityCount('BLOODTHIRST', 'legendary')).toBeGreaterThanOrEqual(1);
     });
 
-    const nonBloodthirstImplants = Object.keys(IMPLANTS).filter((k) => k !== 'BLOODTHIRST');
-    for (const implantKey of nonBloodthirstImplants) {
+    // D-PR2: INTRUSION, ARCANE_SIEGE, WARPSTRIKE now produce 1 ability each.
+    const implementedImplants = new Set(['BLOODTHIRST', 'INTRUSION', 'ARCANE_SIEGE', 'WARPSTRIKE']);
+
+    it('INTRUSION produces 1 ability per rarity (outgoingDamage modifier with scaling)', () => {
+        const variants = IMPLANTS['INTRUSION'].variants;
+        for (const v of variants) {
+            expect(implantAbilityCount('INTRUSION', v.rarity)).toBe(1);
+        }
+    });
+
+    it('ARCANE_SIEGE produces 1 ability per rarity (outgoingDamage modifier gated on self-shield)', () => {
+        const variants = IMPLANTS['ARCANE_SIEGE'].variants;
+        for (const v of variants) {
+            expect(implantAbilityCount('ARCANE_SIEGE', v.rarity)).toBe(1);
+        }
+    });
+
+    it('WARPSTRIKE produces 1 ability per rarity (outgoingDamage modifier gated on self-debuff)', () => {
+        const variants = IMPLANTS['WARPSTRIKE'].variants;
+        for (const v of variants) {
+            expect(implantAbilityCount('WARPSTRIKE', v.rarity)).toBe(1);
+        }
+    });
+
+    const unimplementedImplants = Object.keys(IMPLANTS).filter((k) => !implementedImplants.has(k));
+    for (const implantKey of unimplementedImplants) {
         it(`${implantKey} produces 0 abilities (not yet implemented)`, () => {
             const variants = IMPLANTS[implantKey].variants;
             // Check all available rarities — none should produce abilities yet.

--- a/src/utils/abilities/__tests__/evaluateConditions.test.ts
+++ b/src/utils/abilities/__tests__/evaluateConditions.test.ts
@@ -1,28 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import {
-    ConditionContext,
-    evaluateCondition,
-    conditionMet,
-    conditionsMet,
-    scaledBonus,
-} from '../evaluateConditions';
+import { evaluateCondition, conditionMet, conditionsMet, scaledBonus } from '../evaluateConditions';
 import { buildRoundContext } from '../roundContext';
 import { Ability, Condition } from '../../../types/abilities';
-
-const ctx = (over: Partial<ConditionContext> = {}): ConditionContext => ({
-    selfBuffNames: [],
-    selfDebuffNames: [],
-    enemyBuffNames: [],
-    enemyDebuffCount: 0,
-    enemyType: undefined,
-    effectiveCritRate: 0,
-    adjacentAllyCount: 0,
-    enemyAdjacentCount: 0,
-    enemyDestroyedCount: 0,
-    selfHpPct: 100,
-    enemyHpPct: 100,
-    ...over,
-});
+import { makeConditionContext } from './conditionContextFixture';
 
 const cond = (over: Partial<Condition>): Condition => ({
     subject: 'always',
@@ -32,11 +12,11 @@ const cond = (over: Partial<Condition>): Condition => ({
 
 describe('evaluateCondition', () => {
     it("'always' is 1", () => {
-        expect(evaluateCondition(cond({ subject: 'always' }), ctx())).toBe(1);
+        expect(evaluateCondition(cond({ subject: 'always' }), makeConditionContext())).toBe(1);
     });
 
     it("derivable 'self-buff' counts active self buffs (all, or by name)", () => {
-        const c = ctx({ selfBuffNames: ['Attack Up II', 'Defense Up II'] });
+        const c = makeConditionContext({ selfBuffNames: ['Attack Up II', 'Defense Up II'] });
         expect(evaluateCondition(cond({ subject: 'self-buff', derivable: true }), c)).toBe(2);
         expect(
             evaluateCondition(
@@ -50,7 +30,7 @@ describe('evaluateCondition', () => {
         expect(
             evaluateCondition(
                 cond({ subject: 'enemy-debuff', derivable: true }),
-                ctx({ enemyDebuffCount: 3 })
+                makeConditionContext({ enemyDebuffCount: 3 })
             )
         ).toBe(3);
     });
@@ -59,13 +39,13 @@ describe('evaluateCondition', () => {
         expect(
             evaluateCondition(
                 cond({ subject: 'enemy-buff', derivable: true, buffName: 'Stealth' }),
-                ctx({ enemyBuffNames: ['Stealth'] })
+                makeConditionContext({ enemyBuffNames: ['Stealth'] })
             )
         ).toBe(1);
         expect(
             evaluateCondition(
                 cond({ subject: 'enemy-buff', derivable: true, buffName: 'Stealth' }),
-                ctx()
+                makeConditionContext()
             )
         ).toBe(0);
     });
@@ -74,21 +54,21 @@ describe('evaluateCondition', () => {
         expect(
             evaluateCondition(
                 cond({ subject: 'self-crit', derivable: true }),
-                ctx({ effectiveCritRate: 100 })
+                makeConditionContext({ effectiveCritRate: 100 })
             )
         ).toBe(1);
         expect(
             evaluateCondition(
                 cond({ subject: 'self-crit', derivable: true }),
-                ctx({ effectiveCritRate: 50 })
+                makeConditionContext({ effectiveCritRate: 50 })
             )
         ).toBe(0.5);
     });
 
     it("'enemy-type' is 1 on match else 0", () => {
         const c = cond({ subject: 'enemy-type', derivable: true, requiredEnemyType: 'Defender' });
-        expect(evaluateCondition(c, ctx({ enemyType: 'Defender' }))).toBe(1);
-        expect(evaluateCondition(c, ctx({ enemyType: 'Attacker' }))).toBe(0);
+        expect(evaluateCondition(c, makeConditionContext({ enemyType: 'Defender' }))).toBe(1);
+        expect(evaluateCondition(c, makeConditionContext({ enemyType: 'Attacker' }))).toBe(0);
     });
 
     it("negated 'enemy-type' is 1 when the enemy is NOT the type (non-Defenders)", () => {
@@ -98,10 +78,10 @@ describe('evaluateCondition', () => {
             requiredEnemyType: 'Defender',
             negate: true,
         });
-        expect(evaluateCondition(c, ctx({ enemyType: 'Attacker' }))).toBe(1);
-        expect(evaluateCondition(c, ctx({ enemyType: 'Defender' }))).toBe(0);
+        expect(evaluateCondition(c, makeConditionContext({ enemyType: 'Attacker' }))).toBe(1);
+        expect(evaluateCondition(c, makeConditionContext({ enemyType: 'Defender' }))).toBe(0);
         // Unknown enemy type → cannot confirm "not a Defender" → 0.
-        expect(evaluateCondition(c, ctx({ enemyType: undefined }))).toBe(0);
+        expect(evaluateCondition(c, makeConditionContext({ enemyType: undefined }))).toBe(0);
     });
 
     it("'hp-threshold' below/above resolves against context HP", () => {
@@ -111,8 +91,8 @@ describe('evaluateCondition', () => {
             hpComparator: 'below',
             hpPercent: 50,
         });
-        expect(evaluateCondition(below, ctx({ enemyHpPct: 40 }))).toBe(1);
-        expect(evaluateCondition(below, ctx({ enemyHpPct: 60 }))).toBe(0);
+        expect(evaluateCondition(below, makeConditionContext({ enemyHpPct: 40 }))).toBe(1);
+        expect(evaluateCondition(below, makeConditionContext({ enemyHpPct: 60 }))).toBe(0);
     });
 
     it("'hp-threshold' with hpSubject 'self' resolves against the unit's own HP", () => {
@@ -123,22 +103,37 @@ describe('evaluateCondition', () => {
             hpPercent: 99,
             hpSubject: 'self',
         });
-        expect(evaluateCondition(selfAboveFull, ctx({ selfHpPct: 100, enemyHpPct: 10 }))).toBe(1);
-        expect(evaluateCondition(selfAboveFull, ctx({ selfHpPct: 50, enemyHpPct: 100 }))).toBe(0);
+        expect(
+            evaluateCondition(
+                selfAboveFull,
+                makeConditionContext({ selfHpPct: 100, enemyHpPct: 10 })
+            )
+        ).toBe(1);
+        expect(
+            evaluateCondition(
+                selfAboveFull,
+                makeConditionContext({ selfHpPct: 50, enemyHpPct: 100 })
+            )
+        ).toBe(0);
     });
 
     it('non-derivable uses manualCount (default 1)', () => {
-        expect(evaluateCondition(cond({ subject: 'enemy-buff', derivable: false }), ctx())).toBe(1);
+        expect(
+            evaluateCondition(
+                cond({ subject: 'enemy-buff', derivable: false }),
+                makeConditionContext()
+            )
+        ).toBe(1);
         expect(
             evaluateCondition(
                 cond({ subject: 'enemy-buff', derivable: false, manualCount: 3 }),
-                ctx()
+                makeConditionContext()
             )
         ).toBe(3);
         expect(
             evaluateCondition(
                 cond({ subject: 'enemy-buff', derivable: false, manualCount: 0 }),
-                ctx()
+                makeConditionContext()
             )
         ).toBe(0);
     });
@@ -146,7 +141,7 @@ describe('evaluateCondition', () => {
 
 describe('conditionsMet (AND of OR-groups)', () => {
     it('empty conditions → always met', () => {
-        expect(conditionsMet([], ctx())).toBe(true);
+        expect(conditionsMet([], makeConditionContext())).toBe(true);
     });
 
     it('AND: all groups must have count > 0', () => {
@@ -154,12 +149,18 @@ describe('conditionsMet (AND of OR-groups)', () => {
             cond({ subject: 'enemy-type', requiredEnemyType: 'Defender' }),
             cond({ subject: 'self-crit' }),
         ];
-        expect(conditionsMet(conds, ctx({ enemyType: 'Defender', effectiveCritRate: 100 }))).toBe(
-            true
-        );
-        expect(conditionsMet(conds, ctx({ enemyType: 'Defender', effectiveCritRate: 0 }))).toBe(
-            false
-        );
+        expect(
+            conditionsMet(
+                conds,
+                makeConditionContext({ enemyType: 'Defender', effectiveCritRate: 100 })
+            )
+        ).toBe(true);
+        expect(
+            conditionsMet(
+                conds,
+                makeConditionContext({ enemyType: 'Defender', effectiveCritRate: 0 })
+            )
+        ).toBe(false);
     });
 
     it('OR-group (anyOf): any member > 0 satisfies the group', () => {
@@ -173,8 +174,8 @@ describe('conditionsMet (AND of OR-groups)', () => {
                 buffName: 'Stealth',
             }),
         ];
-        expect(conditionsMet(conds, ctx({ enemyType: 'Defender' }))).toBe(true);
-        expect(conditionsMet(conds, ctx({ enemyType: 'Attacker' }))).toBe(false);
+        expect(conditionsMet(conds, makeConditionContext({ enemyType: 'Defender' }))).toBe(true);
+        expect(conditionsMet(conds, makeConditionContext({ enemyType: 'Attacker' }))).toBe(false);
     });
 
     it('non-adjacent anyOf conditions do NOT merge across a plain condition', () => {
@@ -191,49 +192,58 @@ describe('conditionsMet (AND of OR-groups)', () => {
             }),
         ];
         // type true + buff true, but the plain self-crit group is false (crit 0) → overall false
-        expect(conditionsMet(conds, ctx({ enemyType: 'Defender' }))).toBe(false);
+        expect(conditionsMet(conds, makeConditionContext({ enemyType: 'Defender' }))).toBe(false);
         // all three groups satisfied
-        expect(conditionsMet(conds, ctx({ enemyType: 'Defender', effectiveCritRate: 100 }))).toBe(
-            true
-        );
+        expect(
+            conditionsMet(
+                conds,
+                makeConditionContext({ enemyType: 'Defender', effectiveCritRate: 100 })
+            )
+        ).toBe(true);
     });
 });
 
 describe('conditionMet (count comparator gating)', () => {
     it('no comparator → presence rule (count > 0)', () => {
-        expect(conditionMet(cond({ subject: 'enemy-debuff' }), ctx({ enemyDebuffCount: 1 }))).toBe(
-            true
-        );
-        expect(conditionMet(cond({ subject: 'enemy-debuff' }), ctx({ enemyDebuffCount: 0 }))).toBe(
-            false
-        );
+        expect(
+            conditionMet(
+                cond({ subject: 'enemy-debuff' }),
+                makeConditionContext({ enemyDebuffCount: 1 })
+            )
+        ).toBe(true);
+        expect(
+            conditionMet(
+                cond({ subject: 'enemy-debuff' }),
+                makeConditionContext({ enemyDebuffCount: 0 })
+            )
+        ).toBe(false);
     });
 
     it('gte threshold: met only at/above the count (Crocus "more than 3" → gte 4)', () => {
         const c = cond({ subject: 'enemy-debuff', countComparator: 'gte', countThreshold: 4 });
-        expect(conditionMet(c, ctx({ enemyDebuffCount: 3 }))).toBe(false);
-        expect(conditionMet(c, ctx({ enemyDebuffCount: 4 }))).toBe(true);
-        expect(conditionMet(c, ctx({ enemyDebuffCount: 9 }))).toBe(true);
+        expect(conditionMet(c, makeConditionContext({ enemyDebuffCount: 3 }))).toBe(false);
+        expect(conditionMet(c, makeConditionContext({ enemyDebuffCount: 4 }))).toBe(true);
+        expect(conditionMet(c, makeConditionContext({ enemyDebuffCount: 9 }))).toBe(true);
     });
 
     it('eq 0: met only when the count is exactly zero (Sustainer "no debuffs")', () => {
         const c = cond({ subject: 'self-debuff', countComparator: 'eq', countThreshold: 0 });
-        expect(conditionMet(c, ctx({ selfDebuffNames: [] }))).toBe(true);
-        expect(conditionMet(c, ctx({ selfDebuffNames: ['Burn'] }))).toBe(false);
+        expect(conditionMet(c, makeConditionContext({ selfDebuffNames: [] }))).toBe(true);
+        expect(conditionMet(c, makeConditionContext({ selfDebuffNames: ['Burn'] }))).toBe(false);
     });
 
     it('lte threshold: met at/below the count', () => {
         const c = cond({ subject: 'enemy-debuff', countComparator: 'lte', countThreshold: 2 });
-        expect(conditionMet(c, ctx({ enemyDebuffCount: 2 }))).toBe(true);
-        expect(conditionMet(c, ctx({ enemyDebuffCount: 3 }))).toBe(false);
+        expect(conditionMet(c, makeConditionContext({ enemyDebuffCount: 2 }))).toBe(true);
+        expect(conditionMet(c, makeConditionContext({ enemyDebuffCount: 3 }))).toBe(false);
     });
 
     it('comparator flows through conditionsMet as a gate', () => {
         const conds = [
             cond({ subject: 'enemy-debuff', countComparator: 'gte', countThreshold: 3 }),
         ];
-        expect(conditionsMet(conds, ctx({ enemyDebuffCount: 3 }))).toBe(true);
-        expect(conditionsMet(conds, ctx({ enemyDebuffCount: 2 }))).toBe(false);
+        expect(conditionsMet(conds, makeConditionContext({ enemyDebuffCount: 3 }))).toBe(true);
+        expect(conditionsMet(conds, makeConditionContext({ enemyDebuffCount: 2 }))).toBe(false);
     });
 
     it('comparator does NOT affect scaledBonus (scaling always uses the raw count)', () => {
@@ -249,7 +259,7 @@ describe('conditionMet (count comparator gating)', () => {
             config: { type: 'damage', multiplier: 200 },
         };
         // count 2 < threshold 4 (gate would fail), but scaling still uses raw count 2 → 20.
-        expect(scaledBonus(a, ctx({ enemyDebuffCount: 2 }))).toBe(20);
+        expect(scaledBonus(a, makeConditionContext({ enemyDebuffCount: 2 }))).toBe(20);
     });
 });
 
@@ -270,12 +280,12 @@ describe('scaledBonus', () => {
             perUnit: 10,
             cap: 30,
         });
-        expect(scaledBonus(a, ctx({ enemyDebuffCount: 2 }))).toBe(20);
-        expect(scaledBonus(a, ctx({ enemyDebuffCount: 5 }))).toBe(30);
+        expect(scaledBonus(a, makeConditionContext({ enemyDebuffCount: 2 }))).toBe(20);
+        expect(scaledBonus(a, makeConditionContext({ enemyDebuffCount: 5 }))).toBe(30);
     });
 
     it('returns 0 when no scaling rule', () => {
-        expect(scaledBonus(dmg([], undefined), ctx())).toBe(0);
+        expect(scaledBonus(dmg([], undefined), makeConditionContext())).toBe(0);
     });
 
     it('scaling reads only the indexed condition, even inside an anyOf OR-group', () => {
@@ -289,39 +299,49 @@ describe('scaledBonus', () => {
             ],
             { conditionIndex: 0, perUnit: 10, cap: 30 }
         );
-        expect(scaledBonus(a, ctx({ enemyDebuffCount: 2 }))).toBe(20);
-        expect(scaledBonus(a, ctx({ enemyDebuffCount: 5 }))).toBe(30); // capped
+        expect(scaledBonus(a, makeConditionContext({ enemyDebuffCount: 2 }))).toBe(20);
+        expect(scaledBonus(a, makeConditionContext({ enemyDebuffCount: 5 }))).toBe(30); // capped
         // self-buffs alone satisfy the OR-gate but contribute nothing to scaling
-        expect(scaledBonus(a, ctx({ selfBuffNames: ['Stealth'] }))).toBe(0);
+        expect(scaledBonus(a, makeConditionContext({ selfBuffNames: ['Stealth'] }))).toBe(0);
     });
 });
 
 describe('binary roundCrit', () => {
     it('self-crit returns 1 when roundCrit is true, 0 when false', () => {
         const cond = { subject: 'self-crit' as const, derivable: true };
-        expect(evaluateCondition(cond, ctx({ effectiveCritRate: 70, roundCrit: true }))).toBe(1);
-        expect(evaluateCondition(cond, ctx({ effectiveCritRate: 70, roundCrit: false }))).toBe(0);
+        expect(
+            evaluateCondition(
+                cond,
+                makeConditionContext({ effectiveCritRate: 70, roundCrit: true })
+            )
+        ).toBe(1);
+        expect(
+            evaluateCondition(
+                cond,
+                makeConditionContext({ effectiveCritRate: 70, roundCrit: false })
+            )
+        ).toBe(0);
     });
 
     it('self-crit falls back to probability when roundCrit is undefined', () => {
         const cond = { subject: 'self-crit' as const, derivable: true };
-        expect(evaluateCondition(cond, ctx({ effectiveCritRate: 70 }))).toBe(0.7);
+        expect(evaluateCondition(cond, makeConditionContext({ effectiveCritRate: 70 }))).toBe(0.7);
     });
 });
 
 describe('HP-percentage count subjects', () => {
     it('enemy-hp-pct counts the enemy HP percentage', () => {
         const c = cond({ subject: 'enemy-hp-pct' });
-        expect(evaluateCondition(c, ctx({ enemyHpPct: 100 }))).toBe(100);
-        expect(evaluateCondition(c, ctx({ enemyHpPct: 42 }))).toBe(42);
-        expect(evaluateCondition(c, ctx({ enemyHpPct: 0 }))).toBe(0);
+        expect(evaluateCondition(c, makeConditionContext({ enemyHpPct: 100 }))).toBe(100);
+        expect(evaluateCondition(c, makeConditionContext({ enemyHpPct: 42 }))).toBe(42);
+        expect(evaluateCondition(c, makeConditionContext({ enemyHpPct: 0 }))).toBe(0);
     });
 
     it('enemy-hp-missing-pct counts the missing percentage', () => {
         const c = cond({ subject: 'enemy-hp-missing-pct' });
-        expect(evaluateCondition(c, ctx({ enemyHpPct: 100 }))).toBe(0);
-        expect(evaluateCondition(c, ctx({ enemyHpPct: 30 }))).toBe(70);
-        expect(evaluateCondition(c, ctx({ enemyHpPct: 0 }))).toBe(100);
+        expect(evaluateCondition(c, makeConditionContext({ enemyHpPct: 100 }))).toBe(0);
+        expect(evaluateCondition(c, makeConditionContext({ enemyHpPct: 30 }))).toBe(70);
+        expect(evaluateCondition(c, makeConditionContext({ enemyHpPct: 0 }))).toBe(100);
     });
 });
 
@@ -334,8 +354,8 @@ describe('hp-threshold hpSubject target', () => {
             hpPercent: 40,
             hpSubject: 'target',
         };
-        expect(evaluateCondition(c, ctx({ targetHpPct: 35 }))).toBe(1);
-        expect(evaluateCondition(c, ctx({ targetHpPct: 60 }))).toBe(0);
+        expect(evaluateCondition(c, makeConditionContext({ targetHpPct: 35 }))).toBe(1);
+        expect(evaluateCondition(c, makeConditionContext({ targetHpPct: 60 }))).toBe(0);
     });
 
     it('hp-threshold target defaults to 100 when targetHpPct absent (DPS-mode inert)', () => {
@@ -346,7 +366,7 @@ describe('hp-threshold hpSubject target', () => {
             hpPercent: 40,
             hpSubject: 'target',
         };
-        expect(evaluateCondition(c, ctx())).toBe(0);
+        expect(evaluateCondition(c, makeConditionContext())).toBe(0);
     });
 });
 
@@ -354,14 +374,20 @@ describe('target-repaired-this-round condition', () => {
     const cond = { subject: 'target-repaired-this-round' as const, derivable: true };
 
     it('is met when the target was repaired this round', () => {
-        expect(evaluateCondition(cond, ctx({ targetRepairedThisRound: true }))).toBe(1);
-        expect(conditionsMet([cond], ctx({ targetRepairedThisRound: true }))).toBe(true);
+        expect(
+            evaluateCondition(cond, makeConditionContext({ targetRepairedThisRound: true }))
+        ).toBe(1);
+        expect(conditionsMet([cond], makeConditionContext({ targetRepairedThisRound: true }))).toBe(
+            true
+        );
     });
 
     it('is NOT met when the target was not repaired (false or undefined)', () => {
-        expect(evaluateCondition(cond, ctx({ targetRepairedThisRound: false }))).toBe(0);
-        expect(evaluateCondition(cond, ctx())).toBe(0);
-        expect(conditionsMet([cond], ctx())).toBe(false);
+        expect(
+            evaluateCondition(cond, makeConditionContext({ targetRepairedThisRound: false }))
+        ).toBe(0);
+        expect(evaluateCondition(cond, makeConditionContext())).toBe(0);
+        expect(conditionsMet([cond], makeConditionContext())).toBe(false);
     });
 });
 
@@ -370,12 +396,14 @@ describe('self-shield condition', () => {
         expect(
             evaluateCondition(
                 { subject: 'self-shield', derivable: true },
-                ctx({ selfShielded: true })
+                makeConditionContext({ selfShielded: true })
             )
         ).toBe(1);
     });
     it('evaluates to 0 when selfShielded is false/absent', () => {
-        expect(evaluateCondition({ subject: 'self-shield', derivable: true }, ctx())).toBe(0);
+        expect(
+            evaluateCondition({ subject: 'self-shield', derivable: true }, makeConditionContext())
+        ).toBe(0);
     });
 });
 

--- a/src/utils/abilities/__tests__/evaluateConditions.test.ts
+++ b/src/utils/abilities/__tests__/evaluateConditions.test.ts
@@ -365,6 +365,20 @@ describe('target-repaired-this-round condition', () => {
     });
 });
 
+describe('self-shield condition', () => {
+    it('evaluates to 1 when selfShielded is true', () => {
+        expect(
+            evaluateCondition(
+                { subject: 'self-shield', derivable: true },
+                ctx({ selfShielded: true })
+            )
+        ).toBe(1);
+    });
+    it('evaluates to 0 when selfShielded is false/absent', () => {
+        expect(evaluateCondition({ subject: 'self-shield', derivable: true }, ctx())).toBe(0);
+    });
+});
+
 describe('lowest-speed-ally', () => {
     it('returns 1 when isLowestSpeedAlly is true', () => {
         const ctx = buildRoundContext({

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -5,7 +5,8 @@
  * that the combat engine can consume.
  *
  * Gear-set abilities are resolved via GEAR_SET_ABILITIES (currently: Leech).
- * Implant abilities are resolved via IMPLANT_ABILITIES (currently: Bloodthirst).
+ * Implant abilities are resolved via IMPLANT_ABILITIES (currently: Bloodthirst,
+ * Intrusion, Arcane Siege, Warpstrike).
  *
  * D-PR1 approach (registry, not text-parsing): effect values are baked from the
  * source data in implants.ts / gearSets.ts per the registries above. A variant's
@@ -42,7 +43,7 @@ const GEAR_SET_ABILITIES: Partial<Record<string, () => Omit<Ability, 'id'>>> = {
 };
 
 // ---------------------------------------------------------------------------
-// Implant ability registry (D-PR1: Bloodthirst only)
+// Implant ability registry (D-PR1: Bloodthirst; D-PR2: Intrusion, Arcane Siege, Warpstrike)
 // ---------------------------------------------------------------------------
 //
 // Each entry maps an implant name to a per-rarity builder.  A builder returns

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -62,6 +62,30 @@ const BLOODTHIRST_PROC_CHANCE: Record<string, number> = {
     legendary: 0.2,
 };
 
+const INTRUSION_PER_DEBUFF: Record<string, number> = {
+    common: 1,
+    uncommon: 2,
+    rare: 3,
+    epic: 4,
+    legendary: 5,
+};
+
+const ARCANE_SIEGE_PCT: Record<string, number> = {
+    common: 3,
+    uncommon: 6,
+    rare: 10,
+    epic: 15,
+    legendary: 20,
+};
+
+const WARPSTRIKE_PCT: Record<string, number> = {
+    common: 1,
+    uncommon: 2,
+    rare: 3,
+    epic: 4,
+    legendary: 5,
+};
+
 const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
     BLOODTHIRST: (rarity) => {
         const pct = BLOODTHIRST_HEAL_PCT[rarity];
@@ -78,6 +102,64 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
                 pct,
                 basis: 'damage-dealt',
             },
+            autoFilled: true,
+        };
+    },
+    // Intrusion: +N% outgoing direct damage per debuff on the target. Rides the modifier
+    // fold as a pure scaling modifier (value 0 + scaling); the enemy-debuff condition is a
+    // bare scaling source (no countComparator) so it scales, never gates.
+    INTRUSION: (rarity) => {
+        const perUnit = INTRUSION_PER_DEBUFF[rarity];
+        if (perUnit === undefined) return undefined;
+        return {
+            type: 'modifier',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [{ subject: 'enemy-debuff', derivable: true }],
+            scaling: { conditionIndex: 0, perUnit },
+            config: {
+                type: 'modifier',
+                channel: 'outgoingDamage',
+                value: 0,
+                isMultiplicative: false,
+            },
+            autoFilled: true,
+        };
+    },
+    // Arcane Siege: +X% outgoing direct damage while shielded. Flat value gated on the new
+    // self-shield condition; dormant until sub-project H grants shields in the sim.
+    ARCANE_SIEGE: (rarity) => {
+        const value = ARCANE_SIEGE_PCT[rarity];
+        if (value === undefined) return undefined;
+        return {
+            type: 'modifier',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [{ subject: 'self-shield', derivable: true }],
+            config: { type: 'modifier', channel: 'outgoingDamage', value, isMultiplicative: false },
+            autoFilled: true,
+        };
+    },
+    // Warpstrike (damage half only): +X% outgoing direct damage while self-debuffed. Flat
+    // value + a >=1 self-debuff gate (NOT scaling — scaledBonus uses the raw debuff count and
+    // would over-apply for multiple debuffs). The "reduce a random debuff's duration by 1
+    // turn" half is DEFERRED (self-debuff-mitigation / cleanse-family).
+    WARPSTRIKE: (rarity) => {
+        const value = WARPSTRIKE_PCT[rarity];
+        if (value === undefined) return undefined;
+        return {
+            type: 'modifier',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [
+                {
+                    subject: 'self-debuff',
+                    derivable: true,
+                    countComparator: 'gte',
+                    countThreshold: 1,
+                },
+            ],
+            config: { type: 'modifier', channel: 'outgoingDamage', value, isMultiplicative: false },
             autoFilled: true,
         };
     },

--- a/src/utils/abilities/evaluateConditions.ts
+++ b/src/utils/abilities/evaluateConditions.ts
@@ -26,6 +26,9 @@ export interface ConditionContext {
     /** True when the acting attacker's target was repaired (HP healed) earlier this
      *  round. Live-derived by the engine; defaults false (DPS / un-repaired). */
     targetRepairedThisRound?: boolean;
+    /** True when the condition owner currently has a shield (shieldPool > 0). Live-derived
+     *  by the engine; defaults false (no shield / DPS mode). Used by the Arcane Siege implant. */
+    selfShielded?: boolean;
 }
 
 /** Resolve one condition to a count (>= 0). 0 means "not met". */
@@ -75,6 +78,8 @@ export function evaluateCondition(cond: Condition, ctx: ConditionContext): numbe
             return ctx.isLowestSpeedAlly ? 1 : 0;
         case 'target-repaired-this-round':
             return ctx.targetRepairedThisRound ? 1 : 0;
+        case 'self-shield':
+            return ctx.selfShielded ? 1 : 0;
         default:
             return 0;
     }

--- a/src/utils/abilities/roundContext.ts
+++ b/src/utils/abilities/roundContext.ts
@@ -36,6 +36,8 @@ export function buildRoundContext(state: {
     isLowestSpeedAlly?: boolean;
     /** The acting attacker's target was repaired this round. Default false. */
     targetRepairedThisRound?: boolean;
+    /** True when the acting unit has a shield (shieldPool > 0). Default false. */
+    selfShielded?: boolean;
 }): ConditionContext {
     return {
         selfBuffNames: state.selfBuffNames,
@@ -57,6 +59,7 @@ export function buildRoundContext(state: {
         enemyHpPct: state.enemyHpPct ?? 100,
         isLowestSpeedAlly: state.isLowestSpeedAlly ?? true,
         targetRepairedThisRound: state.targetRepairedThisRound ?? false,
+        selfShielded: state.selfShielded ?? false,
         ...(state.roundCrit !== undefined ? { roundCrit: state.roundCrit } : {}),
     };
 }

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -370,7 +370,7 @@ describe('D-PR2 integration — INTRUSION fold (modifier-level)', () => {
         const getGearPiece = makeGetGearPiece({ 'intrusion-legendary': intrusionPiece });
         const abilities = buildEquipmentAbilities(ship, getGearPiece);
 
-        const intrusion = abilities.find((a) => a.id === 'equip-implant-INTRUSION');
+        const intrusion = abilities.find((a) => a.id.startsWith('equip-implant-INTRUSION'));
         expect(intrusion).toBeDefined();
 
         const totals = modifierTotalsFromAbilities(
@@ -384,7 +384,7 @@ describe('D-PR2 integration — INTRUSION fold (modifier-level)', () => {
         const ship = makeShip({ implants: { implant_major: 'intrusion-legendary' } });
         const getGearPiece = makeGetGearPiece({ 'intrusion-legendary': intrusionPiece });
         const abilities = buildEquipmentAbilities(ship, getGearPiece);
-        const intrusion = abilities.find((a) => a.id === 'equip-implant-INTRUSION');
+        const intrusion = abilities.find((a) => a.id.startsWith('equip-implant-INTRUSION'));
 
         const totals = modifierTotalsFromAbilities(
             [intrusion!],
@@ -407,7 +407,7 @@ describe('D-PR2 integration — WARPSTRIKE fold (modifier-level)', () => {
         const ship = makeShip({ implants: { implant_major: 'warpstrike-legendary' } });
         const getGearPiece = makeGetGearPiece({ 'warpstrike-legendary': warpstrikePiece });
         const abilities = buildEquipmentAbilities(ship, getGearPiece);
-        const warpstrike = abilities.find((a) => a.id === 'equip-implant-WARPSTRIKE');
+        const warpstrike = abilities.find((a) => a.id.startsWith('equip-implant-WARPSTRIKE'));
         expect(warpstrike).toBeDefined();
 
         const totals = modifierTotalsFromAbilities(
@@ -421,7 +421,7 @@ describe('D-PR2 integration — WARPSTRIKE fold (modifier-level)', () => {
         const ship = makeShip({ implants: { implant_major: 'warpstrike-legendary' } });
         const getGearPiece = makeGetGearPiece({ 'warpstrike-legendary': warpstrikePiece });
         const abilities = buildEquipmentAbilities(ship, getGearPiece);
-        const warpstrike = abilities.find((a) => a.id === 'equip-implant-WARPSTRIKE');
+        const warpstrike = abilities.find((a) => a.id.startsWith('equip-implant-WARPSTRIKE'));
 
         const totals = modifierTotalsFromAbilities(
             [warpstrike!],
@@ -437,7 +437,7 @@ describe('D-PR2 integration — WARPSTRIKE fold (modifier-level)', () => {
             const ship = makeShip({ implants: { implant_major: 'warpstrike-legendary' } });
             const getGearPiece = makeGetGearPiece({ 'warpstrike-legendary': warpstrikePiece });
             const abilities = buildEquipmentAbilities(ship, getGearPiece);
-            const warpstrike = abilities.find((a) => a.id === 'equip-implant-WARPSTRIKE');
+            const warpstrike = abilities.find((a) => a.id.startsWith('equip-implant-WARPSTRIKE'));
 
             const totals = modifierTotalsFromAbilities(
                 [warpstrike!],
@@ -458,7 +458,7 @@ describe('D-PR2 integration — ARCANE_SIEGE fold (modifier-level)', () => {
         const ship = makeShip({ implants: { implant_minor: 'arcane-siege-epic' } });
         const getGearPiece = makeGetGearPiece({ 'arcane-siege-epic': arcaneSiegePiece });
         const abilities = buildEquipmentAbilities(ship, getGearPiece);
-        const arcaneSiege = abilities.find((a) => a.id === 'equip-implant-ARCANE_SIEGE');
+        const arcaneSiege = abilities.find((a) => a.id.startsWith('equip-implant-ARCANE_SIEGE'));
         expect(arcaneSiege).toBeDefined();
 
         const totals = modifierTotalsFromAbilities(
@@ -472,7 +472,7 @@ describe('D-PR2 integration — ARCANE_SIEGE fold (modifier-level)', () => {
         const ship = makeShip({ implants: { implant_minor: 'arcane-siege-epic' } });
         const getGearPiece = makeGetGearPiece({ 'arcane-siege-epic': arcaneSiegePiece });
         const abilities = buildEquipmentAbilities(ship, getGearPiece);
-        const arcaneSiege = abilities.find((a) => a.id === 'equip-implant-ARCANE_SIEGE');
+        const arcaneSiege = abilities.find((a) => a.id.startsWith('equip-implant-ARCANE_SIEGE'));
 
         const totals = modifierTotalsFromAbilities(
             [arcaneSiege!],

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -23,13 +23,13 @@
  */
 import { describe, it, expect } from 'vitest';
 import { runCombat, CombatEngineInput } from '../engine';
-import { ShipSkills } from '../../../types/abilities';
+import { Ability, ShipSkills } from '../../../types/abilities';
 import { Ship } from '../../../types/ship';
 import { GearPiece } from '../../../types/gear';
 import { buildShipAbilitiesWithEquipment } from '../../abilities/buildShipAbilitiesWithEquipment';
 import { buildEquipmentAbilities } from '../../abilities/buildEquipmentAbilities';
 import { modifierTotalsFromAbilities } from '../../abilities/applyAbilities';
-import { ConditionContext } from '../../abilities/evaluateConditions';
+import { makeConditionContext } from '../../abilities/__tests__/conditionContextFixture';
 import { SelectedGameBuff } from '../../../types/calculator';
 
 // ---------------------------------------------------------------------------
@@ -324,21 +324,6 @@ describe('D-PR1 integration — Bloodthirst implant proc frequency', () => {
 // Step 2 is an ENGINE-LEVEL smoke-test for INTRUSION (the scaling implant):
 // it runs the full runCombat pipeline and asserts directDamage amplification.
 
-/** Minimal ConditionContext with the same required fields as evaluateConditions.test.ts. */
-const makeCtx = (over: Partial<ConditionContext> = {}): ConditionContext => ({
-    selfBuffNames: [],
-    selfDebuffNames: [],
-    enemyBuffNames: [],
-    enemyDebuffCount: 0,
-    effectiveCritRate: 0,
-    adjacentAllyCount: 0,
-    enemyAdjacentCount: 0,
-    enemyDestroyedCount: 0,
-    selfHpPct: 100,
-    enemyHpPct: 100,
-    ...over,
-});
-
 // ---------------------------------------------------------------------------
 // Gear-piece stubs for the three D-PR2 implants
 // ---------------------------------------------------------------------------
@@ -388,7 +373,10 @@ describe('D-PR2 integration — INTRUSION fold (modifier-level)', () => {
         const intrusion = abilities.find((a) => a.id === 'equip-implant-INTRUSION');
         expect(intrusion).toBeDefined();
 
-        const totals = modifierTotalsFromAbilities([intrusion!], makeCtx({ enemyDebuffCount: 3 }));
+        const totals = modifierTotalsFromAbilities(
+            [intrusion!],
+            makeConditionContext({ enemyDebuffCount: 3 })
+        );
         expect(totals.outgoingDamage).toBe(15); // 3 × 5
     });
 
@@ -398,7 +386,10 @@ describe('D-PR2 integration — INTRUSION fold (modifier-level)', () => {
         const abilities = buildEquipmentAbilities(ship, getGearPiece);
         const intrusion = abilities.find((a) => a.id === 'equip-implant-INTRUSION');
 
-        const totals = modifierTotalsFromAbilities([intrusion!], makeCtx({ enemyDebuffCount: 0 }));
+        const totals = modifierTotalsFromAbilities(
+            [intrusion!],
+            makeConditionContext({ enemyDebuffCount: 0 })
+        );
         expect(totals.outgoingDamage).toBe(0);
     });
 });
@@ -421,7 +412,7 @@ describe('D-PR2 integration — WARPSTRIKE fold (modifier-level)', () => {
 
         const totals = modifierTotalsFromAbilities(
             [warpstrike!],
-            makeCtx({ selfDebuffNames: ['Burn'] })
+            makeConditionContext({ selfDebuffNames: ['Burn'] })
         );
         expect(totals.outgoingDamage).toBe(5);
     });
@@ -432,7 +423,10 @@ describe('D-PR2 integration — WARPSTRIKE fold (modifier-level)', () => {
         const abilities = buildEquipmentAbilities(ship, getGearPiece);
         const warpstrike = abilities.find((a) => a.id === 'equip-implant-WARPSTRIKE');
 
-        const totals = modifierTotalsFromAbilities([warpstrike!], makeCtx({ selfDebuffNames: [] }));
+        const totals = modifierTotalsFromAbilities(
+            [warpstrike!],
+            makeConditionContext({ selfDebuffNames: [] })
+        );
         expect(totals.outgoingDamage).toBe(0);
     });
 
@@ -447,7 +441,7 @@ describe('D-PR2 integration — WARPSTRIKE fold (modifier-level)', () => {
 
             const totals = modifierTotalsFromAbilities(
                 [warpstrike!],
-                makeCtx({ selfDebuffNames: ['A', 'B'] })
+                makeConditionContext({ selfDebuffNames: ['A', 'B'] })
             );
             // Flat value gates once — does NOT scale with debuff count.
             expect(totals.outgoingDamage).toBe(5);
@@ -467,7 +461,10 @@ describe('D-PR2 integration — ARCANE_SIEGE fold (modifier-level)', () => {
         const arcaneSiege = abilities.find((a) => a.id === 'equip-implant-ARCANE_SIEGE');
         expect(arcaneSiege).toBeDefined();
 
-        const totals = modifierTotalsFromAbilities([arcaneSiege!], makeCtx({ selfShielded: true }));
+        const totals = modifierTotalsFromAbilities(
+            [arcaneSiege!],
+            makeConditionContext({ selfShielded: true })
+        );
         expect(totals.outgoingDamage).toBe(15);
     });
 
@@ -479,7 +476,7 @@ describe('D-PR2 integration — ARCANE_SIEGE fold (modifier-level)', () => {
 
         const totals = modifierTotalsFromAbilities(
             [arcaneSiege!],
-            makeCtx({ selfShielded: false })
+            makeConditionContext({ selfShielded: false })
         );
         expect(totals.outgoingDamage).toBe(0);
     });
@@ -521,6 +518,16 @@ describe('D-PR2 integration — INTRUSION engine-level (outgoing damage amplifie
         };
     }
 
+    /** Single-hit 100% damage active shared between the Intrusion and bare ship-skills builders. */
+    const dmgActiveAbility: Ability = {
+        id: 'dmg-active',
+        type: 'damage',
+        target: 'enemy',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'damage', multiplier: 100, hits: 1 },
+    };
+
     /** Ship with legendary INTRUSION implant. Passive slot injected from buildShipAbilitiesWithEquipment. */
     function buildIntrusionShipSkills(): ShipSkills {
         const ship = makeShip({ implants: { implant_major: 'intrusion-legendary' } });
@@ -532,16 +539,7 @@ describe('D-PR2 integration — INTRUSION engine-level (outgoing damage amplifie
             slots: [
                 {
                     slot: 'active',
-                    abilities: [
-                        {
-                            id: 'dmg-active',
-                            type: 'damage',
-                            target: 'enemy',
-                            trigger: 'on-cast',
-                            conditions: [],
-                            config: { type: 'damage', multiplier: 100, hits: 1 },
-                        },
-                    ],
+                    abilities: [dmgActiveAbility],
                 },
                 ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
             ],
@@ -553,16 +551,7 @@ describe('D-PR2 integration — INTRUSION engine-level (outgoing damage amplifie
         slots: [
             {
                 slot: 'active',
-                abilities: [
-                    {
-                        id: 'dmg-active',
-                        type: 'damage',
-                        target: 'enemy',
-                        trigger: 'on-cast',
-                        conditions: [],
-                        config: { type: 'damage', multiplier: 100, hits: 1 },
-                    },
-                ],
+                abilities: [dmgActiveAbility],
             },
         ],
     };

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -27,6 +27,10 @@ import { ShipSkills } from '../../../types/abilities';
 import { Ship } from '../../../types/ship';
 import { GearPiece } from '../../../types/gear';
 import { buildShipAbilitiesWithEquipment } from '../../abilities/buildShipAbilitiesWithEquipment';
+import { buildEquipmentAbilities } from '../../abilities/buildEquipmentAbilities';
+import { modifierTotalsFromAbilities } from '../../abilities/applyAbilities';
+import { ConditionContext } from '../../abilities/evaluateConditions';
+import { SelectedGameBuff } from '../../../types/calculator';
 
 // ---------------------------------------------------------------------------
 // Shared test harness helpers
@@ -304,4 +308,334 @@ describe('D-PR1 integration — Bloodthirst implant proc frequency', () => {
             expect(r.heal).toBeCloseTo(perFireAmount, 6);
         }
     });
+});
+
+// ---------------------------------------------------------------------------
+// D-PR2 — conditional outgoing-damage implants
+// ---------------------------------------------------------------------------
+//
+// Three implants now live in the equipment-ability registry as passive `modifier`
+// abilities with channel 'outgoingDamage'. These tests exercise the REAL fold path:
+//   buildEquipmentAbilities → Ability[] → modifierTotalsFromAbilities(abilities, ctx)
+// which is identical to the path the engine walks inside effectiveDamageStatsOf.
+//
+// Step 1 tests are FOLD-LEVEL (fast, deterministic): they prove the correct
+// value is accumulated into totals.outgoingDamage for each implant.
+// Step 2 is an ENGINE-LEVEL smoke-test for INTRUSION (the scaling implant):
+// it runs the full runCombat pipeline and asserts directDamage amplification.
+
+/** Minimal ConditionContext with the same required fields as evaluateConditions.test.ts. */
+const makeCtx = (over: Partial<ConditionContext> = {}): ConditionContext => ({
+    selfBuffNames: [],
+    selfDebuffNames: [],
+    enemyBuffNames: [],
+    enemyDebuffCount: 0,
+    effectiveCritRate: 0,
+    adjacentAllyCount: 0,
+    enemyAdjacentCount: 0,
+    enemyDestroyedCount: 0,
+    selfHpPct: 100,
+    enemyHpPct: 100,
+    ...over,
+});
+
+// ---------------------------------------------------------------------------
+// Gear-piece stubs for the three D-PR2 implants
+// ---------------------------------------------------------------------------
+
+/** INTRUSION legendary: +5% outgoing damage per enemy debuff (value 0, perUnit 5). */
+const intrusionPiece = makePiece({
+    id: 'intrusion-legendary',
+    slot: 'implant_major',
+    rarity: 'legendary',
+    setBonus: 'INTRUSION',
+});
+
+/** ARCANE_SIEGE epic: +15% outgoing damage while shielded (flat value 15). */
+const arcaneSiegePiece = makePiece({
+    id: 'arcane-siege-epic',
+    slot: 'implant_minor',
+    rarity: 'epic',
+    setBonus: 'ARCANE_SIEGE',
+});
+
+/** WARPSTRIKE legendary: +5% outgoing damage while self-debuffed (flat, >=1 gate). */
+const warpstrikePiece = makePiece({
+    id: 'warpstrike-legendary',
+    slot: 'implant_major',
+    rarity: 'legendary',
+    setBonus: 'WARPSTRIKE',
+});
+
+// ---------------------------------------------------------------------------
+// Step 1: modifier-fold-level integration tests
+// ---------------------------------------------------------------------------
+
+describe('D-PR2 integration — INTRUSION fold (modifier-level)', () => {
+    /**
+     * INTRUSION legendary: value:0, scaling:{conditionIndex:0, perUnit:5}, condition: enemy-debuff.
+     * The scaling condition has no countComparator → it is a BARE scaling source (gateConditions
+     * strips it), so the ability folds unconditionally with bonus = enemyDebuffCount × perUnit.
+     *
+     * At enemyDebuffCount:3 → 0 + 3×5 = 15.
+     * At enemyDebuffCount:0 → 0 + 0×5 = 0.
+     */
+    it('outgoingDamage === 15 when enemyDebuffCount:3 (legendary, 3×5%)', () => {
+        const ship = makeShip({ implants: { implant_major: 'intrusion-legendary' } });
+        const getGearPiece = makeGetGearPiece({ 'intrusion-legendary': intrusionPiece });
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+
+        const intrusion = abilities.find((a) => a.id === 'equip-implant-INTRUSION');
+        expect(intrusion).toBeDefined();
+
+        const totals = modifierTotalsFromAbilities([intrusion!], makeCtx({ enemyDebuffCount: 3 }));
+        expect(totals.outgoingDamage).toBe(15); // 3 × 5
+    });
+
+    it('outgoingDamage === 0 when enemyDebuffCount:0 (no debuffs → zero bonus)', () => {
+        const ship = makeShip({ implants: { implant_major: 'intrusion-legendary' } });
+        const getGearPiece = makeGetGearPiece({ 'intrusion-legendary': intrusionPiece });
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        const intrusion = abilities.find((a) => a.id === 'equip-implant-INTRUSION');
+
+        const totals = modifierTotalsFromAbilities([intrusion!], makeCtx({ enemyDebuffCount: 0 }));
+        expect(totals.outgoingDamage).toBe(0);
+    });
+});
+
+describe('D-PR2 integration — WARPSTRIKE fold (modifier-level)', () => {
+    /**
+     * WARPSTRIKE legendary: flat value:5, condition: self-debuff >=1 (countComparator:'gte',
+     * countThreshold:1). This condition HAS a countComparator, so gateConditions keeps it as
+     * a GATE (not just a scaler). The flat value fires once (not per-debuff).
+     *
+     * Load-bearing assertion: with selfDebuffNames:['A','B'] (2 debuffs) → still === 5,
+     * NOT 10. This proves the flat-value+gate choice (the value does NOT scale with count).
+     */
+    it('outgoingDamage === 5 when selfDebuffNames:["Burn"] (legendary, 1 debuff → flat value)', () => {
+        const ship = makeShip({ implants: { implant_major: 'warpstrike-legendary' } });
+        const getGearPiece = makeGetGearPiece({ 'warpstrike-legendary': warpstrikePiece });
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        const warpstrike = abilities.find((a) => a.id === 'equip-implant-WARPSTRIKE');
+        expect(warpstrike).toBeDefined();
+
+        const totals = modifierTotalsFromAbilities(
+            [warpstrike!],
+            makeCtx({ selfDebuffNames: ['Burn'] })
+        );
+        expect(totals.outgoingDamage).toBe(5);
+    });
+
+    it('outgoingDamage === 0 when selfDebuffNames:[] (no self-debuffs → gate fails)', () => {
+        const ship = makeShip({ implants: { implant_major: 'warpstrike-legendary' } });
+        const getGearPiece = makeGetGearPiece({ 'warpstrike-legendary': warpstrikePiece });
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        const warpstrike = abilities.find((a) => a.id === 'equip-implant-WARPSTRIKE');
+
+        const totals = modifierTotalsFromAbilities([warpstrike!], makeCtx({ selfDebuffNames: [] }));
+        expect(totals.outgoingDamage).toBe(0);
+    });
+
+    it(
+        'outgoingDamage === 5 (NOT 10) when selfDebuffNames:["A","B"] — ' +
+            'flat value, not per-count (load-bearing: proves gate-not-scaler)',
+        () => {
+            const ship = makeShip({ implants: { implant_major: 'warpstrike-legendary' } });
+            const getGearPiece = makeGetGearPiece({ 'warpstrike-legendary': warpstrikePiece });
+            const abilities = buildEquipmentAbilities(ship, getGearPiece);
+            const warpstrike = abilities.find((a) => a.id === 'equip-implant-WARPSTRIKE');
+
+            const totals = modifierTotalsFromAbilities(
+                [warpstrike!],
+                makeCtx({ selfDebuffNames: ['A', 'B'] })
+            );
+            // Flat value gates once — does NOT scale with debuff count.
+            expect(totals.outgoingDamage).toBe(5);
+        }
+    );
+});
+
+describe('D-PR2 integration — ARCANE_SIEGE fold (modifier-level)', () => {
+    /**
+     * ARCANE_SIEGE epic: flat value:15, condition: self-shield (derivable). The self-shield
+     * condition returns selfShielded ? 1 : 0. With countComparator absent it gates on count > 0.
+     */
+    it('outgoingDamage === 15 when selfShielded:true (epic, +15% while shielded)', () => {
+        const ship = makeShip({ implants: { implant_minor: 'arcane-siege-epic' } });
+        const getGearPiece = makeGetGearPiece({ 'arcane-siege-epic': arcaneSiegePiece });
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        const arcaneSiege = abilities.find((a) => a.id === 'equip-implant-ARCANE_SIEGE');
+        expect(arcaneSiege).toBeDefined();
+
+        const totals = modifierTotalsFromAbilities([arcaneSiege!], makeCtx({ selfShielded: true }));
+        expect(totals.outgoingDamage).toBe(15);
+    });
+
+    it('outgoingDamage === 0 when selfShielded:false (gate fails — dormant without shield)', () => {
+        const ship = makeShip({ implants: { implant_minor: 'arcane-siege-epic' } });
+        const getGearPiece = makeGetGearPiece({ 'arcane-siege-epic': arcaneSiegePiece });
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        const arcaneSiege = abilities.find((a) => a.id === 'equip-implant-ARCANE_SIEGE');
+
+        const totals = modifierTotalsFromAbilities(
+            [arcaneSiege!],
+            makeCtx({ selfShielded: false })
+        );
+        expect(totals.outgoingDamage).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Step 2: engine-level smoke test — INTRUSION amplifies direct damage end-to-end
+// ---------------------------------------------------------------------------
+//
+// Assertion form used: QUALITATIVE (strictly more / exactly equal) rather than
+// exact ratio. Reason: the exact per-round debuff count reaching modifierCtx
+// depends on how many scheduled SelectedGameBuff entries resolve as "landed"
+// active buffs on that specific round, which involves the status engine's
+// application timing (recurring vs timed) and the landedEnemyDebuffs array
+// accumulation. Computing the exact expected ratio would require reimplementing
+// that pipeline here. The qualitative assertion is sufficient to confirm that
+// (a) the INTRUSION passive ability is picked up by the engine's modifier fold,
+// (b) non-zero enemyDebuffCount produces a positive outgoingDamage boost, and
+// (c) the boost is absent when there are no debuffs.
+// The Step 1 fold-level tests provide the exact quantitative coverage.
+
+describe('D-PR2 integration — INTRUSION engine-level (outgoing damage amplified)', () => {
+    /**
+     * Minimal SelectedGameBuff stub for an enemy debuff. The parsedEffects only need
+     * to be non-null (the debuff contribution that matters here is PRESENCE in the
+     * landed-debuff count, not the buff's own numeric effects on damage).
+     * skillDuration:'recurring' → the debuff is active every round without needing
+     * a charge schedule (mirrors the "recurring" scheduling in the status engine).
+     */
+    function makeEnemyDebuff(name: string): SelectedGameBuff {
+        return {
+            id: `test-debuff-${name}`,
+            buffName: name,
+            stacks: 1,
+            parsedEffects: {},
+            isStackable: false,
+            skillDuration: 'recurring',
+            autoFilled: false,
+        };
+    }
+
+    /** Ship with legendary INTRUSION implant. Passive slot injected from buildShipAbilitiesWithEquipment. */
+    function buildIntrusionShipSkills(): ShipSkills {
+        const ship = makeShip({ implants: { implant_major: 'intrusion-legendary' } });
+        const getGearPiece = makeGetGearPiece({ 'intrusion-legendary': intrusionPiece });
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+
+        return {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'dmg-active',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 100, hits: 1 },
+                        },
+                    ],
+                },
+                ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+            ],
+        };
+    }
+
+    /** Ship with NO implant — bare damage active only. */
+    const bareShipSkills: ShipSkills = {
+        slots: [
+            {
+                slot: 'active',
+                abilities: [
+                    {
+                        id: 'dmg-active',
+                        type: 'damage',
+                        target: 'enemy',
+                        trigger: 'on-cast',
+                        conditions: [],
+                        config: { type: 'damage', multiplier: 100, hits: 1 },
+                    },
+                ],
+            },
+        ],
+    };
+
+    it(
+        'INTRUSION legendary: directDamage > bare when 3 enemy debuffs are active; ' +
+            'directDamage === bare with no debuffs',
+        () => {
+            const ATTACK = 10_000;
+            // Three recurring enemy debuffs — all land every round.
+            const threeDebuffs = [
+                makeEnemyDebuff('Corrosion'),
+                makeEnemyDebuff('Inferno'),
+                makeEnemyDebuff('Armor Break'),
+            ];
+
+            // Intrusion + debuffs present → modifier should boost outgoingDamage.
+            const withIntrusionWithDebuffs = runCombat(
+                BASE({
+                    attack: ATTACK,
+                    crit: 0,
+                    critDamage: 0,
+                    numRounds: 1,
+                    enemyDebuffs: threeDebuffs,
+                    shipSkills: buildIntrusionShipSkills(),
+                })
+            );
+
+            // Bare (no Intrusion) + same debuffs → no modifier.
+            const bareWithDebuffs = runCombat(
+                BASE({
+                    attack: ATTACK,
+                    crit: 0,
+                    critDamage: 0,
+                    numRounds: 1,
+                    enemyDebuffs: threeDebuffs,
+                    shipSkills: bareShipSkills,
+                })
+            );
+
+            // Intrusion + no debuffs → modifier is 0, same as bare.
+            const withIntrusionNoDebuffs = runCombat(
+                BASE({
+                    attack: ATTACK,
+                    crit: 0,
+                    critDamage: 0,
+                    numRounds: 1,
+                    enemyDebuffs: [],
+                    shipSkills: buildIntrusionShipSkills(),
+                })
+            );
+
+            // Bare + no debuffs → baseline.
+            const bareNoDebuffs = runCombat(
+                BASE({
+                    attack: ATTACK,
+                    crit: 0,
+                    critDamage: 0,
+                    numRounds: 1,
+                    enemyDebuffs: [],
+                    shipSkills: bareShipSkills,
+                })
+            );
+
+            // Qualitative assertion A: INTRUSION fires when debuffs are present.
+            // Intrusion-equipped attacker MUST deal strictly more direct damage than bare.
+            expect(withIntrusionWithDebuffs.rawTotals.direct).toBeGreaterThan(
+                bareWithDebuffs.rawTotals.direct
+            );
+
+            // Qualitative assertion B: INTRUSION is dormant when no debuffs are present.
+            // Direct damage must equal the bare baseline.
+            expect(withIntrusionNoDebuffs.rawTotals.direct).toBe(bareNoDebuffs.rawTotals.direct);
+        }
+    );
 });

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1089,6 +1089,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         targetRepairedThisRound: targetRepairedThisRoundArg,
         enemyBuffNames: enemyBuffNamesArg,
         selfDebuffNames: selfDebuffNamesArg,
+        selfShielded: actor.shieldPool > 0,
     });
     const passiveSkill = shipSkills.slots.find((s) => s.slot === 'passive');
     const modifierAbilities = [


### PR DESCRIPTION
## Summary

Second PR of sub-project D (implants + gear-set abilities) in the combat-realism epic. **Stacked on D-PR1 (#127)** — retarget to `main` once D-PR1 merges.

Lights up the **conditional outgoing-damage** implant bucket, modeling all three as passive `modifier` abilities on channel `outgoingDamage` that ride the engine's **existing** modifier fold (`modifierTotalsFromAbilities` already iterates the passive slot, gates on conditions, and sums flat `value` + per-count `scaling` into the multiplicative `(1 + outgoingDamageBuff/100)` factor — direct-damage-scoped). No `conditionalBonusPct`/damage-path surgery; this is also the more faithful model ("increase outgoing damage by X%" = multiplicative).

- **Intrusion** — +X% outgoing damage per debuff on the target (per-count scaling; X = 1/2/3/4/5 by rarity).
- **Arcane Siege** — +X% outgoing damage while shielded (flat, gated on the new `self-shield` condition; X = 3/6/10/15/20). Dormant in the sim until sub-project H grants shields; unit-tested now.
- **Warpstrike** — +X% outgoing damage while self-debuffed (flat + `>=1` self-debuff gate, so it doesn't over-apply per debuff; X = 1/2/3/4/5). Its "reduce a random debuff's duration" half is deferred (cleanse-family).

Also: new `self-shield` condition primitive (the only new engine code); DPS calculator page wired to `buildShipAbilitiesWithEquipment` (the wiring D-PR1 skipped since its effects were heals); coverage tracker + integration tests; shared `makeConditionContext` test fixture; changelog + docs.

## Test Plan

- [x] Full suite green — 2808 passing (+14 over D-PR1)
- [x] `npm run lint` clean (max-warnings 0), `npx tsc --noEmit` clean
- [x] `npm run audit:skills` 141 ships / 0 findings (unchanged)
- [x] **ZERO golden `.snap` movement** across the PR (no fixture carries these implants — fixture audit was the first step)
- [x] Per-task spec + code-quality review + final holistic review — all approved

Spec: `docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-pr2-design.md`
Plan: `docs/superpowers/plans/2026-06-20-implant-gearset-abilities-D-pr2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Re-opened from #128 (auto-closed when its D-PR1 base branch was deleted on merge); rebased onto `main`. One added commit adapts D-PR2 integration ids to the unique-implant-id format from the D-PR1 review._
