### PR TITLE
feat(combat): D-PR7 — on-death implants (Last Wish / Battlecry / Martyrdom)

### DIFF
--- a/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr7.md
+++ b/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr7.md
@@ -1,0 +1,472 @@
+# On-death Implants (D-PR7) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the three on-death implants — Last Wish (repair all allies, fully modeled), Battlecry (Inc. Damage Down to all allies, emit-only) and Martyrdom (Disable the killer, emit-only) — as registry entries riding the existing `on-destroyed` trigger + reactive heal/buff/debuff executors, plus one surgical engine change so on-destroyed *debuffs* route to the killer.
+
+**Architecture:** Pure additive registry work in `buildEquipmentAbilities.ts` (three `IMPLANT_ABILITIES` entries + two small helpers) and one targeted edit in `triggers.ts` (extend the on-destroyed killer-routing branch from `purge` to `purge | debuff`). No new types, no new ConditionSubject, no new executor branch. Byte-identical for existing fixtures (no combat fixture carries effect-bearing gear; Martyrdom is the first on-destroyed debuff).
+
+**Tech Stack:** TypeScript, Vitest. Combat engine under `src/utils/combat/`; equipment-ability registry under `src/utils/abilities/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr7-design.md`
+
+---
+
+## Background the implementer needs
+
+- **The registry** (`src/utils/abilities/buildEquipmentAbilities.ts`) maps an implant key (the string stored in a gear piece's `setBonus`, e.g. `'LAST_WISH'`) to a builder `(rarity: string) => Omit<Ability,'id'> | undefined`. A builder returns `undefined` when the rarity is unsupported (graceful skip — never throw). The resulting `Ability` is merged into the ship's **passive slot** via `buildShipAbilitiesWithEquipment` (already wired into every consumer; untouched here). Ability id = `equip-implant-${implantKey}` (this worktree's convention — see `equipmentAbilities.integration.test.ts:242`).
+- **Per-rarity value tables** are plain `Record<string, number>` consts near the top of the file (see `MENACE_AMP`, `SECOND_WIND_PROC`, `EXUBERANCE_AMP` for the pattern). A missing rarity key → `undefined` → builder returns `undefined`.
+- **The `on-destroyed` trigger** (`src/utils/combat/triggers.ts` ~378) fires on the `ship-destroyed` event, self-scoped (`e.actorId === ownerId`). Reactive executors already support:
+  - `type:'heal'` with ability `target:'all-allies'` + config `basis:'target-hp'` → repairs each recipient % of its **own** max HP; dead recipients (incl. the dead caster) skipped from credit. (Salvation precedent.)
+  - `type:'buff'` with ability `target:'all-allies'` → applies a self-side timed status to every same-side id `ctx.playerIds` for `config.duration`; emits `buff-applied`.
+  - `type:'debuff'` → applies a timed enemy status to `intent.eventCtx.counterTargetId` (the killer) via the owner's landing gate; emits `debuff-applied`.
+- **Buff/debuff configs require `parsedEffects`** (`ParsedBuffEffects`). Resolve a canonical buff name to its effects with `parseBuffEffects(name, description)` from `src/utils/calculators/buffParser.ts`, after finding the entry in `BUFFS` (`src/constants/buffs.ts`). `isStackable(description)` from the same module returns `{ stackable, maxStacks? }`.
+- **`application: 'apply'` vs `'inflict'`** (debuff): `'apply'` lands unless affinity disadvantage (no landing-chance roll); `'inflict'` draws the hacking-vs-security landing gate. Martyrdom text says "Applies Disable" → `'apply'`.
+- **Implant per-rarity data** lives in `src/constants/implants.ts` under keys `LAST_WISH`, `BATTLECRY`, `MARTYRDOM`.
+
+**Verification commands (run from the worktree root):**
+- Single test file: `npx vitest --run path/to/file.test.ts`
+- Full suite: `npm test` (≈2929+ tests). Pre-commit hook also runs it.
+- Lint: `npm run lint` (max-warnings 0). Type-check: `npx tsc --noEmit`.
+- Skill audit (must stay 141 ships / 0 findings): `npm run audit:skills`
+- **Goldens:** NEVER run `vitest -u`. Any golden/`.snap` movement is a red flag — investigate, don't accept.
+
+**Commits:** end every commit message with the `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer. Code commits run the pre-commit hook (full suite) — that's expected.
+
+---
+
+## Task 1: Last Wish — repair all allies on death (fully modeled)
+
+**Files:**
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (value table + `IMPLANT_ABILITIES.LAST_WISH`)
+- Test: `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`
+
+- [ ] **Step 1: Write the failing test.** Add to `buildEquipmentAbilities.test.ts` a block that builds a ship with a Last Wish implant piece and asserts the resolved ability shape. Use the file's existing helpers (`makeShip`/`makePiece`/`makeGetGearPiece` or whatever it already defines — match the file). Skeleton:
+
+```ts
+describe('Last Wish (on-death repair all allies)', () => {
+    it('legendary → heal/all-allies/on-destroyed, basis target-hp, pct 32, noCrit', () => {
+        const piece = makePiece({ id: 'lw-1', setBonus: 'LAST_WISH', rarity: 'legendary' });
+        const ship = makeShip({ implants: { implant_major: 'lw-1' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'lw-1': piece }));
+        const a = abilities.find((x) => x.id === 'equip-implant-LAST_WISH');
+        expect(a).toBeDefined();
+        expect(a!.trigger).toBe('on-destroyed');
+        expect(a!.target).toBe('all-allies');
+        expect(a!.config).toMatchObject({ type: 'heal', basis: 'target-hp', pct: 32, noCrit: true });
+    });
+
+    it('uncommon → pct 14', () => {
+        const piece = makePiece({ id: 'lw-2', setBonus: 'LAST_WISH', rarity: 'uncommon' });
+        const ship = makeShip({ implants: { implant_major: 'lw-2' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'lw-2': piece }));
+        const a = abilities.find((x) => x.id === 'equip-implant-LAST_WISH');
+        expect(a!.config).toMatchObject({ type: 'heal', pct: 14 });
+    });
+
+    it('common → no ability (no common variant)', () => {
+        const piece = makePiece({ id: 'lw-3', setBonus: 'LAST_WISH', rarity: 'common' });
+        const ship = makeShip({ implants: { implant_major: 'lw-3' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'lw-3': piece }));
+        expect(abilities.find((x) => x.id === 'equip-implant-LAST_WISH')).toBeUndefined();
+    });
+});
+```
+
+(If the test file uses different helper names/imports, adapt — read the top of the file first.)
+
+- [ ] **Step 2: Run it, verify it fails.** `npx vitest --run src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts` → FAIL (`equip-implant-LAST_WISH` not found).
+
+- [ ] **Step 3: Add the value table.** Near the other implant value tables (after the D-PR6 block, ~line 205):
+
+```ts
+// D-PR7: on-death implant value tables
+// Last Wish: repair all allies % of their max HP on death. No common variant.
+const LAST_WISH_PCT: Record<string, number> = { uncommon: 14, rare: 19, epic: 25, legendary: 32 };
+```
+
+- [ ] **Step 4: Add the registry entry.** Inside `IMPLANT_ABILITIES` (before the closing `};` at ~line 455):
+
+```ts
+// D-PR7: on-death implants ----------------------------------------------------
+// Last Wish: "Upon death, repairs X% of all allies' max HP." Rides the reactive
+// heal executor on the on-destroyed trigger (Salvation precedent); basis 'target-hp'
+// repairs each ally % of its OWN max HP. Reactive heals never crit. Fully modeled.
+LAST_WISH: (rarity) => {
+    const pct = LAST_WISH_PCT[rarity];
+    if (pct === undefined) return undefined;
+    return {
+        type: 'heal',
+        target: 'all-allies',
+        trigger: 'on-destroyed',
+        conditions: [],
+        config: { type: 'heal', pct, basis: 'target-hp', noCrit: true },
+        autoFilled: true,
+    };
+},
+```
+
+- [ ] **Step 5: Run the test, verify it passes.** `npx vitest --run src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts` → PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+git commit -m "feat(combat): D-PR7 — Last Wish implant (repair all allies on death)"
+```
+
+---
+
+## Task 2: Battlecry — Inc. Damage Down to all allies on death (emit-only)
+
+**Files:**
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (value table + buff helper + `IMPLANT_ABILITIES.BATTLECRY`)
+- Test: `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`
+
+- [ ] **Step 1: Write the failing test.**
+
+```ts
+describe('Battlecry (on-death Inc. Damage Down to allies — emit-only)', () => {
+    it('legendary → buff/all-allies/on-destroyed, Inc. Damage Down II, duration 3', () => {
+        const piece = makePiece({ id: 'bc-1', setBonus: 'BATTLECRY', rarity: 'legendary' });
+        const ship = makeShip({ implants: { implant_major: 'bc-1' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'bc-1': piece }));
+        const a = abilities.find((x) => x.id === 'equip-implant-BATTLECRY');
+        expect(a).toBeDefined();
+        expect(a!.trigger).toBe('on-destroyed');
+        expect(a!.target).toBe('all-allies');
+        expect(a!.config).toMatchObject({ type: 'buff', buffName: 'Inc. Damage Down II', duration: 3 });
+        // parsedEffects resolved from BUFFS → carries the (currently-unfolded) incomingDamage effect
+        expect((a!.config as { parsedEffects: { incomingDamage?: number } }).parsedEffects.incomingDamage).toBe(-30);
+    });
+
+    it('common → duration 1', () => {
+        const piece = makePiece({ id: 'bc-2', setBonus: 'BATTLECRY', rarity: 'common' });
+        const ship = makeShip({ implants: { implant_major: 'bc-2' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'bc-2': piece }));
+        const a = abilities.find((x) => x.id === 'equip-implant-BATTLECRY');
+        expect(a!.config).toMatchObject({ type: 'buff', duration: 1 });
+    });
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails.** FAIL (`equip-implant-BATTLECRY` not found).
+
+- [ ] **Step 3: Add imports + value table + buff helper.** At the top of `buildEquipmentAbilities.ts`, add two new import lines (neither module is imported yet):
+
+```ts
+import { BUFFS } from '../../constants/buffs';
+import { parseBuffEffects, isStackable } from '../calculators/buffParser';
+```
+
+…and add `AbilityTrigger` to the existing `../../types/abilities` import (currently `import { Ability, HealAmpCondition, IncomingCondition, OutgoingCondition } from '../../types/abilities';` — `AbilityTrigger` is NOT yet imported and the helper below needs it):
+
+```ts
+import { Ability, AbilityTrigger, HealAmpCondition, IncomingCondition, OutgoingCondition } from '../../types/abilities';
+```
+
+Value table (next to `LAST_WISH_PCT`):
+
+```ts
+// Battlecry: grant all allies a named defensive buff on death. Per-rarity = DURATION only;
+// magnitude is intrinsic to the buff tier. No uncommon variant.
+const BATTLECRY_DURATION: Record<string, number> = { common: 1, rare: 2, epic: 2, legendary: 3 };
+```
+
+Shared helper for a named-buff grant (place near the other `mk*` helpers, ~line 257):
+
+```ts
+// D-PR7: build a reactive named-buff grant (e.g. Battlecry's on-death "Inc. Damage Down II").
+// parsedEffects/stackability resolve from the canonical BUFFS entry. EMIT-ONLY for buffs whose
+// effect the engine does not yet fold (self-side incoming-damage buffs) — the status is applied
+// and logged but has no combat effect until that fold exists.
+function mkNamedBuffGrant(
+    buffName: string,
+    target: 'self' | 'ally' | 'all-allies',
+    trigger: AbilityTrigger,
+    duration: number | undefined
+): Omit<Ability, 'id'> | undefined {
+    if (duration === undefined) return undefined;
+    const buff = BUFFS.find((b) => b.name === buffName);
+    if (!buff) return undefined;
+    const { stackable, maxStacks } = isStackable(buff.description);
+    return {
+        type: 'buff',
+        target,
+        trigger,
+        conditions: [],
+        config: {
+            type: 'buff',
+            buffName,
+            parsedEffects: parseBuffEffects(buff.name, buff.description),
+            stacks: 1,
+            isStackable: stackable,
+            maxStacks,
+            duration,
+        },
+        autoFilled: true,
+    };
+}
+```
+
+- [ ] **Step 4: Add the registry entry.** Inside `IMPLANT_ABILITIES`, after `LAST_WISH`:
+
+```ts
+// Battlecry: "Upon death, grants all allies Inc. Damage Down II for N turns." EMIT-ONLY:
+// self-side "Inc. Damage Down" is not folded into incoming damage yet (victimEnemyBuffs reads
+// enemy-side only). The buff is applied + logged; lights up when self-side incoming folding lands.
+BATTLECRY: (rarity) =>
+    mkNamedBuffGrant('Inc. Damage Down II', 'all-allies', 'on-destroyed', BATTLECRY_DURATION[rarity]),
+```
+
+- [ ] **Step 5: Run the test, verify it passes.** PASS. (If `parsedEffects.incomingDamage` is not `-30`, read the `Inc. Damage Down II` entry in `buffs.ts` and `parseBuffEffects` to confirm the regex — adjust the assertion to the actual parsed value, don't force it.)
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+git commit -m "feat(combat): D-PR7 — Battlecry implant (Inc. Damage Down to allies on death, emit-only)"
+```
+
+---
+
+## Task 3: Martyrdom — apply Disable to the killer on death (emit-only registry entry)
+
+This task adds the registry entry only. Without the Task 4 engine change the Disable would land on the *default* enemy; Task 4 routes it to the killer. Keep them as separate commits so the engine change's byte-identical claim is reviewable on its own.
+
+**Files:**
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (value table + debuff helper + `IMPLANT_ABILITIES.MARTYRDOM`)
+- Test: `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`
+
+- [ ] **Step 1: Write the failing test.**
+
+```ts
+describe('Martyrdom (on-death Disable the killer — emit-only)', () => {
+    it('legendary → debuff/enemy/on-destroyed, Disable, application apply, duration 2', () => {
+        const piece = makePiece({ id: 'm-1', setBonus: 'MARTYRDOM', rarity: 'legendary' });
+        const ship = makeShip({ implants: { implant_ultimate: 'm-1' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'm-1': piece }));
+        const a = abilities.find((x) => x.id === 'equip-implant-MARTYRDOM');
+        expect(a).toBeDefined();
+        expect(a!.trigger).toBe('on-destroyed');
+        expect(a!.target).toBe('enemy');
+        expect(a!.config).toMatchObject({
+            type: 'debuff', buffName: 'Disable', application: 'apply', duration: 2,
+        });
+    });
+
+    it('rare → duration 1', () => {
+        const piece = makePiece({ id: 'm-2', setBonus: 'MARTYRDOM', rarity: 'rare' });
+        const ship = makeShip({ implants: { implant_ultimate: 'm-2' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'm-2': piece }));
+        const a = abilities.find((x) => x.id === 'equip-implant-MARTYRDOM');
+        expect(a!.config).toMatchObject({ type: 'debuff', duration: 1 });
+    });
+
+    it('epic → no ability (only rare + legendary variants exist)', () => {
+        const piece = makePiece({ id: 'm-3', setBonus: 'MARTYRDOM', rarity: 'epic' });
+        const ship = makeShip({ implants: { implant_ultimate: 'm-3' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'm-3': piece }));
+        expect(abilities.find((x) => x.id === 'equip-implant-MARTYRDOM')).toBeUndefined();
+    });
+});
+```
+
+(The implant-slot key — `implant_ultimate` vs `implant_major` — only needs to be a truthy slot in `ship.implants`; the resolution loops `Object.values(ship.implants)`. Match whatever the test file already uses if it has a convention.)
+
+- [ ] **Step 2: Run it, verify it fails.** FAIL.
+
+- [ ] **Step 3: Add the value table + debuff helper.** Value table:
+
+```ts
+// Martyrdom: apply a named debuff to the killer on death. Only rare + legendary variants.
+const MARTYRDOM_DURATION: Record<string, number> = { rare: 1, legendary: 2 };
+```
+
+Debuff helper (near `mkNamedBuffGrant`):
+
+```ts
+// D-PR7: build a reactive named-debuff application (Martyrdom's on-death "Disable" on the killer).
+// application:'apply' → lands unless affinity disadvantage (no landing roll), matching "Applies".
+// Killer routing is supplied by the on-destroyed listener via eventCtx.counterTargetId (Task 4).
+function mkNamedDebuff(
+    buffName: string,
+    trigger: AbilityTrigger,
+    duration: number | undefined
+): Omit<Ability, 'id'> | undefined {
+    if (duration === undefined) return undefined;
+    const buff = BUFFS.find((b) => b.name === buffName);
+    const parsedEffects = buff ? parseBuffEffects(buff.name, buff.description) : {};
+    return {
+        type: 'debuff',
+        target: 'enemy',
+        trigger,
+        conditions: [],
+        config: {
+            type: 'debuff',
+            buffName,
+            parsedEffects,
+            stacks: 1,
+            isStackable: false,
+            application: 'apply',
+            duration,
+        },
+        autoFilled: true,
+    };
+}
+```
+
+- [ ] **Step 4: Add the registry entry.** Inside `IMPLANT_ABILITIES`, after `BATTLECRY`:
+
+```ts
+// Martyrdom: "Applies Disable for N turns on the enemy that killed this Unit." EMIT-ONLY:
+// Disable is not a modeled turn-effect yet (only Stasis skips turns) — the debuff is applied to
+// the killer + logged. Killer routing comes from the on-destroyed listener (Task 4).
+MARTYRDOM: (rarity) => mkNamedDebuff('Disable', 'on-destroyed', MARTYRDOM_DURATION[rarity]),
+```
+
+- [ ] **Step 5: Run the test, verify it passes.** PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+git commit -m "feat(combat): D-PR7 — Martyrdom implant registry entry (Disable, emit-only)"
+```
+
+---
+
+## Task 4: Route on-destroyed debuffs to the killer (engine change)
+
+**Files:**
+- Modify: `src/utils/combat/triggers.ts` (the `on-destroyed` listener, ~line 385)
+- Test: `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts` (engine-level Martyrdom routing)
+
+- [ ] **Step 1: Write the failing test.** Add a Martyrdom block to the integration test. Build a focus ship equipped with a legendary Martyrdom implant whose HP is low enough to die to a direct hit, run combat with an enemy that deals lethal direct damage, and assert a `debuff-applied` event with `buffName:'Disable'` whose `targetId` is the **killer** id (not the default enemy). Read the file's existing harness (`makeShip`/`makePiece`/`makeGetGearPiece`/`BASE`/`runCombat`) and event-collection pattern first; mirror the closest existing reactive-on-X test. Skeleton (adapt to the harness):
+
+```ts
+describe('Martyrdom on-destroyed (killer routing)', () => {
+    it('emits Disable on the killer when killed by direct damage', () => {
+        const martyrPiece = makePiece({ id: 'm-leg', setBonus: 'MARTYRDOM', rarity: 'legendary' });
+        // ... build the dying ship with this implant via buildShipAbilitiesWithEquipment,
+        //     give it small HP, configure the enemy/attacker to land a lethal DIRECT hit,
+        //     collect events from the bus/result.
+        const events = /* collected ship-destroyed + debuff-applied events */;
+        const disable = events.filter((e) => e.type === 'debuff-applied' && e.buffName === 'Disable');
+        expect(disable.length).toBeGreaterThanOrEqual(1);
+        expect(disable[0].targetId).toBe(/* the killer's actor id, NOT the default enemy id */);
+    });
+
+    it('does NOT emit Disable when killed by non-direct (DoT) damage', () => {
+        // same setup but lethal via a DoT tick → byDirectDamage:false → no Disable
+        expect(/* debuff-applied Disable count */).toBe(0);
+    });
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails.** The first test fails because the Disable lands on the default enemy id, not the killer (or no `counterTargetId` is set). The second may already pass or fail depending on setup — both must hold after Step 3.
+
+- [ ] **Step 3: Make the engine change.** In `src/utils/combat/triggers.ts`, the `on-destroyed` case (~385), change the routing condition from `purge` only to `purge | debuff`:
+
+```ts
+case 'on-destroyed':
+    bus.on('ship-destroyed', (e) => {
+        // Self-scoped: THIS owner was destroyed (mirrors on-crit's own-id scoping).
+        // Killer-targeted reactions (Faust's PURGE, Martyrdom's DEBUFF) fire only when
+        // killed by DIRECT damage and route to the killer (counterTargetId = e.killerId).
+        // Salvation's self-destruct HEAL (and any other on-destroyed reaction) fires on ANY
+        // death, unchanged.
+        if (e.actorId !== ownerId) return;
+        if (ra.ability.config.type === 'purge' || ra.ability.config.type === 'debuff') {
+            if (!e.byDirectDamage) return;
+            enqueue({
+                ...intent,
+                eventCtx: { ...intent.eventCtx, counterTargetId: e.killerId },
+            });
+        } else {
+            enqueue(intent);
+        }
+    });
+    break;
+```
+
+- [ ] **Step 4: Run the test, verify it passes.** Both Martyrdom routing tests PASS.
+
+- [ ] **Step 5: Verify byte-identical for existing fixtures.** This change only affects an `on-destroyed` ability whose `config.type === 'debuff'`. Confirm none exist outside this PR:
+  - `npm run audit:skills` → must still report **141 ships / 0 findings**.
+  - If `docs/ship-skills.csv` is present locally: `grep -iE "upon death|when .*destroyed|when killed" docs/ship-skills.csv` and confirm none produce a debuff (expected: Faust=purge, Salvation=heal only). If the CSV is absent, the structural guarantee stands (the parser only emits `on-destroyed` for heal+purge — see spec §2.2).
+  - Run the full combat suite and confirm ZERO golden/`.snap` movement: `npm test` then `git status --short` shows no modified `*.snap` / golden files.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/utils/combat/triggers.ts src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+git commit -m "feat(combat): D-PR7 — route on-destroyed debuffs to the killer (Martyrdom)"
+```
+
+---
+
+## Task 5: Engine integration tests for Last Wish + Battlecry + enemy mirror
+
+**Files:**
+- Test: `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts`
+
+- [ ] **Step 1: Last Wish — repairs living allies.** Build a team where a non-focus ally carries a legendary Last Wish implant and dies to a lethal direct hit while at least one OTHER ally is below max HP; run with healing mode on (the `BASE` harness already enables it). Assert the surviving allies' credited repair increases on the destruction round (use the `sumHeal` helper or per-round `perActor` repair bucket), and that the dead caster is not double-credited. Mirror the closest existing reactive-heal integration test for the exact accounting bucket to assert.
+
+- [ ] **Step 2: Run it, verify it passes** (Task 1 already shipped the ability). `npx vitest --run src/utils/combat/__tests__/equipmentAbilities.integration.test.ts`.
+
+- [ ] **Step 3: Battlecry — emits the buff on all living allies (emit-only).** Build a team where a ship with a legendary Battlecry implant dies; assert a `buff-applied` event with `buffName:'Inc. Damage Down II'` fires for each living ally. Do NOT assert any incoming-damage reduction (emit-only — see spec §1.2).
+
+- [ ] **Step 4: Run it, verify it passes.**
+
+- [ ] **Step 5: Enemy-side mirror.** Add one test where an ENEMY ship carries one of these implants (Last Wish or Martyrdom) and dies, proving the same path fires against the player side (the engine is team-agnostic). For Martyrdom-as-enemy: the Disable `debuff-applied` should target the player killer. Keep it qualitative (event fires / targets the right side).
+
+- [ ] **Step 6: Run the whole integration file, verify green.** `npx vitest --run src/utils/combat/__tests__/equipmentAbilities.integration.test.ts`.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+git commit -m "test(combat): D-PR7 — engine integration for Last Wish/Battlecry + enemy mirror"
+```
+
+---
+
+## Task 6: Coverage tracker + changelog + final verification
+
+**Files:**
+- Modify: `src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+- Modify: `src/constants/changelog.ts`
+
+- [ ] **Step 1: Update the coverage tracker.** In `equipmentCoverage.test.ts`, add `BATTLECRY`, `LAST_WISH`, `MARTYRDOM` to the `implementedImplants` expected array (it asserts `.toEqual([...])` in IMPLANTS declaration order — insert each key in the position matching `src/constants/implants.ts`; `MARTYRDOM` and `BATTLECRY` and `LAST_WISH` sit at their declaration offsets). Update the `it('exactly { ... }')` test title to mention the three. Add per-rarity `implantAbilityCount` smoke assertions if the file has them for other implants (e.g. `implantAbilityCount('LAST_WISH','legendary')` ≥ 1; `MARTYRDOM` epic = 0).
+
+- [ ] **Step 2: Run it, verify it passes.** `npx vitest --run src/utils/abilities/__tests__/equipmentCoverage.test.ts`. If the `.toEqual` array order is wrong the failure message shows the expected order — match it (declaration order from `IMPLANTS`).
+
+- [ ] **Step 3: Add the changelog entry.** Append to `UNRELEASED_CHANGES` in `src/constants/changelog.ts` a plain-English line, e.g.:
+
+> "Combat simulator: on-death implants — Last Wish now repairs all allies when its carrier is destroyed. Battlecry (Inc. Damage Down to allies) and Martyrdom (Disable the killer) now apply and show in the combat log (their full combat effect arrives with a later update)."
+
+Match the existing entry format/array shape in the file.
+
+- [ ] **Step 4: Final full verification.** Run all gates from the worktree root and confirm:
+  - `npm test` → all green, and `git status --short` shows ZERO modified `*.snap`/golden files.
+  - `npm run lint` → 0 warnings.
+  - `npx tsc --noEmit` → clean.
+  - `npm run audit:skills` → 141 ships / 0 findings.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/utils/abilities/__tests__/equipmentCoverage.test.ts src/constants/changelog.ts
+git commit -m "test(combat): D-PR7 — coverage tracker + changelog for on-death implants"
+```
+
+---
+
+## Done criteria
+
+- Three implants resolve correctly per rarity (Task 1–3 unit tests).
+- Last Wish repairs living allies on death; Battlecry + Martyrdom emit their statuses (Task 4–5 integration).
+- On-destroyed debuffs route to the killer and gate on direct damage (Task 4).
+- Coverage tracker lists all three; changelog updated.
+- Full suite green, ZERO golden/`.snap` drift, lint + tsc clean, `audit:skills` 141/0.

--- a/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr7.md
+++ b/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr7.md
@@ -342,7 +342,7 @@ git commit -m "feat(combat): D-PR7 — Martyrdom implant registry entry (Disable
 - Modify: `src/utils/combat/triggers.ts` (the `on-destroyed` listener, ~line 385)
 - Test: `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts` (engine-level Martyrdom routing)
 
-- [ ] **Step 1: Write the failing test.** Add a Martyrdom block to the integration test. Build a focus ship equipped with a legendary Martyrdom implant whose HP is low enough to die to a direct hit, run combat with an enemy that deals lethal direct damage, and assert a `debuff-applied` event with `buffName:'Disable'` whose `targetId` is the **killer** id (not the default enemy). Read the file's existing harness (`makeShip`/`makePiece`/`makeGetGearPiece`/`BASE`/`runCombat`) and event-collection pattern first; mirror the closest existing reactive-on-X test. Skeleton (adapt to the harness):
+- [ ] **Step 1: Write the failing test.** Add a Martyrdom block to the integration test. Build a focus ship equipped with a legendary Martyrdom implant whose HP is low enough to die to a direct hit, run combat with an enemy that deals lethal direct damage, and assert a `debuff-applied` event with `buffName:'Disable'` whose `targetId` is the **killer** id (not the default enemy). Read the file's existing harness (`makeShip`/`makePiece`/`makeGetGearPiece`/`BASE`/`runCombat`) first. NOTE: `equipmentAbilities.integration.test.ts` has **no event-collection helper** (it asserts via heal buckets only). For event assertions, copy the `collect()` pattern from `src/utils/combat/__tests__/engine.events.test.ts` (~lines 71-93): create a bus, subscribe `bus.on(type, e => events.push(e))`, and pass it into `runCombat({ ...input, bus })`. Skeleton (adapt to the harness):
 
 ```ts
 describe('Martyrdom on-destroyed (killer routing)', () => {
@@ -438,7 +438,11 @@ git commit -m "test(combat): D-PR7 — engine integration for Last Wish/Battlecr
 - Modify: `src/utils/abilities/__tests__/equipmentCoverage.test.ts`
 - Modify: `src/constants/changelog.ts`
 
-- [ ] **Step 1: Update the coverage tracker.** In `equipmentCoverage.test.ts`, add `BATTLECRY`, `LAST_WISH`, `MARTYRDOM` to the `implementedImplants` expected array (it asserts `.toEqual([...])` in IMPLANTS declaration order — insert each key in the position matching `src/constants/implants.ts`; `MARTYRDOM` and `BATTLECRY` and `LAST_WISH` sit at their declaration offsets). Update the `it('exactly { ... }')` test title to mention the three. Add per-rarity `implantAbilityCount` smoke assertions if the file has them for other implants (e.g. `implantAbilityCount('LAST_WISH','legendary')` ≥ 1; `MARTYRDOM` epic = 0).
+- [ ] **Step 1: Update the coverage tracker — TWO places.** `equipmentCoverage.test.ts` has **two** implemented-implant enumerations; update **both** or you'll get an unexpected second failure:
+  1. The **`.toEqual([...])` array** (~line 115): add `BATTLECRY`, `LAST_WISH`, `MARTYRDOM` each at the position matching `IMPLANTS` **declaration order** in `src/constants/implants.ts` — they are **non-adjacent** (`MARTYRDOM` is declared first at line 19, `BATTLECRY` at ~1316, `LAST_WISH` at ~2217), so slot each at its own offset (the failure message prints the expected order if you get it wrong). Update the `it('exactly { ... }')` test title to mention the three.
+  2. The **`implementedImplants` Set** (~line 182), which drives a loop (~lines 332-341) asserting every implant NOT in the Set "produces 0 abilities." Add the same three keys to this Set, otherwise that loop newly fails with `MARTYRDOM/BATTLECRY/LAST_WISH produces 0 abilities`.
+  
+  Add per-rarity `implantAbilityCount` smoke assertions if the file has them for other implants (e.g. `implantAbilityCount('LAST_WISH','legendary')` ≥ 1; `implantAbilityCount('MARTYRDOM','epic')` === 0).
 
 - [ ] **Step 2: Run it, verify it passes.** `npx vitest --run src/utils/abilities/__tests__/equipmentCoverage.test.ts`. If the `.toEqual` array order is wrong the failure message shows the expected order — match it (declaration order from `IMPLANTS`).
 

--- a/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr7-design.md
+++ b/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr7-design.md
@@ -48,12 +48,21 @@ killer routing.
 
 ### 1.2 Payload fidelity
 
-- **Last Wish** — fully modeled. Reuses the reactive heal fold (no-crit, owner/recipient heal-modifier
-  channels) exactly as Salvation does.
-- **Battlecry** — fully modeled. "Inc. Damage Down II" is a canonical buff (`buffs.ts:296`) whose
-  parsed effect folds into `incomingDamageModifier` (`toEnemyModifiers` → `playerTurn.ts:1301`,
-  `(1 + incomingDamageModifier/100)`), reducing each ally's incoming damage. The per-rarity difference
-  is **duration only**; magnitude is intrinsic to the named buff tier ("II").
+- **Last Wish** — **fully modeled**. Reuses the reactive heal fold (no-crit, owner/recipient
+  heal-modifier channels) exactly as Salvation does. The only on-death implant with real combat impact
+  in this PR.
+- **Battlecry** — **emit-only** (user-confirmed scope). The buff executor applies the canonical
+  "Inc. Damage Down II" buff (`buffs.ts:296`, `-30% Incoming Direct Damage`) to all allies as a
+  **self-side** status and emits `buff-applied`, but it has **no combat effect yet**. The engine only
+  folds incoming-damage modifiers from **enemy-side** statuses on the victim (`victimEnemyBuffs` reads
+  `side:'enemy'` only; the self-buff totals in `buffTotals.ts` fold attack/crit/defence/hp/speed/heal —
+  **not** `incomingDamage`). A unit's own "Inc. Damage Down" self-buff is therefore never folded into the
+  damage it takes. (This is exactly why D-PR3 built dedicated victim-side `incoming-reduction` machinery
+  rather than reusing the named-buff path.) Making Battlecry real requires a **self-side
+  incoming-damage-buff fold** in the victim damage path — a cross-cutting mechanic affecting every ship
+  that self/ally-grants Inc. Damage Down (Makoli, Salvation, Shelter, Refine…) and moving goldens. That
+  is its own PR; Battlecry lights up for free once it lands. The per-rarity difference is **duration
+  only** (magnitude is intrinsic to the named buff tier).
 - **Martyrdom** — **Disable is emit-only** (user-chosen scope). The `debuff-applied` event fires and the
   named "Disable" status is applied to the killer, but Disable has **no turn-effect today** (only Stasis
   is a modeled turn-skip control; `control-applied`/non-Stasis statuses are emit-only). Disable's actual
@@ -129,8 +138,9 @@ Add `BATTLECRY`, `LAST_WISH`, `MARTYRDOM` to the implemented-implants set (IMPLA
 ship-destroyed{actorId, killerId, byDirectDamage}
    └─ on-destroyed listener (actorId === ownerId)
         ├─ Last Wish  (heal,  all-allies) → reactive heal fold → repair living allies % of their max HP
-        ├─ Battlecry  (buff,  all-allies) → applyTimedAbilityStatus "Inc. Damage Down II" to ctx.playerIds
-        │                                    → folds into each ally's incomingDamageModifier next turn
+        ├─ Battlecry  (buff,  all-allies) → applyTimedAbilityStatus "Inc. Damage Down II" (self-side) to
+        │                                    ctx.playerIds + buff-applied event (EMIT-ONLY — self-side
+        │                                    incoming buffs are not folded into incoming damage yet)
         └─ Martyrdom  (debuff, enemy)     → [byDirectDamage gate] counterTargetId = killerId
                                              → landing gate → applyTimedAbilityStatus "Disable" on killer
                                              → debuff-applied event (emit-only; no turn-effect yet)
@@ -157,8 +167,9 @@ any of these implants triggers the same paths against the player side.
 - **Integration (`equipmentAbilities.integration.test.ts` or sibling):**
   - Last Wish: on a carrier's destruction, living allies' HP rises (gross heal credited); dead caster not
     double-credited.
-  - Battlecry: on destruction, all living allies gain "Inc. Damage Down II" (`buff-applied` per ally) and
-    take reduced incoming damage the following turn.
+  - Battlecry: on destruction, all living allies gain "Inc. Damage Down II" (`buff-applied` per ally).
+    Emit-only — assert the events fire; do NOT assert reduced incoming damage (the self-side buff is not
+    folded yet).
   - Martyrdom: on direct-damage death, `debuff-applied` "Disable" lands on the **killer** id (not the
     default enemy); on a non-direct death, no `debuff-applied`.
   - One enemy-side mirror (an enemy carrier dying applies to a player killer) to lock symmetry.
@@ -168,6 +179,10 @@ any of these implants triggers the same paths against the player side.
 
 ## 6. Out of scope / deferred
 
+- **Self-side incoming-damage-buff folding** — making a unit's own / ally-granted "Inc. Damage Down"
+  (and "Inc. Damage Up") actually modify the damage it takes, by gathering the victim's self-side
+  statuses into the incoming-damage fold. Cross-cutting (Makoli/Salvation/Shelter/Refine + Battlecry);
+  golden-moving. Its own PR. Battlecry lights up for free once it lands.
 - **Disable as a turn-effect** — modeling Disable's "prevents active + passive skills" suppression for
   all ~6 inflicting ships. Its own control PR (sub-project B extension). Martyrdom lights up for free
   once it lands.

--- a/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr7-design.md
+++ b/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr7-design.md
@@ -1,0 +1,183 @@
+# Combat Realism Epic — Sub-project D, PR7: On-death Implants (Design)
+
+**Date:** 2026-06-21
+**Sub-project:** D (new ability sources: implants + gear-set skills), seventh PR.
+**Parent spec:** `docs/superpowers/specs/2026-06-20-implant-gearset-abilities-D-design.md`.
+**Builds on:** D-PR1..D-PR6 — `buildEquipmentAbilities` registry, `buildShipAbilitiesWithEquipment`
+passive-slot merge, equipment coverage tracker, the reactive trigger system (`triggers.ts`).
+**Branch:** `feat/combat-d-pr7-on-death`, stacked on the D-PR6 tip `237ddee7`.
+**Status:** design (brainstorm complete, user-approved through all sections).
+
+## 1. Context
+
+D-PR1..D-PR6 shipped the equipment-ability source layer plus heal/leech, conditional outgoing-damage,
+conditional incoming-reduction, outgoing-amplification, and cast/received heal-amplification effects.
+This PR lights up the **on-death** bucket — the three implants whose effect fires "upon death" / "when
+this unit is destroyed":
+
+- **Last Wish** (`src/constants/implants.ts`, type `major`) — "Upon death, repairs X% of all allies'
+  max HP." X = 14/19/25/32 by rarity (uncommon/rare/epic/legendary). No common variant.
+- **Battlecry** (type `major`) — "Upon death, grants all allies Inc. Damage Down II for N turns."
+  N = 1/2/2/3 by rarity (common/rare/epic/legendary).
+- **Martyrdom** (type `ultimate`) — "Applies Disable for N turns on the enemy that killed this Unit."
+  N = 1/2 by rarity (rare/legendary). Only the rare + legendary variants exist.
+
+All three are **deterministic** — none of the implant texts carry a proc chance.
+
+### 1.1 Key finding: the trigger, killer-identity, and all three payload paths already exist
+
+A code-read showed the on-death machinery is almost entirely already present:
+
+- **`on-destroyed` trigger** (`triggers.ts` ~378) — self-scoped (`e.actorId === ownerId`), fires on the
+  `ship-destroyed` event. Salvation's self-destruct heal already rides it; Faust's purge rides it and
+  targets the killer.
+- **Killer identity** — the `ship-destroyed` event already carries `killerId` and `byDirectDamage`
+  (`events.ts` ~159; stamped by `recordDestroyed`, `state.ts:177`). Faust's on-destroyed purge already
+  routes `counterTargetId = e.killerId` to hit the killer.
+- **Reactive payload executors** (`triggers.ts` ~964+) already support:
+  - `type:'heal'` with `target:'all-allies'` and `basis:'target-hp'` (each recipient repairs % of **its
+    own** max HP — resolved per-recipient inside the heal loop, ~1167). Dead recipients (incl. the dead
+    caster) are skipped from credit (~1189). **→ Last Wish.**
+  - `type:'buff'` with `target:'all-allies'` (grants to every same-side id `ctx.playerIds`, with a
+    `duration`; emits `buff-applied`). **→ Battlecry.**
+  - `type:'debuff'` with killer routing via `intent.eventCtx.counterTargetId` + the owner's landing gate
+    (`landsTimedEnemyApplication`; emits `debuff-applied`). **→ Martyrdom.**
+
+So the PR is mostly **three registry entries** plus **one surgical engine change** for Martyrdom's
+killer routing.
+
+### 1.2 Payload fidelity
+
+- **Last Wish** — fully modeled. Reuses the reactive heal fold (no-crit, owner/recipient heal-modifier
+  channels) exactly as Salvation does.
+- **Battlecry** — fully modeled. "Inc. Damage Down II" is a canonical buff (`buffs.ts:296`) whose
+  parsed effect folds into `incomingDamageModifier` (`toEnemyModifiers` → `playerTurn.ts:1301`,
+  `(1 + incomingDamageModifier/100)`), reducing each ally's incoming damage. The per-rarity difference
+  is **duration only**; magnitude is intrinsic to the named buff tier ("II").
+- **Martyrdom** — **Disable is emit-only** (user-chosen scope). The `debuff-applied` event fires and the
+  named "Disable" status is applied to the killer, but Disable has **no turn-effect today** (only Stasis
+  is a modeled turn-skip control; `control-applied`/non-Stasis statuses are emit-only). Disable's actual
+  suppression ("prevents activation of passive and active skills", `buffs.ts:61`) is shared by ~6 ships
+  (APEX, IonScorp, Makoli, Tygr, Xcellence, Yuyan) and belongs in a dedicated control PR, not the
+  on-death bucket. Martyrdom therefore surfaces correctly on the event log and applies a real (if inert)
+  status now, and lights up for free when Disable's effect is later modeled.
+
+## 2. Architecture
+
+Pure additive registry work + one targeted listener extension. No new types, no new ConditionSubject,
+no new executor branch.
+
+### 2.1 Registry entries (`src/utils/abilities/buildEquipmentAbilities.ts`)
+
+Three new `IMPLANT_ABILITIES` entries, values baked per-rarity from `implants.ts`, following the
+established `() => Omit<Ability, 'id'>` pattern. Each is placed in the passive slot via the existing
+`buildShipAbilitiesWithEquipment` wrapper (untouched). Stable ids `equip-implant-${name}-${gearId}`.
+
+| Implant | `trigger` | `type` | `target` | config |
+|---|---|---|---|---|
+| **Last Wish** | `on-destroyed` | `heal` | `all-allies` | `basis:'target-hp'`, `pct` 14/19/25/32, `noCrit:true` |
+| **Battlecry** | `on-destroyed` | `buff` | `all-allies` | `buffName:'Inc. Damage Down II'`, `duration` 1/2/2/3 |
+| **Martyrdom** | `on-destroyed` | `debuff` | `enemy` | `buffName:'Disable'`, `duration` 1/2 |
+
+Rarity → variant resolution reuses the existing implant rarity-picking helper. Variants that don't exist
+(Battlecry has no uncommon; Last Wish has no common; Martyrdom has only rare + legendary) simply produce
+no ability for that rarity — graceful skip, never throw (existing registry contract).
+
+### 2.2 Engine change: killer routing for on-destroyed debuffs (`triggers.ts` ~385)
+
+Today the `on-destroyed` listener routes the killer **only** for `purge`:
+
+```ts
+if (ra.ability.config.type === 'purge') {
+    if (!e.byDirectDamage) return;
+    enqueue({ ...intent, eventCtx: { ...intent.eventCtx, counterTargetId: e.killerId } });
+} else {
+    enqueue(intent);
+}
+```
+
+Extend the killer-routing branch to `purge | debuff`:
+
+```ts
+if (ra.ability.config.type === 'purge' || ra.ability.config.type === 'debuff') {
+    if (!e.byDirectDamage) return;            // no direct killer (e.g. DoT death) → no application
+    enqueue({ ...intent, eventCtx: { ...intent.eventCtx, counterTargetId: e.killerId } });
+} else {
+    enqueue(intent);
+}
+```
+
+This makes a Martyrdom-style on-destroyed debuff (a) gate on `byDirectDamage` (a unit killed by a DoT has
+no clear killer → the implant does nothing, matching "the enemy that killed this Unit") and (b) land on
+the killer via `counterTargetId` rather than the default enemy store.
+
+**Byte-identical claim + the one risk.** This change alters behavior only for an `on-destroyed` ability
+whose `config.type === 'debuff'`. A survey of `docs/ship-skills.csv` shows the only self-`on-destroyed`
+ship reactions are **Faust** (purge) and **Salvation** (heal) — **no ship produces an on-destroyed
+debuff.** Martyrdom is the first. So for every existing fixture this branch is unreached and the run is
+byte-identical. The plan MUST re-verify this with `npm run audit:skills` + a grep, and assert zero
+golden/`.snap` movement. (Liberator/Madax "when an enemy dies" are `on-enemy-destroyed`, a different
+listener — unaffected.)
+
+### 2.3 Coverage tracker (`equipmentCoverage.test.ts`)
+
+Add `BATTLECRY`, `LAST_WISH`, `MARTYRDOM` to the implemented-implants set (IMPLANTS declaration order).
+
+## 3. Data flow
+
+```
+ship-destroyed{actorId, killerId, byDirectDamage}
+   └─ on-destroyed listener (actorId === ownerId)
+        ├─ Last Wish  (heal,  all-allies) → reactive heal fold → repair living allies % of their max HP
+        ├─ Battlecry  (buff,  all-allies) → applyTimedAbilityStatus "Inc. Damage Down II" to ctx.playerIds
+        │                                    → folds into each ally's incomingDamageModifier next turn
+        └─ Martyrdom  (debuff, enemy)     → [byDirectDamage gate] counterTargetId = killerId
+                                             → landing gate → applyTimedAbilityStatus "Disable" on killer
+                                             → debuff-applied event (emit-only; no turn-effect yet)
+```
+
+Symmetric by construction: the engine is team-agnostic post-bySide-unification, so an enemy ship with
+any of these implants triggers the same paths against the player side.
+
+## 4. Edge cases
+
+- **Last Wish dead-caster credit** — `recipients = ctx.playerIds` includes the just-destroyed caster; the
+  existing dead-recipient skip (~1189) drops it from gross credit. Living allies repair normally.
+- **Martyrdom non-direct death** — DoT/indirect kill → `byDirectDamage:false` → no application (no clear
+  killer). Matches the implant text.
+- **Martyrdom landing** — the Disable application draws the **owner's** landing gate
+  (`landsTimedEnemyApplication`), consistent with every other debuff (a Disable can be resisted).
+- **No effect-bearing gear in fixtures** — registry additions are inert for existing combat fixtures →
+  no golden/`.snap` movement from §2.1 / §2.3.
+
+## 5. Testing
+
+- **Registry unit test** — the three implants resolve to the correct config (trigger/type/target/basis/
+  pct/buffName/duration) per rarity; non-existent rarities produce nothing.
+- **Integration (`equipmentAbilities.integration.test.ts` or sibling):**
+  - Last Wish: on a carrier's destruction, living allies' HP rises (gross heal credited); dead caster not
+    double-credited.
+  - Battlecry: on destruction, all living allies gain "Inc. Damage Down II" (`buff-applied` per ally) and
+    take reduced incoming damage the following turn.
+  - Martyrdom: on direct-damage death, `debuff-applied` "Disable" lands on the **killer** id (not the
+    default enemy); on a non-direct death, no `debuff-applied`.
+  - One enemy-side mirror (an enemy carrier dying applies to a player killer) to lock symmetry.
+- **Coverage tracker** updated per §2.3.
+- **Byte-identical gate:** full suite green with ZERO golden/`.snap` drift; `npm run audit:skills`
+  unchanged (141/0); lint + tsc clean.
+
+## 6. Out of scope / deferred
+
+- **Disable as a turn-effect** — modeling Disable's "prevents active + passive skills" suppression for
+  all ~6 inflicting ships. Its own control PR (sub-project B extension). Martyrdom lights up for free
+  once it lands.
+- All other remaining D effects (Voidfire Catalyst bomb modifier; reactive self/ally buffs; charge/DoT/
+  cleanse net-new; Boost/Cloaking; Warpstrike duration-reduction half; CF/Provoke appliers).
+
+## 7. Files touched
+
+- `src/utils/abilities/buildEquipmentAbilities.ts` — 3 registry entries (+ rarity baking).
+- `src/utils/combat/triggers.ts` — `purge` → `purge | debuff` killer-routing in the on-destroyed listener.
+- `src/utils/abilities/__tests__/equipmentCoverage.test.ts` — implemented set += 3.
+- `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts` (+ registry unit test sibling).
+- `src/constants/changelog.ts` — `UNRELEASED_CHANGES` entry.

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -16,6 +16,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat simulator now models three outgoing-damage amplification implants: Menace (chance to amplify a hit's damage on a critical hit), Giant Slayer (chance to amplify a hit's damage against an enemy with higher attack), and Insidiousness (chance to deal bonus damage when you apply a debuff to an enemy).",
     'Combat simulator now models three more heal implants: Second Wind (chance to repair itself when it takes a critical hit), Nourishment (stronger repairs on allies with less HP than the healer), and Vivacious Repair (chance to double a repair on an ally below 25% HP).',
     'Combat simulator now models the Exuberance implant (chance to increase the amount of a repair this unit receives).',
+    'Combat simulator now models three on-death implants: Last Wish (repairs all allies when the carrier is destroyed), Battlecry (grants all allies Inc. Damage Down II on death), and Martyrdom (applies Disable to the unit that landed the killing blow). Last Wish is fully resolved; Battlecry and Martyrdom apply and appear in the combat log with full effects coming in a later update.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -593,7 +593,7 @@ describe('Last Wish (on-death repair all allies)', () => {
         const piece = makePiece({ id: 'lw-1', setBonus: 'LAST_WISH', rarity: 'legendary' });
         const ship = makeShip({ implants: { implant_major: 'lw-1' } });
         const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'lw-1': piece }));
-        const a = abilities.find((x) => x.id === 'equip-implant-LAST_WISH');
+        const a = abilities.find((x) => x.id.startsWith('equip-implant-LAST_WISH'));
         expect(a).toBeDefined();
         expect(a!.trigger).toBe('on-destroyed');
         expect(a!.target).toBe('all-allies');
@@ -608,14 +608,14 @@ describe('Last Wish (on-death repair all allies)', () => {
         const piece = makePiece({ id: 'lw-2', setBonus: 'LAST_WISH', rarity: 'uncommon' });
         const ship = makeShip({ implants: { implant_major: 'lw-2' } });
         const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'lw-2': piece }));
-        const a = abilities.find((x) => x.id === 'equip-implant-LAST_WISH');
+        const a = abilities.find((x) => x.id.startsWith('equip-implant-LAST_WISH'));
         expect(a!.config).toMatchObject({ type: 'heal', pct: 14 });
     });
     it('common → no ability (no common variant)', () => {
         const piece = makePiece({ id: 'lw-3', setBonus: 'LAST_WISH', rarity: 'common' });
         const ship = makeShip({ implants: { implant_major: 'lw-3' } });
         const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'lw-3': piece }));
-        expect(abilities.find((x) => x.id === 'equip-implant-LAST_WISH')).toBeUndefined();
+        expect(abilities.find((x) => x.id.startsWith('equip-implant-LAST_WISH'))).toBeUndefined();
     });
 });
 
@@ -659,7 +659,7 @@ describe('Battlecry (on-death Inc. Damage Down to allies — emit-only)', () => 
         const piece = makePiece({ id: 'bc-1', setBonus: 'BATTLECRY', rarity: 'legendary' });
         const ship = makeShip({ implants: { implant_major: 'bc-1' } });
         const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'bc-1': piece }));
-        const a = abilities.find((x) => x.id === 'equip-implant-BATTLECRY');
+        const a = abilities.find((x) => x.id.startsWith('equip-implant-BATTLECRY'));
         expect(a).toBeDefined();
         expect(a!.trigger).toBe('on-destroyed');
         expect(a!.target).toBe('all-allies');
@@ -677,7 +677,7 @@ describe('Battlecry (on-death Inc. Damage Down to allies — emit-only)', () => 
         const piece = makePiece({ id: 'bc-2', setBonus: 'BATTLECRY', rarity: 'common' });
         const ship = makeShip({ implants: { implant_major: 'bc-2' } });
         const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'bc-2': piece }));
-        const a = abilities.find((x) => x.id === 'equip-implant-BATTLECRY');
+        const a = abilities.find((x) => x.id.startsWith('equip-implant-BATTLECRY'));
         expect(a!.config).toMatchObject({ type: 'buff', duration: 1 });
     });
 });
@@ -690,7 +690,7 @@ describe('Martyrdom (on-death Disable the killer — emit-only)', () => {
         const piece = makePiece({ id: 'm-1', setBonus: 'MARTYRDOM', rarity: 'legendary' });
         const ship = makeShip({ implants: { implant_ultimate: 'm-1' } });
         const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'm-1': piece }));
-        const a = abilities.find((x) => x.id === 'equip-implant-MARTYRDOM');
+        const a = abilities.find((x) => x.id.startsWith('equip-implant-MARTYRDOM'));
         expect(a).toBeDefined();
         expect(a!.trigger).toBe('on-destroyed');
         expect(a!.target).toBe('enemy');
@@ -705,13 +705,13 @@ describe('Martyrdom (on-death Disable the killer — emit-only)', () => {
         const piece = makePiece({ id: 'm-2', setBonus: 'MARTYRDOM', rarity: 'rare' });
         const ship = makeShip({ implants: { implant_ultimate: 'm-2' } });
         const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'm-2': piece }));
-        const a = abilities.find((x) => x.id === 'equip-implant-MARTYRDOM');
+        const a = abilities.find((x) => x.id.startsWith('equip-implant-MARTYRDOM'));
         expect(a!.config).toMatchObject({ type: 'debuff', duration: 1 });
     });
     it('epic → no ability (only rare + legendary variants exist)', () => {
         const piece = makePiece({ id: 'm-3', setBonus: 'MARTYRDOM', rarity: 'epic' });
         const ship = makeShip({ implants: { implant_ultimate: 'm-3' } });
         const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'm-3': piece }));
-        expect(abilities.find((x) => x.id === 'equip-implant-MARTYRDOM')).toBeUndefined();
+        expect(abilities.find((x) => x.id.startsWith('equip-implant-MARTYRDOM'))).toBeUndefined();
     });
 });

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -650,3 +650,34 @@ describe('Second Wind implant', () => {
         expect(buildForImplant('SECOND_WIND', 'common')).toEqual([]);
     });
 });
+
+// ---------------------------------------------------------------------------
+// D-PR7: Battlecry (on-death Inc. Damage Down to allies — emit-only)
+// ---------------------------------------------------------------------------
+describe('Battlecry (on-death Inc. Damage Down to allies — emit-only)', () => {
+    it('legendary → buff/all-allies/on-destroyed, Inc. Damage Down II, duration 3', () => {
+        const piece = makePiece({ id: 'bc-1', setBonus: 'BATTLECRY', rarity: 'legendary' });
+        const ship = makeShip({ implants: { implant_major: 'bc-1' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'bc-1': piece }));
+        const a = abilities.find((x) => x.id === 'equip-implant-BATTLECRY');
+        expect(a).toBeDefined();
+        expect(a!.trigger).toBe('on-destroyed');
+        expect(a!.target).toBe('all-allies');
+        expect(a!.config).toMatchObject({
+            type: 'buff',
+            buffName: 'Inc. Damage Down II',
+            duration: 3,
+        });
+        expect(
+            (a!.config as { parsedEffects: { incomingDamage?: number } }).parsedEffects
+                .incomingDamage
+        ).toBe(-30);
+    });
+    it('common → duration 1', () => {
+        const piece = makePiece({ id: 'bc-2', setBonus: 'BATTLECRY', rarity: 'common' });
+        const ship = makeShip({ implants: { implant_major: 'bc-2' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'bc-2': piece }));
+        const a = abilities.find((x) => x.id === 'equip-implant-BATTLECRY');
+        expect(a!.config).toMatchObject({ type: 'buff', duration: 1 });
+    });
+});

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -574,7 +574,7 @@ describe('Exuberance implant', () => {
         const ab = abilities[0];
         if (ab.config.type === 'incoming-heal-amplification') {
             expect(ab.config.ampPct).toBe(15);
-            expect(ab.config.procChance).toBeCloseTo(0.30);
+            expect(ab.config.procChance).toBeCloseTo(0.3);
         } else {
             throw new Error('Expected incoming-heal-amplification config');
         }
@@ -582,6 +582,40 @@ describe('Exuberance implant', () => {
 
     it('common → no ability (no common variant)', () => {
         expect(buildForImplant('EXUBERANCE', 'common')).toEqual([]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// D-PR7: Last Wish (on-death repair all allies)
+// ---------------------------------------------------------------------------
+describe('Last Wish (on-death repair all allies)', () => {
+    it('legendary → heal/all-allies/on-destroyed, basis target-hp, pct 32, noCrit', () => {
+        const piece = makePiece({ id: 'lw-1', setBonus: 'LAST_WISH', rarity: 'legendary' });
+        const ship = makeShip({ implants: { implant_major: 'lw-1' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'lw-1': piece }));
+        const a = abilities.find((x) => x.id === 'equip-implant-LAST_WISH');
+        expect(a).toBeDefined();
+        expect(a!.trigger).toBe('on-destroyed');
+        expect(a!.target).toBe('all-allies');
+        expect(a!.config).toMatchObject({
+            type: 'heal',
+            basis: 'target-hp',
+            pct: 32,
+            noCrit: true,
+        });
+    });
+    it('uncommon → pct 14', () => {
+        const piece = makePiece({ id: 'lw-2', setBonus: 'LAST_WISH', rarity: 'uncommon' });
+        const ship = makeShip({ implants: { implant_major: 'lw-2' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'lw-2': piece }));
+        const a = abilities.find((x) => x.id === 'equip-implant-LAST_WISH');
+        expect(a!.config).toMatchObject({ type: 'heal', pct: 14 });
+    });
+    it('common → no ability (no common variant)', () => {
+        const piece = makePiece({ id: 'lw-3', setBonus: 'LAST_WISH', rarity: 'common' });
+        const ship = makeShip({ implants: { implant_major: 'lw-3' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'lw-3': piece }));
+        expect(abilities.find((x) => x.id === 'equip-implant-LAST_WISH')).toBeUndefined();
     });
 });
 

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -681,3 +681,37 @@ describe('Battlecry (on-death Inc. Damage Down to allies — emit-only)', () => 
         expect(a!.config).toMatchObject({ type: 'buff', duration: 1 });
     });
 });
+
+// ---------------------------------------------------------------------------
+// D-PR7: Martyrdom (on-death Disable the killer — emit-only)
+// ---------------------------------------------------------------------------
+describe('Martyrdom (on-death Disable the killer — emit-only)', () => {
+    it('legendary → debuff/enemy/on-destroyed, Disable, application apply, duration 2', () => {
+        const piece = makePiece({ id: 'm-1', setBonus: 'MARTYRDOM', rarity: 'legendary' });
+        const ship = makeShip({ implants: { implant_ultimate: 'm-1' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'm-1': piece }));
+        const a = abilities.find((x) => x.id === 'equip-implant-MARTYRDOM');
+        expect(a).toBeDefined();
+        expect(a!.trigger).toBe('on-destroyed');
+        expect(a!.target).toBe('enemy');
+        expect(a!.config).toMatchObject({
+            type: 'debuff',
+            buffName: 'Disable',
+            application: 'apply',
+            duration: 2,
+        });
+    });
+    it('rare → duration 1', () => {
+        const piece = makePiece({ id: 'm-2', setBonus: 'MARTYRDOM', rarity: 'rare' });
+        const ship = makeShip({ implants: { implant_ultimate: 'm-2' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'm-2': piece }));
+        const a = abilities.find((x) => x.id === 'equip-implant-MARTYRDOM');
+        expect(a!.config).toMatchObject({ type: 'debuff', duration: 1 });
+    });
+    it('epic → no ability (only rare + legendary variants exist)', () => {
+        const piece = makePiece({ id: 'm-3', setBonus: 'MARTYRDOM', rarity: 'epic' });
+        const ship = makeShip({ implants: { implant_ultimate: 'm-3' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'm-3': piece }));
+        expect(abilities.find((x) => x.id === 'equip-implant-MARTYRDOM')).toBeUndefined();
+    });
+});

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -99,7 +99,7 @@ function implantAbilityCount(implantKey: string, rarity: GearPiece['rarity']): n
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { LEECH + HARDENED (gear sets), ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + BATTLECRY + BLOODTHIRST + EXUBERANCE + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + MENACE + SECOND_WIND + SHADOWGUARD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
+    it('exactly { LEECH + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + BATTLECRY + BLOODTHIRST + EXUBERANCE + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + MENACE + SECOND_WIND + SHADOWGUARD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -113,6 +113,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
             return variants.some((v) => implantAbilityCount(key, v.rarity) > 0);
         });
         expect(implementedImplants).toEqual([
+            'MARTYRDOM',
             'ARCANE_SIEGE',
             'HYPERION_GAZE',
             'INTRUSION',
@@ -181,7 +182,7 @@ describe('equipmentCoverage — implants', () => {
     // D-PR4: MENACE, GIANT_SLAYER, INSIDIOUSNESS added (outgoing-amplification on-crit / vs higher-attack / on-debuff).
     // D-PR5: SECOND_WIND, NOURISHMENT, VIVACIOUS_REPAIR added (reactive-heal family).
     // D-PR6: EXUBERANCE added (repair-amplification on-repair chance).
-    // D-PR7: LAST_WISH, BATTLECRY added (on-death repair / buff to allies).
+    // D-PR7: LAST_WISH, BATTLECRY, MARTYRDOM added (on-death repair / buff to allies / disable killer).
     const implementedImplants = new Set([
         'BLOODTHIRST',
         'INTRUSION',
@@ -202,6 +203,7 @@ describe('equipmentCoverage — implants', () => {
         'EXUBERANCE',
         'LAST_WISH',
         'BATTLECRY',
+        'MARTYRDOM',
     ]);
 
     it('INTRUSION produces 1 ability per rarity (outgoingDamage modifier with scaling)', () => {
@@ -349,6 +351,11 @@ describe('equipmentCoverage — implants', () => {
         for (const v of variants) {
             expect(implantAbilityCount('BATTLECRY', v.rarity)).toBe(1);
         }
+    });
+
+    it('MARTYRDOM produces 1 ability for rare + legendary (Disable on killer on death; only 2 variants)', () => {
+        expect(implantAbilityCount('MARTYRDOM', 'rare')).toBe(1);
+        expect(implantAbilityCount('MARTYRDOM', 'legendary')).toBe(1);
     });
 
     const unimplementedImplants = Object.keys(IMPLANTS).filter((k) => !implementedImplants.has(k));

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -99,7 +99,7 @@ function implantAbilityCount(implantKey: string, rarity: GearPiece['rarity']): n
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { LEECH + HARDENED (gear sets), ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + BLOODTHIRST + EXUBERANCE + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + MENACE + SECOND_WIND + SHADOWGUARD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
+    it('exactly { LEECH + HARDENED (gear sets), ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + BATTLECRY + BLOODTHIRST + EXUBERANCE + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + MENACE + SECOND_WIND + SHADOWGUARD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -121,6 +121,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
             'VOIDSHADE',
             'VORTEX_VEIL',
             'WARPSTRIKE',
+            'BATTLECRY',
             'BLOODTHIRST',
             'EXUBERANCE',
             'GIANT_SLAYER',
@@ -180,7 +181,7 @@ describe('equipmentCoverage — implants', () => {
     // D-PR4: MENACE, GIANT_SLAYER, INSIDIOUSNESS added (outgoing-amplification on-crit / vs higher-attack / on-debuff).
     // D-PR5: SECOND_WIND, NOURISHMENT, VIVACIOUS_REPAIR added (reactive-heal family).
     // D-PR6: EXUBERANCE added (repair-amplification on-repair chance).
-    // D-PR7: LAST_WISH added (on-death repair all allies).
+    // D-PR7: LAST_WISH, BATTLECRY added (on-death repair / buff to allies).
     const implementedImplants = new Set([
         'BLOODTHIRST',
         'INTRUSION',
@@ -200,6 +201,7 @@ describe('equipmentCoverage — implants', () => {
         'VIVACIOUS_REPAIR',
         'EXUBERANCE',
         'LAST_WISH',
+        'BATTLECRY',
     ]);
 
     it('INTRUSION produces 1 ability per rarity (outgoingDamage modifier with scaling)', () => {
@@ -338,6 +340,14 @@ describe('equipmentCoverage — implants', () => {
         const variants = IMPLANTS['LAST_WISH'].variants;
         for (const v of variants) {
             expect(implantAbilityCount('LAST_WISH', v.rarity)).toBe(1);
+        }
+    });
+
+    it('BATTLECRY produces 1 ability per rarity (Inc. Damage Down to allies on death; no uncommon variant)', () => {
+        expect(implantAbilityCount('BATTLECRY', 'uncommon')).toBe(0);
+        const variants = IMPLANTS['BATTLECRY'].variants;
+        for (const v of variants) {
+            expect(implantAbilityCount('BATTLECRY', v.rarity)).toBe(1);
         }
     });
 

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -354,8 +354,15 @@ describe('equipmentCoverage — implants', () => {
     });
 
     it('MARTYRDOM produces 1 ability for rare + legendary (Disable on killer on death; only 2 variants)', () => {
-        expect(implantAbilityCount('MARTYRDOM', 'rare')).toBe(1);
-        expect(implantAbilityCount('MARTYRDOM', 'legendary')).toBe(1);
+        // Unsupported rarities (no variant) produce nothing — symmetric with the
+        // siblings above, guarding against accidental expansion of supported rarities.
+        expect(implantAbilityCount('MARTYRDOM', 'common')).toBe(0);
+        expect(implantAbilityCount('MARTYRDOM', 'uncommon')).toBe(0);
+        expect(implantAbilityCount('MARTYRDOM', 'epic')).toBe(0);
+        const variants = IMPLANTS['MARTYRDOM'].variants;
+        for (const v of variants) {
+            expect(implantAbilityCount('MARTYRDOM', v.rarity)).toBe(1);
+        }
     });
 
     const unimplementedImplants = Object.keys(IMPLANTS).filter((k) => !implementedImplants.has(k));

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -99,7 +99,7 @@ function implantAbilityCount(implantKey: string, rarity: GearPiece['rarity']): n
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { LEECH + HARDENED (gear sets), ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + BLOODTHIRST + EXUBERANCE + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + MENACE + SECOND_WIND + SHADOWGUARD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
+    it('exactly { LEECH + HARDENED (gear sets), ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + BLOODTHIRST + EXUBERANCE + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + MENACE + SECOND_WIND + SHADOWGUARD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -126,6 +126,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
             'GIANT_SLAYER',
             'INSIDIOUSNESS',
             'IRONCLAD',
+            'LAST_WISH',
             'MENACE',
             'SECOND_WIND',
             'SHADOWGUARD',
@@ -179,6 +180,7 @@ describe('equipmentCoverage — implants', () => {
     // D-PR4: MENACE, GIANT_SLAYER, INSIDIOUSNESS added (outgoing-amplification on-crit / vs higher-attack / on-debuff).
     // D-PR5: SECOND_WIND, NOURISHMENT, VIVACIOUS_REPAIR added (reactive-heal family).
     // D-PR6: EXUBERANCE added (repair-amplification on-repair chance).
+    // D-PR7: LAST_WISH added (on-death repair all allies).
     const implementedImplants = new Set([
         'BLOODTHIRST',
         'INTRUSION',
@@ -197,6 +199,7 @@ describe('equipmentCoverage — implants', () => {
         'NOURISHMENT',
         'VIVACIOUS_REPAIR',
         'EXUBERANCE',
+        'LAST_WISH',
     ]);
 
     it('INTRUSION produces 1 ability per rarity (outgoingDamage modifier with scaling)', () => {
@@ -326,6 +329,15 @@ describe('equipmentCoverage — implants', () => {
         const variants = IMPLANTS['EXUBERANCE'].variants;
         for (const v of variants) {
             expect(implantAbilityCount('EXUBERANCE', v.rarity)).toBe(1);
+        }
+    });
+
+    // D-PR7: on-death implants
+    it('LAST_WISH produces 1 ability per rarity (repair all allies on death; no common variant)', () => {
+        expect(implantAbilityCount('LAST_WISH', 'common')).toBe(0);
+        const variants = IMPLANTS['LAST_WISH'].variants;
+        for (const v of variants) {
+            expect(implantAbilityCount('LAST_WISH', v.rarity)).toBe(1);
         }
     });
 

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -23,9 +23,12 @@
 
 import { GEAR_SETS } from '../../constants/gearSets';
 import { IMPLANTS } from '../../constants/implants';
+import { BUFFS } from '../../constants/buffs';
+import { parseBuffEffects, isStackable } from '../calculators/buffParser';
 import { GearPiece } from '../../types/gear';
 import {
     Ability,
+    AbilityTrigger,
     HealAmpCondition,
     IncomingCondition,
     OutgoingCondition,
@@ -202,6 +205,9 @@ const VIVACIOUS_PROC: Record<string, number> = { rare: 0.21, epic: 0.26, legenda
 // D-PR7: on-death implant value tables
 // Last Wish: repair all allies % of their max HP on death. No common variant.
 const LAST_WISH_PCT: Record<string, number> = { uncommon: 14, rare: 19, epic: 25, legendary: 32 };
+// Battlecry: grant all allies a named defensive buff on death. Per-rarity = DURATION only;
+// magnitude is intrinsic to the buff tier. No uncommon variant.
+const BATTLECRY_DURATION: Record<string, number> = { common: 1, rare: 2, epic: 2, legendary: 3 };
 
 // D-PR6: incoming-heal-amplification implant value tables
 // No common rarity for Exuberance
@@ -261,6 +267,38 @@ function mkHealAmp(
         trigger: 'on-cast',
         conditions: [],
         config: { type: 'heal-amplification', condition, ampPct, procChance },
+        autoFilled: true,
+    };
+}
+
+// D-PR7: build a reactive named-buff grant (e.g. Battlecry's on-death "Inc. Damage Down II").
+// parsedEffects/stackability resolve from the canonical BUFFS entry. EMIT-ONLY for buffs whose
+// effect the engine does not yet fold (self-side incoming-damage buffs) — the status is applied
+// and logged but has no combat effect until that fold exists.
+function mkNamedBuffGrant(
+    buffName: string,
+    target: 'self' | 'ally' | 'all-allies',
+    trigger: AbilityTrigger,
+    duration: number | undefined
+): Omit<Ability, 'id'> | undefined {
+    if (duration === undefined) return undefined;
+    const buff = BUFFS.find((b) => b.name === buffName);
+    if (!buff) return undefined;
+    const { stackable, maxStacks } = isStackable(buff.description);
+    return {
+        type: 'buff',
+        target,
+        trigger,
+        conditions: [],
+        config: {
+            type: 'buff',
+            buffName,
+            parsedEffects: parseBuffEffects(buff.name, buff.description),
+            stacks: 1,
+            isStackable: stackable,
+            maxStacks,
+            duration,
+        },
         autoFilled: true,
     };
 }
@@ -477,6 +515,16 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
             autoFilled: true,
         };
     },
+    // Battlecry: "Upon death, grants all allies Inc. Damage Down II for N turns." EMIT-ONLY:
+    // self-side "Inc. Damage Down" is not folded into incoming damage yet (victimEnemyBuffs reads
+    // enemy-side only). The buff is applied + logged; lights up when self-side incoming folding lands.
+    BATTLECRY: (rarity) =>
+        mkNamedBuffGrant(
+            'Inc. Damage Down II',
+            'all-allies',
+            'on-destroyed',
+            BATTLECRY_DURATION[rarity]
+        ),
 };
 
 // ---------------------------------------------------------------------------

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -208,6 +208,8 @@ const LAST_WISH_PCT: Record<string, number> = { uncommon: 14, rare: 19, epic: 25
 // Battlecry: grant all allies a named defensive buff on death. Per-rarity = DURATION only;
 // magnitude is intrinsic to the buff tier. No uncommon variant.
 const BATTLECRY_DURATION: Record<string, number> = { common: 1, rare: 2, epic: 2, legendary: 3 };
+// Martyrdom: apply a named debuff to the killer on death. Only rare + legendary variants.
+const MARTYRDOM_DURATION: Record<string, number> = { rare: 1, legendary: 2 };
 
 // D-PR6: incoming-heal-amplification implant value tables
 // No common rarity for Exuberance
@@ -297,6 +299,35 @@ function mkNamedBuffGrant(
             stacks: 1,
             isStackable: stackable,
             maxStacks,
+            duration,
+        },
+        autoFilled: true,
+    };
+}
+
+// D-PR7: build a reactive named-debuff application (Martyrdom's on-death "Disable" on the killer).
+// application:'apply' → lands unless affinity disadvantage (no landing roll), matching "Applies".
+// Killer routing is supplied by the on-destroyed listener via eventCtx.counterTargetId (later task).
+function mkNamedDebuff(
+    buffName: string,
+    trigger: AbilityTrigger,
+    duration: number | undefined
+): Omit<Ability, 'id'> | undefined {
+    if (duration === undefined) return undefined;
+    const buff = BUFFS.find((b) => b.name === buffName);
+    const parsedEffects = buff ? parseBuffEffects(buff.name, buff.description) : {};
+    return {
+        type: 'debuff',
+        target: 'enemy',
+        trigger,
+        conditions: [],
+        config: {
+            type: 'debuff',
+            buffName,
+            parsedEffects,
+            stacks: 1,
+            isStackable: false,
+            application: 'apply',
             duration,
         },
         autoFilled: true,
@@ -525,6 +556,10 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
             'on-destroyed',
             BATTLECRY_DURATION[rarity]
         ),
+    // Martyrdom: "Applies Disable for N turns on the enemy that killed this Unit." EMIT-ONLY:
+    // Disable is not a modeled turn-effect yet (only Stasis skips turns) — the debuff is applied to
+    // the killer + logged. Killer routing comes from the on-destroyed listener (later task).
+    MARTYRDOM: (rarity) => mkNamedDebuff('Disable', 'on-destroyed', MARTYRDOM_DURATION[rarity]),
 };
 
 // ---------------------------------------------------------------------------

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -24,7 +24,12 @@
 import { GEAR_SETS } from '../../constants/gearSets';
 import { IMPLANTS } from '../../constants/implants';
 import { GearPiece } from '../../types/gear';
-import { Ability, HealAmpCondition, IncomingCondition, OutgoingCondition } from '../../types/abilities';
+import {
+    Ability,
+    HealAmpCondition,
+    IncomingCondition,
+    OutgoingCondition,
+} from '../../types/abilities';
 import { Ship } from '../../types/ship';
 
 // ---------------------------------------------------------------------------
@@ -193,6 +198,10 @@ const SECOND_WIND_PROC: Record<string, number> = {
 const NOURISHMENT_AMP: Record<string, number> = { uncommon: 10, rare: 15, epic: 20, legendary: 30 };
 // No common/uncommon rarity for Vivacious Repair
 const VIVACIOUS_PROC: Record<string, number> = { rare: 0.21, epic: 0.26, legendary: 0.32 };
+
+// D-PR7: on-death implant value tables
+// Last Wish: repair all allies % of their max HP on death. No common variant.
+const LAST_WISH_PCT: Record<string, number> = { uncommon: 14, rare: 19, epic: 25, legendary: 32 };
 
 // D-PR6: incoming-heal-amplification implant value tables
 // No common rarity for Exuberance
@@ -452,6 +461,22 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
             'target-below-25',
             VIVACIOUS_PROC[rarity]
         ),
+    // D-PR7: on-death implants ----------------------------------------------------
+    // Last Wish: "Upon death, repairs X% of all allies' max HP." Rides the reactive
+    // heal executor on the on-destroyed trigger (Salvation precedent); basis 'target-hp'
+    // repairs each ally % of its OWN max HP. Reactive heals never crit. Fully modeled.
+    LAST_WISH: (rarity) => {
+        const pct = LAST_WISH_PCT[rarity];
+        if (pct === undefined) return undefined;
+        return {
+            type: 'heal',
+            target: 'all-allies',
+            trigger: 'on-destroyed',
+            conditions: [],
+            config: { type: 'heal', pct, basis: 'target-hp', noCrit: true },
+            autoFilled: true,
+        };
+    },
 };
 
 // ---------------------------------------------------------------------------

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -315,7 +315,8 @@ function mkNamedDebuff(
 ): Omit<Ability, 'id'> | undefined {
     if (duration === undefined) return undefined;
     const buff = BUFFS.find((b) => b.name === buffName);
-    const parsedEffects = buff ? parseBuffEffects(buff.name, buff.description) : {};
+    if (!buff) return undefined;
+    const { stackable, maxStacks } = isStackable(buff.description);
     return {
         type: 'debuff',
         target: 'enemy',
@@ -324,9 +325,10 @@ function mkNamedDebuff(
         config: {
             type: 'debuff',
             buffName,
-            parsedEffects,
+            parsedEffects: parseBuffEffects(buff.name, buff.description),
             stacks: 1,
-            isStackable: false,
+            isStackable: stackable,
+            maxStacks,
             application: 'apply',
             duration,
         },

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -307,7 +307,7 @@ function mkNamedBuffGrant(
 
 // D-PR7: build a reactive named-debuff application (Martyrdom's on-death "Disable" on the killer).
 // application:'apply' → lands unless affinity disadvantage (no landing roll), matching "Applies".
-// Killer routing is supplied by the on-destroyed listener via eventCtx.counterTargetId (later task).
+// Killer routing is supplied by the on-destroyed listener via eventCtx.counterTargetId.
 function mkNamedDebuff(
     buffName: string,
     trigger: AbilityTrigger,
@@ -560,7 +560,7 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
         ),
     // Martyrdom: "Applies Disable for N turns on the enemy that killed this Unit." EMIT-ONLY:
     // Disable is not a modeled turn-effect yet (only Stasis skips turns) — the debuff is applied to
-    // the killer + logged. Killer routing comes from the on-destroyed listener (later task).
+    // the killer + logged. Killer routing comes from the on-destroyed listener.
     MARTYRDOM: (rarity) => mkNamedDebuff('Disable', 'on-destroyed', MARTYRDOM_DURATION[rarity]),
 };
 

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -32,6 +32,8 @@ import { buildEquipmentAbilities } from '../../abilities/buildEquipmentAbilities
 import { modifierTotalsFromAbilities } from '../../abilities/applyAbilities';
 import { makeConditionContext } from '../../abilities/__tests__/conditionContextFixture';
 import { SelectedGameBuff } from '../../../types/calculator';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
 
 // ---------------------------------------------------------------------------
 // Shared test harness helpers
@@ -1683,4 +1685,378 @@ describe('D-PR7 Task 4 integration — Martyrdom routes on-destroyed Disable to 
         );
         expect(disableEvents).toHaveLength(0);
     });
+});
+
+// ---------------------------------------------------------------------------
+// D-PR7 Task 5: Last Wish + Battlecry engine integration + enemy-side mirror
+// ---------------------------------------------------------------------------
+//
+// These tests exercise the on-destroyed REACTIVE path for a NON-focus team ally
+// carrying an on-death implant. Killing a non-focus ally requires the POSITIONAL
+// apply path (the non-positional model lands every enemy hit on the heal target),
+// so the fixtures mirror perVictimLeech.test.ts: positioned focus + walked team
+// actor + an offensive positional enemy firing a Line-Range-1 AoE at `front`.
+//
+// Board layout (player side): the DYING carrier sits at the front-most cell (M4 =
+// origin victim → full damage → lethal). The SURVIVOR focus sits one step back (M3
+// = covered victim → half damage → survives) and is the heal target. The enemy at
+// M1 fires `front`, anchoring on the front-most player (the carrier), covering the
+// survivor.
+
+// --- Positional helpers (shared by the Last Wish + Battlecry blocks) ----------
+
+const parsedTargetFront = (): ParsedTarget => ({ raw: 'front', side: 'enemy', selection: 'front' });
+// Line-Range-1: origin + one covered cell one step toward the back (origin full, covered half).
+const lineRange1 = (): ParsedPattern => ({
+    raw: 'line-range-1',
+    shape: 'line',
+    range: 1,
+    modifiers: {},
+});
+
+/** Single-hit 100% basic attack (so a positioned actor has a damage skill / footprint). */
+const basicAttackSlot = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: 'basic-atk',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 100, hits: 1 },
+        },
+    ],
+});
+
+/** A walked PLAYER team actor at a board position, with optional skill slots + HP. */
+function playerActorAt(
+    id: string,
+    position: Position,
+    slots: ShipSkills['slots'],
+    hp: number
+): TeamActorEngineInput {
+    return {
+        id,
+        speed: 1,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        target: parsedTargetFront(),
+        pattern: lineRange1(),
+        walk: {
+            shipSkills: { slots },
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+            healModifier: 0,
+        },
+    };
+}
+
+/** An OFFENSIVE positioned enemy firing a Line-Range-1 AoE at `front`. */
+function offensiveEnemyAt(id: string, position: Position, attack: number) {
+    return {
+        id,
+        stats: { attack, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1_000 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTargetFront(),
+        pattern: lineRange1(),
+        shipSkills: { slots: [basicAttackSlot()] },
+    };
+}
+
+/** Positional base input: healing mode, focus 'attacker' is the heal-target SURVIVOR at M3. */
+const POS_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [basicAttackSlot()] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000, // default focus pool; overridden per-test
+    healModifier: 0,
+    healTargetId: 'attacker',
+    position: 'M3', // focus is the COVERED survivor
+    target: parsedTargetFront(),
+    pattern: lineRange1(),
+    ...overrides,
+});
+
+describe('D-PR7 Task 5 integration — Last Wish repairs living allies on death', () => {
+    const DYER_HP = 1_000; // tiny pool → the front origin hit is lethal
+    const FOCUS_HP = 1_000_000; // large pool → the covered (half) hit is survivable, leaves a deficit
+
+    /** Build the dying ally's skills with the legendary Last Wish implant (via the registry). */
+    function buildLastWishSlots(): ShipSkills['slots'] {
+        const ship = makeShip({ implants: { implant_major: 'lw-legendary' } });
+        const lwPiece = makePiece({
+            id: 'lw-legendary',
+            slot: 'implant_major',
+            rarity: 'legendary',
+            setBonus: 'LAST_WISH',
+        });
+        const getGearPiece = makeGetGearPiece({ 'lw-legendary': lwPiece });
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        // Pre-condition: the Last Wish on-destroyed heal landed in the passive slot.
+        const lw = passive?.abilities.find((a) => a.id === 'equip-implant-LAST_WISH');
+        expect(lw).toBeDefined();
+        expect(lw!.trigger).toBe('on-destroyed');
+        expect(lw!.target).toBe('all-allies');
+        expect(lw!.config.type).toBe('heal');
+
+        return [
+            basicAttackSlot(),
+            ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+        ];
+    }
+
+    it(
+        'A non-focus ally carrying Last Wish dies → surviving allies are repaired; ' +
+            'the credited repair (keyed to the dead caster) is positive and the survivor pool is filled',
+        () => {
+            // Dying carrier at the front origin (M4, lethal full hit). Focus survivor at M3 (covered).
+            // The enemy attack must one-shot the 1000-HP carrier (origin = full) while leaving the
+            // 1_000_000-HP focus alive (covered = half = 2500, a survivable scratch leaving a deficit).
+            const result = runCombat(
+                POS_BASE({
+                    hp: FOCUS_HP,
+                    teamActors: [playerActorAt('dier', 'M4', buildLastWishSlots(), DYER_HP)],
+                    enemyAttackers: [offensiveEnemyAt('enemy-atk', 'M1', 5_000)],
+                })
+            );
+
+            expect(result.healing).toBeDefined();
+
+            // The dead caster ('dier') is credited with the gross Last Wish repair (the engine keys
+            // all reactive-heal credit by the casting owner, summed over LIVING recipients). It must
+            // be strictly positive: at least the surviving focus repaired % of its own max HP.
+            expect(sumHeal(result, 'directHeal', 'dier')).toBeGreaterThan(0);
+
+            // The heal-target survivor's pool was actually filled (effectiveHeal credited under the
+            // dead caster). With a 1_000_000-HP focus scratched for ~2500, the legendary 32% repair
+            // (≈ 320_000) is mostly consumed → effectiveHeal is positive.
+            expect(sumHeal(result, 'effectiveHeal', 'dier')).toBeGreaterThan(0);
+
+            // The dead caster is NOT credited as a LIVING recipient: a `target-hp` legendary repair on
+            // its own 1000-HP pool would be 320; the surviving focus's share alone (32% of 1_000_000 =
+            // 320_000) dwarfs that, proving the caster's own pool was excluded from the gross.
+            expect(sumHeal(result, 'directHeal', 'dier')).toBeGreaterThan(100_000);
+
+            // No OTHER actor id is credited with directHeal — all reactive-heal credit is keyed to
+            // the dead caster ('dier'), never the focus or the enemy.
+            expect(sumHeal(result, 'directHeal', 'attacker')).toBe(0);
+        }
+    );
+});
+
+describe('D-PR7 Task 5 integration — Battlecry emits Inc. Damage Down II on living allies (emit-only)', () => {
+    const DYER_HP = 1_000;
+    const FOCUS_HP = 1_000_000;
+    const ALLY_HP = 1_000_000;
+    const BATTLECRY_NAME = 'Inc. Damage Down II';
+    const LEGENDARY_DURATION = 3; // BATTLECRY_DURATION.legendary
+
+    /** Build the dying ally's skills with the legendary Battlecry implant (via the registry). */
+    function buildBattlecrySlots(): ShipSkills['slots'] {
+        const ship = makeShip({ implants: { implant_major: 'bc-legendary' } });
+        const bcPiece = makePiece({
+            id: 'bc-legendary',
+            slot: 'implant_major',
+            rarity: 'legendary',
+            setBonus: 'BATTLECRY',
+        });
+        const getGearPiece = makeGetGearPiece({ 'bc-legendary': bcPiece });
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        // Pre-condition: the Battlecry on-destroyed buff grant landed in the passive slot.
+        const bc = passive?.abilities.find((a) => a.id === 'equip-implant-BATTLECRY');
+        expect(bc).toBeDefined();
+        expect(bc!.trigger).toBe('on-destroyed');
+        expect(bc!.target).toBe('all-allies');
+        expect(bc!.config.type).toBe('buff');
+
+        return [
+            basicAttackSlot(),
+            ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+        ];
+    }
+
+    /** Collect buff-applied + ship-destroyed events. */
+    function collect(input: CombatEngineInput) {
+        const bus = createEventBus();
+        const events: CombatEvent[] = [];
+        bus.on('buff-applied', (e) => events.push(e as CombatEvent));
+        bus.on('ship-destroyed', (e) => events.push(e as CombatEvent));
+        runCombat({ ...input, bus });
+        return events;
+    }
+
+    it(
+        'A Battlecry carrier dies → a Inc. Damage Down II buff-applied fires once for each living ' +
+            'ally, carrying the legendary duration (3); no damage-reduction asserted (emit-only)',
+        () => {
+            // Dying carrier at the front origin (M4). Two SURVIVORS: focus at M3 (covered, survives)
+            // and a second team ally at M2 (outside the AoE footprint → untouched, survives).
+            const events = collect(
+                POS_BASE({
+                    hp: FOCUS_HP,
+                    teamActors: [
+                        playerActorAt('dier', 'M4', buildBattlecrySlots(), DYER_HP),
+                        playerActorAt('ally-2', 'M2', [basicAttackSlot()], ALLY_HP),
+                    ],
+                    enemyAttackers: [offensiveEnemyAt('enemy-atk', 'M1', 5_000)],
+                })
+            );
+
+            // Sanity: the carrier actually died (so the on-destroyed buff grant fired at all).
+            const destroyed = events.filter(
+                (e) => e.type === 'ship-destroyed' && e.actorId === 'dier'
+            );
+            expect(destroyed.length).toBeGreaterThanOrEqual(1);
+
+            const battlecryEvents = events.filter(
+                (e) => e.type === 'buff-applied' && e.buffName === BATTLECRY_NAME
+            );
+            expect(battlecryEvents.length).toBeGreaterThanOrEqual(1);
+
+            // Each LIVING ally received exactly one Inc. Damage Down II buff-applied event.
+            for (const livingId of ['attacker', 'ally-2']) {
+                const forAlly = battlecryEvents.filter(
+                    (e) => e.type === 'buff-applied' && e.actorId === livingId
+                );
+                expect(forAlly).toHaveLength(1);
+            }
+
+            // The event carries the legendary duration (3).
+            for (const e of battlecryEvents) {
+                if (e.type !== 'buff-applied') continue;
+                expect(e.duration).toBe(LEGENDARY_DURATION);
+            }
+        }
+    );
+});
+
+// ---------------------------------------------------------------------------
+// D-PR7 Task 5: enemy-side mirror — an ENEMY Martyrdom carrier routes Disable to the PLAYER killer
+// ---------------------------------------------------------------------------
+//
+// The engine is team-agnostic: an on-destroyed reaction carried by an ENEMY ship must fire the
+// same path against the player side. We mirror the Task-4 Martyrdom scenario but flip the sides —
+// a positioned ENEMY carries the legendary Martyrdom implant, the PLAYER focus lands a lethal
+// DIRECT hit, and the resulting Disable debuff-applied must target the PLAYER killer ('attacker').
+
+describe('D-PR7 Task 5 integration — enemy-side mirror: enemy Martyrdom routes Disable to the player killer', () => {
+    const ENEMY_HP = 1_000; // tiny → the player's hit one-shots it
+
+    /** Build the enemy's Martyrdom skills (legendary) via the registry. */
+    function buildEnemyMartyrdomSlots(): ShipSkills['slots'] {
+        const ship = makeShip({ implants: { implant_major: 'mart-enemy' } });
+        const martPiece = makePiece({
+            id: 'mart-enemy',
+            slot: 'implant_major',
+            rarity: 'legendary',
+            setBonus: 'MARTYRDOM',
+        });
+        const getGearPiece = makeGetGearPiece({ 'mart-enemy': martPiece });
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        const mart = passive?.abilities.find((a) => a.id === 'equip-implant-MARTYRDOM');
+        expect(mart).toBeDefined();
+        expect(mart!.trigger).toBe('on-destroyed');
+
+        return [
+            basicAttackSlot(),
+            ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+        ];
+    }
+
+    /** A positioned ENEMY carrier of Martyrdom (tiny HP, no offense needed). */
+    function enemyMartyrdomCarrier() {
+        return {
+            id: 'enemy-mart',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: ENEMY_HP, speed: 1 },
+            chargeCount: 0,
+            startCharged: false,
+            position: 'M4' as Position,
+            target: parsedTargetFront(),
+            pattern: lineRange1(),
+            shipSkills: { slots: buildEnemyMartyrdomSlots() },
+        };
+    }
+
+    /** Collect debuff-applied + ship-destroyed events. */
+    function collect(input: CombatEngineInput) {
+        const bus = createEventBus();
+        const events: CombatEvent[] = [];
+        bus.on('debuff-applied', (e) => events.push(e as CombatEvent));
+        bus.on('ship-destroyed', (e) => events.push(e as CombatEvent));
+        runCombat({ ...input, bus });
+        return events;
+    }
+
+    it(
+        'An ENEMY Martyrdom carrier killed by a player DIRECT hit → a Disable debuff-applied fires ' +
+            "targeting the PLAYER killer ('attacker'), proving the on-destroyed path is team-agnostic",
+        () => {
+            // Player focus at M4 fires a lethal Line-Range-1 hit at the front enemy (the carrier at M4).
+            const events = collect(
+                POS_BASE({
+                    attack: 1_000_000, // dwarfs ENEMY_HP → guaranteed lethal direct hit
+                    hp: 1_000_000_000,
+                    position: 'M4', // focus fires from the front
+                    shipSkills: { slots: [basicAttackSlot()] },
+                    enemyAttackers: [enemyMartyrdomCarrier()],
+                })
+            );
+
+            // Sanity: the enemy carrier died.
+            const destroyed = events.filter(
+                (e) => e.type === 'ship-destroyed' && e.actorId === 'enemy-mart'
+            );
+            expect(destroyed.length).toBeGreaterThanOrEqual(1);
+
+            // The Disable debuff fired and targets the PLAYER killer (the focus 'attacker'),
+            // sourced by the dying enemy carrier.
+            const disableEvents = events.filter(
+                (e) => e.type === 'debuff-applied' && e.buffName === 'Disable'
+            );
+            expect(disableEvents.length).toBeGreaterThanOrEqual(1);
+            for (const e of disableEvents) {
+                if (e.type !== 'debuff-applied') continue;
+                expect(e.targetId).toBe('attacker'); // the player killer, NOT an enemy sink
+                expect(e.sourceId).toBe('enemy-mart');
+            }
+        }
+    );
 });

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -1583,7 +1583,7 @@ describe('D-PR7 Task 4 integration — Martyrdom routes on-destroyed Disable to 
                             config: {
                                 type: 'dot' as const,
                                 dotType: 'corrosion' as const,
-                                tier: 8,
+                                tier: 8, // 5 stacks × (8/100) × 1 000 maxHp = 400 dmg/tick → fatal by tick 3 (within 6 rounds)
                                 stacks: 5,
                                 duration: 5,
                             },
@@ -1655,9 +1655,7 @@ describe('D-PR7 Task 4 integration — Martyrdom routes on-destroyed Disable to 
             expect(disableEvents.length).toBeGreaterThanOrEqual(1);
             for (const e of disableEvents) {
                 if (e.type !== 'debuff-applied') continue;
-                expect(e.targetId).toBe(KILLER_ID);
-                // Explicitly NOT the default enemy sink.
-                expect(e.targetId).not.toBe('enemy');
+                expect(e.targetId).toBe(KILLER_ID); // implicitly NOT the default enemy sink
                 // Sourced by the dying carrier.
                 expect(e.sourceId).toBe('attacker');
             }

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -1841,9 +1841,25 @@ describe('D-PR7 Task 5 integration — Last Wish repairs living allies on death'
         ];
     }
 
+    // Last Wish legendary: target-hp basis, pct 32, noCrit. Per LIVING recipient the gross is
+    //   recipientMaxHp × 0.32 × (1 + healModifier/100) × (1 + outgoingHeal/100) × (1 + incomingHeal/100)
+    // and every fold factor here is 1 (dier healModifier 0, no heal-up/incoming-heal buffs).
+    // The ONLY living recipient is the focus survivor ('attacker', maxHP FOCUS_HP) — the dead
+    // caster ('dier', maxHP DYER_HP) is skipped by the recipientHp<=0 guard in the executor.
+    const LW_LEGENDARY_PCT = 32;
+    // Gross over living recipients only = FOCUS_HP × 0.32 = 320_000.
+    const EXPECTED_GROSS = FOCUS_HP * (LW_LEGENDARY_PCT / 100); // 320_000
+    // If the dead caster were wrongly counted as a living recipient, its target-hp share
+    // (DYER_HP × 0.32 = 320) would be ADDED → 320_320. The upper bound below excludes that.
+    const DEAD_CASTER_SHARE = DYER_HP * (LW_LEGENDARY_PCT / 100); // 320
+    // The covered (half-damage) hit the survivor takes: enemy attack 5000 × 100% × ½ = 2500,
+    // mitigated by the focus's defence 0 → 2500. This is the deficit the repair fills, so
+    // effectiveHeal is capped at exactly this (320_000 >> 2500).
+    const SCRATCH_DAMAGE = 2_500;
+
     it(
-        'A non-focus ally carrying Last Wish dies → surviving allies are repaired; ' +
-            'the credited repair (keyed to the dead caster) is positive and the survivor pool is filled',
+        'A non-focus ally carrying Last Wish dies → only the LIVING focus is repaired (dead caster ' +
+            "excluded from the gross); the survivor's scratch deficit is filled",
         () => {
             // Dying carrier at the front origin (M4, lethal full hit). Focus survivor at M3 (covered).
             // The enemy attack must one-shot the 1000-HP carrier (origin = full) while leaving the
@@ -1859,19 +1875,27 @@ describe('D-PR7 Task 5 integration — Last Wish repairs living allies on death'
             expect(result.healing).toBeDefined();
 
             // The dead caster ('dier') is credited with the gross Last Wish repair (the engine keys
-            // all reactive-heal credit by the casting owner, summed over LIVING recipients). It must
-            // be strictly positive: at least the surviving focus repaired % of its own max HP.
-            expect(sumHeal(result, 'directHeal', 'dier')).toBeGreaterThan(0);
+            // all reactive-heal credit by the casting owner, summed over LIVING recipients only). The
+            // gross must equal EXACTLY the focus survivor's share (320_000) and NOT include the dead
+            // caster's own 320 share. The lower bound + upper bound window
+            // [EXPECTED_GROSS − 1, EXPECTED_GROSS + DEAD_CASTER_SHARE/2) pins the value AND excludes
+            // the dead-caster-included total (320_320): 320_320 fails the < (EXPECTED_GROSS + 160)
+            // upper bound. A bare `> 100_000` (the old assertion) would pass for BOTH 320_000 and
+            // 320_320 — this window is what makes the exclusion load-bearing.
+            expect(sumHeal(result, 'directHeal', 'dier')).toBeGreaterThan(EXPECTED_GROSS - 1);
+            expect(sumHeal(result, 'directHeal', 'dier')).toBeLessThan(
+                EXPECTED_GROSS + DEAD_CASTER_SHARE / 2
+            );
+            // Belt-and-suspenders exact pin: toBeCloseTo digits −2 ⇒ tolerance 0.5×10² = ±50, well
+            // under the 320 gap to the dead-caster-included total, so 320_320 would also fail here.
+            expect(sumHeal(result, 'directHeal', 'dier')).toBeCloseTo(EXPECTED_GROSS, -2);
 
-            // The heal-target survivor's pool was actually filled (effectiveHeal credited under the
-            // dead caster). With a 1_000_000-HP focus scratched for ~2500, the legendary 32% repair
-            // (≈ 320_000) is mostly consumed → effectiveHeal is positive.
-            expect(sumHeal(result, 'effectiveHeal', 'dier')).toBeGreaterThan(0);
-
-            // The dead caster is NOT credited as a LIVING recipient: a `target-hp` legendary repair on
-            // its own 1000-HP pool would be 320; the surviving focus's share alone (32% of 1_000_000 =
-            // 320_000) dwarfs that, proving the caster's own pool was excluded from the gross.
-            expect(sumHeal(result, 'directHeal', 'dier')).toBeGreaterThan(100_000);
+            // The heal-target survivor's pool was actually filled: effectiveHeal (credited under the
+            // dead caster) equals the survivor's deficit = the SCRATCH_DAMAGE it took from the covered
+            // hit. The 320_000 repair vastly exceeds the 2500 deficit, so effectiveHeal is capped at
+            // exactly the deficit. Asserting ≈ SCRATCH_DAMAGE distinguishes "pool actually filled"
+            // from a residual/near-zero credit (which a `> 0` check would also accept).
+            expect(sumHeal(result, 'effectiveHeal', 'dier')).toBeCloseTo(SCRATCH_DAMAGE, 6);
 
             // No OTHER actor id is credited with directHeal — all reactive-heal credit is keyed to
             // the dead caster ('dier'), never the focus or the enemy.

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -1511,7 +1511,9 @@ describe('D-PR7 Task 4 integration — Martyrdom routes on-destroyed Disable to 
         const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
         const passive = baseSkills.slots.find((s) => s.slot === 'passive');
         // Pre-condition: the Martyrdom on-destroyed debuff landed in the passive slot.
-        const martyrdom = passive?.abilities.find((a) => a.id === 'equip-implant-MARTYRDOM');
+        const martyrdom = passive?.abilities.find((a) =>
+            a.id.startsWith('equip-implant-MARTYRDOM')
+        );
         expect(martyrdom).toBeDefined();
         expect(martyrdom!.trigger).toBe('on-destroyed');
         expect(martyrdom!.config.type).toBe('debuff');
@@ -1829,7 +1831,7 @@ describe('D-PR7 Task 5 integration — Last Wish repairs living allies on death'
         const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
         const passive = baseSkills.slots.find((s) => s.slot === 'passive');
         // Pre-condition: the Last Wish on-destroyed heal landed in the passive slot.
-        const lw = passive?.abilities.find((a) => a.id === 'equip-implant-LAST_WISH');
+        const lw = passive?.abilities.find((a) => a.id.startsWith('equip-implant-LAST_WISH'));
         expect(lw).toBeDefined();
         expect(lw!.trigger).toBe('on-destroyed');
         expect(lw!.target).toBe('all-allies');
@@ -1924,7 +1926,7 @@ describe('D-PR7 Task 5 integration — Battlecry emits Inc. Damage Down II on li
         const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
         const passive = baseSkills.slots.find((s) => s.slot === 'passive');
         // Pre-condition: the Battlecry on-destroyed buff grant landed in the passive slot.
-        const bc = passive?.abilities.find((a) => a.id === 'equip-implant-BATTLECRY');
+        const bc = passive?.abilities.find((a) => a.id.startsWith('equip-implant-BATTLECRY'));
         expect(bc).toBeDefined();
         expect(bc!.trigger).toBe('on-destroyed');
         expect(bc!.target).toBe('all-allies');
@@ -2015,7 +2017,7 @@ describe('D-PR7 Task 5 integration — enemy-side mirror: enemy Martyrdom routes
         const getGearPiece = makeGetGearPiece({ 'mart-enemy': martPiece });
         const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
         const passive = baseSkills.slots.find((s) => s.slot === 'passive');
-        const mart = passive?.abilities.find((a) => a.id === 'equip-implant-MARTYRDOM');
+        const mart = passive?.abilities.find((a) => a.id.startsWith('equip-implant-MARTYRDOM'));
         expect(mart).toBeDefined();
         expect(mart!.trigger).toBe('on-destroyed');
 

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -23,6 +23,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
 import { Ability, ShipSkills } from '../../../types/abilities';
 import { Ship } from '../../../types/ship';
 import { GearPiece } from '../../../types/gear';
@@ -1021,7 +1022,12 @@ describe('D-PR5 integration — heal-cast amplification fold (Nourishment / Viva
         target: 'self',
         trigger: 'on-cast',
         conditions: [],
-        config: { type: 'heal-amplification', condition, ampPct, ...(procChance !== undefined ? { procChance } : {}) },
+        config: {
+            type: 'heal-amplification',
+            condition,
+            ampPct,
+            ...(procChance !== undefined ? { procChance } : {}),
+        },
         autoFilled: true,
     });
 
@@ -1209,9 +1215,7 @@ describe('D-PR5 integration — heal-cast amplification fold (Nourishment / Viva
                 shipSkills: healerSkills(healAmp('target-below-25', 100, 0.5)),
             })
         );
-        const without = runCombat(
-            AMP_BASE({ numRounds: NUM_ROUNDS, shipSkills: healerSkills() })
-        );
+        const without = runCombat(AMP_BASE({ numRounds: NUM_ROUNDS, shipSkills: healerSkills() }));
         expect(sumHeal(withAmp, 'directHeal')).toBeCloseTo(sumHeal(without, 'directHeal'), 6);
         expect(sumHeal(withAmp, 'directHeal')).toBeCloseTo(NUM_ROUNDS * BASE_PER_CAST, 6);
     });
@@ -1314,9 +1318,7 @@ describe('D-PR6 integration — Exuberance recipient-side incoming-heal amplific
                     shipSkills: skills(exuberance(EXU_AMP, EXU_PROC)),
                 })
             );
-            const baseline = runCombat(
-                EXU_BASE({ numRounds: NUM_ROUNDS, shipSkills: skills() })
-            );
+            const baseline = runCombat(EXU_BASE({ numRounds: NUM_ROUNDS, shipSkills: skills() }));
 
             const baseHeal = sumHeal(baseline, 'directHeal');
             const exuHeal = sumHeal(withExu, 'directHeal');
@@ -1426,10 +1428,7 @@ describe('D-PR6 integration — Exuberance recipient-side incoming-heal amplific
                             { slot: 'active', abilities: [noopActive] },
                             {
                                 slot: 'passive',
-                                abilities: [
-                                    reactiveSelfHeal(1.0),
-                                    exuberance(EXU_AMP, EXU_PROC),
-                                ],
+                                abilities: [reactiveSelfHeal(1.0), exuberance(EXU_AMP, EXU_PROC)],
                             },
                         ],
                     },
@@ -1461,4 +1460,229 @@ describe('D-PR6 integration — Exuberance recipient-side incoming-heal amplific
             expect(exuHeal).toBeGreaterThan(baseHeal);
         }
     );
+});
+
+// ---------------------------------------------------------------------------
+// D-PR7 Task 4: Martyrdom implant — on-destroyed debuff routes to the killer
+// ---------------------------------------------------------------------------
+//
+// Martyrdom is an on-destroyed DEBUFF reaction: "Applies Disable on the enemy that
+// killed this Unit." It fires only when the carrier is killed by DIRECT damage, and
+// the Disable debuff must land on the KILLER — not the engine's default enemy sink.
+//
+// Harness shape (mirrors the Second Wind crit-received scenario):
+//   - The FOCUS actor ('attacker') is the heal target (healTargetId), carries the
+//     legendary Martyrdom implant in its passive slot (via buildShipAbilitiesWithEquipment),
+//     and has a tiny HP pool so a single enemy hit is lethal.
+//   - A named enemy attacker ('mart-killer') deals a lethal DIRECT hit on round 1.
+//     recordDestroyed stamps ship-destroyed with killerId='mart-killer', byDirectDamage:true.
+//   - The on-destroyed listener (post-change) routes the Disable debuff's counterTargetId
+//     to the killer → debuff-applied.targetId === 'mart-killer' (NOT the default 'enemy').
+//
+// Test A: lethal DIRECT kill → a Disable debuff-applied fires, targeting the KILLER.
+// Test B: lethal NON-direct (DoT) kill → no Disable debuff-applied fires (byDirectDamage:false).
+
+describe('D-PR7 Task 4 integration — Martyrdom routes on-destroyed Disable to the killer', () => {
+    const KILLER_ID = 'mart-killer';
+    const FOCUS_HP = 1_000;
+
+    /** No-op active for the focus — deals no damage, just keeps the round cadence. */
+    const noopActive: Ability = {
+        id: 'noop-active',
+        type: 'damage',
+        target: 'enemy',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'damage', multiplier: 0 },
+    };
+
+    /** Build focus ship skills: no-op active + the legendary Martyrdom passive (from the registry). */
+    function buildMartyrdomShipSkills(): ShipSkills {
+        const ship = makeShip({ implants: { implant_major: 'mart-legendary' } });
+        const martyrdomPiece = makePiece({
+            id: 'mart-legendary',
+            slot: 'implant_major',
+            rarity: 'legendary',
+            setBonus: 'MARTYRDOM',
+        });
+        const getGearPiece = makeGetGearPiece({ 'mart-legendary': martyrdomPiece });
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        // Pre-condition: the Martyrdom on-destroyed debuff landed in the passive slot.
+        const martyrdom = passive?.abilities.find((a) => a.id === 'equip-implant-MARTYRDOM');
+        expect(martyrdom).toBeDefined();
+        expect(martyrdom!.trigger).toBe('on-destroyed');
+        expect(martyrdom!.config.type).toBe('debuff');
+
+        return {
+            slots: [
+                { slot: 'active', abilities: [noopActive] },
+                ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+            ],
+        };
+    }
+
+    /** A fast enemy attacker that lands a lethal DIRECT hit on the focus each round. */
+    const directKiller = {
+        id: KILLER_ID,
+        stats: {
+            attack: 1_000_000, // dwarfs FOCUS_HP → guaranteed lethal direct hit
+            crit: 0,
+            critDamage: 0,
+            speed: 1_000, // acts before the slow focus
+            defence: 0,
+            hp: 1_000_000_000,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active' as const,
+                    abilities: [
+                        {
+                            id: 'mart-killer-hit',
+                            type: 'damage' as const,
+                            target: 'enemy' as const,
+                            trigger: 'on-cast' as const,
+                            conditions: [],
+                            config: { type: 'damage' as const, multiplier: 100, hits: 1 },
+                        },
+                    ],
+                },
+            ],
+        } as ShipSkills,
+    };
+
+    /** A fast enemy attacker that lands a corrosion DoT (no direct damage) which kills the focus. */
+    const dotKiller = {
+        id: KILLER_ID,
+        stats: {
+            attack: 1_000_000,
+            crit: 0,
+            critDamage: 0,
+            speed: 1_000,
+            defence: 0,
+            hp: 1_000_000_000,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active' as const,
+                    abilities: [
+                        // DoT only — no direct-damage ability → the kill comes from the
+                        // turn-start DoT tick (byDirectDamage:false), never a direct hit.
+                        {
+                            id: 'mart-killer-dot',
+                            type: 'dot' as const,
+                            target: 'enemy' as const,
+                            trigger: 'on-cast' as const,
+                            conditions: [],
+                            config: {
+                                type: 'dot' as const,
+                                dotType: 'corrosion' as const,
+                                tier: 8,
+                                stacks: 5,
+                                duration: 5,
+                            },
+                        },
+                    ],
+                },
+            ],
+        } as ShipSkills,
+    };
+
+    /** Base engine input: healing mode, slow focus 'attacker' is the heal target. */
+    const MART_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+        attack: 0,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: { slots: [] },
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 3,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: FOCUS_HP,
+        speed: 1, // focus is slow → the enemy acts (and kills it) first
+        healTargetId: 'attacker',
+        ...overrides,
+    });
+
+    /** Collect debuff-applied + ship-destroyed events from a runCombat with the given input. */
+    function collect(input: CombatEngineInput) {
+        const bus = createEventBus();
+        const events: CombatEvent[] = [];
+        bus.on('debuff-applied', (e) => events.push(e as CombatEvent));
+        bus.on('ship-destroyed', (e) => events.push(e as CombatEvent));
+        runCombat({ ...input, bus });
+        return events;
+    }
+
+    it(
+        'A. Focus killed by a DIRECT hit: a Disable debuff-applied fires and targets the KILLER ' +
+            "(not the default 'enemy')",
+        () => {
+            const events = collect(
+                MART_BASE({
+                    shipSkills: buildMartyrdomShipSkills(),
+                    enemyAttackers: [directKiller],
+                })
+            );
+
+            // Sanity: the focus actually died to a DIRECT-damage kill attributed to the killer.
+            const destroyed = events.filter(
+                (e) => e.type === 'ship-destroyed' && e.actorId === 'attacker'
+            );
+            expect(destroyed.length).toBeGreaterThanOrEqual(1);
+
+            // The Disable debuff must be applied, and it must target the KILLER actor id.
+            const disableEvents = events.filter(
+                (e) => e.type === 'debuff-applied' && e.buffName === 'Disable'
+            );
+            expect(disableEvents.length).toBeGreaterThanOrEqual(1);
+            for (const e of disableEvents) {
+                if (e.type !== 'debuff-applied') continue;
+                expect(e.targetId).toBe(KILLER_ID);
+                // Explicitly NOT the default enemy sink.
+                expect(e.targetId).not.toBe('enemy');
+                // Sourced by the dying carrier.
+                expect(e.sourceId).toBe('attacker');
+            }
+        }
+    );
+
+    it('B. Focus killed by NON-direct (DoT) damage: NO Disable debuff-applied fires', () => {
+        const events = collect(
+            MART_BASE({
+                numRounds: 6, // give the DoT time to tick the focus to death
+                shipSkills: buildMartyrdomShipSkills(),
+                enemyAttackers: [dotKiller],
+            })
+        );
+
+        // Sanity: the focus did die (so the on-destroyed listener fired at all).
+        const destroyed = events.filter(
+            (e) => e.type === 'ship-destroyed' && e.actorId === 'attacker'
+        );
+        expect(destroyed.length).toBeGreaterThanOrEqual(1);
+
+        // A DoT kill is byDirectDamage:false → Martyrdom's debuff gate must NOT fire.
+        const disableEvents = events.filter(
+            (e) => e.type === 'debuff-applied' && e.buffName === 'Disable'
+        );
+        expect(disableEvents).toHaveLength(0);
+    });
 });

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -378,11 +378,15 @@ export function registerReactiveListeners(args: {
                 case 'on-destroyed':
                     bus.on('ship-destroyed', (e) => {
                         // Self-scoped: THIS owner was destroyed (mirrors on-crit's own-id scoping).
-                        // Faust's PURGE only fires when killed by DIRECT damage and targets the
-                        // killer (counterTargetId = e.killerId); Salvation's self-destruct HEAL (and
-                        // any other on-destroyed reaction) fires on ANY death, unchanged.
+                        // Killer-targeted reactions (Faust's PURGE, Martyrdom's DEBUFF) fire only when
+                        // killed by DIRECT damage and route to the killer (counterTargetId = e.killerId).
+                        // Salvation's self-destruct HEAL (and any other on-destroyed reaction) fires on ANY
+                        // death, unchanged.
                         if (e.actorId !== ownerId) return;
-                        if (ra.ability.config.type === 'purge') {
+                        if (
+                            ra.ability.config.type === 'purge' ||
+                            ra.ability.config.type === 'debuff'
+                        ) {
                             if (!e.byDirectDamage) return;
                             enqueue({
                                 ...intent,


### PR DESCRIPTION
## Summary

Sub-project D, PR7 — three **on-death** implants, riding the existing `on-destroyed` reactive trigger + reactive heal/buff/debuff executors + killer routing. Stacked on D-PR6 (#134).

- **Last Wish** — repairs all allies % of their own max HP on death. **Fully modeled** (reactive heal, Salvation precedent).
- **Battlecry** — grants all allies *Inc. Damage Down II* on death. **Emit-only**: the buff is applied + logged, but self-side incoming-damage buffs aren't folded into incoming damage yet (that's a cross-cutting fold for a later PR — same reason D-PR3 built dedicated `incoming-reduction` machinery).
- **Martyrdom** — applies *Disable* to the unit that landed the killing blow. **Emit-only**: Disable has no modeled turn-effect yet (only Stasis skips turns); a later control PR lights it up for all ~6 ships that inflict it.

### Engine change (one, surgical)
The `on-destroyed` listener now routes the killer (`counterTargetId = e.killerId`, gated on `byDirectDamage`) for `debuff` reactions, not just `purge` (Faust). Martyrdom is the first on-destroyed debuff, so this is **byte-identical for every existing fixture** (verified structurally: the ship parser only emits `on-destroyed` for heal (Salvation) + purge (Faust)).

### Scope notes (intentional, see spec §6)
- Self-side incoming-damage-buff folding (would make Battlecry real) — deferred, cross-cutting.
- Disable as a turn-effect — deferred to a control PR.

Spec: `docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr7-design.md`
Plan: `docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr7.md`

## Test Plan
- [x] New unit tests: three implants resolve to correct config per rarity (incl. absent-variant skips)
- [x] New engine integration tests: Last Wish repairs surviving allies (dead caster excluded, bounded assertions); Battlecry emits `buff-applied` per living ally (emit-only, no damage-reduction asserted); Martyrdom routes Disable to the killer on direct death + no-op on DoT death; enemy-side mirror (team-agnostic)
- [x] Full suite green (2942 pass), **zero golden/.snap drift**
- [x] `npm run lint` clean, `npx tsc --noEmit` clean, `npm run audit:skills` 141 ships / 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)