### PR TITLE
feat(combat): D-PR13 — Disable as a turn-skip control (lights up Martyrdom)

### DIFF
--- a/docs/superpowers/plans/2026-06-22-disable-turn-skip-control.md
+++ b/docs/superpowers/plans/2026-06-22-disable-turn-skip-control.md
@@ -1,0 +1,360 @@
+# Disable as a turn-skip control effect (D-PR13) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the combat engine treat a `Disable` status as a turn-skip control (skip the afflicted unit's scheduled action + suppress its reactives), without the Stasis-only break-on-hit / immunity behavior — lighting up the D-PR7 Martyrdom implant and the 5 skill-text Disable inflictors with no parser change.
+
+**Architecture:** Buff-name-driven, mirroring Stasis. A new `disableBuffs.ts` defines `DISABLE_BUFFS`/`isDisable`. The engine gains `isDisabled` + a composite `isTurnBlocked = isStasised || isDisabled`, routed through the three turn-action gates and the reactive-suppression drain filter. Break-on-hit / immunity sites stay keyed on `isStasised` (Stasis-only). Cleanse-resume falls out free because `isDisabled` reads `ownerDebuffNames` live each turn.
+
+**Tech Stack:** TypeScript, Vitest. Worktree: `.worktrees/d-pr13-disable-turn-skip` (branch `feat/combat-d-pr13-disable-turn-skip`, off the D-PR12 tip `998416c3`).
+
+**Spec:** `docs/superpowers/specs/2026-06-22-disable-turn-skip-control-design.md`
+
+---
+
+## Conventions for every task
+
+- Run a single test file: `npx vitest run <path>` (add `-t "<name>"` for one test). All commands run from the worktree root `.worktrees/d-pr13-disable-turn-skip`.
+- The pre-commit hook runs the FULL vitest suite. Code commits go through it normally. Docs-only commits use `--no-verify` and `git add -f docs/...` (docs/ is gitignored).
+- Commit messages end with:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- **NEVER** run `vitest -u` to update goldens. If a golden/snapshot moves, a real-ship Disable leaked into a fixture — stop and investigate.
+- Reference files to mirror (read them before writing tests):
+  - `src/utils/combat/stasisBuffs.ts` and its test `src/utils/combat/__tests__/stasisBuffs.test.ts`
+  - `src/utils/combat/__tests__/stasis.test.ts` (the turn-skip + reactive-suppression + break harness — your primary template)
+  - `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts` (the `D-PR7 Task 4` Martyrdom block, ~line 1486)
+
+---
+
+## Task 1: `disableBuffs.ts` module
+
+**Files:**
+- Create: `src/utils/combat/disableBuffs.ts`
+- Test: `src/utils/combat/__tests__/disableBuffs.test.ts`
+
+- [ ] **Step 1: Write the failing test.** Mirror `stasisBuffs.test.ts`.
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { DISABLE_BUFFS, isDisable } from '../disableBuffs';
+
+describe('disableBuffs', () => {
+    it('DISABLE_BUFFS contains Disable', () => {
+        expect(DISABLE_BUFFS.has('Disable')).toBe(true);
+    });
+    it('isDisable returns true for Disable, false otherwise', () => {
+        expect(isDisable('Disable')).toBe(true);
+        expect(isDisable('Stasis')).toBe(false);
+        expect(isDisable('Attack Down')).toBe(false);
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails.** `npx vitest run src/utils/combat/__tests__/disableBuffs.test.ts` → FAIL (`Cannot find module '../disableBuffs'`).
+
+- [ ] **Step 3: Implement.** Create `src/utils/combat/disableBuffs.ts`:
+
+```ts
+/** Named debuffs that mean DISABLE — the game's second turn-skip control (after Stasis).
+ *  While a unit carries an active Disable it cannot take its scheduled ACTION (active/charged
+ *  skill + attack) and its reactive abilities are suppressed — IDENTICAL to Stasis on those two
+ *  axes (recognized via the engine's `isTurnBlocked` composite). DoTs still tick and all timed
+ *  statuses (Disable included) still decrement on the skipped turn, so duration N skips exactly
+ *  N scheduled actions.
+ *
+ *  DIVERGES from Stasis on two axes (do NOT wire Disable into the Stasis-only sites):
+ *    - NOT broken by a direct hit (Stasis is, see engine §4.5) — Disable persists when hit.
+ *    - NO damage immunity — hits land normally (same as Stasis, which also takes damage).
+ *
+ *  Carried as a timed debuff in the victim's per-actor enemy-debuff store (decrements via the
+ *  Post-Turn decrement). Disable carries no stat payload; duration comes from "for N turns".
+ *  Extend from game data as other named turn-skip controls appear (e.g. Stun/Freeze). */
+export const DISABLE_BUFFS: ReadonlySet<string> = new Set(['Disable']);
+
+/** True iff `buffName` is a Disable turn-skip control. */
+export function isDisable(buffName: string): boolean {
+    return DISABLE_BUFFS.has(buffName);
+}
+```
+
+- [ ] **Step 4: Run to verify it passes.** `npx vitest run src/utils/combat/__tests__/disableBuffs.test.ts` → PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/utils/combat/disableBuffs.ts src/utils/combat/__tests__/disableBuffs.test.ts
+git commit -m "feat(combat): D-PR13 — Disable buff-name set + isDisable predicate"
+```
+
+---
+
+## Task 2: Engine turn-skip — `isTurnBlocked` at the three turn-action gates
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts` (reader ~1710; gates ~3690 / ~3878 / ~4090)
+- Test: `src/utils/combat/__tests__/disable.test.ts` (new)
+
+**Read first:** `stasis.test.ts` tests (i), (iii), and B3 Task 2 (i). You will mirror the harness (`ab`, `basicAttack`, `parsedTarget`, `basePattern`, `offensiveEnemyAt`, `teamAttackerAt`, the `run` helper, `POS_*` constants). Copy that harness into `disable.test.ts` and add a `disableInflictAttack(turns)` builder (identical to `stasisInflictAttack` but `buffName: 'Disable'`).
+
+- [ ] **Step 1: Write the failing tests.** Create `src/utils/combat/__tests__/disable.test.ts` with the mirrored harness plus these tests (full code — adapt imports/harness from `stasis.test.ts`):
+
+  **(i) A disabled enemy skips its action.** Mirror `stasis.test.ts` (i) but inflict `Disable(2)` from the focus every round; assert `enemy-front` never emits `ability-performed` across 4 rounds, `enemy-back` (untargeted) fires every round, `result.rounds` has length 4.
+
+  **(ii) Disable(2) decrements on skipped turns → exactly 2 skips.** Mirror `stasis.test.ts` (iii): a `disable-bot` (speed 300, hp 1) inflicts `Disable(2)` on the focus in round 1, a `killer` team actor kills the bot round 1 (so no re-application), focus skips rounds 1–2 and fires in round 3. Assert focus `ability-performed` rounds: not 1, not 2, contains 3.
+
+  **(iii) No immunity + no break-on-hit (the Stasis contrast).** This is the key divergence test.
+
+```ts
+// ── (iii) Disable does NOT break on a direct hit AND damage still lands ──────────────────
+describe('D-PR13 — Disable: direct hit does NOT break it (contrast vs Stasis) and damage lands', () => {
+    it('a disabled focus stays disabled for the full duration despite being hit each round, and takes the damage', () => {
+        idc = 0;
+        /**
+         * disable-bot (speed 300, hp 1): inflicts Disable(3) on the focus in round 1, then is
+         *   killed by `killer` (no re-application).
+         * breaker (speed 150): a plain direct attacker that hits the focus EVERY round. Under
+         *   Stasis this would BREAK the control (stasis B3 Task 2 (i)); under Disable it must NOT.
+         * focus (speed 100, hp large): disabled rounds 1–3, must NOT act until round 4.
+         * Assert: focus fires no ability-performed in rounds 1–3 (stayed disabled despite hits),
+         *   fires in round 4; AND the breaker dealt damage to the focus (no immunity).
+         */
+        const { events, result } = run({
+            /* ...MART-style base: attack 0, basicAttack, hp 1e9, speed 100, healTargetId 'attacker',
+               numRounds 4, position POS_FOCUS, target front, pattern base, hacking 0... */
+            teamActors: [teamAttackerAt('killer', POS_TEAM, 200, 10000)],
+            enemyAttackers: [
+                // disable-bot at front: applies Disable(3) to the focus in round 1, dies to killer.
+                { id: 'disable-bot', /* speed 300, hp 1, hacking 200, security 0, position front,
+                    target front, pattern base, shipSkills: disableInflictAttack(3) */ } as EnemyAttacker,
+                // breaker: plain attacker hitting the focus each round (would break Stasis).
+                offensiveEnemyAt('breaker', POS_ENEMY_BACK, 'front', basicAttack(), 150),
+            ],
+        });
+
+        const abilityPerformed = events.filter(
+            (e): e is Extract<CombatEvent, { type: 'ability-performed' }> => e.type === 'ability-performed'
+        );
+        const focusRounds = abilityPerformed.filter((e) => e.actorId === 'attacker').map((e) => e.round);
+        expect(focusRounds).not.toContain(1);
+        expect(focusRounds).not.toContain(2);
+        expect(focusRounds).not.toContain(3); // NOT broken by the breaker's hits
+        expect(focusRounds).toContain(4);     // Disable(3) expired → acts
+
+        // No immunity: the breaker actually damaged the focus while it was disabled.
+        const hitFocus = events.filter(
+            (e): e is Extract<CombatEvent, { type: 'attacked' }> =>
+                e.type === 'attacked' && e.targetId === 'attacker' && e.attackerId === 'breaker'
+        );
+        expect(hitFocus.length).toBeGreaterThan(0);
+        expect(hitFocus.some((e) => e.damage > 0)).toBe(true);
+        expect(result.rounds).toHaveLength(4);
+    });
+});
+```
+
+  > NOTE on the `attacked` event shape: confirm the field names (`targetId`/`attackerId`/`damage`) against `events.ts` while writing — adapt if they differ.
+
+- [ ] **Step 2: Run to verify they fail.** `npx vitest run src/utils/combat/__tests__/disable.test.ts` → FAIL (Disable not honored: the disabled actor still acts).
+
+- [ ] **Step 3: Implement.** In `src/utils/combat/engine.ts`:
+
+  1. Add the import (next to the stasis import ~line 54): `import { isStasis, STASIS_BUFFS } from './stasisBuffs';` → add `import { isDisable } from './disableBuffs';`
+  2. Just after the `isStasised` reader (~1710) add:
+
+```ts
+    const isDisabled = (actorId: string): boolean => ownerDebuffNames(actorId).some(isDisable);
+    /** Turn-blocked = cannot take its scheduled action this turn (Stasis OR Disable). Used by the
+     *  three turn-action gates and the reactive-suppression drain filter. The Stasis-only break /
+     *  immunity sites intentionally keep using isStasised (Disable never breaks). */
+    const isTurnBlocked = (actorId: string): boolean => isStasised(actorId) || isDisabled(actorId);
+```
+
+  3. At each of the three turn-action gates, change `if (!isStasised(actor.id)) {` → `if (!isTurnBlocked(actor.id)) {`:
+     - focus/attacker gate ~3690
+     - walked-team gate ~3878
+     - enemy gate ~4090
+
+  > Grep `if (!isStasised(actor.id))` to find exactly these three and switch only them. Leave every `tgtWasStasised` / `enemyTgtWasStasised` / `teamTgtWasStasised`, the `stasisBreakPending` reads in the else-branches, the `victimStasised` event fields, and `__testTapIsStasised` on `isStasised` — Disable must NOT break.
+
+- [ ] **Step 4: Run to verify they pass.** `npx vitest run src/utils/combat/__tests__/disable.test.ts` → PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/utils/combat/engine.ts src/utils/combat/__tests__/disable.test.ts
+git commit -m "feat(combat): D-PR13 — Disable skips the afflicted unit's turn (isTurnBlocked gate)"
+```
+
+---
+
+## Task 3: Reactive suppression while disabled
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts` (drain filter ~3323)
+- Test: `src/utils/combat/__tests__/disable.test.ts` (append)
+
+**Read first:** `stasis.test.ts` B3 Task 1 tests (a) on-attacked suppression and (c) incoming DoT still ticks. Mirror them with Disable.
+
+- [ ] **Step 1: Write the failing tests.** Append two tests, copying the `onAttackedSelfBuffSlot` helper from `stasis.test.ts`:
+
+  **(iv) on-attacked self-buff suppressed while disabled.** Focus carries `onAttackedSelfBuffSlot` ('Counter Shield'); a `disable-enemy` inflicts `Disable(4)`; an `attack-enemy` hits the focus each round. Assert zero `buff-applied` `Counter Shield` on `attacker` across all rounds (mirror stasis (a)). Include a non-vacuity control identical to stasis (d) (no Disable → Counter Shield DOES apply) — copy stasis (d) renaming Stasis→Disable, OR rely on the existing stasis (d) test (note in a comment that (d) is the shared symmetry anchor).
+
+  **(v) incoming DoT still ticks on a disabled actor.** Mirror stasis (c): a `dot-disable-enemy` applies corrosion + `Disable(2)` in round 1; assert `dot-ticked` for `attacker` fires in rounds 1 AND 2 (incoming effects untouched).
+
+- [ ] **Step 2: Run to verify (iv) fails, (v) passes.** `npx vitest run src/utils/combat/__tests__/disable.test.ts`. (iv) FAILS (the disabled focus still gets its counter buff — drain filter not yet routed). (v) likely PASSES already (incoming DoT ticks regardless). That's fine — (v) is a lock test.
+
+- [ ] **Step 3: Implement.** In `engine.ts`, change the reactive-suppression drain filter (~3323) from `if (isStasised(intent.ownerId)) continue;` → `if (isTurnBlocked(intent.ownerId)) continue;`.
+
+- [ ] **Step 4: Run to verify both pass.** `npx vitest run src/utils/combat/__tests__/disable.test.ts` → PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/utils/combat/engine.ts src/utils/combat/__tests__/disable.test.ts
+git commit -m "feat(combat): D-PR13 — suppress a disabled unit's reactive abilities"
+```
+
+---
+
+## Task 4: Cleanse-resume lock test
+
+**Files:**
+- Test: `src/utils/combat/__tests__/disable.test.ts` (append). **No production change expected** — `isDisabled` reads `ownerDebuffNames` live, and `cleanse` removes the (removable) `Disable` debuff. This test locks that behavior.
+
+- [ ] **Step 1: Write the test.** A focus is disabled by an enemy, then a team-actor cleanser (faster than the focus) cleanses the focus before its turn, so the focus resumes acting.
+
+```ts
+// ── (vi) cleanse-resume: removing Disable lets the unit walk again ───────────────────────
+describe('D-PR13 — Disable: cleanse removes it and the unit resumes its regular walk', () => {
+    it('a disabled focus whose Disable is cleansed acts again on its next scheduled turn', () => {
+        idc = 0;
+        /**
+         * disable-bot (speed 300, hp 1): inflicts Disable(5) on the focus round 1, killed by `killer`.
+         * cleanser (team actor, speed 150): casts a self/ally cleanse on the focus EACH round
+         *   (heal-target cleanse). Acts before the focus (150 > 100).
+         * focus (speed 100): disabled round 1; in round 2 the cleanser removes Disable BEFORE the
+         *   focus's turn → focus acts in round 2 (well before Disable(5) would expire on its own).
+         * Assert: focus fires in round 2 (resumed early via cleanse), proving cleanse-resume.
+         * Without cleanse, Disable(5) would keep it skipping rounds 1–5.
+         */
+        // Cleanser slot: a `cleanse` ability, target 'ally'/'self' onto the heal target (focus).
+        // Mirror an existing cleanse setup — grep `type: 'cleanse'` in the combat __tests__ for the
+        // exact config shape (count: 1, target resolving to the heal target). Run in healing mode.
+        // ... assert focusFiredRounds.toContain(2);
+    });
+});
+```
+
+  > Read an existing cleanse test (grep `type: 'cleanse'` under `src/utils/combat/__tests__/`) for the exact `cleanse` ability config + how it targets the heal target. The cleanser must be on the SAME side as the disabled unit (cleanse removes the actor's own debuffs). Use the focus (heal target) as the disabled unit so a player-side cleanse applies.
+
+- [ ] **Step 2: Run.** `npx vitest run src/utils/combat/__tests__/disable.test.ts -t "cleanse"` → expected PASS (no prod change). If it FAILS, debug: confirm `cleanse` reaches the focus's debuff store and `Disable` is not classified unremovable.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add src/utils/combat/__tests__/disable.test.ts
+git commit -m "test(combat): D-PR13 — lock cleanse-resume (cleansed Disable restores the walk)"
+```
+
+---
+
+## Task 5: Martyrdom end-to-end — the killer skips after the kill
+
+**Files:**
+- Test: `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts` (extend the `D-PR7 Task 4 integration — Martyrdom` describe block, ~line 1486). **No production change** — this proves Martyrdom (which already emits `Disable` on the killer, Test A) now causes a real turn-skip.
+
+**Read first:** the existing Martyrdom block (`buildMartyrdomShipSkills`, `directKiller`, `MART_BASE`, `collect`) and `stasis.test.ts` positional helpers.
+
+- [ ] **Step 1: Write the test.** Add a Test C that observes the killer skipping after it kills a Martyrdom carrier. Use a SURVIVING heal target + a positioned team-actor carrier so the killer keeps having something to do (non-vacuity), and the carrier's death is the only thing that disables the killer.
+
+  Design (adapt field names to the harness):
+  - `healTargetId: 'tank'` — a high-HP survivor with no offense, positioned BACK (e.g. `M1`).
+  - A team actor `'martyr'` positioned FRONT (`M4`), low HP, `walk.shipSkills = buildMartyrdomShipSkills()` (legendary). It dies to the killer in round 1.
+  - Enemy `killer` (speed high) targets `'front'` with a lethal direct hit: kills `martyr` round 1; from round 2 its `'front'` target is `tank` (still alive).
+  - `numRounds: 4` (legendary Disable = 2).
+  - Collect `ability-performed` for the killer.
+  - **Assert:** killer fires in round 1 (the kill), is ABSENT in rounds 2 and 3 (disabled 2 turns), and fires again in round 4. Sanity: a `ship-destroyed` for `martyr` in round 1, and a `debuff-applied` `Disable` targeting the killer.
+  - **Non-vacuity control:** an identical run where `martyr` carries NO Martyrdom (plain active only) → the killer fires in rounds 2 and 3 (attacking `tank`). Assert that contrast so the absence in the main run is genuine suppression.
+
+  > If team-actor positioning + a surviving tank proves awkward, the equivalent observable is the killer's reactive: give the killer a `start-of-round` self-buff slot (copy `startOfRoundAttackUpSlot` from `stasis.test.ts`) and assert that buff is applied round 1 but suppressed rounds 2–3 (Task 3 suppression), returning round 4 — using a legendary carrier as the heal target itself (combat continues past its death for all `numRounds`). Either observation is acceptable; pick whichever is non-vacuous in the control. Document the chosen rationale in a test comment.
+
+- [ ] **Step 2: Run.** `npx vitest run src/utils/combat/__tests__/equipmentAbilities.integration.test.ts -t "Martyrdom"` → PASS (and the control contrast must be non-vacuous: the killer DOES act in rounds 2–3 without Martyrdom).
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+git commit -m "test(combat): D-PR13 — Martyrdom end-to-end: the disabled killer skips its turns"
+```
+
+---
+
+## Task 6: Skill-text Disable lights up (parser lock test)
+
+**Files:**
+- Test: `src/utils/abilities/__tests__/buildShipAbilities.test.ts` (append). **No production change** — proves "inflicts Disable for N turns" parses to a named `Disable` debuff (so the 5 corpus inflictors ride the same engine gate as Martyrdom).
+
+- [ ] **Step 1: Write the test.** Read the existing Makoli Disable test (~line 1710 in that file) for the `buildShipAbilities` invocation shape. Add a test that builds a ship whose active skill text is e.g. `'This Unit deals <unit-damage>100% damage</unit-damage> and inflicts <unit-skill>Disable</unit-skill> for 1 turn.'` and asserts the produced abilities include a `type: 'debuff'` ability with `config.buffName === 'Disable'` and `config.duration === 1`. (Confirm it is NOT emitted as a `type: 'control'` ability — `parseControlInflict` is Stasis-only.)
+
+- [ ] **Step 2: Run.** `npx vitest run src/utils/abilities/__tests__/buildShipAbilities.test.ts -t "Disable"` → expected PASS. If the duration/shape differs, adapt the assertion to the actual parser output (the point is: a named `Disable` debuff, not a control ability).
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add src/utils/abilities/__tests__/buildShipAbilities.test.ts
+git commit -m "test(combat): D-PR13 — lock skill-text 'inflicts Disable' → named Disable debuff"
+```
+
+---
+
+## Task 7: Docs, changelog, and full verification
+
+**Files:**
+- Modify: `src/constants/changelog.ts` (`UNRELEASED_CHANGES`)
+- Modify (if it tracks control simulation): `docs/skill-model-coverage.md`
+- Modify (if it documents control effects): `src/pages/DocumentationPage.tsx`
+
+- [ ] **Step 1: Changelog.** Add a plain-English entry to `UNRELEASED_CHANGES` in `src/constants/changelog.ts`, e.g.: *"Combat simulator: the Disable control now skips the affected ship's turn (and locks out its reactions), so effects like the Martyrdom implant and Disable-inflicting skills take effect in the simulation."*
+
+- [ ] **Step 2: Coverage doc.** Check `docs/skill-model-coverage.md` (and the `simCoverage.ts` note) for any claim that Disable / control turn-skip is unsimulated. `NOT_SIMULATED_TYPES` stays `{'control'}` (the control *type* still only drives cast-path reactions). If the coverage doc says only Stasis skips turns, update it to note Disable now does too via the named-debuff path. If nothing references it, skip (and say so in the commit).
+
+- [ ] **Step 3: In-app docs.** If `DocumentationPage.tsx` documents control/Stasis behavior in the combat sim, add Disable alongside it. If not, skip.
+
+- [ ] **Step 4: Byte-identical audit.** Confirm no golden/snapshot moved and no fixture carries a turn-taking `Disable`:
+
+```bash
+grep -rn "Disable" src/utils/calculators/__tests__/ src/utils/combat/__tests__/ | grep -v "disable.test.ts\|disableBuffs\|equipmentAbilities.integration\|buildShipAbilities"
+git status --porcelain   # expect NO .snap changes
+```
+
+  Expected: the only `Disable` references outside this PR's new/extended tests are pre-existing (e.g. the Makoli parser test, the existing Martyrdom Test A/B). No `.snap` files in the diff.
+
+- [ ] **Step 5: Full suite + lint + types + skills audit.**
+
+```bash
+npx vitest run            # entire suite green (new tests added, ZERO golden movement)
+npm run lint              # 0 warnings
+npx tsc --noEmit          # clean
+npm run audit:skills      # unchanged (0 findings / 141 ships)
+```
+
+  If any golden/snapshot changed, STOP — investigate the leak (do not `-u`).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/constants/changelog.ts docs/skill-model-coverage.md src/pages/DocumentationPage.tsx
+git commit -m "docs(combat): D-PR13 — changelog + coverage note for Disable turn-skip"
+```
+
+  (Drop paths that you didn't actually change from the `git add`.)
+
+---
+
+## Done criteria
+
+- `disableBuffs.ts` + `isTurnBlocked` route the three turn gates and the reactive drain filter; break/immunity stay Stasis-only.
+- New `disable.test.ts` proves: skip, duration-N decrement, NO break-on-hit, NO immunity, reactive suppression, cleanse-resume.
+- Martyrdom end-to-end test shows the killer skipping after the kill (non-vacuous control).
+- Skill-text `Disable` parses to a named debuff (lock test).
+- Full suite green, goldens byte-identical, lint/tsc/audit clean, changelog updated.

--- a/docs/superpowers/plans/2026-06-22-disable-turn-skip-control.md
+++ b/docs/superpowers/plans/2026-06-22-disable-turn-skip-control.md
@@ -96,6 +96,8 @@ git commit -m "feat(combat): D-PR13 — Disable buff-name set + isDisable predic
 
 **Read first:** `stasis.test.ts` tests (i), (iii), and B3 Task 2 (i). You will mirror the harness (`ab`, `basicAttack`, `parsedTarget`, `basePattern`, `offensiveEnemyAt`, `teamAttackerAt`, the `run` helper, `POS_*` constants). Copy that harness into `disable.test.ts` and add a `disableInflictAttack(turns)` builder (identical to `stasisInflictAttack` but `buffName: 'Disable'`).
 
+**IMPORTANT — event shapes (verified against `events.ts`):** the `attacked` event is `{ type, targetId, attackerId, round, didCrit? }` — it has **NO `damage` field**. To prove "damage lands" (no immunity), observe the `hp-changed` event instead: `{ type:'hp-changed', targetId, round, oldPct, newPct }` (fires when an actor takes HP damage). When you copy the `run` helper, ADD `'hp-changed'` to its `INTERESTING_TYPES` array so it is collected.
+
 - [ ] **Step 1: Write the failing tests.** Create `src/utils/combat/__tests__/disable.test.ts` with the mirrored harness plus these tests (full code — adapt imports/harness from `stasis.test.ts`):
 
   **(i) A disabled enemy skips its action.** Mirror `stasis.test.ts` (i) but inflict `Disable(2)` from the focus every round; assert `enemy-front` never emits `ability-performed` across 4 rounds, `enemy-back` (untargeted) fires every round, `result.rounds` has length 4.
@@ -141,18 +143,19 @@ describe('D-PR13 — Disable: direct hit does NOT break it (contrast vs Stasis) 
         expect(focusRounds).toContain(4);     // Disable(3) expired → acts
 
         // No immunity: the breaker actually damaged the focus while it was disabled.
-        const hitFocus = events.filter(
-            (e): e is Extract<CombatEvent, { type: 'attacked' }> =>
-                e.type === 'attacked' && e.targetId === 'attacker' && e.attackerId === 'breaker'
+        // (The `attacked` event has no damage field — observe hp-changed's pct decline instead.)
+        const focusHpChanged = events.filter(
+            (e): e is Extract<CombatEvent, { type: 'hp-changed' }> =>
+                e.type === 'hp-changed' && e.targetId === 'attacker'
         );
-        expect(hitFocus.length).toBeGreaterThan(0);
-        expect(hitFocus.some((e) => e.damage > 0)).toBe(true);
+        expect(focusHpChanged.length).toBeGreaterThan(0);
+        expect(focusHpChanged.some((e) => e.newPct < e.oldPct)).toBe(true);
         expect(result.rounds).toHaveLength(4);
     });
 });
 ```
 
-  > NOTE on the `attacked` event shape: confirm the field names (`targetId`/`attackerId`/`damage`) against `events.ts` while writing — adapt if they differ.
+  > NOTE: `'hp-changed'` must be added to the copied `run` helper's `INTERESTING_TYPES` array (the stasis copy omits it). The `attacked` event carries no `damage` — do not assert on it.
 
 - [ ] **Step 2: Run to verify they fail.** `npx vitest run src/utils/combat/__tests__/disable.test.ts` → FAIL (Disable not honored: the disabled actor still acts).
 

--- a/docs/superpowers/specs/2026-06-22-disable-turn-skip-control-design.md
+++ b/docs/superpowers/specs/2026-06-22-disable-turn-skip-control-design.md
@@ -1,0 +1,153 @@
+# Disable as a turn-skip control effect (D-PR13) — Design
+
+**Date:** 2026-06-22
+**Branch:** `feat/combat-d-pr13-disable-turn-skip` (off the D-PR12 tip `998416c3`)
+**Bucket:** D (implants + gear-set abilities) — the control-mechanic PR that lights up D-PR7 Martyrdom.
+
+## Problem
+
+The `Disable` status is the game's second turn-skip control (after Stasis), but the
+combat engine does not model it. Today only **Stasis** skips a unit's turn
+(`STASIS_BUFFS` / `isStasised`). Every source of Disable therefore applies an inert
+buff:
+
+- **Martyrdom** (D-PR7 implant) applies `Disable` to the killer on death — but the
+  registry comment states it plainly: *"Disable is not a modeled turn-effect yet
+  (only Stasis skips turns) — the debuff is applied to the killer + logged."* So
+  Martyrdom is emit-only.
+- **5 skill-text inflictors** parse `Disable` as a named timed debuff and land it on
+  enemies, where it currently does nothing: APEX (charged, shield-gated), IonScorp
+  (active, vs Defender), Makoli (reactive on-attacked < 40% HP), Xcellence (charged),
+  Yuyan (charged).
+
+This PR makes the engine honor a `Disable` buff as a turn-skip control. Because the
+turn gate is **buff-name-driven**, this lights up Martyrdom *and* all 5 skill-text
+inflictors with **no parser change**.
+
+## Game model (user-ratified)
+
+Disable = **locked out, takes damage**:
+
+| Axis | Stasis | Disable |
+| --- | --- | --- |
+| Skips the unit's scheduled action (active/charged skill + attack) | yes | **yes** |
+| Reactive abilities suppressed while afflicted | yes | **yes** |
+| Timed statuses + DoTs still tick/decrement on the skipped turn (duration N → N skips) | yes | **yes** |
+| Broken by a direct hit | yes (§4.5) | **no** — persists when hit |
+| Damage immunity | no (hits land, then break) | **no** — hits land normally |
+
+So Disable shares Stasis's **turn-skip + reactive-lockout** axes, and diverges on the
+**break-on-hit** axis (Stasis-only).
+
+## Approach
+
+**Chosen: a shared `isTurnBlocked` predicate.** Mirror `stasisBuffs.ts` with a tiny
+`disableBuffs.ts`, add an `isDisabled` reader and an `isTurnBlocked = isStasised ||
+isDisabled` composite in the engine, and route the **turn-action gates** and the
+**reactive-suppression** site through `isTurnBlocked`. Leave the break/immunity sites
+keyed on `isStasised` so Disable never breaks.
+
+Alternatives rejected:
+
+- *Fold Disable into a renamed `TURN_SKIP_BUFFS` set and special-case the break.* More
+  invasive to existing Stasis semantics, muddies the "Stasis" naming, risks the break
+  logic. No.
+- *Model Disable as a first-class `control` effect with a generalized control-lockout
+  subsystem.* Over-engineered for one new effect; YAGNI. The `control` ability *type*
+  already exists for cast-path `control-applied` reactions and is untouched here.
+
+## Components & changes
+
+### New: `src/utils/combat/disableBuffs.ts` (mirrors `stasisBuffs.ts`)
+
+```ts
+export const DISABLE_BUFFS: ReadonlySet<string> = new Set(['Disable']);
+export function isDisable(buffName: string): boolean { return DISABLE_BUFFS.has(buffName); }
+```
+
+Doc comment spells out the divergence from Stasis: turn-skip + reactive-lockout, but
+**not** broken by hits and **no** damage immunity. Extensible from game data (like
+`STASIS_BUFFS`) if other named turn-skip controls appear (e.g. Stun/Freeze).
+
+### `src/utils/combat/engine.ts` — surgical
+
+1. Import `isDisable` (and `DISABLE_BUFFS` for the skip-body if needed).
+2. Next to `isStasised` (~1689) add:
+   - `const isDisabled = (id) => ownerDebuffNames(id).some(isDisable);`
+   - `const isTurnBlocked = (id) => isStasised(id) || isDisabled(id);`
+3. Swap `isStasised` → `isTurnBlocked` at the **three turn-action gates**: focus
+   (~3437), walked-team (~3625), enemy (~3837).
+4. Swap `isStasised` → `isTurnBlocked` at the **reactive-suppression** site (~3092,
+   `if (isStasised(intent.ownerId)) continue;`).
+
+**Left Stasis-only, untouched** (Disable must not break, and is never break-marked):
+
+- The `tgtWasStasised` break sites (~3463 / ~3643 / ~3882) and the `onHitBreakStasis`
+  hook (~2627).
+- The `stasisBreakPending` consumption in the three skip-body else-branches (a disabled
+  actor is never added to `stasisBreakPending`, so these are no-ops for it).
+- `__testTapIsStasised`.
+
+Decrement story: a disabled unit is still scheduled by `selectNextBySpeed`; the gate
+wraps only the action body, so the Post-Turn decrements still run and the `Disable`
+timed debuff (carried in the per-actor enemy-debuff store, like Stasis) ticks down →
+duration N skips exactly N scheduled turns. Damage lands normally because nothing in
+the incoming pipeline keys on `isStasised`/`isDisabled`.
+
+### What lights up (buff-name-driven, no new parsing)
+
+- **Martyrdom** — on-death `Disable` on the enemy killer; the enemy turn gate (~3837)
+  now skips it. The end-to-end "lights up Martyrdom" proof.
+- **APEX / IonScorp / Makoli / Xcellence / Yuyan** — their `Disable` lands as a named
+  timed enemy debuff; that enemy now skips its turns.
+
+## Out of scope (explicit)
+
+- **Tygr's** "deal 30% more damage to enemies with Stasis or Disable" — an
+  outgoing-damage *condition* subject, not turn-skip; belongs to the conditional-damage
+  bucket.
+- **No UI changes.** The round/simulator display inherits whatever skipped-turn
+  surfacing Stasis already has; no new indicator.
+- `parseControlInflict` stays Stasis-only; no new `ControlEffect` member. Disable rides
+  the existing named-debuff path.
+- `NOT_SIMULATED_TYPES` stays `{'control'}` — unchanged. The `control` ability *type*
+  only drives cast-path `control-applied` reactions; Disable's effect is delivered via
+  the debuff path, exactly like Stasis's own turn-skip.
+
+## Testing
+
+Mirror the existing Stasis suite (`stasisBuffs.test.ts`, `isStasised.test.ts`,
+`stasis.test.ts`).
+
+- **`disableBuffs.test.ts`** — set membership + `isDisable` predicate.
+- **`isTurnBlocked` reader** — coverage that a unit carrying `Disable` reads blocked,
+  and the composite is true for either Stasis or Disable.
+- **Engine `disable.test.ts`** (mirror `stasis.test.ts`):
+  - A disabled actor skips its scheduled turn (no attack/skill); duration N → N skips,
+    then it acts on the next turn.
+  - Reactive abilities are suppressed while disabled (mirror §4.4).
+  - **Contrast vs Stasis:** a direct hit does **not** break Disable — the unit stays
+    disabled and keeps skipping for the remaining duration.
+  - **No immunity:** the hit's damage lands normally on a disabled unit.
+- **Martyrdom end-to-end** — extend D-PR7's `equipmentAbilities.integration.test.ts`
+  Martyrdom block (already asserts the `debuff-applied` event): a focus ship dies to a
+  killer, `Disable` lands on the killer, and the killer **skips** its next turn(s).
+- **Skill-text path** — one synthetic ship inflicting `Disable` on an enemy → enemy
+  skips (proves the buff-name-driven wiring covers the parser path, not just implants).
+
+## Byte-identical gate
+
+No existing golden or battle-sim fixture carries a `Disable` buff on a turn-taking
+unit (synthetic ships only; corpus Disablers are not in the goldens). Audit before
+claiming: `grep -rn Disable` over `src/utils/calculators/__tests__/` and
+`src/utils/combat/__tests__/`. Expect **zero** golden/snapshot movement. If a golden
+moves, a real-ship Disable leaked into a fixture — investigate the leak; never
+`vitest -u` the goldens.
+
+## Risks
+
+- A stasised/disabled **focus** actor in DPS mode would change DPS output — but no DPS
+  golden carries Disable, so this stays inert there.
+- The reactive-suppression generalization (~3092) drops a disabled unit's queued
+  reactives; verified consistent with "locked out". Confirm no test relies on a
+  disabled unit reacting (none expected — Disable was inert before this PR).

--- a/docs/superpowers/specs/2026-06-22-disable-turn-skip-control-design.md
+++ b/docs/superpowers/specs/2026-06-22-disable-turn-skip-control-design.md
@@ -102,6 +102,14 @@ timed debuff (carried in the per-actor enemy-debuff store, like Stasis) ticks do
 duration N skips exactly N scheduled turns. Damage lands normally because nothing in
 the incoming pipeline keys on `isStasised`/`isDisabled`.
 
+**Cleanse resume (verified, free):** because `isDisabled` reads `ownerDebuffNames(id)`
+**live at each turn gate**, a cleanse that removes the `Disable` debuff makes the unit
+resume its regular walk on its next scheduled turn — no extra production wiring.
+Confirmed against the code: `statusEngine.cleanse` → `removeNewestFirst(id, 'debuffs',
+n)` deletes removable timed entries from the per-actor `enemyMaps` store (the same store
+`ownerDebuffNamesFor` reads), and `Disable` is **not** in `UNREMOVABLE_STATUSES`
+(`cheatDeathBuffs.ts`), so it is fully cleanse-removable. This must be locked by a test.
+
 ### What lights up (buff-name-driven, no new parsing)
 
 - **Martyrdom** — on-death `Disable` on the enemy killer; the enemy turn gate (~3837)
@@ -137,6 +145,8 @@ Mirror the existing Stasis suite (`stasisBuffs.test.ts`, `isStasised.test.ts`,
   - **Contrast vs Stasis:** a direct hit does **not** break Disable — the unit stays
     disabled and keeps skipping for the remaining duration.
   - **No immunity:** the hit's damage lands normally on a disabled unit.
+  - **Cleanse resume:** a disabled unit whose `Disable` is cleansed (removed from its
+    debuff store) acts again on its next scheduled turn (no longer turn-blocked).
 - **Martyrdom end-to-end** — extend D-PR7's `equipmentAbilities.integration.test.ts`
   Martyrdom block (already asserts the `debuff-applied` event): a focus ship dies to a
   killer, `Disable` lands on the killer, and the killer **skips** its next turn(s).

--- a/docs/superpowers/specs/2026-06-22-disable-turn-skip-control-design.md
+++ b/docs/superpowers/specs/2026-06-22-disable-turn-skip-control-design.md
@@ -72,20 +72,28 @@ Doc comment spells out the divergence from Stasis: turn-skip + reactive-lockout,
 ### `src/utils/combat/engine.ts` — surgical
 
 1. Import `isDisable` (and `DISABLE_BUFFS` for the skip-body if needed).
-2. Next to `isStasised` (~1689) add:
+2. Next to `isStasised` (~1710) add:
    - `const isDisabled = (id) => ownerDebuffNames(id).some(isDisable);`
    - `const isTurnBlocked = (id) => isStasised(id) || isDisabled(id);`
 3. Swap `isStasised` → `isTurnBlocked` at the **three turn-action gates**: focus
-   (~3437), walked-team (~3625), enemy (~3837).
-4. Swap `isStasised` → `isTurnBlocked` at the **reactive-suppression** site (~3092,
+   (~3690), walked-team (~3878), enemy (~4090) — each `if (!isStasised(actor.id))`.
+4. Swap `isStasised` → `isTurnBlocked` at the **reactive-suppression** site (~3323,
    `if (isStasised(intent.ownerId)) continue;`).
+
+(Line numbers are as of branch base `998416c3`; the implementer should grep for the
+exact `isStasised(` call sites rather than trusting offsets, and confirm each is one of
+the four routed sites above before switching it.)
 
 **Left Stasis-only, untouched** (Disable must not break, and is never break-marked):
 
-- The `tgtWasStasised` break sites (~3463 / ~3643 / ~3882) and the `onHitBreakStasis`
-  hook (~2627).
-- The `stasisBreakPending` consumption in the three skip-body else-branches (a disabled
-  actor is never added to `stasisBreakPending`, so these are no-ops for it).
+- The `tgtWasStasised` / `teamTgtWasStasised` / `enemyTgtWasStasised` break sites
+  (~3716 / ~3896 / ~4135) and the `onHitBreakStasis` hook (param defined
+  `playerTurn.ts:288`, injected at `engine.ts` ~3724 / ~3900 / ~4183).
+- The `stasisBreakPending` consumption in the three skip-body else-branches (~3852 /
+  ~4001 / ~4468) — a disabled actor is never added to `stasisBreakPending`, so these
+  are no-ops for it.
+- The `victimStasised` damage-event metadata fields (~2598 / ~2949 / ~4166 / ~4175) —
+  event reporting, not a turn gate.
 - `__testTapIsStasised`.
 
 Decrement story: a disabled unit is still scheduled by `selectNextBySpeed`; the gate

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -22,6 +22,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator now models two ally-support implants: Spearhead (after the carrier uses its charged skill, a chance to grant all allies Attack Up for 1 turn) and Font of Power (a chance to grant a buff to the allies it repairs). Spearhead is fully resolved; Font of Power applies and appears in the combat log with its attack bonus coming in a later update.',
     "Combat simulator: the Font of Power implant's Power Infused Nanobots buff now grants the repaired ally flat attack equal to 100% of the caster's attack at the time of the repair (previously this attack bonus had no effect).",
     'Combat simulator now models the Fortifying Shroud implant — a chance each turn to grant adjacent allies a Defense Up buff.',
+    "Combat simulator: the Disable control now skips the affected ship's turn and locks out its reactions, so effects that apply Disable — like the Martyrdom implant and Disable-inflicting skills — now take effect in the simulation.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -3246,3 +3246,38 @@ describe('buildShipAbilities — D-PR3 Iridium incoming-reduction parser (T5)', 
         });
     });
 });
