### PR TITLE
feat(combat): D-PR10 — dynamic caster-attack-snapshot flat-attack buff (Power Infused Nanobots / Font of Power)

### DIFF
--- a/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr10.md
+++ b/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr10.md
@@ -1,0 +1,413 @@
+# D-PR10 — Flat-attack caster-snapshot buff subsystem — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Light up the `Power Infused Nanobots` buff (Font of Power implant) — grant the recipient flat attack = 100% of the casting unit's effective attack, snapshotted at grant time.
+
+**Architecture:** A new **flat (absolute-units)** attack buff channel folded **additively** on top of the existing percentage attack fold. The magnitude is resolved at *apply* time (the fold has no caster identity) via a **sentinel → concrete split**: `attackFlatPctOfCaster` (parsed statically, inert in the fold) marks "needs a caster-attack snapshot"; `attackFlat` (the frozen absolute value) is materialized only at the grant site into the per-instance timed-ability-status payload, and is the field the fold sums.
+
+**Tech Stack:** TypeScript, Vitest. Worktree `.worktrees/d-pr10-flat-attack-buff`, branch `feat/combat-d-pr10-flat-attack-buff` (off D-PR9 tip `be3ae187`).
+
+**Spec:** `docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr10-design.md`
+
+**Global invariants (all tasks):**
+- Production goldens / `.snap` files stay **byte-identical** (no committed golden carries a Font-of-Power healer). NEVER run `vitest -u`. If a production golden moves, a fold leaked — fix the leak, don't update the snapshot.
+- `npm run audit:skills` stays 141/0. `npm run lint` and `tsc` clean.
+- docs/ is gitignored → spec/plan commits use `git add -f` and `git commit --no-verify`.
+- All `cd` into the worktree: `/Users/kennethsusort/PersonalProjects/starborne-frontiers-calculator/.worktrees/d-pr10-flat-attack-buff`.
+
+---
+
+### Task 1: Type fields + static parser (sentinel)
+
+**Files:**
+- Modify: `src/types/calculator.ts` — `ParsedBuffEffects` (~line 93) + `Buff` interface `stat` union (~line 60).
+- Modify: `src/utils/calculators/buffParser.ts` — `parseBuffEffects`.
+- Test: `src/utils/calculators/__tests__/buffParser.test.ts` (create if absent; otherwise append).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the buffParser test file (find the existing one first; if none, create `src/utils/calculators/__tests__/buffParser.test.ts` with the standard `import { parseBuffEffects } from '../buffParser';`):
+
+```ts
+describe('parseBuffEffects — flat-attack caster snapshot (D-PR10)', () => {
+    it('extracts the caster-attack percentage sentinel from Power Infused Nanobots', () => {
+        const e = parseBuffEffects(
+            'Power Infused Nanobots',
+            "Grants attack equal to 100% of the caster's attack"
+        );
+        expect(e.attackFlatPctOfCaster).toBe(100);
+        // It must NOT populate the percentage `attack` channel (that is %-of-own-attack).
+        expect(e.attack).toBeUndefined();
+        // The concrete value is materialized only at apply time, never by the parser.
+        expect(e.attackFlat).toBeUndefined();
+    });
+
+    it('does NOT false-match an ordinary percentage Attack buff', () => {
+        const e = parseBuffEffects('Atlas Coordination II', '+20% Attack');
+        expect(e.attackFlatPctOfCaster).toBeUndefined();
+        expect(e.attack).toBe(20);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/utils/calculators/__tests__/buffParser.test.ts -t "caster snapshot"`
+Expected: FAIL — `attackFlatPctOfCaster` is not a property (tsc) / undefined.
+
+- [ ] **Step 3: Add the type fields**
+
+In `src/types/calculator.ts`, inside `ParsedBuffEffects` (after the `// Flat stats (not percentages)` block with `hacking`/`security`):
+
+```ts
+    /** CONCRETE frozen flat attack (absolute units), materialized at grant time from a caster
+     *  snapshot. Summed additively in the fold (see effectiveStats / buffTotals). */
+    attackFlat?: number;
+    /** SENTINEL — "grant flat attack = N% of the CASTER's effective attack". Parsed statically
+     *  from the buff description; carries no concrete value, so it is INERT in the fold. The
+     *  reactive buff-grant site resolves it into `attackFlat` per instance. */
+    attackFlatPctOfCaster?: number;
+```
+
+In the `Buff` interface `stat` union (~line 60), add `'attackFlat'`:
+
+```ts
+        | 'security'
+        | 'attackFlat';
+```
+
+- [ ] **Step 4: Add the parser branch**
+
+In `src/utils/calculators/buffParser.ts`, after the `security` block (~line 58), add:
+
+```ts
+    // Flat attack granted as a percentage of the CASTER's attack ("...equal to 100% of the
+    // caster's attack"). SENTINEL only — the concrete value is snapshotted at grant time.
+    // Keys on the "of the caster('s) attack" phrasing so it never matches "+N% Attack" buffs.
+    const attackFlatPct = description.match(
+        /(\d+(?:\.\d+)?)%\s*of\s*the\s*caster'?s?\s*attack/i
+    );
+    if (attackFlatPct) effects.attackFlatPctOfCaster = parseFloat(attackFlatPct[1]);
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/utils/calculators/__tests__/buffParser.test.ts -t "caster snapshot"`
+Expected: PASS (both cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types/calculator.ts src/utils/calculators/buffParser.ts src/utils/calculators/__tests__/buffParser.test.ts
+git commit -m "feat(combat): D-PR10 Task 1 — attackFlat type fields + caster-attack sentinel parser"
+```
+
+---
+
+### Task 2: Buff-leaf emit + fold totals
+
+**Files:**
+- Modify: `src/utils/calculators/dpsBuffHelpers.ts` — `toSimBuffs`.
+- Modify: `src/utils/combat/buffTotals.ts` — `calculateBuffTotals`.
+- Test: co-located test files for each (find existing `__tests__/dpsBuffHelpers.test.ts` and `__tests__/buffTotals.test.ts`; append, or create alongside).
+
+- [ ] **Step 1: Write the failing tests**
+
+For `toSimBuffs` (append to its test file):
+
+```ts
+it('emits an attackFlat leaf (× stacks) but NOT the sentinel (D-PR10)', () => {
+    const out = toSimBuffs([
+        {
+            id: 'b1',
+            buffName: 'Power Infused Nanobots',
+            stacks: 1,
+            isStackable: false,
+            parsedEffects: { attackFlat: 500, attackFlatPctOfCaster: 100 },
+        },
+    ]);
+    expect(out).toContainEqual({ id: 'b1-attackFlat', stat: 'attackFlat', value: 500 });
+    // The sentinel is inert — no leaf for it.
+    expect(out.some((b) => b.value === 100)).toBe(false);
+});
+```
+
+For `calculateBuffTotals` (append to its test file):
+
+```ts
+it('sums attackFlat into attackFlatBuff (D-PR10)', () => {
+    const t = calculateBuffTotals([
+        { id: 'x', stat: 'attackFlat', value: 300 },
+        { id: 'y', stat: 'attackFlat', value: 200 },
+        { id: 'z', stat: 'attack', value: 20 },
+    ]);
+    expect(t.attackFlatBuff).toBe(500);
+    expect(t.attackBuff).toBe(20); // percentage channel untouched
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run -t "attackFlat"`
+Expected: FAIL — `attackFlatBuff` undefined / no `attackFlat` leaf.
+
+- [ ] **Step 3: Emit the leaf in `toSimBuffs`**
+
+In `src/utils/calculators/dpsBuffHelpers.ts`, after the `security` push (~line 66), add:
+
+```ts
+        if (parsedEffects.attackFlat !== undefined)
+            entries.push({
+                id: `${s.id}-attackFlat`,
+                stat: 'attackFlat',
+                value: parsedEffects.attackFlat * stacks,
+            });
+```
+
+(Do NOT emit `attackFlatPctOfCaster` — it has no concrete value and must stay inert.)
+
+- [ ] **Step 4: Sum it in `calculateBuffTotals`**
+
+In `src/utils/combat/buffTotals.ts`, add alongside the other reducers (after `securityBuff`, ~line 44):
+
+```ts
+    const attackFlatBuff = buffs
+        .filter((b) => b.stat === 'attackFlat')
+        .reduce((sum, b) => sum + b.value, 0);
+```
+
+and add `attackFlatBuff,` to the returned object.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run -t "attackFlat"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/calculators/dpsBuffHelpers.ts src/utils/combat/buffTotals.ts src/utils/calculators/__tests__/ src/utils/combat/__tests__/
+git commit -m "feat(combat): D-PR10 Task 2 — attackFlat buff leaf + attackFlatBuff fold total"
+```
+
+---
+
+### Task 3: Effective-stats additive fold
+
+**Files:**
+- Modify: `src/utils/combat/effectiveStats.ts` — `foldActorBuffTotals`, `effectiveStatsOf`, `effectiveDamageStatsOf`.
+- Test: `src/utils/combat/__tests__/effectiveStats.test.ts` (append; find the existing file).
+
+NOTE: `foldActorBuffTotals` and `effectiveDamageStatsOf` both build a `totals` object by **explicit field-by-field sum** of `calculateBuffTotals` outputs. Because Task 2 added `attackFlatBuff` to the `calculateBuffTotals` return type, tsc will require it in both hand-written sum objects — add it to both or tsc fails.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `effectiveStats.test.ts`. Model it on the existing `effectiveStatsOf` / `effectiveDamageStatsOf` tests in that file (reuse their StatusEngine / selfBuffLookup setup helpers). Core assertions:
+
+```ts
+it('adds attackFlat after the percentage attack term (effectiveStatsOf, D-PR10)', () => {
+    // Actor base attack 1000, with a +20% Attack self-buff AND a 300 attackFlat buff active.
+    // Expected: 1000 * 1.20 + 300 = 1500.
+    // (Use the file's existing harness to register both a percentage Attack buff and a buff
+    //  whose parsedEffects carry attackFlat: 300 on the actor, then call effectiveStatsOf.)
+    expect(result.attack).toBe(1500);
+});
+
+it('adds attackFlat after the percentage attack term (effectiveDamageStatsOf, D-PR10)', () => {
+    // base.attack 1000, scheduledTotals.attackBuff 20, an abilitySelfEffects buff with
+    // attackFlat: 300  →  1000 * 1.20 + 300 = 1500.
+    expect(result.attack).toBe(1500);
+});
+```
+
+If the existing harness makes registering an `attackFlat` self-buff awkward, prefer driving `effectiveDamageStatsOf` directly (it takes plain `base` + `abilitySelfEffects: SelectedGameBuff[]`), which is the lower-friction of the two.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/utils/combat/__tests__/effectiveStats.test.ts -t "attackFlat"`
+Expected: FAIL — attack still `1200` (flat not added) or tsc error for the missing `attackFlatBuff` field.
+
+- [ ] **Step 3: Thread `attackFlatBuff` through `foldActorBuffTotals`**
+
+In the field-by-field return object of `foldActorBuffTotals` (~line 72), add:
+
+```ts
+        attackFlatBuff: scheduled.attackFlatBuff + timed.attackFlatBuff,
+```
+
+- [ ] **Step 4: Add the flat term in `effectiveStatsOf`**
+
+Change the `attack` line (~line 95):
+
+```ts
+        attack: s.attack * (1 + t.attackBuff / 100) + t.attackFlatBuff,
+```
+
+- [ ] **Step 5: Thread + apply in `effectiveDamageStatsOf`**
+
+In the `totals` assembly (~line 186), add (no modifier-channel equivalent exists, so it is scheduled + ability only):
+
+```ts
+        attackFlatBuff: scheduledTotals.attackFlatBuff + ability.attackFlatBuff,
+```
+
+and change the returned `attack` (~line 202):
+
+```ts
+        attack: base.attack * (1 + totals.attackBuff / 100) + totals.attackFlatBuff,
+```
+
+- [ ] **Step 6: Run test + full effectiveStats suite to verify pass + no regression**
+
+Run: `npx vitest run src/utils/combat/__tests__/effectiveStats.test.ts`
+Expected: new tests PASS; all existing PASS (no actor in existing tests carries attackFlat → `+0`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/utils/combat/effectiveStats.ts src/utils/combat/__tests__/effectiveStats.test.ts
+git commit -m "feat(combat): D-PR10 Task 3 — additive attackFlat fold in effectiveStats"
+```
+
+---
+
+### Task 4: Snapshot the caster's attack at the grant site
+
+**Files:**
+- Modify: `src/utils/combat/triggers.ts` — `executeIntent` buff branch (opens ~line 1045; hoisted `status` built ~line 1079).
+- Test: engine-level integration test. Reuse the harness in `src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts` (Font of Power / `on-own-repair-to-ally` patterns from D-PR9 live here and in `enemyReactiveSelfBuffs.test.ts`).
+
+- [ ] **Step 1: Write the failing integration test**
+
+In `equipmentAbilities.integration.test.ts`, add a test that:
+- Builds a small battle where a Font-of-Power healer (the *caster*) with a KNOWN effective attack repairs a **non-self** ally whose own base attack differs from the caster's, forcing the PIN grant (set the proc to fire — if procChance blocks determinism in the harness, follow the D-PR9 tests' approach for forcing the grant, e.g. a rate-gate stub / legendary 100%-path helper already used there).
+- Asserts the recipient's **effective attack after the grant** = `recipientOwnEffectiveAttack + casterEffectiveAttack` (i.e. the increase equals the caster's effective attack, NOT the recipient's base). Use distinct attack stats for caster vs recipient so a wrong-source bug (recipient's own attack) is caught.
+- Asserts the recipient subsequently deals damage consistent with the raised attack (qualitative: damage strictly greater than the no-PIN baseline), to prove the fold reaches the damage path.
+
+Look at the existing PIN presence-only tests (`enemyReactiveSelfBuffs.test.ts` ~lines 391/598) for the exact builder/proc-forcing idiom before writing this.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts -t "Power Infused"`
+Expected: FAIL — recipient attack unchanged (buff still emit-only / no `attackFlat` materialized).
+
+- [ ] **Step 3: Materialize the snapshot in the buff branch**
+
+In `src/utils/combat/triggers.ts`, in `executeIntent` `if (cfg.type === 'buff') { ... }`, BEFORE the hoisted `status` literal (~line 1079), compute the per-instance payload config:
+
+```ts
+        // D-PR10: dynamic caster-attack snapshot. A buff whose parsedEffects carry the
+        // `attackFlatPctOfCaster` sentinel ("N% of the caster's attack") freezes a concrete
+        // `attackFlat` from the CASTER's effective attack at grant time (the same last-turn
+        // ctx value bombs/reactive-damage snapshot). One value for all recipients → the shared
+        // hoisted payload stays correct.
+        const pinPct = cfg.parsedEffects.attackFlatPctOfCaster;
+        const buffCfg =
+            pinPct !== undefined
+                ? (() => {
+                      const ownerCtx = ctx.lastTurnCtxByActor.get(intent.ownerId);
+                      const casterAttack = ownerCtx?.effectiveAttack ?? owner.attack;
+                      return {
+                          ...cfg,
+                          parsedEffects: {
+                              ...cfg.parsedEffects,
+                              attackFlat: casterAttack * (pinPct / 100),
+                          },
+                      };
+                  })()
+                : cfg;
+```
+
+Then change the `status` literal's payload to use `buffCfg`:
+
+```ts
+            payload: payloadFromConfig(buffCfg),
+```
+
+(Leave `cfg.buffName`/`cfg.duration`/`cfg.oncePerCombat` references as-is — only the payload's `parsedEffects` needs the per-instance copy. `payloadFromConfig` reads `buffName`/`stacks`/`parsedEffects`/`application` off its arg, all present on `buffCfg`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts -t "Power Infused"`
+Expected: PASS — recipient effective attack rose by the caster's effective attack; damage strictly above baseline.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/triggers.ts src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts
+git commit -m "feat(combat): D-PR10 Task 4 — snapshot caster attack into Power Infused Nanobots grant"
+```
+
+---
+
+### Task 5: Update emit-only tests + verify coverage tracker
+
+**Files:**
+- Modify: `src/utils/combat/__tests__/enemyReactiveSelfBuffs.test.ts` (~lines 391, 598) — stale "parses to no stat effect" comments + presence-only assertions.
+- Modify: `src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts` (~line 2590) if it carries a similar stale comment.
+- Verify (likely NO edit): `src/utils/abilities/__tests__/equipmentCoverage.test.ts` — FONT_OF_POWER already in `implementedImplants` and the `.toEqual` array (count-only; D-PR10 doesn't change the count).
+
+- [ ] **Step 1: Read each cited site**
+
+Read `enemyReactiveSelfBuffs.test.ts` ~lines 380-410 and ~585-610, and `equipmentAbilities.integration.test.ts` ~line 2580-2600. Identify which assertions observe the recipient's stats/damage (those will now change) vs which only assert buff presence.
+
+- [ ] **Step 2: Update comments + assertions**
+
+For each PIN site: correct the stale comment ("parses to no stat effect" → describe the real flat-attack effect, snapshotted from the caster). Where an assertion previously captured the recipient's stats/damage and now changes, update the expected value (compute from the snapshot). Where the test's sole purpose is the grant *mechanic* (presence), keep the presence assertion but point the comment at the dedicated magnitude test from Task 4. Do NOT `vitest -u`.
+
+- [ ] **Step 3: Run the affected files + confirm coverage unchanged**
+
+Run:
+```bash
+npx vitest run src/utils/combat/__tests__/enemyReactiveSelfBuffs.test.ts \
+  src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts \
+  src/utils/abilities/__tests__/equipmentCoverage.test.ts
+```
+Expected: all PASS; equipmentCoverage PASS with no edit (if it fails, the count assumption was wrong — reconcile per the known decl-order/Set pitfall).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/combat/__tests__/enemyReactiveSelfBuffs.test.ts src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts
+git commit -m "test(combat): D-PR10 Task 5 — PIN emit-only tests now assert real flat-attack effect"
+```
+
+---
+
+### Task 6: Changelog + full-suite verification
+
+**Files:**
+- Modify: `src/constants/changelog.ts` — `UNRELEASED_CHANGES`.
+
+- [ ] **Step 1: Add the changelog entry**
+
+In `UNRELEASED_CHANGES`, add a plain-English line, matching the surrounding style, e.g.:
+
+> "Combat sim: the Font of Power implant's Power Infused Nanobots buff now grants the ally flat attack equal to the caster's attack (previously had no effect)."
+
+- [ ] **Step 2: Full verification sweep**
+
+Run each and confirm:
+```bash
+npm test            # full suite green; production goldens BYTE-IDENTICAL (no .snap in git diff)
+npm run lint        # 0 warnings
+npx tsc --noEmit    # clean
+npm run audit:skills # 141 ships, 0 findings
+git diff --stat origin/main -- '*.snap' 2>/dev/null  # expect EMPTY (no production golden moved)
+```
+Expected: all green. If any production `.snap` shows in the diff, a fold leaked — STOP and fix the leak; do not regenerate.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/constants/changelog.ts
+git commit -m "docs(changelog): D-PR10 — Power Infused Nanobots flat-attack effect"
+```
+
+---
+
+## Final review (after all tasks)
+
+- [ ] Holistic self-review of the full diff against the spec (sentinel inert in fold; concrete only at grant; additive fold both effective-stat accessors; byte-identical production goldens; coverage 141/0).
+- [ ] Confirm the branch is stacked correctly on D-PR9 tip and ready to PR (retarget to main as the lower stack merges). Push and open the PR per the established stack-merge strategy.

--- a/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr10.md
+++ b/docs/superpowers/plans/2026-06-21-implant-gearset-abilities-D-pr10.md
@@ -303,20 +303,18 @@ In `src/utils/combat/triggers.ts`, in `executeIntent` `if (cfg.type === 'buff') 
         // ctx value bombs/reactive-damage snapshot). One value for all recipients → the shared
         // hoisted payload stays correct.
         const pinPct = cfg.parsedEffects.attackFlatPctOfCaster;
-        const buffCfg =
-            pinPct !== undefined
-                ? (() => {
-                      const ownerCtx = ctx.lastTurnCtxByActor.get(intent.ownerId);
-                      const casterAttack = ownerCtx?.effectiveAttack ?? owner.attack;
-                      return {
-                          ...cfg,
-                          parsedEffects: {
-                              ...cfg.parsedEffects,
-                              attackFlat: casterAttack * (pinPct / 100),
-                          },
-                      };
-                  })()
-                : cfg;
+        let buffCfg = cfg;
+        if (pinPct !== undefined) {
+            const ownerCtx = ctx.lastTurnCtxByActor.get(intent.ownerId);
+            const casterAttack = ownerCtx?.effectiveAttack ?? owner.attack;
+            buffCfg = {
+                ...cfg,
+                parsedEffects: {
+                    ...cfg.parsedEffects,
+                    attackFlat: casterAttack * (pinPct / 100),
+                },
+            };
+        }
 ```
 
 Then change the `status` literal's payload to use `buffCfg`:

--- a/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr10-design.md
+++ b/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr10-design.md
@@ -1,0 +1,98 @@
+# D-PR10 — Dynamic caster-attack-snapshot flat-attack buff subsystem
+
+**Date:** 2026-06-21
+**Sub-project:** D (implant + gear-set abilities), combat-realism epic
+**Stacks on:** D-PR9 tip `be3ae187` (branch `feat/combat-d-pr10-flat-attack-buff`, worktree `.worktrees/d-pr10-flat-attack-buff`)
+
+## 1. Goal
+
+Light up the `Power Infused Nanobots` buff — the effect granted by the **Font of Power** implant (Font of Power's `on-own-repair-to-ally` reactive grant shipped in D-PR9, which already lands the buff on the correct allies, but as an **emit-only** status with zero stat effect).
+
+Buff definition (`src/constants/buffs.ts`):
+
+```ts
+{ name: 'Power Infused Nanobots', description: "Grants attack equal to 100% of the caster's attack", type: 'buff' }
+```
+
+The recipient gains **flat attack equal to 100% of the casting unit's effective attack, snapshotted at the moment of the grant.** This requires an engine primitive that does not exist today: a per-instance, dynamic-magnitude, **flat (absolute)** attack buff whose value is **frozen from a different actor (the caster)** at apply time.
+
+## 2. Why the engine cannot model this today
+
+- Attack buffs fold as **percentages of the holder's own attack**: `effectiveStatsOf` computes `attack: s.attack * (1 + attackBuff/100)` (`src/utils/combat/effectiveStats.ts`). There is no absolute-units attack channel.
+- Buff magnitudes are **re-derived from static `BUFFS`** at fold time via `selfBuffLookup` / `parseBuffEffects`. Buff instances carry no per-instance value.
+- The fold has **no caster identity**: a recipient folds *its own* active buffs without knowing who cast each. So a value defined as "% of the caster's attack" cannot be resolved at fold time — it must be resolved (snapshotted) at **apply** time.
+
+`parseBuffEffects` currently cannot parse this description (D-PR9 noted: the attack regex requires a leading `[+-]` sign; `100%` has none, and there is no flat-attack channel). The buff therefore lands with empty effects → no stat change. D-PR10 closes this.
+
+## 3. Locked decisions (from brainstorming)
+
+1. **Snapshot source = caster's EFFECTIVE attack.** The value frozen is the caster's live buffed attack at the moment it performs the repair — `ownerCtx.effectiveAttack` (the same last-turn-context value bombs and reactive-damage already snapshot via `ctx.lastTurnCtxByActor`), falling back to `owner.attack` (base) when no last-turn ctx exists. A Font-of-Power healer that is itself buffed grants more.
+2. **Fold order = additive flat, after the percentage.** The recipient's resolved attack is `recipientBase * (1 + recipientAttackBuff%/100) + grantedFlatAttack`. The frozen amount is added on top of the recipient's own (possibly buffed) attack — a flat stat addition, mirroring the hacking/security additive channel. It is NOT folded into the multiplicative base (which would re-scale the caster's buffs through the recipient's multipliers).
+3. **Freeze at apply, not re-derive per round.** The buff carries the value the caster had when it granted it. (PIN is a 1-turn buff so this is currently moot, but the principle is locked: the timed-ability-status payload is per-instance and holds the frozen value.)
+
+## 4. Architecture — the sentinel → concrete split
+
+Two distinct fields on `ParsedBuffEffects` (`src/types/calculator.ts`), because the snapshot happens at apply time but the description is parsed statically:
+
+| Field | Meaning | Origin | Behavior in fold |
+| --- | --- | --- | --- |
+| `attackFlatPctOfCaster?: number` | **Sentinel** — "needs a caster-attack snapshot of this %". | Parsed from the static buff description (`100` for PIN). | **Inert (0 attack).** No caster context at fold time. |
+| `attackFlat?: number` | **Concrete** frozen absolute attack amount. | Materialized ONLY at apply time, written into the per-instance status payload. | **Summed** into the fold's flat-attack channel. |
+
+This split is self-protecting: if PIN ever reaches a holder via the static re-derive path (scheduled self-buff, `selfBuffLookup`), it carries only the sentinel → contributes 0 — never a broken or double-counted value. Only the snapshot path materializes a concrete `attackFlat`.
+
+## 5. Components & changes
+
+### 5.1 Parser — `src/utils/calculators/buffParser.ts`
+
+Add to `parseBuffEffects`: a regex capturing the percentage in "...equal to N% of the caster's attack" → `effects.attackFlatPctOfCaster = N`. Must NOT false-match ordinary `+N% Attack` buffs (the existing `attack` regex requires the leading sign and the literal `Attack`; the new one keys on the `of the caster's attack` phrasing). Apostrophe-tolerant (`caster's` / `casters`).
+
+### 5.2 Type — `src/types/calculator.ts`
+
+Add `attackFlat?` and `attackFlatPctOfCaster?` to `ParsedBuffEffects` with doc comments distinguishing concrete vs sentinel.
+
+### 5.3 Buff leaf emit + fold totals — `src/utils/calculators/dpsBuffHelpers.ts`, `src/utils/combat/buffTotals.ts`, `Buff` type
+
+The per-stat `Buff` leaves consumed by `calculateBuffTotals` are produced by `toSimBuffs` (`dpsBuffHelpers.ts`), one push per defined `parsedEffects` channel (× stacks) — exactly how `hacking`/`security` were wired in A2. Changes:
+
+- **`Buff.stat` union** (`src/types/calculator.ts`): add `'attackFlat'`.
+- **`toSimBuffs`**: `if (parsedEffects.attackFlat !== undefined) entries.push({ id: \`${s.id}-attackFlat\`, stat: 'attackFlat', value: parsedEffects.attackFlat * stacks })`. (The sentinel `attackFlatPctOfCaster` is deliberately NOT emitted — it has no concrete value and must stay inert.)
+- **`calculateBuffTotals`**: `attackFlatBuff = buffs.filter(b => b.stat === 'attackFlat').reduce((s, b) => s + b.value, 0)`; add `attackFlatBuff` to the returned object.
+
+### 5.4 Effective-stats fold — `src/utils/combat/effectiveStats.ts`
+
+- `foldActorBuffTotals`: sum `attackFlatBuff` across the scheduled + timed layers (the explicit field-by-field sum).
+- `effectiveStatsOf`: `attack: s.attack * (1 + t.attackBuff / 100) + t.attackFlatBuff`.
+- `effectiveDamageStatsOf`: thread `attackFlatBuff` through the `totals` assembly (it has no modifier-channel equivalent, so just `scheduledTotals.attackFlatBuff + ability.attackFlatBuff`) and apply `attack: base.attack * (1 + totals.attackBuff / 100) + totals.attackFlatBuff`.
+
+### 5.5 Snapshot at the grant site — `src/utils/combat/triggers.ts` (buff branch, ~1080)
+
+In `executeIntent`'s `cfg.type === 'buff'` block, before constructing the hoisted `status`:
+
+- If `cfg.parsedEffects.attackFlatPctOfCaster` is defined, resolve `const casterAttack = ownerCtx?.effectiveAttack ?? owner.attack` (resolve `ownerCtx = ctx.lastTurnCtxByActor.get(intent.ownerId)` exactly as the existing damage/heal branches do) and compute `attackFlat = casterAttack * (pct / 100)`.
+- Build a per-instance `parsedEffects` copy `{ ...cfg.parsedEffects, attackFlat }` and pass it into `payloadFromConfig` (or a small per-instance payload override) so the timed-ability-status payload carries the concrete frozen value.
+- The snapshot is one value for all recipients (the caster's attack), so a single shared payload remains correct — the existing hoist-above-the-loop structure is unchanged.
+- When the sentinel is absent (every other buff), the payload is byte-identical to today.
+
+### 5.6 Coverage tracker — `src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+
+`FONT_OF_POWER` moves from the emit-only set to the fully-modeled set (PIN now has a real stat effect). Keep both the `.toEqual` decl-order array and the implemented Set in sync (known pitfall).
+
+## 6. Byte-identical guarantee
+
+No buff in the corpus other than `Power Infused Nanobots` carries `attackFlat`/`attackFlatPctOfCaster` (verified — PIN is the sole match of the `of the caster's attack` phrasing). The new fold channel is `+0` everywhere it is summed → zero golden / `.snap` drift, consistent with every prior D-PR. The grant-site snapshot only triggers when the sentinel is present (PIN only), so all existing buff grants emit identical payloads.
+
+## 7. Testing
+
+- **`buffParser` unit:** the new regex extracts `100` from PIN's description; does not match `+N% Attack` / `Atlas Coordination` buffs (no false positives).
+- **`calculateBuffTotals` / `toSimBuffs` unit:** an `attackFlat` parsedEffect produces an `attackFlatBuff` total (× stacks); a sentinel-only (`attackFlatPctOfCaster`) parsedEffect contributes 0.
+- **`effectiveStats` unit:** `effectiveStatsOf` / `effectiveDamageStatsOf` add `attackFlatBuff` after the percentage term; absent → unchanged.
+- **Engine integration:** a Font-of-Power healer repairs a non-self ally → recipient gains PIN → recipient's effective attack rises by the caster's effective attack (assert magnitude bounded to the caster's snapshot, not the recipient's base), and the recipient subsequently deals correspondingly higher damage. Snapshot-vs-recipient distinction proven by using a caster and recipient with different attack stats. Enemy-side mirror (team-agnostic — Font of Power on an enemy healer grants its enemy ally).
+- **Suite-wide:** goldens byte-identical; `npm run audit:skills` unchanged (141/0); lint/tsc clean.
+
+## 8. Out of scope / follow-ups
+
+- No new buff sources, no other implants. PIN is the only effect this PR lights up.
+- `EffectiveStats` interface shape is unchanged (attack stays a resolved number); only internal arithmetic changes.
+- Stacks: PIN is non-stackable; the `× stacks` term is correct but exercises only the 1× path today.
+- No UI surfacing of the flat magnitude (the buff already displays by name in round status).

--- a/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr10-design.md
+++ b/docs/superpowers/specs/2026-06-21-implant-gearset-abilities-D-pr10-design.md
@@ -65,22 +65,31 @@ The per-stat `Buff` leaves consumed by `calculateBuffTotals` are produced by `to
 - `effectiveStatsOf`: `attack: s.attack * (1 + t.attackBuff / 100) + t.attackFlatBuff`.
 - `effectiveDamageStatsOf`: thread `attackFlatBuff` through the `totals` assembly (it has no modifier-channel equivalent, so just `scheduledTotals.attackFlatBuff + ability.attackFlatBuff`) and apply `attack: base.attack * (1 + totals.attackBuff / 100) + totals.attackFlatBuff`.
 
-### 5.5 Snapshot at the grant site — `src/utils/combat/triggers.ts` (buff branch, ~1080)
+### 5.5 Snapshot at the grant site — `src/utils/combat/triggers.ts` (buff branch, opens ~1045; hoisted `status` built ~1079)
 
-In `executeIntent`'s `cfg.type === 'buff'` block, before constructing the hoisted `status`:
+In `executeIntent`'s `cfg.type === 'buff'` block, before constructing the hoisted `status` (~line 1079):
 
-- If `cfg.parsedEffects.attackFlatPctOfCaster` is defined, resolve `const casterAttack = ownerCtx?.effectiveAttack ?? owner.attack` (resolve `ownerCtx = ctx.lastTurnCtxByActor.get(intent.ownerId)` exactly as the existing damage/heal branches do) and compute `attackFlat = casterAttack * (pct / 100)`.
-- Build a per-instance `parsedEffects` copy `{ ...cfg.parsedEffects, attackFlat }` and pass it into `payloadFromConfig` (or a small per-instance payload override) so the timed-ability-status payload carries the concrete frozen value.
+- If `cfg.parsedEffects.attackFlatPctOfCaster` is defined, resolve `const ownerCtx = ctx.lastTurnCtxByActor.get(intent.ownerId)` and `const casterAttack = ownerCtx?.effectiveAttack ?? owner.attack` (exactly as the heal branch ~1238 and reactive-damage branch ~1328 already do; `owner` is `ctx.runtimes.get(intent.ownerId)`, with `owner.attack` a base-stat fallback). Compute `attackFlat = casterAttack * (pct / 100)`.
+- Materialize a per-instance payload: pass `{ ...cfg, parsedEffects: { ...cfg.parsedEffects, attackFlat } }` into `payloadFromConfig` (~line 914 — it reads `parsedEffects` straight off its `cfg` arg), so the timed-ability-status payload carries the concrete frozen value. When the sentinel is absent, pass `cfg` unchanged.
 - The snapshot is one value for all recipients (the caster's attack), so a single shared payload remains correct — the existing hoist-above-the-loop structure is unchanged.
 - When the sentinel is absent (every other buff), the payload is byte-identical to today.
 
-### 5.6 Coverage tracker — `src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+### 5.6 Emit-only → modeled: update the presence-only tests (NOT the coverage tracker)
 
-`FONT_OF_POWER` moves from the emit-only set to the fully-modeled set (PIN now has a real stat effect). Keep both the `.toEqual` decl-order array and the implemented Set in sync (known pitfall).
+There is no "emit-only set vs fully-modeled set" in `equipmentCoverage.test.ts` — `FONT_OF_POWER` is already in both `implementedImplants` and the `.toEqual` decl-order array there (that test asserts only the per-rarity ability *count*, which D-PR10 does not change). **No edit to `equipmentCoverage.test.ts` is needed.**
+
+The real "emit-only / no stat effect" tracking lives as **presence-only assertions with explanatory comments**:
+
+- `src/utils/combat/__tests__/enemyReactiveSelfBuffs.test.ts` (~lines 391, 598): comments "Emit-only → PRESENCE only (Power Infused Nanobots parses to no stat effect)".
+- `src/utils/abilities/__tests__/equipmentAbilities.integration.test.ts` (~line 2590).
+
+D-PR10 makes these comments **false** (PIN now has a real attack effect). Update each: correct the stale comments, and where a test previously asserted only presence, upgrade it to also assert the recipient's attack rose by the snapshot (or, where the test's purpose is solely the *grant* mechanic, leave the presence assertion but fix the comment to say the magnitude is covered by the dedicated integration test in §7). The implementer must read each cited site and decide per-test; do not assume a single mechanical edit.
 
 ## 6. Byte-identical guarantee
 
-No buff in the corpus other than `Power Infused Nanobots` carries `attackFlat`/`attackFlatPctOfCaster` (verified — PIN is the sole match of the `of the caster's attack` phrasing). The new fold channel is `+0` everywhere it is summed → zero golden / `.snap` drift, consistent with every prior D-PR. The grant-site snapshot only triggers when the sentinel is present (PIN only), so all existing buff grants emit identical payloads.
+No buff in the corpus other than `Power Infused Nanobots` carries `attackFlat`/`attackFlatPctOfCaster` (verified — PIN is the sole match of the `of the caster's attack` phrasing). The new fold channel is `+0` everywhere it is summed; the grant-site snapshot only fires when the sentinel is present (PIN only), so all existing buff grants emit identical payloads → **zero production golden / `.snap` drift** (no committed golden scenario carries a Font-of-Power healer), consistent with every prior D-PR.
+
+**Exception (intended churn, not byte-identical):** the existing **emit-only presence tests** that exercise PIN (the §5.6 sites in `enemyReactiveSelfBuffs.test.ts` and `equipmentAbilities.integration.test.ts`) now produce a real recipient attack increase. Any assertion in those tests that observes the recipient's stats/damage will change and must be updated as part of §5.6. This is confined to those PIN-bearing tests; the broader suite and all production goldens stay byte-identical.
 
 ## 7. Testing
 

--- a/src/components/calculator/GameBuffPicker.tsx
+++ b/src/components/calculator/GameBuffPicker.tsx
@@ -37,10 +37,12 @@ const STAT_LABELS: Record<keyof ParsedBuffEffects, string> = {
     hacking: 'Hacking',
     security: 'Sec',
     speed: 'Speed',
+    attackFlat: 'Atk (flat)',
+    attackFlatPctOfCaster: 'Atk (caster%)',
 };
 
 // Stats stored as flat values, not percentages
-const FLAT_STATS = new Set<keyof ParsedBuffEffects>(['hacking', 'security']);
+const FLAT_STATS = new Set<keyof ParsedBuffEffects>(['hacking', 'security', 'attackFlat']);
 
 function buildEffectSummary(
     effects: ParsedBuffEffects,

--- a/src/components/calculator/GameBuffPicker.tsx
+++ b/src/components/calculator/GameBuffPicker.tsx
@@ -38,7 +38,7 @@ const STAT_LABELS: Record<keyof ParsedBuffEffects, string> = {
     security: 'Sec',
     speed: 'Speed',
     attackFlat: 'Atk (flat)',
-    attackFlatPctOfCaster: 'Atk (caster%)',
+    attackFlatPctOfCaster: 'of caster Atk',
 };
 
 // Stats stored as flat values, not percentages

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -19,6 +19,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator now models three on-death implants: Last Wish (repairs all allies when the carrier is destroyed), Battlecry (grants all allies Inc. Damage Down II on death), and Martyrdom (applies Disable to the unit that landed the killing blow). Last Wish is fully resolved; Battlecry and Martyrdom apply and appear in the combat log with full effects coming in a later update.',
     'Combat simulator now models three reactive self-buff implants: Ambush (grants Crit Power Up to itself when it goes into stealth at round start), Synaptic Resonance (grants Speed Up to itself when any enemy is repaired), and Alacrity (grants Speed Up to itself at round end when it took no damage that round).',
     'Combat simulator now models two ally-support implants: Spearhead (after the carrier uses its charged skill, a chance to grant all allies Attack Up for 1 turn) and Font of Power (a chance to grant a buff to the allies it repairs). Spearhead is fully resolved; Font of Power applies and appears in the combat log with its attack bonus coming in a later update.',
+    "Combat simulator: the Font of Power implant's Power Infused Nanobots buff now grants the repaired ally flat attack equal to 100% of the caster's attack at the time of the repair (previously this attack bonus had no effect).",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/calculator.ts
+++ b/src/types/calculator.ts
@@ -71,7 +71,8 @@ export interface Buff {
         | 'hotPct'
         | 'speed'
         | 'hacking'
-        | 'security';
+        | 'security'
+        | 'attackFlat';
     value: number;
 }
 
@@ -117,6 +118,14 @@ export interface ParsedBuffEffects {
     // Flat stats (not percentages)
     hacking?: number; // flat additive on hacking stat
     security?: number; // flat additive on security stat
+
+    /** CONCRETE frozen flat attack (absolute units), materialized at grant time from a caster
+     *  snapshot. Summed additively in the fold (see effectiveStats / buffTotals). */
+    attackFlat?: number;
+    /** SENTINEL — "grant flat attack = N% of the CASTER's effective attack". Parsed statically
+     *  from the buff description; carries no concrete value, so it is INERT in the fold. The
+     *  reactive buff-grant site resolves it into `attackFlat` per instance. */
+    attackFlatPctOfCaster?: number;
 }
 
 export interface SelectedGameBuff {

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -718,7 +718,7 @@ describe('Martyrdom (on-death Disable the killer — emit-only)', () => {
     });
 });
 
-describe('Power Infused Nanobots buff (D-PR9 — Font of Power, emit-only)', () => {
+describe('Power Infused Nanobots buff (D-PR9 + D-PR10 — Font of Power, flat attack = caster attack)', () => {
     it('exists in the buff corpus as a buff', () => {
         const buff = BUFFS.find((b) => b.name === 'Power Infused Nanobots');
         expect(buff).toBeDefined();

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -725,11 +725,13 @@ describe('Power Infused Nanobots buff (D-PR9 — Font of Power, emit-only)', () 
         expect(buff!.type).toBe('buff');
     });
 
-    it('parses to no stat effect (emit-only — real effect deferred to D-PR10)', () => {
+    it('parses to attackFlatPctOfCaster sentinel (D-PR10 — caster snapshot)', () => {
         const buff = BUFFS.find((b) => b.name === 'Power Infused Nanobots');
         const effects = parseBuffEffects(buff!.name, buff!.description);
-        // Emit-only: the description has no leading +/- sign before "attack", so
-        // nothing parses → applying the buff is a no-op.
-        expect(Object.keys(effects)).toHaveLength(0);
+        // D-PR10: the description "Grants attack equal to 100% of the caster's attack"
+        // now produces the sentinel field; the concrete value is snapshotted at grant time.
+        expect(effects.attackFlatPctOfCaster).toBe(100);
+        expect(effects.attack).toBeUndefined();
+        expect(effects.attackFlat).toBeUndefined();
     });
 });

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -239,8 +239,8 @@ const SPEARHEAD_PROC: Record<string, number> = {
 };
 
 // D-PR9: Font of Power — when repairing another ally, X% chance to grant the repaired
-// allies Power Infused Nanobots for 1 turn. Rare/epic/legendary only. EMIT-ONLY this PR
-// (the caster-attack-snapshot flat-attack fold is D-PR10).
+// allies Power Infused Nanobots for 1 turn. Rare/epic/legendary only. D-PR10: the buff
+// grants flat attack = 100% of the caster's attack (snapshotted at grant time).
 const FONT_OF_POWER_PROC: Record<string, number> = {
     rare: 0.09,
     epic: 0.12,
@@ -634,8 +634,8 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
         return mkNamedBuffGrant('Attack Up I', 'all-allies', 'on-charged-cast', 1, { procChance });
     },
     // D-PR9: Font of Power — on-own-repair-to-ally, grant repaired allies Power Infused
-    // Nanobots (target:'ally' + eventCtx.repairedAllyIds routing). EMIT-ONLY: the buff has
-    // no parseable effect yet; the +100%-of-caster-attack fold lands in D-PR10.
+    // Nanobots (target:'ally' + eventCtx.repairedAllyIds routing). D-PR10: the buff grants
+    // flat attack = 100% of the caster's attack, snapshotted at grant time.
     FONT_OF_POWER: (rarity) => {
         const procChance = FONT_OF_POWER_PROC[rarity];
         if (procChance === undefined) return undefined;

--- a/src/utils/calculators/__tests__/buffParser.test.ts
+++ b/src/utils/calculators/__tests__/buffParser.test.ts
@@ -289,3 +289,21 @@ describe('hasDpsEffect', () => {
         expect(hasDpsEffect({ defense: -30 }, ['defense', 'incomingDamage'])).toBe(true);
     });
 });
+
+describe('parseBuffEffects — flat-attack caster snapshot (D-PR10)', () => {
+    it('extracts the caster-attack percentage sentinel from Power Infused Nanobots', () => {
+        const e = parseBuffEffects(
+            'Power Infused Nanobots',
+            "Grants attack equal to 100% of the caster's attack"
+        );
+        expect(e.attackFlatPctOfCaster).toBe(100);
+        expect(e.attack).toBeUndefined();
+        expect(e.attackFlat).toBeUndefined();
+    });
+
+    it('does NOT false-match an ordinary percentage Attack buff', () => {
+        const e = parseBuffEffects('Atlas Coordination II', '+20% Attack');
+        expect(e.attackFlatPctOfCaster).toBeUndefined();
+        expect(e.attack).toBe(20);
+    });
+});

--- a/src/utils/calculators/__tests__/dpsBuffHelpers.test.ts
+++ b/src/utils/calculators/__tests__/dpsBuffHelpers.test.ts
@@ -194,7 +194,7 @@ describe('toSimBuffs — attackFlat channel (D-PR10)', () => {
             },
         ]);
         expect(out).toContainEqual({ id: 'b1-attackFlat', stat: 'attackFlat', value: 500 });
-        expect(out.some((b) => b.value === 100)).toBe(false); // sentinel inert — no leaf
+        expect(out.some((b) => (b.stat as string) === 'attackFlatPctOfCaster')).toBe(false); // sentinel inert — no leaf
     });
 });
 

--- a/src/utils/calculators/__tests__/dpsBuffHelpers.test.ts
+++ b/src/utils/calculators/__tests__/dpsBuffHelpers.test.ts
@@ -182,6 +182,22 @@ describe('toSimBuffs — hacking/security channels (A2)', () => {
     });
 });
 
