### PR TITLE
feat(combat): D-PR12 — self/friendly-side incoming-damage buff fold

### DIFF
--- a/docs/superpowers/plans/2026-06-22-self-side-incoming-buff-fold.md
+++ b/docs/superpowers/plans/2026-06-22-self-side-incoming-buff-fold.md
@@ -278,8 +278,9 @@ Top-of-file imports:
 ```ts
 // add to the triggers import (the line with victimEnemyBuffs):
 import { /* …, */ victimEnemyBuffs, victimSelfBuffs } from './triggers';
-// add to the dpsBuffHelpers import (the line with toEnemyModifiers):
-import { toSimBuffs, toEnemyModifiers, toEnemyDotModifier, toSelfIncomingDamageModifier } from '../calculators/dpsBuffHelpers';
+// add toSelfIncomingDamageModifier to the EXISTING dpsBuffHelpers import line in engine.ts
+// (it currently imports only toEnemyModifiers — do NOT add toSimBuffs/toEnemyDotModifier here):
+import { toEnemyModifiers, toSelfIncomingDamageModifier } from '../calculators/dpsBuffHelpers';
 ```
 
 Rewrite the closure (rename `victimEnemyModifiers` → `victimIncomingModifiers`; keep the existing comment, append a friendly-side note):
@@ -349,6 +350,9 @@ it('composes ADDITIVELY with a D-PR3 incoming-reduction ability (one factor, not
     // incoming = (-30) - 20 = -50 → factor (1 + -50/100) = 0.50.
     // Assert taken ≈ 0.50× baseline — NOT the product 0.70 × 0.80 = 0.56.
     // (Build the D-PR3 ability side from incomingReductionEngine.test.ts.)
+    // NOTE: the SAME victim must carry BOTH simultaneously — one passive-sourced
+    // incoming-reduction ability AND one friendly Inc. Damage Down self-buff status —
+    // for the -50 → 0.50 magnitude to hold.
 });
 ```
 

--- a/docs/superpowers/plans/2026-06-22-self-side-incoming-buff-fold.md
+++ b/docs/superpowers/plans/2026-06-22-self-side-incoming-buff-fold.md
@@ -1,0 +1,442 @@
+# Self-/friendly-side incoming-damage buff fold (D-PR12) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fold friendly-side `Inc. Damage Down/Up` buffs into the per-victim incoming-damage modifier so a self-/ally-buffed ship actually takes less (or more) damage — lighting up Makoli, Salvation, Shelter, Refine, and the D-PR7 Battlecry implant.
+
+**Architecture:** Mirror the existing enemy-side per-victim incoming fold on the friendly side. A new `victimSelfBuffs` reader (a `'self'`-side twin of `victimEnemyBuffs`) returns the victim's own friendly buffs; a new `toSelfIncomingDamageModifier` extractor sums their `incomingDamage`; the engine's per-victim closure (`victimEnemyModifiers` → renamed `victimIncomingModifiers`) adds that term to the same `incomingDamageModifier` that already flows into `victimHitDamage`'s `nonCritFactor`. Team-agnostic (one unified per-victim seam). Direct-damage channel only — incoming-DoT deferred.
+
+**Tech Stack:** TypeScript, Vitest. Pure combat-engine utilities under `src/utils/combat/` and `src/utils/calculators/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-22-self-side-incoming-buff-fold-design.md`
+
+**Base:** branch `feat/combat-d-pr12-self-side-incoming-buff-fold`, worktree `.worktrees/d-pr12-self-incoming-buff-fold`, stacked on D-PR11 tip `e859a75a`.
+
+---
+
+## Critical conventions (read before starting)
+
+- **NEVER run bare `npm test` / `npm test --`** — it launches Vitest in WATCH mode and hangs the agent. Always use `npx vitest run <path-or-name>`.
+- **NEVER run `vitest -u` / `--update`** to "fix" golden/`.snap` mismatches blindly. Golden movement in this PR is EXPECTED but each delta must be **audited** (Task 6) before any snapshot is updated.
+- **Commits trigger a pre-commit hook that runs the full Vitest suite** (slow). Run targeted `npx vitest run` first to confirm green, then commit. Use the commit messages given.
+- Line numbers in this plan are anchored to the D-PR11 base (`e859a75a`) and are approximate — **resolve every reference by symbol name** (grep), not the number.
+- All sign conventions follow enemy-side: `parsedEffects.incomingDamage` negative = less damage taken (`-30` → `×0.70`); positive = more.
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `src/utils/calculators/dpsBuffHelpers.ts` | buff→modifier extractors | + `toSelfIncomingDamageModifier` (mirror of `toEnemyModifiers`'s incoming reducer) |
+| `src/utils/combat/triggers.ts` | per-victim status readers | + `victimSelfBuffs` (mirror of `victimEnemyBuffs`); import `expandBuffEntry` |
+| `src/utils/combat/engine.ts` | per-victim modifier wiring | rename closure `victimEnemyModifiers` → `victimIncomingModifiers`; add self term; add 2 imports |
+| `src/utils/calculators/__tests__/dpsBuffHelpers.selfIncoming.test.ts` | unit | NEW — Task 1 |
+| `src/utils/combat/__tests__/victimSelfBuffs.test.ts` | unit | NEW — Task 2 (mirror `victimEnemyBuffs.test.ts`) |
+| `src/utils/combat/__tests__/selfIncomingBuffFold.integration.test.ts` | engine integration | NEW — Tasks 3–4 (mirror `incomingReductionEngine.test.ts`) |
+| `src/constants/changelog.ts` | user-facing changelog | + UNRELEASED_CHANGES entry — Task 5 |
+
+---
+
+## Task 1: `toSelfIncomingDamageModifier` extractor (pure)
+
+**Files:**
+- Modify: `src/utils/calculators/dpsBuffHelpers.ts` (next to `toEnemyModifiers`, ~line 71)
+- Test: `src/utils/calculators/__tests__/dpsBuffHelpers.selfIncoming.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { toSelfIncomingDamageModifier } from '../dpsBuffHelpers';
+import type { SelectedGameBuff } from '../../../types/calculator';
+
+function buff(incomingDamage: number, stacks = 1): SelectedGameBuff {
+    return {
+        id: `b-${incomingDamage}-${stacks}`,
+        buffName: 'Inc. Damage Down II',
+        stacks,
+        parsedEffects: { incomingDamage },
+        isStackable: false,
+    };
+}
+
+describe('toSelfIncomingDamageModifier', () => {
+    it('returns 0 for an empty list', () => {
+        expect(toSelfIncomingDamageModifier([])).toBe(0);
+    });
+
+    it('sums incomingDamage across buffs', () => {
+        expect(toSelfIncomingDamageModifier([buff(-30), buff(-15)])).toBe(-45);
+    });
+
+    it('multiplies each entry by its stacks', () => {
+        expect(toSelfIncomingDamageModifier([buff(-10, 3)])).toBe(-30);
+    });
+
+    it('preserves sign (Inc. Damage Up = positive)', () => {
+        expect(toSelfIncomingDamageModifier([buff(30)])).toBe(30);
+    });
+
+    it('ignores buffs without an incomingDamage effect', () => {
+        const noEffect: SelectedGameBuff = {
+            id: 'x', buffName: 'Attack Up I', stacks: 1,
+            parsedEffects: { attack: 15 }, isStackable: false,
+        };
+        expect(toSelfIncomingDamageModifier([noEffect])).toBe(0);
+    });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `npx vitest run src/utils/calculators/__tests__/dpsBuffHelpers.selfIncoming.test.ts`
+Expected: FAIL — `toSelfIncomingDamageModifier is not a function`.
+
+- [ ] **Step 3: Implement** (in `dpsBuffHelpers.ts`, directly after `toEnemyModifiers`)
+
+```ts
+/** Sum the self-/friendly-side incoming-DIRECT-damage modifier from a victim's OWN buffs.
+ *  Mirror of toEnemyModifiers' incoming reducer, but for friendly buffs (Inc. Damage Down/Up).
+ *  Negative = less damage taken; positive = more. Summed into the same per-victim
+ *  incomingDamageModifier as enemy-side debuffs (engine victimIncomingModifiers). */
+export function toSelfIncomingDamageModifier(selected: SelectedGameBuff[]): number {
+    return selected.reduce((sum, s) => sum + (s.parsedEffects.incomingDamage ?? 0) * s.stacks, 0);
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `npx vitest run src/utils/calculators/__tests__/dpsBuffHelpers.selfIncoming.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/calculators/dpsBuffHelpers.ts src/utils/calculators/__tests__/dpsBuffHelpers.selfIncoming.test.ts
+git commit -m "feat(combat): D-PR12 — toSelfIncomingDamageModifier extractor"
+```
+
+---
+
+## Task 2: `victimSelfBuffs` reader
+
+A `'self'`-side twin of `victimEnemyBuffs` (`triggers.ts`, ~line 866). Reads the victim's own friendly buffs across three channels: scheduled self-buffs (`snapshot(victimId).activeSelfBuffs` expanded via `selfBuffLookup`), timed ability statuses, and aura/accumulating ability statuses.
+
+**Files:**
+- Modify: `src/utils/combat/triggers.ts` (add function next to `victimEnemyBuffs`; extend the `./buffTotals` import to include `expandBuffEntry`)
+- Test: `src/utils/combat/__tests__/victimSelfBuffs.test.ts` (create — mirror `victimEnemyBuffs.test.ts`)
+
+**Reference:** `src/utils/combat/__tests__/victimEnemyBuffs.test.ts` for the `createStatusEngine` harness and how to apply timed / aura statuses. Self-side equivalents:
+- scheduled self-buff: seed via the engine's `selfBuffLookup` map + a `snapshot(victimId).activeSelfBuffs` entry (see how `selfBuffNamesForOwners` reads them, `triggers.ts` ~795).
+- timed: `applyTimedAbilityStatus` with `side: 'self'` and `ownerId = victimId`.
+- aura/accumulating: `registerAbilityStatuses` with `side: 'self'`, `ownerId = victimId`.
+
+- [ ] **Step 1: Write the failing test**
+
+Mirror `victimEnemyBuffs.test.ts`, but for `victimSelfBuffs(statusEngine, victimId, selfBuffLookup)` with `parsedEffects.incomingDamage` buffs. Cover:
+1. Empty → `[]`.
+2. A timed self-buff with `{ incomingDamage: -30 }` applied to `victimId` is returned (and `toSelfIncomingDamageModifier` of the result is `-30`).
+3. A scheduled self-buff name present in `activeSelfBuffs` is expanded via `selfBuffLookup`.
+4. **Isolation:** an *enemy-side* debuff on the same `victimId` is NOT returned by `victimSelfBuffs` (it reads the `'self'` store only).
+5. **Per-actor:** a self-buff on actor A is NOT returned when querying actor B.
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { createStatusEngine } from '../statusEngine';
+import { victimSelfBuffs } from '../triggers';
+import { toSelfIncomingDamageModifier } from '../../calculators/dpsBuffHelpers';
+import type { SelectedGameBuff } from '../../../types/calculator';
+
+// (Build the harness by copying the helpers from victimEnemyBuffs.test.ts and switching
+//  side 'enemy' → 'self' and the target/owner plumbing per the signatures in statusEngine.ts:
+//    timedAbilityStatuses('self', ownerId)
+//    activeAbilityStatuses('self', () => ctx, ownerId)
+//    snapshot(ownerId).activeSelfBuffs )
+
+function selfIncomingBuff(name: string, incomingDamage: number): SelectedGameBuff {
+    return { id: `t-${name}`, buffName: name, stacks: 1,
+        parsedEffects: { incomingDamage }, isStackable: false };
+}
+
+describe('victimSelfBuffs', () => {
+    it('returns [] when the victim carries no self-buffs', () => {
+        const se = createStatusEngine(/* … */);
+        expect(victimSelfBuffs(se, 'ship-1', new Map())).toEqual([]);
+    });
+
+    it('returns a timed self incoming-damage buff applied to the victim', () => {
+        // apply a timed 'self' status { incomingDamage: -30 } to 'ship-1'
+        const se = createStatusEngine(/* … */);
+        // … applyTimedAbilityStatus(side:'self', ownerId:'ship-1', payload incomingDamage:-30)
+        const result = victimSelfBuffs(se, 'ship-1', new Map());
+        expect(toSelfIncomingDamageModifier(result)).toBe(-30);
+    });
+
+    it('does NOT return enemy-side debuffs on the same victim id', () => {
+        // apply an enemy-side debuff to 'ship-1'; victimSelfBuffs must ignore it
+        const se = createStatusEngine(/* … */);
+        expect(victimSelfBuffs(se, 'ship-1', new Map())).toEqual([]);
+    });
+
+    it('reads scheduled self-buffs via selfBuffLookup', () => {
+        const lookup = new Map([['Inc. Damage Down I', [selfIncomingBuff('Inc. Damage Down I', -15)]]]);
+        const se = createStatusEngine(/* with activeSelfBuffs: [{buffName:'Inc. Damage Down I'}] on ship-1 */);
+        expect(toSelfIncomingDamageModifier(victimSelfBuffs(se, 'ship-1', lookup))).toBe(-15);
+    });
+});
+```
+
+> The implementer fills the harness from `victimEnemyBuffs.test.ts`. Keep the four behaviors above; the exact status-application calls follow that file's patterns.
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `npx vitest run src/utils/combat/__tests__/victimSelfBuffs.test.ts`
+Expected: FAIL — `victimSelfBuffs is not exported`.
+
+- [ ] **Step 3: Implement** (in `triggers.ts`, directly after `victimEnemyBuffs`)
+
+First extend the import at the top of `triggers.ts`:
+```ts
+import { expandEnemyDebuffs, payloadToSelectedBuff, expandBuffEntry } from './buffTotals';
+```
+
+Then add the reader (reuses the file-local `NEUTRAL_NAMES_CTX`):
+```ts
+/** Friendly twin of victimEnemyBuffs: a victim's OWN self-/ally-granted buffs, across all
+ *  three channels — scheduled self-buffs (snapshot(victimId).activeSelfBuffs, expanded via
+ *  selfBuffLookup), timed ability statuses, and aura/accumulating ability statuses. Used by
+ *  the engine's per-victim incoming fold (victimIncomingModifiers) to source friendly
+ *  Inc. Damage Down/Up. Team-agnostic: 'self'-side statuses are keyed by the actor's own id
+ *  (same read used by selfBuffNamesForOwners for either team). The aura/accumulating channel
+ *  carries the same NEUTRAL-ctx approximation noted on victimEnemyBuffs; the live ship sources
+ *  (Makoli/Salvation/Shelter/Refine/Battlecry) are TIMED and not approximated. */
+export function victimSelfBuffs(
+    statusEngine: StatusEngine,
+    victimId: string,
+    selfBuffLookup: Map<string, SelectedGameBuff[]>
+): SelectedGameBuff[] {
+    const scheduled = statusEngine
+        .snapshot(victimId)
+        .activeSelfBuffs.flatMap((ab) => expandBuffEntry(ab, selfBuffLookup.get(ab.buffName) ?? []));
+    const timed = statusEngine
+        .timedAbilityStatuses('self', victimId)
+        .map((s) => payloadToSelectedBuff(s.payload));
+    const active = statusEngine
+        .activeAbilityStatuses('self', () => NEUTRAL_NAMES_CTX, victimId)
+        .map((s) => payloadToSelectedBuff(s.payload));
+    return [...scheduled, ...timed, ...active];
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `npx vitest run src/utils/combat/__tests__/victimSelfBuffs.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/triggers.ts src/utils/combat/__tests__/victimSelfBuffs.test.ts
+git commit -m "feat(combat): D-PR12 — victimSelfBuffs friendly-side per-victim reader"
+```
+
+---
+
+## Task 3: Wire the friendly term into the engine per-victim closure
+
+Extend the per-victim modifier closure so its `incomingDamageModifier` includes the victim's own friendly buffs, summed with enemy-side. This is the behavior-changing step (lights up the sources). TDD via an engine integration test.
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts` — the `victimEnemyModifiers` closure (~line 2826); imports near top (~line 79 `victimEnemyBuffs` from triggers; ~line 21 dpsBuffHelpers)
+- Test: `src/utils/combat/__tests__/selfIncomingBuffFold.integration.test.ts` (create)
+
+**Reference for the integration harness:** `src/utils/combat/__tests__/incomingReductionEngine.test.ts` — D-PR3's engine test that sets up a victim with an incoming-reduction ability and asserts reduced taken damage via `runCombat`. Mirror its two-team / positional setup but give the victim a friendly `Inc. Damage Down` self-buff instead of an incoming-reduction ability.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Set up a `runCombat` where a victim ship carries `Inc. Damage Down II` (`incomingDamage: -30`) as a self-buff and is hit by an opponent. Capture the victim's taken direct damage, and compare against an identical run WITHOUT the buff. Assert the buffed run's taken damage ≈ 0.70× the baseline (allow a small tolerance for rounding).
+
+```ts
+// Pattern (fill plumbing from incomingReductionEngine.test.ts):
+//   const baseline = runCombat(setupWithoutBuff);
+//   const buffed   = runCombat(setupWithInc.DamageDownII_onVictim);
+//   const takenBase = takenDirectDamage(baseline, victimId);
+//   const takenBuff = takenDirectDamage(buffed, victimId);
+//   expect(takenBuff).toBeCloseTo(takenBase * 0.70, /*precision*/ 0);
+//   expect(takenBuff).toBeLessThan(takenBase);
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `npx vitest run src/utils/combat/__tests__/selfIncomingBuffFold.integration.test.ts`
+Expected: FAIL — buffed taken damage equals baseline (buff is currently emit-only).
+
+- [ ] **Step 3: Implement the fold**
+
+Top-of-file imports:
+```ts
+// add to the triggers import (the line with victimEnemyBuffs):
+import { /* …, */ victimEnemyBuffs, victimSelfBuffs } from './triggers';
+// add to the dpsBuffHelpers import (the line with toEnemyModifiers):
+import { toSimBuffs, toEnemyModifiers, toEnemyDotModifier, toSelfIncomingDamageModifier } from '../calculators/dpsBuffHelpers';
+```
+
+Rewrite the closure (rename `victimEnemyModifiers` → `victimIncomingModifiers`; keep the existing comment, append a friendly-side note):
+```ts
+const victimIncomingModifiers = (
+    victimId: string
+): { enemyDefenseModifier: number; incomingDamageModifier: number } => {
+    const enemy = toEnemyModifiers(victimEnemyBuffs(statusEngine, victimId, enemyDebuffLookup));
+    // D-PR12: friendly-side incoming-DIRECT-damage buffs on the victim's OWN 'self' store
+    // (Inc. Damage Down/Up — Makoli/Salvation/Shelter/Refine/Battlecry). Summed into the SAME
+    // per-victim incomingDamageModifier as enemy debuffs. Team-agnostic (victimId keys the
+    // actor's own self store regardless of side). Direct channel only; incoming-DoT deferred.
+    const selfIncoming = toSelfIncomingDamageModifier(
+        victimSelfBuffs(statusEngine, victimId, selfBuffLookup)
+    );
+    return {
+        enemyDefenseModifier: enemy.enemyDefenseModifier,
+        incomingDamageModifier: enemy.incomingDamageModifier + selfIncoming,
+    };
+};
+```
+
+Update the test-tap call to pass the renamed closure (keep the existing field name `__testTapVictimEnemyModifiers` to avoid type/test churn — it now also reflects the friendly term, which is 0 when no self-buffs are present, so existing tap tests stay green):
+```ts
+input.__testTapVictimEnemyModifiers?.(victimIncomingModifiers);
+```
+
+Verify `selfBuffLookup` is in scope here (declared ~line 1403 in the same `runCombat` body, used alongside `enemyDebuffLookup`). It is.
+
+- [ ] **Step 4: Run the new test + the existing per-victim/tap tests, verify they pass**
+
+```bash
+npx vitest run src/utils/combat/__tests__/selfIncomingBuffFold.integration.test.ts \
+  src/utils/combat/__tests__/perVictimDefenseDebuff.test.ts \
+  src/utils/combat/__tests__/victimEnemyBuffs.test.ts \
+  src/utils/combat/__tests__/incomingReductionEngine.test.ts
+```
+Expected: PASS. (Existing tap/per-victim tests carry no friendly self-buffs → friendly term = 0 → unchanged.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/engine.ts src/utils/combat/__tests__/selfIncomingBuffFold.integration.test.ts
+git commit -m "feat(combat): D-PR12 — fold friendly-side incoming-damage buffs per-victim"
+```
+
+---
+
+## Task 4: Team-agnostic mirror + D-PR3 additive composition
+
+Add two more cases to `selfIncomingBuffFold.integration.test.ts` proving (a) the fold works when the buffed victim is an **enemy-side** ship (team-agnostic) and (b) a friendly buff **and** a D-PR3 `incoming-reduction` ability combine **additively within one factor**, not as a product.
+
+**Files:**
+- Modify: `src/utils/combat/__tests__/selfIncomingBuffFold.integration.test.ts`
+
+- [ ] **Step 1: Add the failing/teaching cases**
+
+```ts
+it('reduces incoming damage for a self-buffing ENEMY-side victim (team-agnostic)', () => {
+    // Mirror the Task-3 setup but place the Inc. Damage Down ship on the ENEMY team and
+    // have a player attack it. Assert its taken damage ≈ 0.70× the no-buff baseline.
+});
+
+it('composes ADDITIVELY with a D-PR3 incoming-reduction ability (one factor, not a product)', () => {
+    // Victim carries BOTH: a friendly Inc. Damage Down II (-30) self-buff AND a D-PR3
+    // incoming-reduction ability worth 20% (equipReductionPct = 20).
+    // incoming = (-30) - 20 = -50 → factor (1 + -50/100) = 0.50.
+    // Assert taken ≈ 0.50× baseline — NOT the product 0.70 × 0.80 = 0.56.
+    // (Build the D-PR3 ability side from incomingReductionEngine.test.ts.)
+});
+```
+
+- [ ] **Step 2: Run, verify the enemy-mirror passes immediately** (the seam is already team-agnostic) **and the composition case asserts 0.50, not 0.56.**
+
+Run: `npx vitest run src/utils/combat/__tests__/selfIncomingBuffFold.integration.test.ts`
+Expected: PASS once the composition assertion is written to the additive 0.50 magnitude. If it was written expecting 0.56 (product), it correctly FAILS — fix the assertion to 0.50, the true engine behavior (`victimDamage.ts` combines all incoming terms into one `(1 + incoming/100)`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/combat/__tests__/selfIncomingBuffFold.integration.test.ts
+git commit -m "test(combat): D-PR12 — team-agnostic mirror + additive D-PR3 composition"
+```
+
+---
+
+## Task 5: Golden-churn audit + changelog
+
+The fold lights up real ship sources, so existing goldens may move where one of the five sources is a **victim while buffed**. Audit, don't blindly update.
+
+**Files:**
+- Possibly modify: golden/`.snap` fixtures under `src/**/__tests__/` (only after auditing)
+- Modify: `src/constants/changelog.ts` (`UNRELEASED_CHANGES`)
+
+- [ ] **Step 1: Run the full suite and capture failures**
+
+Run: `npx vitest run 2>&1 | tee /tmp/d-pr12-suite.txt`
+Identify every failing golden/snapshot test.
+
+- [ ] **Step 2: Audit each delta**
+
+For each moved golden, confirm the delta is a **faithful incoming-damage reduction** (a victim that carries `Inc. Damage Down` now takes proportionally less direct damage; `Inc. Damage Up` more). Confirm the victim genuinely carries the buff at the moment of the hit. If any delta is NOT explained by friendly incoming folding, STOP — it's a bug, not churn; investigate before proceeding. Use `superpowers:systematic-debugging` if a delta is unexplained.
+
+- [ ] **Step 3: Update only audited snapshots**
+
+For confirmed-correct deltas, update the specific snapshot files (targeted, e.g. `npx vitest run <file> -u` for that file ONLY after auditing — never a blanket `-u`). Record in the commit body a one-line justification per moved fixture (which ship, which buff, expected ratio).
+
+- [ ] **Step 4: Add the changelog entry** (`UNRELEASED_CHANGES` in `src/constants/changelog.ts`)
+
+Plain-English, e.g.:
+```
+'Combat sim: ships that buff themselves or allies with "Incoming Damage Down" (Makoli, Salvation, Shelter, Refine) — and allies buffed by the Battlecry implant — now actually take reduced direct damage in the simulation.'
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(combat): D-PR12 — audited golden updates + changelog for friendly incoming fold
+
+<one line per moved fixture: ship / buff / ratio>"
+```
+
+---
+
+## Task 6: Final verification gate
+
+- [ ] **Step 1: Full suite green**
+
+Run: `npx vitest run`
+Expected: all green (count = D-PR11 baseline + the new D-PR12 tests).
+
+- [ ] **Step 2: Lint + types**
+
+Run: `npm run lint && npx tsc --noEmit`
+Expected: 0 errors / 0 warnings (ESLint is max-warnings 0).
+
+- [ ] **Step 3: Skill audit unchanged**
+
+Run: `npm run audit:skills`
+Expected: 141 ships, 0 findings (this PR adds no skill-parser changes).
+
+- [ ] **Step 4: Confirm no unintended drift**
+
+Run: `git diff --stat e859a75a..HEAD`
+Confirm only the files in the File-structure table (+ audited goldens) changed.
+
+- [ ] **Step 5: Request code review**
+
+Use `superpowers:requesting-code-review` for a holistic review (focus: team-agnosticism of the fold, additive D-PR3 composition correctness, golden-churn audit completeness, no enemy-side path regression).
+
+---
+
+## Done criteria
+
+- Friendly-side incoming-DIRECT-damage fold live for all five sources, team-agnostic (player & enemy victims).
+- Enemy-side incoming path unchanged (per-victim tap/defense tests still green).
+- D-PR3 composition additive-within-one-factor (proven by test at the 0.50 magnitude).
+- Every golden delta audited and justified; lint/tsc/`audit:skills` clean.
+- Incoming-DoT explicitly out of scope (deferred per spec).

--- a/docs/superpowers/specs/2026-06-22-self-side-incoming-buff-fold-design.md
+++ b/docs/superpowers/specs/2026-06-22-self-side-incoming-buff-fold-design.md
@@ -93,7 +93,7 @@ export function victimSelfBuffs(
     selfBuffLookup: Map<string, SelectedGameBuff[]>
 ): SelectedGameBuff[] {
     const scheduled = expandSelfBuffs(
-        statusEngine.snapshot(undefined, victimId).activeSelfBuffs,
+        statusEngine.snapshot(victimId).activeSelfBuffs, // self-side: owner id is the FIRST arg
         selfBuffLookup
     );
     const timed = statusEngine

--- a/docs/superpowers/specs/2026-06-22-self-side-incoming-buff-fold-design.md
+++ b/docs/superpowers/specs/2026-06-22-self-side-incoming-buff-fold-design.md
@@ -61,13 +61,13 @@ debuffs already on it. Lights up all five sources above. Direct-damage channel o
 ## Team-agnosticism (unification check)
 
 This stays consistent with the bySide-unification campaign. The seam being extended,
-`victimEnemyModifiers(v.id)` (`engine.ts:2657`), is the single team-agnostic per-victim
-read the unification landed — the engine comment at `engine.ts:2679` states it
+`victimEnemyModifiers(v.id)` (`engine.ts:~2826`), is the single team-agnostic per-victim
+read the unification landed — the engine comment beside it states it
 *"works for ENEMY victims (focus/team site) and PLAYER victims (enemy site) alike — both
 store their debuffs keyed by their own id."* The friendly reader uses
 `timedAbilityStatuses('self', victimId)` / `activeAbilityStatuses('self', …, victimId)`,
 which are already called team-agnostically today (e.g. for enemy attackers' own buffs via
-`selfBuffNamesForOwners`, `triggers.ts:688/734`). So a self-buffing ship (e.g. Makoli)
+`selfBuffNamesForOwners`, `triggers.ts:~795`). So a self-buffing ship (e.g. Makoli)
 receives the reduction on **whichever team it fights for** — no player/enemy branch.
 
 The two readers (`victimEnemyBuffs` for the `'enemy'` store, the new `victimSelfBuffs` for
@@ -79,8 +79,12 @@ different side keys on the victim; their results are **summed into one**
 
 ### 1. New reader: `victimSelfBuffs` (triggers.ts)
 
-A friendly twin of `victimEnemyBuffs` (`triggers.ts:805-821`). Reads the victim's **own**
+A friendly twin of `victimEnemyBuffs` (`triggers.ts:~866`). Reads the victim's **own**
 friendly-side statuses across the same three channels, returning `SelectedGameBuff[]`:
+
+> **Line numbers below are anchored to the D-PR11 base (`e859a75a`) and are approximate** —
+> the stack has shifted them. Resolve every reference by **symbol name** (grep), not the
+> number.
 
 ```ts
 export function victimSelfBuffs(
@@ -143,22 +147,46 @@ const victimIncomingModifiers = (victimId: string) => {
 };
 ```
 
-`selfBuffLookup` is already in scope at this site (`engine.ts:1385`). The
-`__testTapVictimEnemyModifiers` test seam (engine.ts:2663) is renamed to match (or kept as
-an alias). Everything downstream (`defenseProfileOf` → `incomingDamageModifierPct` →
+`selfBuffLookup` is already in scope at this site (`engine.ts:~1403`). The
+`__testTapVictimEnemyModifiers` test seam (`engine.ts:~2830`) is renamed to match (or kept
+as an alias). Everything downstream (`defenseProfileOf` → `incomingDamageModifierPct` →
 `victimHitDamage`) is unchanged.
+
+> **Design note — what this path does NOT touch:** the chosen path reads
+> `parsedEffects.incomingDamage` from the victim's own status payloads
+> (`payloadToSelectedBuff` → `toSelfIncomingDamageModifier`). It **deliberately does not** add
+> `incomingDamage` to the `Buff.stat` union, `toSimBuffs`, or `calculateBuffTotals` — those
+> remain enemy-blind to incoming damage by design. A plan author should NOT add union /
+> `calculateBuffTotals` work; it is unnecessary and would mis-attribute the modifier to the
+> attacker's turn context instead of the victim.
 
 ### 4. Composition with D-PR3 `incoming-reduction`
 
 D-PR3's conditional incoming reduction is **ability-config-sourced** (the
-`incoming-reduction` AbilityConfig, applied via `incomingEffects.ts` as a separate factor in
-`positionalApply.ts`). This PR's fold is **buff-status-sourced** (reads
-`parsedEffects.incomingDamage` from status payloads). The two read **disjoint** sources, so:
+`incoming-reduction` AbilityConfig, applied via `incomingEffects.ts`). This PR's fold is
+**buff-status-sourced** (reads `parsedEffects.incomingDamage` from status payloads). The two
+read **disjoint** sources — `victimSelfBuffs` never sees D-PR3 ability configs (they are not
+buff statuses carrying `incomingDamage`), so there is no double-count.
 
-- No double-count: `victimSelfBuffs` never sees D-PR3 ability configs (they are not buff
-  statuses carrying `incomingDamage`).
-- They stack as separate factors (D-PR3 reduction × this `(1 + incoming/100)`), which is
-  the correct in-game behavior for distinct sources. A composition test pins this.
+**They combine ADDITIVELY within a single damage factor — NOT as a product.** In
+`victimHitDamage` (`victimDamage.ts:100-107`) all incoming terms land in one `incoming`
+scalar before a single `(1 + incoming/100)` multiply:
+
+```ts
+const incoming =
+    (v.incomingDamageModifierPct ?? s.incomingDamageModifierPct)  // ← enemy debuffs + NEW friendly buffs
+    - equipReductionPct;                                          // ← D-PR3 ability reduction
+const nonCritFactor = (1 - damageReduction/100) * (1 + s.outgoingDamageBuffPct/100)
+    * (1 + incoming/100) * affinityMult;
+```
+
+So a `-30%` friendly buff + a `20%` D-PR3 reduction give
+`(1 + (-30 - 20)/100) = 0.50` — **not** the product `0.70 × 0.80 = 0.56`. The new friendly
+term feeds `v.incomingDamageModifierPct` (alongside enemy-side incoming), and D-PR3's
+`equipReductionPct` is subtracted from the same `incoming` scalar. The composition test
+(Testing #3) must assert this additive-within-one-factor magnitude, not a product. This
+additive model is the existing engine behavior and is left unchanged (a true product would
+be out-of-scope and golden-churning).
 
 ## Affected files
 
@@ -190,12 +218,14 @@ running the suite; audit each delta as a faithful incoming-damage reduction. Bot
    without the buff (magnitude proof). Mirror on the enemy side (a self-buffing enemy ship)
    to prove team-agnosticism.
 3. **Composition**: a victim with both a D-PR3 `incoming-reduction` ability and a friendly
-   `Inc. Damage Down` buff → assert both factors apply (product), not one or double.
+   `Inc. Damage Down` buff → assert both terms apply **additively within one factor** (e.g.
+   `-30%` buff + `20%` D-PR3 → `(1 + (-30-20)/100) = 0.50`), NOT a product (`0.56`) and NOT
+   one-or-double.
 4. **Coverage / regression**: full suite green; audit and document every golden delta.
 
 ## Acceptance
 
 - Direct-damage friendly incoming fold live for all five sources, team-agnostic.
-- D-PR3 composition correct (no double-count, factors stack).
+- D-PR3 composition correct (no double-count; additive within one `(1 + incoming/100)` factor).
 - All golden deltas audited and explained; lint/tsc/`audit:skills` clean.
 - Incoming-DoT explicitly deferred with rationale recorded.

--- a/docs/superpowers/specs/2026-06-22-self-side-incoming-buff-fold-design.md
+++ b/docs/superpowers/specs/2026-06-22-self-side-incoming-buff-fold-design.md
@@ -1,0 +1,201 @@
+# Self-/friendly-side incoming-damage buff fold (D-PR12)
+
+**Date:** 2026-06-22
+**Sub-project:** D (new ability sources / cross-cutting folds) — combat-realism epic
+**Status:** spec — direct-damage half only; incoming-DoT deferred
+
+## Problem
+
+Friendly-side incoming-damage buffs (the `Inc. Damage Down` / `Inc. Damage Up` I/II/III
+family — `±15/30/45% Incoming Direct Damage`) are parsed and **applied as statuses**, but
+their stat effect is never folded into the damage a victim takes. They are emit-only.
+
+- `buffParser.ts:49` already extracts `parsedEffects.incomingDamage` for these buffs.
+- But `toSimBuffs` (`dpsBuffHelpers.ts`) has **no** `incomingDamage` branch, and
+  `incomingDamage` is **not** in the `Buff.stat` union (`calculator.ts:62-74`) or
+  `calculateBuffTotals` (`buffTotals.ts`). The channel is consumed only by
+  `toEnemyModifiers` (`dpsBuffHelpers.ts:71`), which is called **only for enemy-side
+  debuffs**. So a victim's own friendly incoming buff is dropped.
+
+This is the documented reason D-PR7's **Battlecry** implant (`Inc. Damage Down II` to all
+allies on death) is emit-only, and why these ship sources have no effect today:
+
+| Source | Slot | Grant |
+| --- | --- | --- |
+| Makoli | active | self `Inc. Damage Down II`, 2 turns |
+| Salvation | active | self `Inc. Damage Down II`, 2 turns |
+| Shelter | passive (HP < 20%, once/battle) | self `Inc. Damage Down II`, 3 turns |
+| Refine | passive (ally directly damaged) | ally `Inc. Damage Down I`, 1–2 turns |
+| Battlecry (implant, D-PR7) | on-death | all-allies `Inc. Damage Down II`, 1–3 turns |
+
+**Enemy-side incoming buffs already fold correctly**, per-victim, via
+`victimEnemyModifiers(victimId)` → `incomingDamageModifierPct` →
+`(1 + incoming/100)` in `victimHitDamage`'s `nonCritFactor` (`victimDamage.ts:101`). This
+PR adds the missing **friendly-side** term to that **same per-victim seam**.
+
+## Goal
+
+When an actor is the victim of a hit, fold its **own** friendly-side `incomingDamage`
+buffs into the per-victim incoming-damage modifier, summed with any enemy-side incoming
+debuffs already on it. Lights up all five sources above. Direct-damage channel only.
+
+## Non-goals / deferred
+
+- **Incoming-DoT (`incomingDotDamage`) is deferred entirely.** No corpus source grants a
+  friendly incoming-DoT buff, so it would be dormant machinery. More importantly, the
+  enemy-side incoming-DoT is **applier-sourced** (frozen into `ctx.dotMult` at apply,
+  read at tick via `ctxFor(e.sourceId)` in `tickDoTs`, `engine.ts:735/748`), whereas a
+  friendly victim's incoming-DoT-down is naturally **victim-sourced at tick time**.
+  Introducing a friendly tick-time term now would create a dual mechanism for one concept.
+  Defer until a real friendly incoming-DoT source exists **and** we can unify both channels
+  onto a single victim-sourced DoT-incoming model in one PR.
+- The **aggregate scalar path** (`playerTurn.ts:1298`, the attacker-fixed `directDamage`
+  number) is **not** modified. It is the DPS-calc single-dummy case; the dummy carries no
+  friendly self-buffs, and in real two-team combat `battleSimulator` threads positions on
+  both sides so every actor's intake runs the per-victim path. Consistent with the existing
+  enemy-side per-victim/scalar split (per-victim already supersedes the scalar for
+  defense/incoming sourcing).
+- No buff-lifecycle changes. Grant, duration decrement, family-overwrite, cleanse/expiry
+  are all unchanged — these statuses already apply; we only start reading their effect.
+
+## Team-agnosticism (unification check)
+
+This stays consistent with the bySide-unification campaign. The seam being extended,
+`victimEnemyModifiers(v.id)` (`engine.ts:2657`), is the single team-agnostic per-victim
+read the unification landed — the engine comment at `engine.ts:2679` states it
+*"works for ENEMY victims (focus/team site) and PLAYER victims (enemy site) alike — both
+store their debuffs keyed by their own id."* The friendly reader uses
+`timedAbilityStatuses('self', victimId)` / `activeAbilityStatuses('self', …, victimId)`,
+which are already called team-agnostically today (e.g. for enemy attackers' own buffs via
+`selfBuffNamesForOwners`, `triggers.ts:688/734`). So a self-buffing ship (e.g. Makoli)
+receives the reduction on **whichever team it fights for** — no player/enemy branch.
+
+The two readers (`victimEnemyBuffs` for the `'enemy'` store, the new `victimSelfBuffs` for
+the `'self'` store) exist only because the two status families are physically filed under
+different side keys on the victim; their results are **summed into one**
+`incomingDamageModifier`, so the fold is unified at the point of use.
+
+## Design
+
+### 1. New reader: `victimSelfBuffs` (triggers.ts)
+
+A friendly twin of `victimEnemyBuffs` (`triggers.ts:805-821`). Reads the victim's **own**
+friendly-side statuses across the same three channels, returning `SelectedGameBuff[]`:
+
+```ts
+export function victimSelfBuffs(
+    statusEngine: StatusEngine,
+    victimId: string,
+    selfBuffLookup: Map<string, SelectedGameBuff[]>
+): SelectedGameBuff[] {
+    const scheduled = expandSelfBuffs(
+        statusEngine.snapshot(undefined, victimId).activeSelfBuffs,
+        selfBuffLookup
+    );
+    const timed = statusEngine
+        .timedAbilityStatuses('self', victimId)
+        .map((s) => payloadToSelectedBuff(s.payload));
+    const active = statusEngine
+        .activeAbilityStatuses('self', () => NEUTRAL_NAMES_CTX, victimId)
+        .map((s) => payloadToSelectedBuff(s.payload));
+    return [...scheduled, ...timed, ...active];
+}
+```
+
+- The **timed + active** ability-status channels are load-bearing for the five live
+  sources (all are dynamically granted statuses carrying `parsedEffects`).
+- The **scheduled** channel mirrors `victimEnemyBuffs`'s scheduled read for parity (covers
+  manually-configured DPS-calc self-buffs). `expandSelfBuffs` is the self-side analog of
+  `expandEnemyDebuffs` (`buffTotals.ts:74`) — both can share the generic `expandBuffEntry`.
+  Use the existing `selfBuffLookup` map (`engine.ts:1385`).
+- Same approximation note as `victimEnemyBuffs` applies to the aura/accumulating `active`
+  channel (NEUTRAL ctx, no per-round re-roll). The five live sources are **timed** (durations
+  in turns), which is **not** approximated.
+
+### 2. New modifier extractor (dpsBuffHelpers.ts)
+
+Mirror of `toEnemyModifiers`, but only the incoming-damage scalar (defense is enemy-only):
+
+```ts
+export function toSelfIncomingDamageModifier(selected: SelectedGameBuff[]): number {
+    return selected.reduce((sum, s) => sum + (s.parsedEffects.incomingDamage ?? 0) * s.stacks, 0);
+}
+```
+
+Sign convention matches enemy-side: negative = less damage taken (`-30` → `×0.70`),
+positive = more. Summing into the same `incomingDamageModifier` "just works".
+
+### 3. Fold site (engine.ts)
+
+Extend the per-victim closure (`engine.ts:2657-2660`); rename `victimEnemyModifiers` →
+`victimIncomingModifiers` to reflect that it now aggregates both sources:
+
+```ts
+const victimIncomingModifiers = (victimId: string) => {
+    const enemy = toEnemyModifiers(victimEnemyBuffs(statusEngine, victimId, enemyDebuffLookup));
+    const selfIncoming = toSelfIncomingDamageModifier(
+        victimSelfBuffs(statusEngine, victimId, selfBuffLookup)
+    );
+    return {
+        enemyDefenseModifier: enemy.enemyDefenseModifier,
+        incomingDamageModifier: enemy.incomingDamageModifier + selfIncoming,
+    };
+};
+```
+
+`selfBuffLookup` is already in scope at this site (`engine.ts:1385`). The
+`__testTapVictimEnemyModifiers` test seam (engine.ts:2663) is renamed to match (or kept as
+an alias). Everything downstream (`defenseProfileOf` → `incomingDamageModifierPct` →
+`victimHitDamage`) is unchanged.
+
+### 4. Composition with D-PR3 `incoming-reduction`
+
+D-PR3's conditional incoming reduction is **ability-config-sourced** (the
+`incoming-reduction` AbilityConfig, applied via `incomingEffects.ts` as a separate factor in
+`positionalApply.ts`). This PR's fold is **buff-status-sourced** (reads
+`parsedEffects.incomingDamage` from status payloads). The two read **disjoint** sources, so:
+
+- No double-count: `victimSelfBuffs` never sees D-PR3 ability configs (they are not buff
+  statuses carrying `incomingDamage`).
+- They stack as separate factors (D-PR3 reduction × this `(1 + incoming/100)`), which is
+  the correct in-game behavior for distinct sources. A composition test pins this.
+
+## Affected files
+
+| File | Change |
+| --- | --- |
+| `src/utils/combat/triggers.ts` | + `victimSelfBuffs` (+ `expandSelfBuffs` helper if not generalizing `expandEnemyDebuffs`) |
+| `src/utils/calculators/dpsBuffHelpers.ts` | + `toSelfIncomingDamageModifier` |
+| `src/utils/combat/engine.ts` | extend `victimEnemyModifiers` → `victimIncomingModifiers`, thread `selfBuffLookup`; rename test tap |
+| `src/utils/combat/buffTotals.ts` | (maybe) export `expandBuffEntry` / `expandSelfBuffs` for self-side reuse |
+| tests | `victimSelfBuffs` unit; `runCombat` integration (victim with Inc. Damage Down → reduced incoming direct damage, magnitude proof); composition with D-PR3 |
+| `src/constants/changelog.ts` | UNRELEASED_CHANGES entry |
+
+## Golden churn
+
+Expected and accepted (audited). Movement is bounded to fixtures where one of the five
+sources is a **victim while carrying** an `Inc. Damage Down` buff — i.e. two-team /
+positional / healing fixtures, not attacker-focused DPS goldens (where these ships, if
+present, are dealing damage and their self-buff has no intake to reduce). Enumerate by
+running the suite; audit each delta as a faithful incoming-damage reduction. Both `Down`
+(reduction) and `Up` (amplification) signs fold.
+
+## Testing
+
+1. **Unit — `victimSelfBuffs`**: mirror `victimEnemyBuffs.test.ts`. Assert it reads timed +
+   active + scheduled `'self'` statuses for a victim id and that
+   `toSelfIncomingDamageModifier` sums `incomingDamage × stacks` with correct sign.
+2. **Integration — direct fold**: `runCombat` two-team setup where a victim carries
+   `Inc. Damage Down II`; assert its incoming direct damage is reduced ~30% vs the same hit
+   without the buff (magnitude proof). Mirror on the enemy side (a self-buffing enemy ship)
+   to prove team-agnosticism.
+3. **Composition**: a victim with both a D-PR3 `incoming-reduction` ability and a friendly
+   `Inc. Damage Down` buff → assert both factors apply (product), not one or double.
+4. **Coverage / regression**: full suite green; audit and document every golden delta.
+
+## Acceptance
+
+- Direct-damage friendly incoming fold live for all five sources, team-agnostic.
+- D-PR3 composition correct (no double-count, factors stack).
+- All golden deltas audited and explained; lint/tsc/`audit:skills` clean.
+- Incoming-DoT explicitly deferred with rationale recorded.

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -6,6 +6,7 @@ export const CURRENT_VERSION = '1.64.0';
 // CHANGELOG (with the new version + today's date), clear this array back to [],
 // and bump CURRENT_VERSION. All three steps must happen together.
 export const UNRELEASED_CHANGES: string[] = [
+    'Combat simulator: ships that grant themselves or allies Incoming Damage Down (Makoli, Salvation, Shelter, Refine) — and allies buffed by the Battlecry implant on death — now actually take reduced direct damage. Previously the buff appeared in the log but had no effect on damage taken.',
     'Combat simulator: lifesteal/leech (heal or shield from damage dealt or taken) now works per ship — each ship heals or shields itself off its own damage, and AoE splash leeches off the reduced (covered-cell) splash damage.',
     'Combat simulator: area-of-effect purge skills now remove buffs from every enemy they hit, not just the primary target.',
     "Combat simulator: Amartya's charge purge now scales with crit power — it removes 1 buff for every 50% crit power (so higher crit power purges more buffs), applied to every enemy hit.",

--- a/src/utils/calculators/__tests__/dpsBuffHelpers.selfIncoming.test.ts
+++ b/src/utils/calculators/__tests__/dpsBuffHelpers.selfIncoming.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { toSelfIncomingDamageModifier } from '../dpsBuffHelpers';
+import type { SelectedGameBuff } from '../../../types/calculator';
+
+function buff(incomingDamage: number, stacks = 1): SelectedGameBuff {
+    return {
+        id: `b-${incomingDamage}-${stacks}`,
+        buffName: 'Inc. Damage Down II',
+        stacks,
+        parsedEffects: { incomingDamage },
+        isStackable: false,
+    };
+}
+
+describe('toSelfIncomingDamageModifier', () => {
+    it('returns 0 for an empty list', () => {
+        expect(toSelfIncomingDamageModifier([])).toBe(0);
+    });
+
+    it('sums incomingDamage across buffs', () => {
+        expect(toSelfIncomingDamageModifier([buff(-30), buff(-15)])).toBe(-45);
+    });
+
+    it('multiplies each entry by its stacks', () => {
+        expect(toSelfIncomingDamageModifier([buff(-10, 3)])).toBe(-30);
+    });
+
+    it('preserves sign (Inc. Damage Up = positive)', () => {
+        expect(toSelfIncomingDamageModifier([buff(30)])).toBe(30);
+    });
+
+    it('ignores buffs without an incomingDamage effect', () => {
+        const noEffect: SelectedGameBuff = {
+            id: 'x',
+            buffName: 'Attack Up I',
+            stacks: 1,
+            parsedEffects: { attack: 15 },
+            isStackable: false,
+        };
+        expect(toSelfIncomingDamageModifier([noEffect])).toBe(0);
+    });
+});

--- a/src/utils/calculators/dpsBuffHelpers.ts
+++ b/src/utils/calculators/dpsBuffHelpers.ts
@@ -90,6 +90,14 @@ export function toEnemyModifiers(selected: SelectedGameBuff[]): {
     };
 }
 
+/** Sum the self-/friendly-side incoming-DIRECT-damage modifier from a victim's OWN buffs.
+ *  Mirror of toEnemyModifiers' incoming reducer, but for friendly buffs (Inc. Damage Down/Up).
+ *  Negative = less damage taken; positive = more. Summed into the same per-victim
+ *  incomingDamageModifier as enemy-side debuffs (engine victimIncomingModifiers, D-PR12). */
+export function toSelfIncomingDamageModifier(selected: SelectedGameBuff[]): number {
+    return selected.reduce((sum, s) => sum + (s.parsedEffects.incomingDamage ?? 0) * s.stacks, 0);
+}
+
 export function toDotAndPenModifiers(
     attacker: SelectedGameBuff[],
     enemy: SelectedGameBuff[]

--- a/src/utils/combat/__tests__/selfIncomingBuffFold.integration.test.ts
+++ b/src/utils/combat/__tests__/selfIncomingBuffFold.integration.test.ts
@@ -372,13 +372,18 @@ function makeVoidshadePiece(): GearPiece {
 }
 
 /** legendary Voidshade passive slot: -20% incoming direct damage while stealthed. */
-function voidshadePassiveSlot(): ShipSkills['slots'][number] | undefined {
+function voidshadePassiveSlot(): ShipSkills['slots'][number] {
     const ship = makeShipForVoidshade('voidshade-ship');
     const piece = makeVoidshadePiece();
     const skills = buildShipAbilitiesWithEquipment(ship, (gearId) =>
         gearId === 'voidshade-piece' ? piece : undefined
     );
-    return skills.slots.find((s) => s.slot === 'passive');
+    const slot = skills.slots.find((s) => s.slot === 'passive');
+    // Fail loudly rather than silently degrade: if VOIDSHADE ever stops emitting a passive
+    // slot, the Case B "both effects" assertion would become a false-pass (only the friendly
+    // buff would apply, and a product model would survive too). Guard against that.
+    if (!slot) throw new Error('VOIDSHADE legendary should always produce a passive slot');
+    return slot;
 }
 
 /** Active slot that self-casts BOTH Stealth (to gate Voidshade) and Inc. Damage Down II (-30%). */
@@ -606,5 +611,19 @@ describe('D-PR12 Task 4 Case B — additive composition with D-PR3 incoming-redu
                 'victim-cb'
             )
         ).toBe(true);
+    });
+
+    it('NO reductions → full 5000 damage (dies at hp=2650, survives at hp=5001)', () => {
+        // Baseline pin: with neither term, incoming = 0 → taken = 5000 (no floor/cap surprise).
+        expect(
+            destroyedIds(run(2650, { voidshade: false, stealth: false, incDmgDown: false })).has(
+                'victim-cb'
+            )
+        ).toBe(true);
+        expect(
+            destroyedIds(run(5001, { voidshade: false, stealth: false, incDmgDown: false })).has(
+                'victim-cb'
+            )
+        ).toBe(false);
     });
 });

--- a/src/utils/combat/__tests__/selfIncomingBuffFold.integration.test.ts
+++ b/src/utils/combat/__tests__/selfIncomingBuffFold.integration.test.ts
@@ -21,6 +21,9 @@ import { createEventBus } from '../events';
 import { ShipSkills, Ability } from '../../../types/abilities';
 import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
 import type { Position } from '../../../types/encounters';
+import { buildShipAbilitiesWithEquipment } from '../../abilities/buildShipAbilitiesWithEquipment';
+import { Ship } from '../../../types/ship';
+import { GearPiece } from '../../../types/gear';
 
 type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
 type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
@@ -234,5 +237,374 @@ describe('D-PR12 Task 3 — friendly-side Inc. Damage Down folds into per-victim
         expect(destroyedIds(run(3500, true)).has('victim')).toBe(true);
         // Survives at hp=3501.
         expect(destroyedIds(run(3501, true)).has('victim')).toBe(false);
+    });
+});
+
+// ── Case A helpers ────────────────────────────────────────────────────────────
+
+/**
+ * A positioned player ATTACKER (focus 'attacker') that fires a 100% single-hit at the
+ * front enemy. attack 5000 × 100% vs defence 0 → 5000 raw damage. The focus position +
+ * target + pattern triggers the positional path (drivePositionalApply → applyPositionalDamage
+ * → victimHitDamage with the enemy's victimIncomingModifiers).
+ */
+const playerAttackerBase = (speed: number): Partial<CombatEngineInput> => ({
+    attack: 5000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: {
+        slots: [
+            {
+                slot: 'active',
+                abilities: [
+                    {
+                        id: 'focus-hit',
+                        type: 'damage',
+                        target: 'enemy',
+                        trigger: 'on-cast',
+                        conditions: [],
+                        config: { type: 'damage', multiplier: 100 },
+                    },
+                ],
+            },
+        ],
+    } as ShipSkills,
+    speed,
+    position: 'M4' as Position,
+    target: { raw: 'front', side: 'enemy', selection: 'front' } as ParsedTarget,
+    pattern: { raw: 'base', shape: 'base', range: 0, modifiers: {} } as ParsedPattern,
+    hp: 1_000_000_000, // immortal — damage direction is player→enemy for this case
+    defence: 0,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    healTargetId: 'attacker',
+});
+
+/**
+ * A positioned ENEMY actor that, on its own turn, grants itself Inc. Damage Down II (-30%).
+ * It ALSO fires a harmless damage hit at the player (attack 1 — does not kill the immortal focus).
+ * speed: when high (e.g. 2000 > focus 1000), it acts FIRST and the self-buff is active when the
+ * focus fires at it. When low (e.g. 1 < focus 1000), the focus fires BEFORE the enemy self-buffs →
+ * the buff is NOT active at hit time → the full 5000 lands.
+ */
+const selfBuffingEnemy = (
+    id: string,
+    position: Position,
+    hp: number,
+    speed: number
+): EnemyAttacker =>
+    ({
+        id,
+        stats: {
+            attack: 1, // negligible against immortal focus
+            crit: 0,
+            critDamage: 0,
+            defence: 0,
+            hp,
+            speed,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: { raw: 'front', side: 'enemy', selection: 'front' } as ParsedTarget,
+        pattern: { raw: 'base', shape: 'base', range: 0, modifiers: {} } as ParsedPattern,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        // Self-buff fires first on this actor's own turn.
+                        incDamageDownSelfBuff(`${id}-inc-dmg-down`),
+                        // Trivial damage at the player (does not kill immortal focus).
+                        {
+                            id: `${id}-dmg`,
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 1 },
+                        },
+                    ],
+                },
+            ],
+        } as ShipSkills,
+    }) as EnemyAttacker;
+
+// ── Case B helpers ────────────────────────────────────────────────────────────
+
+function makeShipForVoidshade(id: string): Ship {
+    return {
+        id,
+        name: 'Test Victim',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'DEFENDER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: { implant_major: 'voidshade-piece' },
+        refits: [],
+    } as Ship;
+}
+
+function makeVoidshadePiece(): GearPiece {
+    return {
+        id: 'voidshade-piece',
+        slot: 'implant_major',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: 'VOIDSHADE',
+    } as GearPiece;
+}
+
+/** legendary Voidshade passive slot: -20% incoming direct damage while stealthed. */
+function voidshadePassiveSlot(): ShipSkills['slots'][number] | undefined {
+    const ship = makeShipForVoidshade('voidshade-ship');
+    const piece = makeVoidshadePiece();
+    const skills = buildShipAbilitiesWithEquipment(ship, (gearId) =>
+        gearId === 'voidshade-piece' ? piece : undefined
+    );
+    return skills.slots.find((s) => s.slot === 'passive');
+}
+
+/** Active slot that self-casts BOTH Stealth (to gate Voidshade) and Inc. Damage Down II (-30%). */
+const stealthAndIncDmgDownActive = (id: string): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: `${id}-stealth`,
+            type: 'buff',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [],
+            config: {
+                type: 'buff',
+                buffName: 'Stealth',
+                parsedEffects: {},
+                stacks: 1,
+                isStackable: false,
+                duration: 99,
+            },
+        },
+        incDamageDownSelfBuff(`${id}-inc-dmg-down`),
+    ],
+});
+
+/** Active slot that self-casts Stealth ONLY (gates Voidshade; no Inc. Damage Down). */
+const stealthOnlyActive = (id: string): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: `${id}-stealth`,
+            type: 'buff',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [],
+            config: {
+                type: 'buff',
+                buffName: 'Stealth',
+                parsedEffects: {},
+                stacks: 1,
+                isStackable: false,
+                duration: 99,
+            },
+        },
+    ],
+});
+
+/**
+ * Build a player victim for Case B:
+ *   - passive: optional Voidshade slot (20% reduction while stealthed)
+ *   - active:  depends on opts (stealth only / inc-dmg-down only / both)
+ */
+const caseB_victim = (
+    hp: number,
+    opts: { voidshade: boolean; stealth: boolean; incDmgDown: boolean }
+): TeamActor => {
+    let activeSlot: ShipSkills['slots'][number];
+    if (opts.stealth && opts.incDmgDown) {
+        activeSlot = stealthAndIncDmgDownActive('victim-cb');
+    } else if (opts.stealth) {
+        activeSlot = stealthOnlyActive('victim-cb');
+    } else if (opts.incDmgDown) {
+        activeSlot = {
+            slot: 'active',
+            abilities: [incDamageDownSelfBuff('victim-cb-inc-dmg-down')],
+        };
+    } else {
+        activeSlot = noopActive;
+    }
+
+    const passive = opts.voidshade ? voidshadePassiveSlot() : undefined;
+    return {
+        id: 'victim-cb',
+        speed: 1000, // acts BEFORE enemy (speed 1) so both buffs are up when the hit lands
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position: 'M4' as Position,
+        walk: {
+            shipSkills: { slots: [activeSlot, ...(passive ? [passive] : [])] },
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    };
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Case A: team-agnostic — the fold works when the ENEMY is the victim
+// ─────────────────────────────────────────────────────────────────────────────
+describe('D-PR12 Task 4 Case A — enemy-side victim: Inc. Damage Down fold is team-agnostic', () => {
+    /**
+     * Focus 'attacker' (attack 5000, speed 1000) fires positionally at the front enemy.
+     * The enemy is the sole enemy-side actor at position M4 (the front-most enemy).
+     *
+     * Two enemy speed variants:
+     *   - speed 2000 → enemy acts BEFORE focus: self-buffs Inc. Damage Down II (-30%) on
+     *     its own turn, THEN the focus fires. Buff is active → landed = 3500.
+     *   - speed 1 → enemy acts AFTER focus: focus fires BEFORE self-buff, so the buff is
+     *     NOT active at hit time → full 5000 lands.
+     *
+     * HP bracket: 4000 → dies on full 5000 (unbuffed); survives on reduced 3500 (buffed).
+     * This proves victimIncomingModifiers(v.id) folds friendly self-buffs regardless of
+     * which side v.id belongs to (direction-agnostic timed-ability status key).
+     */
+    const run = (enemyHp: number, enemyActsFirst: boolean): CombatEngineInput => ({
+        ...BASE({}),
+        ...playerAttackerBase(1000),
+        enemyAttackers: [
+            selfBuffingEnemy(
+                'enemy-sb',
+                'M4',
+                enemyHp,
+                enemyActsFirst ? 2000 : 1 // 2000 > focus speed 1000 → acts first
+            ),
+        ],
+    });
+
+    it('baseline: without early self-buff the enemy takes full 5000 and dies at hp=4000', () => {
+        // Enemy speed=1 → focus (speed 1000) fires BEFORE enemy self-buffs.
+        // Full 5000 > 4000 → dies.
+        expect(destroyedIds(run(4000, false)).has('enemy-sb')).toBe(true);
+        // At hp=5001 it survives (5000 < 5001), confirming the damage cap is 5000.
+        expect(destroyedIds(run(5001, false)).has('enemy-sb')).toBe(false);
+    });
+
+    it('WITH early self-buff the enemy takes 3500 and survives at hp=4000 (enemy-side fold)', () => {
+        // Enemy speed=2000 → enemy self-buffs BEFORE the focus fires.
+        // victimIncomingModifiers('enemy-sb') folds the self-buff → landed = 3500 < 4000 → survives.
+        // (If the fold were player-only, the full 5000 would land → the enemy would die here.)
+        expect(destroyedIds(run(4000, true)).has('enemy-sb')).toBe(false);
+    });
+
+    it('WITH early self-buff the enemy dies at hp=3500 (pinned to 3500 taken)', () => {
+        // Reduced 3500 = 3500 → exactly kills at hp=3500.
+        expect(destroyedIds(run(3500, true)).has('enemy-sb')).toBe(true);
+        // Survives at hp=3501.
+        expect(destroyedIds(run(3501, true)).has('enemy-sb')).toBe(false);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Case B: additive D-PR3 composition — NOT a product
+// ─────────────────────────────────────────────────────────────────────────────
+describe('D-PR12 Task 4 Case B — additive composition with D-PR3 incoming-reduction', () => {
+    /**
+     * Composition model (victimDamage.ts lines ~100-107):
+     *
+     *   incoming = (v.incomingDamageModifierPct ?? s.incomingDamageModifierPct) - equipReductionPct;
+     *   nonCritFactor = (1 - damageReduction/100)
+     *                 * (1 + s.outgoingDamageBuffPct/100)
+     *                 * (1 + incoming/100)       ← ONE scalar factor
+     *                 * affinityMult;
+     *
+     * D-PR12 friendly buff (-30) and D-PR3 Voidshade equipment reduction (20) BOTH land in the
+     * SAME `incoming` scalar, subtracted together before the multiply:
+     *
+     *   incoming = (-30) - 20 = -50  →  nonCritFactor ∋ (1 + -50/100) = 0.50  →  taken = 2500
+     *
+     * ADDITIVE (correct) vs. PRODUCT (wrong — the product would be wrong because there's
+     * literally one factor in the formula):
+     *   additive:  5000 × (1 + (-30 - 20)/100) = 5000 × 0.50 = 2500
+     *   product:   5000 × (1 - 0.30) × (1 - 0.20) = 5000 × 0.70 × 0.80 = 2800
+     *
+     * Discriminating hp = 2650:
+     *   - additive 2500 < 2650 → SURVIVES (correct)
+     *   - product  2800 > 2650 → would DIE (wrong)
+     *
+     * Sub-assertions prove BOTH terms are required: with ONLY one effect the victim still
+     * dies at hp=2650 (4000 > 2650 and 3500 > 2650), so only the additive sum (2500 < 2650)
+     * allows survival — pinning the additive-within-one-factor behavior.
+     *
+     * Voidshade legendary = 20% incoming-direct reduction WHILE STEALTHED.
+     * The victim self-casts Stealth (duration 99) to gate the Voidshade reduction; this is
+     * identical to the D-PR3 Task 6 harness (incomingReductionEngine.test.ts).
+     */
+    const run = (
+        hp: number,
+        opts: { voidshade: boolean; stealth: boolean; incDmgDown: boolean }
+    ): CombatEngineInput =>
+        BASE({
+            teamActors: [caseB_victim(hp, opts)],
+            enemyAttackers: [offensiveEnemy('enemy-cb', 'M1', 'front')],
+        });
+
+    it('BOTH D-PR3 (Voidshade 20%) AND Inc. Damage Down II (-30%) → survives at hp=2650 (additive 2500 < 2650)', () => {
+        // Additive: incoming = -30 - 20 = -50 → taken = 5000 × 0.50 = 2500 < 2650 → SURVIVES.
+        // Product model (wrong): 5000 × 0.70 × 0.80 = 2800 > 2650 → would die — survival here
+        // discriminates ADDITIVE from product and proves (1 + incoming/100) is one factor.
+        expect(
+            destroyedIds(run(2650, { voidshade: true, stealth: true, incDmgDown: true })).has(
+                'victim-cb'
+            )
+        ).toBe(false);
+    });
+
+    it('ONLY D-PR3 Voidshade (20%, no Inc. Damage Down) → dies at hp=2650 (4000 > 2650)', () => {
+        // Without Inc. Damage Down: incoming = 0 - 20 = -20 → taken = 5000 × 0.80 = 4000.
+        // 4000 > 2650 → DIES. Proves the D-PR3 term alone is insufficient to clear 2650.
+        expect(
+            destroyedIds(run(2650, { voidshade: true, stealth: true, incDmgDown: false })).has(
+                'victim-cb'
+            )
+        ).toBe(true);
+    });
+
+    it('ONLY Inc. Damage Down II (-30%, no Voidshade/stealth) → dies at hp=2650 (3500 > 2650)', () => {
+        // Without Voidshade: incoming = -30 - 0 = -30 → taken = 5000 × 0.70 = 3500.
+        // 3500 > 2650 → DIES. Proves the D-PR12 term alone is insufficient to clear 2650.
+        expect(
+            destroyedIds(run(2650, { voidshade: false, stealth: false, incDmgDown: true })).has(
+                'victim-cb'
+            )
+        ).toBe(true);
     });
 });

--- a/src/utils/combat/__tests__/selfIncomingBuffFold.integration.test.ts
+++ b/src/utils/combat/__tests__/selfIncomingBuffFold.integration.test.ts
@@ -1,0 +1,238 @@
+/**
+ * D-PR12 Task 3 — integration test for friendly-side incoming-damage buff fold.
+ *
+ * Before the engine change the buff is "emit-only": it is applied to the victim's own self
+ * store but victimEnemyModifiers only reads the enemy-debuff store, so the incoming-damage
+ * reduction is ignored and the victim takes the full hit.
+ *
+ * After the engine change victimIncomingModifiers reads BOTH stores (enemy-debuff + victim's
+ * own self buffs), so an Inc. Damage Down self-buff reduces the landed hit.
+ *
+ * Harness mirrors incomingReductionEngine.test.ts (D-PR3 Task 6):
+ *   - healingMode (healTargetId = 'attacker') → positioned enemy roster is built.
+ *   - playerVictim: speed 1000 → acts BEFORE the enemy, so the self-buff is up when the enemy hits.
+ *   - offensiveEnemy: attack 5000, speed 1, 100% multiplier → 5000 direct damage.
+ *   - Inc. Damage Down II: incomingDamage = -30 → landed = 5000 × (1 − 0.30) = 3500.
+ *   - HP bracket: victim hp = 4000 → DIES without buff (5000 > 4000), SURVIVES with buff (3500 < 4000).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus } from '../events';
+import { ShipSkills, Ability } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+// ── Targeting helpers ─────────────────────────────────────────────────────────
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+// ── Buff ability helpers ───────────────────────────────────────────────────────
+
+/**
+ * Self-buff ability that grants Inc. Damage Down II on the victim's own active turn.
+ * parsedEffects.incomingDamage = -30 → the status payload carries incomingDamage: -30.
+ * duration 2: the engine decrements on the SAME turn the buff is applied (post-victim-turn),
+ * so duration 1 would expire before the enemy acts. duration 2 → 1 remaining when the enemy
+ * fires → buff is active. (Mirrors how stealthSelfBuff uses duration 99 in the reference harness.)
+ */
+const incDamageDownSelfBuff = (id: string): Ability => ({
+    id,
+    type: 'buff',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: {
+        type: 'buff',
+        buffName: 'Inc. Damage Down II',
+        parsedEffects: { incomingDamage: -30 },
+        stacks: 1,
+        isStackable: false,
+        duration: 2,
+    },
+});
+
+// No-op damage: actor "casts" but deals 0 damage.
+const noopActive: ShipSkills['slots'][number] = {
+    slot: 'active',
+    abilities: [
+        {
+            id: 'noop-dmg',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0 },
+        },
+    ],
+};
+
+// ── Actor constructors ─────────────────────────────────────────────────────────
+
+/**
+ * A positioned PLAYER victim that optionally grants itself Inc. Damage Down II before being hit.
+ * speed 1000 → acts before the enemy (speed 1) so the buff is active when the hit lands.
+ */
+const playerVictim = (
+    id: string,
+    position: Position,
+    hp: number,
+    opts: { incDamageDown?: boolean } = {}
+): TeamActor => {
+    const active: ShipSkills['slots'][number] = opts.incDamageDown
+        ? {
+              slot: 'active',
+              abilities: [incDamageDownSelfBuff(`${id}-inc-dmg-down`)],
+          }
+        : noopActive;
+    return {
+        id,
+        speed: 1000,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        walk: {
+            shipSkills: { slots: [active] },
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    };
+};
+
+/**
+ * A positioned ENEMY attacker: attack 5000 × 100% × 1 hit vs defence 0 → 5000 damage.
+ * speed 1 → acts AFTER the player victim so the victim's self-buff is up when the hit fires.
+ */
+const offensiveEnemy = (
+    id: string,
+    position: Position,
+    selection: ParsedTarget['selection']
+): EnemyAttacker =>
+    ({
+        id,
+        stats: {
+            attack: 5000,
+            crit: 0,
+            critDamage: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 1,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget(selection),
+        pattern: basePattern(),
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: `${id}-hit`,
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 100 },
+                        },
+                    ],
+                },
+            ],
+        } as ShipSkills,
+    }) as EnemyAttacker;
+
+// ── Engine input factory ───────────────────────────────────────────────────────
+const BASE = (overrides: Partial<CombatEngineInput>): CombatEngineInput => ({
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [noopActive] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healTargetId: 'attacker', // healing mode → positioned enemy roster is built
+    ...overrides,
+});
+
+// ── Assertion helpers ──────────────────────────────────────────────────────────
+
+/** Set of actor ids that emitted ship-destroyed in this run. */
+const destroyedIds = (input: CombatEngineInput): Set<string> => {
+    const bus = createEventBus();
+    const ids = new Set<string>();
+    bus.on('ship-destroyed', (e) => ids.add(e.actorId));
+    runCombat({ ...input, bus });
+    return ids;
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('D-PR12 Task 3 — friendly-side Inc. Damage Down folds into per-victim incoming modifier', () => {
+    /**
+     * Build a run where the player victim is hit by a 5000-attack enemy.
+     * incDamageDown = true  → victim grants itself Inc. Damage Down II (-30%) on its own turn.
+     * incDamageDown = false → victim casts a no-op, takes the full 5000.
+     */
+    const run = (hp: number, incDamageDown: boolean): CombatEngineInput =>
+        BASE({
+            teamActors: [playerVictim('victim', 'M4', hp, { incDamageDown })],
+            enemyAttackers: [offensiveEnemy('enemy-1', 'M1', 'front')],
+        });
+
+    it('baseline: WITHOUT Inc. Damage Down the victim takes the full 5000 and dies at hp=4000', () => {
+        // Full 5000 > 4000 → dies.
+        expect(destroyedIds(run(4000, false)).has('victim')).toBe(true);
+        // Full 5000 > 5000? No, 5000 = 5000 → exactly kills.
+        expect(destroyedIds(run(5000, false)).has('victim')).toBe(true);
+        // Full 5000 < 5001 → survives.
+        expect(destroyedIds(run(5001, false)).has('victim')).toBe(false);
+    });
+
+    it('WITH Inc. Damage Down II (-30%) the victim takes 3500 and survives at hp=4000', () => {
+        // Reduced 3500 < 4000 → victim SURVIVES.
+        // (Before the engine change this FAILS: victim still dies because the buff is emit-only.)
+        expect(destroyedIds(run(4000, true)).has('victim')).toBe(false);
+    });
+
+    it('WITH Inc. Damage Down II the victim dies at hp=3500 (pinned to 3500 taken)', () => {
+        // Reduced 3500 = 3500 → exactly kills at hp=3500.
+        expect(destroyedIds(run(3500, true)).has('victim')).toBe(true);
+        // Survives at hp=3501.
+        expect(destroyedIds(run(3501, true)).has('victim')).toBe(false);
+    });
+});

--- a/src/utils/combat/__tests__/victimSelfBuffs.test.ts
+++ b/src/utils/combat/__tests__/victimSelfBuffs.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Direct unit tests for `victimSelfBuffs(statusEngine, victimId, selfBuffLookup)`.
+ *
+ * These tests cover all three internal channels:
+ *
+ *   1. Empty → returns [].
+ *
+ *   2. Timed ability channel (per-victim): a self-buff applied via
+ *      applyTimedAbilityStatus(r, { side:'self', ... }, victimId) appears for victimId
+ *      and toSelfIncomingDamageModifier returns the expected value.
+ *
+ *   3. Isolation: an ENEMY-side debuff applied to victimId does NOT appear via
+ *      victimSelfBuffs (reads only the 'self' store).
+ *
+ *   4. Scheduled channel (selfBuffLookup): an activeSelfBuffs entry whose name is in
+ *      selfBuffLookup is expanded and toSelfIncomingDamageModifier returns the looked-up
+ *      value.
+ *
+ *   5. (Bonus) Self-buff on actor A is not returned when querying actor B.
+ */
+import { describe, it, expect } from 'vitest';
+import { createStatusEngine } from '../statusEngine';
+import type { RegisteredAbilityStatus } from '../statusEngine';
+import { victimSelfBuffs } from '../triggers';
+import { toSelfIncomingDamageModifier } from '../../calculators/dpsBuffHelpers';
+import type { SelectedGameBuff } from '../../../types/calculator';
+
+// ---------------------------------------------------------------------------
+// Minimal helpers
+// ---------------------------------------------------------------------------
+
+/** A SelectedGameBuff with an incomingDamage parsedEffect, usable as a selfBuff lookup entry. */
+function makeSelfBuff(buffName: string, incomingDamagePct: number): SelectedGameBuff {
+    return {
+        id: `test-${buffName}`,
+        buffName,
+        stacks: 1,
+        parsedEffects: { incomingDamage: incomingDamagePct },
+        isStackable: false,
+        skillSource: 'active',
+        skillDuration: 'recurring',
+    };
+}
+
+/** Build a minimal timed RegisteredAbilityStatus (self-side). */
+function timedSelfStatus(
+    buffName: string,
+    incomingDamagePct: number,
+    duration = 3
+): Extract<RegisteredAbilityStatus, { kind: 'timed' }> {
+    return {
+        kind: 'timed',
+        side: 'self',
+        sourceSlot: 'active',
+        conditions: [],
+        duration,
+        payload: {
+            buffName,
+            stacks: 1,
+            parsedEffects: { incomingDamage: incomingDamagePct },
+            application: 'apply',
+        },
+    };
+}
+
+/** Build a minimal aura RegisteredAbilityStatus (self-side, no conditions = always passes). */
+function auraSelfStatus(
+    buffName: string,
+    incomingDamagePct: number
+): Extract<RegisteredAbilityStatus, { kind: 'aura' }> {
+    return {
+        kind: 'aura',
+        side: 'self',
+        sourceSlot: 'passive',
+        conditions: [],
+        payload: {
+            buffName,
+            stacks: 1,
+            parsedEffects: { incomingDamage: incomingDamagePct },
+        },
+    };
+}
+
+/** Build a minimal timed RegisteredAbilityStatus (enemy-side), for the isolation test. */
+function timedEnemyStatus(
+    buffName: string,
+    incomingDamagePct: number,
+    duration = 3
+): Extract<RegisteredAbilityStatus, { kind: 'timed' }> {
+    return {
+        kind: 'timed',
+        side: 'enemy',
+        sourceSlot: 'active',
+        conditions: [],
+        duration,
+        payload: {
+            buffName,
+            stacks: 1,
+            parsedEffects: { incomingDamage: incomingDamagePct },
+            application: 'inflict',
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('victimSelfBuffs — channel coverage', () => {
+    // -----------------------------------------------------------------------
+    // 1. Empty: no buffs applied → returns []
+    // -----------------------------------------------------------------------
+    it('empty: no buffs applied returns []', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.beginRound(1);
+
+        const result = victimSelfBuffs(eng, 'ship-1', new Map());
+
+        expect(result).toEqual([]);
+    });
+
+    // -----------------------------------------------------------------------
+    // 2. Timed ability channel: a self-buff with incomingDamage: -30 is returned,
+    //    and toSelfIncomingDamageModifier returns -30.
+    // -----------------------------------------------------------------------
+    it('timed ability channel: self-buff with incomingDamage returns correct modifier', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.beginRound(1);
+
+        const status = timedSelfStatus('Inc. Damage Down', -30);
+        // Apply to 'ship-1' via the self-side recipientId (3rd arg).
+        eng.applyTimedAbilityStatus(1, status, 'ship-1');
+
+        const result = victimSelfBuffs(eng, 'ship-1', new Map());
+
+        expect(result.some((b) => b.buffName === 'Inc. Damage Down')).toBe(true);
+        expect(toSelfIncomingDamageModifier(result)).toBe(-30);
+    });
+
+    // -----------------------------------------------------------------------
+    // 3. Isolation: an enemy-side debuff applied to 'ship-1' is NOT returned by
+    //    victimSelfBuffs — it reads only the 'self' store.
+    // -----------------------------------------------------------------------
+    it('isolation: enemy-side debuff on victim is NOT returned by victimSelfBuffs', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.beginRound(1);
+
+        const enemyStatus = timedEnemyStatus('Enemy Inc. Damage Up', 20);
+        // Apply as enemy-side debuff — recipientId (3rd arg) is irrelevant for enemy-side,
+        // enemyTargetId (4th arg) routes to 'ship-1'.
+        eng.applyTimedAbilityStatus(1, enemyStatus, undefined, 'ship-1');
+
+        const result = victimSelfBuffs(eng, 'ship-1', new Map());
+
+        expect(result).toEqual([]);
+    });
+
+    // -----------------------------------------------------------------------
+    // 4. Scheduled channel: an activeSelfBuffs entry whose name is in selfBuffLookup
+    //    is expanded and toSelfIncomingDamageModifier returns the looked-up value.
+    //    Use the scheduled selfBuffs injection (createStatusEngine({ selfBuffs: [...] }))
+    //    to seed the scheduled store — these appear as non-payload entries in
+    //    snapshot(ownerId).activeSelfBuffs under 'attacker'.
+    //    For per-ship scheduled entries, use registerAbilityStatuses with an aura self-side
+    //    status and a separate owner id so the lookup correctly expands via selfBuffLookup.
+    // -----------------------------------------------------------------------
+    it('scheduled channel: activeSelfBuffs entry expanded via selfBuffLookup gives correct modifier', () => {
+        const buffName = 'Makoli Shelter';
+        const lookupEntry = makeSelfBuff(buffName, -25);
+        const selfBuffLookup = new Map<string, SelectedGameBuff[]>([[buffName, [lookupEntry]]]);
+
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+
+        // Register an aura self-side status for 'ship-2' so it appears in activeSelfBuffs
+        // via snapshot('ship-2').activeSelfBuffs (non-payload aura) — but we need to use
+        // the scheduled channel. Scheduled selfBuffs injected at createStatusEngine go to
+        // 'attacker'. Use an aura status instead to test expansion via selfBuffLookup.
+        const aura = auraSelfStatus(buffName, -25);
+        eng.registerAbilityStatuses([aura], 'ship-2');
+
+        eng.beginRound(1);
+
+        const result = victimSelfBuffs(eng, 'ship-2', selfBuffLookup);
+
+        // The aura is returned via the active (aura) channel, and its parsedEffects carry
+        // the looked-up value.
+        expect(result.some((b) => b.buffName === buffName)).toBe(true);
+        expect(toSelfIncomingDamageModifier(result)).toBe(-25);
+    });
+
+    // -----------------------------------------------------------------------
+    // 5. (Bonus) Self-buff on actor A is NOT returned when querying actor B.
+    // -----------------------------------------------------------------------
+    it('per-victim isolation: self-buff on actor A does not appear for actor B', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.beginRound(1);
+
+        const status = timedSelfStatus('Actor A Buff', -10);
+        eng.applyTimedAbilityStatus(1, status, 'actor-A');
+
+        const forA = victimSelfBuffs(eng, 'actor-A', new Map());
+        const forB = victimSelfBuffs(eng, 'actor-B', new Map());
+
+        expect(forA.some((b) => b.buffName === 'Actor A Buff')).toBe(true);
+        expect(forB.some((b) => b.buffName === 'Actor A Buff')).toBe(false);
+    });
+});

--- a/src/utils/combat/__tests__/victimSelfBuffs.test.ts
+++ b/src/utils/combat/__tests__/victimSelfBuffs.test.ts
@@ -63,24 +63,6 @@ function timedSelfStatus(
     };
 }
 
-/** Build a minimal aura RegisteredAbilityStatus (self-side, no conditions = always passes). */
-function auraSelfStatus(
-    buffName: string,
-    incomingDamagePct: number
-): Extract<RegisteredAbilityStatus, { kind: 'aura' }> {
-    return {
-        kind: 'aura',
-        side: 'self',
-        sourceSlot: 'passive',
-        conditions: [],
-        payload: {
-            buffName,
-            stacks: 1,
-            parsedEffects: { incomingDamage: incomingDamagePct },
-        },
-    };
-}
-
 /** Build a minimal timed RegisteredAbilityStatus (enemy-side), for the isolation test. */
 function timedEnemyStatus(
     buffName: string,
@@ -156,36 +138,53 @@ describe('victimSelfBuffs — channel coverage', () => {
     });
 
     // -----------------------------------------------------------------------
-    // 4. Scheduled channel: an activeSelfBuffs entry whose name is in selfBuffLookup
-    //    is expanded and toSelfIncomingDamageModifier returns the looked-up value.
-    //    Use the scheduled selfBuffs injection (createStatusEngine({ selfBuffs: [...] }))
-    //    to seed the scheduled store — these appear as non-payload entries in
-    //    snapshot(ownerId).activeSelfBuffs under 'attacker'.
-    //    For per-ship scheduled entries, use registerAbilityStatuses with an aura self-side
-    //    status and a separate owner id so the lookup correctly expands via selfBuffLookup.
+    // 4. Scheduled channel (channel 1): a timed scheduled self-buff (seeded via
+    //    createStatusEngine({ selfBuffs: [...] }) + sourceFired) appears in
+    //    snapshot('attacker').activeSelfBuffs as a BARE NAME ENTRY — its payload/effects
+    //    carry NO incomingDamage. The value MUST come from selfBuffLookup. Guard: the test
+    //    fails if selfBuffLookup is empty (verifies channel 1 is genuinely wired).
+    //
+    //    How seeding works:
+    //      createStatusEngine receives a SelectedGameBuff with skillSource:'active' and a
+    //      numeric skillDuration — isAlwaysActive() returns false so it goes into timedSelf.
+    //      sourceFired('attacker','active',1) upserts it into getSelfMap('attacker') via
+    //      upsertBuff(), which stores NO payload (scheduled path). snapshot('attacker')
+    //      returns it in activeSelfBuffs as { buffName, turnsRemaining } with no effects.
+    //      expandBuffEntry() calls selfBuffLookup.get(buffName) to obtain the effects.
     // -----------------------------------------------------------------------
-    it('scheduled channel: activeSelfBuffs entry expanded via selfBuffLookup gives correct modifier', () => {
+    it('scheduled channel: activeSelfBuffs bare-name entry expanded via selfBuffLookup gives correct modifier', () => {
         const buffName = 'Makoli Shelter';
-        const lookupEntry = makeSelfBuff(buffName, -25);
+        // The lookup carries the incomingDamage effect; the scheduled entry itself carries NONE.
+        const lookupEntry = makeSelfBuff(buffName, -15);
         const selfBuffLookup = new Map<string, SelectedGameBuff[]>([[buffName, [lookupEntry]]]);
 
-        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
-
-        // Register an aura self-side status for 'ship-2' so it appears in activeSelfBuffs
-        // via snapshot('ship-2').activeSelfBuffs (non-payload aura) — but we need to use
-        // the scheduled channel. Scheduled selfBuffs injected at createStatusEngine go to
-        // 'attacker'. Use an aura status instead to test expansion via selfBuffLookup.
-        const aura = auraSelfStatus(buffName, -25);
-        eng.registerAbilityStatuses([aura], 'ship-2');
-
+        // Seed a TIMED scheduled self-buff. parsedEffects is empty — no incomingDamage here.
+        // skillSource:'active' + numeric skillDuration → isAlwaysActive() false → goes to timedSelf.
+        const scheduledBuff: SelectedGameBuff = {
+            id: 'test-scheduled-shelter',
+            buffName,
+            stacks: 1,
+            parsedEffects: {},
+            isStackable: false,
+            skillSource: 'active',
+            skillDuration: 2,
+        };
+        const eng = createStatusEngine({ selfBuffs: [scheduledBuff], enemyDebuffs: [] });
         eng.beginRound(1);
+        // Fire the attacker's active slot so the timed scheduled self-buff is upserted to
+        // getSelfMap('attacker') with NO payload — channel 1 write path.
+        eng.sourceFired('attacker', 'active', 1);
 
-        const result = victimSelfBuffs(eng, 'ship-2', selfBuffLookup);
+        // victimId 'attacker' — scheduled timed self-buffs always land in the 'attacker' owner map.
+        const result = victimSelfBuffs(eng, 'attacker', selfBuffLookup);
 
-        // The aura is returned via the active (aura) channel, and its parsedEffects carry
-        // the looked-up value.
         expect(result.some((b) => b.buffName === buffName)).toBe(true);
-        expect(toSelfIncomingDamageModifier(result)).toBe(-25);
+        expect(toSelfIncomingDamageModifier(result)).toBe(-15);
+
+        // Guard: with an empty lookup the same call yields NO incomingDamage contribution.
+        // This proves the value comes from the lookup, not from the scheduled entry's own payload.
+        const resultNoLookup = victimSelfBuffs(eng, 'attacker', new Map());
+        expect(toSelfIncomingDamageModifier(resultNoLookup)).toBe(0);
     });
 
     // -----------------------------------------------------------------------

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -11,7 +11,7 @@ import type { AffinityName } from '../../types/ship';
 import type { ParsedTarget, ParsedPattern } from '../targetingParser';
 import { makeRateGate, rollRateGate } from '../calculators/rateAccumulator';
 import type { RoundData } from '../calculators/dpsSimulator';
-import { toEnemyModifiers } from '../calculators/dpsBuffHelpers';
+import { toEnemyModifiers, toSelfIncomingDamageModifier } from '../calculators/dpsBuffHelpers';
 import {
     type ExtraActionGrant,
     selectFiringSkill,
@@ -77,6 +77,7 @@ import {
     registerReactiveListeners,
     selfBuffNamesForOwners,
     victimEnemyBuffs,
+    victimSelfBuffs,
 } from './triggers';
 import { adjacentAllyIds } from './adjacency';
 
@@ -2823,13 +2824,27 @@ export function runCombat(input: CombatEngineInput): {
         // lockstep. Attacker-sourced modifiers (outgoing buff, pen) stay attacker-sourced.
         // NOTE: the aura/accumulating ability channel is an approximation (NEUTRAL ctx, no re-roll)
         // — see the victimEnemyBuffs jsdoc (finding I1) for details and acceptance rationale.
-        const victimEnemyModifiers = (
+        const victimIncomingModifiers = (
             victimId: string
-        ): { enemyDefenseModifier: number; incomingDamageModifier: number } =>
-            toEnemyModifiers(victimEnemyBuffs(statusEngine, victimId, enemyDebuffLookup));
+        ): { enemyDefenseModifier: number; incomingDamageModifier: number } => {
+            const enemy = toEnemyModifiers(
+                victimEnemyBuffs(statusEngine, victimId, enemyDebuffLookup)
+            );
+            // D-PR12: friendly-side incoming-DIRECT-damage buffs on the victim's OWN 'self' store
+            // (Inc. Damage Down/Up — Makoli/Salvation/Shelter/Refine/Battlecry). Summed into the SAME
+            // per-victim incomingDamageModifier as enemy debuffs. Team-agnostic (victimId keys the
+            // actor's own self store regardless of side). Direct channel only; incoming-DoT deferred.
+            const selfIncoming = toSelfIncomingDamageModifier(
+                victimSelfBuffs(statusEngine, victimId, selfBuffLookup)
+            );
+            return {
+                enemyDefenseModifier: enemy.enemyDefenseModifier,
+                incomingDamageModifier: enemy.incomingDamageModifier + selfIncoming,
+            };
+        };
         // TEST-ONLY: hand the reader out once so unit tests can assert per-victim debuff reads
         // before B1 Task 3 wires it into a damage path. Inert in production (never set).
-        input.__testTapVictimEnemyModifiers?.(victimEnemyModifiers);
+        input.__testTapVictimEnemyModifiers?.(victimIncomingModifiers);
         input.__testTapIsStasised?.(isStasised);
 
         // Shared positional-apply driver (Task 9, Step A) — the ONE place the three attack
@@ -2842,11 +2857,11 @@ export function runCombat(input: CombatEngineInput): {
         //  - `opposingLiving` — focus/team → enemyAttackerActors; enemy → allPlayerActors,
         //  - `applyToVictim` — focus/team → applyOutgoingToEnemy; enemy → applyIncomingToTarget,
         //  - `acting` — the firing actor's position / ignoresForcedTargeting / id (for provokerOf).
-        // `defenseProfileOf` is identical across all three sites (B1/PR7b: wired to
-        // victimEnemyModifiers — reads the victim's OWN per-actor enemy-debuff store, both
-        // channels: scheduled (__enemy__ global) + ability (per-victim payload). Direction-
-        // agnostic: victimEnemyModifiers(v.id) works for ENEMY victims (focus/team site) and
-        // PLAYER victims (enemy site) alike — both store their debuffs keyed by their own id.
+        // `defenseProfileOf` is identical across all three sites (B1/PR7b + D-PR12: wired to
+        // victimIncomingModifiers — reads the victim's OWN per-actor enemy-debuff store AND
+        // the victim's own self-buff store (both channels: scheduled + ability payload).
+        // Direction-agnostic: victimIncomingModifiers(v.id) works for ENEMY victims
+        // (focus/team site) and PLAYER victims (enemy site) alike.
         // No emitHit: runPlayerTurn already emits ONE aggregate ability-performed per turn;
         // per-hit/per-victim event fidelity is a documented Phase-5 follow-up.
         const drivePositionalApply = (args: {
@@ -2886,16 +2901,16 @@ export function runCombat(input: CombatEngineInput): {
                     provokedBy: provokerOf(statusEngine, args.actingId),
                 },
                 defenseProfileOf: (v) => {
-                    const m = victimEnemyModifiers(v.id);
+                    const m = victimIncomingModifiers(v.id);
                     return {
                         defence: v.stats.defence,
                         // B1/PR7b: per-victim defense-debuff sourcing (was hardcoded 0).
                         // Direction-agnostic — v.id keys the victim's own enemy-debuff store
                         // regardless of side.
                         defenceModifierPct: m.enemyDefenseModifier,
-                        // B1/PR7b: per-victim incoming-damage debuff; overrides the
-                        // attacker-fixed scalar in victimHitDamage. Attacker-sourced scalars
-                        // (outgoing buff, pen) stay attacker-fixed.
+                        // B1/PR7b + D-PR12: per-victim incoming-damage modifier; combines
+                        // enemy-debuff (Out. Damage Up) AND victim's own self-buffs (Inc. Damage
+                        // Down/Up). Attacker-sourced scalars (outgoing buff, pen) stay attacker-fixed.
                         incomingDamageModifierPct: m.incomingDamageModifier,
                         affinity: v.affinity ?? 'antimatter',
                     };

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -959,10 +959,12 @@ export interface CombatEngineInput {
      *  in the callback, not after runCombat returns. Base stats (hacking, security, etc.) are
      *  never mutated, so existing base-stat assertions are safe to read post-run. */
     __testTapActors?: (actors: CombatActor[]) => void;
-    /** TEST-ONLY tap (B1 Task 2): receives the per-victim enemy-debuff-derived modifier reader
-     *  once it is built in the round loop. Unit tests capture the closure and call it with a
-     *  victim id to assert per-actor debuff reads (before B1 Task 3 wires it into any damage
-     *  path). Never set by production code; inert when absent. The closure is per-round-identical
+    /** TEST-ONLY tap (B1 Task 2): receives the per-victim incoming-damage modifier reader
+     *  (`victimIncomingModifiers`) once it is built in the round loop. Since D-PR12 the closure
+     *  sums BOTH the enemy-debuff term AND the victim's own friendly self-buff term (field name
+     *  kept as `__testTapVictimEnemyModifiers` to avoid churning the existing tap tests). Unit
+     *  tests capture the closure and call it with a victim id to assert per-actor modifier reads.
+     *  Never set by production code; inert when absent. The closure is per-round-identical
      *  in behaviour (only the live status-engine state changes), so capturing it once is sufficient
      *  for a single-round test. NOTE: the tap reads LIVE statusEngine state at call time, which
      *  is fine for single-round tests (the state is fully settled after runCombat returns). */
@@ -2832,8 +2834,11 @@ export function runCombat(input: CombatEngineInput): {
             );
             // D-PR12: friendly-side incoming-DIRECT-damage buffs on the victim's OWN 'self' store
             // (Inc. Damage Down/Up — Makoli/Salvation/Shelter/Refine/Battlecry). Summed into the SAME
-            // per-victim incomingDamageModifier as enemy debuffs. Team-agnostic (victimId keys the
-            // actor's own self store regardless of side). Direct channel only; incoming-DoT deferred.
+            // per-victim incomingDamageModifier as enemy debuffs. Team-agnostic for the TIMED + AURA
+            // ability channels (victimId keys the actor's own self store regardless of side). The
+            // SCHEDULED channel reads selfBuffLookup, which today is populated only for player/team
+            // actors (enemy runtimes pass an empty map) — a pre-existing gap, irrelevant until an
+            // enemy carries a scheduled self-buff. Direct channel only; incoming-DoT deferred.
             const selfIncoming = toSelfIncomingDamageModifier(
                 victimSelfBuffs(statusEngine, victimId, selfBuffLookup)
             );
@@ -2842,8 +2847,8 @@ export function runCombat(input: CombatEngineInput): {
                 incomingDamageModifier: enemy.incomingDamageModifier + selfIncoming,
             };
         };
-        // TEST-ONLY: hand the reader out once so unit tests can assert per-victim debuff reads
-        // before B1 Task 3 wires it into a damage path. Inert in production (never set).
+        // TEST-ONLY: expose victimIncomingModifiers (enemy-debuff + friendly self-buff term,
+        // D-PR12) to unit tests that assert per-victim modifier reads. Inert in production (never set).
         input.__testTapVictimEnemyModifiers?.(victimIncomingModifiers);
         input.__testTapIsStasised?.(isStasised);
 

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -6,7 +6,7 @@ import { PERSISTENT_STACKING_BUFFS } from '../../constants/persistentStackingBuf
 import { conditionsMet } from '../abilities/evaluateConditions';
 import { buildRoundContext } from '../abilities/roundContext';
 import { makeRateGate } from '../calculators/rateAccumulator';
-import { expandEnemyDebuffs, payloadToSelectedBuff } from './buffTotals';
+import { expandEnemyDebuffs, payloadToSelectedBuff, expandBuffEntry } from './buffTotals';
 import { liveGateConditions } from './abilityStatusGating';
 import { CombatEventBus } from './events';
 import { CombatActor, ActiveDoTStack, PendingBomb } from './state';
@@ -877,6 +877,33 @@ export function victimEnemyBuffs(
         .map((s) => payloadToSelectedBuff(s.payload));
     const active = statusEngine
         .activeAbilityStatuses('enemy', () => NEUTRAL_NAMES_CTX, undefined, targetId)
+        .map((s) => payloadToSelectedBuff(s.payload));
+    return [...scheduled, ...timed, ...active];
+}
+
+/** Friendly twin of victimEnemyBuffs: a victim's OWN self-/ally-granted buffs, across all
+ *  three channels — scheduled self-buffs (snapshot(victimId).activeSelfBuffs, expanded via
+ *  selfBuffLookup), timed ability statuses, and aura/accumulating ability statuses. Used by
+ *  the engine's per-victim incoming fold (victimIncomingModifiers, D-PR12) to source friendly
+ *  Inc. Damage Down/Up. Team-agnostic: 'self'-side statuses are keyed by the actor's own id
+ *  (same read selfBuffNamesForOwners uses for either team). The aura/accumulating channel
+ *  carries the same NEUTRAL-ctx approximation noted on victimEnemyBuffs; the live ship sources
+ *  (Makoli/Salvation/Shelter/Refine/Battlecry) are TIMED and not approximated. */
+export function victimSelfBuffs(
+    statusEngine: StatusEngine,
+    victimId: string,
+    selfBuffLookup: Map<string, SelectedGameBuff[]>
+): SelectedGameBuff[] {
+    const scheduled = statusEngine
+        .snapshot(victimId)
+        .activeSelfBuffs.flatMap((ab) =>
+            expandBuffEntry(ab, selfBuffLookup.get(ab.buffName) ?? [])
+        );
+    const timed = statusEngine
+        .timedAbilityStatuses('self', victimId)
+        .map((s) => payloadToSelectedBuff(s.payload));
+    const active = statusEngine
+        .activeAbilityStatuses('self', () => NEUTRAL_NAMES_CTX, victimId)
         .map((s) => payloadToSelectedBuff(s.payload));
     return [...scheduled, ...timed, ...active];
 }


### PR DESCRIPTION
## Summary

Folds friendly-side **Incoming Damage Down/Up** buffs into the per-victim incoming-damage modifier, so a ship that buffs itself or an ally with `Inc. Damage Down` actually takes reduced direct damage in the sim. Previously these buffs were applied + logged but had **no damage effect** (emit-only).

Lights up: **Makoli, Salvation, Shelter, Refine** (ship skills) + allies buffed by the **Battlecry** implant (D-PR7, on-death).

**How:** mirrors the existing enemy-side per-victim incoming fold on the friendly side.
- `toSelfIncomingDamageModifier` — pure extractor (mirror of `toEnemyModifiers`' incoming reducer).
- `victimSelfBuffs` — friendly `'self'`-side twin of `victimEnemyBuffs` (reads scheduled + timed + aura channels).
- Engine closure `victimEnemyModifiers` → `victimIncomingModifiers` now sums the friendly term into the **same** `incomingDamageModifier` that flows into `victimHitDamage`'s single `(1 + incoming/100)` factor.

**Team-agnostic** (one unified per-victim seam — proven with an enemy-side victim mirror). Composes **additively** with D-PR3's `incoming-reduction` (one factor: `incoming = enemy + friendly − equipReductionPct`), not as a product — proven with a discriminating threshold test using a real Voidshade-legendary reduction.

**Scope:** direct-damage channel only. Incoming-DoT is explicitly **deferred** (no corpus source grants a friendly incoming-DoT buff; the enemy-side DoT-incoming is applier-sourced, so unifying both channels belongs in a later PR with a real source).

## Stack

Stacked on D-PR11 (#139). Base `feat/combat-d-pr11-fortifying-shroud`; retarget to `main` as lower PRs merge.

## Test Plan

- [x] Unit: `toSelfIncomingDamageModifier` (sum/stacks/sign/empty)
- [x] Unit: `victimSelfBuffs` (3 channels incl. genuine scheduled-channel guard; enemy/per-actor isolation)
- [x] Integration: victim with `Inc. Damage Down II` takes ~30% less direct damage (RED before the fold, GREEN after)
- [x] Integration: enemy-side victim mirror (team-agnostic)
- [x] Integration: additive D-PR3 composition (hp=2650 discriminates additive 2500 from product 2800; single-effect controls)
- [x] Full suite green; lint clean; `tsc` clean; `audit:skills` 141/0; **zero golden/.snap drift** (no existing fixture has a buffed victim → production byte-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)