+
+// D-PR13: 'inflicts Disable for N turns' in active skill text → named Disable DEBUFF, not control.
+// Locks the contract that parseControlInflict is Stasis-only, so Disable falls through to the
+// named-debuff parser. The engine's isTurnBlocked() then recognises any active 'Disable' buff by
+// name, so all five corpus ships (APEX, IonScorp, Makoli, Xcellence, Yuyan) light up for free.
+describe('buildShipAbilities — D-PR13 Disable active-skill: named debuff, not control', () => {
+    it('active skill "inflicts Disable for 1 turn" produces a named Disable DEBUFF, not a control ability', () => {
+        const s = ship({
+            activeSkillText:
+                'This Unit deals <unit-damage>100% damage</unit-damage> and inflicts <unit-skill>Disable</unit-skill> for 1 turn.',
+        });
+
+        const { slots } = buildShipAbilities(s);
+        const active = slot(slots, 'active');
+        expect(active).toBeDefined();
+
+        // Must produce a named debuff with buffName === 'Disable'.
+        const debuff = active!.abilities.find((a) => a.type === 'debuff');
+        expect(debuff).toMatchObject({
+            type: 'debuff',
+            target: 'enemy',
+            trigger: 'on-cast',
+            config: {
+                type: 'debuff',
+                buffName: 'Disable',
+                duration: 1,
+            },
+        });
+
+        // Must NOT produce a control-type ability for Disable
+        // (parseControlInflict is Stasis-only; Disable must not be claimed by it).
+        const control = active!.abilities.find((a) => a.type === 'control');
+        expect(control).toBeUndefined();
+    });
+});