+describe('toSimBuffs — attackFlat channel (D-PR10)', () => {
+    it('emits an attackFlat leaf (× stacks) but NOT the sentinel (D-PR10)', () => {
+        const out = toSimBuffs([
+            {
+                id: 'b1',
+                buffName: 'Power Infused Nanobots',
+                stacks: 1,
+                isStackable: false,
+                parsedEffects: { attackFlat: 500, attackFlatPctOfCaster: 100 },
+            },
+        ]);
+        expect(out).toContainEqual({ id: 'b1-attackFlat', stat: 'attackFlat', value: 500 });
+        expect(out.some((b) => b.value === 100)).toBe(false); // sentinel inert — no leaf
+    });
+});
+
 describe('calculateBuffTotals — hacking/security channels (A2)', () => {
     it('sums hacking buffs', () => {
         const result = calculateBuffTotals([

--- a/src/utils/calculators/buffParser.ts
+++ b/src/utils/calculators/buffParser.ts
@@ -57,6 +57,12 @@ export function parseBuffEffects(name: string, description: string): ParsedBuffE
     const security = extract(/([+-]\d+)\s*Security/);
     if (security !== undefined) effects.security = security;
 
+    // Flat attack granted as a percentage of the CASTER's attack ("...equal to 100% of the
+    // caster's attack"). SENTINEL only — the concrete value is snapshotted at grant time.
+    // Keys on the "of the caster('s) attack" phrasing so it never matches "+N% Attack" buffs.
+    const attackFlatPct = description.match(/(\d+(?:\.\d+)?)%\s*of\s*the\s*caster'?s?\s*attack/i);
+    if (attackFlatPct) effects.attackFlatPctOfCaster = parseFloat(attackFlatPct[1]);
+
     const speed = extract(/([+-]\d+(?:\.\d+)?)%\s*Speed/);
     if (speed !== undefined) effects.speed = speed;
 

--- a/src/utils/calculators/dpsBuffHelpers.ts
+++ b/src/utils/calculators/dpsBuffHelpers.ts
@@ -64,6 +64,12 @@ export function toSimBuffs(selected: SelectedGameBuff[]): Buff[] {
                 stat: 'security',
                 value: parsedEffects.security * stacks,
             });
+        if (parsedEffects.attackFlat !== undefined)
+            entries.push({
+                id: `${s.id}-attackFlat`,
+                stat: 'attackFlat',
+                value: parsedEffects.attackFlat * stacks,
+            });
         return entries;
     });
 }

--- a/src/utils/combat/__tests__/buffTotals.test.ts
+++ b/src/utils/combat/__tests__/buffTotals.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { calculateBuffTotals } from '../buffTotals';
+
+describe('calculateBuffTotals — attackFlat channel (D-PR10)', () => {
+    it('sums attackFlat into attackFlatBuff (D-PR10)', () => {
+        const t = calculateBuffTotals([
+            { id: 'x', stat: 'attackFlat', value: 300 },
+            { id: 'y', stat: 'attackFlat', value: 200 },
+            { id: 'z', stat: 'attack', value: 20 },
+        ]);
+        expect(t.attackFlatBuff).toBe(500);
+        expect(t.attackBuff).toBe(20); // percentage channel untouched
+    });
+});

--- a/src/utils/combat/__tests__/effectiveStats.test.ts
+++ b/src/utils/combat/__tests__/effectiveStats.test.ts
@@ -674,3 +674,91 @@ describe('liveDebuffLandingChance — reproduces the static landing formula with
         expect(live).toBe(0);
     });
 });
