### PR TITLE
feat(combat): D-PR8 — reactive self-buff grants (Ambush / Synaptic Resonance / Alacrity)

### DIFF
--- a/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr8.md
+++ b/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr8.md
@@ -1,0 +1,574 @@
+# D-PR8 — Reactive self-buff grants (Ambush / Synaptic Resonance / Alacrity) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Model three implants that grant a timed self-buff on a trigger — Ambush (Crit Power Up III when stealthed at round start), Synaptic Resonance (Speed Up III when an enemy is repaired), Alacrity (Speed Up III at round end if not hit) — riding the existing reactive-buff executor.
+
+**Architecture:** Two small, precedented engine primitives plus three registry entries. (1) Extend `passesProcChanceGate` into the reactive `buff` executor branch (De-Morgan pass-through → byte-identical for existing grants). (2) A new `not-hit-this-round` condition: a combat-wide `hitThisRound` Set (mirrors `repairedThisRound`) populated in the shared `applyVictimDamage` core, surfaced to gates via a `wasHitThisRoundFor` delegate (mirrors `isLowestSpeedAllyFor`). The three implants become `IMPLANT_ABILITIES` registry entries via the existing `mkNamedBuffGrant` helper (generalized to accept conditions + procChance).
+
+**Tech Stack:** TypeScript, Vitest. Combat engine in `src/utils/combat/`, ability model in `src/utils/abilities/` + `src/types/abilities.ts`, implant data in `src/constants/implants.ts`.
+
+**Worktree:** `.worktrees/d-pr8-reactive-self-buffs` (branch `feat/combat-d-pr8-reactive-self-buffs`, stacked on D-PR7 tip `1e163c82`). Spec: `docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr8-design.md`.
+
+**Load-bearing invariant:** DPS + healing goldens must stay BYTE-IDENTICAL (no fixture equips these implants; both new primitives default to a no-op). If a `.snap` moves, the gate leaked — fix the gate, never `vitest -u`.
+
+**Commands:** `npm test -- <path>` (Vitest), `npm run lint`, `npx tsc --noEmit`. Pre-commit hook runs the FULL suite; docs-only commits use `--no-verify` and `git add -f` (docs/ is gitignored).
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `src/types/abilities.ts` | Add `'not-hit-this-round'` to the `ConditionSubject` union (with doc comment). |
+| `src/utils/abilities/evaluateConditions.ts` | Add `wasHitThisRound?` to `ConditionContext`; add the `case 'not-hit-this-round'`. |
+| `src/utils/abilities/roundContext.ts` | Add `wasHitThisRound?` param + `?? false` default to `buildRoundContext`. |
+| `src/utils/combat/abilityStatusGating.ts` | Add `'not-hit-this-round'` to `LIVE_SUBJECTS`. |
+| `src/utils/combat/triggers.ts` | (a) `passesProcChanceGate` in the `buff` branch; (b) `wasHitThisRoundFor?` on `IntentExecContext`; (c) thread `wasHitThisRound` through `buildDrainContext` + `buildActorConditionContext`. |
+| `src/utils/combat/engine.ts` | `hitThisRound` Set (declare + clear); record hits in `applyVictimDamage`; bind `wasHitThisRoundFor` in the drain IntentExecContext literal. |
+| `src/utils/abilities/buildEquipmentAbilities.ts` | Generalize `mkNamedBuffGrant` (optional conditions + procChance); add AMBUSH / SYNAPTIC_RESONANCE / ALACRITY entries + proc tables. |
+| `src/utils/abilities/__tests__/equipmentCoverage.test.ts` | Add the 3 implants to BOTH the decl-order array and the `implementedImplants` Set. |
+| `src/utils/abilities/__tests__/evaluateConditions.test.ts` | New unit tests for the condition (or co-located). |
+| `src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts` | Engine integration tests (Synaptic / Alacrity / Ambush gate). |
+| `src/constants/changelog.ts` | `UNRELEASED_CHANGES` entry. |
+
+---
+
+## Task 1: `not-hit-this-round` condition primitive (pure layer)
+
+**Files:**
+- Modify: `src/types/abilities.ts` (ConditionSubject union)
+- Modify: `src/utils/abilities/evaluateConditions.ts` (ConditionContext + evaluateCondition)
+- Modify: `src/utils/abilities/roundContext.ts` (buildRoundContext)
+- Test: `src/utils/abilities/__tests__/evaluateConditions.test.ts`
+
+The precedent is `target-repaired-this-round` (a live binary gate present in ConditionContext + evaluateCondition + buildRoundContext default + LIVE_SUBJECTS). NOT `self-shield` — that one is modifier-path-only and is deliberately absent from LIVE_SUBJECTS.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/utils/abilities/__tests__/evaluateConditions.test.ts` (create the import block if the file is new; mirror existing tests in that dir):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { evaluateCondition, ConditionContext } from '../evaluateConditions';
+import { Condition } from '../../../types/abilities';
+
+function ctx(over: Partial<ConditionContext> = {}): ConditionContext {
+    return {
+        selfBuffNames: [], selfDebuffNames: [], enemyBuffNames: [],
+        enemyDebuffCount: 0, effectiveCritRate: 0,
+        adjacentAllyCount: 0, enemyAdjacentCount: 0, enemyDestroyedCount: 0,
+        selfHpPct: 100, enemyHpPct: 100,
+        ...over,
+    };
+}
+
+describe('not-hit-this-round condition', () => {
+    const cond: Condition = { subject: 'not-hit-this-round', derivable: true };
+
+    it('is met (1) when wasHitThisRound is false', () => {
+        expect(evaluateCondition(cond, ctx({ wasHitThisRound: false }))).toBe(1);
+    });
+    it('is met (1) when wasHitThisRound is undefined (default)', () => {
+        expect(evaluateCondition(cond, ctx())).toBe(1);
+    });
+    it('is NOT met (0) when wasHitThisRound is true', () => {
+        expect(evaluateCondition(cond, ctx({ wasHitThisRound: true }))).toBe(0);
+    });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npm test -- src/utils/abilities/__tests__/evaluateConditions.test.ts`
+Expected: FAIL — `'not-hit-this-round'` is not assignable to `ConditionSubject` (tsc) / `evaluateCondition` returns 0 (default case).
+
+- [ ] **Step 3: Add the ConditionSubject member**
+
+In `src/types/abilities.ts`, in the `ConditionSubject` union (right after `'self-shield'`), add:
+
+```ts
+    // Binary gate: the condition owner received ZERO direct hits this round (a "hit" =
+    // a direct attack that landed damage on shield or HP; DoT ticks and fully-Barrier-blocked
+    // attacks do not count). Live-derived (ConditionContext.wasHitThisRound); defaults false
+    // (DPS / not-yet-hit → "not hit" ⇒ met). Used by the Alacrity implant.
+    | 'not-hit-this-round';
+```
+
+- [ ] **Step 4: Add the ConditionContext field + evaluateCondition case**
+
+In `src/utils/abilities/evaluateConditions.ts`, add to the `ConditionContext` interface (after `selfShielded?`):
+
+```ts
+    /** True when the condition owner was hit by a direct attack this round (damage landed
+     *  on shield or HP). Live-derived by the engine; defaults false (DPS / not-yet-hit). */
+    wasHitThisRound?: boolean;
+```
+
+And add the case in `evaluateCondition` (after `case 'self-shield':`):
+
+```ts
+        case 'not-hit-this-round':
+            return ctx.wasHitThisRound ? 0 : 1;
+```
+
+- [ ] **Step 5: Add the buildRoundContext param + default**
+
+In `src/utils/abilities/roundContext.ts`, add to the `state` param type (after `selfShielded?`):
+
+```ts
+    /** True when the acting unit was hit by a direct attack this round. Default false. */
+    wasHitThisRound?: boolean;
+```
+
+And in the returned object (after `selfShielded: state.selfShielded ?? false,`):
+
+```ts
+        wasHitThisRound: state.wasHitThisRound ?? false,
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `npm test -- src/utils/abilities/__tests__/evaluateConditions.test.ts`
+Expected: PASS (3/3).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/types/abilities.ts src/utils/abilities/evaluateConditions.ts src/utils/abilities/roundContext.ts src/utils/abilities/__tests__/evaluateConditions.test.ts
+git commit -m "feat(combat): D-PR8 — not-hit-this-round condition primitive"
+```
+
+---
+
+## Task 2: `not-hit-this-round` in LIVE_SUBJECTS
+
+**Files:**
+- Modify: `src/utils/combat/abilityStatusGating.ts`
+- Test: `src/utils/combat/__tests__/abilityStatusGating.test.ts` (if present; else co-locate)
+
+Without this, `liveGateConditions` neutralizes a derivable `not-hit-this-round` gate to `always` and Alacrity would grant even when hit.
+
+- [ ] **Step 1: Write the failing test**
+
+Find the existing test for `liveGateConditions` (grep `liveGateConditions` under `src/utils/combat`). Add a case mirroring the `target-repaired-this-round` test:
+
+```ts
+it('keeps a derivable not-hit-this-round condition (live subject, not neutralized)', () => {
+    const out = liveGateConditions([{ subject: 'not-hit-this-round', derivable: true }]);
+    expect(out[0].subject).toBe('not-hit-this-round');
+});
+```
+
+If no such test file exists, create `src/utils/combat/__tests__/abilityStatusGating.test.ts` with the import `import { liveGateConditions } from '../abilityStatusGating';`.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npm test -- abilityStatusGating`
+Expected: FAIL — subject neutralized to `'always'`.
+
+- [ ] **Step 3: Add to LIVE_SUBJECTS**
+
+In `src/utils/combat/abilityStatusGating.ts`, add `'not-hit-this-round',` to the `LIVE_SUBJECTS` set (after `'target-repaired-this-round',`).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- abilityStatusGating`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/abilityStatusGating.ts src/utils/combat/__tests__/abilityStatusGating.test.ts
+git commit -m "feat(combat): D-PR8 — not-hit-this-round is a live gate subject"
+```
+
+---
+
+## Task 3: procChance in the reactive buff executor branch
+
+**Files:**
+- Modify: `src/utils/combat/triggers.ts` (the `cfg.type === 'buff'` branch, ~line 1000)
+- Test: mirror the existing damage-branch procChance test (grep `passesProcChanceGate` / `procChance` under `src/utils/combat/__tests__`; D-PR4 Insidiousness added the damage-branch one).
+
+The buff branch currently does NOT call `passesProcChanceGate` (only heal/shield ~1160 and damage ~1264 do). `passesProcChanceGate` returns `true` whenever `procChance` is `undefined`/`≤0`/`≥1`, so existing buff grants (none carry procChance) stay byte-identical.
+
+- [ ] **Step 1: Write the failing test**
+
+Locate the test harness used to exercise `executeIntent` / the buff executor directly (the damage-branch procChance test is the template). Add a test: a reactive `buff` intent carrying `procChance` low enough not to fire on the first gate roll does NOT apply the buff; the same intent with no `procChance` DOES apply it. (Use the same `procChanceGates` Map seeding the existing test uses.)
+
+If a direct executor harness is awkward, defer this to the Task 6 Alacrity integration test and note it here — but prefer the focused test.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npm test -- triggers` (or the chosen file)
+Expected: FAIL — buff applied despite the unmet proc gate.
+
+- [ ] **Step 3: Add the gate to the buff branch**
+
+In `src/utils/combat/triggers.ts`, inside `if (cfg.type === 'buff') {`, immediately AFTER the `oncePerCombat` cap block and BEFORE `const duration = …`, add:
+
+```ts
+        // D-PR8: procChance gate for reactive buff grants (Ambush 5-16%, Alacrity 12-20%).
+        // De-Morgan pass-through — true when procChance is undefined/≤0/≥1, so every existing
+        // (procChance-less) buff grant stays byte-identical. Mirrors the heal/shield + damage
+        // branches. Keys on `${ownerId}:${ability.id}` via ctx.procChanceGates.
+        if (!passesProcChanceGate(intent, ctx)) return;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- triggers`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full combat suite — confirm goldens byte-identical**
+
+Run: `npm test -- src/utils/calculators/__tests__`
+Expected: PASS, ZERO `.snap` changes (no existing buff grant carries procChance).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/combat/triggers.ts src/utils/combat/__tests__/
+git commit -m "feat(combat): D-PR8 — honor procChance in the reactive buff executor"
+```
+
+---
+
+## Task 4: Engine hit-tracking + `wasHitThisRoundFor` delegate
+
+**Files:**
+- Modify: `src/utils/combat/triggers.ts` (`IntentExecContext` + `buildDrainContext` + `buildActorConditionContext`)
+- Modify: `src/utils/combat/engine.ts` (`hitThisRound` Set + record site + delegate binding)
+- Test: `src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts` (Alacrity end-to-end, hand-built ability to isolate the condition from proc timing)
+
+- [ ] **Step 1: Write the failing integration test**
+
+In `equipmentAbilities.integration.test.ts` (follow the existing engine-integration setup in that file — `runCombat`/board helpers used by D-PR3/D-PR7), add an Alacrity-style test using a HAND-BUILT reactive buff ability (NOT the registry — isolates the condition from proc-gate timing): `type:'buff'`, `target:'self'`, `trigger:'end-of-round'`, `conditions:[{subject:'not-hit-this-round', derivable:true}]`, NO `procChance`, buffName e.g. `'Speed Up III'`, duration 2. Place it on a passive-slot owner.
+  - Assert: in a round where the owner takes NO direct hit, the buff is granted (`buff-applied` for the owner / appears in its active statuses).
+  - Assert: in a round where the owner IS directly hit, the buff is NOT granted.
+  - Assert: a round where the owner takes only a SHIELD-absorbed direct hit → counts as hit → withheld. (Seed a shield pool on the owner.)
+  - Assert: a round where the owner takes only a DoT tick (no direct attack) → NOT a hit → granted.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npm test -- equipmentAbilities.integration`
+Expected: FAIL — buff granted regardless of hit state (`hitThisRound` not populated; delegate undefined → `wasHitThisRound` defaults false → always "not hit" → always granted; the hit-case assertions fail).
+
+- [ ] **Step 3: Add `wasHitThisRoundFor` to IntentExecContext**
+
+In `src/utils/combat/triggers.ts`, in the `IntentExecContext` interface (after `isLowestSpeedAllyFor?`), add:
+
+```ts
+    /** Whether `ownerId` was hit by a direct attack this round, feeding the
+     *  `not-hit-this-round` gate at drain time. Engine-populated from the combat-wide
+     *  hitThisRound Set. Absent → buildDrainContext defaults the gate to false (DPS /
+     *  not-yet-hit → "not hit" ⇒ met), keeping existing drain gating byte-identical. */
+    wasHitThisRoundFor?: (ownerId: string) => boolean;
+```
+
+- [ ] **Step 4: Thread it through buildDrainContext + buildActorConditionContext**
+
+In `buildActorConditionContext`'s `shared` param type (after `isLowestSpeedAlly?`), add:
+
+```ts
+        /** Owner was hit by a direct attack this round. Default false. Populated by
+         *  buildDrainContext (D-PR8). */
+        wasHitThisRound?: boolean;
+```
+
+In its `buildRoundContext({...})` call (after `isLowestSpeedAlly: shared.isLowestSpeedAlly,`), add:
+
+```ts
+        wasHitThisRound: shared.wasHitThisRound,
+```
+
+In `buildDrainContext`, in the object passed to `buildActorConditionContext` (after `isLowestSpeedAlly: ctx.isLowestSpeedAllyFor?.(ownerId) ?? true,`), add:
+
+```ts
+        // D-PR8: live not-hit-this-round gate (Alacrity). Default false → DPS / no-delegate
+        // paths read "not hit" ⇒ met and stay byte-identical.
+        wasHitThisRound: ctx.wasHitThisRoundFor?.(ownerId) ?? false,
+```
+
+- [ ] **Step 5: Add the `hitThisRound` Set to the engine (declare + clear)**
+
+In `src/utils/combat/engine.ts`, next to `const repairedThisRound = new Set<string>();` (~line 1922):
+
+```ts
+    // D-PR8: actors hit by a direct attack this round (damage landed on shield or HP).
+    // Mirrors repairedThisRound. Feeds the not-hit-this-round gate (Alacrity). Cleared each
+    // round alongside repairedThisRound.
+    const hitThisRound = new Set<string>();
+```
+
+Next to `repairedThisRound.clear();` (~line 2373):
+
+```ts
+        hitThisRound.clear();
+```
+
+- [ ] **Step 6: Record hits in `applyVictimDamage`**
+
+In `src/utils/combat/engine.ts`, in `applyVictimDamage`, immediately BEFORE the final non-barriered `return { shieldBefore, hpDamage, barriered: false };` (~line 2710), add:
+
+```ts
+            // D-PR8: record a direct hit for the not-hit-this-round gate. A hit = a direct
+            // attack that landed damage on shield or HP (absorbed > 0 || hpDamage > 0). The
+            // byDirectDamage guard excludes DoT-tick batches (they pass byDirectDamage:false);
+            // fully-Barrier-blocked hits return earlier (barriered:true) and are not recorded.
+            if (cause?.byDirectDamage && (absorbed > 0 || hpDamage > 0)) {
+                hitThisRound.add(victim.id);
+            }
+```
+
+(`absorbed` and `hpDamage` are both in scope here, declared at ~2639/2642. `absorbed > 0 || hpDamage > 0` is equivalent to post-block `damage > 0`.)
+
+- [ ] **Step 7: Bind the delegate in the drain IntentExecContext literal**
+
+In `src/utils/combat/engine.ts`, in the IntentExecContext literal built for the drain (next to `selfHpPctFor: sideCtx.selfHpPctFor,` / `enemyWithMostBuffs: sideCtx.enemyWithMostBuffs,`, ~line 3356), add:
+
+```ts
+                        // D-PR8: live not-hit-this-round gate (Alacrity). hitThisRound is a single
+                        // combat-wide Set, so the SAME closure serves both sides (team-agnostic) —
+                        // no per-side sideCtx field needed (unlike isLowestSpeedAllyFor).
+                        wasHitThisRoundFor: (ownerId) => hitThisRound.has(ownerId),
+```
+
+- [ ] **Step 8: Run the integration test to verify it passes**
+
+Run: `npm test -- equipmentAbilities.integration`
+Expected: PASS (unhit → granted; hit → withheld; shield-only hit → withheld; DoT-only → granted).
+
+- [ ] **Step 9: Run the full combat suite — confirm goldens byte-identical**
+
+Run: `npm test -- src/utils/calculators/__tests__` then `npx tsc --noEmit`
+Expected: PASS, ZERO `.snap` changes, tsc clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/utils/combat/triggers.ts src/utils/combat/engine.ts src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts
+git commit -m "feat(combat): D-PR8 — engine hit-tracking + wasHitThisRound gate delegate"
+```
+
+---
+
+## Task 5: Registry entries + proc tables + coverage tracker
+
+**Files:**
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts`
+- Modify: `src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+
+- [ ] **Step 1: Write the failing coverage + shape tests**
+
+In `equipmentCoverage.test.ts`:
+- Add `'AMBUSH'`, `'ALACRITY'`, `'SYNAPTIC_RESONANCE'` to BOTH the `.toEqual([...])` decl-order array (in `'exactly { … }'` test) AND the `implementedImplants` `new Set([...])` (known pitfall — both must move together). **Decl-order matters**: insert each at its position in `Object.keys(IMPLANTS)` order — verify by reading the IMPLANTS declaration order; do not guess.
+- Add per-implant shape assertions (mirror the INTRUSION/WARPSTRIKE blocks):
+
+```ts
+it('SYNAPTIC_RESONANCE produces 1 self Speed Up III buff on-enemy-repaired per rarity (no procChance)', () => {
+    for (const v of IMPLANTS['SYNAPTIC_RESONANCE'].variants) {
+        expect(implantAbilityCount('SYNAPTIC_RESONANCE', v.rarity)).toBe(1);
+    }
+});
+it('AMBUSH produces 1 self Crit Power Up III buff (start-of-round, self-buff Stealth gate, procChance) per rarity', () => {
+    for (const v of IMPLANTS['AMBUSH'].variants) {
+        expect(implantAbilityCount('AMBUSH', v.rarity)).toBe(1);
+    }
+});
+it('ALACRITY produces 1 self Speed Up III buff (end-of-round, not-hit-this-round gate, procChance) per rarity', () => {
+    for (const v of IMPLANTS['ALACRITY'].variants) {
+        expect(implantAbilityCount('ALACRITY', v.rarity)).toBe(1);
+    }
+});
+```
+
+Also remove these three from the `unimplementedImplants` "produces 0" loop coverage automatically (they leave the `unimplementedImplants` filter once added to `implementedImplants`).
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npm test -- equipmentCoverage`
+Expected: FAIL — implants not yet implemented (counts 0; `.toEqual` mismatch).
+
+- [ ] **Step 3: Generalize `mkNamedBuffGrant` for conditions + procChance**
+
+In `src/utils/abilities/buildEquipmentAbilities.ts`, change `mkNamedBuffGrant`'s signature to accept an optional opts object and apply it (Battlecry passes nothing → output byte-identical):
+
+```ts
+function mkNamedBuffGrant(
+    buffName: string,
+    target: 'self' | 'ally' | 'all-allies',
+    trigger: AbilityTrigger,
+    duration: number | undefined,
+    opts?: { conditions?: Condition[]; procChance?: number }
+): Omit<Ability, 'id'> | undefined {
+    if (duration === undefined) return undefined;
+    const buff = BUFFS.find((b) => b.name === buffName);
+    if (!buff) return undefined;
+    const { stackable, maxStacks } = isStackable(buff.description);
+    return {
+        type: 'buff',
+        target,
+        trigger,
+        conditions: opts?.conditions ?? [],
+        ...(opts?.procChance !== undefined ? { procChance: opts.procChance } : {}),
+        config: {
+            type: 'buff',
+            buffName,
+            parsedEffects: parseBuffEffects(buff.name, buff.description),
+            stacks: 1,
+            isStackable: stackable,
+            maxStacks,
+            duration,
+        },
+        autoFilled: true,
+    };
+}
+```
+
+Add `Condition` to the `import { Ability } from '../../types/abilities';` line → `import { Ability, Condition } from '../../types/abilities';` (verify exact current import).
+
+- [ ] **Step 4: Add proc tables + registry entries**
+
+Near the other per-rarity tables (e.g. by `WARPSTRIKE_PCT`):
+
+```ts
+const AMBUSH_PROC: Record<string, number> = {
+    common: 0.05, uncommon: 0.07, rare: 0.09, epic: 0.12, legendary: 0.16,
+};
+const ALACRITY_PROC: Record<string, number> = {
+    uncommon: 0.12, rare: 0.14, epic: 0.16, legendary: 0.2, // no common variant
+};
+```
+
+In `IMPLANT_ABILITIES`, add (placement free; group with the other D-PR8 self-buff grants):
+
+```ts
+    // D-PR8: Ambush — start-of-round, if Stealthed, X% chance to gain Crit Power Up III for 1 turn.
+    // Gate is self-buff/Stealth (NOT self-stealth — that's an IncomingCondition, not a
+    // ConditionSubject). DORMANT until a stealth source exists in the sim (Cloaking / sub-project H);
+    // entry + gate are correct now, only the Stealth source is missing.
+    AMBUSH: (rarity) => {
+        const procChance = AMBUSH_PROC[rarity];
+        if (procChance === undefined) return undefined;
+        return mkNamedBuffGrant('Crit Power Up III', 'self', 'start-of-round', 1, {
+            conditions: [{ subject: 'self-buff', buffName: 'Stealth', derivable: true }],
+            procChance,
+        });
+    },
+    // D-PR8: Synaptic Resonance — gain Speed Up III for 1 turn when an enemy is directly repaired.
+    // DETERMINISTIC (no procChance). LIVE today (E5 gave enemies real healing → on-enemy-repaired
+    // fires). The "+X% next-crit critDamage" half is DEFERRED (stacking next-crit consumable, no seam).
+    SYNAPTIC_RESONANCE: () =>
+        mkNamedBuffGrant('Speed Up III', 'self', 'on-enemy-repaired', 1),
+    // D-PR8: Alacrity — at end of round, if not hit, X% chance to gain Speed Up III for 2 turns.
+    ALACRITY: (rarity) => {
+        const procChance = ALACRITY_PROC[rarity];
+        if (procChance === undefined) return undefined; // no common variant
+        return mkNamedBuffGrant('Speed Up III', 'self', 'end-of-round', 2, {
+            conditions: [{ subject: 'not-hit-this-round', derivable: true }],
+            procChance,
+        });
+    },
+```
+
+(`ImplantAbilityBuilder` is `(rarity: string) => Omit<Ability,'id'> | undefined`; SYNAPTIC_RESONANCE ignores `rarity` — the builder may declare `()` since the registry stores `ImplantAbilityBuilder`; if tsc complains about arity, use `(_rarity) =>`.)
+
+- [ ] **Step 5: Run the coverage + shape tests to verify they pass**
+
+Run: `npm test -- equipmentCoverage`
+Expected: PASS. If the `.toEqual` decl-order array fails, fix the insertion order to match `Object.keys(IMPLANTS)`.
+
+- [ ] **Step 6: Confirm the id-collision note holds**
+
+The implant id is `equip-implant-${implantName}` (no per-piece suffix — academic, real loadouts equip one of each). No action; this step is a reminder not to "fix" it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/equipmentCoverage.test.ts
+git commit -m "feat(combat): D-PR8 — Ambush / Synaptic Resonance / Alacrity registry entries"
+```
+
+---
+
+## Task 6: Engine integration — Synaptic Resonance (live) + Ambush gate
+
+**Files:**
+- Test: `src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts`
+
+- [ ] **Step 1: Write the Synaptic Resonance integration test**
+
+Equip SYNAPTIC_RESONANCE (via `buildShipAbilitiesWithEquipment` + `getGearPiece` stub, as D-PR1+ tests do) on an owner. Run a combat where an enemy actor gets directly repaired (mirror the E5 symmetric-healing test setup — an enemy with a heal). Assert the owner gains `Speed Up III` (via `buff-applied` for the owner or its active statuses). Deterministic — no procChance.
+
+- [ ] **Step 2: Write the Ambush gate integration test**
+
+AMBUSH is dormant (nothing grants Stealth), so seed a `Stealth` buff directly onto the owner before round start, and use a HAND-BUILT copy of the Ambush ability with `procChance` omitted (or `1`) to bypass proc timing — assert: with Stealth present → Crit Power Up III granted at start-of-round; with Stealth absent → not granted. This proves the gate uses `self-buff`/`Stealth` correctly (would silently fail with the broken `self-stealth` IncomingCondition).
+
+- [ ] **Step 3: Run the tests to verify they pass**
+
+Run: `npm test -- equipmentAbilities.integration`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts
+git commit -m "test(combat): D-PR8 — Synaptic Resonance live + Ambush gate integration"
+```
+
+---
+
+## Task 7: Changelog, docs, final verification
+
+**Files:**
+- Modify: `src/constants/changelog.ts`
+- Verify: full suite, lint, tsc, audit
+
+- [ ] **Step 1: Add the changelog entry**
+
+In `src/constants/changelog.ts`, add to `UNRELEASED_CHANGES` a plain-English combat-sim entry, e.g.: "Combat sim: modeled the Ambush, Synaptic Resonance, and Alacrity implants (self-buff grants — Crit Power, Speed)." Match the surrounding entry style.
+
+- [ ] **Step 2: Full suite + lint + tsc**
+
+Run:
+```bash
+npm test
+npm run lint
+npx tsc --noEmit
+```
+Expected: all green; goldens byte-identical (confirm no `.snap` in `git diff --stat`).
+
+- [ ] **Step 3: Skill audit (no regression)**
+
+Run: `npm run audit:skills`
+Expected: 141 ships, 0 findings (unchanged — D adds equipment abilities, not ship-skill parses).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/constants/changelog.ts
+git commit -m "docs(combat): D-PR8 — changelog entry"
+```
+
+- [ ] **Step 5: Push + open PR (stacked on D-PR7)**
+
+```bash
+gh auth switch --user TheSusort
+git push -u origin feat/combat-d-pr8-reactive-self-buffs 2>&1 | cat
+gh pr create --base feat/combat-d-pr7-on-death --head feat/combat-d-pr8-reactive-self-buffs --title "feat(combat): D-PR8 — reactive self-buff grants (Ambush / Synaptic Resonance / Alacrity)" --body "..."
+```
+
+(Base = the D-PR7 branch per the stacking strategy; retarget to main as the lower stack merges. Commit the spec + plan docs with `git add -f` + `--no-verify` if not already committed.)
+
+---
+
+## Notes for the implementer
+
+- **Never `vitest -u`** to "fix" a moved golden — a moved snapshot means a gate leaked; fix the gate.
+- **Decl-order in the coverage `.toEqual`** must match `Object.keys(IMPLANTS)` exactly — read the IMPLANTS declaration order, don't guess.
+- **`self-stealth` is a trap** — it's an `IncomingCondition`, not a `ConditionSubject`. AMBUSH gates on `self-buff` + `buffName:'Stealth'`.
+- **The hit predicate** is `cause?.byDirectDamage && (absorbed > 0 || hpDamage > 0)` in `applyVictimDamage` — the `byDirectDamage` flag is what excludes DoT ticks (they call in with `byDirectDamage:false`); fully-Barrier-blocked hits return earlier and never reach the record site.
+- **TO-VERIFY (in-game):** whether a fully-Barrier-blocked direct attack should count as "hit" for Alacrity. Current default: not a hit. Leave a `// TODO(verify):` near the record site.
+- **Worktree env:** `.env` + `docs/*.csv` are symlinked from the main checkout; if tests fail on missing env/data, re-check the symlinks.