--- a/src/utils/combat/__tests__/disable.test.ts
+++ b/src/utils/combat/__tests__/disable.test.ts
@@ -438,3 +438,278 @@ describe('D-PR13 Task 2 — Disable turn-skip: (iii) Disable does NOT break on a
         expect(result.rounds).toHaveLength(4);
     });
 });
+
+// ── B3 — reactive suppression while disabled ─────────────────────────────────────────────
+
+/**
+ * D-PR13 Task 3 — drain-time reactive suppression for Disable.
+ *
+ * While a unit is disabled, every queued reactive intent whose ownerId matches the
+ * disabled actor is dropped at drainQueue's per-intent loop — IDENTICAL to Stasis.
+ * This is achieved by routing the drain guard through `isTurnBlocked` (isStasised OR
+ * isDisabled) rather than only isStasised.
+ *
+ * Two invariants proved (mirroring B3 Task 1 (a) and (c) for Stasis):
+ *   (iv) on-attacked self-buff reactive on the PLAYER (focus) is suppressed while disabled.
+ *   (v)  INCOMING effects (DoT ticks) on the disabled actor are UNTOUCHED.
+ *
+ * Non-vacuity: the stasis B3 tests (a) and (d) prove the reactive fires absent the
+ * control; the symmetric structure here (same skill builder, same harness) guarantees
+ * the reactive WOULD fire if Disable were not present — suppression is real.
+ */
+
+// Skill helpers for Disable B3 tests ─────────────────────────────────────────────────────
+
+/**
+ * A passive `on-attacked` self-buff slot: 'Counter Shield' (+10% attack, duration 99).
+ * The focus carries this; when hit while NOT disabled it fires buff-applied 'Counter Shield'.
+ * While disabled the intent's ownerId === 'attacker' → dropped by the drain guard.
+ * (Copied from stasis.test.ts B3 — same helper, same semantics.)
+ */
+const onAttackedSelfBuffSlot = (): ShipSkills['slots'][number] => ({
+    slot: 'passive',
+    abilities: [
+        ab({
+            type: 'buff',
+            target: 'self',
+            trigger: 'on-attacked',
+            config: {
+                type: 'buff',
+                buffName: 'Counter Shield',
+                stacks: 1,
+                parsedEffects: { attack: 10 },
+                isStackable: false,
+                duration: 99,
+            },
+        }),
+    ],
+});
+
+// ── (iv) on-attacked counter suppressed while disabled ────────────────────────────────────
+
+describe('D-PR13 Task 3 — reactive suppression: (iv) on-attacked self-buff suppressed while focus is disabled', () => {
+    it('a disabled focus does NOT receive its on-attacked buff when the enemy strikes it', () => {
+        idc = 0;
+        /**
+         * Setup (mirrors stasis B3 (a) but with Disable):
+         *   - Focus ('attacker') at POS_FOCUS carries onAttackedSelfBuffSlot.
+         *     Speed 50 — SLOWER than the enemies so the enemy acts FIRST each round.
+         *   - disable-enemy (id='disable-enemy', speed=200): fires disableInflictAttack(4)
+         *     at 'front' player (= focus at M4) in round 1. Disable(4) keeps the focus
+         *     disabled for rounds 1–4.
+         *   - attack-enemy (id='attack-enemy', speed=100): a bare flat-card attacker that
+         *     hits the focus every round (speed 100 > focus speed 50, acts before focus).
+         *   - numRounds: 4.
+         *
+         * Round ordering each round: disable-enemy(200) → attack-enemy(100) → focus(50)
+         *
+         * Round 1:
+         *   disable-enemy applies Disable(4) to focus.
+         *   attack-enemy attacks focus → focus is disabled → `attacked` event fires → listener
+         *   enqueues intent(ownerId='attacker') → drain guard: isTurnBlocked('attacker')=true → DROP.
+         *   No 'Counter Shield' buff-applied in round 1.
+         *   focus's own turn: disabled → skip.
+         *
+         * Rounds 2–4: attack-enemy attacks focus every round → intent dropped → no Counter Shield.
+         *
+         * Assert: zero 'buff-applied' events for 'Counter Shield' on actorId='attacker' across
+         *   all 4 rounds (the listener fires, the intent enqueues, but drain discards it).
+         */
+        const bus = createEventBus();
+        const buffApplied: CombatEvent[] = [];
+        bus.on('buff-applied', (e) => buffApplied.push(e as CombatEvent));
+
+        runCombat({
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [onAttackedSelfBuffSlot()] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 4,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            hacking: 0, // focus cannot inflict anything
+            speed: 50, // SLOWER than all enemies → enemies always act before focus
+            healTargetId: 'attacker',
+            position: POS_FOCUS, // M4 = front-most player
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            bus,
+            enemyAttackers: [
+                // disable-enemy: applies Disable(4) to the front player (focus).
+                {
+                    id: 'disable-enemy',
+                    stats: {
+                        attack: 100,
+                        crit: 0,
+                        critDamage: 0,
+                        defence: 0,
+                        hp: 1_000_000_000,
+                        speed: 200, // fastest — acts first
+                        security: 0,
+                        hacking: 200,
+                    },
+                    chargeCount: 0,
+                    startCharged: false,
+                    position: POS_ENEMY_FRONT,
+                    target: parsedTarget('front'),
+                    pattern: basePattern(),
+                    shipSkills: { slots: [disableInflictAttack(4)] },
+                } as EnemyAttacker,
+                // attack-enemy: bare attacker that triggers the on-attacked listener each round.
+                {
+                    id: 'attack-enemy',
+                    stats: {
+                        attack: 100,
+                        crit: 0,
+                        critDamage: 0,
+                        defence: 0,
+                        hp: 1_000_000_000,
+                        speed: 100, // acts after disable-enemy, before focus
+                        security: 0,
+                        hacking: 0,
+                    },
+                    chargeCount: 0,
+                    startCharged: false,
+                    position: POS_ENEMY_BACK,
+                    target: parsedTarget('front'),
+                    pattern: basePattern(),
+                    shipSkills: { slots: [basicAttack()] },
+                } as EnemyAttacker,
+            ],
+        });
+
+        // The on-attacked intent was enqueued each round (the enemy hit the focus), but the
+        // drain guard must have dropped every one (focus disabled rounds 1–4).
+        // → Zero 'Counter Shield' buff-applied events for the focus.
+        const counterShield = buffApplied.filter(
+            (e): e is Extract<CombatEvent, { type: 'buff-applied' }> =>
+                e.type === 'buff-applied' &&
+                e.actorId === 'attacker' &&
+                e.buffName === 'Counter Shield'
+        );
+        expect(counterShield).toHaveLength(0);
+    });
+});
+
+// ── (v) incoming DoT still ticks on a disabled actor ─────────────────────────────────────
+
+describe('D-PR13 Task 3 — reactive suppression: (v) incoming DoT still ticks on a disabled actor', () => {
+    it('a DoT applied by an enemy still ticks on the disabled focus — incoming effects are not suppressed', () => {
+        idc = 0;
+        /**
+         * Mirrors stasis B3 (c): only the disabled actor's OWN outgoing intents are suppressed.
+         * Incoming DoT ticks (tickDoTs at turn-start) are completely unaffected.
+         *
+         * Setup: dot-disable-enemy applies Corrosion + Disable(2) in round 1.
+         *   dot-disable-enemy (speed=120) acts BEFORE focus (speed=50) in every round.
+         *   Round 1: applies Corrosion(tier=5, stacks=3, dur=10) + Disable(2) to focus.
+         *   Rounds 1–2: focus disabled; dot-ticked events must still appear for 'attacker'.
+         *
+         * Assert: dot-ticked events for targetId='attacker' fire in both round 1 AND round 2
+         *   (incoming effects are untouched regardless of Disable).
+         */
+        const { events } = run({
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 3,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            hacking: 0,
+            speed: 50, // focus slower → enemy always acts first
+            healTargetId: 'attacker',
+            enemyAttackers: [
+                {
+                    id: 'dot-disable-enemy',
+                    stats: {
+                        attack: 1000,
+                        crit: 0,
+                        critDamage: 0,
+                        defence: 0,
+                        hp: 1_000_000_000,
+                        speed: 120, // fast — always acts before the focus
+                        security: 0,
+                        hacking: 200,
+                    },
+                    chargeCount: 0,
+                    startCharged: false,
+                    shipSkills: {
+                        slots: [
+                            {
+                                slot: 'active',
+                                abilities: [
+                                    // Apply corrosion DoT
+                                    ab({
+                                        type: 'dot',
+                                        target: 'enemy',
+                                        config: {
+                                            type: 'dot',
+                                            dotType: 'corrosion',
+                                            tier: 5,
+                                            stacks: 3,
+                                            duration: 10,
+                                        },
+                                    }),
+                                    // Apply Disable to the heal target
+                                    ab({
+                                        type: 'debuff',
+                                        target: 'enemy',
+                                        config: {
+                                            type: 'debuff',
+                                            buffName: 'Disable',
+                                            application: 'inflict',
+                                            duration: 2,
+                                            stacks: 1,
+                                            isStackable: false,
+                                            parsedEffects: {},
+                                        },
+                                    }),
+                                ],
+                            },
+                        ],
+                    },
+                } as EnemyAttacker,
+            ],
+        });
+
+        const dotTicked = events.filter(
+            (e): e is Extract<CombatEvent, { type: 'dot-ticked' }> => e.type === 'dot-ticked'
+        );
+
+        // Focus is disabled in rounds 1–2 (enemy acts first in round 1 and applies both DoT
+        // and Disable, then focus's turn is skipped in rounds 1–2 but DoT ticks at turn-start).
+        // Incoming DoT must still fire for 'attacker' in rounds 1 AND 2.
+        const dotRoundsForFocus = dotTicked
+            .filter((e) => e.targetId === 'attacker')
+            .map((e) => e.round);
+        expect(dotRoundsForFocus).toContain(1);
+        expect(dotRoundsForFocus).toContain(2);
+    });
+});