+
+// ---------------------------------------------------------------------------
+// attackFlat additive fold — D-PR10 Task 3
+// ---------------------------------------------------------------------------
+
+describe('attackFlat additive fold — adds AFTER the percentage term', () => {
+    it('effectiveStatsOf: base 1000 + 20% Attack buff + attackFlat 300 → 1500', () => {
+        // Register two self-buffs: a +20% attack (parsedEffects.attack) and an
+        // attackFlat:300 buff (parsedEffects.attackFlat). Both are scheduled
+        // self-buffs routed through foldActorBuffTotals → effectiveStatsOf.
+        const { statusEngine, selfBuffLookup, actor } = buildHarness({
+            base: {
+                attack: 1000,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                defence: 0,
+                hp: 1,
+                speed: 50,
+            },
+            selfBuffs: [
+                { stat: 'attack', value: 20 },
+                { stat: 'attackFlat', value: 300 },
+            ],
+        });
+        const eff = effectiveStatsOf(statusEngine, selfBuffLookup, actor);
+        // 1000 * 1.20 + 300 = 1500
+        expect(eff.attack).toBeCloseTo(1500);
+    });
+
+    it('effectiveDamageStatsOf: base 1000 + scheduledAttackBuff 20 + abilitySelfEffects attackFlat 300 → 1500', () => {
+        // Layer 1: scheduled totals carry attackBuff=20 (no flat)
+        const scheduledBuffs: SelectedGameBuff[] = [
+            {
+                id: 'sched-atk',
+                buffName: 'Attack Up',
+                stacks: 1,
+                parsedEffects: { attack: 20 },
+                isStackable: false,
+            },
+        ];
+        const scheduledTotals = calculateBuffTotals(toSimBuffs(scheduledBuffs));
+
+        // Layer 2+3: ability self-effects carry attackFlat=300
+        const abilitySelfEffects: SelectedGameBuff[] = [
+            {
+                id: 'abl-flat',
+                buffName: 'Flat Attack Boost',
+                stacks: 1,
+                parsedEffects: { attackFlat: 300 },
+                isStackable: false,
+            },
+        ];
+
+        const modifierCtx: ConditionContext = {
+            selfBuffNames: [],
+            selfDebuffNames: [],
+            enemyBuffNames: [],
+            enemyDebuffCount: 0,
+            effectiveCritRate: 0,
+            adjacentAllyCount: 0,
+            enemyAdjacentCount: 0,
+            enemyDestroyedCount: 0,
+            selfHpPct: 100,
+            enemyHpPct: 100,
+        };
+
+        const base = {
+            attack: 1000,
+            defence: 0,
+            crit: 0,
+            critDamage: 0,
+            hp: 1,
+            defensePenetration: 0,
+            defensePenetrationBuff: 0,
+        };
+
+        const dmg = effectiveDamageStatsOf({
+            base,
+            scheduledTotals,
+            abilitySelfEffects,
+            modifierAbilities: [],
+            modifierCtx,
+        });
+        // 1000 * (1 + 20/100) + 300 = 1000 * 1.20 + 300 = 1500
+        expect(dmg.attack).toBeCloseTo(1500);
+    });
+});

