### PR TITLE
feat(combat): D-PR6 — Exuberance (heal-received amplification)

### DIFF
--- a/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr6.md
+++ b/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr6.md
@@ -1,0 +1,294 @@
+# D-PR6: Exuberance (heal-received amplification) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Light up the Exuberance implant — a recipient-side amplification of repairs *received* ("when repaired, 17–30% chance to increase that repair by 12–15%") — across all repair-apply sites, keeping all goldens byte-identical.
+
+**Architecture:** A single optional `HealingRuntimeCtx.recipientIncomingHealAmpPct(rid)` method (engine-populated; rolls the recipient's incoming-heal-amp procs once via a combat-lifetime gate keyed `${rid}:${abilityId}`) is called at every repair-apply site (both cast-heal branches, the reactive heal executor, and HoT ticks). No new trigger. Reuses D-PR5's `healAmplification.ts` module + D-PR4's `rollRateGate`/`procChanceGates`.
+
+**Tech Stack:** TypeScript, Vitest. Combat engine under `src/utils/combat/`; equipment registry under `src/utils/abilities/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr6-design.md`
+
+**Branch / worktree:** `feat/combat-d-pr6-exuberance` (worktree `.worktrees/d-pr6-exuberance`), stacked on D-PR5 tip `03cff2a6`. Retarget to `main` after the D stack merges.
+
+---
+
+## CRITICAL WORKFLOW NOTES (read once)
+
+- **Test runner:** NEVER `npm test` (Vitest watch, hangs). Use `npx vitest run <pathOrName>`.
+- **Goldens load-bearing:** NEVER `vitest -u`. All goldens must stay **byte-identical** (no fixture carries Exuberance; the ctx method is unpopulated for them → `?? 0`). If a `.snap` moves, a default leaked.
+- **docs/ gitignored:** `git add -f` for plan/spec; `--no-verify` for docs-only commits.
+- After each code task: `npx vitest run` touched files, `npm run lint` (max-warnings 0), `npx tsc --noEmit`. Run FULL suite on any byte-identical claim; confirm `git diff --stat 03cff2a6 -- '**/*.snap' '**/__snapshots__/**'` EMPTY.
+- KNOWN: `equipmentCoverage.test.ts` will fail for EXUBERANCE ("produces 0 abilities") between Task 4 and Task 7 — EXPECTED; commit `--no-verify` if that's the sole pre-commit block, and say so.
+
+---
+
+## Source values (from `src/constants/implants.ts`, EXUBERANCE)
+
+uncommon/rare/epic/legendary: procChance 0.17/0.20/0.24/0.30; ampPct 12/13/14/15. No common.
+
+---
+
+## Task 1: Fixture audit (byte-identical safety — no code)
+
+- [ ] **Step 1:**
+```bash
+cd .worktrees/d-pr6-exuberance
+grep -rniE "exuberance" src/utils/combat src/utils/calculators src/utils/abilities --include='*.ts' | grep -viE "docs/|\.md" || echo "NONE FOUND"
+```
+Expected: `NONE FOUND`. If a real fixture carries Exuberance, STOP and re-confirm the byte-identical premise.
+- [ ] **Step 2:** Record result. No commit.
+
+---
+
+## Task 2: Types — `incoming-heal-amplification` config
+
+**Files:** Modify `src/types/abilities.ts` (mirror how `heal-amplification` / `outgoing-amplification` were added in D-PR5/D-PR4).
+
+- [ ] **Step 1:** Add `'incoming-heal-amplification'` to the `AbilityType` union.
+- [ ] **Step 2:** Add the `AbilityConfig` member (UNCONDITIONAL — no condition field):
+```ts
+      | {
+            type: 'incoming-heal-amplification';
+            /** Amplification added to a repair RECEIVED when it fires, in percentage points. */
+            ampPct: number;
+            /** Proc chance in (0,1). Rolled once per repair received (combat-lifetime gate keyed by recipient+ability). */
+            procChance: number;
+        }
+```
+- [ ] **Step 3:** `npx tsc --noEmit`. Add minimal mirror entries to the 3 editor-exhaustiveness files (same set D-PR4/D-PR5 touched): `src/components/skills/AbilityCard.tsx` + `src/components/skills/AbilityTypePicker.tsx` label maps (`'incoming-heal-amplification': 'Incoming Heal Amplification'`); `src/components/skills/abilityDefaults.ts` switch case (`case 'incoming-heal-amplification': return { type, ampPct: 0, procChance: 0 };`) + `DEFAULT_TARGETS` (`'incoming-heal-amplification': 'self'`). Match the shape of the existing `heal-amplification` entries.
+- [ ] **Step 4:** `npx tsc --noEmit` + `npm run lint` clean. Commit:
+```bash
+git add src/types/abilities.ts src/components/skills/AbilityCard.tsx src/components/skills/AbilityTypePicker.tsx src/components/skills/abilityDefaults.ts
+git commit -m "feat(combat): D-PR6 — incoming-heal-amplification ability config type"
+```
+
+---
+
+## Task 3: Pure evaluator `incomingHealAmpForRecipient`
+
+**Files:** Modify `src/utils/combat/healAmplification.ts` (add alongside `healAmplificationForCast`); Test `src/utils/combat/__tests__/healAmplification.test.ts` (extend).
+
+- [ ] **Step 1: Write failing tests** (extend the existing describe block; reuse the test's `Ability` literal style):
+```ts
+import { incomingHealAmpForRecipient } from '../healAmplification';
+const inc = (id: string, ampPct: number, procChance: number): Ability => ({
+    id, type: 'incoming-heal-amplification', target: 'self', trigger: 'on-cast', conditions: [],
+    config: { type: 'incoming-heal-amplification', ampPct, procChance },
+});
+describe('incomingHealAmpForRecipient', () => {
+    it('returns 0 with no incoming-heal-amplification abilities', () => {
+        expect(incomingHealAmpForRecipient([], () => true)).toBe(0);
+    });
+    it('adds ampPct when the proc fires', () => {
+        expect(incomingHealAmpForRecipient([inc('e', 13, 0.5)], () => true)).toBe(13);
+    });
+    it('returns 0 when the proc does not fire', () => {
+        expect(incomingHealAmpForRecipient([inc('e', 13, 0.5)], () => false)).toBe(0);
+    });
+    it('rolls with (abilityId, procChance) and sums additively across abilities', () => {
+        const roll = vi.fn(() => true);
+        expect(incomingHealAmpForRecipient([inc('a', 12, 0.17), inc('b', 15, 0.3)], roll)).toBe(27);
+        expect(roll).toHaveBeenCalledWith('a', 0.17);
+        expect(roll).toHaveBeenCalledWith('b', 0.3);
+    });
+    it('ignores non-incoming-heal-amplification configs', () => {
+        const other = { id: 'x', type: 'heal', target: 'self', trigger: 'on-cast', conditions: [], config: { type: 'heal', pct: 10, basis: 'hp' } } as Ability;
+        expect(incomingHealAmpForRecipient([other], () => true)).toBe(0);
+    });
+});
+```
+- [ ] **Step 2:** Run, verify FAIL: `npx vitest run src/utils/combat/__tests__/healAmplification.test.ts`
+- [ ] **Step 3: Implement** (append to `healAmplification.ts`):
+```ts
+/**
+ * Summed incoming-heal amplification % for ONE repair landing on a recipient (Exuberance).
+ * Unconditional ("when repaired"): for each incoming-heal-amplification ability the recipient carries,
+ * add ampPct iff its proc fires. `rollProc` MUST be keyed by the recipient so all repairs the unit
+ * receives share one combat-lifetime gate (single probability stream, per the design). Returns 0 when
+ * nothing applies → byte-identical with no such equipment.
+ */
+export function incomingHealAmpForRecipient(
+    recipientAbilities: Ability[],
+    rollProc: (abilityId: string, chance: number) => boolean
+): number {
+    let sum = 0;
+    for (const a of recipientAbilities) {
+        if (a.config.type !== 'incoming-heal-amplification') continue;
+        if (!rollProc(a.id, a.config.procChance)) continue;
+        sum += a.config.ampPct;
+    }
+    return sum;
+}
+```
+- [ ] **Step 4:** Run, verify PASS. `npx tsc --noEmit` + `npm run lint`.
+- [ ] **Step 5:** Commit:
+```bash
+git add src/utils/combat/healAmplification.ts src/utils/combat/__tests__/healAmplification.test.ts
+git commit -m "feat(combat): D-PR6 — pure incomingHealAmpForRecipient evaluator (Exuberance)"
+```
+
+---
+
+## Task 4: Registry — Exuberance entry
+
+**Files:** Modify `src/utils/abilities/buildEquipmentAbilities.ts`; Test `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`.
+
+- [ ] **Step 1: Unit tests** (reuse the single-implant-ability resolution helper): Exuberance 'epic' → `incoming-heal-amplification` config, ampPct 14, procChance ≈ 0.24; 'legendary' ampPct 15, procChance ≈ 0.30; 'common' → undefined (no common variant).
+- [ ] **Step 2:** Run, verify FAIL.
+- [ ] **Step 3: Implement:**
+```ts
+const EXUBERANCE_PROC: Record<string, number> = { uncommon: 0.17, rare: 0.2, epic: 0.24, legendary: 0.3 };
+const EXUBERANCE_AMP: Record<string, number> = { uncommon: 12, rare: 13, epic: 14, legendary: 15 };
+
+// in IMPLANT_ABILITIES:
+EXUBERANCE: (rarity) => {
+    const amp = EXUBERANCE_AMP[rarity];
+    const pc = EXUBERANCE_PROC[rarity];
+    if (amp === undefined) return undefined;
+    return {
+        type: 'incoming-heal-amplification',
+        target: 'self',
+        trigger: 'on-cast', // inert: not event-driven; consumed by the recipient-side fold
+        conditions: [],
+        procChance: pc,
+        config: { type: 'incoming-heal-amplification', ampPct: amp, procChance: pc },
+        autoFilled: true,
+    };
+},
+```
+- [ ] **Step 4:** Run unit (PASS) + FULL suite. Byte-identical (config inert until Task 6 wires the apply sites): snapshot diff EMPTY. `npm run lint && npx tsc --noEmit`. KNOWN: `equipmentCoverage.test.ts` now fails for EXUBERANCE — expected. Commit `--no-verify` if sole block.
+- [ ] **Step 5:** Commit:
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+git commit -m "feat(combat): D-PR6 — Exuberance incoming-heal-amplification registry entry"
+```
+
+---
+
+## Task 5: Engine plumbing — `recipientIncomingHealAmpPct` ctx method + per-recipient ability map
+
+**Files:** Modify `src/utils/combat/playerTurn.ts` (`HealingRuntimeCtx` interface ~line 83); `src/utils/combat/engine.ts` (build the map ~line 2112 alongside `incomingAbilitiesById`; populate the ctx method where the healing ctx is constructed ~line 1925-1965).
+
+This task adds the wiring with NO caller yet → byte-identical. (The apply-site calls land in Task 6.)
+
+- [ ] **Step 1:** Add the optional method to the `HealingRuntimeCtx` interface (playerTurn.ts:83, next to `recipientIncomingHealPct`):
+```ts
+/** D-PR6: summed incoming-heal amplification % for a repair landing on `rid` (Exuberance). Rolls the
+ *  recipient's incoming-heal-amp procs ONCE (combat-lifetime gate keyed rid+ability). Absent → callers
+ *  use 0 → byte-identical. */
+recipientIncomingHealAmpPct?: (rid: string) => number;
+```
+- [ ] **Step 2:** In `engine.ts`, build the per-recipient ability map ALONGSIDE the existing `incomingAbilitiesById` (~line 2112), mirroring it exactly but filtering `config.type === 'incoming-heal-amplification'`:
+```ts
+const incomingHealAmpAbilitiesById = new Map<string, Ability[]>();
+for (const rt of [...runtimesById.values(), ...enemyPlayerRuntimeByActorId.values()]) {
+    if (incomingHealAmpAbilitiesById.has(rt.actor.id)) continue;
+    const heals: Ability[] = [];
+    for (const slot of rt.castSkills.slots) {
+        if (slot.slot !== 'passive') continue;
+        for (const a of slot.abilities) {
+            if (a.config.type === 'incoming-heal-amplification') heals.push(a);
+        }
+    }
+    if (heals.length) incomingHealAmpAbilitiesById.set(rt.actor.id, heals);
+}
+const incomingHealAmpAbilitiesOf = (id: string): Ability[] => incomingHealAmpAbilitiesById.get(id) ?? [];
+```
+(Match the EXACT iteration/dedupe shape of the real `incomingAbilitiesById` block — read it first; the runtime collection it iterates may differ slightly.)
+- [ ] **Step 3:** Populate the ctx method where the engine builds the `HealingRuntimeCtx` (~1925-1965, where `recipientIncomingHealPct` is set). Import `incomingHealAmpForRecipient` from `./healAmplification` and confirm `rollRateGate` (from `../calculators/rateAccumulator`) + `procChanceGates` are in scope (both exist):
+```ts
+recipientIncomingHealAmpPct: (rid) =>
+    incomingHealAmpForRecipient(
+        incomingHealAmpAbilitiesOf(rid),
+        (abilityId, chance) => rollRateGate(procChanceGates, `${rid}:${abilityId}`, chance)
+    ),
+```
+NOTE: the ctx is constructed (~1925) BEFORE the map is declared (~2112). This is fine — the closure is only invoked during the round loop (after the map initializes); a `const` referenced later in the same function body resolves at call time. Declare `incomingHealAmpAbilitiesOf` with `const` (do NOT inline the map at the ctx). If tsc complains about use-before-declaration (it should not for a closure), report it.
+- [ ] **Step 4:** FULL suite — byte-identical (nothing CALLS the method yet): snapshot diff EMPTY, all green except the known EXUBERANCE coverage failure. `npm run lint && npx tsc --noEmit`.
+- [ ] **Step 5:** Commit (`--no-verify` if the coverage failure is the sole block):
+```bash
+git add src/utils/combat/playerTurn.ts src/utils/combat/engine.ts
+git commit -m "feat(combat): D-PR6 — recipientIncomingHealAmpPct ctx method + per-recipient ability map"
+```
+
+---
+
+## Task 6: Apply-site folds + integration tests
+
+**Files:** Modify `src/utils/combat/playerTurn.ts` (cast-heal player branch ~1773 area, `healEventOnly` branch ~1750 area, HoT tick `raw` ~1672); `src/utils/combat/triggers.ts` (reactive heal `raw` ~1214-1219). Test an integration test file.
+
+At each site, immediately AFTER the existing per-recipient incoming factor (`incomingPctFor(rid)` / `holderIncomingFactor`) and BEFORE `applyHealToTarget`/`credit`, multiply the repair once. Call the ctx method EXACTLY ONCE per application (it rolls the gate once → one proc event per repair received).
+
+- [ ] **Step 1: Write failing integration tests (healing-mode `runCombat`):**
+  - A unit carrying Exuberance (e.g. legendary, procChance 0.30 — or pick a rarity/round-count that makes the deterministic gate fire a known number of times) is repaired repeatedly (cast heals) over N rounds → the boosted repairs land at the gated frequency (~proc×N of them are ×(1+ampPct/100)); total received exceeds the no-Exuberance baseline by the expected amount.
+  - A unit WITHOUT Exuberance → unchanged (baseline).
+  - **Single-stream check (the fidelity property):** if the harness can deliver repairs from two sources to the same unit (e.g. a cast heal + a reactive self-heal, or cast + HoT), assert the proc frequency is computed over the COMBINED repair stream (one gate), not per-source. If a two-source setup is impractical, at minimum cover the cast path thoroughly and add a focused assertion that a reactive self-heal on an Exuberance carrier is ALSO boosted (proving the reactive site folds too).
+  Reference the D-PR5 healing-mode integration tests (`equipmentAbilities.integration.test.ts`) for harness shape; inject Exuberance into the recipient's passive slot.
+- [ ] **Step 2:** Run, verify FAIL (ctx method exists but no apply site calls it yet).
+- [ ] **Step 3: Implement the four folds.** At each site:
+  - **Cast player branch** (playerTurn.ts; `raw` is already `let` from D-PR5, with `... * (1 + incomingPctFor(rid)/100)` then `raw *= 1 + healAmpPctFor(rid)/100`): append
+    ```ts
+    raw *= 1 + (healing.recipientIncomingHealAmpPct?.(rid) ?? 0) / 100;
+    ```
+  - **Cast `healEventOnly` branch** (playerTurn.ts; same shape, already `let raw`): append the same line (recipient `rid`).
+  - **HoT tick** (playerTurn.ts ~1672, `const raw = maxHp * (hotPct/100) * stacks * holderIncomingFactor`): change to `let raw`, then append `raw *= 1 + (healing.recipientIncomingHealAmpPct?.(actor.id) ?? 0) / 100;` (recipient = holder = `actor.id`). Place after the `if (raw <= 0) return;` guard? NO — compute the amp on the post-incoming `raw` BEFORE the `raw <= 0` guard is irrelevant (raw>0 here); put the `raw *=` right after the `const→let raw =` line and before `healing.credit`. Verify there is only ONE HoT `raw` computation; if an enemy/event-only HoT path computes a separate `raw` that lands a repair on a recipient, fold there too (and report if the HoT path is thornier than a single raw).
+  - **Reactive heal** (triggers.ts ~1214-1219; `const raw = cfg.type==='heal' ? basisValue * ... * (1 + incomingPctFor(rid)/100) : basisValue * (cfg.pct/100)`): change to `let raw`, then AFTER it, for the heal case only, append:
+    ```ts
+    if (cfg.type === 'heal') raw *= 1 + (ctx.healing.recipientIncomingHealAmpPct?.(rid) ?? 0) / 100;
+    ```
+    (Do NOT amplify the shield branch.) Place before the `ctx.healing.credit(...)` calls.
+- [ ] **Step 4:** Run integration tests (PASS) + FULL suite. Byte-identical: snapshot diff EMPTY (no fixture has Exuberance → method returns 0). `npm run lint && npx tsc --noEmit`. KNOWN: only the EXUBERANCE coverage failure remains. Commit `--no-verify` if sole block.
+- [ ] **Step 5:** Commit:
+```bash
+git add src/utils/combat/playerTurn.ts src/utils/combat/triggers.ts src/utils/combat/__tests__/<file>
+git commit -m "feat(combat): D-PR6 — fold Exuberance at all repair-apply sites (cast/reactive/HoT)"
+```
+
+---
+
+## Task 7: Coverage tracker update
+
+**Files:** Modify `src/utils/abilities/__tests__/equipmentCoverage.test.ts`.
+
+- [ ] **Step 1:** Add `EXUBERANCE` to BOTH the `.toEqual([...])` ordered array (determine position empirically — run the test, match received order; follows `Object.keys(IMPLANTS)`) and the `implementedImplants` Set.
+- [ ] **Step 2:** Add a per-implant assertion block: Exuberance produces 1 ability for uncommon/rare/epic/legendary; common → 0. Confirm Voidfire Catalyst REMAINS in the unimplemented loop (still deferred — 0 abilities).
+- [ ] **Step 3:** `npx vitest run src/utils/abilities/__tests__/equipmentCoverage.test.ts` → PASS. FULL suite → ALL GREEN. Snapshot diff EMPTY. `npm run lint && npx tsc --noEmit`.
+- [ ] **Step 4:** Commit (NO `--no-verify` — branch fully green now):
+```bash
+git add src/utils/abilities/__tests__/equipmentCoverage.test.ts
+git commit -m "test(combat): D-PR6 — coverage tracker includes Exuberance"
+```
+
+---
+
+## Task 8: Changelog + docs
+
+**Files:** `src/constants/changelog.ts`; `src/pages/DocumentationPage.tsx`.
+
+- [ ] **Step 1:** Add an `UNRELEASED_CHANGES` entry (match sibling phrasing, no emojis): e.g. "Combat simulator now models the Exuberance implant (chance to increase a repair the unit receives)."
+- [ ] **Step 2:** Extend the DocumentationPage implant-effects paragraph with Exuberance (bold name + parenthetical), accurately: chance to boost a repair the unit *receives*.
+- [ ] **Step 3:** `npm run lint && npx tsc --noEmit` clean; snapshot diff EMPTY. Commit:
+```bash
+git add src/constants/changelog.ts src/pages/DocumentationPage.tsx
+git commit -m "docs(combat): D-PR6 — changelog + docs for Exuberance"
+```
+
+---
+
+## Task 9: Final verification + PR
+
+- [ ] **Step 1:** FULL suite `npx vitest run` → ALL green; `git diff --stat 03cff2a6 -- '**/*.snap' '**/__snapshots__/**'` EMPTY.
+- [ ] **Step 2:** `npm run audit:skills` → 141 ships, 0 findings.
+- [ ] **Step 3:** `npm run lint` + `npx tsc --noEmit` clean.
+- [ ] **Step 4:** Push + PR stacked on D-PR5 (base `feat/combat-d-pr5-reactive-heal`; retarget to main after the stack merges). `gh auth switch --user TheSusort` first; pipe push through `| cat`.
+
+---
+
+## Notes for the implementer
+
+- **Byte-identical is the contract.** Every FULL-suite step must show zero golden movement. The ctx method returns 0 when the recipient has no Exuberance → `raw` unchanged.
+- **Single gate per recipient:** the method keys the gate `${rid}:${abilityId}` so every repair the unit receives (cast/reactive/HoT) draws from ONE accumulator → the proc fires at the rarity % over the unit's whole repair stream. Call the method exactly ONCE per applied repair.
+- **Scope:** repairs only — do NOT amplify shields (skip the shield branch) or leeches (engine.ts leech sites credit the source, not the recipient; out of scope). Exuberance is the last "reactive heal/leech" effect; only Voidfire Catalyst stays deferred.
+- **HoT nuance:** verify whether the HoT tick has one `raw` or an additional enemy/event-only path; fold wherever a repair lands on a recipient. If the HoT accounting is thornier than a single `raw`, report it rather than guessing.

--- a/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr6.md
+++ b/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr6.md
@@ -135,7 +135,7 @@ git commit -m "feat(combat): D-PR6 — pure incomingHealAmpForRecipient evaluato
 
 **Files:** Modify `src/utils/abilities/buildEquipmentAbilities.ts`; Test `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`.
 
-- [ ] **Step 1: Unit tests** (reuse the single-implant-ability resolution helper): Exuberance 'epic' → `incoming-heal-amplification` config, ampPct 14, procChance ≈ 0.24; 'legendary' ampPct 15, procChance ≈ 0.30; 'common' → undefined (no common variant).
+- [ ] **Step 1: Unit tests** (reuse the single-implant-ability resolution helper): Exuberance 'epic' → `config.type === 'incoming-heal-amplification'`, `config.ampPct === 14`, `config.procChance ≈ 0.24`; 'legendary' `config.ampPct === 15`, `config.procChance ≈ 0.30`; 'common' → undefined (no common variant). (Assert on `config.procChance`, NOT the top-level `Ability.procChance` — Exuberance doesn't set the latter.)
 - [ ] **Step 2:** Run, verify FAIL.
 - [ ] **Step 3: Implement:**
 ```ts
@@ -152,12 +152,12 @@ EXUBERANCE: (rarity) => {
         target: 'self',
         trigger: 'on-cast', // inert: not event-driven; consumed by the recipient-side fold
         conditions: [],
-        procChance: pc,
         config: { type: 'incoming-heal-amplification', ampPct: amp, procChance: pc },
         autoFilled: true,
     };
 },
 ```
+NOTE: do NOT set the top-level `Ability.procChance` here — Exuberance is not reactive (no trigger gate reads it); the proc lives in `config.procChance`, consumed by the recipient-side fold evaluator. Matches the sibling `mkHealAmp`/`mkReduction` helpers, which set procChance only in `config`.
 - [ ] **Step 4:** Run unit (PASS) + FULL suite. Byte-identical (config inert until Task 6 wires the apply sites): snapshot diff EMPTY. `npm run lint && npx tsc --noEmit`. KNOWN: `equipmentCoverage.test.ts` now fails for EXUBERANCE — expected. Commit `--no-verify` if sole block.
 - [ ] **Step 5:** Commit:
 ```bash
@@ -236,9 +236,9 @@ At each site, immediately AFTER the existing per-recipient incoming factor (`inc
   - **HoT tick** (playerTurn.ts ~1672, `const raw = maxHp * (hotPct/100) * stacks * holderIncomingFactor`): change to `let raw`, then append `raw *= 1 + (healing.recipientIncomingHealAmpPct?.(actor.id) ?? 0) / 100;` (recipient = holder = `actor.id`). Place after the `if (raw <= 0) return;` guard? NO — compute the amp on the post-incoming `raw` BEFORE the `raw <= 0` guard is irrelevant (raw>0 here); put the `raw *=` right after the `const→let raw =` line and before `healing.credit`. Verify there is only ONE HoT `raw` computation; if an enemy/event-only HoT path computes a separate `raw` that lands a repair on a recipient, fold there too (and report if the HoT path is thornier than a single raw).
   - **Reactive heal** (triggers.ts ~1214-1219; `const raw = cfg.type==='heal' ? basisValue * ... * (1 + incomingPctFor(rid)/100) : basisValue * (cfg.pct/100)`): change to `let raw`, then AFTER it, for the heal case only, append:
     ```ts
-    if (cfg.type === 'heal') raw *= 1 + (ctx.healing.recipientIncomingHealAmpPct?.(rid) ?? 0) / 100;
+    if (cfg.type === 'heal') raw *= 1 + (healing.recipientIncomingHealAmpPct?.(rid) ?? 0) / 100;
     ```
-    (Do NOT amplify the shield branch.) Place before the `ctx.healing.credit(...)` calls.
+    (`healing` is the local `const healing = ctx.healing` binding at triggers.ts ~1147, matching the surrounding `incomingPctFor`/`healing.*` style; `ctx.healing.` also compiles.) Do NOT amplify the shield branch. Place before the `ctx.healing.credit(...)` calls.
 - [ ] **Step 4:** Run integration tests (PASS) + FULL suite. Byte-identical: snapshot diff EMPTY (no fixture has Exuberance → method returns 0). `npm run lint && npx tsc --noEmit`. KNOWN: only the EXUBERANCE coverage failure remains. Commit `--no-verify` if sole block.
 - [ ] **Step 5:** Commit:
 ```bash
@@ -253,7 +253,7 @@ git commit -m "feat(combat): D-PR6 — fold Exuberance at all repair-apply sites
 **Files:** Modify `src/utils/abilities/__tests__/equipmentCoverage.test.ts`.
 
 - [ ] **Step 1:** Add `EXUBERANCE` to BOTH the `.toEqual([...])` ordered array (determine position empirically — run the test, match received order; follows `Object.keys(IMPLANTS)`) and the `implementedImplants` Set.
-- [ ] **Step 2:** Add a per-implant assertion block: Exuberance produces 1 ability for uncommon/rare/epic/legendary; common → 0. Confirm Voidfire Catalyst REMAINS in the unimplemented loop (still deferred — 0 abilities).
+- [ ] **Step 2:** Add a per-implant assertion block: Exuberance produces 1 ability for uncommon/rare/epic/legendary; common → 0. Confirm Voidfire Catalyst (and the many other not-yet-modeled implants) REMAIN in the `unimplementedImplants` loop — that loop auto-asserts 0 abilities for everything not in the implemented Set, so only the EXUBERANCE additions are needed. (Within the D-design "reactive heal/leech" row, Exuberance was the last unshipped effect; Voidfire Catalyst belongs to a different row and stays deferred.)
 - [ ] **Step 3:** `npx vitest run src/utils/abilities/__tests__/equipmentCoverage.test.ts` → PASS. FULL suite → ALL GREEN. Snapshot diff EMPTY. `npm run lint && npx tsc --noEmit`.
 - [ ] **Step 4:** Commit (NO `--no-verify` — branch fully green now):
 ```bash

--- a/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr6-design.md
+++ b/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr6-design.md
@@ -1,0 +1,198 @@
+# Combat Realism Epic — Sub-project D, PR6: Exuberance (Design)
+
+**Date:** 2026-06-21
+**Sub-project:** D (implant + gear-set abilities), PR6.
+**Parent spec:** `docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-design.md` (§5.2 "reactive heal/leech" row — the last effect in that row).
+**Stacks on:** D-PR5 (`feat/combat-d-pr5-reactive-heal`, tip `03cff2a6`, PR #133). Branch
+`feat/combat-d-pr6-exuberance`; retarget to `main` once the D stack merges.
+**Status:** design (brainstorm complete, user-approved through architecture + scope).
+
+## 1. Context
+
+D-PR5 shipped the caster-side heal-cast amplification primitive (Nourishment, Vivacious Repair) and
+Second Wind, and deferred **Exuberance** — the recipient-side amplification — as a distinct seam. This
+PR completes the "reactive heal/leech" row with it.
+
+- **Exuberance** — "When repaired, there is a 17–30% chance to increase that repair by 12–15%."
+  Carried by the unit being healed; **unconditional** (no HP gate); proc-gated per repair received.
+
+Reconnaissance findings that shape this design:
+- **No new trigger is needed.** Every place a repair lands on a recipient already applies a
+  per-recipient incoming-heal factor and shares the same `HealingRuntimeCtx`. Exuberance is the
+  recipient-side analogue of D-PR5's caster-side `healAmplificationForCast`, folded at the heal-apply
+  sites — not a reactive event.
+- The heal-apply sites that should honor "when repaired" (each already multiplies a per-recipient
+  incoming factor immediately before `applyHealToTarget`):
+  - cast-heal fold, **player branch** (`playerTurn.ts`, after `incomingPctFor(rid)`)
+  - cast-heal fold, **`healEventOnly` branch** (`playerTurn.ts`, after `incomingPctFor(rid)`)
+  - **reactive heal executor** (`triggers.ts`, after `incomingPctFor(rid)`)
+  - **HoT tick** (`playerTurn.ts`, the `holderIncomingFactor` line; recipient = the holder)
+- **Excluded:** shields (not repairs — they skip all heal channels) and leech sites (`engine.ts`
+  `procStandingLeeches` / taken-leech — credited to the leech *source*, and do not apply
+  `incomingPctFor`; Exuberance-on-the-victim does not apply there).
+- The engine already builds per-actor ability lookups (`incomingAbilitiesById` D-PR3,
+  `outgoingAbilitiesById` D-PR4) and already exposes a recipient-side per-rid accessor
+  `recipientIncomingHealPct(rid)` on `HealingRuntimeCtx` (sourced from the recipient's last-turn ctx).
+  Exuberance follows both precedents.
+
+## 2. Goals / non-goals
+
+**Goals**
+
+- Light up **Exuberance** in the combat engine across all repair-received sites (cast, reactive, HoT).
+- Add a reusable **recipient-side incoming-heal amplification** path: a `HealingRuntimeCtx` method that
+  rolls the recipient's incoming-heal-amp procs and returns the summed % — the recipient-side analogue
+  of D-PR5's caster-side amplification.
+- Keep all DPS / healing / battle-sim **goldens byte-identical** (no fixture carries Exuberance; the
+  ctx method is unpopulated → returns 0).
+
+**Non-goals**
+
+- No new trigger / event / status machinery (the fold-at-apply-sites approach is sufficient).
+- No leech-site or shield amplification (out of "when repaired" scope).
+- No UI / autogear / scoring changes.
+
+## 3. Architecture
+
+### 3.1 Fidelity model (user-ratified)
+
+Exuberance is **one effect on the receiving unit**, and **every repair the unit receives is one
+"when repaired" event** feeding **one probability stream**. The engine approximates "X% chance" with a
+deterministic `makeRateGate` accumulator (the locked convention for all procs). Therefore the proc must
+ride **a single combat-lifetime gate keyed `${recipientId}:${abilityId}`**, rolled **once per repair
+the unit receives**, across **all** repair sources (cast/reactive/HoT). A single
+`HealingRuntimeCtx` method guarantees this single-stream property by construction (one place computes
+the boost; every apply site calls it).
+
+### 3.2 New ability config (unconditional)
+
+```ts
+// types/abilities.ts
+{ type: 'incoming-heal-amplification'; ampPct: number; procChance: number }
+```
+No condition field — Exuberance is unconditional ("when repaired"). (Add `'incoming-heal-amplification'`
+to `AbilityType` + the 3 editor-exhaustiveness UI stubs, same as D-PR4/D-PR5.)
+
+### 3.3 Pure evaluator
+
+Add to `src/utils/combat/healAmplification.ts` (sibling to `healAmplificationForCast`):
+
+```ts
+export function incomingHealAmpForRecipient(
+  recipientAbilities: Ability[],
+  rollProc: (abilityId: string, chance: number) => boolean,
+): number {
+  let sum = 0;
+  for (const a of recipientAbilities) {
+    if (a.config.type !== 'incoming-heal-amplification') continue;
+    if (!rollProc(a.id, a.config.procChance)) continue;
+    sum += a.config.ampPct;
+  }
+  return sum;
+}
+```
+Unconditional → no context arg; pure and unit-testable.
+
+### 3.4 The single `HealingRuntimeCtx` method
+
+Add an OPTIONAL method to `HealingRuntimeCtx`:
+
+```ts
+/** D-PR6: summed incoming-heal amplification % for a repair landing on `rid` (Exuberance).
+ *  Rolls the recipient's incoming-heal-amp procs ONCE (combat-lifetime gate keyed by rid+ability).
+ *  Absent → callers use 0 → byte-identical. */
+recipientIncomingHealAmpPct?: (rid: string) => number;
+```
+
+The engine populates it (where it constructs the healing ctx):
+```ts
+recipientIncomingHealAmpPct: (rid) =>
+  incomingHealAmpForRecipient(
+    incomingHealAmpAbilitiesOf(rid),
+    (abilityId, chance) => rollRateGate(procChanceGates, `${rid}:${abilityId}`, chance)
+  ),
+```
+with a new `incomingHealAmpAbilitiesById` map (built exactly like `incomingAbilitiesById`, filtering
+passive-slot abilities for `config.type === 'incoming-heal-amplification'`) + accessor
+`incomingHealAmpAbilitiesOf(id)`. `rollRateGate` + `procChanceGates` already exist (D-PR4).
+
+**Optional → byte-identical:** standalone/test callers that build a `HealingRuntimeCtx` without this
+method are unaffected; call sites use `?? 0`.
+
+### 3.5 Apply-site folds (all share the one ctx)
+
+At each of the four repair-apply sites, immediately after the existing per-recipient incoming factor and
+before `applyHealToTarget`/`credit`, multiply once:
+```ts
+raw *= 1 + (healing.recipientIncomingHealAmpPct?.(rid) ?? 0) / 100;
+```
+- cast player branch + cast `healEventOnly` branch (`playerTurn.ts`) — `rid` is the loop variable.
+- reactive heal executor (`triggers.ts`) — `ctx.healing.recipientIncomingHealAmpPct?.(rid)`, `rid` the
+  loop variable.
+- HoT tick (`playerTurn.ts`) — recipient is the holder (`actor.id`); call once per tick.
+**Call exactly once per application** (it rolls the gate once → one proc event per repair received).
+A single cast/reactive/HoT application of a repair to `rid` = one event. (`raw` becomes `let`.)
+
+### 3.6 Registry
+
+`buildEquipmentAbilities.ts`:
+```ts
+const EXUBERANCE_PROC: Record<string, number> = { uncommon: 0.17, rare: 0.20, epic: 0.24, legendary: 0.30 };
+const EXUBERANCE_AMP:  Record<string, number> = { uncommon: 12,   rare: 13,   epic: 14,   legendary: 15 };
+
+EXUBERANCE: (rarity) => {
+  const amp = EXUBERANCE_AMP[rarity]; const pc = EXUBERANCE_PROC[rarity];
+  if (amp === undefined) return undefined;
+  return {
+    type: 'incoming-heal-amplification',
+    target: 'self',
+    trigger: 'on-cast',           // inert: not event-driven; consumed by the recipient-side fold
+    conditions: [],
+    procChance: pc,
+    config: { type: 'incoming-heal-amplification', ampPct: amp, procChance: pc },
+    autoFilled: true,
+  };
+},
+```
+(No common variant.)
+
+## 4. Credit semantics
+
+Amplifying `raw` before `applyHealToTarget`/`credit` inflates the **caster's** credited
+effectiveHeal/overheal — identical to how the existing `incomingPctFor(rid)` recipient modifier already
+behaves. Exuberance inherits that accounting; no special crediting. (Flagged, not changed — consistent
+with the engine's existing recipient-side incoming-heal treatment.)
+
+## 5. Coverage / corpus
+
+`equipmentCoverage.test.ts`: implemented-implants set gains `EXUBERANCE`. With it, the entire D-design
+"reactive heal/leech" row is implemented; only Voidfire Catalyst (a different row) remains flagged
+deferred.
+
+## 6. Testing & invariants
+
+- **Unit — `incomingHealAmpForRecipient`:** sums ampPct for abilities whose proc fires; 0 when none /
+  when gate never fires; additive across multiple abilities; non-`incoming-heal-amplification` configs
+  ignored.
+- **Unit — `buildEquipmentAbilities`:** Exuberance → `incoming-heal-amplification`, per-rarity
+  ampPct/procChance, no common variant.
+- **Integration (healing-mode `runCombat`):** a unit carrying Exuberance, repaired repeatedly, receives
+  boosted repairs at the gated frequency (e.g. a 0.5-ish proc over N repairs boosts ~N/2 of them by
+  ampPct); a unit WITHOUT Exuberance is unchanged. Cover at least the cast-heal path; add reactive
+  and/or HoT coverage if the harness supports it cheaply (the single ctx method means all paths share
+  one code path, so cast coverage exercises the core; reactive/HoT differ only in the call site).
+- **Single-stream check:** repairs from different sources to the same unit draw from ONE gate (assert
+  the combined frequency, not per-path) — the fidelity property §3.1.
+- **Load-bearing invariant:** all DPS / healing / battle-sim goldens **byte-identical** (the ctx method
+  is unpopulated for fixtures without Exuberance → `?? 0`). Plan step 1 = fixture audit. Never
+  `vitest -u`.
+- `audit:skills` unchanged.
+
+## 7. Open questions for the plan
+
+1. Exact `HealingRuntimeCtx` interface location + every construction site (the engine populates it; do
+   any OTHER `HealingRuntimeCtx` builders exist that must stay `?? 0`?).
+2. The exact reactive-heal executor recipient loop + whether `ctx.healing` is the same `HealingRuntimeCtx`
+   instance there (it is, per recon) so the one method covers it.
+3. HoT-tick recipient identity (holder = `actor.id`) and that calling the method there rolls the gate
+   once per tick.

--- a/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr6-design.md
+++ b/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr6-design.md
@@ -16,6 +16,14 @@ PR completes the "reactive heal/leech" row with it.
 - **Exuberance** — "When repaired, there is a 17–30% chance to increase that repair by 12–15%."
   Carried by the unit being healed; **unconditional** (no HP gate); proc-gated per repair received.
 
+**Incoming vs outgoing (key distinction).** Exuberance is an **incoming** (recipient-side) amplifier —
+it boosts repairs the carrier *receives*. This is a different channel from every heal-amp shipped so far,
+all of which are **outgoing** (caster-side): the Repair gear set (`healModifier: 20%`, a stat that boosts
+heals the wearer *casts* — already handled by stat folding) and D-PR5's Nourishment/Vivacious
+(caster-side `heal-amplification`). Concretely, Exuberance folds at the recipient's `incomingPctFor(rid)`
+channel, NOT the caster's `healModifier`/`outgoingHeal` channels (which sit elsewhere in the same `raw`
+product). So it is "the same kind of % bump as an incoming-repair buff, gated behind a random proc."
+
 Reconnaissance findings that shape this design:
 - **No new trigger is needed.** Every place a repair lands on a recipient already applies a
   per-recipient incoming-heal factor and shares the same `HealingRuntimeCtx`. Exuberance is the

--- a/src/components/skills/AbilityCard.tsx
+++ b/src/components/skills/AbilityCard.tsx
@@ -58,6 +58,7 @@ const ABILITY_TYPE_LABELS: Record<Ability['type'], string> = {
     'incoming-block': 'Incoming Block',
     'outgoing-amplification': 'Outgoing Amplification',
     'heal-amplification': 'Heal Amplification',
+    'incoming-heal-amplification': 'Incoming Heal Amplification',
 };
 
 const TARGET_OPTIONS: { value: AbilityTarget; label: string }[] = [

--- a/src/components/skills/AbilityTypePicker.tsx
+++ b/src/components/skills/AbilityTypePicker.tsx
@@ -28,6 +28,7 @@ const TYPE_LABELS: Record<AbilityType, string> = {
     'incoming-block': 'Incoming Block',
     'outgoing-amplification': 'Outgoing Amplification',
     'heal-amplification': 'Heal Amplification',
+    'incoming-heal-amplification': 'Incoming Heal Amplification',
 };
 
 const CATEGORIES: { label: string; types: AbilityType[]; note?: string }[] = [

--- a/src/components/skills/abilityDefaults.ts
+++ b/src/components/skills/abilityDefaults.ts
@@ -75,6 +75,8 @@ const makeDefaultConfig = (type: AbilityType): AbilityConfig => {
             };
         case 'heal-amplification':
             return { type: 'heal-amplification', condition: 'target-hp-below-self', ampPct: 0 };
+        case 'incoming-heal-amplification':
+            return { type, ampPct: 0, procChance: 0 };
     }
 };
 
@@ -99,6 +101,7 @@ const DEFAULT_TARGETS: Record<AbilityType, AbilityTarget> = {
     'incoming-block': 'self',
     'outgoing-amplification': 'self',
     'heal-amplification': 'self',
+    'incoming-heal-amplification': 'self',
 };
 
 /**

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -15,6 +15,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat simulator now models conditional incoming-damage-reduction implants and gear sets: Voidshade and Shadowguard (reduced damage while stealthed), Nebula Nullifier (reduced damage while in Stasis), Hyperion Gaze, the Hardened set, and Iridium's passive (reduced incoming critical-hit damage), Vortex Veil (reduced Inferno and Corrosion damage), and Ironclad (a chance to block a repeat hit from the same attacker). Ships with these equipped now take less damage when the relevant conditions are met.",
     "Combat simulator now models three outgoing-damage amplification implants: Menace (chance to amplify a hit's damage on a critical hit), Giant Slayer (chance to amplify a hit's damage against an enemy with higher attack), and Insidiousness (chance to deal bonus damage when you apply a debuff to an enemy).",
     'Combat simulator now models three more heal implants: Second Wind (chance to repair itself when it takes a critical hit), Nourishment (stronger repairs on allies with less HP than the healer), and Vivacious Repair (chance to double a repair on an ally below 25% HP).',
+    'Combat simulator now models the Exuberance implant (chance to increase the amount of a repair this unit receives).',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3095,8 +3095,9 @@ const DocumentationPage: React.FC = () => {
                                     when it takes a critical hit), <strong>Nourishment</strong>{' '}
                                     (stronger repairs on allies with less HP than the healer), and{' '}
                                     <strong>Vivacious Repair</strong> (chance to double a repair on
-                                    an ally below 25% HP). More implant and gear-set effects will be
-                                    added in future updates.
+                                    an ally below 25% HP), and <strong>Exuberance</strong> (chance
+                                    to increase the amount of a repair this unit receives). More
+                                    implant and gear-set effects will be added in future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -23,7 +23,8 @@ export type AbilityType =
     | 'incoming-reduction'
     | 'incoming-block'
     | 'outgoing-amplification'
-    | 'heal-amplification';
+    | 'heal-amplification'
+    | 'incoming-heal-amplification';
 
 export type AbilityTarget =
     | 'self'
@@ -368,6 +369,14 @@ export type AbilityConfig =
           ampPct: number;
           /** Proc chance in (0,1); ABSENT = deterministic (always fires when gated). */
           procChance?: number;
+      }
+    // D-PR6 recipient-side incoming heal amplification (unconditional — no condition field).
+    | {
+          type: 'incoming-heal-amplification';
+          /** Amplification added to a repair RECEIVED when it fires, in percentage points. */
+          ampPct: number;
+          /** Proc chance in (0,1). Rolled once per repair received. */
+          procChance: number;
       };
 
 /** Crowd-control effects a `control` ability can apply. The engine does not simulate

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -549,6 +549,42 @@ describe('Vivacious Repair implant', () => {
     });
 });
 
+// ---------------------------------------------------------------------------
+// D-PR6: Exuberance implant (incoming-heal-amplification, probabilistic)
+// ---------------------------------------------------------------------------
+describe('Exuberance implant', () => {
+    it('epic → incoming-heal-amplification, ampPct 14, procChance ≈ 0.24', () => {
+        const abilities = buildForImplant('EXUBERANCE', 'epic');
+        expect(abilities).toHaveLength(1);
+        const ab = abilities[0];
+        expect(ab.type).toBe('incoming-heal-amplification');
+        expect(ab.target).toBe('self');
+        expect(ab.autoFilled).toBe(true);
+        if (ab.config.type === 'incoming-heal-amplification') {
+            expect(ab.config.ampPct).toBe(14);
+            expect(ab.config.procChance).toBeCloseTo(0.24);
+        } else {
+            throw new Error('Expected incoming-heal-amplification config');
+        }
+    });
+
+    it('legendary → ampPct 15, procChance ≈ 0.30', () => {
+        const abilities = buildForImplant('EXUBERANCE', 'legendary');
+        expect(abilities).toHaveLength(1);
+        const ab = abilities[0];
+        if (ab.config.type === 'incoming-heal-amplification') {
+            expect(ab.config.ampPct).toBe(15);
+            expect(ab.config.procChance).toBeCloseTo(0.30);
+        } else {
+            throw new Error('Expected incoming-heal-amplification config');
+        }
+    });
+
+    it('common → no ability (no common variant)', () => {
+        expect(buildForImplant('EXUBERANCE', 'common')).toEqual([]);
+    });
+});
+
 // D-PR5: Second Wind implant (reactive self-heal on crit-received)
 // ---------------------------------------------------------------------------
 describe('Second Wind implant', () => {

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -99,7 +99,7 @@ function implantAbilityCount(implantKey: string, rarity: GearPiece['rarity']): n
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { LEECH + HARDENED (gear sets), ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + BLOODTHIRST + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + MENACE + SECOND_WIND + SHADOWGUARD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
+    it('exactly { LEECH + HARDENED (gear sets), ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + BLOODTHIRST + EXUBERANCE + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + MENACE + SECOND_WIND + SHADOWGUARD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -122,6 +122,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
             'VORTEX_VEIL',
             'WARPSTRIKE',
             'BLOODTHIRST',
+            'EXUBERANCE',
             'GIANT_SLAYER',
             'INSIDIOUSNESS',
             'IRONCLAD',
@@ -177,6 +178,7 @@ describe('equipmentCoverage — implants', () => {
     // D-PR3: VOIDSHADE, NEBULA_NULLIFIER, HYPERION_GAZE, VORTEX_VEIL, IRONCLAD, SHADOWGUARD added.
     // D-PR4: MENACE, GIANT_SLAYER, INSIDIOUSNESS added (outgoing-amplification on-crit / vs higher-attack / on-debuff).
     // D-PR5: SECOND_WIND, NOURISHMENT, VIVACIOUS_REPAIR added (reactive-heal family).
+    // D-PR6: EXUBERANCE added (repair-amplification on-repair chance).
     const implementedImplants = new Set([
         'BLOODTHIRST',
         'INTRUSION',
@@ -194,6 +196,7 @@ describe('equipmentCoverage — implants', () => {
         'SECOND_WIND',
         'NOURISHMENT',
         'VIVACIOUS_REPAIR',
+        'EXUBERANCE',
     ]);
 
     it('INTRUSION produces 1 ability per rarity (outgoingDamage modifier with scaling)', () => {
@@ -313,6 +316,16 @@ describe('equipmentCoverage — implants', () => {
         const variants = IMPLANTS['VIVACIOUS_REPAIR'].variants;
         for (const v of variants) {
             expect(implantAbilityCount('VIVACIOUS_REPAIR', v.rarity)).toBe(1);
+        }
+    });
+
+    // D-PR6: repair-amplification implant
+    it('EXUBERANCE produces 1 ability per rarity (repair-amplification on-repair chance; no common variant)', () => {
+        // EXUBERANCE has uncommon/rare/epic/legendary — no common variant.
+        expect(implantAbilityCount('EXUBERANCE', 'common')).toBe(0);
+        const variants = IMPLANTS['EXUBERANCE'].variants;
+        for (const v of variants) {
+            expect(implantAbilityCount('EXUBERANCE', v.rarity)).toBe(1);
         }
     });
 

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -194,6 +194,16 @@ const NOURISHMENT_AMP: Record<string, number> = { uncommon: 10, rare: 15, epic: 
 // No common/uncommon rarity for Vivacious Repair
 const VIVACIOUS_PROC: Record<string, number> = { rare: 0.21, epic: 0.26, legendary: 0.32 };
 
+// D-PR6: incoming-heal-amplification implant value tables
+// No common rarity for Exuberance
+const EXUBERANCE_PROC: Record<string, number> = {
+    uncommon: 0.17,
+    rare: 0.2,
+    epic: 0.24,
+    legendary: 0.3,
+};
+const EXUBERANCE_AMP: Record<string, number> = { uncommon: 12, rare: 13, epic: 14, legendary: 15 };
+
 // D-PR3: shared helper for incoming-reduction abilities
 function mkReduction(
     pct: number | undefined,
@@ -418,6 +428,22 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
     // Nourishment: +X% repair when targeting an ally with lower HP. Deterministic (no procChance).
     // No common rarity.
     NOURISHMENT: (rarity) => mkHealAmp(NOURISHMENT_AMP[rarity], 'target-hp-below-self'),
+    // D-PR6: incoming-heal-amplification implants
+    // Exuberance: X% chance to increase incoming repair by Y%. No common rarity.
+    // Recipient-side fold is wired in a later task; this entry is inert until then.
+    EXUBERANCE: (rarity) => {
+        const amp = EXUBERANCE_AMP[rarity];
+        const pc = EXUBERANCE_PROC[rarity];
+        if (amp === undefined) return undefined;
+        return {
+            type: 'incoming-heal-amplification',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'incoming-heal-amplification', ampPct: amp, procChance: pc },
+            autoFilled: true,
+        };
+    },
     // Vivacious Repair: X% chance to double the repair amount when targeting an ally below 25% HP.
     // No common/uncommon rarity.
     VIVACIOUS_REPAIR: (rarity) =>

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -1216,3 +1216,249 @@ describe('D-PR5 integration — heal-cast amplification fold (Nourishment / Viva
         expect(sumHeal(withAmp, 'directHeal')).toBeCloseTo(NUM_ROUNDS * BASE_PER_CAST, 6);
     });
 });
+
+// ---------------------------------------------------------------------------
+// D-PR6 Task 6: Exuberance implant — recipient-side incoming-heal amplification fold
+// ---------------------------------------------------------------------------
+//
+// Exuberance is a RECIPIENT-side, unconditional ("when repaired") incoming-heal
+// amplification: each repair landing on the carrier rolls a combat-lifetime proc gate
+// (keyed `${recipientId}:${abilityId}`); when it fires, the repair's raw is multiplied
+// by (1 + ampPct/100). The gate is SHARED across every repair source the unit receives
+// (one probability stream), so cast heals, reactive heals, and HoT ticks all draw from it.
+//
+// Harness shape (deterministic): the FOCUS actor ('attacker') is the HEALER AND the
+// recipient — it self-casts a `target: 'self'` repair (basis 'hp' → raw = own max HP × pct,
+// a CONSTANT per cast). Exuberance lives in its OWN passive slot, so the engine's
+// incomingHealAmpAbilitiesById picks it up. With procChance 0.5 over N rounds the gate fires
+// floor(N × 0.5) times (back-loaded: calls 2,4,6,8,10 for N=10), so exactly that many casts
+// are boosted by ampPct, and the rest land at baseline.
+//
+// Because the basis is 'hp' (constant raw) and the cast is noCrit, the ONLY variable between
+// the Exuberance and no-Exuberance runs is the amplification factor → the difference isolates
+// EXACTLY (number of procs) × baseRaw × (ampPct/100).
+
+describe('D-PR6 integration — Exuberance recipient-side incoming-heal amplification', () => {
+    const SELF_HP = 10_000;
+    const HEAL_PCT = 10; // self-repair = SELF_HP × 10% = 1000 per cast (basis 'hp', no other folds)
+    const BASE_PER_CAST = SELF_HP * (HEAL_PCT / 100); // 1000
+    const EXU_PROC = 0.5; // deterministic: floor(N × 0.5) procs (back-loaded calls 2,4,...)
+    const EXU_AMP = 50; // +50% per boosted repair
+
+    /** The actor's self-repair (basis 'hp' → constant raw; noCrit so the crit gate never perturbs). */
+    const selfRepair: Ability = {
+        id: 'self-repair',
+        type: 'heal',
+        target: 'self',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'heal', pct: HEAL_PCT, basis: 'hp', noCrit: true },
+    };
+
+    /** Exuberance passive ability (recipient-side incoming-heal amplification). */
+    const exuberance = (ampPct: number, procChance: number): Ability => ({
+        id: 'equip-implant-EXUBERANCE',
+        type: 'incoming-heal-amplification',
+        target: 'self',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'incoming-heal-amplification', ampPct, procChance },
+        autoFilled: true,
+    });
+
+    /** Ship skills: self-repair active + optional Exuberance passive. */
+    const skills = (exuAbility?: Ability): ShipSkills => ({
+        slots: [
+            { slot: 'active', abilities: [selfRepair] },
+            ...(exuAbility ? [{ slot: 'passive' as const, abilities: [exuAbility] }] : []),
+        ],
+    });
+
+    /** Base input: healing mode, focus 'attacker' is healer + recipient (self-heal). Never attacked. */
+    const EXU_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+        attack: 1,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: skills(),
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 10,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: SELF_HP,
+        healModifier: 0,
+        healTargetId: 'attacker',
+        ...overrides,
+    });
+
+    it(
+        'Carrier repaired by cast heals: boosted repairs land at the gated frequency; ' +
+            'total received exceeds baseline by ampPct × (number of procs)',
+        () => {
+            const NUM_ROUNDS = 10;
+            const EXPECTED_PROCS = Math.floor(NUM_ROUNDS * EXU_PROC); // 5
+
+            const withExu = runCombat(
+                EXU_BASE({
+                    numRounds: NUM_ROUNDS,
+                    shipSkills: skills(exuberance(EXU_AMP, EXU_PROC)),
+                })
+            );
+            const baseline = runCombat(
+                EXU_BASE({ numRounds: NUM_ROUNDS, shipSkills: skills() })
+            );
+
+            const baseHeal = sumHeal(baseline, 'directHeal');
+            const exuHeal = sumHeal(withExu, 'directHeal');
+
+            // Baseline: NUM_ROUNDS casts × 1000.
+            expect(baseHeal).toBeCloseTo(NUM_ROUNDS * BASE_PER_CAST, 6);
+            // With Exuberance: EXPECTED_PROCS casts boosted by +50% → the rest at baseline.
+            const expectedExu =
+                NUM_ROUNDS * BASE_PER_CAST + EXPECTED_PROCS * BASE_PER_CAST * (EXU_AMP / 100);
+            expect(exuHeal).toBeCloseTo(expectedExu, 6);
+            expect(exuHeal).toBeGreaterThan(baseHeal);
+
+            // The boost lands on exactly EXPECTED_PROCS rounds (back-loaded gate schedule),
+            // each boosted round crediting baseRaw × (1 + ampPct/100).
+            const boostedRounds = withExu
+                .healing!.rounds.map((rd, i) => ({
+                    round: i + 1,
+                    heal: rd.perActor.get('attacker')?.directHeal ?? 0,
+                }))
+                .filter((r) => r.heal > BASE_PER_CAST + 1e-6);
+            expect(boostedRounds).toHaveLength(EXPECTED_PROCS);
+            for (const r of boostedRounds) {
+                expect(r.heal).toBeCloseTo(BASE_PER_CAST * (1 + EXU_AMP / 100), 6);
+            }
+        }
+    );
+
+    it('No Exuberance: every cast lands at baseline (control, byte-identical fold)', () => {
+        const NUM_ROUNDS = 10;
+        const result = runCombat(EXU_BASE({ numRounds: NUM_ROUNDS, shipSkills: skills() }));
+        expect(result.healing).toBeDefined();
+        expect(sumHeal(result, 'directHeal')).toBeCloseTo(NUM_ROUNDS * BASE_PER_CAST, 6);
+        // Every round credits exactly the unboosted base.
+        for (const rd of result.healing!.rounds) {
+            expect(rd.perActor.get('attacker')?.directHeal ?? 0).toBeCloseTo(BASE_PER_CAST, 6);
+        }
+    });
+
+    // ── Second-source assertion: reactive self-heal on an Exuberance carrier ──────
+    //
+    // Proves the REACTIVE repair-apply fold (triggers.ts) also draws from the recipient's
+    // single Exuberance gate. The focus 'attacker' carries BOTH a reactive Second-Wind-style
+    // self-heal (on-attacked + crit, basis 'hp') AND Exuberance. An enemy crits it every
+    // round; the reactive heal fires at its own rate and — when Exuberance's gate fires —
+    // the landed reactive repair is boosted.
+
+    /** Reactive self-heal: fires on a crit received (basis 'hp' → constant raw). */
+    const reactiveSelfHeal = (procChance: number): Ability => ({
+        id: 'equip-implant-REACTIVE_HEAL',
+        type: 'heal',
+        target: 'self',
+        trigger: 'on-attacked',
+        triggerCritFilter: 'crit',
+        conditions: [],
+        procChance,
+        config: { type: 'heal', pct: HEAL_PCT, basis: 'hp' },
+        autoFilled: true,
+    });
+
+    /** A no-op active so the focus actor still takes a turn each round (deals no damage). */
+    const noopActive: Ability = {
+        id: 'noop-active',
+        type: 'damage',
+        target: 'enemy',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'damage', multiplier: 0 },
+    };
+
+    /** Enemy that crits the focus actor every round (minimal attack so `attacked` is emitted). */
+    const critEnemy = {
+        id: 'exu-enemy',
+        stats: { attack: 1, crit: 100, critDamage: 0, speed: 1, defence: 0, hp: 1_000_000_000 },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active' as const,
+                    abilities: [
+                        {
+                            id: 'exu-enemy-hit',
+                            type: 'damage' as const,
+                            target: 'enemy' as const,
+                            trigger: 'on-cast' as const,
+                            conditions: [],
+                            config: { type: 'damage' as const, multiplier: 100, hits: 1 },
+                        },
+                    ],
+                },
+            ],
+        } as ShipSkills,
+    };
+
+    it(
+        'Reactive self-heal on an Exuberance carrier is boosted (proves the reactive site folds ' +
+            'and shares the recipient gate)',
+        () => {
+            const NUM_ROUNDS = 10;
+            // Reactive heal fires every round (procChance 1.0) → a repair lands each round →
+            // the recipient gate is rolled once per landed reactive repair.
+            const withExu = runCombat(
+                EXU_BASE({
+                    numRounds: NUM_ROUNDS,
+                    shipSkills: {
+                        slots: [
+                            { slot: 'active', abilities: [noopActive] },
+                            {
+                                slot: 'passive',
+                                abilities: [
+                                    reactiveSelfHeal(1.0),
+                                    exuberance(EXU_AMP, EXU_PROC),
+                                ],
+                            },
+                        ],
+                    },
+                    enemyAttackers: [critEnemy],
+                })
+            );
+            const baseline = runCombat(
+                EXU_BASE({
+                    numRounds: NUM_ROUNDS,
+                    shipSkills: {
+                        slots: [
+                            { slot: 'active', abilities: [noopActive] },
+                            { slot: 'passive', abilities: [reactiveSelfHeal(1.0)] },
+                        ],
+                    },
+                    enemyAttackers: [critEnemy],
+                })
+            );
+
+            const baseHeal = sumHeal(baseline, 'directHeal');
+            const exuHeal = sumHeal(withExu, 'directHeal');
+            // Reactive heal fires every round → NUM_ROUNDS landed repairs of baseRaw each.
+            expect(baseHeal).toBeCloseTo(NUM_ROUNDS * BASE_PER_CAST, 6);
+            // Exuberance boosts floor(NUM_ROUNDS × 0.5) of those landed repairs.
+            const EXPECTED_PROCS = Math.floor(NUM_ROUNDS * EXU_PROC);
+            const expectedExu =
+                NUM_ROUNDS * BASE_PER_CAST + EXPECTED_PROCS * BASE_PER_CAST * (EXU_AMP / 100);
+            expect(exuHeal).toBeCloseTo(expectedExu, 6);
+            expect(exuHeal).toBeGreaterThan(baseHeal);
+        }
+    );
+});

--- a/src/utils/combat/__tests__/healAmplification.test.ts
+++ b/src/utils/combat/__tests__/healAmplification.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { healAmplificationForCast } from '../healAmplification';
+import { healAmplificationForCast, incomingHealAmpForRecipient } from '../healAmplification';
 import { Ability } from '../../../types/abilities';
 
 const amp = (
@@ -50,5 +50,43 @@ describe('healAmplificationForCast', () => {
             amp('v', 'target-below-25', 100, undefined),
         ];
         expect(healAmplificationForCast(a, { targetHpPct: 10, selfHpPct: 90 }, always)).toBe(130);
+    });
+});
+
+const inc = (id: string, ampPct: number, procChance: number): Ability => ({
+    id,
+    type: 'incoming-heal-amplification',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'incoming-heal-amplification', ampPct, procChance },
+});
+
+describe('incomingHealAmpForRecipient', () => {
+    it('returns 0 with no incoming-heal-amplification abilities', () => {
+        expect(incomingHealAmpForRecipient([], () => true)).toBe(0);
+    });
+    it('adds ampPct when the proc fires', () => {
+        expect(incomingHealAmpForRecipient([inc('e', 13, 0.5)], () => true)).toBe(13);
+    });
+    it('returns 0 when the proc does not fire', () => {
+        expect(incomingHealAmpForRecipient([inc('e', 13, 0.5)], () => false)).toBe(0);
+    });
+    it('rolls with (abilityId, procChance) and sums additively across abilities', () => {
+        const roll = vi.fn(() => true);
+        expect(incomingHealAmpForRecipient([inc('a', 12, 0.17), inc('b', 15, 0.3)], roll)).toBe(27);
+        expect(roll).toHaveBeenCalledWith('a', 0.17);
+        expect(roll).toHaveBeenCalledWith('b', 0.3);
+    });
+    it('ignores non-incoming-heal-amplification configs', () => {
+        const other = {
+            id: 'x',
+            type: 'heal',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'heal', pct: 10, basis: 'hp' },
+        } as Ability;
+        expect(incomingHealAmpForRecipient([other], () => true)).toBe(0);
     });
 });

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -51,6 +51,7 @@ import {
 import type { AttackerDamageScalars } from './victimDamage';
 import { incomingReductionForHit, incomingBlockForIntake } from './incomingEffects';
 import { outgoingAmplificationForHit } from './outgoingEffects';
+import { incomingHealAmpForRecipient } from './healAmplification';
 import { CHEAT_DEATH_BUFFS } from './cheatDeathBuffs';
 import { BARRIER_BUFFS } from './barrierBuffs';
 import { isStasis, STASIS_BUFFS } from './stasisBuffs';
@@ -1930,6 +1931,12 @@ export function runCombat(input: CombatEngineInput): {
               },
               recipientMaxHp,
               recipientIncomingHealPct,
+              recipientIncomingHealAmpPct: (rid) =>
+                  incomingHealAmpForRecipient(
+                      incomingHealAmpAbilitiesOf(rid),
+                      (abilityId, chance) =>
+                          rollRateGate(procChanceGates, `${rid}:${abilityId}`, chance)
+                  ),
               // Foreign HoT applier max HP (Task 7): lastTurnCtxByActor ONLY, NO base-stat
               // fallback (strict corrosion applier-ctx rule — undefined → the holder skips the tick).
               applierMaxHp: (id) => lastTurnCtxByActor.get(id)?.effectiveMaxHp,
@@ -2124,6 +2131,25 @@ export function runCombat(input: CombatEngineInput): {
         if (incoming.length) incomingAbilitiesById.set(rt.actor.id, incoming);
     }
     const incomingAbilitiesOf = (id: string): Ability[] => incomingAbilitiesById.get(id) ?? [];
+
+    // D-PR6: per-actor recipient-side incoming-heal-amplification abilities (Exuberance),
+    // side-agnostic (a ship can be a heal recipient on either team). Built once from BOTH runtime
+    // maps; empty for actors without the relevant equipment. Consumed by the heal-apply fold (a
+    // later task) — nothing reads it yet, so this is byte-identical.
+    const incomingHealAmpAbilitiesById = new Map<string, Ability[]>();
+    for (const rt of [...runtimesById.values(), ...enemyPlayerRuntimeByActorId.values()]) {
+        if (incomingHealAmpAbilitiesById.has(rt.actor.id)) continue; // dedupe if an actor is in both maps
+        const heals: Ability[] = [];
+        for (const slot of rt.castSkills.slots) {
+            if (slot.slot !== 'passive') continue;
+            for (const a of slot.abilities) {
+                if (a.config.type === 'incoming-heal-amplification') heals.push(a);
+            }
+        }
+        if (heals.length) incomingHealAmpAbilitiesById.set(rt.actor.id, heals);
+    }
+    const incomingHealAmpAbilitiesOf = (id: string): Ability[] =>
+        incomingHealAmpAbilitiesById.get(id) ?? [];
 
     // D-PR4: per-actor attacker-side outgoing-amplification abilities (Menace/Giant Slayer),
     // side-agnostic (a ship amplifies on either team). Built once from BOTH runtime maps; empty for

--- a/src/utils/combat/healAmplification.ts
+++ b/src/utils/combat/healAmplification.ts
@@ -30,3 +30,22 @@ export function healAmplificationForCast(
     }
     return sum;
 }
+
+/**
+ * Summed incoming-heal amplification % for ONE repair landing on a recipient (Exuberance).
+ * Unconditional ("when repaired"): for each incoming-heal-amplification ability the recipient carries,
+ * add ampPct iff its proc fires. `rollProc` MUST be keyed by the recipient so all repairs the unit
+ * receives share one combat-lifetime gate (single probability stream). Returns 0 when nothing applies.
+ */
+export function incomingHealAmpForRecipient(
+    recipientAbilities: Ability[],
+    rollProc: (abilityId: string, chance: number) => boolean
+): number {
+    let sum = 0;
+    for (const a of recipientAbilities) {
+        if (a.config.type !== 'incoming-heal-amplification') continue;
+        if (!rollProc(a.id, a.config.procChance)) continue;
+        sum += a.config.ampPct;
+    }
+    return sum;
+}

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -86,6 +86,10 @@ export interface HealingRuntimeCtx {
     /** Recipient stats via lastTurnCtxByActor with base-stat fallback (pre-first-turn). */
     recipientMaxHp: (actorId: string) => number;
     recipientIncomingHealPct: (actorId: string) => number;
+    /** D-PR6: summed incoming-heal amplification % for a repair landing on `rid` (Exuberance). Rolls the
+     *  recipient's incoming-heal-amp procs ONCE (combat-lifetime gate keyed rid+ability). Absent → callers
+     *  use 0 → byte-identical. */
+    recipientIncomingHealAmpPct?: (rid: string) => number;
     /** A FOREIGN HoT applier's effective max HP at tick time (Task 7): reads
      *  lastTurnCtxByActor ONLY — NO base-stat fallback (the strict corrosion applier-ctx
      *  rule). Returns undefined when the applier has not acted this run yet, in which case

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1674,7 +1674,10 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
             if (maxHp === undefined) return; // foreign applier with no ctx yet → skip the tick
             // Scheduled HoT (no caster) attributes to the holder; otherwise to the applier.
             const creditId = applierId ?? actor.id;
-            const raw = maxHp * (hotPct / 100) * stacks * holderIncomingFactor;
+            let raw = maxHp * (hotPct / 100) * stacks * holderIncomingFactor;
+            // D-PR6: recipient-side incoming-heal amplification (Exuberance) — the HoT recipient is
+            // the holder (actor.id). Rolls its combat-lifetime gate ONCE per tick (0 → byte-identical).
+            raw *= 1 + (healing.recipientIncomingHealAmpPct?.(actor.id) ?? 0) / 100;
             if (raw <= 0) return;
             healing.credit(creditId, 'hotHeal', raw);
             // Holder === target → the heal lands on the target; split consumption to the applier.
@@ -1755,6 +1758,9 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                             (1 + incomingPctFor(rid) / 100);
                         // D-PR5: caster heal-cast amplification (rolls the proc gate ONCE per recipient).
                         raw *= 1 + healAmpPctFor(rid) / 100;
+                        // D-PR6: recipient-side incoming-heal amplification (Exuberance) — rolls the
+                        // recipient's combat-lifetime gate ONCE per applied repair (0 → byte-identical).
+                        raw *= 1 + (healing.recipientIncomingHealAmpPct?.(rid) ?? 0) / 100;
                         const recipientActor = healing.recipientActor(rid);
                         if (recipientActor) healing.applyHealToTarget(raw, recipientActor);
                         healTargets.push(rid);
@@ -1776,6 +1782,9 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                         (1 + incomingPctFor(rid) / 100);
                     // D-PR5: caster heal-cast amplification (rolls the proc gate ONCE per recipient).
                     raw *= 1 + healAmpPctFor(rid) / 100;
+                    // D-PR6: recipient-side incoming-heal amplification (Exuberance) — rolls the
+                    // recipient's combat-lifetime gate ONCE per applied repair (0 → byte-identical).
+                    raw *= 1 + (healing.recipientIncomingHealAmpPct?.(rid) ?? 0) / 100;
                     healing.credit(actor.id, 'directHeal', raw);
                     if (rid === healing.targetId) {
                         const { consumed, overheal } = healing.applyHealToTarget(raw);

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1211,7 +1211,7 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
             if (recipientHp !== undefined && recipientHp <= 0) continue;
             const basisValue =
                 cfg.basis === 'target-hp' ? ctx.healing.recipientMaxHp(rid) : nonTargetHpBasis;
-            const raw =
+            let raw =
                 cfg.type === 'heal'
                     ? basisValue *
                       (cfg.pct / 100) *
@@ -1219,6 +1219,10 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
                       (1 + ownerOutgoing / 100) *
                       (1 + incomingPctFor(rid) / 100)
                     : basisValue * (cfg.pct / 100);
+            // D-PR6: recipient-side incoming-heal amplification (Exuberance) — HEAL case ONLY (NOT
+            // shields). Rolls the recipient's combat-lifetime gate ONCE per applied repair (0 → byte-identical).
+            if (cfg.type === 'heal')
+                raw *= 1 + (healing.recipientIncomingHealAmpPct?.(rid) ?? 0) / 100;
             if (cfg.type === 'heal') {
                 ctx.healing.credit(intent.ownerId, 'directHeal', raw);
                 if (rid === ctx.healing.targetId) {


### PR DESCRIPTION
## Summary

Completes the sub-project D **reactive heal/leech** row. Stacked on D-PR5 (#133); retarget to `main` after the D stack merges.

**Exuberance** — "When repaired, there is a 17–30% chance to increase that repair by 12–15%." It's the carrier's *incoming* effect: it boosts repairs the unit **receives** (recipient-side), unconditional, proc-gated. Distinct from the outgoing healing effects shipped so far (the Repair gear set's `healModifier`, and D-PR5's Nourishment/Vivacious), which boost repairs you *cast*.

### Mechanism (no new trigger)
Every place a repair lands on a recipient already applies a per-recipient incoming factor and shares one `HealingRuntimeCtx`, so Exuberance folds in there rather than needing an `on-heal-received` event:
- New unconditional `incoming-heal-amplification` `AbilityConfig` + pure `incomingHealAmpForRecipient` evaluator (`healAmplification.ts`).
- One optional `HealingRuntimeCtx.recipientIncomingHealAmpPct(rid)` method — engine-populated via a new per-recipient `incomingHealAmpAbilitiesById` map + a **recipient-keyed** gate `rollRateGate(procChanceGates, \`${rid}:${abilityId}\`)`. Keying by the recipient means every repair a unit receives (cast / reactive / HoT) draws from **one** combat-lifetime accumulator → the proc fires at the rarity % over the unit's whole repair stream (single probability stream, matching one in-game effect).
- Called at all four repair-apply sites (two cast-heal branches + HoT tick in `playerTurn.ts`, reactive heal in `triggers.ts`), once per applied repair. **Shields and leeches excluded** (not repairs / credited to the source).

### Invariants
- All DPS / healing / battle-sim **goldens byte-identical** (2929 tests green, zero snapshot drift). The ctx method is unpopulated/returns 0 for non-carriers (`?? 0` guarded), and no gate key is even created for them.
- `audit:skills` unchanged (141 ships, 0 findings); lint + tsc clean.

Spec: `docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr6-design.md`
Plan: `docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr6.md`

This is the last unshipped effect in the "reactive heal/leech" row; only Voidfire Catalyst (a different row) remains deferred.

## Test Plan
- [x] Full suite: 2929 passing, zero golden/snapshot drift vs D-PR5 base
- [x] `npm run audit:skills` — 141 ships, 0 findings
- [x] `npm run lint` (max-warnings 0) + `npx tsc --noEmit` clean
- [x] Unit: `incomingHealAmpForRecipient` (sums on proc fire; 0 when none; rolls per ability id)
- [x] Integration (healing-mode `runCombat`): cast-heal carrier boosted at the gated frequency (5/10 at 0.5, ×1.5 each); no-Exuberance baseline; reactive self-heal on a carrier also boosted (proves the reactive fold + shared single gate)

### Known follow-up
- HoT-tick fold is covered by the pure evaluator + spec-review code inspection; a dedicated engine-level HoT integration test is a cheap future add (same ctx-method code path as the tested cast/reactive sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)