--- a/src/utils/combat/__tests__/disable.test.ts
+++ b/src/utils/combat/__tests__/disable.test.ts
@@ -1,0 +1,439 @@
+/**
+ * D-PR13 Task 2 — Disable turn-skip integration tests.
+ *
+ * Disable mirrors Stasis on the turn-action gate (a disabled unit skips its scheduled
+ * action), but DIVERGES on two axes:
+ *   - Disable is NOT broken by a direct hit (Stasis is).
+ *   - Disable grants NO damage immunity (hits land normally).
+ *
+ * Three invariants:
+ *   (i)   A disabled enemy skips its action.
+ *   (ii)  Disable(2) decrements on skipped turns → exactly 2 skips.
+ *   (iii) Disable does NOT break on a direct hit, and damage still lands.
+ *
+ * Harness mirrors stasis.test.ts (ab / basicAttack / disableInflictAttack / parsedTarget /
+ * basePattern / teamAttackerAt / offensiveEnemyAt). The run helper additionally collects
+ * 'hp-changed' to prove incoming damage (the `attacked` event carries no damage field).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import type { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+// ── ID counter (reset per test block via `idc = 0`) ─────────────────────────────────────
+let idc = 0;
+
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `dis${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+// ── Skill builders ───────────────────────────────────────────────────────────────────────
+
+/** A single-hit 100% damage active skill (no status). */
+const basicAttack = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } }),
+    ],
+});
+
+/**
+ * A combined damage + Disable-inflict active skill.
+ * hacking:200 + security:0 on victims → landing chance 1.0 (always lands).
+ */
+const disableInflictAttack = (turns: number): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } }),
+        ab({
+            type: 'debuff',
+            target: 'enemy',
+            config: {
+                type: 'debuff',
+                buffName: 'Disable',
+                application: 'inflict',
+                duration: turns,
+                stacks: 1,
+                isStackable: false,
+                parsedEffects: {},
+            },
+        }),
+    ],
+});
+
+// ── ParsedTarget / Pattern helpers ──────────────────────────────────────────────────────
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+// ── Actor builders ───────────────────────────────────────────────────────────────────────
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
+
+/**
+ * A positioned enemy attacker with a configurable skill.
+ * security:0 → player Disable inflict always lands on this enemy.
+ */
+const offensiveEnemyAt = (
+    id: string,
+    position: Position,
+    selection: ParsedTarget['selection'],
+    skills: ShipSkills['slots'][number],
+    speedOverride = 1
+): EnemyAttacker =>
+    ({
+        id,
+        stats: {
+            attack: 2000,
+            crit: 0,
+            critDamage: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: speedOverride,
+            security: 0,
+            hacking: 200,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget(selection),
+        pattern: basePattern(),
+        shipSkills: { slots: [skills] },
+    }) as EnemyAttacker;
+
+/** A walked team actor. attackOverride defaults to 0 (no offense). */
+const teamAttackerAt = (
+    id: string,
+    position: Position,
+    speedOverride = 100,
+    attackOverride = 0
+): TeamActor => ({
+    id,
+    speed: speedOverride,
+    chargeCount: 0,
+    startCharged: false,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    position,
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    walk: {
+        shipSkills: { slots: [basicAttack()] },
+        stats: {
+            attack: attackOverride,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            hacking: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+        },
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        hasChargedSkill: false,
+    },
+});
+
+// ── Position constants ────────────────────────────────────────────────────────────────────
+const POS_FOCUS: Position = 'M4'; // front-most player
+const POS_TEAM: Position = 'M3';
+const POS_ENEMY_FRONT: Position = 'M4';
+const POS_ENEMY_BACK: Position = 'M1';
+
+// ── Run helper (collects all relevant events) ─────────────────────────────────────────────
+
+const INTERESTING_TYPES: CombatEvent['type'][] = [
+    'ability-performed',
+    'attacked',
+    'dot-ticked',
+    'buff-applied',
+    'buff-expired',
+    'debuff-applied',
+    'ship-destroyed',
+    'hp-changed',
+];
+
+const run = (input: CombatEngineInput) => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    for (const t of INTERESTING_TYPES) {
+        bus.on(t, (e) => events.push(e as CombatEvent));
+    }
+    const result = runCombat({ ...input, bus });
+    return { events, result };
+};
+
+// ── (i) ENEMY disabled by player: skips action ───────────────────────────────────────────
+
+describe('D-PR13 Task 2 — Disable turn-skip: (i) disabled enemy skips its action', () => {
+    it('a disabled enemy deals NO damage and emits NO ability-performed on the skipped turns', () => {
+        idc = 0;
+        /**
+         * Setup (mirrors stasis (i) but with Disable):
+         *   - Focus at POS_FOCUS fires `front` with disableInflictAttack(2) EVERY round.
+         *     player speed 100 > enemy speed 1 → focus always acts before enemy-front.
+         *   - The focus re-applies Disable each round, perpetually keeping enemy-front disabled.
+         *   - enemy-front is therefore NEVER able to act across all 4 rounds.
+         *   - enemy-back at M1 is not targeted (focus targets 'front' = M4) → acts normally
+         *     every round (control).
+         *   - numRounds:4.
+         */
+        const { events, result } = run({
+            attack: 5000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [disableInflictAttack(2)] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 4,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            hacking: 200,
+            healTargetId: 'attacker',
+            position: POS_FOCUS,
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            enemyAttackers: [
+                offensiveEnemyAt('enemy-front', POS_ENEMY_FRONT, 'front', basicAttack()),
+                offensiveEnemyAt('enemy-back', POS_ENEMY_BACK, 'back', basicAttack()),
+            ],
+        });
+
+        const abilityPerformed = events.filter(
+            (e): e is Extract<CombatEvent, { type: 'ability-performed' }> =>
+                e.type === 'ability-performed'
+        );
+
+        // enemy-front is perpetually disabled and NEVER fires in any of the 4 rounds.
+        const frontActedInRound = (r: number) =>
+            abilityPerformed.some((e) => e.actorId === 'enemy-front' && e.round === r);
+        for (let r = 1; r <= 4; r++) {
+            expect(frontActedInRound(r)).toBe(false);
+        }
+
+        // No 'attacked' events from enemy-front at all (it never deals damage).
+        const attackedByFront = events.filter(
+            (e): e is Extract<CombatEvent, { type: 'attacked' }> =>
+                e.type === 'attacked' && e.attackerId === 'enemy-front'
+        );
+        expect(attackedByFront).toHaveLength(0);
+
+        // The non-disabled enemy-back always fires (control: no effect on it).
+        for (let r = 1; r <= 4; r++) {
+            expect(abilityPerformed.some((e) => e.actorId === 'enemy-back' && e.round === r)).toBe(
+                true
+            );
+        }
+
+        expect(result.rounds).toHaveLength(4);
+    });
+});
+
+// ── (ii) Disable(2) decrements on skipped turns → exactly 2 skips ────────────────────────
+
+describe('D-PR13 Task 2 — Disable turn-skip: (ii) Disable(2) decrements on skipped turn → exactly 2 skips', () => {
+    it('the disabled actor skips rounds 1-2 and fires on round 3 (the round after expiry)', () => {
+        idc = 0;
+        /**
+         * Setup (disable-bot dies after round 1 so it cannot re-apply Disable):
+         *   - focus at POS_FOCUS (speed=100, basicAttack): disabled for rounds 1-2, fires round 3.
+         *   - killer at POS_TEAM (speed=200, attack=10000): acts before focus, kills disable-bot.
+         *   - disable-bot at POS_ENEMY_FRONT (speed=300, hp=1, hacking=200):
+         *     acts first in round 1, fires disableInflictAttack(2) targeting 'front' (=focus).
+         *     Then killer kills it. Dead → cannot re-apply Disable in round 2+.
+         *   - numRounds:3.
+         *
+         * Round 1 order: disable-bot(300) → killer(200) → focus(100)
+         *   1. disable-bot fires Disable(2) on focus.
+         *   2. killer kills disable-bot.
+         *   3. focus disabled → skip. Post-Turn: Disable 2→1.
+         * Round 2: disable-bot dead. killer fires. focus disabled(1) → skip. Post-Turn: 1→0 EXPIRED.
+         * Round 3: focus NOT disabled → fires.
+         */
+        const { events, result } = run({
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [basicAttack()] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 3,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            hacking: 0,
+            healTargetId: 'attacker',
+            position: POS_FOCUS,
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            teamActors: [teamAttackerAt('killer', POS_TEAM, 200, 10000)],
+            enemyAttackers: [
+                {
+                    id: 'disable-bot',
+                    stats: {
+                        attack: 2000,
+                        crit: 0,
+                        critDamage: 0,
+                        defence: 0,
+                        hp: 1, // killed by killer in round 1 → cannot re-apply Disable
+                        speed: 300, // acts before killer(200) and focus(100)
+                        security: 0,
+                        hacking: 200,
+                    },
+                    chargeCount: 0,
+                    startCharged: false,
+                    position: POS_ENEMY_FRONT,
+                    target: parsedTarget('front'),
+                    pattern: basePattern(),
+                    shipSkills: { slots: [disableInflictAttack(2)] },
+                } as EnemyAttacker,
+            ],
+        });
+
+        const abilityPerformed = events.filter(
+            (e): e is Extract<CombatEvent, { type: 'ability-performed' }> =>
+                e.type === 'ability-performed'
+        );
+        const focusFiredRounds = abilityPerformed
+            .filter((e) => e.actorId === 'attacker')
+            .map((e) => e.round);
+
+        expect(focusFiredRounds).not.toContain(1); // skip 1
+        expect(focusFiredRounds).not.toContain(2); // skip 2
+        expect(focusFiredRounds).toContain(3); // expired → acts
+
+        expect(result.rounds).toHaveLength(3);
+    });
+});
+
+// ── (iii) Disable does NOT break on a direct hit, and damage still lands ──────────────────
+
+describe('D-PR13 Task 2 — Disable turn-skip: (iii) Disable does NOT break on a direct hit', () => {
+    it('a disabled focus stays disabled across direct hits (no break) and still takes damage (no immunity)', () => {
+        idc = 0;
+        /**
+         * KEY DIVERGENCE from Stasis: a direct hit does NOT break Disable.
+         *
+         * Setup:
+         *   - disable-bot (speed=300, hp=1, hacking=200) at POS_ENEMY_FRONT fires
+         *     disableInflictAttack(3) at 'front' (=focus) in round 1. Acts first.
+         *   - killer (speed=200, attack=10000) kills disable-bot in round 1.
+         *   - breaker (offensiveEnemyAt at POS_ENEMY_BACK, speed=150) hits the focus with a
+         *     plain direct attack every round.
+         *   - focus (speed=100, attack 0, hp 1e9): disabled for rounds 1-3, fires round 4.
+         *     A Stasis would break on the breaker's hits; Disable must NOT.
+         *   - numRounds:4.
+         */
+        const { events, result } = run({
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [basicAttack()] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 4,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            hacking: 0,
+            speed: 100,
+            healTargetId: 'attacker',
+            position: POS_FOCUS,
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            teamActors: [teamAttackerAt('killer', POS_TEAM, 200, 10000)],
+            enemyAttackers: [
+                {
+                    id: 'disable-bot',
+                    stats: {
+                        attack: 2000,
+                        crit: 0,
+                        critDamage: 0,
+                        defence: 0,
+                        hp: 1, // killed by killer in round 1 → cannot re-apply Disable
+                        speed: 300, // acts before killer(200), breaker(150), focus(100)
+                        security: 0,
+                        hacking: 200,
+                    },
+                    chargeCount: 0,
+                    startCharged: false,
+                    position: POS_ENEMY_FRONT,
+                    target: parsedTarget('front'),
+                    pattern: basePattern(),
+                    shipSkills: { slots: [disableInflictAttack(3)] },
+                } as EnemyAttacker,
+                // breaker: plain direct hit at the focus every round (would break Stasis).
+                offensiveEnemyAt('breaker', POS_ENEMY_BACK, 'front', basicAttack(), 150),
+            ],
+        });
+
+        const abilityPerformed = events.filter(
+            (e): e is Extract<CombatEvent, { type: 'ability-performed' }> =>
+                e.type === 'ability-performed'
+        );
+        const focusRounds = abilityPerformed
+            .filter((e) => e.actorId === 'attacker')
+            .map((e) => e.round);
+
+        expect(focusRounds).not.toContain(1);
+        expect(focusRounds).not.toContain(2);
+        expect(focusRounds).not.toContain(3); // NOT broken by the breaker's hits (Stasis WOULD break)
+        expect(focusRounds).toContain(4);
+
+        // No immunity: focus HP declined while disabled (attacked has no damage field — use hp-changed).
+        const focusHp = events.filter(
+            (e): e is Extract<CombatEvent, { type: 'hp-changed' }> =>
+                e.type === 'hp-changed' && e.targetId === 'attacker'
+        );
+        expect(focusHp.length).toBeGreaterThan(0);
+        expect(focusHp.some((e) => e.newPct < e.oldPct)).toBe(true);
+
+        expect(result.rounds).toHaveLength(4);
+    });
+});

