### PR TITLE
feat(combat): D-PR5 — reactive heal/leech (Second Wind / Nourishment / Vivacious Repair)

### DIFF
--- a/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr5.md
+++ b/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr5.md
@@ -1,0 +1,365 @@
+# D-PR5: Reactive heal/leech (Second Wind / Nourishment / Vivacious Repair) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Light up three implant heal effects — Second Wind (reactive self-heal on receiving a crit), Nourishment + Vivacious Repair (a new heal-cast amplification primitive) — keeping all goldens byte-identical.
+
+**Architecture:** Second Wind is a registry entry riding the existing reactive heal executor (`on-attacked` + `triggerCritFilter: 'crit'`, basis maxHP). Nourishment + Vivacious add a pure `healAmplification.ts` evaluator + a `heal-amplification` AbilityConfig, folded multiplicatively into the cast-heal `raw` per recipient, gated on heal-target HP, reusing D-PR4's `rollOutgoingProc` gate closure.
+
+**Tech Stack:** TypeScript, Vitest. Combat engine under `src/utils/combat/`; equipment registry under `src/utils/abilities/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr5-design.md`
+
+**Branch / worktree:** `feat/combat-d-pr5-reactive-heal` (worktree `.worktrees/d-pr5-reactive-heal`), stacked on D-PR4 tip `29bafb64`. Retarget to `main` after the D stack merges.
+
+---
+
+## CRITICAL WORKFLOW NOTES (read once)
+
+- **Test runner:** NEVER `npm test` / `npm test --` (Vitest **watch** mode, hangs). Use `npx vitest run <pathOrName>`.
+- **Goldens are load-bearing:** NEVER `vitest -u`. All DPS/healing/battle-sim snapshots must stay **byte-identical** (no fixture carries these implants; new code is inert at defaults). If a `.snap` moves, a default leaked — fix the code.
+- **docs/ is gitignored:** `git add -f` for plan/spec; `git commit --no-verify` for docs-only commits.
+- **Worktree env:** `.env` + `docs/*.csv` + `docs/combat-system.md` are symlinked in already.
+- After each code task: `npx vitest run` the touched files, then `npm run lint` (max-warnings 0) + `npx tsc --noEmit`. Run the FULL suite on any task claiming byte-identical goldens; confirm `git diff --stat 29bafb64 -- '**/*.snap' '**/__snapshots__/**'` is EMPTY.
+
+---
+
+## Source values (from `src/constants/implants.ts`)
+
+- **Second Wind** (uncommon/rare/epic/legendary): procChance 0.07/0.09/0.12/0.16; always repair **10% of max HP**. No common.
+- **Nourishment** (uncommon/rare/epic/legendary): ampPct 10/15/20/30; deterministic (no proc). No common.
+- **Vivacious Repair** (rare/epic/legendary): procChance 0.21/0.26/0.32; ampPct **100** (double). No common/uncommon.
+
+---
+
+## Task 1: Fixture audit (byte-identical safety gate — no code)
+
+- [ ] **Step 1:** Confirm no fixture carries these implants:
+```bash
+cd .worktrees/d-pr5-reactive-heal
+grep -rniE "second.?wind|nourishment|vivacious" src/utils/combat src/utils/calculators src/utils/abilities --include='*.ts' | grep -viE "docs/|\.md" || echo "NONE FOUND"
+```
+Expected: `NONE FOUND` (or only this plan/spec). If a real fixture builds a ship with these implants, STOP and re-confirm the byte-identical premise.
+- [ ] **Step 2:** Record result. No commit (read-only).
+
+---
+
+## Task 2: Types — `heal-amplification` config + condition/context
+
+**Files:** Modify `src/types/abilities.ts` (mirror how `outgoing-amplification` / `OutgoingCondition` were added in D-PR4).
+
+- [ ] **Step 1:** Add near the `OutgoingCondition`/`OutgoingHitContext` block:
+```ts
+/**
+ * Condition for a heal-cast amplification, evaluated against the HealAmpContext at the cast-heal
+ * seam (per recipient) — NOT a global ConditionSubject. Mirrors OutgoingCondition (D-PR4).
+ */
+export type HealAmpCondition = 'target-hp-below-self' | 'target-below-25';
+
+export interface HealAmpContext {
+    /** The heal recipient's HP% at cast time. */
+    targetHpPct: number;
+    /** The caster's HP% at cast time. */
+    selfHpPct: number;
+}
+```
+- [ ] **Step 2:** Add `'heal-amplification'` to the `AbilityType` union (alongside `'outgoing-amplification'`).
+- [ ] **Step 3:** Add the `AbilityConfig` union member (mirror `outgoing-amplification`'s shape):
+```ts
+      | {
+            type: 'heal-amplification';
+            condition: HealAmpCondition;
+            /** Amplification added to the cast repair when it fires, in percentage points. */
+            ampPct: number;
+            /** Proc chance in (0,1); ABSENT = deterministic (always fires when gated). */
+            procChance?: number;
+        }
+```
+- [ ] **Step 4:** `npx tsc --noEmit`. If a NEW exhaustive `Record<AbilityType,...>`/switch error surfaces in the editor UI files (`AbilityCard.tsx`, `AbilityTypePicker.tsx`, `abilityDefaults.ts` — the same 3 files D-PR4 touched), add MINIMAL mirror entries (label `'Heal Amplification'`; `abilityDefaults` switch case returning `{ type, condition: 'target-hp-below-self', ampPct: 0 }` and a `DEFAULT_TARGETS` `'heal-amplification': 'self'`) — exactly mirroring the `outgoing-amplification` entries already there. Do NOT add unrelated logic.
+- [ ] **Step 5:** `npx tsc --noEmit` clean + `npm run lint`. Commit:
+```bash
+git add src/types/abilities.ts src/components/skills/AbilityCard.tsx src/components/skills/AbilityTypePicker.tsx src/components/skills/abilityDefaults.ts
+git commit -m "feat(combat): D-PR5 — heal-amplification ability config + HealAmpCondition/Context types"
+```
+(Only `git add` the UI files if Step 4 required them.)
+
+---
+
+## Task 3: Pure evaluator `healAmplification.ts`
+
+**Files:** Create `src/utils/combat/healAmplification.ts`; Test `src/utils/combat/__tests__/healAmplification.test.ts`. Mirror `src/utils/combat/outgoingEffects.ts` (read it first).
+
+- [ ] **Step 1: Write the failing test:**
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { healAmplificationForCast } from '../healAmplification';
+import { Ability } from '../../../types/abilities';
+
+const amp = (id: string, condition: 'target-hp-below-self' | 'target-below-25', ampPct: number, procChance?: number): Ability => ({
+    id,
+    type: 'heal-amplification',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'heal-amplification', condition, ampPct, procChance },
+});
+const always = () => true;
+const never = () => false;
+
+describe('healAmplificationForCast', () => {
+    it('returns 0 with no heal-amplification abilities', () => {
+        expect(healAmplificationForCast([], { targetHpPct: 10, selfHpPct: 90 }, always)).toBe(0);
+    });
+    it('target-hp-below-self fires only when target HP% < self HP% (deterministic, no proc roll)', () => {
+        const roll = vi.fn(() => true);
+        const a = [amp('n', 'target-hp-below-self', 30)]; // no procChance
+        expect(healAmplificationForCast(a, { targetHpPct: 40, selfHpPct: 90 }, roll)).toBe(30);
+        expect(healAmplificationForCast(a, { targetHpPct: 95, selfHpPct: 90 }, roll)).toBe(0);
+        expect(roll).not.toHaveBeenCalled(); // deterministic → gate never consulted
+    });
+    it('target-below-25 with procChance respects the gate', () => {
+        const a = [amp('v', 'target-below-25', 100, 0.5)];
+        expect(healAmplificationForCast(a, { targetHpPct: 20, selfHpPct: 50 }, always)).toBe(100);
+        expect(healAmplificationForCast(a, { targetHpPct: 20, selfHpPct: 50 }, never)).toBe(0);
+        expect(healAmplificationForCast(a, { targetHpPct: 30, selfHpPct: 50 }, always)).toBe(0); // not <25
+    });
+    it('eligibility gates the proc roll (ineligible target does not consume the gate)', () => {
+        const roll = vi.fn(() => true);
+        healAmplificationForCast([amp('v', 'target-below-25', 100, 0.5)], { targetHpPct: 80, selfHpPct: 50 }, roll);
+        expect(roll).not.toHaveBeenCalled();
+    });
+    it('sums additively across abilities', () => {
+        const a = [amp('n', 'target-hp-below-self', 30), amp('v', 'target-below-25', 100, undefined)];
+        expect(healAmplificationForCast(a, { targetHpPct: 10, selfHpPct: 90 }, always)).toBe(130);
+    });
+});
+```
+(Add any required `Ability` fields per the interface, copying a valid literal from `outgoingEffects.test.ts`.)
+
+- [ ] **Step 2:** Run, verify FAIL (module not found): `npx vitest run src/utils/combat/__tests__/healAmplification.test.ts`
+- [ ] **Step 3: Implement:**
+```ts
+import { Ability, HealAmpCondition, HealAmpContext } from '../../types/abilities';
+
+function conditionMet(cond: HealAmpCondition, ctx: HealAmpContext): boolean {
+    switch (cond) {
+        case 'target-hp-below-self':
+            return ctx.targetHpPct < ctx.selfHpPct;
+        case 'target-below-25':
+            return ctx.targetHpPct < 25;
+    }
+}
+
+/**
+ * Summed heal-cast amplification % for one cast on one recipient (mirror of
+ * outgoingAmplificationForHit). For each heal-amplification ability whose condition is met:
+ * deterministic (no procChance) → always add ampPct; proc'd → add ampPct iff rollProc fires.
+ * Eligibility gates the proc roll. Returns 0 when nothing applies → byte-identical with no such equipment.
+ */
+export function healAmplificationForCast(
+    casterAbilities: Ability[],
+    ctx: HealAmpContext,
+    rollProc: (abilityId: string, chance: number) => boolean
+): number {
+    let sum = 0;
+    for (const a of casterAbilities) {
+        if (a.config.type !== 'heal-amplification') continue;
+        if (!conditionMet(a.config.condition, ctx)) continue;
+        const pc = a.config.procChance;
+        if (pc !== undefined && !rollProc(a.id, pc)) continue;
+        sum += a.config.ampPct;
+    }
+    return sum;
+}
+```
+- [ ] **Step 4:** Run, verify PASS (5 tests). `npx tsc --noEmit` + `npm run lint`.
+- [ ] **Step 5:** Commit:
+```bash
+git add src/utils/combat/healAmplification.ts src/utils/combat/__tests__/healAmplification.test.ts
+git commit -m "feat(combat): D-PR5 — pure healAmplificationForCast evaluator (Nourishment/Vivacious)"
+```
+
+---
+
+## Task 4: Second Wind registry entry (reactive self-heal on crit-received)
+
+**Files:** Modify `src/utils/abilities/buildEquipmentAbilities.ts`; Test `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts` + an engine integration test.
+
+Mirror the BLOODTHIRST entry but trigger on receiving a crit. Confirm `triggerCritFilter` is a valid `Ability` field and that the `on-attacked` listener applies it (it does — see `triggers.ts`).
+
+- [ ] **Step 1: Unit test** (reuse the existing single-implant-ability resolution helper): Second Wind 'epic' → reactive `heal` ability, `trigger: 'on-attacked'`, `triggerCritFilter: 'crit'`, `target: 'self'`, `config.basis === 'hp'`, `config.pct === 10`, `procChance ≈ 0.12`; 'legendary' procChance ≈ 0.16; no 'common' variant.
+- [ ] **Step 2: Integration test (healing-mode `runCombat`)** — find the healing/reactive test harness (search `runCombat(` + healing mode + an attacker that crits a tank; the Bloodthirst end-to-end test and `reactiveDamageProcGate`/Second-Wind-like setups are good references). Build a TANK (the heal target) carrying Second Wind, attacked by a forced-crit enemy over N rounds; assert the tank receives reactive self-repair at the gated frequency (procChance, so ~proc×N fires), and assert a non-crit attacker yields zero Second Wind repair (crit filter). Use the heal target as the Second Wind carrier so HP-restore applies (per the spec's §3.1 limitation).
+- [ ] **Step 3:** Run, verify FAIL.
+- [ ] **Step 4: Implement** the registry entry:
+```ts
+const SECOND_WIND_PROC: Record<string, number> = { uncommon: 0.07, rare: 0.09, epic: 0.12, legendary: 0.16 };
+
+// in IMPLANT_ABILITIES:
+SECOND_WIND: (rarity) => {
+    const pc = SECOND_WIND_PROC[rarity];
+    if (pc === undefined) return undefined;
+    return {
+        type: 'heal',
+        target: 'self',
+        trigger: 'on-attacked',
+        triggerCritFilter: 'crit',
+        conditions: [],
+        procChance: pc,
+        config: { type: 'heal', pct: 10, basis: 'hp' },
+        autoFilled: true,
+    };
+},
+```
+Verify `basis: 'hp'` is the correct enum for "max HP" in the heal config (the reactive executor resolves `'hp'` → owner effective max HP). If the heal config's basis field uses a different literal for max HP, match it.
+- [ ] **Step 5:** Run unit + integration (PASS) + FULL suite. Byte-identical: snapshot diff EMPTY. `npm run lint && npx tsc --noEmit`.
+  KNOWN: `equipmentCoverage.test.ts` will fail for SECOND_WIND ("produces 0 abilities") — EXPECTED, fixed in Task 7. If pre-commit blocks ONLY on that, commit `--no-verify` and say so.
+- [ ] **Step 6:** Commit:
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/<files>
+git commit -m "feat(combat): D-PR5 — Second Wind reactive self-heal on crit-received"
+```
+
+---
+
+## Task 5: Nourishment + Vivacious registry entries (heal-amplification configs)
+
+**Files:** Modify `src/utils/abilities/buildEquipmentAbilities.ts`; Test the unit test file.
+
+- [ ] **Step 1: Unit tests:** Nourishment 'epic' → `heal-amplification` config, condition `'target-hp-below-self'`, ampPct 20, NO procChance (undefined); Nourishment 'legendary' ampPct 30; no common. Vivacious 'legendary' → condition `'target-below-25'`, ampPct 100, procChance ≈ 0.32; 'rare' procChance ≈ 0.21; no common/uncommon.
+- [ ] **Step 2:** Run, verify FAIL.
+- [ ] **Step 3: Implement** value tables + a helper + two entries:
+```ts
+const NOURISHMENT_AMP: Record<string, number> = { uncommon: 10, rare: 15, epic: 20, legendary: 30 };
+const VIVACIOUS_PROC: Record<string, number> = { rare: 0.21, epic: 0.26, legendary: 0.32 };
+
+function mkHealAmp(
+    ampPct: number | undefined,
+    condition: HealAmpCondition,
+    procChance?: number
+): Omit<Ability, 'id'> | undefined {
+    if (ampPct === undefined) return undefined;
+    return {
+        type: 'heal-amplification',
+        target: 'self',
+        trigger: 'on-cast', // inert: live condition lives in config, evaluated per-cast
+        conditions: [],
+        config: { type: 'heal-amplification', condition, ampPct, procChance },
+        autoFilled: true,
+    };
+}
+
+// in IMPLANT_ABILITIES:
+NOURISHMENT: (rarity) => mkHealAmp(NOURISHMENT_AMP[rarity], 'target-hp-below-self'),          // deterministic
+VIVACIOUS_REPAIR: (rarity) => mkHealAmp(VIVACIOUS_PROC[rarity] !== undefined ? 100 : undefined, 'target-below-25', VIVACIOUS_PROC[rarity]),
+```
+Add `HealAmpCondition` to the `../../types/abilities` import.
+- [ ] **Step 4:** Run unit (PASS) + FULL suite. Byte-identical (these configs aren't consumed until Task 6 wires the fold, so still byte-identical). `npm run lint && npx tsc --noEmit`.
+  KNOWN: `equipmentCoverage.test.ts` now also fails for NOURISHMENT/VIVACIOUS_REPAIR — EXPECTED (Task 7). Commit `--no-verify` if that's the sole block.
+- [ ] **Step 5:** Commit:
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/<file>
+git commit -m "feat(combat): D-PR5 — Nourishment + Vivacious Repair heal-amplification registry entries"
+```
+
+---
+
+## Task 6: Cast-heal wiring (`playerTurn.ts`) — the heal-amplification fold
+
+**Files:** Modify `src/utils/combat/playerTurn.ts` (the heal block: the two `raw =` sites at ~1717-1723 and ~1736-1742; `incomingPctFor` helper at ~1540); Test an integration test file.
+
+Read the heal block first (the `for (const ability of healAbilities)` loop, the `healEventOnly` branch and the player branch, each with a `for (const rid of recipients)` loop computing `raw`). Both `raw` computations get the amplification multiply per recipient.
+
+- [ ] **Step 1: Write failing integration tests (healing-mode `runCombat`):**
+  - **Nourishment:** a healer with Nourishment repairs an ally whose HP% is BELOW the healer's → repair is boosted by ampPct; when the ally's HP% is ABOVE the healer's → no boost (baseline). Assert the credited/applied repair differs accordingly. (Set healer and target HP% so the comparison is unambiguous; force/await a cast heal.)
+  - **Vivacious:** a healer with Vivacious repairs an ally at <25% HP → repair roughly doubles at the gated frequency over N casts; a target ≥25% HP → never doubles.
+  - A no-implant control run → equals the pre-task baseline (byte-identical sanity).
+  Reference the existing healing-mode `runCombat` / `simulateHealing` tests for harness shape; inject the implant ability into the healer's passive slot the way the Task-4/D-PR4 engine tests do.
+- [ ] **Step 2:** Run, verify FAIL (engine passes the abilities but the fold doesn't yet apply them).
+- [ ] **Step 3: Implement.** In `runPlayerTurn`, before the heal loop (near where `rollOutgoingProc` is read, ~line 1148, and where `incomingPctFor` is defined ~1540), add:
+```ts
+const healAmpAbilities = (passiveSkill?.abilities ?? []).filter(
+    (a) => a.config.type === 'heal-amplification'
+);
+// Per-recipient HP% at cast time (NEW — there is no existing per-recipient HP% accessor; incomingPctFor
+// is the sibling pattern). Uses the healing runtime's per-recipient pool. Falls back to the engine
+// targetHpPct arg for the bound heal target, then 100.
+const recipientHpPctFor = (rid: string): number => {
+    const max = healing.recipientMaxHp(rid);
+    const a = healing.recipientActor(rid);
+    if (a && max > 0) return (100 * Math.max(0, a.currentHp)) / max;
+    if (rid === healing.targetId) return targetHpPctArg;
+    return 100;
+};
+const healAmpPctFor = (rid: string): number =>
+    healAmpAbilities.length > 0 && rollOutgoingProc
+        ? healAmplificationForCast(
+              healAmpAbilities,
+              { targetHpPct: recipientHpPctFor(rid), selfHpPct: selfHpPctArg },
+              rollOutgoingProc
+          )
+        : 0;
+```
+Import `healAmplificationForCast` from `./healAmplification`. Confirm `targetHpPctArg` and `selfHpPctArg` are the destructured arg names in scope (they are — `selfHpPct: selfHpPctArg = 100`, and `targetHpPct: targetHpPctArg`). Confirm `healing.recipientActor`/`recipientMaxHp`/`targetId` exist on the healing ctx (they do).
+
+Then multiply BOTH `raw` computations by `(1 + healAmpPctFor(rid) / 100)`. In each `for (const rid of recipients)` loop, after `raw` is computed (the existing 6-factor product), apply:
+```ts
+raw *= 1 + healAmpPctFor(rid) / 100;
+```
+IMPORTANT:
+- Call `healAmpPctFor(rid)` exactly ONCE per recipient per cast (it rolls the proc gate). Place the multiply right after each `const raw = ...` and before any `applyHealToTarget`/`credit`. A single cast takes ONLY ONE of the two branches (healEventOnly vs player), so a recipient is rolled once.
+- `recipientHpPctFor` for a self-cast (`rid === actor.id`): `target-hp-below-self` → `selfHpPct < selfHpPct` = false (correct — not a lower-HP ally).
+- The `raw` is `const` today — change to `let` (or apply the factor inline in the product). Prefer `let raw = ...; raw *= 1 + healAmpPctFor(rid)/100;` to keep the existing 6-factor expression readable.
+- [ ] **Step 4:** Run the integration tests (PASS) + FULL suite. Byte-identical: snapshot diff EMPTY (no fixture has a heal-amp ability → `healAmpAbilities` empty → factor 1.0). `npm run lint && npx tsc --noEmit`.
+  KNOWN: only the `equipmentCoverage.test.ts` SECOND_WIND/NOURISHMENT/VIVACIOUS_REPAIR failures remain. Commit `--no-verify` if that's the sole block.
+- [ ] **Step 5:** Commit:
+```bash
+git add src/utils/combat/playerTurn.ts src/utils/combat/__tests__/<file>
+git commit -m "feat(combat): D-PR5 — fold heal-cast amplification into the cast-heal raw (Nourishment/Vivacious)"
+```
+
+---
+
+## Task 7: Coverage tracker update
+
+**Files:** Modify `src/utils/abilities/__tests__/equipmentCoverage.test.ts`.
+
+- [ ] **Step 1:** Add `NOURISHMENT`, `SECOND_WIND`, `VIVACIOUS_REPAIR` to BOTH the `.toEqual([...])` ordered array and the `implementedImplants` Set. Determine the array ORDER empirically (run the test, read the received-vs-expected diff — do NOT guess; it follows `Object.keys(IMPLANTS)`).
+- [ ] **Step 2:** Add per-implant assertion blocks (mirror existing ones): Second Wind 1 ability for each of uncommon/rare/epic/legendary (no common → 0); Nourishment 1 for uncommon/rare/epic/legendary (no common); Vivacious 1 for rare/epic/legendary (no common/uncommon). Confirm Exuberance STAYS in the unimplemented loop (deferred → 0 abilities).
+- [ ] **Step 3:** `npx vitest run src/utils/abilities/__tests__/equipmentCoverage.test.ts` → PASS. Then FULL suite → ALL GREEN. Snapshot diff EMPTY. `npm run lint && npx tsc --noEmit`.
+- [ ] **Step 4:** Commit (NO `--no-verify` — branch should be fully green now; let the hook run):
+```bash
+git add src/utils/abilities/__tests__/equipmentCoverage.test.ts
+git commit -m "test(combat): D-PR5 — coverage tracker includes Second Wind/Nourishment/Vivacious Repair"
+```
+
+---
+
+## Task 8: Changelog + docs
+
+**Files:** Modify `src/constants/changelog.ts` (`UNRELEASED_CHANGES`); `src/pages/DocumentationPage.tsx` (the implant/gear-set effects paragraph the prior D PRs extended).
+
+- [ ] **Step 1:** Add an `UNRELEASED_CHANGES` entry matching sibling phrasing (present tense, "Combat simulator now models …", no emojis), e.g.: "Combat simulator now models three more heal implants: Second Wind (chance to repair itself when it takes a critical hit), Nourishment (stronger repairs on allies with less HP than the healer), and Vivacious Repair (chance to double a repair on a critically wounded ally)."
+- [ ] **Step 2:** Extend the DocumentationPage implant-effects paragraph with the three effects (bold name + parenthetical), consistent with the existing entries. Accurate wording: Second Wind = self-repair chance on receiving a critical hit; Nourishment = larger repairs when the target's HP is below the healer's; Vivacious Repair = chance to double a repair on an ally below 25% HP.
+- [ ] **Step 3:** `npm run lint && npx tsc --noEmit` clean; snapshot diff EMPTY. Commit:
+```bash
+git add src/constants/changelog.ts src/pages/DocumentationPage.tsx
+git commit -m "docs(combat): D-PR5 — changelog + docs for Second Wind/Nourishment/Vivacious Repair"
+```
+
+---
+
+## Task 9: Final verification
+
+- [ ] **Step 1:** FULL suite: `npx vitest run` → ALL green; `git diff --stat 29bafb64 -- '**/*.snap' '**/__snapshots__/**'` EMPTY.
+- [ ] **Step 2:** `npm run audit:skills` → 141 ships, 0 findings (unchanged).
+- [ ] **Step 3:** `npm run lint` + `npx tsc --noEmit` clean.
+- [ ] **Step 4:** Push + create PR stacked on D-PR4 (base `feat/combat-d-pr4-outgoing-amplification`; retarget to main after the stack merges). `gh auth switch --user TheSusort` first; pipe push through `| cat`.
+
+---
+
+## Notes for the implementer
+
+- **Byte-identical is the contract.** Every "FULL suite" step must show zero golden movement. If a snapshot moves, the heal-amp fold or Second Wind leaked — fix it, never `-u`.
+- **Gate determinism:** heal-amp procs ride the same `rollOutgoingProc` per-(owner,ability) gate as D-PR4; heal-amp ability ids are distinct, so no collision. Call `healAmpPctFor(rid)` once per recipient per cast.
+- **Scope:** amplification applies to the cast repair only; Second Wind is the reactive rider; Exuberance is deferred to D-PR6. Don't widen scope.
+- **The `selfHpPctArg` provenance is verified** (engine `buildTurnArgs` computes it from the acting actor's live HP%) — `target-hp-below-self` is viable without new plumbing. If the integration test shows the caster reading 100% unexpectedly, re-check that the healer is the acting actor in the harness.

--- a/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr5-design.md
+++ b/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr5-design.md
@@ -1,0 +1,212 @@
+# Combat Realism Epic — Sub-project D, PR5: Reactive heal/leech (Design)
+
+**Date:** 2026-06-21
+**Sub-project:** D (implant + gear-set abilities), PR5.
+**Parent spec:** `docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-design.md` (§5.2 "reactive heal/leech" row).
+**Stacks on:** D-PR4 (`feat/combat-d-pr4-outgoing-amplification`, tip `29bafb64`, PR #132). Branch
+`feat/combat-d-pr5-reactive-heal`; retarget to `main` once the D stack merges.
+**Status:** design (brainstorm complete, user-approved through scope + game-rule decisions).
+
+## 1. Context
+
+D-PR1 shipped Bloodthirst + the Leech set (the on-crit / standing leech effects) and built the reactive
+heal executor (basis cases attack/defense/target-hp/maxHp/damage-dealt). D-PR4 generalized the reactive
+`damage` executor to honor `procChance` (via `passesProcChanceGate`) and added the `rollOutgoingProc`
+per-(owner,ability) gate closure. This PR lights up three more of the §5.2 "reactive heal/leech" row:
+
+- **Second Wind** — "Upon receiving critical direct damage, there is a 7–16% chance to repair 10% of
+  this unit's max HP." Reactive self-heal triggered by *receiving* a critical hit.
+- **Nourishment** — "Increases repair by 10–30% when targeting an ally with lower HP." Deterministic
+  heal-*cast* amplifier, gated on the heal target's HP relative to the caster.
+- **Vivacious Repair** — "When repairing an ally with less than 25% HP, there is a 21–32% chance to
+  double the repair." Proc heal-*cast* amplifier, gated on the target's absolute HP.
+
+**Exuberance** ("when repaired, chance to increase that repair") is the fourth effect in the row but is
+**deferred** — it is heal-*received* amplification, which has no existing seam (no `on-heal-received`
+trigger, no post-heal hook). It is a distinct, higher-risk mechanism and gets its own PR (D-PR6), the
+way Voidfire Catalyst was deferred from D-PR4.
+
+Reconnaissance findings that shape this design:
+- The reactive heal executor (`triggers.ts`) already supports `basis: 'hp'` (= caster max HP) and now
+  honors `procChance`. The on-attacked listener already supports `triggerCritFilter: 'crit'`. So Second
+  Wind rides existing machinery entirely.
+- The cast-heal fold (`playerTurn.ts`, the heal block) multiplies `raw` by
+  `healModifier × outgoingHealBuff × incomingHealBuff(recipient)`. The conditional `modifier` fold
+  (`modifierTotalsFromAbilities`) **ignores heal channels** ("outgoingHeal has no DPS bucket — ignore"),
+  and the cast heal has **no conditional outgoing-heal amplifier** and **no proc**. So Nourishment +
+  Vivacious need a new **heal-cast amplification primitive** (the heal mirror of D-PR4's
+  `outgoingEffects`).
+- Both `targetHpPct` (recipient) and `selfHpPct` (caster) already exist in the condition context
+  (`ConditionContext` / `roundContext.ts`), threaded from `selfHpPctArg`/`targetHpPctArg` into
+  `runPlayerTurn`.
+
+## 2. Goals / non-goals
+
+**Goals**
+
+- Light up **Second Wind, Nourishment, Vivacious Repair** in the combat engine.
+- A reusable **heal-cast amplification primitive** — a per-recipient multiplier on a cast repair, gated
+  by heal-target HP conditions, deterministic (Nourishment) or proc'd (Vivacious) — the heal-side
+  analogue of D-PR4's `outgoingAmplificationForHit`.
+- Keep all DPS / healing / battle-sim **goldens byte-identical** (no fixture carries these implants; the
+  primitive returns 0 at its defaults).
+
+**Non-goals**
+
+- **Exuberance** (heal-received amplification) → D-PR6.
+- No UI / autogear / scoring changes.
+- No change to the deterministic proc model — heal-amp procs ride the same `rollOutgoingProc` gate
+  closure D-PR4 added (a generic `(abilityId, chance) ⇒ bool` over the combat-lifetime
+  `procChanceGates` map).
+
+## 3. Architecture
+
+### 3.1 Second Wind — rides existing machinery (registry entry only)
+
+Mirror Bloodthirst's `IMPLANT_ABILITIES` entry, with:
+
+```ts
+SECOND_WIND: (rarity) => {
+  const pc = SECOND_WIND_PROC[rarity];   // uncommon 0.07 / rare 0.09 / epic 0.12 / legendary 0.16
+  if (pc === undefined) return undefined;
+  return {
+    type: 'heal',
+    target: 'self',
+    trigger: 'on-attacked',
+    triggerCritFilter: 'crit',            // fires only on a critical hit received
+    conditions: [],
+    procChance: pc,
+    config: { type: 'heal', pct: 10, basis: 'hp' },  // 10% of caster max HP
+    autoFilled: true,
+  };
+}
+```
+
+- The `on-attacked` listener already self-scopes (`e.targetId === ownerId`) and applies
+  `triggerCritFilter` against the hit's `didCrit`. The reactive heal executor computes `basis: 'hp'` as
+  the owner's effective max HP, rolls `procChance` via `passesProcChanceGate`, and credits/applies the
+  repair. No new engine code.
+- **Known limitation (documented, pre-existing healing-model behavior):** in single-target
+  healing-calculator mode, a self-heal from a non-heal-target actor credits gross repair but only
+  *restores HP* if that actor is the heal target. In the battle simulator (per-actor pools, post-E5) it
+  restores the actor's own HP. Accepted; Second Wind on the tank (the usual heal target) works fully.
+
+### 3.2 Heal-cast amplification primitive — Nourishment + Vivacious Repair
+
+A new pure module **`src/utils/combat/healAmplification.ts`** (the heal-side mirror of
+`outgoingEffects.ts`):
+
+```ts
+// types/abilities.ts additions
+export type HealAmpCondition = 'target-hp-below-self' | 'target-below-25';
+export interface HealAmpContext {
+  targetHpPct: number;   // the heal recipient's HP% at cast time
+  selfHpPct: number;     // the caster's HP% at cast time
+}
+// new AbilityConfig member
+{ type: 'heal-amplification'; condition: HealAmpCondition; ampPct: number; procChance?: number }
+
+// healAmplification.ts
+export function healAmplificationForCast(
+  casterAbilities: Ability[],
+  ctx: HealAmpContext,
+  rollProc: (abilityId: string, chance: number) => boolean,
+): number   // summed amplification % for this cast on this recipient (0 when nothing applies)
+```
+
+Semantics (mirror `outgoingAmplificationForHit`): for each `heal-amplification` ability whose condition
+is met, fire iff `procChance` is absent (deterministic) OR `rollProc(id, procChance)` returns true; on
+firing, add `ampPct`. Eligibility gates the proc roll.
+
+- `conditionMet`: `'target-hp-below-self'` → `ctx.targetHpPct < ctx.selfHpPct`; `'target-below-25'` →
+  `ctx.targetHpPct < 25`.
+- **Deterministic vs proc:** an ability with no `procChance` always fires when gated (Nourishment); one
+  with `procChance` rolls the gate (Vivacious). `healAmplificationForCast` treats `procChance === undefined`
+  as "always" (no roll) — so deterministic effects never touch a gate.
+
+Registry entries (`buildEquipmentAbilities.ts`), `trigger: 'on-cast'` / `conditions: []` inert (the live
+condition lives in `config`, evaluated per-cast by the evaluator — mirrors D-PR4):
+
+| Implant | condition | ampPct | procChance |
+|---|---|---|---|
+| **Nourishment** | `target-hp-below-self` | 10/15/20/30 (uncommon/rare/epic/legendary) | — (deterministic) |
+| **Vivacious Repair** | `target-below-25` | 100 (double) | 0.21/0.26/0.32 (rare/epic/legendary) |
+
+### 3.3 Cast-heal wiring (`playerTurn.ts`)
+
+In the cast-heal fold (the heal block), after `raw` is computed for a recipient with the existing
+`healModifier × outgoingHealBuff × incomingHealBuff` factors, apply the amplification multiplicatively:
+
+```ts
+const healAmpAbilities = (passiveSkill?.abilities ?? []).filter(
+  (a) => a.config.type === 'heal-amplification'
+);
+// per recipient `rid`, with its targetHpPct:
+const healAmpPct = healAmpAbilities.length > 0 && rollOutgoingProc
+  ? healAmplificationForCast(healAmpAbilities,
+      { targetHpPct: recipientHpPctFor(rid), selfHpPct: selfHpPctArg }, rollOutgoingProc)
+  : 0;
+raw *= 1 + healAmpPct / 100;
+```
+
+- Guarded by `healAmpAbilities.length > 0 && rollOutgoingProc` → when no heal-amp ability exists the
+  fold is untouched → **byte-identical**.
+- Reuses `args.rollOutgoingProc` (D-PR4) verbatim — a generic per-(owner,ability) gate roller; heal-amp
+  ability ids are distinct from any outgoing-amp ids, so gates never collide.
+- `selfHpPct` = the caster's HP% (`selfHpPctArg`); `targetHpPct` = the recipient's HP% (the per-recipient
+  value the cast fold already resolves for the recipient's incoming-heal / condition context).
+- Applies to the cast repair only (reactive heals are a separate executor; Nourishment/Vivacious are
+  about the *caster's* repair output).
+
+### 3.4 Condition context
+
+`target-hp-below-self` consumes both `targetHpPct` and `selfHpPct`, which already exist in
+`ConditionContext`. The `HealAmpCondition` is kept **local to the heal-amp evaluator** (not added as a
+global `ConditionSubject`), mirroring how D-PR4's `OutgoingCondition` lived with `outgoingEffects` — the
+comparison is specific to the heal-cast seam.
+
+## 4. Integration risks to verify FIRST (plan step 1)
+
+1. **`selfHpPctArg` must be the caster's live HP% in the cast-heal path.** It defaults to 100. If the
+   engine does not thread the acting healer's real HP% into `runPlayerTurn` for the healing/sim paths,
+   `target-hp-below-self` degenerates (always true when the caster reads 100% and the target is below).
+   Verify what `selfHpPctArg` carries at the heal-cast sites BEFORE relying on the comparison; if it is
+   not the caster's live HP%, that wiring is part of this PR (or Nourishment's condition must be
+   reconsidered). **Characterize this before writing the plan's Nourishment task.**
+2. **`targetHpPct` per recipient at cast time** — confirm the cast fold can supply each recipient's HP%
+   to the evaluator (single-target heal: the bound heal target; multi-recipient: per recipient). For a
+   self-cast, `targetHpPct === selfHpPct` → `target-hp-below-self` is false (correct: not healing a
+   lower-HP ally).
+3. **Second Wind HP-restore routing** for a non-heal-target actor — confirm/accept the §3.1 limitation.
+
+## 5. Effect coverage / corpus
+
+- Coverage tracker `equipmentCoverage.test.ts`: implemented-implants set gains `NOURISHMENT`,
+  `SECOND_WIND`, `VIVACIOUS_REPAIR`. Exuberance stays in the unimplemented loop (deferred — keeps it
+  flagged, not silently passing).
+
+## 6. Testing & invariants
+
+- **Unit — `healAmplificationForCast`:** each condition fires only when its HP gate is met; deterministic
+  (no procChance) always fires when gated; proc'd respects `rollProc`; eligibility gates the proc roll;
+  additive sum across abilities.
+- **Unit — `buildEquipmentAbilities`:** Second Wind → reactive `heal` on `on-attacked`+crit-filter, basis
+  `hp`, pct 10, per-rarity procChance; Nourishment → `heal-amplification` target-hp-below-self, per-rarity
+  ampPct, no procChance; Vivacious → `heal-amplification` target-below-25, ampPct 100, per-rarity
+  procChance; no-common/uncommon variants skipped where the source lacks them.
+- **Integration (healing-mode `runCombat`):** Nourishment boosts a cast repair when the target's HP% is
+  below the caster's and not otherwise; Vivacious doubles a repair on a <25% target at its gated
+  frequency (and 0 above 25%); Second Wind repairs the receiver at its gated frequency when it takes a
+  critical hit (and not on a non-crit hit).
+- **Load-bearing invariant:** all DPS / healing / battle-sim goldens **byte-identical** (plan step 1 =
+  fixture audit for Second Wind / Nourishment / Vivacious; the cast-heal fold and reactive executor are
+  inert at defaults). Never `vitest -u`.
+- `audit:skills` unchanged.
+
+## 7. Open questions for the plan
+
+1. The exact `selfHpPctArg` provenance at each cast-heal site (risk #1) — characterize and, if needed,
+   scope the plumbing.
+2. The exact per-recipient `targetHpPct` accessor in the cast-heal fold to feed the evaluator.
+3. Whether `healAmplificationForCast` belongs in its own module or alongside `outgoingEffects` (default:
+   own module `healAmplification.ts` for focus; they share only the `rollProc` shape).

--- a/src/components/skills/AbilityCard.tsx
+++ b/src/components/skills/AbilityCard.tsx
@@ -57,6 +57,7 @@ const ABILITY_TYPE_LABELS: Record<Ability['type'], string> = {
     'incoming-reduction': 'Incoming Reduction',
     'incoming-block': 'Incoming Block',
     'outgoing-amplification': 'Outgoing Amplification',
+    'heal-amplification': 'Heal Amplification',
 };
 
 const TARGET_OPTIONS: { value: AbilityTarget; label: string }[] = [

--- a/src/components/skills/AbilityTypePicker.tsx
+++ b/src/components/skills/AbilityTypePicker.tsx
@@ -27,6 +27,7 @@ const TYPE_LABELS: Record<AbilityType, string> = {
     'incoming-reduction': 'Incoming Reduction',
     'incoming-block': 'Incoming Block',
     'outgoing-amplification': 'Outgoing Amplification',
+    'heal-amplification': 'Heal Amplification',
 };
 
 const CATEGORIES: { label: string; types: AbilityType[]; note?: string }[] = [

--- a/src/components/skills/abilityDefaults.ts
+++ b/src/components/skills/abilityDefaults.ts
@@ -73,6 +73,8 @@ const makeDefaultConfig = (type: AbilityType): AbilityConfig => {
                 ampPct: 0,
                 procChance: 0,
             };
+        case 'heal-amplification':
+            return { type: 'heal-amplification', condition: 'target-hp-below-self', ampPct: 0 };
     }
 };
 
@@ -96,6 +98,7 @@ const DEFAULT_TARGETS: Record<AbilityType, AbilityTarget> = {
     'incoming-reduction': 'self',
     'incoming-block': 'self',
     'outgoing-amplification': 'self',
+    'heal-amplification': 'self',
 };
 
 /**

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -14,6 +14,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat & DPS simulators now model three conditional damage implants: Intrusion (more outgoing damage per debuff on the target), Arcane Siege (more outgoing damage while your ship is shielded), and Warpstrike (more outgoing damage while your ship is debuffed). The DPS calculator now also accounts for equipped implant and gear-set effects.',
     "Combat simulator now models conditional incoming-damage-reduction implants and gear sets: Voidshade and Shadowguard (reduced damage while stealthed), Nebula Nullifier (reduced damage while in Stasis), Hyperion Gaze, the Hardened set, and Iridium's passive (reduced incoming critical-hit damage), Vortex Veil (reduced Inferno and Corrosion damage), and Ironclad (a chance to block a repeat hit from the same attacker). Ships with these equipped now take less damage when the relevant conditions are met.",
     "Combat simulator now models three outgoing-damage amplification implants: Menace (chance to amplify a hit's damage on a critical hit), Giant Slayer (chance to amplify a hit's damage against an enemy with higher attack), and Insidiousness (chance to deal bonus damage when you apply a debuff to an enemy).",
+    'Combat simulator now models three more heal implants: Second Wind (chance to repair itself when it takes a critical hit), Nourishment (stronger repairs on allies with less HP than the healer), and Vivacious Repair (chance to double a repair on an ally below 25% HP).',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3090,8 +3090,13 @@ const DocumentationPage: React.FC = () => {
                                     <strong>Giant Slayer</strong> (chance to amplify a hit&apos;s
                                     damage against an enemy with higher attack), and{' '}
                                     <strong>Insidiousness</strong> (chance to deal bonus damage when
-                                    you apply a debuff to an enemy). More implant and gear-set
-                                    effects will be added in future updates.
+                                    you apply a debuff to an enemy). Three heal implants are also
+                                    modeled: <strong>Second Wind</strong> (chance to repair itself
+                                    when it takes a critical hit), <strong>Nourishment</strong>{' '}
+                                    (stronger repairs on allies with less HP than the healer), and{' '}
+                                    <strong>Vivacious Repair</strong> (chance to double a repair on
+                                    an ally below 25% HP). More implant and gear-set effects will be
+                                    added in future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -22,7 +22,8 @@ export type AbilityType =
     | 'control'
     | 'incoming-reduction'
     | 'incoming-block'
-    | 'outgoing-amplification';
+    | 'outgoing-amplification'
+    | 'heal-amplification';
 
 export type AbilityTarget =
     | 'self'
@@ -199,6 +200,19 @@ export interface IncomingHitContext {
  */
 export type OutgoingCondition = 'amplify-on-crit' | 'amplify-vs-higher-attack';
 
+/**
+ * Condition for a heal-cast amplification, evaluated against the HealAmpContext at the cast-heal
+ * seam (per recipient) — NOT a global ConditionSubject. Mirrors OutgoingCondition (D-PR4).
+ */
+export type HealAmpCondition = 'target-hp-below-self' | 'target-below-25';
+
+export interface HealAmpContext {
+    /** The heal recipient's HP% at cast time. */
+    targetHpPct: number;
+    /** The caster's HP% at cast time. */
+    selfHpPct: number;
+}
+
 export interface OutgoingHitContext {
     /** Did this individual hit critically strike? (Menace.) */
     didCrit: boolean;
@@ -345,6 +359,15 @@ export type AbilityConfig =
           ampPct: number;
           /** Per-(owner,ability) proc chance in (0,1). Rolled per eligible hit. */
           procChance: number;
+      }
+    // D-PR5 caster-side heal amplification (folded at the cast-heal seam per recipient).
+    | {
+          type: 'heal-amplification';
+          condition: HealAmpCondition;
+          /** Amplification added to the cast repair when it fires, in percentage points. */
+          ampPct: number;
+          /** Proc chance in (0,1); ABSENT = deterministic (always fires when gated). */
+          procChance?: number;
       };
 
 /** Crowd-control effects a `control` ability can apply. The engine does not simulate

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -475,3 +475,36 @@ describe('Insidiousness implant', () => {
         }
     });
 });
+
+// ---------------------------------------------------------------------------
+// D-PR5: Second Wind implant (reactive self-heal on crit-received)
+// ---------------------------------------------------------------------------
+describe('Second Wind implant', () => {
+    it('epic → reactive heal with trigger on-attacked, triggerCritFilter crit, target self, basis hp, pct 10, procChance ≈ 0.12', () => {
+        const abilities = buildForImplant('SECOND_WIND', 'epic');
+        expect(abilities).toHaveLength(1);
+        const ab = abilities[0];
+        expect(ab.trigger).toBe('on-attacked');
+        expect(ab.triggerCritFilter).toBe('crit');
+        expect(ab.target).toBe('self');
+        expect(ab.conditions).toEqual([]);
+        expect(ab.autoFilled).toBe(true);
+        expect(ab.procChance).toBeCloseTo(0.12);
+        expect(ab.config.type).toBe('heal');
+        if (ab.config.type === 'heal') {
+            expect(ab.config.pct).toBe(10);
+            expect(ab.config.basis).toBe('hp');
+        } else {
+            throw new Error('Expected heal config');
+        }
+    });
+
+    it('legendary → procChance ≈ 0.16', () => {
+        const ab = buildForImplant('SECOND_WIND', 'legendary')[0];
+        expect(ab.procChance).toBeCloseTo(0.16);
+    });
+
+    it('common → no ability (no common variant)', () => {
+        expect(buildForImplant('SECOND_WIND', 'common')).toEqual([]);
+    });
+});

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -477,6 +477,78 @@ describe('Insidiousness implant', () => {
 });
 
 // ---------------------------------------------------------------------------
+// D-PR5: Nourishment implant (heal-amplification, target-hp-below-self, deterministic)
+// ---------------------------------------------------------------------------
+describe('Nourishment implant', () => {
+    it('epic → heal-amplification, condition target-hp-below-self, ampPct 20, no procChance', () => {
+        const abilities = buildForImplant('NOURISHMENT', 'epic');
+        expect(abilities).toHaveLength(1);
+        const ab = abilities[0];
+        expect(ab.type).toBe('heal-amplification');
+        expect(ab.target).toBe('self');
+        expect(ab.autoFilled).toBe(true);
+        expect(ab.procChance).toBeUndefined();
+        if (ab.config.type === 'heal-amplification') {
+            expect(ab.config.condition).toBe('target-hp-below-self');
+            expect(ab.config.ampPct).toBe(20);
+            expect(ab.config.procChance).toBeUndefined();
+        } else {
+            throw new Error('Expected heal-amplification config');
+        }
+    });
+
+    it('legendary → ampPct 30', () => {
+        const ab = buildForImplant('NOURISHMENT', 'legendary')[0];
+        if (ab.config.type === 'heal-amplification') {
+            expect(ab.config.ampPct).toBe(30);
+        } else {
+            throw new Error('Expected heal-amplification config');
+        }
+    });
+
+    it('common → no ability (no common variant)', () => {
+        expect(buildForImplant('NOURISHMENT', 'common')).toEqual([]);
+    });
+});
+
+// D-PR5: Vivacious Repair implant (heal-amplification, target-below-25, probabilistic)
+// ---------------------------------------------------------------------------
+describe('Vivacious Repair implant', () => {
+    it('legendary → heal-amplification, condition target-below-25, ampPct 100, procChance ≈ 0.32', () => {
+        const abilities = buildForImplant('VIVACIOUS_REPAIR', 'legendary');
+        expect(abilities).toHaveLength(1);
+        const ab = abilities[0];
+        expect(ab.type).toBe('heal-amplification');
+        expect(ab.target).toBe('self');
+        expect(ab.autoFilled).toBe(true);
+        if (ab.config.type === 'heal-amplification') {
+            expect(ab.config.condition).toBe('target-below-25');
+            expect(ab.config.ampPct).toBe(100);
+            expect(ab.config.procChance).toBeCloseTo(0.32);
+        } else {
+            throw new Error('Expected heal-amplification config');
+        }
+    });
+
+    it('rare → procChance ≈ 0.21', () => {
+        const ab = buildForImplant('VIVACIOUS_REPAIR', 'rare')[0];
+        if (ab.config.type === 'heal-amplification') {
+            expect(ab.config.ampPct).toBe(100);
+            expect(ab.config.procChance).toBeCloseTo(0.21);
+        } else {
+            throw new Error('Expected heal-amplification config');
+        }
+    });
+
+    it('common → no ability (no common variant)', () => {
+        expect(buildForImplant('VIVACIOUS_REPAIR', 'common')).toEqual([]);
+    });
+
+    it('uncommon → no ability (no uncommon variant)', () => {
+        expect(buildForImplant('VIVACIOUS_REPAIR', 'uncommon')).toEqual([]);
+    });
+});
+
 // D-PR5: Second Wind implant (reactive self-heal on crit-received)
 // ---------------------------------------------------------------------------
 describe('Second Wind implant', () => {

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -10,6 +10,8 @@
  * D-PR3 added the incoming-reduction / block family
  * (VOIDSHADE, NEBULA_NULLIFIER, HYPERION_GAZE, VORTEX_VEIL, IRONCLAD, SHADOWGUARD
  * implants + HARDENED gear set).
+ * D-PR5 added the reactive-heal family
+ * (SECOND_WIND, NOURISHMENT, VIVACIOUS_REPAIR implants).
  *
  * Assertions are plain `expect` calls — no snapshot files.
  */
@@ -97,7 +99,7 @@ function implantAbilityCount(implantKey: string, rarity: GearPiece['rarity']): n
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { LEECH + HARDENED (gear sets), ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + BLOODTHIRST + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + MENACE + SHADOWGUARD (implants) } are currently implemented', () => {
+    it('exactly { LEECH + HARDENED (gear sets), ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + BLOODTHIRST + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + MENACE + SECOND_WIND + SHADOWGUARD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -115,6 +117,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
             'HYPERION_GAZE',
             'INTRUSION',
             'NEBULA_NULLIFIER',
+            'NOURISHMENT',
             'VOIDSHADE',
             'VORTEX_VEIL',
             'WARPSTRIKE',
@@ -123,7 +126,9 @@ describe('equipmentCoverage — implemented effects registry', () => {
             'INSIDIOUSNESS',
             'IRONCLAD',
             'MENACE',
+            'SECOND_WIND',
             'SHADOWGUARD',
+            'VIVACIOUS_REPAIR',
         ]);
     });
 });
@@ -171,6 +176,7 @@ describe('equipmentCoverage — implants', () => {
     // D-PR2: INTRUSION, ARCANE_SIEGE, WARPSTRIKE now produce 1 ability each.
     // D-PR3: VOIDSHADE, NEBULA_NULLIFIER, HYPERION_GAZE, VORTEX_VEIL, IRONCLAD, SHADOWGUARD added.
     // D-PR4: MENACE, GIANT_SLAYER, INSIDIOUSNESS added (outgoing-amplification on-crit / vs higher-attack / on-debuff).
+    // D-PR5: SECOND_WIND, NOURISHMENT, VIVACIOUS_REPAIR added (reactive-heal family).
     const implementedImplants = new Set([
         'BLOODTHIRST',
         'INTRUSION',
@@ -185,6 +191,9 @@ describe('equipmentCoverage — implants', () => {
         'MENACE',
         'GIANT_SLAYER',
         'INSIDIOUSNESS',
+        'SECOND_WIND',
+        'NOURISHMENT',
+        'VIVACIOUS_REPAIR',
     ]);
 
     it('INTRUSION produces 1 ability per rarity (outgoingDamage modifier with scaling)', () => {
@@ -275,6 +284,35 @@ describe('equipmentCoverage — implants', () => {
         const variants = IMPLANTS['INSIDIOUSNESS'].variants;
         for (const v of variants) {
             expect(implantAbilityCount('INSIDIOUSNESS', v.rarity)).toBe(1);
+        }
+    });
+
+    // D-PR5: reactive-heal implants
+    it('SECOND_WIND produces 1 ability per rarity (on-crit-hit reactive heal; no common variant)', () => {
+        // SECOND_WIND has uncommon/rare/epic/legendary — no common variant.
+        expect(implantAbilityCount('SECOND_WIND', 'common')).toBe(0);
+        const variants = IMPLANTS['SECOND_WIND'].variants;
+        for (const v of variants) {
+            expect(implantAbilityCount('SECOND_WIND', v.rarity)).toBe(1);
+        }
+    });
+
+    it('NOURISHMENT produces 1 ability per rarity (repair amplification vs lower-HP ally; no common variant)', () => {
+        // NOURISHMENT has uncommon/rare/epic/legendary — no common variant.
+        expect(implantAbilityCount('NOURISHMENT', 'common')).toBe(0);
+        const variants = IMPLANTS['NOURISHMENT'].variants;
+        for (const v of variants) {
+            expect(implantAbilityCount('NOURISHMENT', v.rarity)).toBe(1);
+        }
+    });
+
+    it('VIVACIOUS_REPAIR produces 1 ability per rarity (double-repair chance vs low-HP ally; rare/epic/legendary only)', () => {
+        // VIVACIOUS_REPAIR has rare/epic/legendary — no common or uncommon variant.
+        expect(implantAbilityCount('VIVACIOUS_REPAIR', 'common')).toBe(0);
+        expect(implantAbilityCount('VIVACIOUS_REPAIR', 'uncommon')).toBe(0);
+        const variants = IMPLANTS['VIVACIOUS_REPAIR'].variants;
+        for (const v of variants) {
+            expect(implantAbilityCount('VIVACIOUS_REPAIR', v.rarity)).toBe(1);
         }
     });
 

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -24,7 +24,7 @@
 import { GEAR_SETS } from '../../constants/gearSets';
 import { IMPLANTS } from '../../constants/implants';
 import { GearPiece } from '../../types/gear';
-import { Ability, IncomingCondition, OutgoingCondition } from '../../types/abilities';
+import { Ability, HealAmpCondition, IncomingCondition, OutgoingCondition } from '../../types/abilities';
 import { Ship } from '../../types/ship';
 
 // ---------------------------------------------------------------------------
@@ -188,6 +188,12 @@ const SECOND_WIND_PROC: Record<string, number> = {
     legendary: 0.16,
 };
 
+// D-PR5: heal-amplification implant value tables
+// No common rarity for Nourishment
+const NOURISHMENT_AMP: Record<string, number> = { uncommon: 10, rare: 15, epic: 20, legendary: 30 };
+// No common/uncommon rarity for Vivacious Repair
+const VIVACIOUS_PROC: Record<string, number> = { rare: 0.21, epic: 0.26, legendary: 0.32 };
+
 // D-PR3: shared helper for incoming-reduction abilities
 function mkReduction(
     pct: number | undefined,
@@ -219,6 +225,23 @@ function mkAmplification(
         trigger: 'on-cast', // inert: the live condition lives in config, evaluated per-hit
         conditions: [],
         config: { type: 'outgoing-amplification', condition, ampPct, procChance },
+        autoFilled: true,
+    };
+}
+
+// D-PR5: shared helper for heal-amplification abilities
+function mkHealAmp(
+    ampPct: number | undefined,
+    condition: HealAmpCondition,
+    procChance?: number
+): Omit<Ability, 'id'> | undefined {
+    if (ampPct === undefined) return undefined;
+    return {
+        type: 'heal-amplification',
+        target: 'self',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'heal-amplification', condition, ampPct, procChance },
         autoFilled: true,
     };
 }
@@ -391,6 +414,18 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
             autoFilled: true,
         };
     },
+    // D-PR5: heal-amplification implants
+    // Nourishment: +X% repair when targeting an ally with lower HP. Deterministic (no procChance).
+    // No common rarity.
+    NOURISHMENT: (rarity) => mkHealAmp(NOURISHMENT_AMP[rarity], 'target-hp-below-self'),
+    // Vivacious Repair: X% chance to double the repair amount when targeting an ally below 25% HP.
+    // No common/uncommon rarity.
+    VIVACIOUS_REPAIR: (rarity) =>
+        mkHealAmp(
+            VIVACIOUS_PROC[rarity] !== undefined ? 100 : undefined,
+            'target-below-25',
+            VIVACIOUS_PROC[rarity]
+        ),
 };
 
 // ---------------------------------------------------------------------------

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -180,6 +180,14 @@ const GIANT_SLAYER_PROC: Record<string, number> = {
     legendary: 0.2,
 };
 
+// D-PR5: Second Wind reactive self-heal on crit-received value table
+const SECOND_WIND_PROC: Record<string, number> = {
+    uncommon: 0.07,
+    rare: 0.09,
+    epic: 0.12,
+    legendary: 0.16,
+};
+
 // D-PR3: shared helper for incoming-reduction abilities
 function mkReduction(
     pct: number | undefined,
@@ -344,6 +352,22 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
                 blockPct: b.pct,
                 oncePerRound: false,
             },
+            autoFilled: true,
+        };
+    },
+    // Second Wind: X% chance to repair 10% of max HP upon receiving a critical hit.
+    // No common variant.
+    SECOND_WIND: (rarity) => {
+        const pc = SECOND_WIND_PROC[rarity];
+        if (pc === undefined) return undefined;
+        return {
+            type: 'heal',
+            target: 'self',
+            trigger: 'on-attacked',
+            triggerCritFilter: 'crit',
+            conditions: [],
+            procChance: pc,
+            config: { type: 'heal', pct: 10, basis: 'hp' },
             autoFilled: true,
         };
     },

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -22,7 +22,7 @@
  *   directHeal = 5000 × 0.20 = 1000. 2 fires → 2000 total.
  */
 import { describe, it, expect } from 'vitest';
-import { runCombat, CombatEngineInput } from '../engine';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
 import { Ability, ShipSkills } from '../../../types/abilities';
 import { Ship } from '../../../types/ship';
 import { GearPiece } from '../../../types/gear';
@@ -968,5 +968,251 @@ describe('D-PR5 integration — Second Wind reactive self-heal on crit-received'
         expect(result.healing).toBeDefined();
         // No crits → no on-attacked+crit triggers → Second Wind never fires.
         expect(sumHeal(result, 'directHeal')).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// D-PR5 Task 6: heal-cast amplification fold (Nourishment / Vivacious)
+// ---------------------------------------------------------------------------
+//
+// A heal-amplification ability in the CASTER's passive slot boosts the cast repair's
+// raw when its condition is met at cast time. The fold multiplies the existing 6-factor
+// `raw` by (1 + ampPct/100), so directHeal scales linearly with the boost.
+//
+// Harness shape (deterministic):
+//   - The FOCUS actor ('attacker') is the HEALER. It is never attacked (the enemy drains
+//     all of its damage into the heal target), so the healer's HP% stays at 100.
+//   - The heal target is a TEAM actor ('tank'), set as healTargetId. The healer casts a
+//     `target: 'ally'` repair, which routes to healing.targetId === 'tank'.
+//   - An enemy attacker (faster than the healer) damages 'tank' at the round top, so by the
+//     time the healer acts, the heal target's HP% is BELOW the healer's 100%.
+//   - The repair basis is 'hp' → the raw equals the HEALER's effective max HP × pct, which
+//     is CONSTANT regardless of the target's current HP. Only the amp CONDITION reads the
+//     target/healer HP%, so directHeal_with / directHeal_without isolates the amp factor.
+//
+// selfHpPct (engine buildTurnArgs) = the ACTING actor's live HP% = the healer's 100.
+// targetHpPct = the heal target's live HP% (healTargetHpPctNow()).
+
+describe('D-PR5 integration — heal-cast amplification fold (Nourishment / Vivacious)', () => {
+    const HEALER_HP = 10_000;
+    const TANK_HP = 10_000;
+    const HEAL_PCT = 10; // repair = HEALER_HP × 10% = 1000 per cast (basis 'hp', no other folds)
+    const BASE_PER_CAST = HEALER_HP * (HEAL_PCT / 100); // 1000
+
+    /** The healer's active repair, targeting an ally (routes to the heal target). noCrit so
+     *  the heal crit gate never perturbs raw — the only variable is the amp factor. */
+    const repairAlly: Ability = {
+        id: 'repair-ally',
+        type: 'heal',
+        target: 'ally',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'heal', pct: HEAL_PCT, basis: 'hp', noCrit: true },
+    };
+
+    /** A passive-slot heal-amplification ability. */
+    const healAmp = (
+        condition: 'target-hp-below-self' | 'target-below-25',
+        ampPct: number,
+        procChance?: number
+    ): Ability => ({
+        id: `equip-implant-AMP-${condition}`,
+        type: 'heal-amplification',
+        target: 'self',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'heal-amplification', condition, ampPct, ...(procChance !== undefined ? { procChance } : {}) },
+        autoFilled: true,
+    });
+
+    /** Healer ship skills: active repair + optional heal-amp passive. */
+    const healerSkills = (ampAbility?: Ability): ShipSkills => ({
+        slots: [
+            { slot: 'active', abilities: [repairAlly] },
+            ...(ampAbility ? [{ slot: 'passive' as const, abilities: [ampAbility] }] : []),
+        ],
+    });
+
+    /** Team-actor heal target (the tank). Inert skills — it just receives the heal & enemy hits. */
+    const tankActor = (speed: number): TeamActorEngineInput => ({
+        id: 'tank',
+        speed,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        walk: {
+            shipSkills: { slots: [] },
+            stats: {
+                attack: 1,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp: TANK_HP,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    });
+
+    /** An enemy attacker that damages the heal target ('tank') for `dmgPerRound` each round.
+     *  attack === multiplier-scaled damage; speed high so it acts before the healer. */
+    const enemyHitter = (dmgPerRound: number, speed = 1_000) => ({
+        id: 'amp-enemy',
+        stats: {
+            attack: dmgPerRound,
+            crit: 0,
+            critDamage: 0,
+            speed,
+            defence: 0,
+            hp: 1_000_000_000,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active' as const,
+                    abilities: [
+                        {
+                            id: 'amp-enemy-hit',
+                            type: 'damage' as const,
+                            target: 'enemy' as const,
+                            trigger: 'on-cast' as const,
+                            conditions: [],
+                            config: { type: 'damage' as const, multiplier: 100, hits: 1 },
+                        },
+                    ],
+                },
+            ],
+        } as ShipSkills,
+    });
+
+    /** Base input: healing mode, focus 'attacker' is the HEALER (slow), heal target is 'tank'. */
+    const AMP_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+        attack: 1,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: healerSkills(),
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: HEALER_HP,
+        speed: 10, // healer is slow → acts AFTER the enemy hit each round
+        healTargetId: 'tank',
+        teamActors: [tankActor(20)], // tank also acts before the healer (inert)
+        ...overrides,
+    });
+
+    // ── Control: no implant → byte-identical to the bare baseline ────────────────
+    it('Control: no heal-amp implant → directHeal = base per-cast (1000), unchanged', () => {
+        const result = runCombat(
+            AMP_BASE({
+                shipSkills: healerSkills(),
+                enemyAttackers: [enemyHitter(3000)], // damage tank below healer, but no amp ability
+            })
+        );
+        expect(result.healing).toBeDefined();
+        expect(sumHeal(result, 'directHeal')).toBeCloseTo(BASE_PER_CAST, 6);
+    });
+
+    // ── Nourishment (deterministic, +30%) ────────────────────────────────────────
+    it('Nourishment: target HP% BELOW healer → cast repair ×1.30', () => {
+        // Enemy drops tank to 70% (< healer 100%) before the healer casts.
+        const withAmp = runCombat(
+            AMP_BASE({
+                shipSkills: healerSkills(healAmp('target-hp-below-self', 30)),
+                enemyAttackers: [enemyHitter(3000)],
+            })
+        );
+        const without = runCombat(
+            AMP_BASE({
+                shipSkills: healerSkills(),
+                enemyAttackers: [enemyHitter(3000)],
+            })
+        );
+        const ampHeal = sumHeal(withAmp, 'directHeal');
+        const baseHeal = sumHeal(without, 'directHeal');
+        expect(baseHeal).toBeCloseTo(BASE_PER_CAST, 6);
+        expect(ampHeal).toBeCloseTo(baseHeal * 1.3, 6);
+    });
+
+    it('Nourishment: target HP% NOT below healer → no boost (equals baseline)', () => {
+        // No enemy → tank stays at 100%; healer at 100% → target-hp-below-self is FALSE.
+        const withAmp = runCombat(
+            AMP_BASE({
+                shipSkills: healerSkills(healAmp('target-hp-below-self', 30)),
+            })
+        );
+        const without = runCombat(AMP_BASE({ shipSkills: healerSkills() }));
+        expect(sumHeal(withAmp, 'directHeal')).toBeCloseTo(sumHeal(without, 'directHeal'), 6);
+        expect(sumHeal(withAmp, 'directHeal')).toBeCloseTo(BASE_PER_CAST, 6);
+    });
+
+    // ── Vivacious (proc'd, target-below-25) ──────────────────────────────────────
+    it('Vivacious: target <25% HP → repair roughly doubles at the gated frequency', () => {
+        const NUM_ROUNDS = 10;
+        const VIV_PROC = 0.5; // floor(10 × 0.5) = 5 fires (back-loaded at rate 0.5)
+        const VIV_AMP = 100; // +100% → ×2 when it fires
+        // Enemy hits hard enough to keep tank below 25% (heal basis 'hp' restores only 1000/round
+        // into a 10000 tank → with 8000 dmg/round the tank stays pinned far below 25%).
+        const withAmp = runCombat(
+            AMP_BASE({
+                numRounds: NUM_ROUNDS,
+                shipSkills: healerSkills(healAmp('target-below-25', VIV_AMP, VIV_PROC)),
+                enemyAttackers: [enemyHitter(8000)],
+            })
+        );
+        const without = runCombat(
+            AMP_BASE({
+                numRounds: NUM_ROUNDS,
+                shipSkills: healerSkills(),
+                enemyAttackers: [enemyHitter(8000)],
+            })
+        );
+        const baseHeal = sumHeal(without, 'directHeal');
+        const ampHeal = sumHeal(withAmp, 'directHeal');
+        // Baseline: 10 casts × 1000 = 10000. With 5 proc'd ×2 fires: 5 normal + 5 doubled =
+        // 5×1000 + 5×2000 = 15000.
+        expect(baseHeal).toBeCloseTo(NUM_ROUNDS * BASE_PER_CAST, 6);
+        const EXPECTED_FIRES = Math.floor(NUM_ROUNDS * VIV_PROC); // 5
+        const expectedAmp =
+            NUM_ROUNDS * BASE_PER_CAST + EXPECTED_FIRES * BASE_PER_CAST * (VIV_AMP / 100);
+        expect(ampHeal).toBeCloseTo(expectedAmp, 6);
+        expect(ampHeal).toBeGreaterThan(baseHeal);
+    });
+
+    it('Vivacious: target ≥25% HP → never doubles (equals baseline)', () => {
+        const NUM_ROUNDS = 5;
+        // No enemy → tank stays at 100% (≥25%) → target-below-25 never met.
+        const withAmp = runCombat(
+            AMP_BASE({
+                numRounds: NUM_ROUNDS,
+                shipSkills: healerSkills(healAmp('target-below-25', 100, 0.5)),
+            })
+        );
+        const without = runCombat(
+            AMP_BASE({ numRounds: NUM_ROUNDS, shipSkills: healerSkills() })
+        );
+        expect(sumHeal(withAmp, 'directHeal')).toBeCloseTo(sumHeal(without, 'directHeal'), 6);
+        expect(sumHeal(withAmp, 'directHeal')).toBeCloseTo(NUM_ROUNDS * BASE_PER_CAST, 6);
     });
 });

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -790,3 +790,183 @@ describe('D-PR4 Task 9 integration — Insidiousness reactive damage fires on de
         }
     );
 });
+
+// ---------------------------------------------------------------------------
+// D-PR5: Second Wind implant — reactive self-heal on crit-received
+// ---------------------------------------------------------------------------
+//
+// Second Wind fires a reactive self-heal when the OWNER receives a critting hit
+// (trigger: 'on-attacked', triggerCritFilter: 'crit'). The heal basis is 'hp'
+// (owner effective max HP). The ability is placed in the 'attacker' (healTarget)
+// passive slot so HP-restore actually applies.
+//
+// Test A: crit attacker fires Second Wind at the gated rate.
+//   - 'attacker' (hp 10000) carries Second Wind (procChance 0.5, pct 10, basis 'hp').
+//   - enemyAttacker with crit 100 attacks the 'attacker' every round for 10 rounds.
+//   - Each round: attacked event with didCrit:true → on-attacked + crit filter → enqueued.
+//   - Rate gate 0.5 over 10 calls fires exactly 5 times (back-loaded: calls 2,4,6,8,10).
+//   - Each fire: 10000 × 10% = 1000 directHeal. total = 5000.
+//   - 'attacker' starts at full HP → effectiveHeal = 0, overheal = 5000.
+//
+// Test B: non-crit attacker — Second Wind never fires (crit filter).
+//   - Same setup but enemyAttacker with crit 0 → no attacked events with didCrit:true.
+//   - directHeal must be 0.
+//
+// NOTE: The Second Wind ability is injected DIRECTLY into the passive slot (not via the
+// registry) to keep the integration test independent of the registry entry. The unit tests
+// (buildEquipmentAbilities.test.ts) cover the registry. The injected ability shape matches
+// the spec exactly (trigger, triggerCritFilter, basis, procChance) and exercises the real
+// engine on-attacked reactive-heal path.
+
+describe('D-PR5 integration — Second Wind reactive self-heal on crit-received', () => {
+    const ATTACKER_HP = 10_000;
+    const NUM_ROUNDS = 10;
+    const SW_PROC = 0.5; // deterministic: floor(10 × 0.5) = 5 fires (calls 2,4,6,8,10)
+    const EXPECTED_FIRES = Math.floor(NUM_ROUNDS * SW_PROC); // 5
+    const PER_FIRE = ATTACKER_HP * (10 / 100); // 1000 (10% of max HP)
+    const EXPECTED_TOTAL = EXPECTED_FIRES * PER_FIRE; // 5000
+
+    /** Second Wind ability injected directly into passive slot (procChance 0.5 for determinism). */
+    const secondWindAbility: Ability = {
+        id: 'equip-implant-SECOND_WIND',
+        type: 'heal',
+        target: 'self',
+        trigger: 'on-attacked',
+        triggerCritFilter: 'crit',
+        conditions: [],
+        procChance: SW_PROC,
+        config: { type: 'heal', pct: 10, basis: 'hp' },
+        autoFilled: true,
+    };
+
+    /** No-op active for the 'attacker' (focus) — it deals no damage, just keeps the round cadence. */
+    const noopActive: Ability = {
+        id: 'noop-active',
+        type: 'damage',
+        target: 'enemy',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'damage', multiplier: 0 },
+    };
+
+    /** ShipSkills with Second Wind in passive slot and a no-op active. */
+    const shipSkillsWithSW: ShipSkills = {
+        slots: [
+            { slot: 'active', abilities: [noopActive] },
+            { slot: 'passive', abilities: [secondWindAbility] },
+        ],
+    };
+
+    /** ShipSkills without Second Wind (control). */
+    const shipSkillsNoSW: ShipSkills = {
+        slots: [{ slot: 'active', abilities: [noopActive] }],
+    };
+
+    /** A positioned enemy attacker that crits the 'attacker' (healTarget) every turn.
+     *  Attack must be > 0 so the engine emits `attacked` events (the emit is gated on damage > 0). */
+    function makeEnemyAttacker(critRate: number) {
+        return {
+            id: 'sw-enemy',
+            stats: {
+                attack: 1, // minimal attack so damage > 0 → attacked event is emitted
+                crit: critRate,
+                critDamage: 0,
+                speed: 1,
+                defence: 0,
+                hp: 1_000_000_000,
+            },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active' as const,
+                        abilities: [
+                            {
+                                id: 'sw-enemy-hit',
+                                type: 'damage' as const,
+                                target: 'enemy' as const,
+                                trigger: 'on-cast' as const,
+                                conditions: [],
+                                config: { type: 'damage' as const, multiplier: 100, hits: 1 },
+                            },
+                        ],
+                    },
+                ],
+            } as ShipSkills,
+        };
+    }
+
+    /** Base engine input for Second Wind integration: healing mode, 'attacker' is the healTarget. */
+    const SW_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+        attack: 0,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: shipSkillsNoSW,
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: NUM_ROUNDS,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: ATTACKER_HP,
+        healTargetId: 'attacker',
+        ...overrides,
+    });
+
+    it(
+        'A. Crit attacker: Second Wind fires 5 times (rate 0.5 × 10 crits); ' +
+            'total directHeal = 5000, effectiveHeal = 0 (full HP → all overheal)',
+        () => {
+            const result = runCombat(
+                SW_BASE({
+                    shipSkills: shipSkillsWithSW,
+                    enemyAttackers: [makeEnemyAttacker(100)],
+                })
+            );
+
+            expect(result.healing).toBeDefined();
+            expect(result.healing!.rounds).toHaveLength(NUM_ROUNDS);
+
+            // directHeal = 5 fires × (ATTACKER_HP × 10%) = 5 × 1000 = 5000.
+            // basis 'hp' resolves to effectiveMaxHp (unchanged regardless of current HP).
+            expect(sumHeal(result, 'directHeal')).toBeCloseTo(EXPECTED_TOTAL, 6);
+
+            // Verify the gated schedule: fires on rounds 2, 4, 6, 8, 10 (back-loaded at rate 0.5).
+            const firedRounds = result
+                .healing!.rounds.map((rd, i) => ({
+                    round: i + 1,
+                    heal: rd.perActor.get('attacker')?.directHeal ?? 0,
+                }))
+                .filter((r) => r.heal > 0);
+            expect(firedRounds).toHaveLength(EXPECTED_FIRES);
+            expect(firedRounds[0].round).toBe(2);
+            expect(firedRounds[EXPECTED_FIRES - 1].round).toBe(NUM_ROUNDS);
+            for (const r of firedRounds) {
+                expect(r.heal).toBeCloseTo(PER_FIRE, 6);
+            }
+        }
+    );
+
+    it('B. Non-crit attacker: Second Wind (crit filter) never fires — directHeal = 0', () => {
+        const result = runCombat(
+            SW_BASE({
+                shipSkills: shipSkillsWithSW,
+                enemyAttackers: [makeEnemyAttacker(0)],
+            })
+        );
+
+        expect(result.healing).toBeDefined();
+        // No crits → no on-attacked+crit triggers → Second Wind never fires.
+        expect(sumHeal(result, 'directHeal')).toBe(0);
+    });
+});

--- a/src/utils/combat/__tests__/healAmplification.test.ts
+++ b/src/utils/combat/__tests__/healAmplification.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { healAmplificationForCast } from '../healAmplification';
+import { Ability } from '../../../types/abilities';
+
+const amp = (
+    id: string,
+    condition: 'target-hp-below-self' | 'target-below-25',
+    ampPct: number,
+    procChance?: number
+): Ability => ({
+    id,
+    type: 'heal-amplification',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'heal-amplification', condition, ampPct, procChance },
+});
+const always = () => true;
+const never = () => false;
+
+describe('healAmplificationForCast', () => {
+    it('returns 0 with no heal-amplification abilities', () => {
+        expect(healAmplificationForCast([], { targetHpPct: 10, selfHpPct: 90 }, always)).toBe(0);
+    });
+    it('target-hp-below-self fires only when target HP% < self HP% (deterministic, no proc roll)', () => {
+        const roll = vi.fn(() => true);
+        const a = [amp('n', 'target-hp-below-self', 30)]; // no procChance
+        expect(healAmplificationForCast(a, { targetHpPct: 40, selfHpPct: 90 }, roll)).toBe(30);
+        expect(healAmplificationForCast(a, { targetHpPct: 95, selfHpPct: 90 }, roll)).toBe(0);
+        expect(roll).not.toHaveBeenCalled();
+    });
+    it('target-below-25 with procChance respects the gate', () => {
+        const a = [amp('v', 'target-below-25', 100, 0.5)];
+        expect(healAmplificationForCast(a, { targetHpPct: 20, selfHpPct: 50 }, always)).toBe(100);
+        expect(healAmplificationForCast(a, { targetHpPct: 20, selfHpPct: 50 }, never)).toBe(0);
+        expect(healAmplificationForCast(a, { targetHpPct: 30, selfHpPct: 50 }, always)).toBe(0);
+    });
+    it('eligibility gates the proc roll (ineligible target does not consume the gate)', () => {
+        const roll = vi.fn(() => true);
+        healAmplificationForCast(
+            [amp('v', 'target-below-25', 100, 0.5)],
+            { targetHpPct: 80, selfHpPct: 50 },
+            roll
+        );
+        expect(roll).not.toHaveBeenCalled();
+    });
+    it('sums additively across abilities', () => {
+        const a = [
+            amp('n', 'target-hp-below-self', 30),
+            amp('v', 'target-below-25', 100, undefined),
+        ];
+        expect(healAmplificationForCast(a, { targetHpPct: 10, selfHpPct: 90 }, always)).toBe(130);
+    });
+});

--- a/src/utils/combat/healAmplification.ts
+++ b/src/utils/combat/healAmplification.ts
@@ -1,0 +1,32 @@
+import { Ability, HealAmpCondition, HealAmpContext } from '../../types/abilities';
+
+function conditionMet(cond: HealAmpCondition, ctx: HealAmpContext): boolean {
+    switch (cond) {
+        case 'target-hp-below-self':
+            return ctx.targetHpPct < ctx.selfHpPct;
+        case 'target-below-25':
+            return ctx.targetHpPct < 25;
+    }
+}
+
+/**
+ * Summed heal-cast amplification % for one cast on one recipient (mirror of
+ * outgoingAmplificationForHit). For each heal-amplification ability whose condition is met:
+ * deterministic (no procChance) → always add ampPct; proc'd → add ampPct iff rollProc fires.
+ * Eligibility gates the proc roll. Returns 0 when nothing applies → byte-identical with no such equipment.
+ */
+export function healAmplificationForCast(
+    casterAbilities: Ability[],
+    ctx: HealAmpContext,
+    rollProc: (abilityId: string, chance: number) => boolean
+): number {
+    let sum = 0;
+    for (const a of casterAbilities) {
+        if (a.config.type !== 'heal-amplification') continue;
+        if (!conditionMet(a.config.condition, ctx)) continue;
+        const pc = a.config.procChance;
+        if (pc !== undefined && !rollProc(a.id, pc)) continue;
+        sum += a.config.ampPct;
+    }
+    return sum;
+}

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -39,6 +39,7 @@ import { buildActorConditionContext, type ReactiveAbility } from './triggers';
 import type { AttackerDamageScalars } from './victimDamage';
 import { effectiveDamageStatsOf, liveDebuffLandingChance } from './effectiveStats';
 import { outgoingAmplificationForHit } from './outgoingEffects';
+import { healAmplificationForCast } from './healAmplification';
 // Buff-fold leaf helpers. Imported for in-file use and re-exported to preserve the
 // historical public API (engine.ts + tests import these from playerTurn). Keeping the
 // definitions in the leaf module breaks the playerTurn ⇄ effectiveStats import cycle.
@@ -1541,6 +1542,32 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
             rid === actor.id
                 ? dmgStats.totals.incomingHealBuff
                 : healing.recipientIncomingHealPct(rid);
+        // D-PR5: caster-side heal-cast amplification (Nourishment/Vivacious), sourced from the
+        // passive slot. Per recipient, fold (1 + ampPct/100) into the cast-heal raw. With no
+        // heal-amplification ability OR no engine-supplied proc gate, the guard short-circuits to
+        // 0 (and never rolls) → byte-identical for every fixture without one.
+        const healAmpAbilities = (passiveSkill?.abilities ?? []).filter(
+            (a) => a.config.type === 'heal-amplification'
+        );
+        // Recipient HP% at cast time: live ctx via recipientActor/recipientMaxHp; fall back to the
+        // engine-threaded targetHpPct for the heal target before it has a ctx, else 100.
+        const recipientHpPctFor = (rid: string): number => {
+            const max = healing.recipientMaxHp(rid);
+            const a = healing.recipientActor(rid);
+            if (a && max > 0) return (100 * Math.max(0, a.currentHp)) / max;
+            if (rid === healing.targetId) return targetHpPctArg;
+            return 100;
+        };
+        // Summed amp % for ONE cast on recipient `rid`. Rolls each ability's proc gate exactly
+        // once (call this ONCE per recipient per cast). selfHpPctArg = the caster's live HP%.
+        const healAmpPctFor = (rid: string): number =>
+            healAmpAbilities.length > 0 && rollOutgoingProc
+                ? healAmplificationForCast(
+                      healAmpAbilities,
+                      { targetHpPct: recipientHpPctFor(rid), selfHpPct: selfHpPctArg },
+                      rollOutgoingProc
+                  )
+                : 0;
         // Recipient routing (user-confirmed): self → caster; ally → the bombarded target;
         // all-allies → every player in fixed source order. Shared by the heal + shield branches.
         const isEnemyCaster = actor.side === 'enemy';
@@ -1715,13 +1742,15 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                     if (didCrit) healCritCount += 1;
                     for (const rid of recipients) {
                         const basis = basisValue(cfg.basis, rid);
-                        const raw =
+                        let raw =
                             basis *
                             (cfg.pct / 100) *
                             (didCrit ? 1 + effectiveCritDamage / 100 : 1) *
                             (1 + healModifier / 100) *
                             (1 + dmgStats.totals.outgoingHealBuff / 100) *
                             (1 + incomingPctFor(rid) / 100);
+                        // D-PR5: caster heal-cast amplification (rolls the proc gate ONCE per recipient).
+                        raw *= 1 + healAmpPctFor(rid) / 100;
                         const recipientActor = healing.recipientActor(rid);
                         if (recipientActor) healing.applyHealToTarget(raw, recipientActor);
                         healTargets.push(rid);
@@ -1734,13 +1763,15 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 if (didCrit) healCritCount += 1;
                 for (const rid of recipients) {
                     const basis = basisValue(cfg.basis, rid);
-                    const raw =
+                    let raw =
                         basis *
                         (cfg.pct / 100) *
                         (didCrit ? 1 + effectiveCritDamage / 100 : 1) *
                         (1 + healModifier / 100) *
                         (1 + dmgStats.totals.outgoingHealBuff / 100) *
                         (1 + incomingPctFor(rid) / 100);
+                    // D-PR5: caster heal-cast amplification (rolls the proc gate ONCE per recipient).
+                    raw *= 1 + healAmpPctFor(rid) / 100;
                     healing.credit(actor.id, 'directHeal', raw);
                     if (rid === healing.targetId) {
                         const { consumed, overheal } = healing.applyHealToTarget(raw);


### PR DESCRIPTION
## Summary

Continues sub-project D's **reactive heal/leech** row. Stacked on D-PR4 (#132); retarget to `main` after the D stack merges.

Three implant effects:
- **Second Wind** — chance (7–16% by rarity) to repair itself for 10% max HP when it *receives a critical hit*.
- **Nourishment** — repairs are stronger (+10–30%) when the target has lower HP% than the healer.
- **Vivacious Repair** — chance (21–32%) to *double* a repair cast on an ally below 25% HP.

### Mechanism
- **Second Wind** rides the existing reactive heal executor — registry entry only (`trigger: 'on-attacked'` + `triggerCritFilter: 'crit'`, `target: 'self'`, basis max HP, `procChance`). No engine code.
- **Nourishment + Vivacious** add a new **heal-cast amplification primitive** — pure `src/utils/combat/healAmplification.ts` (`healAmplificationForCast`) + a `heal-amplification` `AbilityConfig` + `HealAmpCondition`/`HealAmpContext` types, folded multiplicatively into the cast-heal `raw` per recipient in `playerTurn.ts` (both the player and `healEventOnly` branches). Nourishment is deterministic gated on `target-hp-below-self`; Vivacious is proc'd gated on `target-below-25`. Reuses D-PR4's `rollOutgoingProc` per-(owner,ability) gate closure; deterministic abilities never consume a gate.
- **Exuberance** (heal-*received* amplification) deferred to a follow-up — it needs a distinct `on-heal-received` / post-heal seam.

### Invariants
- All DPS / healing / battle-sim **goldens byte-identical** (2918 tests green, zero snapshot drift). The cast-heal fold is guarded by `healAmpAbilities.length > 0 && rollOutgoingProc` → inert at defaults; Second Wind absent → no reactive heal.
- `audit:skills` unchanged (141 ships, 0 findings); lint + tsc clean.

Spec: `docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr5-design.md`
Plan: `docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr5.md`

## Test Plan
- [x] Full suite: 2918 passing, zero golden/snapshot drift vs D-PR4 base
- [x] `npm run audit:skills` — 141 ships, 0 findings
- [x] `npm run lint` (max-warnings 0) + `npx tsc --noEmit` clean
- [x] Unit: `healAmplificationForCast` (eligibility gates the proc roll; deterministic never rolls; additive)
- [x] Integration (healing-mode `runCombat`): Second Wind fires 5/10 on crit hits, 0 on non-crits; Nourishment ×1.30 when target below healer, baseline otherwise; Vivacious doubles a <25% repair at the gated frequency, baseline ≥25%

🤖 Generated with [Claude Code](https://claude.com/claude-code)