### PR TITLE
feat(combat): D-PR11 — Fortifying Shroud (per-turn adjacency buff grant)

### DIFF
--- a/docs/superpowers/plans/2026-06-22-implant-gearset-abilities-D-pr11.md
+++ b/docs/superpowers/plans/2026-06-22-implant-gearset-abilities-D-pr11.md
@@ -1,0 +1,558 @@
+# Fortifying Shroud (D-PR11) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Model the Fortifying Shroud implant — "Every turn, X% chance to grant all adjacent allies Defense Up 1 for 1 turn" — in the combat engine, by adding a reusable `start-of-turn` trigger and an `adjacent-allies` recipient scope.
+
+**Architecture:** A new `start-of-turn` reactive trigger rides the already-emitted per-actor `turn-started` event (self-scoped, team-agnostic). A new `adjacent-allies` `AbilityTarget` is resolved at drain time via a new per-side `adjacentAllyIdsFor(ownerId)` delegate, computed from board positions by a pure `adjacency.ts` helper (positional → `neighbors(owner.pos)` ∩ living same-side allies; non-positional → all same-side allies). The implant is one registry entry using the existing `mkNamedBuffGrant` helper.
+
+**Tech Stack:** TypeScript, Vitest. No new deps.
+
+**Spec:** `docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr11-design.md`
+
+**Worktree:** `.worktrees/d-pr11-fortifying-shroud` (branch `feat/combat-d-pr11-fortifying-shroud`, stacked on D-PR10 tip `3138f1fa`). All commands run from this worktree.
+
+**Global invariants (do NOT violate):**
+- DPS + healing goldens stay **byte-identical**. If a golden moves, a gate leaked — fix the gate, never `vitest -u` to mask it. (No fixture equips Fortifying Shroud, so churn = a real bug.)
+- `npm run audit:skills` stays 141 ships / 0 findings.
+- `npm run lint` (max-warnings 0) + `tsc` clean.
+- Commit after every green task. Pre-commit hook runs the full suite; that's expected. Docs-only commits use `git add -f` (docs/ is gitignored) + `--no-verify`.
+
+---
+
+### Task 1: Pure adjacency helper
+
+**Files:**
+- Create: `src/utils/combat/adjacency.ts`
+- Test: `src/utils/combat/__tests__/adjacency.test.ts`
+
+The recipient math, extracted pure so it's unit-testable independent of the engine. `CombatActor` structurally satisfies the `{ id, position?, destroyedRound? }` param.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { adjacentAllyIds } from '../adjacency';
+import type { Position } from '../../../types/encounters';
+
+// Board adjacency (board.ts neighbors): M2 neighbors = T1,T2,M1,M3,B1,B2.
+const a = (id: string, position?: Position, destroyedRound?: number) => ({
+    id,
+    position,
+    destroyedRound,
+});
+
+describe('adjacentAllyIds', () => {
+    it('positional: returns living same-side allies on neighbouring cells, owner excluded', () => {
+        const actors = [
+            a('owner', 'M2'),
+            a('adjT2', 'T2'), // neighbour of M2
+            a('adjM3', 'M3'), // neighbour of M2
+            a('farB4', 'B4'), // not a neighbour
+        ];
+        expect(adjacentAllyIds('owner', actors).sort()).toEqual(['adjM3', 'adjT2']);
+    });
+
+    it('positional: excludes a destroyed adjacent ally', () => {
+        const actors = [a('owner', 'M2'), a('deadT2', 'T2', 3), a('adjM3', 'M3')];
+        expect(adjacentAllyIds('owner', actors)).toEqual(['adjM3']);
+    });
+
+    it('non-positional (owner has no position): falls back to all living same-side allies', () => {
+        const actors = [a('owner'), a('ally1'), a('ally2'), a('dead', undefined, 2)];
+        expect(adjacentAllyIds('owner', actors).sort()).toEqual(['ally1', 'ally2']);
+    });
+
+    it('positional but no other actor positioned: falls back to all living allies', () => {
+        const actors = [a('owner', 'M2'), a('ally1')]; // ally1 unpositioned
+        expect(adjacentAllyIds('owner', actors)).toEqual(['ally1']);
+    });
+
+    it('empty / owner-only roster → []', () => {
+        expect(adjacentAllyIds('owner', [a('owner', 'M2')])).toEqual([]);
+        expect(adjacentAllyIds('owner', [])).toEqual([]);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/utils/combat/__tests__/adjacency.test.ts`
+Expected: FAIL — `adjacentAllyIds` not exported / module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import { neighbors } from '../targeting/board';
+import type { Position } from '../../types/encounters';
+
+/** Minimal shape this helper needs from a combat actor. CombatActor satisfies it. */
+interface AdjacencyActor {
+    id: string;
+    position?: Position;
+    destroyedRound?: number;
+}
+
+/**
+ * Resolve the recipient id list for an `adjacent-allies` grant.
+ *
+ * Positional (the owner AND at least one OTHER actor carry a board position):
+ *   living same-side actors whose position is a hex-neighbour of the owner's, owner excluded.
+ * Non-positional (no board positions wired — every current production path):
+ *   all living same-side actors, owner excluded (the all-allies fallback, per spec §3.3).
+ *
+ * "Living" = `destroyedRound === undefined` (engine's canonical destroyed signal).
+ */
+export function adjacentAllyIds(ownerId: string, actors: AdjacencyActor[]): string[] {
+    const living = actors.filter((x) => x.destroyedRound === undefined && x.id !== ownerId);
+    const owner = actors.find((x) => x.id === ownerId);
+    const anyOtherPositioned = actors.some((x) => x.id !== ownerId && x.position != null);
+    if (owner?.position != null && anyOtherPositioned) {
+        const nbrs = new Set<Position>(neighbors(owner.position));
+        return living.filter((x) => x.position != null && nbrs.has(x.position)).map((x) => x.id);
+    }
+    return living.map((x) => x.id);
+}
+```
+
+> Confirm the `Position` import path: `neighbors` lives in `src/utils/targeting/board.ts`; `Position` is exported from `src/types/encounters.ts` (used by board.ts). Adjust the import if board.ts re-exports it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/utils/combat/__tests__/adjacency.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/adjacency.ts src/utils/combat/__tests__/adjacency.test.ts
+git commit -m "feat(combat): D-PR11 — pure adjacentAllyIds helper"
+```
+
+---
+
+### Task 2: `start-of-turn` trigger
+
+**Files:**
+- Modify: `src/types/abilities.ts` (AbilityTrigger union ~line 38-68; LIVE_TRIGGERS set ~line 78)
+- Modify: `src/utils/combat/triggers.ts` (listener registration switch, near `start-of-round` ~line 346)
+- Test: `src/utils/combat/__tests__/triggers.test.ts` (or the nearest existing trigger-registration test file — search for a `start-of-round` registration test and co-locate)
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test that registering a `start-of-turn` ability enqueues the intent **only** when `turn-started` fires with `actorId === ownerId`, not for another actor's turn. Mirror the existing `on-charged-cast` / `start-of-round` registration tests in that file (find one and copy its harness — it builds a bus, registers listeners for an owner, emits events, asserts the queue). Example shape:
+
+```ts
+it('start-of-turn enqueues on the owner\'s own turn-started, not another actor\'s', () => {
+    // …existing harness: register a start-of-turn buff ability for owner 'A'…
+    bus.emit({ type: 'turn-started', actorId: 'B', round: 1 });
+    expect(queue.length).toBe(0);
+    bus.emit({ type: 'turn-started', actorId: 'A', round: 1 });
+    expect(queue.length).toBe(1);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/utils/combat/__tests__/triggers.test.ts -t "start-of-turn"`
+Expected: FAIL — `'start-of-turn'` not assignable to `AbilityTrigger` (tsc) / no enqueue.
+
+- [ ] **Step 3: Implement**
+
+In `src/types/abilities.ts`, add `'start-of-turn'` to the `AbilityTrigger` union (place it next to `'start-of-round'` with a comment) AND to the `LIVE_TRIGGERS` set:
+
+```ts
+    | 'start-of-round'
+    | 'start-of-turn' // Fortifying Shroud: fires at the OWNER's own turn-start (rides
+                      // the per-actor turn-started event; self-scoped on actorId === ownerId)
+```
+
+```ts
+// in LIVE_TRIGGERS:
+    'start-of-round',
+    'start-of-turn',
+```
+
+In `src/utils/combat/triggers.ts`, add a case beside `start-of-round` (~line 346):
+
+```ts
+                case 'start-of-turn':
+                    bus.on('turn-started', (e) => {
+                        // Self-scoped: THIS owner's own turn began. turn-started fires once per
+                        // actor (both sides run the same turn path), so the ownerId guard scopes
+                        // it per registered owner — team-agnostic, like on-charged-cast.
+                        if (e.actorId === ownerId) enqueue(intent);
+                    });
+                    break;
+```
+
+> The `turn-started` event payload is `{ type: 'turn-started'; actorId: string; round: number }` (events.ts:36). No new event needed.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/utils/combat/__tests__/triggers.test.ts -t "start-of-turn"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/abilities.ts src/utils/combat/triggers.ts src/utils/combat/__tests__/triggers.test.ts
+git commit -m "feat(combat): D-PR11 — start-of-turn trigger (rides turn-started, self-scoped)"
+```
+
+---
+
+### Task 3: `adjacent-allies` target + buff-branch recipient resolution
+
+**Files:**
+- Modify: `src/types/abilities.ts` (AbilityTarget union ~line 29)
+- Modify: `src/utils/combat/triggers.ts` (IntentExecContext interface ~line 607 region; buff-branch recipients ~line 1069)
+- Test: the executor test file covering the buff branch (search for a test exercising `cfg.type === 'buff'` recipient resolution / `reactiveRecipients` siblings; co-locate there)
+
+- [ ] **Step 1: Write the failing test**
+
+Test the buff-branch recipient resolution: an intent whose `ability.target === 'adjacent-allies'` resolves recipients via `ctx.adjacentAllyIdsFor(ownerId)`, and falls back to `ctx.playerIds` when the delegate is absent. Drive `executeIntent` with a stub ctx whose `adjacentAllyIdsFor` returns a fixed set, assert the Defense Up status lands on exactly those ids. Mirror an existing D-PR8/D-PR9 buff-grant executor test (e.g. the Spearhead/Ambush tests) for the harness.
+
+```ts
+it('adjacent-allies buff grants to ctx.adjacentAllyIdsFor result', () => {
+    // stub ctx.adjacentAllyIdsFor = () => ['ally1', 'ally2']
+    // intent: buff Defense Up I, target 'adjacent-allies', start-of-turn
+    // executeIntent(intent, ctx)
+    // assert applyTimedAbilityStatus called for ally1 and ally2 only (not owner, not ally3)
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- <that test file> -t "adjacent-allies"`
+Expected: FAIL — `'adjacent-allies'` not assignable to `AbilityTarget` (tsc) / recipients empty.
+
+- [ ] **Step 3: Implement**
+
+In `src/types/abilities.ts`, add to `AbilityTarget` (~line 29):
+
+```ts
+export type AbilityTarget =
+    | 'self'
+    | 'ally'
+    | 'all-allies'
+    | 'adjacent-allies' // Fortifying Shroud: living same-side allies on neighbouring board
+                        // cells (non-positional → all same-side allies). Resolved via
+                        // IntentExecContext.adjacentAllyIdsFor.
+    | 'enemy'
+    | 'all-enemies'
+    | 'enemy-most-buffs';
+```
+
+In `src/utils/combat/triggers.ts`, add the delegate to `IntentExecContext` (beside `isLowestSpeedAllyFor` ~line 607):
+
+```ts
+    /** Same-side ids adjacent to `ownerId` on the board (living, owner excluded), feeding the
+     *  `adjacent-allies` buff target. Engine-populated per side. Absent / undefined → the
+     *  recipient resolver falls back to ctx.playerIds (all same-side allies). */
+    adjacentAllyIdsFor?: (ownerId: string) => string[];
+```
+
+In the buff branch recipient ternary (~line 1069), prepend the `adjacent-allies` branch:
+
+```ts
+        const recipients: string[] =
+            intent.ability.target === 'adjacent-allies'
+                ? (ctx.adjacentAllyIdsFor?.(intent.ownerId) ?? ctx.playerIds)
+                : intent.ability.target === 'ally' && intent.eventCtx?.repairedAllyIds?.length
+                  ? intent.eventCtx.repairedAllyIds
+                  : intent.ability.target === 'ally' && intent.eventCtx?.damagedAllyId
+                    ? [intent.eventCtx.damagedAllyId]
+                    : intent.ability.target === 'ally' || intent.ability.target === 'all-allies'
+                      ? ctx.playerIds
+                      : [intent.ownerId];
+```
+
+> Only the buff branch needs this (Fortifying Shroud is a buff). Do NOT touch `reactiveRecipients` (heal/cleanse/purge) — no adjacent-allies heal exists.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- <that test file> -t "adjacent-allies"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/abilities.ts src/utils/combat/triggers.ts <test file>
+git commit -m "feat(combat): D-PR11 — adjacent-allies buff target + recipient resolution"
+```
+
+---
+
+### Task 4: Engine `adjacentAllyIdsFor` per-side wiring
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts`
+  - `SideContext` interface (~line 1735)
+  - `buildSideContext` closure (~line 1749)
+  - `ReactiveSideCtx` interface (~line 1024)
+  - `drainQueue` ctx literal (~line 3376, beside `isLowestSpeedAllyFor: sideCtx.isLowestSpeedAllyFor`)
+  - `drainIntents` sideCtx literal (~line 3401)
+  - `drainEnemyIntents` sideCtx literal (~line 3422)
+  - import `adjacentAllyIds` from `./adjacency`
+
+This is plumbing of an already-tested pure helper; covered end-to-end by Task 6's integration test (no separate unit test — the closure is a one-liner over `adjacentAllyIds`).
+
+- [ ] **Step 1: Implement**
+
+Add the import near the other combat-util imports:
+
+```ts
+import { adjacentAllyIds } from './adjacency';
+```
+
+`SideContext` interface (~1735) — add a field:
+
+```ts
+        /** Same-side ids adjacent to `ownerId` on the board (living, owner excluded). Positional
+         *  → board neighbours; non-positional (no positions wired) → all living same-side allies. */
+        adjacentAllyIdsFor: (ownerId: string) => string[];
+```
+
+`buildSideContext` return object (~1751, beside `lowestSpeedIds`):
+
+```ts
+            adjacentAllyIdsFor: (ownerId: string): string[] => adjacentAllyIds(ownerId, actors),
+```
+
+`ReactiveSideCtx` interface (~1024) — add:
+
+```ts
+    /** Per-side adjacent-allies resolver (Fortifying Shroud). See IntentExecContext. */
+    adjacentAllyIdsFor: (ownerId: string) => string[];
+```
+
+`drainQueue` ctx literal (~3376, after `wasHitThisRoundFor`):
+
+```ts
+                        // D-PR11: live adjacent-allies resolver (Fortifying Shroud). Sourced
+                        // per-side from sideCtx; positional neighbours, else all same-side allies.
+                        adjacentAllyIdsFor: sideCtx.adjacentAllyIdsFor,
+```
+
+`drainIntents` literal (~3401):
+
+```ts
+                adjacentAllyIdsFor: bySide('player').adjacentAllyIdsFor,
+```
+
+`drainEnemyIntents` literal (~3422):
+
+```ts
+                adjacentAllyIdsFor: bySide('enemy').adjacentAllyIdsFor,
+```
+
+- [ ] **Step 2: Verify tsc + existing engine tests pass**
+
+Run: `npx tsc --noEmit` → clean.
+Run: `npm test -- src/utils/combat/__tests__/` → all green (no behavioural change yet; delegate unused until an ability targets `adjacent-allies`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/combat/engine.ts
+git commit -m "feat(combat): D-PR11 — wire per-side adjacentAllyIdsFor delegate into the drain ctx"
+```
+
+---
+
+### Task 5: Fortifying Shroud registry entry + coverage
+
+**Files:**
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (proc-chance constant; `mkNamedBuffGrant` target type ~line 319; `IMPLANT_ABILITIES.FORTIFYING_SHROUD`)
+- Modify: `src/utils/abilities/__tests__/equipmentCoverage.test.ts` (the `implementedImplants` `.toEqual` array AND the `Set`)
+- Test: `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts` (or the existing equipment-abilities registry test file)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('emits Fortifying Shroud as an adjacent-allies start-of-turn Defense Up I buff', () => {
+    // ship with a legendary Fortifying Shroud implant equipped (getGearPiece returns
+    // { setBonus: 'Fortifying Shroud', rarity: 'legendary', … })
+    const abilities = buildEquipmentAbilities(ship, getGearPiece);
+    const a = abilities.find((x) => x.id.startsWith('equip-implant-FORTIFYING_SHROUD'));
+    expect(a).toBeDefined();
+    expect(a!.type).toBe('buff');
+    expect(a!.target).toBe('adjacent-allies');
+    expect(a!.trigger).toBe('start-of-turn');
+    expect(a!.procChance).toBeCloseTo(0.32);
+    expect(a!.config).toMatchObject({ type: 'buff', buffName: 'Defense Up I', duration: 1 });
+});
+```
+
+(Mirror the exact ship/getGearPiece fixture shape from an existing implant test in that file — e.g. the Bloodthirst or Ambush test.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- <registry test file> -t "Fortifying Shroud"`
+Expected: FAIL — no FORTIFYING_SHROUD entry.
+
+- [ ] **Step 3: Implement**
+
+Widen `mkNamedBuffGrant`'s `target` param (~line 319):
+
+```ts
+    target: 'self' | 'ally' | 'all-allies' | 'adjacent-allies',
+```
+
+Add the proc-chance constant beside the other implant tables (match the existing per-rarity `Record<string, number>` style, e.g. `BLOODTHIRST_PROC_CHANCE`):
+
+```ts
+const FORTIFYING_SHROUD_PROC_CHANCE: Record<string, number> = {
+    uncommon: 0.18,
+    rare: 0.21,
+    epic: 0.26,
+    legendary: 0.32,
+};
+```
+
+Add the registry entry to `IMPLANT_ABILITIES`:
+
+```ts
+    // Fortifying Shroud: at the start of its own turn, a proc chance to grant all adjacent
+    // allies Defense Up I for 1 turn. The adjacent-allies target resolves to board neighbours
+    // in the simulator and to all same-side allies in non-positional modes.
+    FORTIFYING_SHROUD: (rarity) => {
+        const procChance = FORTIFYING_SHROUD_PROC_CHANCE[rarity];
+        if (procChance === undefined) return undefined;
+        return mkNamedBuffGrant('Defense Up I', 'adjacent-allies', 'start-of-turn', 1, {
+            procChance,
+        });
+    },
+```
+
+Coverage test (`equipmentCoverage.test.ts`) — add `'FORTIFYING_SHROUD'` to BOTH:
+- the `implementedImplants` `.toEqual([...])` array, in `IMPLANTS` **declaration order** (check where `FORTIFYING_SHROUD` sits in `implants.ts` relative to the others already listed), AND
+- the `implementedImplants` `new Set([...])`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- <registry test file> -t "Fortifying Shroud"` → PASS.
+Run: `npm test -- src/utils/abilities/__tests__/equipmentCoverage.test.ts` → PASS.
+Run: `npm run audit:skills` → 141 ships, 0 findings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/equipmentCoverage.test.ts <registry test file>
+git commit -m "feat(combat): D-PR11 — Fortifying Shroud implant registry entry + coverage"
+```
+
+---
+
+### Task 6: Editor exhaustiveness stubs
+
+**Files:**
+- Modify: `src/components/skills/AbilityCard.tsx` (`TARGET_OPTIONS` ~line 64; `TRIGGER_OPTIONS` ~line 126)
+
+UI completeness only — no combat behaviour. The new union members may already force `tsc` errors at exhaustive sites; run `tsc` first to find them all.
+
+- [ ] **Step 1: Find every exhaustive site**
+
+Run: `npx tsc --noEmit`
+Expected: errors at any `Record<AbilityTarget, …>` / `Record<AbilityTrigger, …>` or exhaustive `switch`. Fix each.
+
+- [ ] **Step 2: Add the picker options**
+
+`TARGET_OPTIONS` (~line 64):
+
+```ts
+    { value: 'adjacent-allies', label: 'Adjacent allies' },
+```
+
+`TRIGGER_OPTIONS` (~line 126):
+
+```ts
+    { value: 'start-of-turn', label: 'Start of own turn' },
+```
+
+Add any other stub entries `tsc` demanded.
+
+- [ ] **Step 3: Verify**
+
+Run: `npx tsc --noEmit` → clean.
+Run: `npm run lint` → 0 warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/skills/AbilityCard.tsx <any other tsc-forced files>
+git commit -m "feat(combat): D-PR11 — editor stubs for start-of-turn / adjacent-allies"
+```
+
+---
+
+### Task 7: Engine integration test (positional + enemy mirror) + golden gate
+
+**Files:**
+- Test: a new or existing combat integration test file (e.g. `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts` — the file D-PR2/D-PR4 used for fold/engine smoke tests)
+
+- [ ] **Step 1: Write the positional integration test**
+
+Use the positional board harness used by D-PR3/D-PR4 (search for `perVictimLeech`-style board fixtures / tests that set `position` on actors and pass them into `simulateBattle` / `runCombat`). Build a player team where the owner carries Fortifying Shroud and sits at a cell with 2 adjacent + 1 non-adjacent living ally; force the proc gate (legendary, or seed the accumulator so it crosses 1). Assert after the owner's turn:
+- the 2 adjacent allies carry a `Defense Up I` status;
+- the non-adjacent ally does NOT;
+- the owner does NOT (excluded from its own grant).
+
+- [ ] **Step 2: Write the enemy-side mirror test**
+
+Same board on the enemy side (an enemy carries Fortifying Shroud). Assert its enemy-side adjacent allies get Defense Up — proving team-agnosticism with zero production change.
+
+- [ ] **Step 3: Run the new tests**
+
+Run: `npm test -- <integration file> -t "Fortifying Shroud"`
+Expected: PASS.
+
+- [ ] **Step 4: Golden gate — prove byte-identical**
+
+Run the full suite:
+Run: `npm test`
+Expected: ALL green, and crucially the DPS + healing golden/`.snap` files show **no diff** (`git status` clean for snapshot files). If any golden moved → STOP, a gate leaked; the adjacent-allies fallback must not fire in goldens because no fixture equips the implant. Investigate before continuing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add <integration file>
+git commit -m "test(combat): D-PR11 — Fortifying Shroud positional + enemy-mirror integration"
+```
+
+---
+
+### Task 8: Changelog + docs
+
+**Files:**
+- Modify: `src/constants/changelog.ts` (`UNRELEASED_CHANGES`)
+- Modify: `src/pages/DocumentationPage.tsx` (only if it enumerates modelled implant/combat effects — check first)
+
+- [ ] **Step 1: Add changelog entry**
+
+Add a plain-English `UNRELEASED_CHANGES` line, e.g.: "Combat simulator now models the Fortifying Shroud implant — a chance each turn to grant adjacent allies a Defense Up buff."
+
+- [ ] **Step 2: Docs (conditional)**
+
+If `DocumentationPage.tsx` lists supported implant/gear-set abilities, add Fortifying Shroud. If not, skip.
+
+- [ ] **Step 3: Verify + commit**
+
+Run: `npm run lint && npx tsc --noEmit` → clean.
+
+```bash
+git add src/constants/changelog.ts src/pages/DocumentationPage.tsx
+git commit -m "docs(combat): D-PR11 — changelog + docs for Fortifying Shroud"
+```
+
+---
+
+### Final verification
+
+- [ ] `npm test` → all green, goldens byte-identical (`git status` shows no snapshot diffs).
+- [ ] `npm run lint` → 0 warnings.
+- [ ] `npx tsc --noEmit` → clean.
+- [ ] `npm run audit:skills` → 141 ships / 0 findings.
+- [ ] Final holistic review (opus): confirm no third recipient-resolution path bypasses the new branch; confirm the `start-of-turn` intent is actually drained within the same turn (the per-turn drain following `turn-started`); confirm enemy mirror is genuinely zero-prod-change.
+- [ ] Open PR stacked on D-PR10 (#138); retarget base to main as the lower stack merges.

--- a/docs/superpowers/plans/2026-06-22-implant-gearset-abilities-D-pr11.md
+++ b/docs/superpowers/plans/2026-06-22-implant-gearset-abilities-D-pr11.md
@@ -427,8 +427,11 @@ Add the registry entry to `IMPLANT_ABILITIES`:
 ```
 
 Coverage test (`equipmentCoverage.test.ts`) — add `'FORTIFYING_SHROUD'` to BOTH:
-- the `implementedImplants` `.toEqual([...])` array, in `IMPLANTS` **declaration order** (check where `FORTIFYING_SHROUD` sits in `implants.ts` relative to the others already listed), AND
-- the `implementedImplants` `new Set([...])`.
+- the `implementedImplants` `.toEqual([...])` array — **insert it between `'FONT_OF_POWER'` and `'GIANT_SLAYER'`** (that is its `IMPLANTS` declaration-order position; `implants.ts` has FONT_OF_POWER @1752, FORTIFYING_SHROUD @1798, GIANT_SLAYER @1881). A wrong position silently fails the ordered `.toEqual`.
+- the `implementedImplants` `new Set([...])` (order-independent — add anywhere).
+- the `it('exactly { … }')` description string also enumerates the set in prose; add `FORTIFYING_SHROUD` there too for accuracy (not assertion-bearing, but keep it honest).
+
+Note: the registry test's `id.startsWith('equip-implant-FORTIFYING_SHROUD')` matches the exact id `equip-implant-FORTIFYING_SHROUD` (no `-gearId` suffix in current code — buildEquipmentAbilities.ts:711).
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -450,12 +453,12 @@ git commit -m "feat(combat): D-PR11 — Fortifying Shroud implant registry entry
 **Files:**
 - Modify: `src/components/skills/AbilityCard.tsx` (`TARGET_OPTIONS` ~line 64; `TRIGGER_OPTIONS` ~line 126)
 
-UI completeness only — no combat behaviour. The new union members may already force `tsc` errors at exhaustive sites; run `tsc` first to find them all.
+UI completeness only — no combat behaviour. Note: there are currently **no** `Record<AbilityTarget,…>` / `Record<AbilityTrigger,…>` or `assertNever`/exhaustive `switch` sites over these unions in `src/`, so adding the members forces **zero** tsc errors — the picker arrays below are non-exhaustive typed arrays. This task is purely additive UI completeness. Run `tsc` anyway to be safe.
 
-- [ ] **Step 1: Find every exhaustive site**
+- [ ] **Step 1: Find any exhaustive site (likely none)**
 
 Run: `npx tsc --noEmit`
-Expected: errors at any `Record<AbilityTarget, …>` / `Record<AbilityTrigger, …>` or exhaustive `switch`. Fix each.
+Expected: clean (no forced errors). If any `Record<AbilityTarget,…>` / exhaustive `switch` does error, fix each.
 
 - [ ] **Step 2: Add the picker options**
 

--- a/docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr11-design.md
+++ b/docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr11-design.md
@@ -1,0 +1,254 @@
+# D-PR11 — Fortifying Shroud (per-turn adjacency buff grant)
+
+**Date:** 2026-06-22
+**Sub-project:** D (implant + gear-set abilities), combat-realism epic
+**Stacks on:** D-PR10 (`feat/combat-d-pr10-flat-attack-buff`, tip `3138f1fa`, PR #138)
+**Branch:** `feat/combat-d-pr11-fortifying-shroud`
+
+## 1. Motivation
+
+Fortifying Shroud is the next slice of the "reactive self/ally buff" bucket and the
+**first effect that grants a buff to a positionally-defined recipient set** ("all
+adjacent allies"). It introduces two reusable engine primitives — a `start-of-turn`
+trigger and an `adjacent-allies` recipient scope — that future positional buff/heal
+implants can reuse.
+
+## 2. Effect data (source of truth)
+
+`src/constants/implants.ts` → `IMPLANTS.FORTIFYING_SHROUD` (a `major` implant), four
+rarity variants, identical text modulo the proc percentage:
+
+> "Every turn, there is a **X%** chance to grant **all adjacent allies** Defense Up 1
+> for 1 turn"
+
+| rarity     | proc chance |
+|------------|-------------|
+| uncommon   | 18%         |
+| rare       | 21%         |
+| epic       | 26%         |
+| legendary  | 32%         |
+
+(No common variant.) The flat-defence / %-HP stat lines on each variant are ordinary
+gear stats already folded into combat stats — out of scope; this PR adds only the
+special-effect ability. The `description` string is used solely as a presence gate
+(the D-PR1 convention); the magnitudes are baked into the registry from constants.
+
+The granted buff is **Defense Up I** (`src/constants/buffs.ts:654`), which folds through
+the existing `defence` buff channel — no new fold work. The implant text says "Defense
+Up 1" (numeral); the registry hard-codes the corpus name `'Defense Up I'`.
+
+## 3. Design overview
+
+Three pieces, smallest-blast-radius first:
+
+1. **`start-of-turn` trigger** — a new reactive `AbilityTrigger` that rides the
+   **already-emitted `turn-started` event**, self-scoped to the owner.
+2. **`adjacent-allies` recipient scope** — a new `AbilityTarget` resolved at drain time
+   via a new per-side engine delegate `adjacentAllyIdsFor(ownerId)`.
+3. **Registry entry** — one `IMPLANT_ABILITIES.FORTIFYING_SHROUD` builder using the
+   existing `mkNamedBuffGrant` helper (widened to accept the new target).
+
+### 3.1 `start-of-turn` trigger
+
+"Every turn" means **at the start of the ship's own turn** (user-confirmed). The engine
+already emits exactly this signal:
+
+```
+engine.ts:3562  bus.emit({ type: 'turn-started', actorId: actor.id, round: r });
+```
+
+emitted once per actor at the top of that actor's turn body, in the unified turn loop
+(both player and enemy actors). It is currently consumed by nothing as a trigger —
+`start-of-round` was deliberately mapped to `round-started` instead precisely because
+`turn-started` fires per-actor (`events.ts:11-14`, `types/abilities.ts:33-37`). That
+per-actor cadence is exactly what we want.
+
+Wiring (mirrors `on-charged-cast`, which rides `skill-fired` self-scoped, triggers.ts:265):
+
+```ts
+case 'start-of-turn':
+    bus.on('turn-started', (e) => {
+        if (e.actorId === ownerId) enqueue(intent);
+    });
+    break;
+```
+
+- Add `'start-of-turn'` to the `AbilityTrigger` union (`types/abilities.ts`) **and** to
+  `LIVE_TRIGGERS` (consumed by a listener).
+- The intent is drained by the per-turn `drainIntents` / `drainEnemyIntents` that follow
+  the turn body — **team-agnostic by construction** (the enemy mirror works with zero
+  extra code, like every prior reactive trigger; an enemy-side integration test proves
+  it with no production change).
+- Timing: the grant fires at the owner's turn-start, *before* the owner acts. Defense Up
+  then protects adjacent allies against incoming damage they take later in the round (and
+  is subject to the engine's existing buff-duration-decrement timing — a pre-existing,
+  out-of-scope behaviour we inherit, not change).
+
+### 3.2 `adjacent-allies` recipient scope
+
+Add `'adjacent-allies'` to the `AbilityTarget` union (`types/abilities.ts:29`).
+
+Resolved in the **buff branch** recipient list (triggers.ts:1069-1076) by prepending a
+branch:
+
+```ts
+const recipients: string[] =
+    intent.ability.target === 'adjacent-allies'
+        ? (ctx.adjacentAllyIdsFor?.(intent.ownerId) ?? ctx.playerIds)
+        : intent.ability.target === 'ally' && intent.eventCtx?.repairedAllyIds?.length
+          ? intent.eventCtx.repairedAllyIds
+          : /* …existing branches unchanged… */;
+```
+
+`ctx.playerIds` is the same-side recipient id list (`sideCtx.recipientIds`), so the
+`?? ctx.playerIds` fallback is side-correct (it's the all-allies set for whichever side
+is draining).
+
+**New delegate** `IntentExecContext.adjacentAllyIdsFor?(ownerId): string[]`
+(triggers.ts, next to `isLowestSpeedAllyFor` / `wasHitThisRoundFor`), plumbed through
+`sideCtx` exactly like `isLowestSpeedAllyFor` (triggers.ts:607, engine.ts:3364).
+
+**Engine computation** (per side, mirroring the `lowestSpeedIds` side closures at
+engine.ts:1733-1758), over the side's roster (`allPlayerActors` for player,
+`enemyAttackerActors` for enemy):
+
+```
+adjacentAllyIdsFor(ownerId):
+    owner = roster.find(id === ownerId)
+    if owner has a board position AND ≥1 OTHER roster actor has a position:
+        nbrs = neighbors(owner.position)                       // board.ts:56
+        return living same-side actors whose position ∈ nbrs   // excludes owner
+    else:
+        return all OTHER living same-side actor ids            // non-positional fallback (§3.3)
+```
+
+- `neighbors()` already encodes the game's 6-direction hex adjacency (board geometry
+  resolver, PR #106, user-verified cell-by-cell).
+- "Living" = not destroyed (same liveness predicate the engine already uses for roster
+  filtering; confirm exact accessor during implementation).
+- The owner is **excluded** from its own grant ("adjacent allies", not "self + adjacent").
+
+### 3.3 Non-positional fallback → all-allies (user decision)
+
+DPS calc and healing calc pass **no board positions**. In that mode `adjacentAllyIdsFor`
+returns **all same-side allies** (the user's chosen fallback), so the implant still has a
+meaningful effect off-board. This is side-correct (computed per-side) and degrades the
+positional "adjacent" set to the whole team when adjacency is undefined.
+
+**Golden safety:** no existing DPS or healing golden fixture equips Fortifying Shroud
+(true for every D-PR to date — effect-bearing gear is never present in goldens), so the
+all-allies fallback never fires in any golden → **zero golden / `.snap` churn**. The
+effect is exercised only by new tests and real loadouts.
+
+### 3.4 Registry entry
+
+`mkNamedBuffGrant`'s `target` parameter widens from
+`'self' | 'ally' | 'all-allies'` to additionally allow `'adjacent-allies'`
+(buildEquipmentAbilities.ts:319). Then:
+
+```ts
+FORTIFYING_SHROUD: (rarity) => {
+    const procChance = FORTIFYING_SHROUD_PROC_CHANCE[rarity]; // 0.18/0.21/0.26/0.32
+    return mkNamedBuffGrant('Defense Up I', 'adjacent-allies', 'start-of-turn', 1, {
+        procChance,
+    });
+},
+```
+
+`mkNamedBuffGrant` returns `undefined` for an unknown rarity (no common variant) or a
+missing buff — graceful skip, never throws (existing contract). `procChance` rides the
+D-PR8 buff-branch proc gate (`passesProcChanceGate`, triggers.ts:1058) keyed
+`${ownerId}:${ability.id}`. The ability id is suffixed with the gear-piece id
+(`equip-implant-FORTIFYING_SHROUD-${gearId}`) so duplicate copies get independent gates
+(D-PR1 convention).
+
+A new `FORTIFYING_SHROUD_PROC_CHANCE` per-rarity constant lives beside the other implant
+constant tables (buildEquipmentAbilities.ts), values from `implants.ts`.
+
+## 4. Editor exhaustiveness stubs
+
+Adding a union member forces a few editor switch/Record updates (the pattern every prior
+D-PR followed):
+
+- **Trigger picker** — surface `'start-of-turn'` as a trigger option (AbilityCard /
+  TRIGGER_OPTIONS), label e.g. "Start of own turn".
+- **Target picker** — surface `'adjacent-allies'` as a target option wherever
+  `AbilityTarget` is enumerated for the editor.
+
+These are UI completeness only; they do not change combat behaviour. The exact set is
+discovered by `tsc` (exhaustive `Record`/`switch` errors) during implementation.
+
+## 5. Coverage tracker
+
+`src/utils/abilities/__tests__/equipmentCoverage.test.ts`: add `'FORTIFYING_SHROUD'` to
+**both** the `implementedImplants` array (`.toEqual`, in `IMPLANTS` declaration order)
+**and** the `implementedImplants` `Set` (the known two-place pitfall from D-PR7).
+
+## 6. Testing
+
+1. **Pure delegate unit test** (`adjacentAllyIdsFor` math): on a board with the owner +
+   adjacent allies + a non-adjacent ally + a dead adjacent ally → returns exactly the
+   living adjacent allies, owner excluded; owner with no position → all living same-side
+   allies (non-positional fallback); empty same-side → `[]`.
+2. **Registry test**: `buildEquipmentAbilities` for a ship carrying Fortifying Shroud
+   emits a `buff` / `adjacent-allies` / `start-of-turn` ability with the right proc
+   chance and `Defense Up I` parsed effects; absent for a ship without it.
+3. **Engine integration (positional)**: owner with 2 adjacent + 1 non-adjacent living
+   ally, deterministic proc (force the gate) → only the 2 adjacent allies receive Defense
+   Up I; the non-adjacent ally does not; assert the buff lands on a `turn-started` of the
+   owner's turn.
+4. **Proc-gate determinism**: with proc < 1 and a seeded/zeroed gate, no grant; with the
+   accumulator crossing 1, exactly one grant for that owner+ability.
+5. **Enemy-side mirror**: an enemy carrying Fortifying Shroud grants its enemy-side
+   adjacent allies Defense Up — proving team-agnosticism with **zero** production change.
+6. **Golden gate**: full DPS + healing golden suites byte-identical (no fixture equips the
+   implant).
+
+## 7. Scope / out of scope
+
+**In scope:** Fortifying Shroud only. Builds the reusable `start-of-turn` trigger and
+`adjacent-allies` recipient scope.
+
+**Out of scope / deferred:**
+
+- The "**when an adjacent ally is directly damaged → apply Provoke**" implant
+  (`implants.ts:1446`, the Sentinel's-Vigil-style effect) is a *different* mechanism: an
+  adjacency-gated **trigger** (`on-adjacent-ally-attacked`) plus **Provoke** forced-target
+  control, which the engine does not yet simulate. It belongs to the CF/Provoke-appliers
+  bucket, not this PR.
+- The pre-existing `adjacentAllyCount` / `enemyAdjacentCount` condition subjects
+  (evaluateConditions.ts:15-16, defaulted to 0 / inert) are a scaling-count concept, not a
+  recipient set; this PR does not wire them to real positions. (Could be revisited later
+  using the same `neighbors()` machinery.)
+
+## 8. Files touched (anticipated)
+
+- `src/types/abilities.ts` — `AbilityTrigger` += `start-of-turn` (+ `LIVE_TRIGGERS`);
+  `AbilityTarget` += `adjacent-allies`.
+- `src/utils/combat/triggers.ts` — `start-of-turn` listener; `adjacent-allies` recipient
+  branch in the buff executor; `adjacentAllyIdsFor` on `IntentExecContext` + `sideCtx`.
+- `src/utils/combat/engine.ts` — per-side `adjacentAllyIdsFor` closure (mirror
+  `lowestSpeedIds`), wired into both `sideCtx` literals.
+- `src/utils/abilities/buildEquipmentAbilities.ts` — `FORTIFYING_SHROUD` registry entry,
+  proc-chance constant, `mkNamedBuffGrant` target widening.
+- Editor: trigger/target picker stubs (exact files via `tsc`).
+- `src/utils/abilities/__tests__/equipmentCoverage.test.ts` — coverage entry (two places).
+- New/updated tests per §6.
+- `src/constants/changelog.ts` — `UNRELEASED_CHANGES` entry.
+- `src/pages/DocumentationPage.tsx` — if the implant/combat docs enumerate modelled
+  effects, add Fortifying Shroud.
+
+## 9. Risks / known limitations
+
+- **Buff-duration timing:** "1 turn" granted at the owner's turn-start inherits the
+  engine's existing buff-decrement timing (memory: `buff_duration_decrement_timing`). Not
+  changed here; matches every other 1-turn reactive grant.
+- **Liveness accessor:** confirm the exact "is alive" predicate used by the engine roster
+  so dead adjacent allies are excluded consistently.
+- **All-allies fallback fidelity:** off-board the effect over-grants (whole team rather
+  than true neighbours). Accepted (user decision); only the simulator has real positions.
+- **`start-of-turn` drain ordering:** confirm the per-turn drain that follows
+  `turn-started` executes the enqueued intent within the same turn (the
+  `on-charged-cast` precedent rides a later same-turn event and is drained, so this is
+  expected, but verify in the integration test).
+```

--- a/docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr11-design.md
+++ b/docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr11-design.md
@@ -167,9 +167,11 @@ FORTIFYING_SHROUD: (rarity) => {
 `mkNamedBuffGrant` returns `undefined` for an unknown rarity (no common variant) or a
 missing buff — graceful skip, never throws (existing contract). `procChance` rides the
 D-PR8 buff-branch proc gate (`passesProcChanceGate`, defined triggers.ts:953, called in
-the buff branch triggers.ts:1058) keyed `${ownerId}:${ability.id}`. The ability id is suffixed with the gear-piece id
-(`equip-implant-FORTIFYING_SHROUD-${gearId}`) so duplicate copies get independent gates
-(D-PR1 convention).
+the buff branch triggers.ts:1058) keyed `${ownerId}:${ability.id}`. The implant ability id
+is `equip-implant-FORTIFYING_SHROUD` (current code uses `equip-implant-${implantName}` with
+no per-piece suffix, buildEquipmentAbilities.ts:711), so all copies of the implant on one
+owner share a single proc-chance stream — consistent with the "one effect = one
+probability stream per (owner, ability)" fidelity model.
 
 A new `FORTIFYING_SHROUD_PROC_CHANCE` per-rarity constant lives beside the other implant
 constant tables (buildEquipmentAbilities.ts), values from `implants.ts`.

--- a/docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr11-design.md
+++ b/docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr11-design.md
@@ -168,9 +168,9 @@ FORTIFYING_SHROUD: (rarity) => {
 missing buff — graceful skip, never throws (existing contract). `procChance` rides the
 D-PR8 buff-branch proc gate (`passesProcChanceGate`, defined triggers.ts:953, called in
 the buff branch triggers.ts:1058) keyed `${ownerId}:${ability.id}`. The implant ability id
-is `equip-implant-FORTIFYING_SHROUD` (current code uses `equip-implant-${implantName}` with
-no per-piece suffix, buildEquipmentAbilities.ts:711), so all copies of the implant on one
-owner share a single proc-chance stream — consistent with the "one effect = one
+is `equip-implant-${implantName}-${gearId}` (per-piece suffix, buildEquipmentAbilities.ts:734),
+so each equipped copy of the implant gets a distinct ability id and therefore its own
+proc-chance stream — keyed per (owner, gear piece) — consistent with the "one effect = one
 probability stream per (owner, ability)" fidelity model.
 
 A new `FORTIFYING_SHROUD_PROC_CHANCE` per-rarity constant lives beside the other implant

--- a/docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr11-design.md
+++ b/docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr11-design.md
@@ -33,7 +33,7 @@ gear stats already folded into combat stats — out of scope; this PR adds only 
 special-effect ability. The `description` string is used solely as a presence gate
 (the D-PR1 convention); the magnitudes are baked into the registry from constants.
 
-The granted buff is **Defense Up I** (`src/constants/buffs.ts:654`), which folds through
+The granted buff is **Defense Up I** (`src/constants/buffs.ts:659`, `+15% Defense`), which folds through
 the existing `defence` buff channel — no new fold work. The implant text says "Defense
 Up 1" (numeral); the registry hard-codes the corpus name `'Defense Up I'`.
 
@@ -122,10 +122,12 @@ adjacentAllyIdsFor(ownerId):
         return all OTHER living same-side actor ids            // non-positional fallback (§3.3)
 ```
 
-- `neighbors()` already encodes the game's 6-direction hex adjacency (board geometry
-  resolver, PR #106, user-verified cell-by-cell).
-- "Living" = not destroyed (same liveness predicate the engine already uses for roster
-  filtering; confirm exact accessor during implementation).
+- `neighbors()` (`src/utils/targeting/board.ts:56`, **not** under `combat/`) already
+  encodes the game's 6-direction hex adjacency (board geometry resolver, PR #106,
+  user-verified cell-by-cell).
+- "Living" = not destroyed. The engine's canonical destroyed signal is
+  `destroyedRound !== undefined` (engine.ts:3528-3546), **not** `currentHp <= 0` — use
+  that accessor.
 - The owner is **excluded** from its own grant ("adjacent allies", not "self + adjacent").
 
 ### 3.3 Non-positional fallback → all-allies (user decision)
@@ -135,10 +137,17 @@ returns **all same-side allies** (the user's chosen fallback), so the implant st
 meaningful effect off-board. This is side-correct (computed per-side) and degrades the
 positional "adjacent" set to the whole team when adjacency is undefined.
 
+**Current reality:** no production caller wires board `position` onto team actors yet —
+`position` is set-at-construction plumbing only; DPS, healing, *and* the simulator all
+pass no positions today. So in every current production path the **all-allies fallback is
+what runs**, and the true positional `neighbors()` branch is exercised **only by the new
+unit/integration tests** in this PR until a future PR wires real board positions from
+loadouts. The branch is built now so it's ready when positions arrive.
+
 **Golden safety:** no existing DPS or healing golden fixture equips Fortifying Shroud
-(true for every D-PR to date — effect-bearing gear is never present in goldens), so the
-all-allies fallback never fires in any golden → **zero golden / `.snap` churn**. The
-effect is exercised only by new tests and real loadouts.
+(true for every D-PR to date — effect-bearing gear is never present in goldens), so
+neither the positional branch nor the all-allies fallback fires in any golden → **zero
+golden / `.snap` churn**.
 
 ### 3.4 Registry entry
 
@@ -157,8 +166,8 @@ FORTIFYING_SHROUD: (rarity) => {
 
 `mkNamedBuffGrant` returns `undefined` for an unknown rarity (no common variant) or a
 missing buff — graceful skip, never throws (existing contract). `procChance` rides the
-D-PR8 buff-branch proc gate (`passesProcChanceGate`, triggers.ts:1058) keyed
-`${ownerId}:${ability.id}`. The ability id is suffixed with the gear-piece id
+D-PR8 buff-branch proc gate (`passesProcChanceGate`, defined triggers.ts:953, called in
+the buff branch triggers.ts:1058) keyed `${ownerId}:${ability.id}`. The ability id is suffixed with the gear-piece id
 (`equip-implant-FORTIFYING_SHROUD-${gearId}`) so duplicate copies get independent gates
 (D-PR1 convention).
 
@@ -243,10 +252,12 @@ discovered by `tsc` (exhaustive `Record`/`switch` errors) during implementation.
 - **Buff-duration timing:** "1 turn" granted at the owner's turn-start inherits the
   engine's existing buff-decrement timing (memory: `buff_duration_decrement_timing`). Not
   changed here; matches every other 1-turn reactive grant.
-- **Liveness accessor:** confirm the exact "is alive" predicate used by the engine roster
-  so dead adjacent allies are excluded consistently.
+- **Liveness accessor:** use `destroyedRound !== undefined` (engine.ts:3528-3546) so dead
+  adjacent allies are excluded consistently.
 - **All-allies fallback fidelity:** off-board the effect over-grants (whole team rather
-  than true neighbours). Accepted (user decision); only the simulator has real positions.
+  than true neighbours). Accepted (user decision). Note this is the *only* path that runs
+  in production today (no caller wires positions yet) — the positional branch is test-only
+  until a future PR supplies board positions.
 - **`start-of-turn` drain ordering:** confirm the per-turn drain that follows
   `turn-started` executes the enqueued intent within the same turn (the
   `on-charged-cast` precedent rides a later same-turn event and is drained, so this is

--- a/src/components/skills/AbilityCard.tsx
+++ b/src/components/skills/AbilityCard.tsx
@@ -65,6 +65,7 @@ const TARGET_OPTIONS: { value: AbilityTarget; label: string }[] = [
     { value: 'self', label: 'Self' },
     { value: 'ally', label: 'Ally' },
     { value: 'all-allies', label: 'All allies' },
+    { value: 'adjacent-allies', label: 'Adjacent allies' },
     { value: 'enemy', label: 'Enemy' },
     { value: 'all-enemies', label: 'All enemies' },
 ];
@@ -125,6 +126,7 @@ const ROLE_FILTER_OPTIONS: { value: ShipRoleCategory; label: string }[] = [
 
 const TRIGGER_OPTIONS: { value: AbilityTrigger; label: string }[] = [
     { value: 'on-cast', label: 'On cast (default)' },
+    { value: 'start-of-turn', label: 'Start of own turn' },
     { value: 'start-of-round', label: 'Start of round' },
     { value: 'on-crit', label: 'On critical hit' },
     { value: 'on-attacked', label: 'When attacked' },

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -20,6 +20,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator now models three reactive self-buff implants: Ambush (grants Crit Power Up to itself when it goes into stealth at round start), Synaptic Resonance (grants Speed Up to itself when any enemy is repaired), and Alacrity (grants Speed Up to itself at round end when it took no damage that round).',
     'Combat simulator now models two ally-support implants: Spearhead (after the carrier uses its charged skill, a chance to grant all allies Attack Up for 1 turn) and Font of Power (a chance to grant a buff to the allies it repairs). Spearhead is fully resolved; Font of Power applies and appears in the combat log with its attack bonus coming in a later update.',
     "Combat simulator: the Font of Power implant's Power Infused Nanobots buff now grants the repaired ally flat attack equal to 100% of the caster's attack at the time of the repair (previously this attack bonus had no effect).",
+    'Combat simulator now models the Fortifying Shroud implant — a chance each turn to grant adjacent allies a Defense Up buff.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -30,6 +30,9 @@ export type AbilityTarget =
     | 'self'
     | 'ally'
     | 'all-allies'
+    | 'adjacent-allies' // Fortifying Shroud: living same-side allies on neighbouring board
+    // cells (non-positional → all same-side allies). Resolved via
+    // IntentExecContext.adjacentAllyIdsFor.
     | 'enemy'
     | 'all-enemies'
     | 'enemy-most-buffs';

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -43,6 +43,8 @@ export type AbilityTarget =
 export type AbilityTrigger =
     | 'on-cast'
     | 'start-of-round'
+    | 'start-of-turn' // Fortifying Shroud: fires at the OWNER's own turn-start (rides the
+    // per-actor turn-started event; self-scoped on actorId === ownerId)
     | 'end-of-round' // Rhodium end-of-round purge — C2b-2
     | 'on-crit'
     | 'on-debuff-inflicted'
@@ -90,6 +92,7 @@ export type AbilityTrigger =
  */
 export const LIVE_TRIGGERS = new Set<AbilityTrigger>([
     'start-of-round',
+    'start-of-turn',
     'end-of-round', // Rhodium end-of-round purge — C2b-2
     'on-crit',
     'on-debuff-inflicted',

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -718,6 +718,67 @@ describe('Martyrdom (on-death Disable the killer — emit-only)', () => {
     });
 });
 
+// ---------------------------------------------------------------------------
+// D-PR11: Fortifying Shroud implant (adjacent-allies Defense Up I, start-of-turn)
+// ---------------------------------------------------------------------------
+describe('Fortifying Shroud implant', () => {
+    it('emits Fortifying Shroud as an adjacent-allies start-of-turn Defense Up I buff', () => {
+        const implantPiece = makePiece({
+            id: 'fs-implant',
+            slot: 'implant_major',
+            rarity: 'legendary',
+            setBonus: 'FORTIFYING_SHROUD',
+        });
+        const ship = makeShip({
+            implants: { implant_major: 'fs-implant' },
+        });
+        const getGearPiece = makeGetGearPiece({ 'fs-implant': implantPiece });
+
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        const a = abilities.find((x) => x.id.startsWith('equip-implant-FORTIFYING_SHROUD'));
+        expect(a).toBeDefined();
+        expect(a!.type).toBe('buff');
+        expect(a!.target).toBe('adjacent-allies');
+        expect(a!.trigger).toBe('start-of-turn');
+        expect(a!.procChance).toBeCloseTo(0.32);
+        expect(a!.config).toMatchObject({ type: 'buff', buffName: 'Defense Up I', duration: 1 });
+    });
+
+    it('uncommon → procChance ≈ 0.18', () => {
+        const piece = makePiece({ id: 'fs-2', setBonus: 'FORTIFYING_SHROUD', rarity: 'uncommon' });
+        const ship = makeShip({ implants: { implant_major: 'fs-2' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'fs-2': piece }));
+        const a = abilities.find((x) => x.id === 'equip-implant-FORTIFYING_SHROUD');
+        expect(a).toBeDefined();
+        expect(a!.procChance).toBeCloseTo(0.18);
+    });
+
+    it('rare → procChance ≈ 0.21', () => {
+        const piece = makePiece({ id: 'fs-3', setBonus: 'FORTIFYING_SHROUD', rarity: 'rare' });
+        const ship = makeShip({ implants: { implant_major: 'fs-3' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'fs-3': piece }));
+        const a = abilities.find((x) => x.id === 'equip-implant-FORTIFYING_SHROUD');
+        expect(a).toBeDefined();
+        expect(a!.procChance).toBeCloseTo(0.21);
+    });
+
+    it('epic → procChance ≈ 0.26', () => {
+        const piece = makePiece({ id: 'fs-4', setBonus: 'FORTIFYING_SHROUD', rarity: 'epic' });
+        const ship = makeShip({ implants: { implant_major: 'fs-4' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'fs-4': piece }));
+        const a = abilities.find((x) => x.id === 'equip-implant-FORTIFYING_SHROUD');
+        expect(a).toBeDefined();
+        expect(a!.procChance).toBeCloseTo(0.26);
+    });
+
+    it('common → no ability (no common variant)', () => {
+        const piece = makePiece({ id: 'fs-5', setBonus: 'FORTIFYING_SHROUD', rarity: 'common' });
+        const ship = makeShip({ implants: { implant_major: 'fs-5' } });
+        const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'fs-5': piece }));
+        expect(abilities.find((x) => x.id === 'equip-implant-FORTIFYING_SHROUD')).toBeUndefined();
+    });
+});
+
 describe('Power Infused Nanobots buff (D-PR9 + D-PR10 — Font of Power, flat attack = caster attack)', () => {
     it('exists in the buff corpus as a buff', () => {
         const buff = BUFFS.find((b) => b.name === 'Power Infused Nanobots');

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -748,7 +748,7 @@ describe('Fortifying Shroud implant', () => {
         const piece = makePiece({ id: 'fs-2', setBonus: 'FORTIFYING_SHROUD', rarity: 'uncommon' });
         const ship = makeShip({ implants: { implant_major: 'fs-2' } });
         const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'fs-2': piece }));
-        const a = abilities.find((x) => x.id === 'equip-implant-FORTIFYING_SHROUD');
+        const a = abilities.find((x) => x.id.startsWith('equip-implant-FORTIFYING_SHROUD'));
         expect(a).toBeDefined();
         expect(a!.procChance).toBeCloseTo(0.18);
     });
@@ -757,7 +757,7 @@ describe('Fortifying Shroud implant', () => {
         const piece = makePiece({ id: 'fs-3', setBonus: 'FORTIFYING_SHROUD', rarity: 'rare' });
         const ship = makeShip({ implants: { implant_major: 'fs-3' } });
         const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'fs-3': piece }));
-        const a = abilities.find((x) => x.id === 'equip-implant-FORTIFYING_SHROUD');
+        const a = abilities.find((x) => x.id.startsWith('equip-implant-FORTIFYING_SHROUD'));
         expect(a).toBeDefined();
         expect(a!.procChance).toBeCloseTo(0.21);
     });
@@ -766,7 +766,7 @@ describe('Fortifying Shroud implant', () => {
         const piece = makePiece({ id: 'fs-4', setBonus: 'FORTIFYING_SHROUD', rarity: 'epic' });
         const ship = makeShip({ implants: { implant_major: 'fs-4' } });
         const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'fs-4': piece }));
-        const a = abilities.find((x) => x.id === 'equip-implant-FORTIFYING_SHROUD');
+        const a = abilities.find((x) => x.id.startsWith('equip-implant-FORTIFYING_SHROUD'));
         expect(a).toBeDefined();
         expect(a!.procChance).toBeCloseTo(0.26);
     });
@@ -775,7 +775,9 @@ describe('Fortifying Shroud implant', () => {
         const piece = makePiece({ id: 'fs-5', setBonus: 'FORTIFYING_SHROUD', rarity: 'common' });
         const ship = makeShip({ implants: { implant_major: 'fs-5' } });
         const abilities = buildEquipmentAbilities(ship, makeGetGearPiece({ 'fs-5': piece }));
-        expect(abilities.find((x) => x.id === 'equip-implant-FORTIFYING_SHROUD')).toBeUndefined();
+        expect(
+            abilities.find((x) => x.id.startsWith('equip-implant-FORTIFYING_SHROUD'))
+        ).toBeUndefined();
     });
 });
 

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -17,6 +17,7 @@
  * D-PR7 added the on-death family (LAST_WISH, BATTLECRY, MARTYRDOM).
  * D-PR8 added reactive self-buffs (SYNAPTIC_RESONANCE, ALACRITY, AMBUSH).
  * D-PR9 added ally-wide / new-trigger buff grants (SPEARHEAD, FONT_OF_POWER).
+ * D-PR11 added adjacent-ally buff grant (FORTIFYING_SHROUD).
  *
  * Assertions are plain `expect` calls — no snapshot files.
  */
@@ -104,7 +105,7 @@ function implantAbilityCount(implantKey: string, rarity: GearPiece['rarity']): n
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { LEECH + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + EXUBERANCE + FONT_OF_POWER + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + MENACE + SECOND_WIND + SHADOWGUARD + SPEARHEAD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
+    it('exactly { LEECH + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + EXUBERANCE + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + MENACE + SECOND_WIND + SHADOWGUARD + SPEARHEAD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -134,6 +135,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
             'BLOODTHIRST',
             'EXUBERANCE',
             'FONT_OF_POWER',
+            'FORTIFYING_SHROUD',
             'GIANT_SLAYER',
             'INSIDIOUSNESS',
             'IRONCLAD',
@@ -220,6 +222,7 @@ describe('equipmentCoverage — implants', () => {
         'AMBUSH',
         'SPEARHEAD',
         'FONT_OF_POWER',
+        'FORTIFYING_SHROUD',
     ]);
 
     it('INTRUSION produces 1 ability per rarity (outgoingDamage modifier with scaling)', () => {
@@ -409,6 +412,17 @@ describe('equipmentCoverage — implants', () => {
         const SUPPORTED = new Set(['rare', 'epic', 'legendary']);
         for (const v of IMPLANTS['FONT_OF_POWER'].variants) {
             expect(implantAbilityCount('FONT_OF_POWER', v.rarity)).toBe(
+                SUPPORTED.has(v.rarity) ? 1 : 0
+            );
+        }
+    });
+
+    // D-PR11: adjacent-ally buff grant
+    it('FORTIFYING_SHROUD produces 1 adjacent-allies Defense Up I buff for uncommon/rare/epic/legendary (start-of-turn, procChance); no common variant', () => {
+        expect(implantAbilityCount('FORTIFYING_SHROUD', 'common')).toBe(0);
+        const SUPPORTED = new Set(['uncommon', 'rare', 'epic', 'legendary']);
+        for (const v of IMPLANTS['FORTIFYING_SHROUD'].variants) {
+            expect(implantAbilityCount('FORTIFYING_SHROUD', v.rarity)).toBe(
                 SUPPORTED.has(v.rarity) ? 1 : 0
             );
         }

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -247,6 +247,15 @@ const FONT_OF_POWER_PROC: Record<string, number> = {
     legendary: 0.16,
 };
 
+// D-PR11: Fortifying Shroud — start-of-turn proc chance to grant adjacent allies Defense Up I.
+// No common variant.
+const FORTIFYING_SHROUD_PROC_CHANCE: Record<string, number> = {
+    uncommon: 0.18,
+    rare: 0.21,
+    epic: 0.26,
+    legendary: 0.32,
+};
+
 // D-PR6: incoming-heal-amplification implant value tables
 // No common rarity for Exuberance
 const EXUBERANCE_PROC: Record<string, number> = {
@@ -316,7 +325,7 @@ function mkHealAmp(
 // D-PR8: generalised with optional `opts` for conditions + procChance (Battlecry call is byte-identical).
 function mkNamedBuffGrant(
     buffName: string,
-    target: 'self' | 'ally' | 'all-allies',
+    target: 'self' | 'ally' | 'all-allies' | 'adjacent-allies',
     trigger: AbilityTrigger,
     duration: number | undefined,
     opts?: { conditions?: Condition[]; procChance?: number }
@@ -640,6 +649,17 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
         const procChance = FONT_OF_POWER_PROC[rarity];
         if (procChance === undefined) return undefined;
         return mkNamedBuffGrant('Power Infused Nanobots', 'ally', 'on-own-repair-to-ally', 1, {
+            procChance,
+        });
+    },
+    // D-PR11: Fortifying Shroud — at the start of its own turn, X% chance to grant all
+    // adjacent allies Defense Up I for 1 turn. The adjacent-allies target resolves to board
+    // neighbours in the simulator and to all same-side allies in non-positional modes.
+    // No common variant.
+    FORTIFYING_SHROUD: (rarity) => {
+        const procChance = FORTIFYING_SHROUD_PROC_CHANCE[rarity];
+        if (procChance === undefined) return undefined;
+        return mkNamedBuffGrant('Defense Up I', 'adjacent-allies', 'start-of-turn', 1, {
             procChance,
         });
     },

--- a/src/utils/combat/__tests__/adjacency.test.ts
+++ b/src/utils/combat/__tests__/adjacency.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { adjacentAllyIds } from '../adjacency';
+import type { Position } from '../../../types/encounters';
+
+// Board adjacency (board.ts neighbors): M2 neighbors = T1,T2,M1,M3,B1,B2.
+const a = (id: string, position?: Position, destroyedRound?: number) => ({
+    id,
+    position,
+    destroyedRound,
+});
+
+describe('adjacentAllyIds', () => {
+    it('positional: returns living same-side allies on neighbouring cells, owner excluded', () => {
+        const actors = [
+            a('owner', 'M2'),
+            a('adjT2', 'T2'), // neighbour of M2
+            a('adjM3', 'M3'), // neighbour of M2
+            a('farB4', 'B4'), // not a neighbour
+        ];
+        expect(adjacentAllyIds('owner', actors).sort()).toEqual(['adjM3', 'adjT2']);
+    });
+
+    it('positional: excludes a destroyed adjacent ally', () => {
+        const actors = [a('owner', 'M2'), a('deadT2', 'T2', 3), a('adjM3', 'M3')];
+        expect(adjacentAllyIds('owner', actors)).toEqual(['adjM3']);
+    });
+
+    it('non-positional (owner has no position): falls back to all living same-side allies', () => {
+        const actors = [a('owner'), a('ally1'), a('ally2'), a('dead', undefined, 2)];
+        expect(adjacentAllyIds('owner', actors).sort()).toEqual(['ally1', 'ally2']);
+    });
+
+    it('positional but no other actor positioned: falls back to all living allies', () => {
+        const actors = [a('owner', 'M2'), a('ally1')]; // ally1 unpositioned
+        expect(adjacentAllyIds('owner', actors)).toEqual(['ally1']);
+    });
+
+    it('empty / owner-only roster → []', () => {
+        expect(adjacentAllyIds('owner', [a('owner', 'M2')])).toEqual([]);
+        expect(adjacentAllyIds('owner', [])).toEqual([]);
+    });
+});

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -3127,3 +3127,322 @@ describe('Spearhead — on-charged-cast all-allies Attack Up I', () => {
         expect(grantedAttackUp).toBe(false);
     });
 });
+
+// ---------------------------------------------------------------------------
+// D-PR11 integration — Fortifying Shroud adjacent-allies buff: positional
+//   recipient resolution through the real engine delegate (board positions wired).
+//
+// Goal: prove that when an owner with `target:'adjacent-allies'` + `trigger:'start-of-turn'`
+// fires its start-of-turn reactive buff, ONLY the living allies on neighbouring board cells
+// receive the buff — NOT the owner itself, NOT a non-adjacent ally.
+//
+// Board layout (M2 neighbours per board.ts: T1, T2, M1, M3, B1, B2):
+//   Owner  : M2  (the focus 'attacker')
+//   ally-T2: T2  (adjacent   → must receive the buff)
+//   ally-M3: M3  (adjacent   → must receive the buff)
+//   ally-B4: B4  (NON-adjacent → must NOT receive the buff — the crux non-vacuity assertion)
+//
+// Test strategy:
+//   Inject the Fortifying-Shroud-shaped ability directly into the focus actor's passive slot
+//   (procChance omitted → deterministic, fires every owner turn), run 1 round, and collect
+//   'buff-applied' events via the event bus. Assert the actorId set exactly: {ally-T2, ally-M3}.
+//   A second test mirrors this on the ENEMY SIDE to prove team-agnosticism.
+//
+// Why a test ability rather than the real registry implant:
+//   The legendary Fortifying Shroud procChance (0.32) is non-deterministic over a single turn;
+//   verifying adjacency via the real registry implant would require running enough rounds to
+//   force a proc, making the test fragile. By dropping procChance we get determinism and keep
+//   the assertion focused on the adjacency + trigger + engine-delegate path (which is exactly
+//   what Task 5 registers and D-PR11 T3 already proved at the executor level — this task proves
+//   it end-to-end through runCombat with real board positions).
+// ---------------------------------------------------------------------------
+
+/** Minimal walked team actor placed at a board position. No skills, high HP, no damage. */
+function makePositionedAlly(id: string, position: Position): TeamActorEngineInput {
+    return {
+        id,
+        speed: 50, // slower than the focus (100) so the focus always acts first
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        walk: {
+            shipSkills: { slots: [] },
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp: 1_000_000_000,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    };
+}
+
+/** The Fortifying Shroud ability with procChance OMITTED for determinism.
+ *  Fires on start-of-turn (self-scoped) and grants 'Defense Up I' to adjacent allies. */
+const fortifyingShroudAbility: Ability = {
+    id: 'test-fortifying-shroud',
+    type: 'buff',
+    target: 'adjacent-allies',
+    trigger: 'start-of-turn',
+    conditions: [],
+    // No procChance → the proc gate is absent → buff fires on every owner turn (deterministic).
+    config: {
+        type: 'buff',
+        buffName: 'Defense Up I',
+        stacks: 1,
+        isStackable: false,
+        duration: 1,
+        parsedEffects: {},
+    },
+    autoFilled: true,
+};
+
+/** A no-op active so the focus actor takes a turn (required to emit turn-started). */
+const noopDmgActive: Ability = {
+    id: 'noop-dmg',
+    type: 'damage',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'damage', multiplier: 0 },
+};
+
+/** Base engine input for the Fortifying Shroud tests: focus at M2, healing mode (required
+ *  for team actors), 1 round. The event bus is injected per-call so we can observe events. */
+function makeShroudInput(
+    bus: ReturnType<typeof createEventBus>,
+    teamActors: TeamActorEngineInput[],
+    opts: { focusPosition?: Position; side?: 'player' } = {}
+): CombatEngineInput {
+    return {
+        attack: 1,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: {
+            slots: [
+                { slot: 'active', abilities: [noopDmgActive] },
+                { slot: 'passive', abilities: [fortifyingShroudAbility] },
+            ],
+        },
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        // Healing mode is required to use team actors.
+        healTargetId: 'attacker',
+        position: opts.focusPosition ?? 'M2',
+        teamActors,
+        bus,
+        speed: 100,
+    };
+}
+
+describe('D-PR11 integration — Fortifying Shroud: positional adjacent-allies buff (player side)', () => {
+    /**
+     * Board layout:
+     *   Owner  : M2  (focus 'attacker')
+     *   ally-T2: T2  (adjacent to M2 — receives Defense Up I)
+     *   ally-M3: M3  (adjacent to M2 — receives Defense Up I)
+     *   ally-B4: B4  (NON-adjacent to M2 — must NOT receive the buff; the crux assertion)
+     *
+     * After the owner's first turn (start-of-turn fires the ability), we expect exactly:
+     *   - ally-T2 got Defense Up I
+     *   - ally-M3 got Defense Up I
+     *   - 'attacker' (owner) did NOT get the buff
+     *   - ally-B4 (non-adjacent) did NOT get the buff
+     */
+    it('buff lands on exactly the two adjacent allies (T2, M3) — NOT the owner, NOT the non-adjacent ally (B4)', () => {
+        const bus = createEventBus();
+
+        const buffGrantedTo = new Set<string>();
+        bus.on('buff-applied', (e) => {
+            if (e.buffName === 'Defense Up I') buffGrantedTo.add(e.actorId);
+        });
+
+        const teamActors: TeamActorEngineInput[] = [
+            makePositionedAlly('ally-T2', 'T2'),
+            makePositionedAlly('ally-M3', 'M3'),
+            makePositionedAlly('ally-B4', 'B4'),
+        ];
+
+        runCombat(makeShroudInput(bus, teamActors));
+
+        // Adjacent allies get the buff.
+        expect(buffGrantedTo.has('ally-T2')).toBe(true);
+        expect(buffGrantedTo.has('ally-M3')).toBe(true);
+
+        // Non-vacuity: the non-adjacent ally must NOT have the buff.
+        expect(buffGrantedTo.has('ally-B4')).toBe(false);
+
+        // The owner must NOT grant the buff to itself.
+        expect(buffGrantedTo.has('attacker')).toBe(false);
+
+        // Exactly two recipients — no spurious extras.
+        expect(buffGrantedTo.size).toBe(2);
+    });
+
+    it('without board positions (non-positional): buff falls back to all same-side allies (all-allies)', () => {
+        // When no positions are wired, adjacentAllyIds falls back to all living same-side
+        // allies (owner excluded). The ability still fires (start-of-turn, no procChance),
+        // and all three team actors receive the buff.
+        const bus = createEventBus();
+
+        const buffGrantedTo = new Set<string>();
+        bus.on('buff-applied', (e) => {
+            if (e.buffName === 'Defense Up I') buffGrantedTo.add(e.actorId);
+        });
+
+        // Team actors without position (non-positional path).
+        const teamActors: TeamActorEngineInput[] = [
+            makePositionedAlly('ally-A', 'T2'),
+            makePositionedAlly('ally-B', 'M3'),
+            makePositionedAlly('ally-C', 'B4'),
+        ].map((a) => ({ ...a, position: undefined }));
+
+        // Focus also without position.
+        const input: CombatEngineInput = {
+            ...makeShroudInput(bus, teamActors),
+            position: undefined,
+        };
+
+        runCombat(input);
+
+        // Without positions all three allies get the buff (all-allies fallback).
+        expect(buffGrantedTo.has('ally-A')).toBe(true);
+        expect(buffGrantedTo.has('ally-B')).toBe(true);
+        expect(buffGrantedTo.has('ally-C')).toBe(true);
+        // Owner still excluded (adjacentAllyIds always excludes the owner).
+        expect(buffGrantedTo.has('attacker')).toBe(false);
+        expect(buffGrantedTo.size).toBe(3);
+    });
+});
+
+describe('D-PR11 integration — Fortifying Shroud: enemy-side mirror (team-agnosticism)', () => {
+    /**
+     * Mirror test: place the Fortifying Shroud owner on the ENEMY side to prove the engine's
+     * `adjacentAllyIdsFor` delegate is correctly wired for enemy actors too.
+     *
+     * Setup: one enemy attacker at M2 carries the test ability; two enemy bystanders at T2
+     * and M3 (adjacent); one enemy bystander at B4 (non-adjacent). The player team is the
+     * focus ('attacker') and two passive allies, all with enough HP to survive.
+     *
+     * Observable: 'buff-applied' events — the enemy actor at M2 fires its start-of-turn
+     * reactive buff; the engine's enemy-side sideCtx.adjacentAllyIdsFor routes the recipients
+     * to exactly the enemy actors at T2 and M3, and B4 is excluded.
+     *
+     * Why we can observe enemy-side buffs: the status engine and bus are shared between player
+     * and enemy turns, so enemy buff-applied events are emitted on the same bus.
+     */
+    it('enemy owner at M2 grants Defense Up I to enemy-side adjacent allies (T2, M3) — NOT B4', () => {
+        const bus = createEventBus();
+
+        const buffGrantedTo = new Set<string>();
+        bus.on('buff-applied', (e) => {
+            if (e.buffName === 'Defense Up I') buffGrantedTo.add(e.actorId);
+        });
+
+        /** A positioned enemy attacker (active skill: deal 0 damage; passive: Fortifying Shroud). */
+        const shroudEnemy = (
+            id: string,
+            position: Position,
+            withShroud: boolean
+        ): NonNullable<CombatEngineInput['enemyAttackers']>[number] => ({
+            id,
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                speed: 10, // all enemies slower than the focus (100); order within enemy side is speed-based
+                defence: 0,
+                hp: 1_000_000_000,
+            },
+            chargeCount: 0,
+            startCharged: false,
+            position,
+            shipSkills: {
+                slots: withShroud
+                    ? [
+                          { slot: 'active', abilities: [noopDmgActive] },
+                          { slot: 'passive', abilities: [fortifyingShroudAbility] },
+                      ]
+                    : [{ slot: 'active', abilities: [noopDmgActive] }],
+            },
+        });
+
+        const input: CombatEngineInput = {
+            attack: 1,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: {
+                slots: [{ slot: 'active', abilities: [noopDmgActive] }],
+            },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            // Healing mode is required for enemy attackers to be populated.
+            healTargetId: 'attacker',
+            speed: 100,
+            bus,
+            enemyAttackers: [
+                shroudEnemy('enemy-M2', 'M2', true), // the owner: carries Fortifying Shroud
+                shroudEnemy('enemy-T2', 'T2', false), // adjacent to M2 → should receive buff
+                shroudEnemy('enemy-M3', 'M3', false), // adjacent to M2 → should receive buff
+                shroudEnemy('enemy-B4', 'B4', false), // NON-adjacent → must NOT receive buff
+            ],
+        };
+
+        runCombat(input);
+
+        // Adjacent enemy-side allies receive the buff.
+        expect(buffGrantedTo.has('enemy-T2')).toBe(true);
+        expect(buffGrantedTo.has('enemy-M3')).toBe(true);
+
+        // Non-vacuity: the non-adjacent enemy ally must NOT have the buff.
+        expect(buffGrantedTo.has('enemy-B4')).toBe(false);
+
+        // The owner must NOT grant the buff to itself.
+        expect(buffGrantedTo.has('enemy-M2')).toBe(false);
+
+        // No player-side actor should ever receive an enemy-side buff grant.
+        expect(buffGrantedTo.has('attacker')).toBe(false);
+
+        // Exactly two recipients.
+        expect(buffGrantedTo.size).toBe(2);
+    });
+});

--- a/src/utils/combat/__tests__/reactiveBuffProcGate.test.ts
+++ b/src/utils/combat/__tests__/reactiveBuffProcGate.test.ts
@@ -7,6 +7,15 @@
  *     (back-loaded: calls 5, 10). Must NOT be 10 (absent gate = broken behavior).
  * (b) A reactive `buff` intent WITHOUT procChance applies the buff on every call
  *     (pass-through — byte-identical to today).
+ *
+ * D-PR11 Task 3: `adjacent-allies` buff target recipient resolution.
+ *
+ * Tests that:
+ * (c) A buff intent with target `'adjacent-allies'` and a stub
+ *     `ctx.adjacentAllyIdsFor` lands on exactly the two adjacent-ally ids returned
+ *     by the delegate (NOT the owner, NOT a non-adjacent ally).
+ * (d) When `ctx.adjacentAllyIdsFor` is absent (undefined), recipients fall back to
+ *     `ctx.playerIds` (all same-side allies, owner included).
  */
 import { describe, it, expect } from 'vitest';
 import { executeIntent, Intent, IntentExecContext } from '../triggers';
@@ -57,6 +66,31 @@ function makeBuffIntent(opts?: { procChance?: number }): Intent {
  * Condition gate: intent.ability.conditions is [] → conditionsMet → passes.
  * StatusEngine must be advanced to round 1 (beginRound) before executeIntent is called.
  */
+const ALLY1_ID = 'ally1';
+const ALLY2_ID = 'ally2';
+const NON_ADJACENT_ID = 'non-adjacent';
+
+function makeAdjacentBuffIntent(): Intent {
+    return {
+        ownerId: OWNER_ID,
+        sourceSlot: 'passive',
+        ability: {
+            id: 'fortifying-shroud-ab',
+            type: 'buff',
+            target: 'adjacent-allies',
+            trigger: 'start-of-turn',
+            conditions: [],
+            config: {
+                type: 'buff',
+                buffName: 'Defense Up',
+                stacks: 1,
+                duration: 1,
+                parsedEffects: {},
+            },
+        },
+    } as unknown as Intent;
+}
+
 function makeCtx(opts?: {
     procChanceGates?: Map<string, ReturnType<typeof makeRateGate>>;
 }): IntentExecContext & { buffAppliedEvents: string[] } {
@@ -121,6 +155,78 @@ function makeCtx(opts?: {
     return ctx;
 }
 
+/**
+ * Build a minimal IntentExecContext for the `adjacent-allies` buff branch.
+ *
+ * playerIds = [OWNER_ID, ALLY1_ID, ALLY2_ID, NON_ADJACENT_ID] — the full same-side roster.
+ * adjacentAllyIdsFor (when provided) returns [ALLY1_ID, ALLY2_ID] for OWNER_ID.
+ *
+ * The buff-applied actorId tracks which recipients were actually granted the buff.
+ */
+function makeAdjacentCtx(opts?: {
+    includeAdjacentDelegate?: boolean;
+}): IntentExecContext & { appliedActorIds: string[] } {
+    const bus = createEventBus();
+    const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+    se.beginRound(1);
+
+    const appliedActorIds: string[] = [];
+    bus.on('buff-applied', (e) => {
+        appliedActorIds.push(e.actorId);
+    });
+
+    const allPlayerIds = [OWNER_ID, ALLY1_ID, ALLY2_ID, NON_ADJACENT_ID];
+
+    const ctx = {
+        round: 1,
+        enemy: { id: 'enemy1', currentHp: 100000 } as CombatActor,
+        enemyId: 'enemy1',
+        statusEngine: se,
+        bus,
+        corrosionEntries: [],
+        infernoEntries: [],
+        pendingBombs: [],
+        runtimes: new Map([
+            [
+                OWNER_ID,
+                {
+                    actor: { id: OWNER_ID, chargeCount: 0, charges: 0 } as unknown as CombatActor,
+                    attack: 10000,
+                    defence: 0,
+                    hp: 10000,
+                    healModifier: 0,
+                    selfDotModifier: 0,
+                    defensePenetrationBuff: 0,
+                    affinityDamageModifier: 0,
+                    affinityCritCap: 100,
+                    affinityCritPenalty: 0,
+                    affinityDisadvantage: false,
+                    selfBuffLookup: new Map(),
+                    enemyDebuffLookup: new Map(),
+                } as never,
+            ],
+        ]),
+        grantAllyCharges: () => {},
+        grantExtraAction: () => {},
+        playerIds: allPlayerIds,
+        lastTurnCtxByActor: new Map([
+            [OWNER_ID, { effectiveAttack: 10000, affinityMult: 1 } as never],
+        ]),
+        enemyHp: 100000,
+        cumulativeDamage: 0,
+        recordResisted: () => {},
+        ...(opts?.includeAdjacentDelegate
+            ? {
+                  adjacentAllyIdsFor: (ownerId: string) =>
+                      ownerId === OWNER_ID ? [ALLY1_ID, ALLY2_ID] : [],
+              }
+            : {}),
+    } as unknown as IntentExecContext & { appliedActorIds: string[] };
+
+    (ctx as unknown as Record<string, unknown>).appliedActorIds = appliedActorIds;
+    return ctx;
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -152,5 +258,31 @@ describe('D-PR8 T3: reactive buff branch — passesProcChanceGate', () => {
 
         // No gate → fires every time.
         expect(ctx.buffAppliedEvents).toHaveLength(4);
+    });
+});
+
+describe('D-PR11 T3: adjacent-allies buff target — recipient resolution', () => {
+    it('(c) with adjacentAllyIdsFor delegate: buff lands on exactly ally1 and ally2 (not owner, not non-adjacent)', () => {
+        const intent = makeAdjacentBuffIntent();
+        const ctx = makeAdjacentCtx({ includeAdjacentDelegate: true });
+
+        executeIntent(intent, ctx);
+
+        // Only the two adjacent allies should receive the buff.
+        expect(ctx.appliedActorIds).toEqual([ALLY1_ID, ALLY2_ID]);
+        // Owner must NOT be in the recipient list.
+        expect(ctx.appliedActorIds).not.toContain(OWNER_ID);
+        // Non-adjacent ally must NOT be in the recipient list.
+        expect(ctx.appliedActorIds).not.toContain(NON_ADJACENT_ID);
+    });
+
+    it('(d) without adjacentAllyIdsFor delegate: recipients fall back to ctx.playerIds (all same-side allies)', () => {
+        const intent = makeAdjacentBuffIntent();
+        const ctx = makeAdjacentCtx({ includeAdjacentDelegate: false });
+
+        executeIntent(intent, ctx);
+
+        // Falls back to the full playerIds list: [OWNER_ID, ALLY1_ID, ALLY2_ID, NON_ADJACENT_ID].
+        expect(ctx.appliedActorIds).toEqual([OWNER_ID, ALLY1_ID, ALLY2_ID, NON_ADJACENT_ID]);
     });
 });

--- a/src/utils/combat/__tests__/triggers.test.ts
+++ b/src/utils/combat/__tests__/triggers.test.ts
@@ -3263,6 +3263,106 @@ describe('on-ally-attacked engine integration (scenario 16)', () => {
 });
 
 // ----------------------------------------------------------------------
+// D-PR11: start-of-turn trigger — self-scoped on turn-started.
+//
+// Fortifying Shroud fires once at the START of the owner's OWN turn
+// (not every actor's turn). The engine emits `turn-started` once per actor
+// per round; the listener must enqueue ONLY when actorId === ownerId.
+//
+// Pattern mirrors on-cheat-death-activated (self-scoped event subscription).
+// ----------------------------------------------------------------------
+describe('start-of-turn live trigger (D-PR11)', () => {
+    // A minimal reactive buff ability carrying the start-of-turn trigger.
+    const startOfTurnBuff = (): Ability => ({
+        id: 'sot-buff',
+        type: 'buff',
+        target: 'self',
+        trigger: 'start-of-turn',
+        conditions: [],
+        config: {
+            type: 'buff',
+            buffName: 'Fortifying Shroud',
+            stacks: 1,
+            parsedEffects: { defense: 20 },
+            isStackable: false,
+            duration: 1,
+        },
+    });
+
+    function emitTurnStarted(ownerId: string, actorId: string): Intent[] {
+        const bus = createEventBus();
+        const intents: Intent[] = [];
+        const ra: ReactiveAbility = { ability: startOfTurnBuff(), sourceSlot: 'passive' };
+        registerReactiveListeners({
+            bus,
+            perOwner: [{ ownerId, reactiveAbilities: [ra] }],
+            enqueue: (i) => intents.push(i),
+            isOpposing: (id) => id === 'enemy',
+        });
+        bus.emit({ type: 'turn-started', actorId, round: 1 });
+        return intents;
+    }
+
+    it("start-of-turn enqueues on the owner's own turn-started, not another actor's", () => {
+        // Non-owner's turn-started: must NOT enqueue
+        const bus = createEventBus();
+        const queue: Intent[] = [];
+        const ra: ReactiveAbility = { ability: startOfTurnBuff(), sourceSlot: 'passive' };
+        registerReactiveListeners({
+            bus,
+            perOwner: [{ ownerId: 'A', reactiveAbilities: [ra] }],
+            enqueue: (i) => queue.push(i),
+            isOpposing: (id) => id === 'enemy',
+        });
+
+        bus.emit({ type: 'turn-started', actorId: 'B', round: 1 });
+        expect(queue.length).toBe(0);
+
+        bus.emit({ type: 'turn-started', actorId: 'A', round: 1 });
+        expect(queue.length).toBe(1);
+        expect(queue[0].ownerId).toBe('A');
+        expect(queue[0].ability.trigger).toBe('start-of-turn');
+    });
+
+    it('enqueues the intent when the owner own turn-started fires', () => {
+        const intents = emitTurnStarted('A', 'A');
+        expect(intents).toHaveLength(1);
+        expect(intents[0].ownerId).toBe('A');
+        expect(intents[0].ability.trigger).toBe('start-of-turn');
+    });
+
+    it('does NOT enqueue when a DIFFERENT actor turn-started fires', () => {
+        expect(emitTurnStarted('A', 'B')).toHaveLength(0);
+    });
+
+    it('listener is pure: no enqueue on registration, only on matching emit', () => {
+        const bus = createEventBus();
+        const intents: Intent[] = [];
+        const ra: ReactiveAbility = { ability: startOfTurnBuff(), sourceSlot: 'passive' };
+        registerReactiveListeners({
+            bus,
+            perOwner: [{ ownerId: 'A', reactiveAbilities: [ra] }],
+            enqueue: (i) => intents.push(i),
+            isOpposing: (id) => id === 'enemy',
+        });
+        expect(intents).toHaveLength(0);
+        bus.emit({ type: 'turn-started', actorId: 'B', round: 1 });
+        expect(intents).toHaveLength(0);
+        bus.emit({ type: 'turn-started', actorId: 'A', round: 1 });
+        expect(intents).toHaveLength(1);
+    });
+
+    it('LIVE_TRIGGERS contains start-of-turn', () => {
+        expect(LIVE_TRIGGERS.has('start-of-turn')).toBe(true);
+    });
+
+    it('AbilityTrigger includes start-of-turn (type-level compile check)', () => {
+        const _trigger: AbilityTrigger = 'start-of-turn';
+        expect(_trigger).toBe('start-of-turn');
+    });
+});
+
+// ----------------------------------------------------------------------
 // C2b-1 — purge partition guard.
 // An `on-cast` purge ability MUST stay in castSkills (the on-cast path
 // handles it). An `on-enemy-purged` purge ability MUST route to

--- a/src/utils/combat/adjacency.ts
+++ b/src/utils/combat/adjacency.ts
@@ -1,0 +1,30 @@
+import { neighbors } from '../targeting/board';
+import type { Position } from '../../types/encounters';
+
+/** Minimal shape this helper needs from a combat actor. CombatActor satisfies it. */
+interface AdjacencyActor {
+    id: string;
+    position?: Position;
+    destroyedRound?: number;
+}
+
+/**
+ * Resolve the recipient id list for an `adjacent-allies` grant.
+ *
+ * Positional (the owner AND at least one OTHER actor carry a board position):
+ *   living same-side actors whose position is a hex-neighbour of the owner's, owner excluded.
+ * Non-positional (no board positions wired — every current production path):
+ *   all living same-side actors, owner excluded (the all-allies fallback, per spec §3.3).
+ *
+ * "Living" = `destroyedRound === undefined` (engine's canonical destroyed signal).
+ */
+export function adjacentAllyIds(ownerId: string, actors: AdjacencyActor[]): string[] {
+    const living = actors.filter((x) => x.destroyedRound === undefined && x.id !== ownerId);
+    const owner = actors.find((x) => x.id === ownerId);
+    const anyOtherPositioned = actors.some((x) => x.id !== ownerId && x.position != null);
+    if (owner?.position != null && anyOtherPositioned) {
+        const nbrs = new Set<Position>(neighbors(owner.position));
+        return living.filter((x) => x.position != null && nbrs.has(x.position)).map((x) => x.id);
+    }
+    return living.map((x) => x.id);
+}

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -78,6 +78,7 @@ import {
     selfBuffNamesForOwners,
     victimEnemyBuffs,
 } from './triggers';
+import { adjacentAllyIds } from './adjacency';
 
 /** Backstop for pathological extra-action loops (a non-once-per-round grant whose
  *  conditions stay true re-fires on the extra turn it granted). Real texts are
@@ -1032,6 +1033,8 @@ interface ReactiveSideCtx {
     selfHpPctFor?: (ownerId: string) => number;
     /** Per-side most-buffs opposing-actor resolver (Rhodium). See IntentExecContext. */
     enemyWithMostBuffs?: (ownerId: string) => string | undefined;
+    /** Per-side adjacent-allies resolver (Fortifying Shroud). See IntentExecContext. */
+    adjacentAllyIdsFor: (ownerId: string) => string[];
 }
 
 /** Per-victim incoming accounting bucket (PR5a foundation — written in parallel with the
@@ -1744,6 +1747,9 @@ export function runCombat(input: CombatEngineInput): {
          *  defaults to 100). Enemy side returns 100 for every owner (no per-actor enemy HP until
          *  PR5). Consumed in Task 2. */
         selfHpPctFor?: (ownerId: string) => number;
+        /** Same-side ids adjacent to `ownerId` on the board (living, owner excluded). Positional
+         *  → board neighbours; non-positional (no positions wired) → all living same-side allies. */
+        adjacentAllyIdsFor: (ownerId: string) => string[];
     }
 
     const buildSideContext = (side: Side): SideContext => {
@@ -1777,6 +1783,7 @@ export function runCombat(input: CombatEngineInput): {
                           }
                         : undefined
                     : (): number => 100,
+            adjacentAllyIdsFor: (ownerId: string): string[] => adjacentAllyIds(ownerId, actors),
         };
     };
 
@@ -3373,6 +3380,9 @@ export function runCombat(input: CombatEngineInput): {
                         // combat-wide Set, so the SAME closure serves both sides (team-agnostic) —
                         // no per-side sideCtx field needed (unlike isLowestSpeedAllyFor).
                         wasHitThisRoundFor: (ownerId) => hitThisRound.has(ownerId),
+                        // D-PR11: live adjacent-allies resolver (Fortifying Shroud). Sourced
+                        // per-side from sideCtx; positional neighbours, else all same-side allies.
+                        adjacentAllyIdsFor: sideCtx.adjacentAllyIdsFor,
                     });
                 }
             }
@@ -3405,6 +3415,7 @@ export function runCombat(input: CombatEngineInput): {
                 grantAllyCharges: bySide('player').grantAllyCharges,
                 selfHpPctFor: bySide('player').selfHpPctFor,
                 enemyWithMostBuffs: () => mostBuffsAmong(enemyAttackerActors),
+                adjacentAllyIdsFor: bySide('player').adjacentAllyIdsFor,
             });
 
         // Enemy drain (enemy-team PR1) — binds the SEPARATE enemy queue + enemy-side ctx.
@@ -3426,6 +3437,7 @@ export function runCombat(input: CombatEngineInput): {
                 grantAllyCharges: bySide('enemy').grantAllyCharges,
                 selfHpPctFor: bySide('enemy').selfHpPctFor,
                 enemyWithMostBuffs: () => mostBuffsAmong(allPlayerActors),
+                adjacentAllyIdsFor: bySide('enemy').adjacentAllyIdsFor,
             });
         };
 

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -613,6 +613,10 @@ export interface IntentExecContext {
      *  is static turn-order in this sim). Absent → buildDrainContext defaults the gate to true
      *  (lone-actor DPS assumption). */
     isLowestSpeedAllyFor?: (ownerId: string) => boolean;
+    /** Same-side ids adjacent to `ownerId` on the board (living, owner excluded), feeding the
+     *  `adjacent-allies` buff target. Engine-populated per side. Absent / undefined → the
+     *  recipient resolver falls back to ctx.playerIds (all same-side allies). */
+    adjacentAllyIdsFor?: (ownerId: string) => string[];
     /** Whether `ownerId` was hit by a direct attack this round, feeding the
      *  `not-hit-this-round` gate at drain time. Engine-populated from the combat-wide
      *  hitThisRound Set. Absent → buildDrainContext defaults the gate to false (DPS /
@@ -1075,13 +1079,15 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
         // casterId = ownerId so its gate evaluates against the caster's ctx even when it
         // lives on another recipient.
         const recipients: string[] =
-            intent.ability.target === 'ally' && intent.eventCtx?.repairedAllyIds?.length
-                ? intent.eventCtx.repairedAllyIds
-                : intent.ability.target === 'ally' && intent.eventCtx?.damagedAllyId
-                  ? [intent.eventCtx.damagedAllyId]
-                  : intent.ability.target === 'ally' || intent.ability.target === 'all-allies'
-                    ? ctx.playerIds
-                    : [intent.ownerId];
+            intent.ability.target === 'adjacent-allies'
+                ? (ctx.adjacentAllyIdsFor?.(intent.ownerId) ?? ctx.playerIds)
+                : intent.ability.target === 'ally' && intent.eventCtx?.repairedAllyIds?.length
+                  ? intent.eventCtx.repairedAllyIds
+                  : intent.ability.target === 'ally' && intent.eventCtx?.damagedAllyId
+                    ? [intent.eventCtx.damagedAllyId]
+                    : intent.ability.target === 'ally' || intent.ability.target === 'all-allies'
+                      ? ctx.playerIds
+                      : [intent.ownerId];
         // D-PR10: dynamic caster-attack snapshot. A buff carrying the `attackFlatPctOfCaster`
         // sentinel ("N% of the caster's attack") freezes a concrete `attackFlat` from the
         // CASTER's effective attack at grant time (the same last-turn ctx value that

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -346,6 +346,14 @@ export function registerReactiveListeners(args: {
                 case 'start-of-round':
                     bus.on('round-started', () => enqueue(intent));
                     break;
+                case 'start-of-turn':
+                    bus.on('turn-started', (e) => {
+                        // Self-scoped: THIS owner's own turn began. turn-started fires once per
+                        // actor (both sides run the same turn path), so the ownerId guard scopes
+                        // it per registered owner — team-agnostic, like on-charged-cast.
+                        if (e.actorId === ownerId) enqueue(intent);
+                    });
+                    break;
                 case 'end-of-round':
                     // Global, like start-of-round: every round-ended enqueues this owner's intent
                     // (Rhodium's end-of-round purge). Gating handled in the executor.


### PR DESCRIPTION
## D-PR11 — Fortifying Shroud

Models the **Fortifying Shroud** implant: *"Every turn, X% chance to grant all adjacent allies Defense Up 1 for 1 turn."* Introduces two reusable combat primitives plus the implant.

**Stacked on D-PR10 (#138).** Retarget base → main as the lower stack merges.

### New primitives
- **`start-of-turn` trigger** — rides the already-emitted per-actor `turn-started` event, self-scoped on `actorId === ownerId` (mirrors `on-charged-cast`). No new emit site. Team-agnostic by construction. Added to `AbilityTrigger` + `LIVE_TRIGGERS`.
- **`adjacent-allies` `AbilityTarget`** — resolved at drain time via a new per-side engine delegate `adjacentAllyIdsFor(ownerId)` = pure `adjacentAllyIds(ownerId, sideRoster)`:
  - **positional** → `neighbors(owner.position)` ∩ living same-side allies (owner excluded), using the board geometry resolver;
  - **non-positional** (no board positions wired — every current production path) → all living same-side allies (the all-allies fallback).

### Implant
- `IMPLANT_ABILITIES.FORTIFYING_SHROUD` → `mkNamedBuffGrant('Defense Up I', 'adjacent-allies', 'start-of-turn', 1, { procChance })`, proc 18/21/26/32% (uncommon→legendary, no common). Defense Up I folds via the existing defence channel.

### Reach today
No production caller wires board positions yet (not even the simulator), so in current production paths the all-allies fallback runs and the positional branch is exercised by the new integration tests — built now so it's ready when positions arrive.

### Safety
- **Zero golden/`.snap` churn** — no fixture equips the implant and no existing ability targets `adjacent-allies` / uses `start-of-turn`, so the new code is dormant in every existing fixture. The recipient-ternary change is a pure prepend (existing branches byte-identical).
- 2994 tests green · tsc clean · lint 0 warnings · `audit:skills` 141 ships / 0 findings.

### Tests
- Pure `adjacentAllyIds` unit tests (adjacency math, fallback, liveness, owner-exclusion).
- `start-of-turn` trigger registration (self-scoped) + `adjacent-allies` recipient resolution (executor-level).
- End-to-end positional integration: owner@M2 with adjacent allies@T2/M3 + non-adjacent@B4 → buff lands on T2/M3 only (not owner, not B4); non-positional fallback → all allies; **enemy-side mirror** (zero production change).

Spec: `docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr11-design.md`
Plan: `docs/superpowers/plans/2026-06-22-implant-gearset-abilities-D-pr11.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)