--- a/src/utils/combat/__tests__/disable.test.ts
+++ b/src/utils/combat/__tests__/disable.test.ts
@@ -187,7 +187,8 @@ describe('D-PR13 Task 2 — Disable turn-skip: (i) disabled enemy skips its acti
          * Setup (mirrors stasis (i) but with Disable):
          *   - Focus at POS_FOCUS fires `front` with disableInflictAttack(2) EVERY round.
          *     player speed 100 > enemy speed 1 → focus always acts before enemy-front.
-         *   - The focus re-applies Disable each round, perpetually keeping enemy-front disabled.
+         *   - Because familyApplicationWins allows overwrite when new duration > remaining,
+         *     the focus re-applies Disable each round, perpetually keeping enemy-front disabled.
          *   - enemy-front is therefore NEVER able to act across all 4 rounds.
          *   - enemy-back at M1 is not targeted (focus targets 'front' = M4) → acts normally
          *     every round (control).

--- a/src/utils/combat/__tests__/disable.test.ts
+++ b/src/utils/combat/__tests__/disable.test.ts
@@ -713,3 +713,158 @@ describe('D-PR13 Task 3 — reactive suppression: (v) incoming DoT still ticks o
         expect(dotRoundsForFocus).toContain(2);
     });
 });
+
+// ── D-PR13 Task 4 — cleanse-resume: a cleansed Disable restores the walk ──────────────────
+
+/**
+ * Disable is a REMOVABLE debuff (NOT in UNREMOVABLE_STATUSES), and the turn-action gate
+ * reads `ownerDebuffNames(id)` LIVE at each turn. So a `cleanse` that removes the Disable
+ * debuff from the focus's per-actor debuff store lets the focus resume acting on its very
+ * next scheduled turn — with NO extra production code. This test locks that.
+ *
+ * `cleanse` config shape (copied from cleanseCastPath.test.ts): { type: 'cleanse', count: 'all' }.
+ * Targeting 'all-allies' so the player-side cleanser reaches every player ally's debuff store,
+ * including the focus (the heal target).
+ */
+const cleanseAllAlliesSlot = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        ab({
+            type: 'cleanse',
+            target: 'all-allies',
+            config: { type: 'cleanse', count: 'all' },
+        }),
+    ],
+});
+
+/** A walked team actor carrying a cleanse-all-allies active (mirrors teamAttackerAt's walk shape). */
+const teamCleanserAt = (id: string, position: Position, speedOverride: number): TeamActor => ({
+    id,
+    speed: speedOverride,
+    chargeCount: 0,
+    startCharged: false,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    position,
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    walk: {
+        shipSkills: { slots: [cleanseAllAlliesSlot()] },
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            hacking: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+        },
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        hasChargedSkill: false,
+    },
+});
+
+describe('D-PR13 Task 4 — cleanse-resume: a cleansed Disable restores the focus walk', () => {
+    it('a same-side cleanser removes Disable(5) so the focus resumes acting immediately, NOT after the natural Disable expiry', () => {
+        idc = 0;
+        /**
+         * Setup (mirrors the disable-bot + killer pattern from tests (ii)/(iii)):
+         *   - disable-bot at POS_ENEMY_FRONT (speed=400, hp=1, hacking=200):
+         *     acts first in round 1, fires disableInflictAttack(5) at 'front' (= focus).
+         *     Then it is killed → Disable is NOT re-applied in later rounds.
+         *   - killer (team actor, speed=300, attack=10000): acts after the bot, kills it in round 1.
+         *   - cleanser (team actor, speed=200, attack=0): acts AFTER the killer but BEFORE the
+         *     focus; its walk carries cleanseAllAlliesSlot → it cleanses every player ally,
+         *     removing the freshly-applied Disable from the focus's debuff store.
+         *   - focus ('attacker', speed=100, basicAttack): acts LAST. By its turn the cleanser
+         *     has already removed Disable → the live gate sees no Disable → the focus FIRES.
+         *   - numRounds:3.
+         *
+         * Round 1 turn order: disable-bot(400) → killer(300) → cleanser(200) → focus(100)
+         *   1. disable-bot applies Disable(5) to focus.
+         *   2. killer kills disable-bot (no re-apply possible later).
+         *   3. cleanser cleanses all allies → focus's Disable is REMOVED.
+         *   4. focus's turn: live gate reads ownerDebuffNames('attacker') → no Disable → FIRES.
+         *
+         * KEY PROOF: WITHOUT the cleanse, Disable(5) keeps the focus disabled rounds 1–5 (it
+         * would only act in round 6). WITH the per-round cleanse the focus acts in round 1 —
+         * far earlier than the natural expiry. No production change is required: the gate read
+         * is live, so removing the debuff frees the unit on its next scheduled turn.
+         */
+        const { events, result } = run({
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [basicAttack()] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 3,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            hacking: 0,
+            speed: 100, // focus is the slowest → acts LAST every round
+            healTargetId: 'attacker', // focus is the disabled unit → player-side cleanse reaches it
+            position: POS_FOCUS,
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            teamActors: [
+                teamAttackerAt('killer', POS_TEAM, 300, 10000),
+                teamCleanserAt('cleanser', POS_TEAM, 200),
+            ],
+            enemyAttackers: [
+                {
+                    id: 'disable-bot',
+                    stats: {
+                        attack: 2000,
+                        crit: 0,
+                        critDamage: 0,
+                        defence: 0,
+                        hp: 1, // killed by killer in round 1 → cannot re-apply Disable
+                        speed: 400, // acts before killer(300), cleanser(200), focus(100)
+                        security: 0,
+                        hacking: 200,
+                    },
+                    chargeCount: 0,
+                    startCharged: false,
+                    position: POS_ENEMY_FRONT,
+                    target: parsedTarget('front'),
+                    pattern: basePattern(),
+                    shipSkills: { slots: [disableInflictAttack(5)] },
+                } as EnemyAttacker,
+            ],
+        });
+
+        const abilityPerformed = events.filter(
+            (e): e is Extract<CombatEvent, { type: 'ability-performed' }> =>
+                e.type === 'ability-performed'
+        );
+        const focusFiredRounds = abilityPerformed
+            .filter((e) => e.actorId === 'attacker')
+            .map((e) => e.round);
+
+        // The cleanser removes Disable before the focus's round-1 turn → focus FIRES round 1.
+        // This is only reachable if Disable was removed: Disable(5) would otherwise block
+        // rounds 1–5 (natural expiry at round 6, beyond this 3-round battle).
+        expect(focusFiredRounds).toContain(1);
+        // Non-vacuity: the focus fires in a round strictly < 5 — impossible under an
+        // unremoved Disable(5). Proves the cleanse genuinely freed the walk.
+        expect(focusFiredRounds.some((r) => r < 5)).toBe(true);
+
+        expect(result.rounds).toHaveLength(3);
+    });
+});