--- a/src/utils/combat/__tests__/enemyReactiveSelfBuffs.test.ts
+++ b/src/utils/combat/__tests__/enemyReactiveSelfBuffs.test.ts
@@ -378,7 +378,7 @@ describe('enemy attacker reactive self-buffs (Chakara-as-enemy)', () => {
 //   - Spearhead       — trigger `on-charged-cast` → grant all allies `Attack Up I` (1 turn)
 //                        after a charged-skill cast (per-rarity proc).
 //   - Font of Power   — trigger `on-own-repair-to-ally` → grant `Power Infused Nanobots`
-//                        (emit-only) to every repaired NON-self ally (per-rarity proc).
+//                        (flat attack = 100% of caster's attack, D-PR10) to every repaired NON-self ally (per-rarity proc).
 //
 // The engine registers reactive listeners for BOTH sides; the listeners self-scope via
 // `e.actorId === ownerId` / `e.casterId === ownerId`. So an ENEMY-side carrier of either
@@ -388,7 +388,9 @@ describe('enemy attacker reactive self-buffs (Chakara-as-enemy)', () => {
 //
 // Determinism: same back-loaded makeRateGate accumulator keyed `${ownerId}:${abilityId}`.
 // There is NO proc=1 hook — we run enough qualifying casts that the accumulator fires and
-// assert PRESENCE of the grant (Power Infused Nanobots is emit-only → presence only).
+// assert PRESENCE of the grant (Power Infused Nanobots now grants flat attack = 100% of caster's
+// attack, D-PR10; magnitude is covered by the dedicated snapshot test in
+// equipmentAbilities.integration.test.ts).
 //
 // EXPECTED: these tests PASS immediately if the engine is truly team-agnostic. A FAILURE
 // here indicates a real side-routing regression, NOT a test bug.
@@ -595,7 +597,9 @@ describe('D-PR9 team-agnostic mirror — enemy-side Spearhead + Font of Power', 
             // repaired NON-self recipient. A plain ship anchors the PLAYER team. The carrier
             // repairs every enemy ally each round → the OTHER enemy ally is a non-self
             // recipient. Over 16 casts the accumulator fires → that ally carries the buff.
-            // Emit-only → PRESENCE only (Power Infused Nanobots parses to no stat effect).
+            // PRESENCE only — this test covers the grant mechanic (correct ally, correct side).
+            // Power Infused Nanobots now grants flat attack = 100% of caster's attack (D-PR10);
+            // magnitude is covered by the dedicated snapshot test in equipmentAbilities.integration.test.ts.
             const result = simulateBattle(
                 {
                     playerTeam: [

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -2872,6 +2872,8 @@ describe('Font of Power — on-own-repair-to-ally Power Infused Nanobots', () =>
     // proc fires, identical across runs (back-loaded makeRateGate accumulator), so the boosted
     // turn count is the same in every run → the damage delta tracks ONLY the caster's attack.
     describe('D-PR10 — caster-attack snapshot raises the recipient by the CASTER attack', () => {
+        // The first player attacker's runtime actorId, which simulateBattle reassigns to
+        // 'attacker' regardless of the makeTeamShip id passed in.
         const FOCUS = 'attacker';
 
         /** Sum the FOCUS recipient's per-round damageDealt across the whole battle. */

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -2855,6 +2855,98 @@ describe('Font of Power — on-own-repair-to-ally Power Infused Nanobots', () =>
         expect(buffed.has(ALLY1)).toBe(true);
         expect(buffed.has(CARRIER)).toBe(false);
     });
+
+    // ── D-PR10 Task 4 — caster-attack snapshot into the grant ────────────────
+    //
+    // PIN's description "Grants attack equal to 100% of the caster's attack" parses to the
+    // `attackFlatPctOfCaster: 100` sentinel. At grant time the trigger must freeze a concrete
+    // `attackFlat` = (CASTER's effective attack) × 100/100 into the per-instance payload, so
+    // the recipient's effective attack — and thus its damage output — rises by the caster's
+    // effective attack (NOT the recipient's own attack).
+    //
+    // Harness: the carrier is a Font-of-Power AoE-repair support with statOverrides.attack =
+    // casterAttack; the FOCUS attacker (a non-self repaired recipient) has a DIFFERENT base
+    // attack and is the only thing punching the enemy, so the focus's `damageDealt` isolates
+    // the recipient's attack. PIN is 1-turn, granted on the carrier's turn → it folds into
+    // the focus's same-round attack. Determinism mirrors the presence tests: floor(16×0.16)=2
+    // proc fires, identical across runs (back-loaded makeRateGate accumulator), so the boosted
+    // turn count is the same in every run → the damage delta tracks ONLY the caster's attack.
+    describe('D-PR10 — caster-attack snapshot raises the recipient by the CASTER attack', () => {
+        const FOCUS = 'attacker';
+
+        /** Sum the FOCUS recipient's per-round damageDealt across the whole battle. */
+        const focusDamage = (result: ReturnType<typeof simulateBattle>): number => {
+            let total = 0;
+            for (const round of result.rounds) {
+                for (const ship of round.ships) {
+                    if (ship.actorId === FOCUS) total += ship.damageDealt;
+                }
+            }
+            return total;
+        };
+
+        /**
+         * Focus = a damage attacker (recipient, base attack 1000). Carrier = Font-of-Power
+         * AoE-repair support at `casterAttack`. The enemy is a fat bag so the battle runs all
+         * rounds. `withFont=false` drops the implant for a clean no-PIN baseline.
+         */
+        const run = (casterAttack: number, withFont: boolean) =>
+            simulateBattle(
+                {
+                    playerTeam: [
+                        place(
+                            makeTeamShip('focus', 'Focus', { repair: 'damage' }),
+                            'M4',
+                            1000, // recipient's OWN base attack — deliberately != casterAttack
+                            1_000_000_000
+                        ),
+                        place(
+                            makeTeamShip('carrier', 'Carrier', {
+                                repair: 'all-allies',
+                                withFont,
+                            }),
+                            'M3',
+                            casterAttack,
+                            1_000_000_000
+                        ),
+                    ],
+                    enemyTeam: [
+                        place(
+                            makeTeamShip('enemy', 'Enemy', { repair: 'damage' }),
+                            'M4',
+                            1,
+                            1_000_000_000
+                        ),
+                    ],
+                    rounds: ROUNDS,
+                },
+                getGearPiece
+            );
+
+        it('PIN raises the recipient damage above the no-PIN baseline, and the increase tracks the CASTER attack (not the recipient)', () => {
+            const baseline = focusDamage(run(8000, false)); // no Font → no PIN
+            const withLowCaster = focusDamage(run(4000, true)); // PIN snapshots caster=4000
+            const withHighCaster = focusDamage(run(20000, true)); // PIN snapshots caster=20000
+
+            // (a) Magnitude: PIN can only ADD attack (crit=0 → otherwise-constant per-round
+            // damage), so a granted run strictly exceeds the identical no-PIN baseline.
+            expect(withLowCaster).toBeGreaterThan(baseline);
+            expect(withHighCaster).toBeGreaterThan(baseline);
+
+            // (b) Source: the only thing differing between the two PIN runs is the CASTER's
+            // attack. If the snapshot wrongly used the recipient's own attack (1000, identical
+            // in both runs), the two deltas would be EQUAL. A bigger caster attack must yield a
+            // strictly bigger recipient-damage increase → the boost is sourced from the caster.
+            const deltaLow = withLowCaster - baseline;
+            const deltaHigh = withHighCaster - baseline;
+            expect(deltaHigh).toBeGreaterThan(deltaLow);
+
+            // The deltas scale ~5× with the 5× caster-attack change (4000 → 20000). Allow a
+            // wide band (other folds, rounding) but require it is clearly proportional, not a
+            // flat recipient-sourced offset.
+            expect(deltaHigh).toBeGreaterThan(deltaLow * 3);
+        });
+    });
 });
 
 describe('Spearhead — on-charged-cast all-allies Attack Up I', () => {

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -2613,8 +2613,8 @@ describe('D-PR8 Task 6 integration — Ambush gate via seeded Stealth (start-of-
 // `on-own-repair-to-ally` reactive trigger — a self-scoped listener on `heal-performed`
 // matching casterId === ownerId with >= 1 NON-self recipient. One enqueue per qualifying
 // repair cast → one proc-gate roll; the grant fans out to every repaired non-self ally
-// via eventCtx.repairedAllyIds. EMIT-ONLY this PR: Power Infused Nanobots parses to no
-// stat effect, so we assert PRESENCE of the buff, never a damage/stat change.
+// via eventCtx.repairedAllyIds. Power Infused Nanobots now grants flat attack = 100% of
+// the caster's attack (snapshotted at grant time, D-PR10); we assert PRESENCE + fan-out.
 //
 // Driven through `simulateBattle` because the carrier must repair an OTHER ally — the
 // engine routes a non-focus team actor's bare ally-repair to the heal target (the focus
@@ -2625,7 +2625,7 @@ describe('D-PR8 Task 6 integration — Ambush gate via seeded Stealth (start-of-
 // firing floor(N × 0.16) over N qualifying repair casts (back-loaded). The carrier repairs
 // once per round it acts, so over R rounds N ≈ R. At 16 rounds → floor(16 × 0.16) = 2 fires.
 // There is NO proc=1 override; we run enough qualifying casts that the accumulator fires
-// and assert presence (+ fan-out / self-exclusion / self-only-no-grant).
+// and assert presence + fan-out / self-exclusion / self-only-no-grant.
 
 describe('Font of Power — on-own-repair-to-ally Power Infused Nanobots', () => {
     const NANOBOTS = 'Power Infused Nanobots';

--- a/src/utils/combat/buffTotals.ts
+++ b/src/utils/combat/buffTotals.ts
@@ -42,6 +42,9 @@ export function calculateBuffTotals(buffs: Buff[]) {
     const securityBuff = buffs
         .filter((b) => b.stat === 'security')
         .reduce((sum, b) => sum + b.value, 0);
+    const attackFlatBuff = buffs
+        .filter((b) => b.stat === 'attackFlat')
+        .reduce((sum, b) => sum + b.value, 0);
     return {
         attackBuff,
         critBuff,
@@ -54,6 +57,7 @@ export function calculateBuffTotals(buffs: Buff[]) {
         speedBuff,
         hackingBuff,
         securityBuff,
+        attackFlatBuff,
     };
 }
 

--- a/src/utils/combat/effectiveStats.ts
+++ b/src/utils/combat/effectiveStats.ts
@@ -71,7 +71,6 @@ export function foldActorBuffTotals(
     // Field-by-field sum is intentional: explicit enumeration preserves type-safety over a generic key reduce.
     return {
         attackBuff: scheduled.attackBuff + timed.attackBuff,
-        attackFlatBuff: scheduled.attackFlatBuff + timed.attackFlatBuff,
         critBuff: scheduled.critBuff + timed.critBuff,
         critDamageBuff: scheduled.critDamageBuff + timed.critDamageBuff,
         outgoingDamageBuff: scheduled.outgoingDamageBuff + timed.outgoingDamageBuff,
@@ -82,6 +81,7 @@ export function foldActorBuffTotals(
         speedBuff: scheduled.speedBuff + timed.speedBuff,
         hackingBuff: scheduled.hackingBuff + timed.hackingBuff,
         securityBuff: scheduled.securityBuff + timed.securityBuff,
+        attackFlatBuff: scheduled.attackFlatBuff + timed.attackFlatBuff,
     };
 }
 
@@ -93,7 +93,7 @@ export function effectiveStatsOf(
     const t = foldActorBuffTotals(statusEngine, selfBuffLookup, actor.id);
     const s = actor.stats;
     return {
-        attack: s.attack * (1 + t.attackBuff / 100) + t.attackFlatBuff,
+        attack: s.attack * (1 + t.attackBuff / 100) + t.attackFlatBuff, // base × (1+%) + attackFlatBuff (absolute-units, D-PR10)
         defence: s.defence * (1 + t.defenceBuff / 100),
         crit: s.crit + t.critBuff,
         critDamage: s.critDamage + t.critDamageBuff,
@@ -186,7 +186,6 @@ export function effectiveDamageStatsOf(args: {
 
     const totals: ReturnType<typeof calculateBuffTotals> = {
         attackBuff: scheduledTotals.attackBuff + ability.attackBuff + mod.attack,
-        attackFlatBuff: scheduledTotals.attackFlatBuff + ability.attackFlatBuff,
         critBuff: scheduledTotals.critBuff + ability.critBuff + mod.crit,
         critDamageBuff: scheduledTotals.critDamageBuff + ability.critDamageBuff + mod.critDamage,
         outgoingDamageBuff:
@@ -198,10 +197,11 @@ export function effectiveDamageStatsOf(args: {
         speedBuff: scheduledTotals.speedBuff + ability.speedBuff,
         hackingBuff: scheduledTotals.hackingBuff + ability.hackingBuff,
         securityBuff: scheduledTotals.securityBuff + ability.securityBuff,
+        attackFlatBuff: scheduledTotals.attackFlatBuff + ability.attackFlatBuff,
     };
 
     return {
-        attack: base.attack * (1 + totals.attackBuff / 100) + totals.attackFlatBuff,
+        attack: base.attack * (1 + totals.attackBuff / 100) + totals.attackFlatBuff, // base × (1+%) + attackFlatBuff (absolute-units, D-PR10)
         defence: base.defence * (1 + totals.defenceBuff / 100),
         crit: base.crit + totals.critBuff,
         critDamage: base.critDamage + totals.critDamageBuff,

--- a/src/utils/combat/effectiveStats.ts
+++ b/src/utils/combat/effectiveStats.ts
@@ -71,6 +71,7 @@ export function foldActorBuffTotals(
     // Field-by-field sum is intentional: explicit enumeration preserves type-safety over a generic key reduce.
     return {
         attackBuff: scheduled.attackBuff + timed.attackBuff,
+        attackFlatBuff: scheduled.attackFlatBuff + timed.attackFlatBuff,
         critBuff: scheduled.critBuff + timed.critBuff,
         critDamageBuff: scheduled.critDamageBuff + timed.critDamageBuff,
         outgoingDamageBuff: scheduled.outgoingDamageBuff + timed.outgoingDamageBuff,
@@ -92,7 +93,7 @@ export function effectiveStatsOf(
     const t = foldActorBuffTotals(statusEngine, selfBuffLookup, actor.id);
     const s = actor.stats;
     return {
-        attack: s.attack * (1 + t.attackBuff / 100),
+        attack: s.attack * (1 + t.attackBuff / 100) + t.attackFlatBuff,
         defence: s.defence * (1 + t.defenceBuff / 100),
         crit: s.crit + t.critBuff,
         critDamage: s.critDamage + t.critDamageBuff,
@@ -185,6 +186,7 @@ export function effectiveDamageStatsOf(args: {
 
     const totals: ReturnType<typeof calculateBuffTotals> = {
         attackBuff: scheduledTotals.attackBuff + ability.attackBuff + mod.attack,
+        attackFlatBuff: scheduledTotals.attackFlatBuff + ability.attackFlatBuff,
         critBuff: scheduledTotals.critBuff + ability.critBuff + mod.crit,
         critDamageBuff: scheduledTotals.critDamageBuff + ability.critDamageBuff + mod.critDamage,
         outgoingDamageBuff:
@@ -199,7 +201,7 @@ export function effectiveDamageStatsOf(args: {
     };
 
     return {
-        attack: base.attack * (1 + totals.attackBuff / 100),
+        attack: base.attack * (1 + totals.attackBuff / 100) + totals.attackFlatBuff,
         defence: base.defence * (1 + totals.defenceBuff / 100),
         crit: base.crit + totals.critBuff,
         critDamage: base.critDamage + totals.critDamageBuff,

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1074,10 +1074,27 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
                   : intent.ability.target === 'ally' || intent.ability.target === 'all-allies'
                     ? ctx.playerIds
                     : [intent.ownerId];
+        // D-PR10: dynamic caster-attack snapshot. A buff carrying the `attackFlatPctOfCaster`
+        // sentinel ("N% of the caster's attack") freezes a concrete `attackFlat` from the
+        // CASTER's effective attack at grant time (same last-turn ctx value bombs/reactive-damage
+        // snapshot). One value for all recipients → the shared hoisted payload stays correct.
+        const pinPct = cfg.parsedEffects.attackFlatPctOfCaster;
+        let buffCfg = cfg;
+        if (pinPct !== undefined) {
+            const ownerCtx = ctx.lastTurnCtxByActor.get(intent.ownerId);
+            const casterAttack = ownerCtx?.effectiveAttack ?? owner.attack;
+            buffCfg = {
+                ...cfg,
+                parsedEffects: {
+                    ...cfg.parsedEffects,
+                    attackFlat: casterAttack * (pinPct / 100),
+                },
+            };
+        }
         // The status object is identical for every recipient — hoist it above the loop.
         // Only the applyTimedAbilityStatus recipientId argument varies per iteration.
         const status: Extract<RegisteredAbilityStatus, { kind: 'timed' }> = {
-            payload: payloadFromConfig(cfg),
+            payload: payloadFromConfig(buffCfg),
             side: 'self',
             sourceSlot: intent.sourceSlot,
             conditions: gateConditions,

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1076,8 +1076,9 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
                     : [intent.ownerId];
         // D-PR10: dynamic caster-attack snapshot. A buff carrying the `attackFlatPctOfCaster`
         // sentinel ("N% of the caster's attack") freezes a concrete `attackFlat` from the
-        // CASTER's effective attack at grant time (same last-turn ctx value bombs/reactive-damage
-        // snapshot). One value for all recipients → the shared hoisted payload stays correct.
+        // CASTER's effective attack at grant time (the same last-turn ctx value that
+        // bombs/reactive-damage snapshot). One value for all recipients → the shared hoisted
+        // payload stays correct.
         const pinPct = cfg.parsedEffects.attackFlatPctOfCaster;
         let buffCfg = cfg;
         if (pinPct !== undefined) {


### PR DESCRIPTION
## Summary

Lights up the **Font of Power** implant's `Power Infused Nanobots` buff. D-PR9 already lands the buff on the right allies via the reactive `on-own-repair-to-ally` grant, but as an **emit-only no-effect** status. This PR adds the engine primitive needed to make it real: a **flat (absolute-units) attack buff whose magnitude is snapshotted from the caster's effective attack at grant time**, folded additively.

- **Sentinel → concrete split** on `ParsedBuffEffects`: `attackFlatPctOfCaster` (parsed statically from the description, **inert** in the fold) marks "needs a caster snapshot"; `attackFlat` (the frozen absolute value) is materialized **only** at the grant site into the per-instance timed-ability-status payload, and is the field the fold sums. Self-protecting — the static re-derive path can never produce a broken/double-counted value.
- **Snapshot** (`triggers.ts` buff branch): `casterAttack = lastTurnCtxByActor.effectiveAttack ?? owner.attack` (the same idiom bombs/reactive-damage use); `attackFlat = casterAttack × pct/100`; one value, frozen, fanned out to all recipients via the shared hoisted payload (no shared-config mutation, no cross-recipient desync).
- **Additive fold** in both `effectiveStatsOf` and `effectiveDamageStatsOf`: `base × (1 + attackBuff/100) + attackFlatBuff` (flat after the percentage). New `attackFlat` leaf in `toSimBuffs`; `attackFlatBuff` total in `calculateBuffTotals`.

`Power Infused Nanobots` is the **sole** corpus match → the new fold channel is `+0` everywhere and the snapshot only fires on the sentinel ⇒ **production goldens byte-identical**.

Stacked on D-PR9 (#137); base = `feat/combat-d-pr9-ally-reactive-buffs`. Retarget to `main` as the stack merges.

## Test Plan
- [x] `npx vitest run` — 2973 tests pass (unit at each fold layer + engine integration proving magnitude AND caster-source, with a wrong-source guard)
- [x] `npx tsc --noEmit` clean; `npm run lint` 0 warnings
- [x] `npm run audit:skills` — 141 ships, 0 findings
- [x] Production `.snap` goldens byte-identical (no committed golden carries a Font-of-Power healer)
- [x] Final holistic review: confirmed no third effective-attack accessor / raw `stats.attack` damage path bypasses the fold (PIN can't be silently partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)