--- a/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr8.md
+++ b/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr8.md
@@ -29,7 +29,7 @@
 | `src/utils/abilities/buildEquipmentAbilities.ts` | Generalize `mkNamedBuffGrant` (optional conditions + procChance); add AMBUSH / SYNAPTIC_RESONANCE / ALACRITY entries + proc tables. |
 | `src/utils/abilities/__tests__/equipmentCoverage.test.ts` | Add the 3 implants to BOTH the decl-order array and the `implementedImplants` Set. |
 | `src/utils/abilities/__tests__/evaluateConditions.test.ts` | New unit tests for the condition (or co-located). |
-| `src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts` | Engine integration tests (Synaptic / Alacrity / Ambush gate). |
+| `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts` | Engine integration tests (Synaptic / Alacrity / Ambush gate). |
 | `src/constants/changelog.ts` | `UNRELEASED_CHANGES` entry. |
 
 ---
@@ -46,37 +46,28 @@ The precedent is `target-repaired-this-round` (a live binary gate present in Con
 
 - [ ] **Step 1: Write the failing test**
 
-Add to `src/utils/abilities/__tests__/evaluateConditions.test.ts` (create the import block if the file is new; mirror existing tests in that dir):
+`src/utils/abilities/__tests__/evaluateConditions.test.ts` ALREADY EXISTS and uses the shared
+`makeConditionContext` fixture from `./conditionContextFixture`. Reuse it (it spreads overrides, and
+`wasHitThisRound` being optional on `ConditionContext` means NO fixture change is needed). Add:
 
 ```ts
-import { describe, it, expect } from 'vitest';
-import { evaluateCondition, ConditionContext } from '../evaluateConditions';
-import { Condition } from '../../../types/abilities';
-
-function ctx(over: Partial<ConditionContext> = {}): ConditionContext {
-    return {
-        selfBuffNames: [], selfDebuffNames: [], enemyBuffNames: [],
-        enemyDebuffCount: 0, effectiveCritRate: 0,
-        adjacentAllyCount: 0, enemyAdjacentCount: 0, enemyDestroyedCount: 0,
-        selfHpPct: 100, enemyHpPct: 100,
-        ...over,
-    };
-}
-
+// (makeConditionContext is already imported at the top of this file)
 describe('not-hit-this-round condition', () => {
     const cond: Condition = { subject: 'not-hit-this-round', derivable: true };
 
     it('is met (1) when wasHitThisRound is false', () => {
-        expect(evaluateCondition(cond, ctx({ wasHitThisRound: false }))).toBe(1);
+        expect(evaluateCondition(cond, makeConditionContext({ wasHitThisRound: false }))).toBe(1);
     });
     it('is met (1) when wasHitThisRound is undefined (default)', () => {
-        expect(evaluateCondition(cond, ctx())).toBe(1);
+        expect(evaluateCondition(cond, makeConditionContext())).toBe(1);
     });
     it('is NOT met (0) when wasHitThisRound is true', () => {
-        expect(evaluateCondition(cond, ctx({ wasHitThisRound: true }))).toBe(0);
+        expect(evaluateCondition(cond, makeConditionContext({ wasHitThisRound: true }))).toBe(0);
     });
 });
 ```
+
+(If `Condition` isn't already imported in that file, add it to its `../../../types/abilities` import.)
 
 - [ ] **Step 2: Run it to verify it fails**
 
@@ -240,7 +231,7 @@ git commit -m "feat(combat): D-PR8 — honor procChance in the reactive buff exe
 **Files:**
 - Modify: `src/utils/combat/triggers.ts` (`IntentExecContext` + `buildDrainContext` + `buildActorConditionContext`)
 - Modify: `src/utils/combat/engine.ts` (`hitThisRound` Set + record site + delegate binding)
-- Test: `src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts` (Alacrity end-to-end, hand-built ability to isolate the condition from proc timing)
+- Test: `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts` (Alacrity end-to-end, hand-built ability to isolate the condition from proc timing)
 
 - [ ] **Step 1: Write the failing integration test**
 
@@ -348,7 +339,7 @@ Expected: PASS, ZERO `.snap` changes, tsc clean.
 - [ ] **Step 10: Commit**
 
 ```bash
-git add src/utils/combat/triggers.ts src/utils/combat/engine.ts src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts
+git add src/utils/combat/triggers.ts src/utils/combat/engine.ts src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
 git commit -m "feat(combat): D-PR8 — engine hit-tracking + wasHitThisRound gate delegate"
 ```
 
@@ -363,7 +354,7 @@ git commit -m "feat(combat): D-PR8 — engine hit-tracking + wasHitThisRound gat
 - [ ] **Step 1: Write the failing coverage + shape tests**
 
 In `equipmentCoverage.test.ts`:
-- Add `'AMBUSH'`, `'ALACRITY'`, `'SYNAPTIC_RESONANCE'` to BOTH the `.toEqual([...])` decl-order array (in `'exactly { … }'` test) AND the `implementedImplants` `new Set([...])` (known pitfall — both must move together). **Decl-order matters**: insert each at its position in `Object.keys(IMPLANTS)` order — verify by reading the IMPLANTS declaration order; do not guess.
+- Add `'AMBUSH'`, `'ALACRITY'`, `'SYNAPTIC_RESONANCE'` to BOTH the `.toEqual([...])` array AND the `implementedImplants` `new Set([...])`. Only the `.toEqual` array is order-sensitive (it compares a `filter` over `Object.keys(IMPLANTS)`); the Set is membership-only. **Decl-order (confirmed against `implants.ts`):** insert `SYNAPTIC_RESONANCE` after `NOURISHMENT` (before `VOIDFIRE_CATALYST`); insert `ALACRITY` then `AMBUSH` after `VIVACIOUS_REPAIR` / before `BATTLECRY`. Re-verify by reading the IMPLANTS declaration order; the failing test surfaces any mismatch.
 - Add per-implant shape assertions (mirror the INTRUSION/WARPSTRIKE blocks):
 
 ```ts
@@ -427,7 +418,10 @@ function mkNamedBuffGrant(
 }
 ```
 
-Add `Condition` to the `import { Ability } from '../../types/abilities';` line → `import { Ability, Condition } from '../../types/abilities';` (verify exact current import).
+Add `Condition` to the EXISTING multi-line abilities import block (it currently imports
+`Ability, AbilityTrigger, HealAmpCondition, IncomingCondition, OutgoingCondition` from
+`'../../types/abilities'` across several lines — `buildEquipmentAbilities.ts:~29-35`). Insert
+`Condition,` into that block; there is NO single-line `import { Ability }` to find/replace.
 
 - [ ] **Step 4: Add proc tables + registry entries**
 
@@ -496,7 +490,7 @@ git commit -m "feat(combat): D-PR8 — Ambush / Synaptic Resonance / Alacrity re
 ## Task 6: Engine integration — Synaptic Resonance (live) + Ambush gate
 
 **Files:**
-- Test: `src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts`
+- Test: `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts`
 
 - [ ] **Step 1: Write the Synaptic Resonance integration test**
 
@@ -514,7 +508,7 @@ Expected: PASS.
 - [ ] **Step 4: Commit**
 
 ```bash
-git add src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts
+git add src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
 git commit -m "test(combat): D-PR8 — Synaptic Resonance live + Ambush gate integration"
 ```
 
@@ -569,6 +563,7 @@ gh pr create --base feat/combat-d-pr7-on-death --head feat/combat-d-pr8-reactive
 - **Never `vitest -u`** to "fix" a moved golden — a moved snapshot means a gate leaked; fix the gate.
 - **Decl-order in the coverage `.toEqual`** must match `Object.keys(IMPLANTS)` exactly — read the IMPLANTS declaration order, don't guess.
 - **`self-stealth` is a trap** — it's an `IncomingCondition`, not a `ConditionSubject`. AMBUSH gates on `self-buff` + `buffName:'Stealth'`.
-- **The hit predicate** is `cause?.byDirectDamage && (absorbed > 0 || hpDamage > 0)` in `applyVictimDamage` — the `byDirectDamage` flag is what excludes DoT ticks (they call in with `byDirectDamage:false`); fully-Barrier-blocked hits return earlier and never reach the record site.
+- **The hit predicate** is `cause?.byDirectDamage && (absorbed > 0 || hpDamage > 0)` in `applyVictimDamage` — the `byDirectDamage` flag is what excludes DoT ticks (they call in with `byDirectDamage:false`); fully-Barrier-blocked hits return earlier and never reach the record site. **This plan intentionally refines the spec's `shieldBefore > 0` wording to `absorbed > 0` (= post-block `damage > 0`, i.e. "damage actually landed") — follow the plan, not the spec, here.**
+- **Delegate binding:** the plan binds `wasHitThisRoundFor` ONCE in the shared `drainQueue` IntentExecContext literal (the combat-wide `hitThisRound` Set serves both sides). The spec described per-side binding mirroring `isLowestSpeedAllyFor`; the plan's single binding is simpler and correct — follow the plan.
 - **TO-VERIFY (in-game):** whether a fully-Barrier-blocked direct attack should count as "hit" for Alacrity. Current default: not a hit. Leave a `// TODO(verify):` near the record site.
 - **Worktree env:** `.env` + `docs/*.csv` are symlinked from the main checkout; if tests fail on missing env/data, re-check the symlinks.

--- a/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr8-design.md
+++ b/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr8-design.md
@@ -1,0 +1,181 @@
+# D-PR8 — Reactive self-buff grants (Ambush / Synaptic Resonance / Alacrity)
+
+**Date:** 2026-06-21
+**Sub-project:** D (implants + gear-set abilities), combat-realism epic.
+**Bucket:** Reactive self/ally buff grants — first sub-PR ("reactive **self**-buff grants").
+**Stack:** `feat/combat-d-pr8-reactive-self-buffs` on D-PR7 tip `1e163c82`; own worktree `.worktrees/d-pr8-reactive-self-buffs`. Retarget to main as the lower stack merges.
+
+## 1. Goal
+
+Model three implants that **grant a timed self-buff on a trigger**, all riding the existing
+reactive-buff executor. This is the first slice of the "reactive self/ally buff grant" bucket;
+ally-wide grants (Spearhead all-allies, Fortifying Shroud adjacency) and shield/repair-triggered
+grants (Resonating Fury, Font of Power) are later sub-PRs.
+
+| Implant | Trigger | Gate condition | Buff granted | Duration | Proc chance (by rarity) |
+|---|---|---|---|---|---|
+| **AMBUSH** (major) | `start-of-round` | `self-stealth` | Crit Power Up III | 1 turn | 0.05 / 0.07 / 0.09 / 0.12 / 0.16 (common→legendary) |
+| **SYNAPTIC_RESONANCE** (ultimate) | `on-enemy-repaired` | none | Speed Up III | 1 turn | — (deterministic, no proc) |
+| **ALACRITY** (major) | `end-of-round` | `not-hit-this-round` | Speed Up III | 2 turns | 0.12 / 0.14 / 0.16 / 0.20 (uncommon→legendary; no common) |
+
+Source data: `src/constants/implants.ts` variant `description` strings (quoted in §6).
+
+## 2. What already exists (grounding, verified in the D-PR7 worktree)
+
+- **Reactive buff executor** — `triggers.ts:~1000` (`cfg.type === 'buff'`): resolves recipients
+  (`self` → `[ownerId]`; `ally`/`all-allies` → `ctx.playerIds`), applies a `kind:'timed'` status
+  via `applyTimedAbilityStatus`, emits `buff-applied`. Gated by `gateConditions` at drain time via
+  `conditionsMet`. D-PR7's Battlecry (`buff`/`all-allies`/`on-destroyed`) is the precedent; its
+  `mkNamedBuffGrant` resolves `parsedEffects` from `BUFFS` and derives `isStackable`.
+- **Triggers** — `start-of-round`, `end-of-round`, `on-enemy-repaired` are all in `AbilityTrigger`
+  and `LIVE_TRIGGERS` (`types/abilities.ts`). `on-enemy-repaired` already fires in the sim because
+  E5 gave the enemy real healing (`heal-performed` for enemy actors). `end-of-round` is live
+  (Rhodium C2b-2 purge rides it). `start-of-round` is live (Chakara PR6).
+- **`self-stealth` condition** — exists as a `ConditionSubject` (`types/abilities.ts:178`,
+  built in D-PR3 for Voidshade/Shadowguard). Usable in the gate path.
+- **`procChance` machinery** — `procChanceGates` Map on `IntentExecContext` + `passesProcChanceGate`
+  (`triggers.ts:908`), the deterministic rate-gate accumulator. Currently consumed by the
+  **heal/shield** branch (`triggers.ts:1160`) and the **damage** branch (`triggers.ts:1264`) only.
+- **Buff names** — `Crit Power Up III`, `Speed Up III` exist in `src/constants/buffs.ts`.
+- **Condition delegate threading precedent** — Chakara's `isLowestSpeedAllyFor`:
+  `IntentExecContext.isLowestSpeedAllyFor?(ownerId)` (`engine.ts:1027`) → `buildDrainContext`
+  (`triggers.ts:696` `isLowestSpeedAlly: ctx.isLowestSpeedAllyFor?.(ownerId) ?? true`) →
+  `buildRoundContext`. Engine populates it per-side (`engine.ts:3385/3406`). `not-hit-this-round`
+  mirrors this exactly.
+
+## 3. Two new engine primitives
+
+### 3.1 `procChance` in the reactive buff branch
+
+Add to the top of the `cfg.type === 'buff'` executor (after the `oncePerCombat` cap, before
+recipient resolution):
+
+```ts
+if (!passesProcChanceGate(intent, ctx)) return;
+```
+
+This is the identical extension D-PR4 made to the `damage` branch. `passesProcChanceGate` is a
+De-Morgan pass-through: it returns `true` whenever `procChance` is `undefined`/`≤0`/`≥1`, so **every
+existing buff grant (none carry `procChance`) is byte-identical**. The gate keys on
+`${ownerId}:${ability.id}` in `procChanceGates`, consistent with all other proc sites.
+
+Needed by AMBUSH + ALACRITY. SYNAPTIC_RESONANCE carries no `procChance` → unaffected.
+
+### 3.2 `not-hit-this-round` condition
+
+New `ConditionSubject` `'not-hit-this-round'`. Semantics: **true when the owner received zero
+direct hits during the current round.**
+
+- **"Hit" rule (locked):** any **direct** attack that lands damage on the ship's shield **or** HP
+  counts as a hit. A direct attack does not have to reach HP — touching the shield is enough.
+  **DoT ticks do NOT count** as being hit (not a direct attack).
+- **TO VERIFY (not locked):** a direct attack **fully absorbed by Barrier** (touches neither shield
+  nor HP). Default for this PR: **not a hit** (nothing is touched). Flagged in code as a
+  to-verify-in-game item; revisit if the in-game behavior says a blocked attack still counts.
+
+**Engine state:** a per-round `Set<string>` of actor ids hit this round.
+- Cleared at round start (`beginRound`).
+- Populated inside `applyIncomingToTarget` (`engine.ts:~2643`) for a **direct** attack when
+  `outcome.shieldBefore` was reduced **or** `outcome.hpDamage > 0` — i.e. damage actually landed.
+  (The closure already returns `{shieldBefore, hpDamage, barriered}`; `barriered === true` ⇒ not a
+  hit, satisfying the default above.) The DoT-batch intake path must NOT record into this set.
+
+**Threading:** new optional delegate `wasHitThisRoundFor?(ownerId: string): boolean` on
+`IntentExecContext` (next to `isLowestSpeedAllyFor`). `buildDrainContext` forwards
+`wasHitThisRound: ctx.wasHitThisRoundFor?.(ownerId) ?? false` into the condition bag;
+`buildRoundContext` owns the `?? false` default. `evaluateCondition` adds the
+`'not-hit-this-round'` case returning `ctx.wasHitThisRound ? 0 : 1` (i.e. condition met when NOT
+hit). `'not-hit-this-round'` is added to `LIVE_SUBJECTS` (else `liveGateConditions` neutralizes it
+to always-true). Engine populates the delegate on **both** side contexts (player + enemy) from the
+per-round hit set — team-agnostic, so an enemy Alacrity behaves identically.
+
+ALACRITY fires at `end-of-round`, by which point all direct attacks for the round have landed, so
+the hit set is complete when the gate evaluates.
+
+Needed by ALACRITY only.
+
+## 4. Three registry entries
+
+In `buildEquipmentAbilities.ts` `IMPLANT_ABILITIES`, add a small `mkSelfBuffGrant` helper (mirrors
+D-PR7 `mkNamedBuffGrant`: resolve `parsedEffects` via `parseBuffEffects` from `BUFFS`, derive
+`isStackable`, guard buff-not-found → `undefined`). Each entry is `type:'buff'`, `target:'self'`.
+
+```text
+AMBUSH(rarity):              trigger 'start-of-round',   conditions [self-stealth],
+                             buffName 'Crit Power Up III', duration 1,
+                             procChance AMBUSH_PROC[rarity]            (5 rarities)
+SYNAPTIC_RESONANCE(rarity):  trigger 'on-enemy-repaired', conditions [],
+                             buffName 'Speed Up III', duration 1       (no procChance; all 5 rarities)
+ALACRITY(rarity):            trigger 'end-of-round',     conditions [not-hit-this-round],
+                             buffName 'Speed Up III', duration 2,
+                             procChance ALACRITY_PROC[rarity]          (4 rarities; common → undefined)
+```
+
+Per-rarity tables baked from §6. Builders return `undefined` for unsupported rarities (e.g.
+ALACRITY common) → graceful skip, consistent with the registry contract.
+
+The implant ability ids keep the existing `equip-implant-${name}-${gearId}` suffix (unique per
+piece so the proc-rate gate doesn't collapse independent procs).
+
+## 5. Liveness & known limits (accepted)
+
+- **AMBUSH is dormant today** — nothing grants Stealth in the sim yet, so `self-stealth` is always
+  false → the buff never fires. Accepted, same pattern as D-PR2's Arcane Siege (dormant until
+  shields). Lights up when Cloaking / a stealth-grant lands (a later D / sub-project H PR). The
+  registry entry + condition are correct now; only the trigger source is missing.
+- **SYNAPTIC_RESONANCE is live** — `on-enemy-repaired` fires whenever an enemy actor is repaired
+  (E5 symmetric healing). The **"+X% next-crit critDamage" half is DEFERRED** — it is a stacking,
+  single-consume next-crit modifier with no existing seam; out of scope. Only the Speed Up III
+  grant is modeled this PR. Documented in the registry comment.
+- **ALACRITY is live** — the granted Speed Up III folds into turn order via the A effective-stats
+  backbone (speed is dynamic).
+
+## 6. Source descriptions (verbatim, for value derivation)
+
+**AMBUSH** (proc % scales with rarity; buff + duration constant):
+- common 5% / uncommon 7% / rare 9% / epic 12% / legendary 16%
+- "At the start of the round, if in stealth, there is a N% chance to gain Crit Power Up 3 for 1 turn."
+
+**SYNAPTIC_RESONANCE** (deterministic; the trailing critDamage clause is the deferred half):
+- "Gains Speed Up 3 for 1 turn when an enemy gets directly repaired. Increases the critDamage of
+  the next crit by {2/4/6/8/10}%" (common→legendary)
+
+**ALACRITY** (proc % scales with rarity; no common variant):
+- uncommon 12% / rare 14% / epic 16% / legendary 20%
+- "At the end of the round, if not hit, there is a N% chance to gain Speed Up 3 for 2 turns"
+
+("Speed Up 3" / "Crit Power Up 3" map to the roman-numeral buff tiers Speed Up III / Crit Power Up III.)
+
+## 7. Testing
+
+- **Registry unit tests** (`buildEquipmentAbilities.test.ts` or coverage): each of the 3 implants
+  produces exactly 1 ability per supported rarity, with the right trigger/target/buffName/duration
+  and (for AMBUSH/ALACRITY) the right `procChance`; ALACRITY common → 0 abilities.
+- **Coverage tracker** (`equipmentCoverage.test.ts`): add `AMBUSH`, `ALACRITY`,
+  `SYNAPTIC_RESONANCE` to BOTH the `.toEqual` decl-order array AND the `implementedImplants` Set
+  (known pitfall — both must move together).
+- **Pure evaluator test** for `not-hit-this-round`: `evaluateCondition` returns met when
+  `wasHitThisRound` is false/undefined, not-met when true.
+- **Engine integration tests:**
+  - SYNAPTIC_RESONANCE: an enemy actor is repaired → the equipped owner gains Speed Up III for 1
+    turn (assert via `buff-applied` / the owner's active statuses).
+  - ALACRITY: round where the owner takes no direct hit → Speed Up III granted (proc forced via a
+    procChance that the rate-gate accumulates to fire); round where the owner is hit → withheld.
+  - Hit-recording: a direct attack that only drains shield records the victim as hit (so ALACRITY
+    withholds); a DoT-only round does not record a hit (ALACRITY may still grant).
+- **Goldens byte-identical** — no DPS/healing golden fixture equips these implants; the
+  procChance-in-buff extension is De-Morgan pass-through; the new condition defaults to `false`
+  (not-hit ⇒ met) only when the delegate is present (engine populates it), and no fixture carries
+  an `end-of-round` self-buff implant. Confirm zero `.snap` movement; if a golden moves, the gate
+  leaked — fix the gate, never `vitest -u`.
+
+## 8. Out of scope (later sub-PRs of this bucket)
+
+- **SPEARHEAD** (all-allies Attack Up I, after-charged-skill) — needs a charged-cast trigger +
+  all-allies fan-out. D-PR9.
+- **FORTIFYING_SHROUD** (adjacent-allies Defense Up I, every turn) — needs per-turn trigger +
+  adjacency (positional). D-PR10.
+- **RESONATING_FURY** (self Crit Power Up III, on-shield-applied) — needs shields (sub-project H).
+- **FONT_OF_POWER** (self Power Infused Nanobots, on-own-repair-to-ally) — needs an on-own-repair
+  trigger; may fold into D-PR9.
+- SYNAPTIC_RESONANCE's next-crit critDamage half (stacking consumable).

--- a/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr8-design.md
+++ b/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr8-design.md
@@ -84,15 +84,19 @@ direct hits during the current round.**
 `repairedThisRound` Set (cleared at `engine.ts:~2373` right after `beginRound`; that Set is the
 direct precedent for clear-timing and shape).
 - Cleared at round start (right after `beginRound`, alongside `repairedThisRound`).
-- Populated inside the `applyIncomingToTarget` direct-hit path (`engine.ts:~2643`). The closure
-  returns `{shieldBefore, hpDamage, barriered}`. **Exact predicate (locked):** record the victim as
-  hit when `!barriered && (shieldBefore > 0 || hpDamage > 0)` for a direct attack with non-zero
-  incoming damage — i.e. damage landed on shield or HP. `shieldBefore` is the pre-hit pool, so
-  "shield was touched" = `!barriered && shieldBefore > 0 && damage > 0` (the non-barriered branch
-  always drains some shield before HP). A fully Barrier-blocked hit (`barriered === true`, early
-  return `engine.ts:~2636`) records **nothing** → not a hit (the TO-VERIFY default above).
-- The **DoT-batch intake** path (`applyIncomingToTarget(..., { byDirectDamage: false })`,
-  `engine.ts:~3610`/`~4239`) must NOT record into this set — DoT ticks are not "being hit."
+- Populated inside the **shared `applyVictimDamage` core closure** (`engine.ts:~2534`), NOT in a
+  named wrapper. There are two wrappers over this core — `applyIncomingToTarget` (enemy→player
+  victim, `~2729`) and `applyOutgoingToEnemy` (player→enemy victim, `~2760`) — so recording in the
+  core is what makes the hit set **team-agnostic** (an enemy Alacrity must see its own hits too).
+  The core takes a `cause?: { killerId?; byDirectDamage? }` (`~2542`); the wrappers default
+  `byDirectDamage: true`, the DoT-tick batch overrides `byDirectDamage: false`
+  (`applyIncomingToTarget(..., { byDirectDamage: false })`, `~3610`).
+- **Exact predicate (locked):** record the victim as hit when
+  `cause?.byDirectDamage === true && !barriered && (shieldBefore > 0 || hpDamage > 0)`. The
+  `byDirectDamage` guard subsumes the DoT exclusion in one flag — DoT ticks pass `false` and never
+  record. `shieldBefore` is the pre-hit pool (the non-barriered branch always drains shield before
+  HP, so `shieldBefore > 0` ⇒ shield was touched). A fully Barrier-blocked hit (`barriered === true`,
+  early return `~2569`/`~2636`) records **nothing** → not a hit (the TO-VERIFY default above).
 
 **Threading (three files change in lockstep, same triad `self-shield` touched):**
 1. `ConditionContext` + `RoundContextInput` gain `wasHitThisRound?: boolean` (`roundContext.ts`),
@@ -134,8 +138,11 @@ ALACRITY(rarity):            trigger 'end-of-round',     conditions [not-hit-thi
 Per-rarity tables baked from §6. Builders return `undefined` for unsupported rarities (e.g.
 ALACRITY common) → graceful skip, consistent with the registry contract.
 
-The implant ability ids keep the existing `equip-implant-${name}-${gearId}` suffix (unique per
-piece so the proc-rate gate doesn't collapse independent procs).
+The implant ability id follows the current registry convention `equip-implant-${implantName}`
+(no per-piece suffix — the gearId suffix from D-PR1 was dropped in the PR3–7 registry refactor).
+The proc-rate gate keys on `${ownerId}:${ability.id}`, so two copies of the *same* implant on one
+ship would share a gate; this is academic (real loadouts equip one of each implant) and out of
+scope — if per-piece proc independence is ever needed it's a separate change.
 
 ## 5. Liveness & known limits (accepted)
 

--- a/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr8-design.md
+++ b/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr8-design.md
@@ -14,7 +14,7 @@ grants (Resonating Fury, Font of Power) are later sub-PRs.
 
 | Implant | Trigger | Gate condition | Buff granted | Duration | Proc chance (by rarity) |
 |---|---|---|---|---|---|
-| **AMBUSH** (major) | `start-of-round` | `self-stealth` | Crit Power Up III | 1 turn | 0.05 / 0.07 / 0.09 / 0.12 / 0.16 (common→legendary) |
+| **AMBUSH** (major) | `start-of-round` | `self-buff` Stealth | Crit Power Up III | 1 turn | 0.05 / 0.07 / 0.09 / 0.12 / 0.16 (common→legendary) |
 | **SYNAPTIC_RESONANCE** (ultimate) | `on-enemy-repaired` | none | Speed Up III | 1 turn | — (deterministic, no proc) |
 | **ALACRITY** (major) | `end-of-round` | `not-hit-this-round` | Speed Up III | 2 turns | 0.12 / 0.14 / 0.16 / 0.20 (uncommon→legendary; no common) |
 
@@ -31,8 +31,15 @@ Source data: `src/constants/implants.ts` variant `description` strings (quoted i
   and `LIVE_TRIGGERS` (`types/abilities.ts`). `on-enemy-repaired` already fires in the sim because
   E5 gave the enemy real healing (`heal-performed` for enemy actors). `end-of-round` is live
   (Rhodium C2b-2 purge rides it). `start-of-round` is live (Chakara PR6).
-- **`self-stealth` condition** — exists as a `ConditionSubject` (`types/abilities.ts:178`,
-  built in D-PR3 for Voidshade/Shadowguard). Usable in the gate path.
+- **`self-buff` + `buffName` gate** — `self-buff` is a live `ConditionSubject`
+  (`types/abilities.ts`, in `LIVE_SUBJECTS`); `evaluateCondition` matches it via
+  `countNames(ctx.selfBuffNames, cond.buffName)` (`evaluateConditions.ts:41`), and `buildDrainContext`
+  → `buildActorConditionContext` populates `selfBuffNames` from the owner's live status snapshot
+  (`triggers.ts:643`). The `'Stealth'` buff name exists in `buffs.ts:142`. **NOTE:** `self-stealth`
+  is NOT a `ConditionSubject` — it is a member of the `IncomingCondition` union (the per-incoming-hit
+  victim seam used by D-PR3 Voidshade/Shadowguard). AMBUSH's "if in stealth" gate therefore uses
+  `{ subject: 'self-buff', buffName: 'Stealth', derivable: true }`, the standard self-buff path, NOT
+  `self-stealth`.
 - **`procChance` machinery** — `procChanceGates` Map on `IntentExecContext` + `passesProcChanceGate`
   (`triggers.ts:908`), the deterministic rate-gate accumulator. Currently consumed by the
   **heal/shield** branch (`triggers.ts:1160`) and the **damage** branch (`triggers.ts:1264`) only.
@@ -73,21 +80,33 @@ direct hits during the current round.**
   nor HP). Default for this PR: **not a hit** (nothing is touched). Flagged in code as a
   to-verify-in-game item; revisit if the in-game behavior says a blocked attack still counts.
 
-**Engine state:** a per-round `Set<string>` of actor ids hit this round.
-- Cleared at round start (`beginRound`).
-- Populated inside `applyIncomingToTarget` (`engine.ts:~2643`) for a **direct** attack when
-  `outcome.shieldBefore` was reduced **or** `outcome.hpDamage > 0` — i.e. damage actually landed.
-  (The closure already returns `{shieldBefore, hpDamage, barriered}`; `barriered === true` ⇒ not a
-  hit, satisfying the default above.) The DoT-batch intake path must NOT record into this set.
+**Engine state:** a per-round `Set<string>` of actor ids hit this round — mirrors the existing
+`repairedThisRound` Set (cleared at `engine.ts:~2373` right after `beginRound`; that Set is the
+direct precedent for clear-timing and shape).
+- Cleared at round start (right after `beginRound`, alongside `repairedThisRound`).
+- Populated inside the `applyIncomingToTarget` direct-hit path (`engine.ts:~2643`). The closure
+  returns `{shieldBefore, hpDamage, barriered}`. **Exact predicate (locked):** record the victim as
+  hit when `!barriered && (shieldBefore > 0 || hpDamage > 0)` for a direct attack with non-zero
+  incoming damage — i.e. damage landed on shield or HP. `shieldBefore` is the pre-hit pool, so
+  "shield was touched" = `!barriered && shieldBefore > 0 && damage > 0` (the non-barriered branch
+  always drains some shield before HP). A fully Barrier-blocked hit (`barriered === true`, early
+  return `engine.ts:~2636`) records **nothing** → not a hit (the TO-VERIFY default above).
+- The **DoT-batch intake** path (`applyIncomingToTarget(..., { byDirectDamage: false })`,
+  `engine.ts:~3610`/`~4239`) must NOT record into this set — DoT ticks are not "being hit."
 
-**Threading:** new optional delegate `wasHitThisRoundFor?(ownerId: string): boolean` on
-`IntentExecContext` (next to `isLowestSpeedAllyFor`). `buildDrainContext` forwards
-`wasHitThisRound: ctx.wasHitThisRoundFor?.(ownerId) ?? false` into the condition bag;
-`buildRoundContext` owns the `?? false` default. `evaluateCondition` adds the
-`'not-hit-this-round'` case returning `ctx.wasHitThisRound ? 0 : 1` (i.e. condition met when NOT
-hit). `'not-hit-this-round'` is added to `LIVE_SUBJECTS` (else `liveGateConditions` neutralizes it
-to always-true). Engine populates the delegate on **both** side contexts (player + enemy) from the
-per-round hit set — team-agnostic, so an enemy Alacrity behaves identically.
+**Threading (three files change in lockstep, same triad `self-shield` touched):**
+1. `ConditionContext` + `RoundContextInput` gain `wasHitThisRound?: boolean` (`roundContext.ts`),
+   defaulting `?? false` in `buildRoundContext` (mirrors `selfShielded`).
+2. `evaluateCondition` adds the `'not-hit-this-round'` case returning `ctx.wasHitThisRound ? 0 : 1`
+   (met ⇔ NOT hit) (`evaluateConditions.ts`).
+3. `'not-hit-this-round'` is added to `LIVE_SUBJECTS` (`abilityStatusGating.ts`) — otherwise
+   `liveGateConditions` neutralizes it to always-true and ALACRITY would grant even when hit.
+
+**Delegate:** new optional `wasHitThisRoundFor?(ownerId: string): boolean` on `IntentExecContext`
+(next to `isLowestSpeedAllyFor`/`selfHpPctFor`); `buildDrainContext` forwards
+`wasHitThisRound: ctx.wasHitThisRoundFor?.(ownerId) ?? false`. The engine binds it on **both** side
+contexts (player `drainIntents` ~`engine.ts:3385`/`3381`, enemy `drainEnemyIntents` ~`3406`/`3398`)
+from the per-round hit set — team-agnostic, so an enemy Alacrity behaves identically.
 
 ALACRITY fires at `end-of-round`, by which point all direct attacks for the round have landed, so
 the hit set is complete when the gate evaluates.
@@ -101,7 +120,8 @@ D-PR7 `mkNamedBuffGrant`: resolve `parsedEffects` via `parseBuffEffects` from `B
 `isStackable`, guard buff-not-found → `undefined`). Each entry is `type:'buff'`, `target:'self'`.
 
 ```text
-AMBUSH(rarity):              trigger 'start-of-round',   conditions [self-stealth],
+AMBUSH(rarity):              trigger 'start-of-round',
+                             conditions [{subject:'self-buff', buffName:'Stealth', derivable:true}],
                              buffName 'Crit Power Up III', duration 1,
                              procChance AMBUSH_PROC[rarity]            (5 rarities)
 SYNAPTIC_RESONANCE(rarity):  trigger 'on-enemy-repaired', conditions [],
@@ -119,10 +139,17 @@ piece so the proc-rate gate doesn't collapse independent procs).
 
 ## 5. Liveness & known limits (accepted)
 
-- **AMBUSH is dormant today** — nothing grants Stealth in the sim yet, so `self-stealth` is always
-  false → the buff never fires. Accepted, same pattern as D-PR2's Arcane Siege (dormant until
-  shields). Lights up when Cloaking / a stealth-grant lands (a later D / sub-project H PR). The
-  registry entry + condition are correct now; only the trigger source is missing.
+- **AMBUSH is dormant today** — nothing grants the Stealth buff in the sim yet, so the `self-buff`
+  Stealth gate is always unmet → the buff never fires. Accepted, same pattern as D-PR2's Arcane
+  Siege (dormant until shields). Lights up when Cloaking / a stealth-grant lands (a later D PR). The
+  registry entry + gate are correct now; only the Stealth source is missing. **Intra-drain ordering
+  TODO (for when a stealth source ships):** at round start the engine emits `round-started` then
+  calls `drainIntents()`; AMBUSH reads the owner's live `selfBuffNames` at drain time, so if a
+  *different* start-of-round ability is what grants Stealth, queue drain order decides whether
+  AMBUSH sees it that round. Not a blocker now (dormant); flag in code so it isn't forgotten.
+- **Timed-buff expiry:** AMBUSH/ALACRITY's granted self-buffs ride the same reactive-self-buff
+  duration-decrement timing as every other timed self-buff (the documented "1-turn self-buff
+  expires one turn early" engine behavior). Not solved here — shared with all reactive grants.
 - **SYNAPTIC_RESONANCE is live** — `on-enemy-repaired` fires whenever an enemy actor is repaired
   (E5 symmetric healing). The **"+X% next-crit critDamage" half is DEFERRED** — it is a stacking,
   single-consume next-crit modifier with no existing seam; out of scope. Only the Speed Up III
@@ -156,6 +183,10 @@ piece so the proc-rate gate doesn't collapse independent procs).
   (known pitfall — both must move together).
 - **Pure evaluator test** for `not-hit-this-round`: `evaluateCondition` returns met when
   `wasHitThisRound` is false/undefined, not-met when true.
+- **AMBUSH gate test** — assert AMBUSH's gate is `self-buff` Stealth and evaluates met only when the
+  owner carries the Stealth buff (proves the gate uses the correct ConditionSubject, not the broken
+  `self-stealth` IncomingCondition). Since no sim source grants Stealth, an engine-level
+  "fires when Stealth present" test seeds the buff directly onto the owner.
 - **Engine integration tests:**
   - SYNAPTIC_RESONANCE: an enemy actor is repaired → the equipped owner gains Speed Up III for 1
     turn (assert via `buff-applied` / the owner's active statuses).

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
             "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
@@ -101,12 +102,12 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -115,30 +116,30 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
-            "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "license": "MIT",
             "dependencies": {
-                "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.26.0",
-                "@babel/generator": "^7.26.0",
-                "@babel/helper-compilation-targets": "^7.25.9",
-                "@babel/helper-module-transforms": "^7.26.0",
-                "@babel/helpers": "^7.26.0",
-                "@babel/parser": "^7.26.0",
-                "@babel/template": "^7.25.9",
-                "@babel/traverse": "^7.25.9",
-                "@babel/types": "^7.26.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -154,13 +155,13 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.29.1",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -183,13 +184,13 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-            "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.28.6",
-                "@babel/helper-validator-option": "^7.27.1",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -256,9 +257,9 @@
             }
         },
         "node_modules/@babel/helper-globals": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -279,27 +280,27 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.28.6",
-                "@babel/helper-validator-identifier": "^7.28.5",
-                "@babel/traverse": "^7.28.6"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -382,27 +383,27 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -424,25 +425,25 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
-            "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.27.0",
-                "@babel/types": "^7.27.0"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-            "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.0"
+                "@babel/types": "^7.29.7"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -1566,31 +1567,31 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.28.6",
-                "@babel/parser": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -1598,13 +1599,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2396,19 +2397,6 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
-        "node_modules/@isaacs/fs-minipass": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-            "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^7.0.4"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
         "node_modules/@istanbuljs/schema": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -2426,6 +2414,16 @@
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
@@ -3730,6 +3728,118 @@
             "engines": {
                 "node": ">=20.0.0"
             }
+        },
+        "node_modules/@supabase/cli-darwin-arm64": {
+            "version": "2.107.0",
+            "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-arm64/-/cli-darwin-arm64-2.107.0.tgz",
+            "integrity": "sha512-930MojHei14+PrGNF0QzlPJAjOYilCofgO9aTtKiQ6x36ZUI7dc4ujl5VzccC/19ex/f4ird0lH1d2U92MwDqQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@supabase/cli-darwin-x64": {
+            "version": "2.107.0",
+            "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-x64/-/cli-darwin-x64-2.107.0.tgz",
+            "integrity": "sha512-qcnichkHiCCNybtCqoeqYO6q8WuTxilaah18QilZskEM+zCSdV5rOXXfeF1BPexRxsvGYbghZ+fEQfWp7+lOUQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@supabase/cli-linux-arm64": {
+            "version": "2.107.0",
+            "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64/-/cli-linux-arm64-2.107.0.tgz",
+            "integrity": "sha512-an0dsOhPcLQXZ0sFEBm6NU1HFUjXCStHxetfJvgt4u7SiH/EyDMLfDvV7W9ef56bgG+3hoWHtih2Kplj3cecQA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@supabase/cli-linux-arm64-musl": {
+            "version": "2.107.0",
+            "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.107.0.tgz",
+            "integrity": "sha512-5se1bYRIzivL+ehImnwFjBpzKZ+AwLS6/cBg6lvJOJdWatuaK9Edu6wOZAmPjVMy4vZRJ27tdL+3F7N+Vk64AA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@supabase/cli-linux-x64": {
+            "version": "2.107.0",
+            "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64/-/cli-linux-x64-2.107.0.tgz",
+            "integrity": "sha512-8ttnpfBFEXk0JFmH6gw8ZCVcMa/UNH1sD6iG9PQLbK2eXdZ6kDIzGs5g+CEvxZ3j6HxEIYn9h9rfxoqGoBUgwA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@supabase/cli-linux-x64-musl": {
+            "version": "2.107.0",
+            "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64-musl/-/cli-linux-x64-musl-2.107.0.tgz",
+            "integrity": "sha512-gXDzvDsmmJw9HbeVRFD6xboGwbu/cpBp84ZESEcXKyB8Onvs3igWKwoXMofx+ppFM1EaZb/flTwJ77b19EMD1A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@supabase/cli-windows-arm64": {
+            "version": "2.107.0",
+            "resolved": "https://registry.npmjs.org/@supabase/cli-windows-arm64/-/cli-windows-arm64-2.107.0.tgz",
+            "integrity": "sha512-V/4q5dbDgBQXhDAJaHamTm9u/kY2UJ4nNibVKOYMaLh9q7H74b8unteJ+rYHSwWZy0EIT8DTDryGP6xatKQicw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@supabase/cli-windows-x64": {
+            "version": "2.107.0",
+            "resolved": "https://registry.npmjs.org/@supabase/cli-windows-x64/-/cli-windows-x64-2.107.0.tgz",
+            "integrity": "sha512-ciDDFUGHt6bFjtVD00cojFhB5oscZAyjPo2vg94RGUeKHXx1zo/UzfMvUlCA32y5b5KONZ4TKStCHhlFK7Clrw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@supabase/functions-js": {
             "version": "2.105.1",
@@ -5912,23 +6022,6 @@
                 "node": ">=10.0.0"
             }
         },
-        "node_modules/bin-links": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.0.tgz",
-            "integrity": "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "cmd-shim": "^8.0.0",
-                "npm-normalize-package-bin": "^5.0.0",
-                "proc-log": "^6.0.0",
-                "read-cmd-shim": "^6.0.0",
-                "write-file-atomic": "^7.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -6283,16 +6376,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/chownr": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/chromium-bidi": {
             "version": "14.0.0",
             "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
@@ -6444,16 +6527,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/cmd-shim": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
-            "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/color-convert": {
@@ -8521,17 +8594,17 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -9008,9 +9081,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9098,9 +9171,9 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-            "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+            "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -9962,9 +10035,19 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -10740,19 +10823,6 @@
                 "node": ">=16 || 14 >=14.17"
             }
         },
-        "node_modules/minizlib": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
         "node_modules/mitt": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -10910,16 +10980,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/npm-normalize-package-bin": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
-            "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/npm-run-path": {
@@ -11767,16 +11827,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/proc-log": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
         "node_modules/progress": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -12157,16 +12207,6 @@
             "license": "MIT",
             "dependencies": {
                 "pify": "^2.3.0"
-            }
-        },
-        "node_modules/read-cmd-shim": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
-            "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/readdirp": {
@@ -13631,47 +13671,23 @@
             }
         },
         "node_modules/supabase": {
-            "version": "2.95.1",
-            "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.95.1.tgz",
-            "integrity": "sha512-zQY21c8xVtWsU1SuhlLsJKzfwoCfZHsdwQ/H1B8uIZzfVAhMS/cdZ4CqONY4WBlZ9Cn2N4ftcAPMxUC4Pm9sdA==",
+            "version": "2.107.0",
+            "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.107.0.tgz",
+            "integrity": "sha512-qYAbm3D//buhnY5v4L//IrBQhowN2Jd2kx16hNyOfu0+TVuWVIR1L5WsS/YOk+UJh3Ch5ABmqKebWpwn1p0ysg==",
             "dev": true,
-            "hasInstallScript": true,
             "license": "MIT",
-            "dependencies": {
-                "bin-links": "^6.0.0",
-                "https-proxy-agent": "^9.0.0",
-                "node-fetch": "^3.3.2",
-                "tar": "7.5.13"
-            },
             "bin": {
-                "supabase": "bin/supabase"
+                "supabase": "dist/supabase.js"
             },
-            "engines": {
-                "npm": ">=8"
-            }
-        },
-        "node_modules/supabase/node_modules/agent-base": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
-            "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 20"
-            }
-        },
-        "node_modules/supabase/node_modules/https-proxy-agent": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
-            "integrity": "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "9.0.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 20"
+            "optionalDependencies": {
+                "@supabase/cli-darwin-arm64": "2.107.0",
+                "@supabase/cli-darwin-x64": "2.107.0",
+                "@supabase/cli-linux-arm64": "2.107.0",
+                "@supabase/cli-linux-arm64-musl": "2.107.0",
+                "@supabase/cli-linux-x64": "2.107.0",
+                "@supabase/cli-linux-x64-musl": "2.107.0",
+                "@supabase/cli-windows-arm64": "2.107.0",
+                "@supabase/cli-windows-x64": "2.107.0"
             }
         },
         "node_modules/supports-color": {
@@ -13751,23 +13767,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/tar": {
-            "version": "7.5.13",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-            "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/fs-minipass": "^4.0.0",
-                "chownr": "^3.0.0",
-                "minipass": "^7.1.2",
-                "minizlib": "^3.1.0",
-                "yallist": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/tar-fs": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
@@ -13809,16 +13808,6 @@
                 "react-native-b4a": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/tar/node_modules/yallist": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/teex": {
@@ -14653,9 +14642,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.4.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-            "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+            "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.25.0",
@@ -15768,19 +15757,6 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/write-file-atomic": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
-            "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "signal-exit": "^4.0.1"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
         },
         "node_modules/ws": {
             "version": "8.21.0",

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -17,6 +17,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator now models three more heal implants: Second Wind (chance to repair itself when it takes a critical hit), Nourishment (stronger repairs on allies with less HP than the healer), and Vivacious Repair (chance to double a repair on an ally below 25% HP).',
     'Combat simulator now models the Exuberance implant (chance to increase the amount of a repair this unit receives).',
     'Combat simulator now models three on-death implants: Last Wish (repairs all allies when the carrier is destroyed), Battlecry (grants all allies Inc. Damage Down II on death), and Martyrdom (applies Disable to the unit that landed the killing blow). Last Wish is fully resolved; Battlecry and Martyrdom apply and appear in the combat log with full effects coming in a later update.',
+    'Combat simulator now models three reactive self-buff implants: Ambush (grants Crit Power Up to itself when it goes into stealth at round start), Synaptic Resonance (grants Speed Up to itself when any enemy is repaired), and Alacrity (grants Speed Up to itself at round end when it took no damage that round).',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -144,7 +144,12 @@ export type ConditionSubject =
     // Binary gate: the condition owner currently has a shield (CombatActor.shieldPool > 0).
     // Live-derived (ConditionContext.selfShielded); defaults false (no shield / DPS mode).
     // Dormant until sub-project H grants shields in the sim. Used by the Arcane Siege implant.
-    | 'self-shield';
+    | 'self-shield'
+    // Binary gate: the condition owner received ZERO direct hits this round (a "hit" =
+    // a direct attack that landed damage on shield or HP; DoT ticks and fully-Barrier-blocked
+    // attacks do not count). Live-derived (ConditionContext.wasHitThisRound); defaults false
+    // (DPS / not-yet-hit → "not hit" ⇒ met). Used by the Alacrity implant.
+    | 'not-hit-this-round';
 
 export interface Condition {
     subject: ConditionSubject;

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -99,7 +99,7 @@ function implantAbilityCount(implantKey: string, rarity: GearPiece['rarity']): n
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { LEECH + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + BATTLECRY + BLOODTHIRST + EXUBERANCE + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + MENACE + SECOND_WIND + SHADOWGUARD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
+    it('exactly { LEECH + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + EXUBERANCE + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + MENACE + SECOND_WIND + SHADOWGUARD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -119,9 +119,12 @@ describe('equipmentCoverage — implemented effects registry', () => {
             'INTRUSION',
             'NEBULA_NULLIFIER',
             'NOURISHMENT',
+            'SYNAPTIC_RESONANCE',
             'VOIDSHADE',
             'VORTEX_VEIL',
             'WARPSTRIKE',
+            'ALACRITY',
+            'AMBUSH',
             'BATTLECRY',
             'BLOODTHIRST',
             'EXUBERANCE',
@@ -183,6 +186,7 @@ describe('equipmentCoverage — implants', () => {
     // D-PR5: SECOND_WIND, NOURISHMENT, VIVACIOUS_REPAIR added (reactive-heal family).
     // D-PR6: EXUBERANCE added (repair-amplification on-repair chance).
     // D-PR7: LAST_WISH, BATTLECRY, MARTYRDOM added (on-death repair / buff to allies / disable killer).
+    // D-PR8: SYNAPTIC_RESONANCE, ALACRITY, AMBUSH added (reactive self-buff grants).
     const implementedImplants = new Set([
         'BLOODTHIRST',
         'INTRUSION',
@@ -204,6 +208,9 @@ describe('equipmentCoverage — implants', () => {
         'LAST_WISH',
         'BATTLECRY',
         'MARTYRDOM',
+        'SYNAPTIC_RESONANCE',
+        'ALACRITY',
+        'AMBUSH',
     ]);
 
     it('INTRUSION produces 1 ability per rarity (outgoingDamage modifier with scaling)', () => {
@@ -362,6 +369,23 @@ describe('equipmentCoverage — implants', () => {
         const variants = IMPLANTS['MARTYRDOM'].variants;
         for (const v of variants) {
             expect(implantAbilityCount('MARTYRDOM', v.rarity)).toBe(1);
+        }
+    });
+
+    // D-PR8: reactive self-buff implants
+    it('SYNAPTIC_RESONANCE produces 1 self Speed Up III buff on-enemy-repaired per rarity (no procChance)', () => {
+        for (const v of IMPLANTS['SYNAPTIC_RESONANCE'].variants) {
+            expect(implantAbilityCount('SYNAPTIC_RESONANCE', v.rarity)).toBe(1);
+        }
+    });
+    it('AMBUSH produces 1 self Crit Power Up III buff per rarity (start-of-round, self-buff Stealth gate)', () => {
+        for (const v of IMPLANTS['AMBUSH'].variants) {
+            expect(implantAbilityCount('AMBUSH', v.rarity)).toBe(1);
+        }
+    });
+    it('ALACRITY produces 1 self Speed Up III buff per rarity (end-of-round, not-hit-this-round gate)', () => {
+        for (const v of IMPLANTS['ALACRITY'].variants) {
+            expect(implantAbilityCount('ALACRITY', v.rarity)).toBe(1);
         }
     });
 

--- a/src/utils/abilities/__tests__/evaluateConditions.test.ts
+++ b/src/utils/abilities/__tests__/evaluateConditions.test.ts
@@ -407,6 +407,19 @@ describe('self-shield condition', () => {
     });
 });
 
+describe('not-hit-this-round condition', () => {
+    const cond: Condition = { subject: 'not-hit-this-round', derivable: true };
+    it('is met (1) when wasHitThisRound is false', () => {
+        expect(evaluateCondition(cond, makeConditionContext({ wasHitThisRound: false }))).toBe(1);
+    });
+    it('is met (1) when wasHitThisRound is undefined (default)', () => {
+        expect(evaluateCondition(cond, makeConditionContext())).toBe(1);
+    });
+    it('is NOT met (0) when wasHitThisRound is true', () => {
+        expect(evaluateCondition(cond, makeConditionContext({ wasHitThisRound: true }))).toBe(0);
+    });
+});
+
 describe('lowest-speed-ally', () => {
     it('returns 1 when isLowestSpeedAlly is true', () => {
         const ctx = buildRoundContext({

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -29,6 +29,7 @@ import { GearPiece } from '../../types/gear';
 import {
     Ability,
     AbilityTrigger,
+    Condition,
     HealAmpCondition,
     IncomingCondition,
     OutgoingCondition,
@@ -211,6 +212,23 @@ const BATTLECRY_DURATION: Record<string, number> = { common: 1, rare: 2, epic: 2
 // Martyrdom: apply a named debuff to the killer on death. Only rare + legendary variants.
 const MARTYRDOM_DURATION: Record<string, number> = { rare: 1, legendary: 2 };
 
+// D-PR8: reactive self-buff implant value tables
+// Ambush: start-of-round, if Stealthed, X% chance to gain Crit Power Up III for 1 turn.
+const AMBUSH_PROC: Record<string, number> = {
+    common: 0.05,
+    uncommon: 0.07,
+    rare: 0.09,
+    epic: 0.12,
+    legendary: 0.16,
+};
+// Alacrity: end-of-round, if not hit, X% chance to gain Speed Up III for 2 turns. No common variant.
+const ALACRITY_PROC: Record<string, number> = {
+    uncommon: 0.12,
+    rare: 0.14,
+    epic: 0.16,
+    legendary: 0.2,
+};
+
 // D-PR6: incoming-heal-amplification implant value tables
 // No common rarity for Exuberance
 const EXUBERANCE_PROC: Record<string, number> = {
@@ -277,11 +295,13 @@ function mkHealAmp(
 // parsedEffects/stackability resolve from the canonical BUFFS entry. EMIT-ONLY for buffs whose
 // effect the engine does not yet fold (self-side incoming-damage buffs) — the status is applied
 // and logged but has no combat effect until that fold exists.
+// D-PR8: generalised with optional `opts` for conditions + procChance (Battlecry call is byte-identical).
 function mkNamedBuffGrant(
     buffName: string,
     target: 'self' | 'ally' | 'all-allies',
     trigger: AbilityTrigger,
-    duration: number | undefined
+    duration: number | undefined,
+    opts?: { conditions?: Condition[]; procChance?: number }
 ): Omit<Ability, 'id'> | undefined {
     if (duration === undefined) return undefined;
     const buff = BUFFS.find((b) => b.name === buffName);
@@ -291,7 +311,8 @@ function mkNamedBuffGrant(
         type: 'buff',
         target,
         trigger,
-        conditions: [],
+        conditions: opts?.conditions ?? [],
+        ...(opts?.procChance !== undefined ? { procChance: opts.procChance } : {}),
         config: {
             type: 'buff',
             buffName,
@@ -562,6 +583,31 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
     // Disable is not a modeled turn-effect yet (only Stasis skips turns) — the debuff is applied to
     // the killer + logged. Killer routing comes from the on-destroyed listener.
     MARTYRDOM: (rarity) => mkNamedDebuff('Disable', 'on-destroyed', MARTYRDOM_DURATION[rarity]),
+    // D-PR8: Ambush — start-of-round, if Stealthed, X% chance to gain Crit Power Up III for 1 turn.
+    // Gate is self-buff/Stealth (NOT self-stealth — that's an IncomingCondition). DORMANT until a
+    // stealth source exists in the sim (Cloaking / sub-project H); entry + gate are correct now.
+    AMBUSH: (rarity) => {
+        const procChance = AMBUSH_PROC[rarity];
+        if (procChance === undefined) return undefined;
+        return mkNamedBuffGrant('Crit Power Up III', 'self', 'start-of-round', 1, {
+            conditions: [{ subject: 'self-buff', buffName: 'Stealth', derivable: true }],
+            procChance,
+        });
+    },
+    // D-PR8: Synaptic Resonance — gain Speed Up III for 1 turn when an enemy is directly repaired.
+    // DETERMINISTIC (no procChance). LIVE today (enemies have real healing → on-enemy-repaired fires).
+    // The "+X% next-crit critDamage" half is DEFERRED (stacking next-crit consumable, no seam).
+    SYNAPTIC_RESONANCE: (_rarity) =>
+        mkNamedBuffGrant('Speed Up III', 'self', 'on-enemy-repaired', 1),
+    // D-PR8: Alacrity — at end of round, if not hit, X% chance to gain Speed Up III for 2 turns.
+    ALACRITY: (rarity) => {
+        const procChance = ALACRITY_PROC[rarity];
+        if (procChance === undefined) return undefined; // no common variant
+        return mkNamedBuffGrant('Speed Up III', 'self', 'end-of-round', 2, {
+            conditions: [{ subject: 'not-hit-this-round', derivable: true }],
+            procChance,
+        });
+    },
 };
 
 // ---------------------------------------------------------------------------

--- a/src/utils/abilities/evaluateConditions.ts
+++ b/src/utils/abilities/evaluateConditions.ts
@@ -29,6 +29,9 @@ export interface ConditionContext {
     /** True when the condition owner currently has a shield (shieldPool > 0). Live-derived
      *  by the engine; defaults false (no shield / DPS mode). Used by the Arcane Siege implant. */
     selfShielded?: boolean;
+    /** True when the condition owner was hit by a direct attack this round (damage landed
+     *  on shield or HP). Live-derived by the engine; defaults false (DPS / not-yet-hit). */
+    wasHitThisRound?: boolean;
 }
 
 /** Resolve one condition to a count (>= 0). 0 means "not met". */
@@ -80,6 +83,8 @@ export function evaluateCondition(cond: Condition, ctx: ConditionContext): numbe
             return ctx.targetRepairedThisRound ? 1 : 0;
         case 'self-shield':
             return ctx.selfShielded ? 1 : 0;
+        case 'not-hit-this-round':
+            return ctx.wasHitThisRound ? 0 : 1;
         default:
             return 0;
     }

--- a/src/utils/abilities/roundContext.ts
+++ b/src/utils/abilities/roundContext.ts
@@ -38,6 +38,8 @@ export function buildRoundContext(state: {
     targetRepairedThisRound?: boolean;
     /** True when the acting unit has a shield (shieldPool > 0). Default false. */
     selfShielded?: boolean;
+    /** True when the acting unit was hit by a direct attack this round. Default false. */
+    wasHitThisRound?: boolean;
 }): ConditionContext {
     return {
         selfBuffNames: state.selfBuffNames,
@@ -60,6 +62,7 @@ export function buildRoundContext(state: {
         isLowestSpeedAlly: state.isLowestSpeedAlly ?? true,
         targetRepairedThisRound: state.targetRepairedThisRound ?? false,
         selfShielded: state.selfShielded ?? false,
+        wasHitThisRound: state.wasHitThisRound ?? false,
         ...(state.roundCrit !== undefined ? { roundCrit: state.roundCrit } : {}),
     };
 }

--- a/src/utils/combat/__tests__/abilityStatusGating.test.ts
+++ b/src/utils/combat/__tests__/abilityStatusGating.test.ts
@@ -81,7 +81,16 @@ describe('liveGateConditions — target-repaired-this-round (C2b-3)', () => {
     // LIVE_SUBJECTS, the condition would neutralize to 'always' and Nayra's
     // Stasis/Exposed inflicts would silently fire unconditionally again.
     it('keeps a derivable target-repaired-this-round condition (does NOT neutralize to always)', () => {
-        const out = liveGateConditions([{ subject: 'target-repaired-this-round', derivable: true }]);
+        const out = liveGateConditions([
+            { subject: 'target-repaired-this-round', derivable: true },
+        ]);
         expect(out).toEqual([{ subject: 'target-repaired-this-round', derivable: true }]);
+    });
+});
+
+describe('liveGateConditions — not-hit-this-round (D-PR8)', () => {
+    it('keeps a derivable not-hit-this-round condition (live subject, not neutralized)', () => {
+        const out = liveGateConditions([{ subject: 'not-hit-this-round', derivable: true }]);
+        expect(out[0].subject).toBe('not-hit-this-round');
     });
 });

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -2291,3 +2291,280 @@ describe('D-PR8 Task 4 integration — not-hit-this-round gate (engine hit-track
         expect(grants.length).toBeGreaterThanOrEqual(1);
     });
 });
+
+// ---------------------------------------------------------------------------
+// D-PR8 Task 6: Synaptic Resonance (LIVE on-enemy-repaired) + Ambush gate (seeded Stealth)
+// ---------------------------------------------------------------------------
+//
+// Two reactive self-buff-grant implants from the D-PR8 registry:
+//
+//   SYNAPTIC_RESONANCE — type:'buff', target:'self', trigger:'on-enemy-repaired',
+//     grants 'Speed Up III' for 1 turn, DETERMINISTIC (no procChance). LIVE today:
+//     enemies have real (symmetric) healing, so 'on-enemy-repaired' fires. We drive a
+//     genuine enemy repair the way nayraEnemyRepairedPurge.test.ts does — an enemy ally
+//     takes a dent and then self-heals (HP-restoring → heal-performed with an opposing
+//     caster), which routes through the on-enemy-repaired listener to the player owner.
+//
+//   AMBUSH — type:'buff', target:'self', trigger:'start-of-round', grants 'Crit Power
+//     Up III' for 1 turn, gated { subject:'self-buff', buffName:'Stealth', derivable:true }
+//     + a procChance. DORMANT in normal play (nothing grants Stealth). To test the GATE in
+//     isolation from proc timing, we (a) SEED a recurring 'Stealth' self-buff on the owner
+//     ('attacker'), which surfaces in snapshot('attacker').activeSelfBuffs every round and
+//     thus in the start-of-round drain gate's selfBuffNames, and (b) inject a HAND-BUILT
+//     Ambush-shaped buff ability with procChance OMITTED (so the proc gate always passes —
+//     the only variable is the Stealth gate).
+
+describe('D-PR8 Task 6 integration — Synaptic Resonance fires on enemy repair (LIVE, deterministic)', () => {
+    const OWNER_ID = 'attacker';
+    const ENEMY_ALLY_ID = 'syn-enemy-ally';
+    const SPEED_UP = 'Speed Up III';
+
+    /** SYNAPTIC_RESONANCE legendary implant gear stub. */
+    const synapticPiece = makePiece({
+        id: 'syn-legendary',
+        slot: 'implant_major',
+        rarity: 'legendary',
+        setBonus: 'SYNAPTIC_RESONANCE',
+    });
+
+    /** A basic 100% hit (so the focus dents the enemy ally → opens the deficit its self-heal fills). */
+    const hitActive: Ability = {
+        id: 'syn-hit',
+        type: 'damage',
+        target: 'enemy',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'damage', multiplier: 100, hits: 1 },
+    };
+
+    /** Build the owner's ship skills: a damage active + the Synaptic Resonance passive (registry). */
+    function buildSynapticShipSkills(): ShipSkills {
+        const ship = makeShip({ implants: { implant_major: 'syn-legendary' } });
+        const getGearPiece = makeGetGearPiece({ 'syn-legendary': synapticPiece });
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        // Pre-condition: the Synaptic Resonance on-enemy-repaired buff grant landed in the passive slot.
+        const syn = passive?.abilities.find((a) => a.id === 'equip-implant-SYNAPTIC_RESONANCE');
+        expect(syn).toBeDefined();
+        expect(syn!.trigger).toBe('on-enemy-repaired');
+        expect(syn!.target).toBe('self');
+        expect(syn!.config.type).toBe('buff');
+        expect(syn!.procChance).toBeUndefined(); // deterministic — no proc gate
+
+        return {
+            slots: [
+                { slot: 'active', abilities: [hitActive] },
+                ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+            ],
+        };
+    }
+
+    /** An enemy ally that takes the focus's dent each round and self-heals it back (HP-restoring
+     *  → heal-performed with an opposing caster → on-enemy-repaired fires for the player owner).
+     *  Mirrors nayraEnemyRepairedPurge.test.ts's deficit→self-heal sequence. Acts FIRST (fast) so
+     *  by round 2 it consumes the round-1 deficit (> 0 → a real repair). */
+    function makeRepairingEnemyAlly() {
+        return {
+            id: ENEMY_ALLY_ID,
+            stats: { attack: 1, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000, speed: 200 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active' as const,
+                        abilities: [
+                            // Self-heal 10% of own max HP — consumes any HP deficit (> 0 → repaired).
+                            {
+                                id: 'syn-enemy-self-heal',
+                                type: 'heal' as const,
+                                target: 'self' as const,
+                                trigger: 'on-cast' as const,
+                                conditions: [],
+                                config: { type: 'heal' as const, pct: 10, basis: 'target-hp' },
+                            },
+                        ],
+                    },
+                ],
+            } as ShipSkills,
+        };
+    }
+
+    /** Collect buff-applied events for the owner with the Synaptic buff name. */
+    function collectGrants(input: CombatEngineInput): CombatEvent[] {
+        const bus = createEventBus();
+        const events: CombatEvent[] = [];
+        bus.on('buff-applied', (e) => events.push(e as CombatEvent));
+        runCombat({ ...input, bus });
+        return events.filter(
+            (e) => e.type === 'buff-applied' && e.actorId === OWNER_ID && e.buffName === SPEED_UP
+        );
+    }
+
+    it(
+        'Owner equipped with SYNAPTIC_RESONANCE gains Speed Up III when an enemy is directly ' +
+            'repaired (on-enemy-repaired, deterministic — no proc flakiness)',
+        () => {
+            // The focus (slow, acts last) dents the enemy ally each round; the enemy ally (fast)
+            // self-heals the prior-round deficit → a real enemy repair → heal-performed (opposing
+            // caster) → Synaptic Resonance grants Speed Up III to the owner.
+            const grants = collectGrants(
+                BASE({
+                    attack: 5_000,
+                    crit: 0,
+                    critDamage: 0,
+                    numRounds: 3,
+                    enemyHp: 1_000_000_000,
+                    hp: 1_000_000,
+                    speed: 100, // focus acts AFTER the enemy ally (200) — irrelevant for the listener,
+                    // but mirrors the established deficit→heal cadence.
+                    shipSkills: buildSynapticShipSkills(),
+                    enemyAttackers: [makeRepairingEnemyAlly()],
+                })
+            );
+
+            // The enemy was repaired → on-enemy-repaired fired → owner gained Speed Up III at least once.
+            expect(grants.length).toBeGreaterThanOrEqual(1);
+        }
+    );
+
+    it('Control: no enemy repair → Synaptic Resonance never fires (owner gains no Speed Up III)', () => {
+        // Same owner + Synaptic implant, but the enemy ally NEVER self-heals (no heal-performed →
+        // on-enemy-repaired never fires). The grant must be absent — proving the trigger is keyed
+        // to a genuine enemy repair, not merely to the implant's presence.
+        const nonHealingEnemyAlly = {
+            id: ENEMY_ALLY_ID,
+            stats: { attack: 1, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000, speed: 200 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active' as const,
+                        abilities: [
+                            {
+                                id: 'syn-enemy-hit',
+                                type: 'damage' as const,
+                                target: 'enemy' as const,
+                                trigger: 'on-cast' as const,
+                                conditions: [],
+                                config: { type: 'damage' as const, multiplier: 100, hits: 1 },
+                            },
+                        ],
+                    },
+                ],
+            } as ShipSkills,
+        };
+
+        const grants = collectGrants(
+            BASE({
+                attack: 5_000,
+                crit: 0,
+                critDamage: 0,
+                numRounds: 3,
+                enemyHp: 1_000_000_000,
+                hp: 1_000_000,
+                speed: 100,
+                shipSkills: buildSynapticShipSkills(),
+                enemyAttackers: [nonHealingEnemyAlly],
+            })
+        );
+
+        expect(grants).toHaveLength(0);
+    });
+});
+
+describe('D-PR8 Task 6 integration — Ambush gate via seeded Stealth (start-of-round self-buff)', () => {
+    const OWNER_ID = 'attacker';
+    const CRIT_POWER_UP = 'Crit Power Up III';
+    const STEALTH = 'Stealth';
+    const NUM_ROUNDS = 2;
+
+    /** A no-op active so the owner takes a turn each round (deals no damage). */
+    const noopActive: Ability = {
+        id: 'amb-noop',
+        type: 'damage',
+        target: 'enemy',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'damage', multiplier: 0 },
+    };
+
+    /** Hand-built Ambush-shaped reactive buff: procChance OMITTED so the proc gate always passes,
+     *  isolating the self-buff/Stealth gate. start-of-round, self, Crit Power Up III for 1 turn. */
+    const ambushBuff: Ability = {
+        id: 'ambush-shaped-buff',
+        type: 'buff',
+        target: 'self',
+        trigger: 'start-of-round',
+        conditions: [{ subject: 'self-buff', buffName: STEALTH, derivable: true }],
+        config: {
+            type: 'buff',
+            buffName: CRIT_POWER_UP,
+            parsedEffects: {},
+            stacks: 1,
+            isStackable: false,
+            duration: 1,
+        },
+    };
+
+    /** Ship skills: a no-op active + the Ambush-shaped buff in the passive slot. */
+    const ambushSkills: ShipSkills = {
+        slots: [
+            { slot: 'active', abilities: [noopActive] },
+            { slot: 'passive', abilities: [ambushBuff] },
+        ],
+    };
+
+    /** A recurring 'Stealth' self-buff seeded on the owner ('attacker'). Recurring (always-active)
+     *  scheduled self-buffs surface in snapshot('attacker').activeSelfBuffs from round 1, so the
+     *  start-of-round drain gate sees Stealth in its selfBuffNames. */
+    const stealthSeed: SelectedGameBuff = {
+        id: 'seed-stealth',
+        buffName: STEALTH,
+        stacks: 1,
+        parsedEffects: {},
+        isStackable: false,
+        skillDuration: 'recurring',
+        autoFilled: false,
+    };
+
+    /** Collect buff-applied events for the owner with the Crit Power Up buff name. */
+    function collectGrants(input: CombatEngineInput): CombatEvent[] {
+        const bus = createEventBus();
+        const events: CombatEvent[] = [];
+        bus.on('buff-applied', (e) => events.push(e as CombatEvent));
+        runCombat({ ...input, bus });
+        return events.filter(
+            (e) =>
+                e.type === 'buff-applied' && e.actorId === OWNER_ID && e.buffName === CRIT_POWER_UP
+        );
+    }
+
+    it('Stealth present on the owner → start-of-round self-buff gate met → Crit Power Up III IS granted', () => {
+        const grants = collectGrants(
+            BASE({
+                attack: 0,
+                numRounds: NUM_ROUNDS,
+                hp: 100_000,
+                shipSkills: ambushSkills,
+                selfBuffs: [stealthSeed], // recurring Stealth → visible at start-of-round each round
+            })
+        );
+        // Gate met every round → at least one Crit Power Up III grant.
+        expect(grants.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('Stealth ABSENT → self-buff gate fails → Crit Power Up III is NOT granted', () => {
+        const grants = collectGrants(
+            BASE({
+                attack: 0,
+                numRounds: NUM_ROUNDS,
+                hp: 100_000,
+                shipSkills: ambushSkills,
+                selfBuffs: [], // no Stealth → gate's selfBuffNames lacks Stealth → never fires
+            })
+        );
+        expect(grants).toHaveLength(0);
+    });
+});

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -2287,7 +2287,19 @@ describe('D-PR8 Task 4 integration — not-hit-this-round gate (engine hit-track
         // The enemy applies ONLY a Corrosion DoT (no direct-damage ability). The turn-start DoT
         // batch intake passes byDirectDamage:false → never recorded in hitThisRound → gate met.
         // Give the DoT time to tick at least once (numRounds 2: applied round 1, ticks round 2).
-        const grants = collectGrants(PR8_BASE({ numRounds: 2, enemyAttackers: [makeDotEnemy()] }));
+        // Capture dot-ticked alongside buff-applied: assert the DoT actually ticked on the focus,
+        // otherwise this would pass vacuously — a round where the DoT never lands is indistinguishable
+        // from scenario (a) (no hit at all → buff granted), proving nothing about the DoT path.
+        const bus = createEventBus();
+        const events: CombatEvent[] = [];
+        bus.on('buff-applied', (e) => events.push(e as CombatEvent));
+        bus.on('dot-ticked', (e) => events.push(e as CombatEvent));
+        runCombat({ ...PR8_BASE({ numRounds: 2, enemyAttackers: [makeDotEnemy()] }), bus });
+        const dotTicks = events.filter((e) => e.type === 'dot-ticked' && e.targetId === 'attacker');
+        const grants = events.filter(
+            (e) => e.type === 'buff-applied' && e.actorId === 'attacker' && e.buffName === BUFF_NAME
+        );
+        expect(dotTicks.length).toBeGreaterThanOrEqual(1);
         expect(grants.length).toBeGreaterThanOrEqual(1);
     });
 });

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -2344,7 +2344,9 @@ describe('D-PR8 Task 6 integration — Synaptic Resonance fires on enemy repair 
         const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
         const passive = baseSkills.slots.find((s) => s.slot === 'passive');
         // Pre-condition: the Synaptic Resonance on-enemy-repaired buff grant landed in the passive slot.
-        const syn = passive?.abilities.find((a) => a.id === 'equip-implant-SYNAPTIC_RESONANCE');
+        const syn = passive?.abilities.find((a) =>
+            a.id.startsWith('equip-implant-SYNAPTIC_RESONANCE')
+        );
         expect(syn).toBeDefined();
         expect(syn!.trigger).toBe('on-enemy-repaired');
         expect(syn!.target).toBe('self');

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -2086,3 +2086,208 @@ describe('D-PR7 Task 5 integration — enemy-side mirror: enemy Martyrdom routes
         }
     );
 });
+
+// ---------------------------------------------------------------------------
+// D-PR8 Task 4: not-hit-this-round gate — engine hit-tracking → drain-time gate
+// ---------------------------------------------------------------------------
+//
+// Alacrity grants a self-buff at end-of-round ONLY if the owner took no DIRECT hit
+// that round. We exercise the gate with a HAND-BUILT reactive buff ability (NOT the
+// implant registry) so the test isolates the `not-hit-this-round` condition from any
+// proc-gate timing: type 'buff', target 'self', trigger 'end-of-round', a single
+// condition { subject:'not-hit-this-round', derivable:true }, NO procChance, a
+// recognizable buffName, duration 2.
+//
+// The ability sits in the FOCUS actor's ('attacker', the heal target) passive slot.
+// At round tail the engine drains the end-of-round queue; buildDrainContext reads the
+// owner's wasHitThisRound (engine-populated from the combat-wide hitThisRound Set) into
+// the gate. Met (not hit) → buff-applied for 'attacker' fires; not met (hit) → no grant.
+//
+// Scenarios:
+//   (a) no direct hit  → buff IS granted (enemy with attack 0).
+//   (b) direct HP hit  → buff NOT granted (enemy lands HP damage).
+//   (c) shield-absorbed hit only → counts as a hit → NOT granted (focus self-grants a
+//        large shield before the enemy lands a fully-absorbed hit).
+//   (d) DoT tick only (no direct attack) → NOT a hit → buff granted (byDirectDamage:false).
+
+describe('D-PR8 Task 4 integration — not-hit-this-round gate (engine hit-tracking)', () => {
+    const BUFF_NAME = 'Speed Up III';
+    const FOCUS_HP = 100_000;
+    const NUM_ROUNDS = 1;
+
+    /** The hand-built reactive self-buff gated solely on not-hit-this-round (no procChance). */
+    const reactiveSelfBuff: Ability = {
+        id: 'reactive-not-hit-buff',
+        type: 'buff',
+        target: 'self',
+        trigger: 'end-of-round',
+        conditions: [{ subject: 'not-hit-this-round', derivable: true }],
+        config: {
+            type: 'buff',
+            buffName: BUFF_NAME,
+            parsedEffects: {},
+            stacks: 1,
+            isStackable: false,
+            duration: 2,
+        },
+    };
+
+    /** A self-shield active (basis 'hp') so the focus can seed its own shield pool before a hit. */
+    const selfShieldActive: Ability = {
+        id: 'self-shield',
+        type: 'shield',
+        target: 'self',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'shield', pct: 100, basis: 'hp', noCrit: true },
+    };
+
+    /** A no-op active so the focus takes a turn each round (deals no damage). */
+    const noopActive: Ability = {
+        id: 'noop-active',
+        type: 'damage',
+        target: 'enemy',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'damage', multiplier: 0 },
+    };
+
+    /** Build the focus ship skills: an active + the reactive buff in the passive slot. */
+    const focusSkills = (active: Ability): ShipSkills => ({
+        slots: [
+            { slot: 'active', abilities: [active] },
+            { slot: 'passive', abilities: [reactiveSelfBuff] },
+        ],
+    });
+
+    /** An enemy attacker that lands a single-hit attack each round. attack 0 → no damage hit. */
+    function makeEnemyAttacker(attack: number, speed = 1_000) {
+        return {
+            id: 'pr8-enemy',
+            stats: { attack, crit: 0, critDamage: 0, speed, defence: 0, hp: 1_000_000_000 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active' as const,
+                        abilities: [
+                            {
+                                id: 'pr8-enemy-hit',
+                                type: 'damage' as const,
+                                target: 'enemy' as const,
+                                trigger: 'on-cast' as const,
+                                conditions: [],
+                                config: { type: 'damage' as const, multiplier: 100, hits: 1 },
+                            },
+                        ],
+                    },
+                ],
+            } as ShipSkills,
+        };
+    }
+
+    /** An enemy that lands ONLY a Corrosion DoT (no direct-damage ability). */
+    function makeDotEnemy(speed = 1_000) {
+        return {
+            id: 'pr8-dot-enemy',
+            stats: { attack: 10_000, crit: 0, critDamage: 0, speed, defence: 0, hp: 1_000_000_000 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active' as const,
+                        abilities: [
+                            {
+                                id: 'pr8-dot',
+                                type: 'dot' as const,
+                                target: 'enemy' as const,
+                                trigger: 'on-cast' as const,
+                                conditions: [],
+                                config: {
+                                    type: 'dot' as const,
+                                    dotType: 'corrosion' as const,
+                                    tier: 2,
+                                    stacks: 1,
+                                    duration: 5,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            } as ShipSkills,
+        };
+    }
+
+    /** Base engine input: healing mode, 'attacker' is the heal target carrying the reactive buff. */
+    const PR8_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+        attack: 0,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: focusSkills(noopActive),
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: NUM_ROUNDS,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: FOCUS_HP,
+        healTargetId: 'attacker',
+        ...overrides,
+    });
+
+    /** Collect buff-applied events for the focus carrier with the recognizable buff name. */
+    function collectGrants(input: CombatEngineInput): CombatEvent[] {
+        const bus = createEventBus();
+        const events: CombatEvent[] = [];
+        bus.on('buff-applied', (e) => events.push(e as CombatEvent));
+        runCombat({ ...input, bus });
+        return events.filter(
+            (e) => e.type === 'buff-applied' && e.actorId === 'attacker' && e.buffName === BUFF_NAME
+        );
+    }
+
+    it('(a) no direct hit → not-hit-this-round met → buff IS granted', () => {
+        // Enemy attack 0 → no damage hit lands on the focus → hitThisRound stays empty.
+        const grants = collectGrants(PR8_BASE({ enemyAttackers: [makeEnemyAttacker(0)] }));
+        expect(grants.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('(b) direct HP hit → not-hit-this-round NOT met → buff NOT granted', () => {
+        // Enemy lands a real HP hit on the focus → hitThisRound.add('attacker') → gate fails.
+        const grants = collectGrants(PR8_BASE({ enemyAttackers: [makeEnemyAttacker(5_000)] }));
+        expect(grants).toHaveLength(0);
+    });
+
+    it('(c) shield-absorbed hit only → counts as a hit → buff NOT granted', () => {
+        // Focus is FAST: it self-grants a shield (100% of max HP = 100_000) before the slow
+        // enemy's 5_000 hit lands ENTIRELY on the shield (absorbed > 0, hpDamage 0). A shield
+        // absorption still counts as a direct hit → gate fails.
+        const grants = collectGrants(
+            PR8_BASE({
+                shipSkills: focusSkills(selfShieldActive),
+                speed: 10_000, // focus acts BEFORE the enemy → shield is up when the hit lands
+                enemyAttackers: [makeEnemyAttacker(5_000, 1_000)],
+            })
+        );
+        expect(grants).toHaveLength(0);
+    });
+
+    it('(d) DoT tick only (no direct attack) → NOT a hit → buff IS granted', () => {
+        // The enemy applies ONLY a Corrosion DoT (no direct-damage ability). The turn-start DoT
+        // batch intake passes byDirectDamage:false → never recorded in hitThisRound → gate met.
+        // Give the DoT time to tick at least once (numRounds 2: applied round 1, ticks round 2).
+        const grants = collectGrants(PR8_BASE({ numRounds: 2, enemyAttackers: [makeDotEnemy()] }));
+        expect(grants.length).toBeGreaterThanOrEqual(1);
+    });
+});

--- a/src/utils/combat/__tests__/reactiveBuffProcGate.test.ts
+++ b/src/utils/combat/__tests__/reactiveBuffProcGate.test.ts
@@ -1,0 +1,156 @@
+/**
+ * D-PR8 Task 3: reactive buff branch honors procChance (passesProcChanceGate).
+ *
+ * Tests that:
+ * (a) A reactive `buff` intent with procChance 0.2 over 10 calls does NOT apply the buff
+ *     every time — the deterministic makeRateGate(0.2) accumulator fires 2/10 times
+ *     (back-loaded: calls 5, 10). Must NOT be 10 (absent gate = broken behavior).
+ * (b) A reactive `buff` intent WITHOUT procChance applies the buff on every call
+ *     (pass-through — byte-identical to today).
+ */
+import { describe, it, expect } from 'vitest';
+import { executeIntent, Intent, IntentExecContext } from '../triggers';
+import { makeRateGate } from '../../calculators/rateAccumulator';
+import { createEventBus } from '../events';
+import { createStatusEngine } from '../statusEngine';
+import type { CombatActor } from '../state';
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+const OWNER_ID = 'owner1';
+const ABILITY_ID = 'reactive-buff-ab';
+
+function makeBuffIntent(opts?: { procChance?: number }): Intent {
+    return {
+        ownerId: OWNER_ID,
+        sourceSlot: 'passive',
+        ability: {
+            id: ABILITY_ID,
+            type: 'buff',
+            target: 'self',
+            trigger: 'on-crit',
+            conditions: [],
+            ...(opts?.procChance !== undefined ? { procChance: opts.procChance } : {}),
+            config: {
+                type: 'buff',
+                buffName: 'Attack Up',
+                stacks: 1,
+                duration: 2,
+                parsedEffects: {},
+            },
+        },
+    } as unknown as Intent;
+}
+
+/**
+ * Build a minimal IntentExecContext for the buff branch.
+ *
+ * The buff branch in executeIntent reads:
+ *   - ctx.runtimes.get(intent.ownerId)  → must exist (throws if missing)
+ *   - ctx.statusEngine                  → applyTimedAbilityStatus is called on buff apply
+ *   - ctx.bus                           → buff-applied event is emitted
+ *   - ctx.playerIds                     → recipient resolution for 'self' target (falls back to [ownerId])
+ *   - ctx.procChanceGates               → provided when testing the gate; absent for pass-through
+ *
+ * Condition gate: intent.ability.conditions is [] → conditionsMet → passes.
+ * StatusEngine must be advanced to round 1 (beginRound) before executeIntent is called.
+ */
+function makeCtx(opts?: {
+    procChanceGates?: Map<string, ReturnType<typeof makeRateGate>>;
+}): IntentExecContext & { buffAppliedEvents: string[] } {
+    const bus = createEventBus();
+    const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+    // Advance to round 1 so applyTimedAbilityStatus accepts round=1 calls.
+    se.beginRound(1);
+
+    const buffAppliedEvents: string[] = [];
+    bus.on('buff-applied', (e) => {
+        buffAppliedEvents.push(e.buffName);
+    });
+
+    const ctx = {
+        round: 1,
+        enemy: { id: 'enemy1', currentHp: 100000 } as CombatActor,
+        enemyId: 'enemy1',
+        statusEngine: se,
+        bus,
+        corrosionEntries: [],
+        infernoEntries: [],
+        pendingBombs: [],
+        runtimes: new Map([
+            [
+                OWNER_ID,
+                {
+                    actor: { id: OWNER_ID, chargeCount: 0, charges: 0 } as unknown as CombatActor,
+                    attack: 10000,
+                    defence: 0,
+                    hp: 10000,
+                    healModifier: 0,
+                    selfDotModifier: 0,
+                    defensePenetrationBuff: 0,
+                    affinityDamageModifier: 0,
+                    affinityCritCap: 100,
+                    affinityCritPenalty: 0,
+                    affinityDisadvantage: false,
+                    selfBuffLookup: new Map(),
+                    enemyDebuffLookup: new Map(),
+                } as never,
+            ],
+        ]),
+        grantAllyCharges: () => {},
+        grantExtraAction: () => {},
+        playerIds: [OWNER_ID],
+        lastTurnCtxByActor: new Map([
+            [
+                OWNER_ID,
+                {
+                    effectiveAttack: 10000,
+                    affinityMult: 1,
+                } as never,
+            ],
+        ]),
+        enemyHp: 100000,
+        cumulativeDamage: 0,
+        recordResisted: () => {},
+        procChanceGates: opts?.procChanceGates,
+    } as unknown as IntentExecContext & { buffAppliedEvents: string[] };
+
+    (ctx as unknown as Record<string, unknown>).buffAppliedEvents = buffAppliedEvents;
+    return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('D-PR8 T3: reactive buff branch — passesProcChanceGate', () => {
+    it('(a) procChance 0.2 over 10 calls fires buff-applied exactly 2 times (not 10)', () => {
+        // Shared gate map — same owner+ability key re-uses ONE gate across all 10 calls,
+        // producing the deterministic 2/10 accumulator schedule (fires on calls 5, 10).
+        const procChanceGates = new Map<string, ReturnType<typeof makeRateGate>>();
+        const intent = makeBuffIntent({ procChance: 0.2 });
+        const ctx = makeCtx({ procChanceGates });
+
+        for (let i = 0; i < 10; i++) {
+            executeIntent(intent, ctx);
+        }
+
+        // The deterministic accumulator fires exactly 2/10 times.
+        expect(ctx.buffAppliedEvents).toHaveLength(2);
+    });
+
+    it('(b) no procChance: buff-applied fires on all 4 calls (pass-through)', () => {
+        const procChanceGates = new Map<string, ReturnType<typeof makeRateGate>>();
+        const intent = makeBuffIntent(/* no procChance */);
+        const ctx = makeCtx({ procChanceGates });
+
+        for (let i = 0; i < 4; i++) {
+            executeIntent(intent, ctx);
+        }
+
+        // No gate → fires every time.
+        expect(ctx.buffAppliedEvents).toHaveLength(4);
+    });
+});

--- a/src/utils/combat/abilityStatusGating.ts
+++ b/src/utils/combat/abilityStatusGating.ts
@@ -25,6 +25,7 @@ const LIVE_SUBJECTS: ReadonlySet<ConditionSubject> = new Set([
     'enemy-hp-missing-pct',
     'lowest-speed-ally',
     'target-repaired-this-round',
+    'not-hit-this-round',
 ]);
 
 /**

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -1921,6 +1921,11 @@ export function runCombat(input: CombatEngineInput): {
     // Cleared at each round top; read in buildTurnArgs for the target-repaired gate.
     const repairedThisRound = new Set<string>();
 
+    // D-PR8: actors hit by a direct attack this round (damage landed on shield or HP).
+    // Mirrors repairedThisRound. Feeds the not-hit-this-round gate (Alacrity). Cleared each
+    // round alongside repairedThisRound.
+    const hitThisRound = new Set<string>();
+
     // The SHARED healing ctx (built once; closures capture the live target + currentRoundHealing
     // through the `let`/the target reference). Only constructed in healing mode.
     const healingCtx: HealingRuntimeCtx | undefined = healTarget
@@ -2371,6 +2376,7 @@ export function runCombat(input: CombatEngineInput): {
         // Clear the per-round repaired set HERE (not at the round-started emit) so start-of-round
         // reactive heals fired by that emit correctly count toward THIS round (C2b-3).
         repairedThisRound.clear();
+        hitThisRound.clear();
 
         // Forced-targeting/stealth lookup for a roster (phase 3). Reads the status engine
         // for each actor's Concentrate Fire / Taunt / Stealth flags so resolvePositionalTarget
@@ -2706,6 +2712,15 @@ export function runCombat(input: CombatEngineInput): {
                     oldPct: (100 * hpBefore) / maxHp,
                     newPct: (100 * victim.currentHp) / maxHp,
                 });
+            }
+            // D-PR8: record a direct hit for the not-hit-this-round gate. A hit = a direct
+            // attack that landed damage on shield or HP (absorbed > 0 || hpDamage > 0). The
+            // byDirectDamage guard excludes DoT-tick batches (they pass byDirectDamage:false);
+            // fully-Barrier-blocked hits return earlier (barriered:true) and are not recorded.
+            // TODO(verify): whether a fully-Barrier-blocked direct attack should count as a hit
+            // for Alacrity is unconfirmed in-game; current default is "not a hit".
+            if (cause?.byDirectDamage && (absorbed > 0 || hpDamage > 0)) {
+                hitThisRound.add(victim.id);
             }
             return { shieldBefore, hpDamage, barriered: false };
         };
@@ -3354,6 +3369,10 @@ export function runCombat(input: CombatEngineInput): {
                         // side: 100 for every owner until PR5. byte-identical to the old inline spread.
                         selfHpPctFor: sideCtx.selfHpPctFor,
                         enemyWithMostBuffs: sideCtx.enemyWithMostBuffs,
+                        // D-PR8: live not-hit-this-round gate (Alacrity). hitThisRound is a single
+                        // combat-wide Set, so the SAME closure serves both sides (team-agnostic) —
+                        // no per-side sideCtx field needed (unlike isLowestSpeedAllyFor).
+                        wasHitThisRoundFor: (ownerId) => hitThisRound.has(ownerId),
                     });
                 }
             }

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -572,6 +572,11 @@ export interface IntentExecContext {
      *  is static turn-order in this sim). Absent → buildDrainContext defaults the gate to true
      *  (lone-actor DPS assumption). */
     isLowestSpeedAllyFor?: (ownerId: string) => boolean;
+    /** Whether `ownerId` was hit by a direct attack this round, feeding the
+     *  `not-hit-this-round` gate at drain time. Engine-populated from the combat-wide
+     *  hitThisRound Set. Absent → buildDrainContext defaults the gate to false (DPS /
+     *  not-yet-hit → "not hit" ⇒ met), keeping existing drain gating byte-identical. */
+    wasHitThisRoundFor?: (ownerId: string) => boolean;
     /** Credit reactive direct damage to the owner's round damage map against the shared
      *  enemy pool (Phase 4c PR 4 — Grif's on-enemy-cleansed 75% damage proc). Wraps the
      *  engine's `creditDamage(ownerId, 'direct', amount)` so the standing-leech hook still
@@ -637,6 +642,9 @@ export function buildActorConditionContext(
         /** Owner has the lowest Speed among its player team. Default true (lone-actor /
          *  DPS assumption). Populated by buildDrainContext (Phase 4c PR 6). */
         isLowestSpeedAlly?: boolean;
+        /** Owner was hit by a direct attack this round. Default false. Populated by
+         *  buildDrainContext (D-PR8). */
+        wasHitThisRound?: boolean;
     }
 ) {
     const snap = statusEngine.snapshot(ownerId);
@@ -663,6 +671,7 @@ export function buildActorConditionContext(
         enemyBuffNames: shared.enemyBuffNames,
         selfDebuffNames: shared.selfDebuffNames,
         isLowestSpeedAlly: shared.isLowestSpeedAlly,
+        wasHitThisRound: shared.wasHitThisRound,
     });
 }
 
@@ -694,6 +703,9 @@ function buildDrainContext(ctx: IntentExecContext, ownerId: string) {
         // Phase 4c PR 6: live lowest-speed-ally gate (Chakara). Default true → DPS / no-delegate
         // paths keep the lone-actor assumption and stay byte-identical.
         isLowestSpeedAlly: ctx.isLowestSpeedAllyFor?.(ownerId) ?? true,
+        // D-PR8: live not-hit-this-round gate (Alacrity). Default false → DPS / no-delegate
+        // paths read "not hit" ⇒ met and stay byte-identical.
+        wasHitThisRound: ctx.wasHitThisRoundFor?.(ownerId) ?? false,
     });
 }
 

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1006,6 +1006,11 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
             if (ctx.oncePerCombatFired?.has(key)) return;
             ctx.oncePerCombatFired?.add(key);
         }
+        // D-PR8: procChance gate for reactive buff grants (Ambush 5-16%, Alacrity 12-20%).
+        // De-Morgan pass-through — true when procChance is undefined/≤0/≥1, so every existing
+        // (procChance-less) buff grant stays byte-identical. Mirrors the heal/shield + damage
+        // branches. Keys on `${ownerId}:${ability.id}` via ctx.procChanceGates.
+        if (!passesProcChanceGate(intent, ctx)) return;
         // Reactive buffs bypass the aura-by-passive-slot classification — their own
         // duration decides; a duration-less buff defaults to a 1-turn window.
         const duration = typeof cfg.duration === 'number' ? cfg.duration : 1;


### PR DESCRIPTION
## D-PR8 — reactive self-buff grants

Models three implants that grant a timed **self-buff on a trigger**, riding the existing reactive-buff executor. First slice of the "reactive self/ally buff grant" bucket in sub-project D.

| Implant | Trigger | Gate | Grants | Live? |
|---|---|---|---|---|
| **Ambush** | start-of-round | self-buff `Stealth` | Crit Power Up III (1t), proc 5–16% | dormant (no stealth source yet — like Arcane Siege awaiting shields) |
| **Synaptic Resonance** | on-enemy-repaired | none | Speed Up III (1t), deterministic | **live** (enemies have real healing via E5) |
| **Alacrity** | end-of-round | not-hit-this-round | Speed Up III (2t), proc 12–20% | **live** |

### Two engine primitives (both small, both precedented)
1. **`procChance` in the reactive buff branch** — extends `passesProcChanceGate` into the `cfg.type === 'buff'` executor (mirrors the D-PR4 damage-branch extension). De-Morgan pass-through → byte-identical for every existing buff grant (none carry `procChance`).
2. **`not-hit-this-round` condition** — a combat-wide `hitThisRound` Set (mirrors `repairedThisRound`) populated in the shared `applyVictimDamage` core, gated on `byDirectDamage && (absorbed>0 || hpDamage>0)` (DoT ticks + Barrier-blocked hits excluded). Surfaced to the drain gate via a `wasHitThisRoundFor` delegate (mirrors `isLowestSpeedAllyFor`), team-agnostic (one Set serves both sides).

### Locked rule
**Hit = any direct damage landing on shield or HP.** A fully Barrier-blocked attack defaults to *not* a hit (flagged `TODO(verify)` in code — unconfirmed in-game).

### Deferred / dormant
- Synaptic Resonance's "+X% next-crit critDamage" half (stacking next-crit consumable — no seam).
- Ambush stays dormant until a stealth source exists (Cloaking / sub-project H).
- Later sub-PRs: Spearhead (all-allies), Fortifying Shroud (adjacency), Resonating Fury (on-shield-applied), Font of Power (on-own-repair).

### Verification
- 2956 tests pass; **DPS + healing goldens byte-identical** (zero `.snap` changes).
- `tsc` + `lint` clean; `audit:skills` 141 ships / 0 findings (unchanged).
- New: condition evaluator unit tests, LIVE_SUBJECTS test, reactive-buff procChance executor test (mutation-verified), engine hit-tracking integration (4 scenarios: unhit→grant, hit→withhold, shield-only→withhold, DoT-only→grant — mutation-verified), coverage tracker, Synaptic-live + Ambush-gate integration (mutation-verified).

Spec: `docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr8-design.md`
Plan: `docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr8.md`

Rebased onto `main` after D-PR7 (#135) merged; base retargeted to `main`. One test-only follow-up applied during rebase: the Synaptic Resonance lookup now uses `.startsWith()` to match the evolved `equip-implant-<name>-<gearId>` ability-id scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