--- a/src/utils/combat/__tests__/disableBuffs.test.ts
+++ b/src/utils/combat/__tests__/disableBuffs.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { DISABLE_BUFFS, isDisable } from '../disableBuffs';
+
+describe('disableBuffs', () => {
+    it('DISABLE_BUFFS contains Disable', () => {
+        expect(DISABLE_BUFFS.has('Disable')).toBe(true);
+    });
+    it('isDisable returns true for Disable, false otherwise', () => {
+        expect(isDisable('Disable')).toBe(true);
+        expect(isDisable('Stasis')).toBe(false);
+        expect(isDisable('Attack Down')).toBe(false);
+    });
+});

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -1754,7 +1754,7 @@ describe('D-PR7 Task 4 integration — Martyrdom routes on-destroyed Disable to 
         const getGearPiece = makeGetGearPiece({ 'mart-skip': martPiece });
         const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
         const passive = baseSkills.slots.find((s) => s.slot === 'passive');
-        const mart = passive?.abilities.find((a) => a.id === 'equip-implant-MARTYRDOM');
+        const mart = passive?.abilities.find((a) => a.id.startsWith('equip-implant-MARTYRDOM'));
         expect(mart).toBeDefined();
         expect(mart!.trigger).toBe('on-destroyed');
         return [

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -1688,6 +1688,156 @@ describe('D-PR7 Task 4 integration — Martyrdom routes on-destroyed Disable to 
         );
         expect(disableEvents).toHaveLength(0);
     });
+
+    // -----------------------------------------------------------------------
+    // D-PR13 Task 5: END-TO-END consequence — the disabled killer SKIPS its turns
+    // -----------------------------------------------------------------------
+    //
+    // APPROACH A (the faithful design): a dying TEAM-actor Martyrdom carrier +
+    // a surviving tank focus + an enemy killer. Tests A/B above proved Martyrdom
+    // EMITS a Disable targeting the killer. THIS test proves the CONSEQUENCE:
+    // once the Disable lands, the killer actually skips its scheduled turns
+    // (observed via the absence of its `ability-performed` in the disabled rounds),
+    // and a non-Martyrdom CONTROL run shows the killer WOULD have acted — so the
+    // observed absence is genuine turn-suppression, not a vacuous artefact.
+    //
+    // Board / roster (uses the module-level positional helpers defined below:
+    // `playerActorAt`, `offensiveEnemyAt`, `parsedTargetFront`, `lineRange1`, `POS_BASE`):
+    //   - Focus 'attacker' (heal target, the TANK): huge HP, positioned BACK at M1,
+    //     no offense (POS_BASE's basicAttackSlot fires but deals 0 with attack:0). It
+    //     outlives the whole battle so it stays a valid `front` target after the martyr dies.
+    //   - Team actor 'martyr' at the FRONT cell M4, tiny HP (MARTYR_HP), carrying the
+    //     legendary Martyrdom passive in its `walk.shipSkills`. It is the front-most
+    //     player → the killer's `front` target in round 1 → dies to the lethal hit.
+    //   - Enemy 'mart-killer' at M1, fast (speed 1000 ≫ player speed 1), attack ≫ HP,
+    //     firing a Line-Range-1 hit at `front`. Round 1 it one-shots the front-most
+    //     player (the martyr). From round 2 on, the only living player is the tank at
+    //     M1, so absent Disable the killer keeps emitting `ability-performed`.
+    //
+    // Turn order per round: the fast killer acts first, then the slow players.
+    //   Round 1: killer fires → kills 'martyr' → Martyrdom on-destroyed routes a
+    //            Disable onto the killer. The killer's round-1 `ability-performed`
+    //            IS emitted (the disable lands during/after that turn's kill).
+    //   Round 2: the killer is Disabled → its scheduled turn is SUPPRESSED → NO
+    //            `ability-performed` from the killer. (The Disable is also decremented
+    //            on this skipped turn and expires at its tail.)
+    //   Round 3: the Disable has expired → the killer acts again (attacks the tank).
+    //
+    // numRounds: 3 — enough to observe act(R1) → skip(R2) → resume(R3).
+    //
+    // NOTE ON DURATION: the legendary Martyrdom Disable is duration 2, but the engine's
+    // timed-status decrement runs on the skipped turn too (the documented decrement-
+    // timing behaviour — a debuff applied during an actor's turn is decremented again at
+    // that actor's NEXT post-turn, i.e. the skipped one). The Disable is applied during
+    // the killer's round-1 turn, so it covers exactly ONE scheduled action (round 2) and
+    // expires before round 3. This test LOCKS the engine's actual end-to-end behaviour
+    // (one observable skipped turn for a legendary carrier), not a hand-computed turn count.
+    //
+    // NON-VACUITY CONTROL: an identical run where 'martyr' carries NO Martyrdom (a
+    // plain basic-attack slot only) → no Disable is ever applied → the killer emits
+    // `ability-performed` in round 2 (and every round). This proves the absence in the
+    // main run is genuine Disable suppression, not the killer simply having nothing to do.
+
+    const MARTYR_HP = 1_000; // tiny → the front origin hit one-shots the martyr
+    const TANK_HP = 1_000_000_000; // huge → the tank survives every round it is hit
+    const SKIP_NUM_ROUNDS = 3;
+
+    /** Martyr team-actor slots: a basic attack footprint + the legendary Martyrdom passive. */
+    function buildMartyrdomSlots(): ShipSkills['slots'] {
+        const ship = makeShip({ implants: { implant_major: 'mart-skip' } });
+        const martPiece = makePiece({
+            id: 'mart-skip',
+            slot: 'implant_major',
+            rarity: 'legendary',
+            setBonus: 'MARTYRDOM',
+        });
+        const getGearPiece = makeGetGearPiece({ 'mart-skip': martPiece });
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        const mart = passive?.abilities.find((a) => a.id === 'equip-implant-MARTYRDOM');
+        expect(mart).toBeDefined();
+        expect(mart!.trigger).toBe('on-destroyed');
+        return [
+            basicAttackSlot(),
+            ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+        ];
+    }
+
+    /** A fast positional enemy killer firing a lethal Line-Range-1 hit at `front`. */
+    const skipKiller = () => offensiveEnemyAt(KILLER_ID, 'M1', 1_000_000);
+
+    /** Run the positional skip scenario; collect ability-performed + ship-destroyed + debuff-applied. */
+    function runSkip(martyrSlots: ShipSkills['slots']) {
+        const bus = createEventBus();
+        const events: CombatEvent[] = [];
+        bus.on('ability-performed', (e) => events.push(e as CombatEvent));
+        bus.on('ship-destroyed', (e) => events.push(e as CombatEvent));
+        bus.on('debuff-applied', (e) => events.push(e as CombatEvent));
+        runCombat({
+            ...POS_BASE({
+                numRounds: SKIP_NUM_ROUNDS,
+                hp: TANK_HP, // the focus tank survives the whole battle
+                position: 'M1', // tank sits at the BACK
+                teamActors: [playerActorAt('martyr', 'M4', martyrSlots, MARTYR_HP)],
+                enemyAttackers: [skipKiller()],
+            }),
+            bus,
+        });
+        return events;
+    }
+
+    const killerActedInRound = (events: CombatEvent[], r: number) =>
+        events.some(
+            (e) => e.type === 'ability-performed' && e.actorId === KILLER_ID && e.round === r
+        );
+
+    it(
+        'C. End-to-end: after killing a Martyrdom carrier the killer is Disabled and SKIPS its turn ' +
+            '(acts round 1, suppressed round 2, resumes round 3) — non-Martyrdom control proves non-vacuity',
+        () => {
+            // --- Main run: martyr carries legendary Martyrdom -----------------
+            const main = runSkip(buildMartyrdomSlots());
+
+            // Sanity: the martyr died in round 1 ...
+            const martyrDeath = main.filter(
+                (e) => e.type === 'ship-destroyed' && e.actorId === 'martyr'
+            );
+            expect(martyrDeath.length).toBeGreaterThanOrEqual(1);
+            expect(martyrDeath.some((e) => e.type === 'ship-destroyed' && e.round === 1)).toBe(
+                true
+            );
+            // ... and a Disable debuff landed on the killer (the cause of the skip).
+            const disableOnKiller = main.filter(
+                (e) =>
+                    e.type === 'debuff-applied' &&
+                    e.buffName === 'Disable' &&
+                    e.targetId === KILLER_ID
+            );
+            expect(disableOnKiller.length).toBeGreaterThanOrEqual(1);
+
+            // The CONSEQUENCE: the killer acts in round 1 (the kill), is SUPPRESSED in
+            // round 2 (Disabled), and acts again in round 3 (Disable expired).
+            expect(killerActedInRound(main, 1)).toBe(true);
+            expect(killerActedInRound(main, 2)).toBe(false);
+            expect(killerActedInRound(main, 3)).toBe(true);
+
+            // --- Control run: martyr carries NO Martyrdom (plain basic attack only) ---
+            // No Disable is ever applied → the killer must keep acting every round it
+            // has a living target (the tank). This is what makes the main-run absence
+            // in round 2 a genuine suppression rather than a vacuous artefact.
+            const control = runSkip([basicAttackSlot()]);
+
+            // No Disable in the control.
+            expect(
+                control.filter((e) => e.type === 'debuff-applied' && e.buffName === 'Disable')
+            ).toHaveLength(0);
+            // The killer acts in every round 1-3 — crucially round 2, exactly where the
+            // main run was suppressed.
+            for (let r = 1; r <= SKIP_NUM_ROUNDS; r++) {
+                expect(killerActedInRound(control, r)).toBe(true);
+            }
+        }
+    );
 });
 
 // ---------------------------------------------------------------------------

--- a/src/utils/combat/disableBuffs.ts
+++ b/src/utils/combat/disableBuffs.ts
@@ -1,11 +1,10 @@
 /** Named debuffs that mean DISABLE — the game's second turn-skip control (after Stasis).
  *  While a unit carries an active Disable it cannot take its scheduled ACTION (active/charged
- *  skill + attack) and its reactive abilities are suppressed — IDENTICAL to Stasis on those two
- *  axes (recognized via the engine's `isTurnBlocked` composite; the reactive drain filter is
- *  routed through `isTurnBlocked` in the reactive-suppression task; until then a disabled unit's
- *  reactives still fire). DoTs still tick and all timed
- *  statuses (Disable included) still decrement on the skipped turn, so duration N skips exactly
- *  N scheduled actions.
+ *  skill + attack) and its reactive abilities ARE suppressed — IDENTICAL to Stasis on those two
+ *  axes (recognized via the engine's `isTurnBlocked` composite; the reactive drain filter routes
+ *  through `isTurnBlocked`, so a disabled unit's reactive intents are dropped at drain time).
+ *  DoTs still tick and all timed statuses (Disable included) still decrement on the skipped turn,
+ *  so duration N skips exactly N scheduled actions.
  *
  *  DIVERGES from Stasis on two axes (do NOT wire Disable into the Stasis-only sites):
  *    - NOT broken by a direct hit (Stasis is, see engine §4.5) — Disable persists when hit.

--- a/src/utils/combat/disableBuffs.ts
+++ b/src/utils/combat/disableBuffs.ts
@@ -6,9 +6,9 @@
  *  DoTs still tick and all timed statuses (Disable included) still decrement on the skipped turn,
  *  so duration N skips exactly N scheduled actions.
  *
- *  DIVERGES from Stasis on two axes (do NOT wire Disable into the Stasis-only sites):
- *    - NOT broken by a direct hit (Stasis is, see engine §4.5) — Disable persists when hit.
- *    - NO damage immunity — hits land normally (same as Stasis, which also takes damage).
+ *  DIVERGES from Stasis on ONE axis (do NOT wire Disable into the Stasis-only break/immunity
+ *  sites): it is NOT broken by a direct hit (Stasis is, see engine §4.5) — Disable persists when
+ *  hit. Like Stasis, a disabled unit has NO damage immunity — hits land normally.
  *
  *  Carried as a timed debuff in the victim's per-actor enemy-debuff store (decrements via the
  *  Post-Turn decrement). Disable carries no stat payload; duration comes from "for N turns".

--- a/src/utils/combat/disableBuffs.ts
+++ b/src/utils/combat/disableBuffs.ts
@@ -1,0 +1,20 @@
+/** Named debuffs that mean DISABLE — the game's second turn-skip control (after Stasis).
+ *  While a unit carries an active Disable it cannot take its scheduled ACTION (active/charged
+ *  skill + attack) and its reactive abilities are suppressed — IDENTICAL to Stasis on those two
+ *  axes (recognized via the engine's `isTurnBlocked` composite). DoTs still tick and all timed
+ *  statuses (Disable included) still decrement on the skipped turn, so duration N skips exactly
+ *  N scheduled actions.
+ *
+ *  DIVERGES from Stasis on two axes (do NOT wire Disable into the Stasis-only sites):
+ *    - NOT broken by a direct hit (Stasis is, see engine §4.5) — Disable persists when hit.
+ *    - NO damage immunity — hits land normally (same as Stasis, which also takes damage).
+ *
+ *  Carried as a timed debuff in the victim's per-actor enemy-debuff store (decrements via the
+ *  Post-Turn decrement). Disable carries no stat payload; duration comes from "for N turns".
+ *  Extend from game data as other named turn-skip controls appear (e.g. Stun/Freeze). */
+export const DISABLE_BUFFS: ReadonlySet<string> = new Set(['Disable']);
+
+/** True iff `buffName` is a Disable turn-skip control. */
+export function isDisable(buffName: string): boolean {
+    return DISABLE_BUFFS.has(buffName);
+}

--- a/src/utils/combat/disableBuffs.ts
+++ b/src/utils/combat/disableBuffs.ts
@@ -1,7 +1,9 @@
 /** Named debuffs that mean DISABLE — the game's second turn-skip control (after Stasis).
  *  While a unit carries an active Disable it cannot take its scheduled ACTION (active/charged
  *  skill + attack) and its reactive abilities are suppressed — IDENTICAL to Stasis on those two
- *  axes (recognized via the engine's `isTurnBlocked` composite). DoTs still tick and all timed
+ *  axes (recognized via the engine's `isTurnBlocked` composite; the reactive drain filter is
+ *  routed through `isTurnBlocked` in the reactive-suppression task; until then a disabled unit's
+ *  reactives still fire). DoTs still tick and all timed
  *  statuses (Disable included) still decrement on the skipped turn, so duration N skips exactly
  *  N scheduled actions.
  *

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -1711,8 +1711,8 @@ export function runCombat(input: CombatEngineInput): {
     const isStasised = (actorId: string): boolean => ownerDebuffNames(actorId).some(isStasis);
     const isDisabled = (actorId: string): boolean => ownerDebuffNames(actorId).some(isDisable);
     /** Turn-blocked = cannot take its scheduled action this turn (Stasis OR Disable). Used by the
-     *  three turn-action gates and (in a later change) the reactive drain filter. The Stasis-only
-     *  break / immunity sites intentionally keep using isStasised — Disable never breaks. */
+     *  three turn-action gates AND the reactive drain filter (drainQueue). The Stasis-only break /
+     *  immunity sites intentionally keep using isStasised — Disable never breaks. */
     const isTurnBlocked = (actorId: string): boolean => isStasised(actorId) || isDisabled(actorId);
 
     // Base-HP fallback for recipientMaxHp before an actor has taken its first turn (no ctx yet):
@@ -3318,15 +3318,17 @@ export function runCombat(input: CombatEngineInput): {
                 // Snapshot this generation's batch; new enqueues during execution run next pass.
                 const batch = queue.splice(0, queue.length);
                 for (const intent of batch) {
-                    // §4.4 STASIS reactive suppression (B3): a stasised unit's reactives are FULLY locked out.
-                    // Drop every queued intent whose OWNER is currently stasised — on-attacked, on-ally-attacked,
-                    // on-crit, on-enemy-destroyed, AND start-of-round self-buffs (Chakara via round-started) all
-                    // carry intent.ownerId, so this ONE filter covers every reactive type for BOTH sides
-                    // (drainIntents and drainEnemyIntents share this drainQueue). Filtered at the DRAIN, before
-                    // executeIntent. Listeners only ENQUEUE (pure), so dropping an intent leaves NO partial state.
-                    // Incoming effects (damage/heals/ally buffs/DoT ticks) are UNTOUCHED — only the stasised
-                    // unit's OWN outgoing intents drop.
-                    if (isStasised(intent.ownerId)) continue;
+                    // §4.4 TURN-BLOCK reactive suppression (B3 / D-PR13): a turn-blocked unit's reactives are
+                    // FULLY locked out. Drop every queued intent whose OWNER is currently turn-blocked (Stasis OR
+                    // Disable) — on-attacked, on-ally-attacked, on-crit, on-enemy-destroyed, AND start-of-round
+                    // self-buffs (Chakara via round-started) all carry intent.ownerId, so this ONE filter covers
+                    // every reactive type for BOTH sides (drainIntents and drainEnemyIntents share this drainQueue).
+                    // Filtered at the DRAIN, before executeIntent. Listeners only ENQUEUE (pure), so dropping an
+                    // intent leaves NO partial state. Incoming effects (damage/heals/ally buffs/DoT ticks) are
+                    // UNTOUCHED — only the turn-blocked unit's OWN outgoing intents drop.
+                    // NOTE: Stasis-only sites (break-on-hit, damage-immunity) intentionally keep using isStasised
+                    // directly — Disable never breaks and does not grant immunity.
+                    if (isTurnBlocked(intent.ownerId)) continue;
                     executeIntent(intent, {
                         round: r,
                         enemy,

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -55,6 +55,7 @@ import { incomingHealAmpForRecipient } from './healAmplification';
 import { CHEAT_DEATH_BUFFS } from './cheatDeathBuffs';
 import { BARRIER_BUFFS } from './barrierBuffs';
 import { isStasis, STASIS_BUFFS } from './stasisBuffs';
+import { isDisable } from './disableBuffs';
 import { CombatEventBus, createEventBus } from './events';
 import { normalizeTeamActorsToWalked } from './teamActorWalk';
 import {
@@ -1708,6 +1709,11 @@ export function runCombat(input: CombatEngineInput): {
     const ownerDebuffNames = (ownerId: string): string[] =>
         ownerDebuffNamesFor(statusEngine, ownerId);
     const isStasised = (actorId: string): boolean => ownerDebuffNames(actorId).some(isStasis);
+    const isDisabled = (actorId: string): boolean => ownerDebuffNames(actorId).some(isDisable);
+    /** Turn-blocked = cannot take its scheduled action this turn (Stasis OR Disable). Used by the
+     *  three turn-action gates and (in a later change) the reactive drain filter. The Stasis-only
+     *  break / immunity sites intentionally keep using isStasised — Disable never breaks. */
+    const isTurnBlocked = (actorId: string): boolean => isStasised(actorId) || isDisabled(actorId);
 
     // Base-HP fallback for recipientMaxHp before an actor has taken its first turn (no ctx yet):
     // attacker → input.hp; walked team → walk stats hp; enemy attackers → their CombatActor hp
@@ -3687,7 +3693,7 @@ export function runCombat(input: CombatEngineInput): {
                     // skips exactly N scheduled actions (each skipped turn decrements Stasis).
                     // A stasised FOCUS actor must push a synthesized focus turn so the
                     // post-round `focusTurns.length` guard does not throw.
-                    if (!isStasised(actor.id)) {
+                    if (!isTurnBlocked(actor.id)) {
                         const target = parsedTargetFor(actor);
                         const pattern = parsedPatternFor(actor);
                         // Positional target selection (Task C1, GATED). When the focus attacker
@@ -3875,7 +3881,7 @@ export function runCombat(input: CombatEngineInput): {
                     // body. The DoT-tick prologue (healTarget branch above) and Post-Turn decrements
                     // (below) still run. A walked team actor is never the focus → no focusTurns
                     // synthesis needed (no-else). §4.3 deviation: skip action, decrement preserved.
-                    if (!isStasised(actor.id)) {
+                    if (!isTurnBlocked(actor.id)) {
                         // Positional target selection (Task C2, GATED). Mirrors the focus-turn
                         // branch (C1) but keyed to THIS team actor's own board position
                         // (`actor.position`) and parsed target (`teamTargetById` lookup), not the
@@ -4087,7 +4093,7 @@ export function runCombat(input: CombatEngineInput): {
                     // action body and is correctly skipped — matches in-game "charges do not
                     // generate while stasised"). §4.3 deviation: skip action, decrement
                     // preserved. No cadence-advance in the skip path.
-                    if (!isStasised(actor.id)) {
+                    if (!isTurnBlocked(actor.id)) {
                         const enemyRuntime = runtimeFor(actor);
                         // Positional target selection (Task C3, side-symmetric, GATED). Mirrors the
                         // focus-turn (C1) and team-turn (C2) branches, but the OPPOSING roster from the


### PR DESCRIPTION
## Summary

Makes the combat engine treat a **Disable** status as a turn-skip control, mirroring the existing **Stasis** mechanic. This **lights up the D-PR7 Martyrdom implant** (which applied `Disable` to the killer on death but was emit-only — its registry comment literally said *"Disable is not a modeled turn-effect yet"*), plus the 5 skill-text Disable inflictors (APEX, IonScorp, Makoli, Xcellence, Yuyan) — all for free, no parser change.

Stacked on `feat/combat-d-pr12-self-side-incoming-buff-fold`; retarget to `main` as lower PRs merge.

## What it does

A disabled unit **skips its scheduled action** and its **reactive abilities are suppressed** — identical to Stasis on those axes. It **diverges on one axis**: a direct hit does **not** break Disable (Stasis breaks, §4.5). Like Stasis, it grants **no damage immunity**, DoTs still tick, and it decrements on the skipped turn (duration N → N skips). A **cleanse removes it** and the unit resumes its walk.

## Design (buff-name-driven, surgical)

- New `src/utils/combat/disableBuffs.ts` (`DISABLE_BUFFS` / `isDisable`), mirroring `stasisBuffs.ts`.
- `engine.ts`: `isDisabled` reader + composite `isTurnBlocked = isStasised || isDisabled`, routed through the **three turn-action gates** (focus / team / enemy) and the **reactive-drain filter**. The break/immunity/metadata sites stay keyed on `isStasised`, so Disable never breaks.
- `parseControlInflict` stays Stasis-only; `NOT_SIMULATED_TYPES` stays `{'control'}`. Disable rides the named-debuff path, so the engine honors it from both the Martyrdom implant and skill text.

## Known behavior (not a bug in this PR)

Legendary Martyrdom `Disable(2)` skips **one** observable enemy turn end-to-end (act R1 → skip R2 → resume R3), because the Disable lands during the killer's own turn and that turn's post-turn decrement consumes one tick — the known/deferred decrement-timing behavior, consistent with Stasis. The end-to-end test locks the real behavior.

## Tests

New `disable.test.ts` (skip / decrement / **no-break contrast vs Stasis** / no-immunity / reactive-suppression / cleanse-resume), a Martyrdom **end-to-end** integration test (disabled killer skips, with a non-vacuous no-Martyrdom control), and a parser lock test (`"inflicts Disable"` → named `Disable` debuff). **3024 tests green, lint/tsc clean, `audit:skills` 0/141, zero golden/snapshot movement.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)