### PR TITLE
feat(combat): D-PR14 — CF/Provoke applier implants (Bulwark / Doomsayer)

### DIFF
--- a/docs/superpowers/plans/2026-06-22-implant-gearset-abilities-D-pr14.md
+++ b/docs/superpowers/plans/2026-06-22-implant-gearset-abilities-D-pr14.md
@@ -24,8 +24,9 @@
 - `on-ally-attacked` listener: `triggers.ts:391`; already enqueues `eventCtx: { counterTargetId: e.attackerId, damagedAllyId: e.targetId }`. `roleFilter` precedent at `triggers.ts:402-409`.
 - `registerReactiveListeners` args: `triggers.ts:218-232` (destructures `{ bus, perOwner, enqueue, isOpposing, roleOf }` — NO adjacency helper today).
 - `bySide(...).adjacentAllyIdsFor` built as `(ownerId) => adjacentAllyIds(ownerId, actors)` at `engine.ts:1795`.
-- Round turn-loop: `engine.ts:3544` (`for (let actor = selectNext(); ...)`); `actingActorId = actor.id` + `turn-started` emit ~3601-3602; Stasis/Disable skip via `isTurnBlocked(actor.id)` at `engine.ts:3698` (the `if (!isTurnBlocked(actor.id))` block wrapping `runPlayerTurn` ~3730). `isTurnBlocked` defined `engine.ts:1713`.
-- Condition system: `ConditionContext` (`evaluateConditions.ts:4-35`), `evaluateCondition` switch (`evaluateConditions.ts:38-91`), `conditionsMet`. `buildDrainContext` at `triggers.ts:723` calls `buildActorConditionContext(statusEngine, ownerId, {...})`. `ConditionSubject` union at `abilities.ts:126`; `Condition` interface at `abilities.ts:172` (`{ subject, derivable: boolean, ... }`). ALACRITY end-of-round gate precedent: `conditions: [{ subject: 'not-hit-this-round', derivable: true }]`.
+- Round turn-loop: `engine.ts:3544` (`for (let actor = selectNext(); ...)`); `actingActorId = actor.id` + `turn-started` emit ~3601-3602. There are **THREE** `if (!isTurnBlocked(actor.id))` turn-body gates (one per actor kind): attacker at `engine.ts:3698`, walked-team ally at ~3886, real-enemy at ~4098. `isTurnBlocked` defined `engine.ts:1716`. A Stasis/Disable-skipped actor emits `turn-started` but does NOT enter these blocks.
+- Condition system: `ConditionContext` (`evaluateConditions.ts:4-35`), `evaluateCondition` switch with a `default: return 0` (`evaluateConditions.ts:38-91` — so a new subject causes NO tsc error; the case is for behavior), `conditionsMet`. `buildActorConditionContext` lives at `triggers.ts:670` and delegates to `buildRoundContext` (`src/utils/abilities/roundContext.ts:13-68`) — the ACTUAL constructor; fields flow options-bag → `buildRoundContext` `state` param (~roundContext.ts:42) → return (~roundContext.ts:65) → `ConditionContext` (the `wasHitThisRound` path is the template). `buildDrainContext` at `triggers.ts:723`. `ConditionSubject` union at `abilities.ts:126`; `Condition` interface at `abilities.ts:172`.
+- **Gate liveness:** `liveGateConditions` (`src/utils/combat/abilityStatusGating.ts:37-43`) rewrites any `derivable` condition whose subject is NOT in `LIVE_SUBJECTS` (`:15-29`) to `{ subject: 'always' }`; it runs at `triggers.ts:1068` before `conditionsMet`. ALACRITY's `not-hit-this-round` works ONLY because it is in `LIVE_SUBJECTS` (`:28`). `first-activator` MUST be added there too.
 - Registry helpers: `mkNamedDebuff` (`buildEquipmentAbilities.ts:359-385`, hardcodes `target:'enemy'`), `mkNamedBuffGrant` with `opts.procChance` (`326-354`), proc tables `AMBUSH_PROC`/`SPEARHEAD_PROC`/`ALACRITY_PROC` (`217-239`), `IMPLANT_ABILITIES` map (`387`), implant id stamping `equip-implant-${implantName}` (`732`).
 - `AbilityTarget` union: `abilities.ts:29-38` (currently ends `'enemy-most-buffs'`).
 - `'Provoke'` (`buffs.ts:127`) and `'Concentrate Fire'` (`buffs.ts:461`) exist in `BUFFS`.
@@ -39,10 +40,11 @@
 - **Create** `src/utils/combat/highestAttack.ts` — pure `highestAttackAmong(ids, attackOf, isLiving)` selector (unit-testable).
 - **Create** `src/utils/combat/__tests__/highestAttack.test.ts`.
 - **Modify** `src/types/abilities.ts` — `AbilityTarget += 'enemy-highest-attack'`; `Ability.oncePerRound?`, `Ability.requireDamagedAllyAdjacent?`; `ConditionSubject += 'first-activator'`; `ConditionContext.firstActivator?`.
-- **Modify** `src/utils/abilities/evaluateConditions.ts` — `first-activator` case + `firstActivator` field.
-- **Modify** `src/utils/abilities/buildActorConditionContext.ts` (wherever it lives) — accept + set `firstActivator`.
-- **Modify** `src/utils/combat/triggers.ts` — `buildDrainContext` threading; `IntentExecContext` fields (`enemyWithHighestAttack`, `oncePerRoundConsumed`, `firstActivatorId`); debuff-executor proc gate + once-per-round + target routing; `registerReactiveListeners` adjacency arg + listener filter.
-- **Modify** `src/utils/combat/engine.ts` — `firstActivatorId` round-state + set-site; `oncePerRoundConsumed` Set; `highestAttackAmong` binding into both drain seams; `registerReactiveListeners` call passes `adjacentAllyIdsFor`.
+- **Modify** `src/utils/abilities/evaluateConditions.ts` — `first-activator` case + `firstActivator` field on `ConditionContext`.
+- **Modify** `src/utils/abilities/roundContext.ts` — `buildRoundContext` `state` param + return object carry `firstActivator` (this is the ACTUAL `ConditionContext` constructor; `buildActorConditionContext` delegates to it).
+- **Modify** `src/utils/combat/abilityStatusGating.ts` — add `'first-activator'` to `LIVE_SUBJECTS` (else `liveGateConditions` rewrites the gate to `always` and Doomsayer fires unconditionally — the same step that makes ALACRITY's `not-hit-this-round` work).
+- **Modify** `src/utils/combat/triggers.ts` — `buildActorConditionContext` (lives HERE, ~670, not a standalone file) + `buildDrainContext` (~723) threading; `IntentExecContext` fields (`enemyWithHighestAttack`, `oncePerRoundConsumed`, `firstActivatorId`); debuff-executor proc gate + once-per-round + target routing; `registerReactiveListeners` adjacency arg + listener filter.
+- **Modify** `src/utils/combat/engine.ts` — `firstActivatorId` round-state + set-site (ALL THREE `!isTurnBlocked` turn-body gates); `oncePerRoundConsumed` Set; `highestAttackAmong` binding into both drain seams; both `registerReactiveListeners` calls pass `adjacentAllyIdsFor`.
 - **Modify** `src/utils/abilities/buildEquipmentAbilities.ts` — `mkNamedDebuff` opts; `BULWARK_PROC`/`DOOMSAYER_PROC`; `BULWARK`/`DOOMSAYER` registry entries.
 - **Modify** `src/utils/abilities/__tests__/equipmentCoverage.test.ts` — add both implants.
 - **Create** `src/utils/combat/__tests__/cfProvokeAppliers.integration.test.ts` — Bulwark + Doomsayer end-to-end.
@@ -178,11 +180,11 @@ At the `ConditionSubject` union (`abilities.ts:126`), add:
 - [ ] **Step 4: Run tsc, confirm what breaks**
 
 Run: `npx tsc --noEmit`
-Expected: errors ONLY for non-exhaustive `switch`/`Record` over `AbilityTarget` or `ConditionSubject` that now miss the new members. **Record every such location** — these are the editor/eval exhaustiveness sites. Likely: `evaluateCondition` (handled in Task 3), and possibly editor UI (`AbilityCard`/`AbilityTypePicker`/`abilityDefaults`) or a target-resolution switch. If a switch has a `default` branch it won't error; only add a stub where tsc demands it. Do NOT add behavior — a `case 'enemy-highest-attack':` that mirrors `'enemy-most-buffs'`'s editor default, or a no-op, is sufficient for editor sites.
+Expected: in this codebase there is **no `switch` over `AbilityTarget`** and `evaluateCondition` has a `default` branch, so the new members likely produce **NO** tsc errors. Whatever errors DO appear are exhaustive `switch`/`Record` sites missing the new member (e.g. editor UI `AbilityCard`/`AbilityTypePicker`/`abilityDefaults`). **Record every such location.** If none, proceed (the editor-stub concern is moot).
 
-- [ ] **Step 5: Add minimal stubs ONLY where tsc errors (editor exhaustiveness)**
+- [ ] **Step 5: Add minimal stubs ONLY where tsc errors**
 
-For each tsc error outside `evaluateConditions.ts`, add the minimal case to satisfy exhaustiveness, mirroring the neighbouring `'enemy-most-buffs'` handling. (If no errors outside Task 3's file, skip.)
+For each tsc error, add the minimal case to satisfy exhaustiveness, mirroring the neighbouring `'enemy-most-buffs'` handling (no behavior). If Step 4 produced no errors, skip this step.
 
 - [ ] **Step 6: Commit**
 
@@ -197,10 +199,13 @@ git commit --no-verify -m "feat(combat): D-PR14 — types (enemy-highest-attack 
 ## Task 3: `first-activator` condition evaluation + context threading
 
 **Files:**
-- Modify: `src/utils/abilities/evaluateConditions.ts`
-- Modify: `src/utils/abilities/buildActorConditionContext.ts` (locate via `grep -rn "buildActorConditionContext" src/`)
-- Modify: `src/utils/combat/triggers.ts` (buildDrainContext + IntentExecContext.firstActivatorId)
-- Test: extend an existing evaluateConditions test file or create `src/utils/abilities/__tests__/firstActivatorCondition.test.ts`
+- Modify: `src/utils/abilities/evaluateConditions.ts` (`ConditionContext.firstActivator` + `evaluateCondition` case)
+- Modify: `src/utils/abilities/roundContext.ts` (`buildRoundContext` state param + return — the REAL constructor)
+- Modify: `src/utils/combat/abilityStatusGating.ts` (`LIVE_SUBJECTS += 'first-activator'`)
+- Modify: `src/utils/combat/triggers.ts` (`buildActorConditionContext` ~670 + `buildDrainContext` ~723 + `IntentExecContext.firstActivatorId`)
+- Test: create `src/utils/abilities/__tests__/firstActivatorCondition.test.ts`
+
+> **Threading chain (mirror `wasHitThisRound` end-to-end):** `IntentExecContext.firstActivatorId` → `buildDrainContext` computes `firstActivator: ctx.firstActivatorId === ownerId` → `buildActorConditionContext` options bag → `buildRoundContext` `state` param → `buildRoundContext` return → `ConditionContext.firstActivator` → `evaluateCondition`. AND `LIVE_SUBJECTS` must include `'first-activator'` or `liveGateConditions` neutralizes it to `always`. Miss ANY link and Doomsayer is silently broken (fires always, or never).
 
 - [ ] **Step 1: Write the failing test**
 
@@ -228,9 +233,9 @@ describe('first-activator condition', () => {
 Run: `npx vitest run <test file>`
 Expected: FAIL — `'first-activator'` not handled / `firstActivator` not on the fixture.
 
-- [ ] **Step 3: Implement**
+- [ ] **Step 3: Implement (follow the threading chain end-to-end)**
 
-`evaluateConditions.ts` — add to `ConditionContext` (after `wasHitThisRound?`):
+(a) `evaluateConditions.ts` — add to `ConditionContext` (after `wasHitThisRound?`):
 
 ```typescript
     firstActivator?: boolean; // D-PR14: this owner took the round's first real turn.
@@ -243,31 +248,35 @@ Add a case in `evaluateCondition` (mirror `'not-hit-this-round'`):
             return ctx.firstActivator ? 1 : 0;
 ```
 
-`buildActorConditionContext.ts` — add `firstActivator` to the options bag it accepts and pass it onto the returned context (mirror how `wasHitThisRound` flows through).
+(b) `roundContext.ts` — `buildRoundContext`'s `state` param type: add `firstActivator?: boolean;` (next to `wasHitThisRound`); and in the returned object add `firstActivator: state.firstActivator ?? false,` (mirror the `wasHitThisRound` line exactly).
 
-`triggers.ts` `buildDrainContext` (~723) — add to the options object passed to `buildActorConditionContext`:
+(c) `triggers.ts` `buildActorConditionContext` (~670) — it receives an options bag and forwards to `buildRoundContext`. Add `firstActivator` to the options type and forward it (mirror `wasHitThisRound`).
+
+(d) `triggers.ts` `buildDrainContext` (~723) — add to the options object it passes:
 
 ```typescript
         firstActivator: ctx.firstActivatorId === ownerId,
 ```
 
-`triggers.ts` `IntentExecContext` (near `enemyWithMostBuffs`, ~634) — add:
+(e) `triggers.ts` `IntentExecContext` (near `enemyWithMostBuffs`, ~634) — add:
 
 ```typescript
     /** D-PR14: id of the round's first real (non-Stasis/Disable-skipped) activator. */
     firstActivatorId?: string;
 ```
 
+(f) `abilityStatusGating.ts` — add `'first-activator'` to the `LIVE_SUBJECTS` set (~`:15-29`). **Without this, `liveGateConditions` rewrites Doomsayer's gate to `always` → it fires every round it procs.**
+
 - [ ] **Step 4: Run it, verify it passes** (+ tsc)
 
-Run: `npx vitest run <test file> && npx tsc --noEmit`
-Expected: PASS; tsc clean (the Task-2 `evaluateCondition` exhaustiveness error is now resolved).
+Run: `npx vitest run src/utils/abilities/__tests__/firstActivatorCondition.test.ts && npx tsc --noEmit`
+Expected: PASS; tsc clean.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add src/utils/abilities/evaluateConditions.ts src/utils/abilities/buildActorConditionContext.ts src/utils/combat/triggers.ts <test file>
-git commit --no-verify -m "feat(combat): D-PR14 — first-activator condition + drain-context threading"
+git add src/utils/abilities/evaluateConditions.ts src/utils/abilities/roundContext.ts src/utils/combat/abilityStatusGating.ts src/utils/combat/triggers.ts src/utils/abilities/__tests__/firstActivatorCondition.test.ts
+git commit --no-verify -m "feat(combat): D-PR14 — first-activator condition (live-subject + roundContext threading)"
 ```
 
 ---
@@ -295,7 +304,7 @@ If `drainIntents` is defined ONCE outside the round loop, instead declare both i
 
 Import at top of file: `import { highestAttackAmong } from './highestAttack';`
 
-After `mostBuffsAmong` (~3437), add a thin adapter that supplies live effective attack + liveness (mirror exactly how effective attack is read elsewhere in engine.ts — search for `effectiveStatsOf(` and use `.attack`; mirror how liveness is checked, `a.destroyedRound === undefined`):
+After `mostBuffsAmong` (~3437), add a thin adapter. **`effectiveStatsOf` takes THREE args** — `effectiveStatsOf(statusEngine, selfBuffLookup, actor: CombatActor)` (`effectiveStats.ts:88`); the working highest-attack idiom is at `engine.ts:2974-2975` (`effectiveStatsOf(statusEngine, selfBuffLookup, actor).attack`, and `selfBuffLookup` is in scope). Liveness = `destroyedRound === undefined`:
 
 ```typescript
             // D-PR14: living opposing actor with the greatest LIVE effective attack
@@ -303,12 +312,15 @@ After `mostBuffsAmong` (~3437), add a thin adapter that supplies live effective 
             const highestAttackInRoster = (roster: CombatActor[]): string | undefined =>
                 highestAttackAmong(
                     roster.map((a) => a.id),
-                    (id) => effectiveStatsOf(id).attack,
+                    (id) => {
+                        const a = roster.find((x) => x.id === id);
+                        return a ? effectiveStatsOf(statusEngine, selfBuffLookup, a).attack : 0;
+                    },
                     (id) => roster.find((a) => a.id === id)?.destroyedRound === undefined
                 );
 ```
 
-(Adjust `effectiveStatsOf(id).attack` to the real accessor signature found in engine.ts.)
+(Confirm `effectiveStatsOf` / `selfBuffLookup` are in scope at this point — both are used at 2974; if `selfBuffLookup` is named differently here, match the 2974 call.)
 
 - [ ] **Step 3: Bind into both drain-seam ctx literals**
 
@@ -330,17 +342,19 @@ In `drainEnemyIntents` (~3467), add:
 
 (`firstActivatorId` is read inside the arrow body at call time → reads the live value. If declared in the enclosing scope as a `let`, the closure reads it live; confirm.)
 
-- [ ] **Step 4: Set `firstActivatorId` at the real-activation site**
+- [ ] **Step 4: Set `firstActivatorId` at ALL THREE real-activation sites**
 
-At `engine.ts:3698`, inside `if (!isTurnBlocked(actor.id)) {`, as the FIRST statement (before `parsedTargetFor`/`runPlayerTurn`):
+There are three `if (!isTurnBlocked(actor.id)) {` turn-body gates (attacker ~3698, walked-team ally ~3886, real-enemy ~4098). A team ally or an enemy can be the round's first activator (enemy-side Doomsayer rides the `drainEnemyIntents` seam), so set it in ALL THREE, as the FIRST statement inside each block:
 
 ```typescript
                     if (!isTurnBlocked(actor.id)) {
                         // D-PR14: first REAL activation of the round (Stasis/Disable-skipped
-                        // actors never reach here, so they don't count). ??= writes once.
+                        // actors never enter these blocks, so they don't count). ??= writes once.
                         firstActivatorId ??= actor.id;
-                        const target = parsedTargetFor(actor);
+                        // ... existing block body ...
 ```
+
+Confirm each of the three sites with `grep -n "if (!isTurnBlocked(actor.id))" src/utils/combat/engine.ts` and add the line at the top of each. Goldens are unaffected (no fixture equips the implant); the three sites are for multi-actor / enemy-side correctness.
 
 - [ ] **Step 5: Run tsc**
 
@@ -454,15 +468,15 @@ In the `case 'on-ally-attacked':` listener (`triggers.ts:391`), after the `roleF
                         }
 ```
 
-- [ ] **Step 3: Pass `adjacentAllyIdsFor` from the engine call site**
+- [ ] **Step 3: Pass `adjacentAllyIdsFor` from BOTH engine call sites**
 
-Find the `registerReactiveListeners({ ... })` call(s) in `engine.ts` (`grep -n "registerReactiveListeners" src/utils/combat/engine.ts`). Add to the args:
+There are TWO `registerReactiveListeners({ ... })` calls (player ~`engine.ts:2028`, enemy ~`engine.ts:2049`; confirm via `grep -n "registerReactiveListeners" src/utils/combat/engine.ts`). Add to BOTH args objects:
 
 ```typescript
             adjacentAllyIdsFor: (ownerId: string) => adjacentAllyIds(ownerId, actors),
 ```
 
-(Reuse the existing `adjacentAllyIds(ownerId, actors)` already used at `engine.ts:1795`; `adjacentAllyIds` is already imported. The helper is side-correct — it returns same-side allies of `ownerId` regardless of which team's listeners are being registered.)
+`adjacentAllyIds` is already imported (`engine.ts:83`) and is side-correct (returns same-side allies of `ownerId` regardless of which team's listeners are registered), so the same line works for both. (The per-side `bySide(...).adjacentAllyIdsFor` helper at `engine.ts:1795` is equivalent if you prefer reusing it.)
 
 - [ ] **Step 4: tsc + combat regression**
 
@@ -655,7 +669,12 @@ describe('D-PR14 Doomsayer (Concentrate Fire on highest-attack enemy at end of r
         // highest-effective-attack enemy at end of round (read via ownerDebuffNamesFor / targeting).
     });
     it('does NOT apply when the owner is not the first activator', () => {
-        // make another actor faster; assert no CF applied by Doomsayer.
+        // make another actor (team ally) faster so it activates first; assert no CF from Doomsayer.
+        // This also exercises the walked-team-ally firstActivatorId set-site (~3886).
+    });
+    it('works for an ENEMY-side Doomsayer that activates first', () => {
+        // Doomsayer on an enemy ship, fastest overall; assert CF applied to the highest-attack
+        // PLAYER actor. Exercises the real-enemy set-site (~4098) + drainEnemyIntents seam.
     });
 });
 ```
@@ -742,6 +761,7 @@ git commit --no-verify -m "feat(combat): D-PR14 — coverage tracker + changelog
 
 - **`git commit --no-verify`**: the pre-commit hook runs the full vitest suite; use `--no-verify` for incremental commits and rely on the explicit per-task test runs. Run the full suite once at Task 9.
 - **Byte-identical invariant**: every executor change is gated on a new optional field (`procChance`/`oncePerRound`/`requireDamagedAllyAdjacent`/`target === 'enemy-highest-attack'`). If ANY existing golden moves, a gate's pass-through is broken — stop and fix before continuing.
-- **`liveGateConditions`**: confirm it does not strip `first-activator` (ALACRITY's `not-hit-this-round` is the working precedent for a derivable self-condition used as an end-of-round gate).
+- **`liveGateConditions` (REQUIRED, Task 3f)**: `first-activator` MUST be added to `LIVE_SUBJECTS` in `abilityStatusGating.ts`. Otherwise the gate is rewritten to `always` and Doomsayer fires every round it procs (ALACRITY's `not-hit-this-round` only works because it IS in that set).
+- **Doomsayer threading is fragile**: the field flows through SIX hops (IntentExecContext → buildDrainContext → buildActorConditionContext → buildRoundContext state → buildRoundContext return → ConditionContext) plus LIVE_SUBJECTS. Miss any hop → Doomsayer fires always or never. The integration tests (Task 8) are what catch a broken hop — do not skip them.
 - **Decrement-timing**: a "1 turn" Provoke/CF may expire after one observable enemy turn (locked behavior; not changed here).
 - **DPS calculator page**: intentionally NOT wired — both effects are targeting debuffs that matter only in the battle sim.

--- a/docs/superpowers/plans/2026-06-22-implant-gearset-abilities-D-pr14.md
+++ b/docs/superpowers/plans/2026-06-22-implant-gearset-abilities-D-pr14.md
@@ -1,0 +1,747 @@
+# D-PR14 — CF / Provoke applier implants (Bulwark + Doomsayer) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Model two implant special-effects that apply targeting-control debuffs the combat engine already honors — Bulwark (Provoke on an adjacent ally being damaged, once per round) and Doomsayer (Concentrate Fire on the highest-attack enemy at end-of-round if first to activate).
+
+**Architecture:** Bulwark rides the existing `on-ally-attacked` + `counterTargetId` reactive path (Guardian precedent), adding a pure listener-level adjacency filter + an executor-side once-per-round gate. Doomsayer rides `end-of-round`, gated by a new `first-activator` condition, routing Concentrate Fire to a new `enemy-highest-attack` global-selector target. Both proc via the existing deterministic proc-chance gate. No combat fixture equips either implant → byte-identical goldens.
+
+**Tech Stack:** TypeScript, Vitest. Combat engine in `src/utils/combat/`, ability registry in `src/utils/abilities/`, types in `src/types/abilities.ts`.
+
+**Spec:** `docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr14-design.md`
+
+**Branch:** `feat/combat-d-pr14-cf-provoke-appliers` (worktree `.worktrees/d-pr14-cf-provoke-appliers`, stacked on D-PR13 tip).
+
+---
+
+## Key anchors (verified against current code)
+
+- Debuff executor branch: `src/utils/combat/triggers.ts:1161` (`if (cfg.type === 'debuff')`). Routes via `intent.eventCtx?.counterTargetId` → `applyTimedAbilityStatus(round, status, undefined, counterTargetId)`; falls back to `ctx.enemy.id`. NO proc-gate today.
+- `passesProcChanceGate(intent, ctx)` at `triggers.ts:992`; pass-through when `procChance` is undefined/≤0/≥1. Already used in heal/shield (1097), damage (1271), shield (1375) branches — NOT debuff.
+- Purge global-selector precedent: `triggers.ts:1423` resolves `intent.ability.target === 'enemy-most-buffs' ? ctx.enemyWithMostBuffs?.(ownerId) ?? ctx.enemyId : counterTargetId`.
+- `IntentExecContext.enemyWithMostBuffs?: (ownerId) => string | undefined` at `triggers.ts:634`; `adjacentAllyIdsFor?` at `triggers.ts:619`.
+- `mostBuffsAmong` selector + drain-seam bindings: `engine.ts:3423` (selector), `engine.ts:3445` (`enemyWithMostBuffs: () => mostBuffsAmong(enemyAttackerActors)`, player drain), `engine.ts:3467` (`mostBuffsAmong(allPlayerActors)`, enemy drain).
+- `on-ally-attacked` listener: `triggers.ts:391`; already enqueues `eventCtx: { counterTargetId: e.attackerId, damagedAllyId: e.targetId }`. `roleFilter` precedent at `triggers.ts:402-409`.
+- `registerReactiveListeners` args: `triggers.ts:218-232` (destructures `{ bus, perOwner, enqueue, isOpposing, roleOf }` — NO adjacency helper today).
+- `bySide(...).adjacentAllyIdsFor` built as `(ownerId) => adjacentAllyIds(ownerId, actors)` at `engine.ts:1795`.
+- Round turn-loop: `engine.ts:3544` (`for (let actor = selectNext(); ...)`); `actingActorId = actor.id` + `turn-started` emit ~3601-3602; Stasis/Disable skip via `isTurnBlocked(actor.id)` at `engine.ts:3698` (the `if (!isTurnBlocked(actor.id))` block wrapping `runPlayerTurn` ~3730). `isTurnBlocked` defined `engine.ts:1713`.
+- Condition system: `ConditionContext` (`evaluateConditions.ts:4-35`), `evaluateCondition` switch (`evaluateConditions.ts:38-91`), `conditionsMet`. `buildDrainContext` at `triggers.ts:723` calls `buildActorConditionContext(statusEngine, ownerId, {...})`. `ConditionSubject` union at `abilities.ts:126`; `Condition` interface at `abilities.ts:172` (`{ subject, derivable: boolean, ... }`). ALACRITY end-of-round gate precedent: `conditions: [{ subject: 'not-hit-this-round', derivable: true }]`.
+- Registry helpers: `mkNamedDebuff` (`buildEquipmentAbilities.ts:359-385`, hardcodes `target:'enemy'`), `mkNamedBuffGrant` with `opts.procChance` (`326-354`), proc tables `AMBUSH_PROC`/`SPEARHEAD_PROC`/`ALACRITY_PROC` (`217-239`), `IMPLANT_ABILITIES` map (`387`), implant id stamping `equip-implant-${implantName}` (`732`).
+- `AbilityTarget` union: `abilities.ts:29-38` (currently ends `'enemy-most-buffs'`).
+- `'Provoke'` (`buffs.ts:127`) and `'Concentrate Fire'` (`buffs.ts:461`) exist in `BUFFS`.
+- Coverage test array: `equipmentCoverage.test.ts:121-148`; `BLOODTHIRST` at index 13, `EXUBERANCE` at 14 — `BULWARK`/`DOOMSAYER` insert per `IMPLANTS` declaration order (Bulwark `implants.ts:~1435`, Doomsayer `~1531`).
+- Bulwark proc by rarity: 5/7/9/12/16% (common→legendary). Doomsayer: 7/9/12/16% (uncommon→legendary, NO common).
+
+---
+
+## File structure
+
+- **Create** `src/utils/combat/highestAttack.ts` — pure `highestAttackAmong(ids, attackOf, isLiving)` selector (unit-testable).
+- **Create** `src/utils/combat/__tests__/highestAttack.test.ts`.
+- **Modify** `src/types/abilities.ts` — `AbilityTarget += 'enemy-highest-attack'`; `Ability.oncePerRound?`, `Ability.requireDamagedAllyAdjacent?`; `ConditionSubject += 'first-activator'`; `ConditionContext.firstActivator?`.
+- **Modify** `src/utils/abilities/evaluateConditions.ts` — `first-activator` case + `firstActivator` field.
+- **Modify** `src/utils/abilities/buildActorConditionContext.ts` (wherever it lives) — accept + set `firstActivator`.
+- **Modify** `src/utils/combat/triggers.ts` — `buildDrainContext` threading; `IntentExecContext` fields (`enemyWithHighestAttack`, `oncePerRoundConsumed`, `firstActivatorId`); debuff-executor proc gate + once-per-round + target routing; `registerReactiveListeners` adjacency arg + listener filter.
+- **Modify** `src/utils/combat/engine.ts` — `firstActivatorId` round-state + set-site; `oncePerRoundConsumed` Set; `highestAttackAmong` binding into both drain seams; `registerReactiveListeners` call passes `adjacentAllyIdsFor`.
+- **Modify** `src/utils/abilities/buildEquipmentAbilities.ts` — `mkNamedDebuff` opts; `BULWARK_PROC`/`DOOMSAYER_PROC`; `BULWARK`/`DOOMSAYER` registry entries.
+- **Modify** `src/utils/abilities/__tests__/equipmentCoverage.test.ts` — add both implants.
+- **Create** `src/utils/combat/__tests__/cfProvokeAppliers.integration.test.ts` — Bulwark + Doomsayer end-to-end.
+- **Modify** `src/constants/changelog.ts` — `UNRELEASED_CHANGES` entry.
+
+---
+
+## Task 1: Pure `highestAttackAmong` selector
+
+**Files:**
+- Create: `src/utils/combat/highestAttack.ts`
+- Test: `src/utils/combat/__tests__/highestAttack.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { highestAttackAmong } from '../highestAttack';
+
+describe('highestAttackAmong', () => {
+    const attackOf = (id: string) => ({ a: 100, b: 250, c: 250, d: 50 })[id] ?? 0;
+    const living = (dead: string[]) => (id: string) => !dead.includes(id);
+
+    it('returns the id with the greatest attack', () => {
+        expect(highestAttackAmong(['a', 'b', 'd'], attackOf, living([]))).toBe('b');
+    });
+
+    it('breaks ties by roster order (first wins)', () => {
+        expect(highestAttackAmong(['a', 'b', 'c'], attackOf, living([]))).toBe('b');
+    });
+
+    it('skips dead actors', () => {
+        expect(highestAttackAmong(['b', 'c'], attackOf, living(['b']))).toBe('c');
+    });
+
+    it('returns undefined when no living candidate', () => {
+        expect(highestAttackAmong(['a', 'b'], attackOf, living(['a', 'b']))).toBeUndefined();
+        expect(highestAttackAmong([], attackOf, living([]))).toBeUndefined();
+    });
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `npx vitest run src/utils/combat/__tests__/highestAttack.test.ts`
+Expected: FAIL — cannot find module `../highestAttack`.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+/**
+ * D-PR14: pick the living actor id with the greatest (live, effective) attack from `ids`.
+ * Ties resolve to the FIRST in `ids` order (deterministic for goldens). Returns undefined
+ * when no living candidate exists. Pure — the caller supplies live attack + liveness, so the
+ * engine wires effectiveStatsOf / destroyedRound and this stays unit-testable (mirrors
+ * incomingEffects.ts / outgoingEffects.ts).
+ */
+export function highestAttackAmong(
+    ids: string[],
+    attackOf: (id: string) => number,
+    isLiving: (id: string) => boolean
+): string | undefined {
+    let best: string | undefined;
+    let bestAtk = -Infinity;
+    for (const id of ids) {
+        if (!isLiving(id)) continue;
+        const atk = attackOf(id);
+        if (atk > bestAtk) {
+            bestAtk = atk;
+            best = id;
+        }
+    }
+    return best;
+}
+```
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `npx vitest run src/utils/combat/__tests__/highestAttack.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/highestAttack.ts src/utils/combat/__tests__/highestAttack.test.ts
+git commit --no-verify -m "feat(combat): D-PR14 — pure highestAttackAmong selector"
+```
+
+---
+
+## Task 2: Type additions
+
+**Files:**
+- Modify: `src/types/abilities.ts`
+
+These are pure type additions; the compiler is the test (later tasks consume them). No new runtime behavior here.
+
+- [ ] **Step 1: Add the `AbilityTarget` value**
+
+At `abilities.ts:38`, after `| 'enemy-most-buffs'`:
+
+```typescript
+    | 'enemy-most-buffs'
+    | 'enemy-highest-attack'; // D-PR14 Doomsayer: living opposing actor with the greatest
+    //                           live effective attack (global selector, resolved at drain).
+```
+
+- [ ] **Step 2: Add the two optional `Ability` fields**
+
+Near `roleFilter?` (`abilities.ts:425`), add:
+
+```typescript
+    /** D-PR14 Bulwark: this reactive applies at most once per round per (owner, ability).
+     *  Gated executor-side via IntentExecContext.oncePerRoundConsumed (check BEFORE the
+     *  proc draw, mark only on a successful proc). Absent → no per-round limit. */
+    oncePerRound?: boolean;
+    /** D-PR14 Bulwark: an on-ally-attacked reactive fires only when the DAMAGED ally is
+     *  adjacent to this owner (board neighbours; non-positional → any living same-side ally).
+     *  Filtered in the listener via registerReactiveListeners' adjacentAllyIdsFor. Absent →
+     *  any ally (existing behavior). */
+    requireDamagedAllyAdjacent?: boolean;
+```
+
+- [ ] **Step 3: Add the `ConditionSubject` value**
+
+At the `ConditionSubject` union (`abilities.ts:126`), add:
+
+```typescript
+    | 'first-activator' // D-PR14 Doomsayer: this owner was the first actor to take a REAL
+    //                     (non-Stasis/Disable-skipped) turn this round.
+```
+
+- [ ] **Step 4: Run tsc, confirm what breaks**
+
+Run: `npx tsc --noEmit`
+Expected: errors ONLY for non-exhaustive `switch`/`Record` over `AbilityTarget` or `ConditionSubject` that now miss the new members. **Record every such location** — these are the editor/eval exhaustiveness sites. Likely: `evaluateCondition` (handled in Task 3), and possibly editor UI (`AbilityCard`/`AbilityTypePicker`/`abilityDefaults`) or a target-resolution switch. If a switch has a `default` branch it won't error; only add a stub where tsc demands it. Do NOT add behavior — a `case 'enemy-highest-attack':` that mirrors `'enemy-most-buffs'`'s editor default, or a no-op, is sufficient for editor sites.
+
+- [ ] **Step 5: Add minimal stubs ONLY where tsc errors (editor exhaustiveness)**
+
+For each tsc error outside `evaluateConditions.ts`, add the minimal case to satisfy exhaustiveness, mirroring the neighbouring `'enemy-most-buffs'` handling. (If no errors outside Task 3's file, skip.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types/abilities.ts
+# plus any editor files touched in Step 5
+git commit --no-verify -m "feat(combat): D-PR14 — types (enemy-highest-attack target, oncePerRound/adjacency ability fields, first-activator condition)"
+```
+
+---
+
+## Task 3: `first-activator` condition evaluation + context threading
+
+**Files:**
+- Modify: `src/utils/abilities/evaluateConditions.ts`
+- Modify: `src/utils/abilities/buildActorConditionContext.ts` (locate via `grep -rn "buildActorConditionContext" src/`)
+- Modify: `src/utils/combat/triggers.ts` (buildDrainContext + IntentExecContext.firstActivatorId)
+- Test: extend an existing evaluateConditions test file or create `src/utils/abilities/__tests__/firstActivatorCondition.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { conditionsMet } from '../evaluateConditions';
+// Reuse the shared condition-context fixture if present (makeConditionContext); else inline a full ConditionContext.
+
+describe('first-activator condition', () => {
+    it('is met when firstActivator is true', () => {
+        const ctx = makeConditionContext({ firstActivator: true });
+        expect(conditionsMet([{ subject: 'first-activator', derivable: true }], ctx)).toBe(true);
+    });
+    it('is NOT met when firstActivator is false/absent', () => {
+        const ctx = makeConditionContext({ firstActivator: false });
+        expect(conditionsMet([{ subject: 'first-activator', derivable: true }], ctx)).toBe(false);
+    });
+});
+```
+
+(If no `makeConditionContext` fixture exists at `src/utils/abilities/__tests__/conditionContextFixture.ts` — created in D-PR2 — build a full `ConditionContext` literal inline.)
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `npx vitest run <test file>`
+Expected: FAIL — `'first-activator'` not handled / `firstActivator` not on the fixture.
+
+- [ ] **Step 3: Implement**
+
+`evaluateConditions.ts` — add to `ConditionContext` (after `wasHitThisRound?`):
+
+```typescript
+    firstActivator?: boolean; // D-PR14: this owner took the round's first real turn.
+```
+
+Add a case in `evaluateCondition` (mirror `'not-hit-this-round'`):
+
+```typescript
+        case 'first-activator':
+            return ctx.firstActivator ? 1 : 0;
+```
+
+`buildActorConditionContext.ts` — add `firstActivator` to the options bag it accepts and pass it onto the returned context (mirror how `wasHitThisRound` flows through).
+
+`triggers.ts` `buildDrainContext` (~723) — add to the options object passed to `buildActorConditionContext`:
+
+```typescript
+        firstActivator: ctx.firstActivatorId === ownerId,
+```
+
+`triggers.ts` `IntentExecContext` (near `enemyWithMostBuffs`, ~634) — add:
+
+```typescript
+    /** D-PR14: id of the round's first real (non-Stasis/Disable-skipped) activator. */
+    firstActivatorId?: string;
+```
+
+- [ ] **Step 4: Run it, verify it passes** (+ tsc)
+
+Run: `npx vitest run <test file> && npx tsc --noEmit`
+Expected: PASS; tsc clean (the Task-2 `evaluateCondition` exhaustiveness error is now resolved).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/abilities/evaluateConditions.ts src/utils/abilities/buildActorConditionContext.ts src/utils/combat/triggers.ts <test file>
+git commit --no-verify -m "feat(combat): D-PR14 — first-activator condition + drain-context threading"
+```
+
+---
+
+## Task 4: Engine round-state — `firstActivatorId`, `oncePerRoundConsumed`, `enemyWithHighestAttack` binding
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts`
+
+No standalone unit test (engine internals) — verified by tsc here and by the Task 7 integration tests. Keep changes byte-identical for non-D-PR14 paths.
+
+- [ ] **Step 1: Declare per-round state**
+
+In the per-round scope (the body of the `for` over rounds, BEFORE the `drainIntents`/`drainEnemyIntents` definitions at ~3438 and the turn-loop at ~3544 — confirm the round-loop boundary by reading around 3400-3440), add:
+
+```typescript
+            // D-PR14: per-round state — reset each round.
+            let firstActivatorId: string | undefined;
+            const oncePerRoundConsumed = new Set<string>();
+```
+
+If `drainIntents` is defined ONCE outside the round loop, instead declare both in the enclosing combat scope and add, at the top of each round iteration, `firstActivatorId = undefined; oncePerRoundConsumed.clear();`. (Read the actual structure and pick the spot that resets every round AND is visible to both the turn-loop set-site and the drain option literals.)
+
+- [ ] **Step 2: Add the `highestAttackAmong` binding next to `mostBuffsAmong`**
+
+Import at top of file: `import { highestAttackAmong } from './highestAttack';`
+
+After `mostBuffsAmong` (~3437), add a thin adapter that supplies live effective attack + liveness (mirror exactly how effective attack is read elsewhere in engine.ts — search for `effectiveStatsOf(` and use `.attack`; mirror how liveness is checked, `a.destroyedRound === undefined`):
+
+```typescript
+            // D-PR14: living opposing actor with the greatest LIVE effective attack
+            // (Doomsayer's enemy-highest-attack target). Ties → roster order.
+            const highestAttackInRoster = (roster: CombatActor[]): string | undefined =>
+                highestAttackAmong(
+                    roster.map((a) => a.id),
+                    (id) => effectiveStatsOf(id).attack,
+                    (id) => roster.find((a) => a.id === id)?.destroyedRound === undefined
+                );
+```
+
+(Adjust `effectiveStatsOf(id).attack` to the real accessor signature found in engine.ts.)
+
+- [ ] **Step 3: Bind into both drain-seam ctx literals**
+
+In `drainIntents` (~3445), add to the options object:
+
+```typescript
+                enemyWithHighestAttack: () => highestAttackInRoster(enemyAttackerActors),
+                firstActivatorId,
+                oncePerRoundConsumed,
+```
+
+In `drainEnemyIntents` (~3467), add:
+
+```typescript
+                enemyWithHighestAttack: () => highestAttackInRoster(allPlayerActors),
+                firstActivatorId,
+                oncePerRoundConsumed,
+```
+
+(`firstActivatorId` is read inside the arrow body at call time → reads the live value. If declared in the enclosing scope as a `let`, the closure reads it live; confirm.)
+
+- [ ] **Step 4: Set `firstActivatorId` at the real-activation site**
+
+At `engine.ts:3698`, inside `if (!isTurnBlocked(actor.id)) {`, as the FIRST statement (before `parsedTargetFor`/`runPlayerTurn`):
+
+```typescript
+                    if (!isTurnBlocked(actor.id)) {
+                        // D-PR14: first REAL activation of the round (Stasis/Disable-skipped
+                        // actors never reach here, so they don't count). ??= writes once.
+                        firstActivatorId ??= actor.id;
+                        const target = parsedTargetFor(actor);
+```
+
+- [ ] **Step 5: Run tsc**
+
+Run: `npx tsc --noEmit`
+Expected: errors — `enemyWithHighestAttack`/`oncePerRoundConsumed` not yet on `IntentExecContext`. (Added in Task 5; if you want this task to compile standalone, add those two `IntentExecContext` fields here. Recommended: add the field declarations in Task 5's first step and accept that Task 4 + Task 5 compile together — note this and proceed.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/combat/engine.ts
+git commit --no-verify -m "feat(combat): D-PR14 — engine round-state (firstActivatorId, oncePerRoundConsumed, highest-attack binding)"
+```
+
+---
+
+## Task 5: Debuff executor — proc gate, once-per-round, `enemy-highest-attack` routing
+
+**Files:**
+- Modify: `src/utils/combat/triggers.ts` (debuff branch at 1161 + `IntentExecContext`)
+
+- [ ] **Step 1: Add the two `IntentExecContext` fields**
+
+Near `enemyWithMostBuffs` (~634):
+
+```typescript
+    /** D-PR14 Doomsayer: living opposing actor with the greatest live effective attack. */
+    enemyWithHighestAttack?: (ownerId: string) => string | undefined;
+    /** D-PR14 Bulwark: per-(owner,ability) once-per-round consume set (reset each round in engine). */
+    oncePerRoundConsumed?: Set<string>;
+```
+
+- [ ] **Step 2: Add proc gate + once-per-round + target routing to the debuff branch**
+
+Replace the head of the `if (cfg.type === 'debuff') {` branch (1161) and its `counterTargetId` computation. The new branch body opens:
+
+```typescript
+    if (cfg.type === 'debuff') {
+        // D-PR14: once-per-round gate (Bulwark) — check consumed BEFORE drawing the proc gate,
+        // so a failed roll never locks the round (mirrors D-PR3 incoming-block invariant).
+        const onceKey = `${intent.ownerId}:${intent.ability.id}`;
+        if (intent.ability.oncePerRound && ctx.oncePerRoundConsumed?.has(onceKey)) return;
+        // D-PR14: proc-chance gate for reactive debuff appliers (Bulwark). Pass-through when
+        // procChance is undefined → BYTE-IDENTICAL for every existing debuff applier (Martyrdom).
+        if (!passesProcChanceGate(intent, ctx)) return;
+        // Mark consumed ONLY after a successful proc (before the landing roll — "once per round"
+        // is per attempt, matching the spec's read).
+        if (intent.ability.oncePerRound) ctx.oncePerRoundConsumed?.add(onceKey);
+
+        const status: Extract<RegisteredAbilityStatus, { kind: 'timed' }> = {
+            // ... unchanged ...
+        };
+        // D-PR14: target resolution — enemy-highest-attack global selector (Doomsayer) else the
+        // counter-infliction route (Bulwark/Warden). Existing appliers use counterTargetId → identical.
+        const counterTargetId =
+            intent.ability.target === 'enemy-highest-attack'
+                ? ctx.enemyWithHighestAttack?.(intent.ownerId)
+                : intent.eventCtx?.counterTargetId;
+        // No living highest-attack enemy → no-op (don't apply to the default enemy).
+        if (intent.ability.target === 'enemy-highest-attack' && counterTargetId === undefined) return;
+        // ... rest of the branch (landsTimedEnemyApplication / applyTimedAbilityStatus / emits) UNCHANGED ...
+```
+
+Keep the existing `status` literal and the `if (owner.landsTimedEnemyApplication(...))` block verbatim — only the lines above the `status` literal and the `counterTargetId` computation change.
+
+- [ ] **Step 3: tsc + full debuff-path regression**
+
+Run: `npx tsc --noEmit && npx vitest run src/utils/combat`
+Expected: tsc clean. Combat suite GREEN with ZERO golden/.snap changes (Martyrdom/Warden debuff appliers have no `procChance`/`oncePerRound`/`enemy-highest-attack` → pass-through). If any golden moves, STOP — the pass-through is broken.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/combat/triggers.ts
+git commit --no-verify -m "feat(combat): D-PR14 — debuff executor proc gate + once-per-round + enemy-highest-attack routing"
+```
+
+---
+
+## Task 6: Listener adjacency filter (Bulwark)
+
+**Files:**
+- Modify: `src/utils/combat/triggers.ts` (registerReactiveListeners args + on-ally-attacked listener)
+- Modify: `src/utils/combat/engine.ts` (pass `adjacentAllyIdsFor` into the registerReactiveListeners call)
+
+- [ ] **Step 1: Add the optional arg to `registerReactiveListeners`**
+
+In the args object (`triggers.ts:218-232`), after `roleOf?`:
+
+```typescript
+    /** D-PR14 Bulwark: same-side ids adjacent to an owner (living, owner excluded; non-positional
+     *  → all living same-side allies). Used to gate requireDamagedAllyAdjacent reactions. Optional:
+     *  DPS/unit fixtures omit it (→ treat any ally as adjacent). */
+    adjacentAllyIdsFor?: (ownerId: string) => string[];
+```
+
+Destructure it: `const { bus, perOwner, enqueue, isOpposing, roleOf, adjacentAllyIdsFor } = args;`
+
+- [ ] **Step 2: Filter in the on-ally-attacked listener**
+
+In the `case 'on-ally-attacked':` listener (`triggers.ts:391`), after the `roleFilter` block (line ~409) and BEFORE the `enqueue({...})`:
+
+```typescript
+                        // D-PR14 Bulwark: fire only when the DAMAGED ally is adjacent to this
+                        // owner. Pure read (listener stays enqueue-only). Helper absent → allow.
+                        if (
+                            ra.ability.requireDamagedAllyAdjacent &&
+                            adjacentAllyIdsFor &&
+                            !adjacentAllyIdsFor(ownerId).includes(e.targetId)
+                        ) {
+                            return;
+                        }
+```
+
+- [ ] **Step 3: Pass `adjacentAllyIdsFor` from the engine call site**
+
+Find the `registerReactiveListeners({ ... })` call(s) in `engine.ts` (`grep -n "registerReactiveListeners" src/utils/combat/engine.ts`). Add to the args:
+
+```typescript
+            adjacentAllyIdsFor: (ownerId: string) => adjacentAllyIds(ownerId, actors),
+```
+
+(Reuse the existing `adjacentAllyIds(ownerId, actors)` already used at `engine.ts:1795`; `adjacentAllyIds` is already imported. The helper is side-correct — it returns same-side allies of `ownerId` regardless of which team's listeners are being registered.)
+
+- [ ] **Step 4: tsc + combat regression**
+
+Run: `npx tsc --noEmit && npx vitest run src/utils/combat`
+Expected: tsc clean; GREEN, ZERO golden movement (no existing ability sets `requireDamagedAllyAdjacent`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/triggers.ts src/utils/combat/engine.ts
+git commit --no-verify -m "feat(combat): D-PR14 — on-ally-attacked adjacency filter for Bulwark"
+```
+
+---
+
+## Task 7: Registry entries + proc tables + `mkNamedDebuff` opts
+
+**Files:**
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts`
+- Test: `src/utils/abilities/__tests__/equipmentCoverage.test.ts` (registry unit assertions) — full coverage update is Task 8; here add focused build assertions.
+
+- [ ] **Step 1: Write failing registry unit tests**
+
+Add to a new `src/utils/abilities/__tests__/cfProvokeRegistry.test.ts` (or extend equipmentCoverage):
+
+```typescript
+import { describe, it, expect } from 'vitest';
+// Build a ship equipping BULWARK / DOOMSAYER at each rarity and inspect the produced ability.
+// Reuse the implant-equipping helper pattern from equipmentCoverage.test.ts (makePiece + getGearPiece).
+
+describe('D-PR14 registry — Bulwark', () => {
+    it('produces a Provoke debuff: on-ally-attacked, target enemy, oncePerRound, adjacency-required, procChance per rarity', () => {
+        const ab = buildBulwark('epic'); // helper: build & return the single equip-implant ability
+        expect(ab.config.type).toBe('debuff');
+        expect(ab.config.buffName).toBe('Provoke');
+        expect(ab.trigger).toBe('on-ally-attacked');
+        expect(ab.target).toBe('enemy');
+        expect(ab.oncePerRound).toBe(true);
+        expect(ab.requireDamagedAllyAdjacent).toBe(true);
+        expect(ab.procChance).toBeCloseTo(0.12);
+        expect(ab.config.duration).toBe(1);
+    });
+});
+
+describe('D-PR14 registry — Doomsayer', () => {
+    it('produces a Concentrate Fire debuff: end-of-round, target enemy-highest-attack, first-activator gate, procChance per rarity', () => {
+        const ab = buildDoomsayer('legendary');
+        expect(ab.config.buffName).toBe('Concentrate Fire');
+        expect(ab.trigger).toBe('end-of-round');
+        expect(ab.target).toBe('enemy-highest-attack');
+        expect(ab.conditions).toContainEqual({ subject: 'first-activator', derivable: true });
+        expect(ab.procChance).toBeCloseTo(0.16);
+        expect(ab.config.duration).toBe(1);
+    });
+});
+```
+
+(Implement `buildBulwark`/`buildDoomsayer` test helpers using the same equip-and-`buildEquipmentAbilities` mechanics as `implantAbilityCount` in equipmentCoverage.test.ts, returning the single produced ability.)
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `npx vitest run src/utils/abilities/__tests__/cfProvokeRegistry.test.ts`
+Expected: FAIL — no abilities produced (registry entries absent → count 0).
+
+- [ ] **Step 3: Extend `mkNamedDebuff` with an opts bag**
+
+Change `mkNamedDebuff` signature (1359-385) to accept opts (keep existing callers working — opts optional, defaults preserve current behavior):
+
+```typescript
+function mkNamedDebuff(
+    buffName: string,
+    trigger: AbilityTrigger,
+    duration: number | undefined,
+    opts?: { target?: AbilityTarget; procChance?: number; conditions?: Condition[] }
+): Omit<Ability, 'id'> | undefined {
+    if (duration === undefined) return undefined;
+    const buff = BUFFS.find((b) => b.name === buffName);
+    if (!buff) return undefined;
+    const { stackable, maxStacks } = isStackable(buff.description);
+    return {
+        type: 'debuff',
+        target: opts?.target ?? 'enemy',
+        trigger,
+        conditions: opts?.conditions ?? [],
+        ...(opts?.procChance !== undefined ? { procChance: opts.procChance } : {}),
+        config: {
+            type: 'debuff',
+            buffName,
+            parsedEffects: parseBuffEffects(buff.name, buff.description),
+            stacks: 1,
+            isStackable: stackable,
+            maxStacks,
+            application: 'apply',
+            duration,
+        },
+        autoFilled: true,
+    };
+}
+```
+
+(Martyrdom's existing call `mkNamedDebuff('Disable', 'on-destroyed', n)` is unchanged → byte-identical.)
+
+- [ ] **Step 4: Add proc tables**
+
+Near the other `*_PROC` tables (~217-239):
+
+```typescript
+// D-PR14: Bulwark — X% chance, when an adjacent ally is directly damaged, apply Provoke 1 turn, once per round.
+const BULWARK_PROC: Record<string, number> = {
+    common: 0.05,
+    uncommon: 0.07,
+    rare: 0.09,
+    epic: 0.12,
+    legendary: 0.16,
+};
+// D-PR14: Doomsayer — at end of round, if first to activate, X% chance to apply Concentrate Fire
+// to the highest-attack enemy 1 turn. No common variant. (Proc from THIS table, not the
+// description text — Doomsayer's legendary text has a "change"/"chance" typo.)
+const DOOMSAYER_PROC: Record<string, number> = {
+    uncommon: 0.07,
+    rare: 0.09,
+    epic: 0.12,
+    legendary: 0.16,
+};
+```
+
+- [ ] **Step 5: Add the registry entries**
+
+In `IMPLANT_ABILITIES` (~387), add:
+
+```typescript
+    BULWARK: (rarity) => {
+        const procChance = BULWARK_PROC[rarity];
+        if (procChance === undefined) return undefined;
+        const base = mkNamedDebuff('Provoke', 'on-ally-attacked', 1, { procChance });
+        if (!base) return undefined;
+        return { ...base, oncePerRound: true, requireDamagedAllyAdjacent: true };
+    },
+    DOOMSAYER: (rarity) => {
+        const procChance = DOOMSAYER_PROC[rarity];
+        if (procChance === undefined) return undefined;
+        return mkNamedDebuff('Concentrate Fire', 'end-of-round', 1, {
+            procChance,
+            target: 'enemy-highest-attack',
+            conditions: [{ subject: 'first-activator', derivable: true }],
+        });
+    },
+```
+
+- [ ] **Step 6: Run the registry tests + tsc**
+
+Run: `npx vitest run src/utils/abilities/__tests__/cfProvokeRegistry.test.ts && npx tsc --noEmit`
+Expected: PASS; tsc clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/cfProvokeRegistry.test.ts
+git commit --no-verify -m "feat(combat): D-PR14 — Bulwark + Doomsayer registry entries + proc tables"
+```
+
+---
+
+## Task 8: Engine integration tests (Bulwark + Doomsayer end-to-end)
+
+**Files:**
+- Create: `src/utils/combat/__tests__/cfProvokeAppliers.integration.test.ts`
+
+Use an existing two-team `simulateBattle` integration test as the template (search `src/utils/combat/__tests__` for tests that build two real teams + pass `getGearPiece`, e.g. the D-PR3/D-PR4 incoming/outgoing integration tests). Equip the implant via `getGearPiece` (implant `setBonus` = implant NAME, `rarity` picks the variant). Force procs by using a rarity whose `procChance` makes the deterministic accumulator fire on the first eligible event (or assert across enough events that the deterministic gate fires); follow the proc-forcing pattern the prior D integration tests use.
+
+- [ ] **Step 1: Write the tests**
+
+```typescript
+describe('D-PR14 Bulwark (Provoke on adjacent-ally damage)', () => {
+    it('applies Provoke to the attacker when an adjacent ally is directly damaged', () => {
+        // two-team sim, Bulwark on a player ship adjacent to the hit ally;
+        // assert provokerOf(statusEngine, attackerId) === bulwarkOwnerId after the hit.
+    });
+    it('does NOT fire when the damaged ally is not adjacent (positional)', () => {
+        // position Bulwark owner away from the hit ally; assert no Provoke applied.
+    });
+    it('applies at most once per round', () => {
+        // two adjacent-ally hits in one round; assert Provoke applied once (gate consumed).
+    });
+});
+
+describe('D-PR14 Doomsayer (Concentrate Fire on highest-attack enemy at end of round)', () => {
+    it('applies Concentrate Fire to the highest-attack enemy when the owner is first activator', () => {
+        // Doomsayer owner is fastest (first to act) + proc forced; assert CF on the
+        // highest-effective-attack enemy at end of round (read via ownerDebuffNamesFor / targeting).
+    });
+    it('does NOT apply when the owner is not the first activator', () => {
+        // make another actor faster; assert no CF applied by Doomsayer.
+    });
+});
+```
+
+- [ ] **Step 2: Run, verify behavior**
+
+Run: `npx vitest run src/utils/combat/__tests__/cfProvokeAppliers.integration.test.ts`
+Expected: PASS. If the proc/first-activator gating doesn't fire as expected, debug via `superpowers:systematic-debugging` (likely a `liveGateConditions` stripping `first-activator`, or the adjacency helper not threaded — verify against Task 3/6).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/combat/__tests__/cfProvokeAppliers.integration.test.ts
+git commit --no-verify -m "test(combat): D-PR14 — Bulwark + Doomsayer integration tests"
+```
+
+---
+
+## Task 9: Coverage tracker + changelog + full-suite/golden verification
+
+**Files:**
+- Modify: `src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+- Modify: `src/constants/changelog.ts`
+
+- [ ] **Step 1: Update the coverage assertion**
+
+In `equipmentCoverage.test.ts`, insert `'BULWARK'` and `'DOOMSAYER'` into the implemented-implants `toEqual([...])` array at their `IMPLANTS` declaration-order positions (between `'BLOODTHIRST'` and `'EXUBERANCE'` — confirm exact order against `constants/implants.ts`; if Bulwark/Doomsayer declare before Bloodthirst, place accordingly). Add per-rarity `it(...)` assertions mirroring SPEARHEAD's `for (const v of IMPLANTS['SPEARHEAD'].variants) expect(implantAbilityCount('SPEARHEAD', v.rarity)).toBe(1)`:
+
+```typescript
+    it('BULWARK produces 1 Provoke debuff per rarity (on-ally-attacked, once-per-round, procChance)', () => {
+        for (const v of IMPLANTS['BULWARK'].variants) {
+            expect(implantAbilityCount('BULWARK', v.rarity)).toBe(1);
+        }
+    });
+    it('DOOMSAYER produces 1 Concentrate Fire debuff per rarity (end-of-round, first-activator, procChance)', () => {
+        for (const v of IMPLANTS['DOOMSAYER'].variants) {
+            expect(implantAbilityCount('DOOMSAYER', v.rarity)).toBe(1);
+        }
+    });
+```
+
+Remove BULWARK/DOOMSAYER from the "unimplemented → 0 abilities" assertions if they were explicitly listed there.
+
+- [ ] **Step 2: Add the changelog entry**
+
+In `src/constants/changelog.ts`, add to `UNRELEASED_CHANGES` (plain English, user-facing):
+
+```
+'Combat sim: Bulwark implants now apply Provoke to an enemy that damages a nearby ally, and Doomsayer implants apply Concentrate Fire to the strongest enemy at the end of the round.'
+```
+
+(Match the exact array/format of neighbouring entries.)
+
+- [ ] **Step 3: Full suite + lint + tsc + audit**
+
+Run:
+```bash
+npx vitest run
+npx tsc --noEmit
+npm run lint
+npm run audit:skills   # if present in this repo's scripts; else skip
+```
+Expected: ALL tests GREEN, **ZERO golden/.snap movement** (no fixture equips these implants — confirm `git status` shows no `.snap` / golden changes), tsc clean, lint clean (max-warnings 0).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/abilities/__tests__/equipmentCoverage.test.ts src/constants/changelog.ts
+git commit --no-verify -m "feat(combat): D-PR14 — coverage tracker + changelog for Bulwark/Doomsayer"
+```
+
+---
+
+## Final verification & handoff
+
+- [ ] **Verify** the whole suite is green with no golden movement: `npx vitest run` + `git status` clean of `.snap`.
+- [ ] **Verify** `npx tsc --noEmit` and `npm run lint` clean.
+- [ ] **Self-review** the diff for the byte-identical claims: the debuff-branch proc gate + once-per-round + target routing collapse to the prior code when `procChance`/`oncePerRound`/`enemy-highest-attack` are all absent; the adjacency filter is inert without `requireDamagedAllyAdjacent`.
+- [ ] **Push** the branch and open the PR stacked on D-PR13 (`gh pr create --base feat/combat-d-pr13-disable-turn-skip`), per the D-stack strategy. Use `gh auth switch --user TheSusort` first if needed.
+
+---
+
+## Notes / gotchas
+
+- **`git commit --no-verify`**: the pre-commit hook runs the full vitest suite; use `--no-verify` for incremental commits and rely on the explicit per-task test runs. Run the full suite once at Task 9.
+- **Byte-identical invariant**: every executor change is gated on a new optional field (`procChance`/`oncePerRound`/`requireDamagedAllyAdjacent`/`target === 'enemy-highest-attack'`). If ANY existing golden moves, a gate's pass-through is broken — stop and fix before continuing.
+- **`liveGateConditions`**: confirm it does not strip `first-activator` (ALACRITY's `not-hit-this-round` is the working precedent for a derivable self-condition used as an end-of-round gate).
+- **Decrement-timing**: a "1 turn" Provoke/CF may expire after one observable enemy turn (locked behavior; not changed here).
+- **DPS calculator page**: intentionally NOT wired — both effects are targeting debuffs that matter only in the battle sim.

--- a/docs/superpowers/plans/2026-06-22-implant-gearset-abilities-D-pr14.md
+++ b/docs/superpowers/plans/2026-06-22-implant-gearset-abilities-D-pr14.md
@@ -159,7 +159,10 @@ Near `roleFilter?` (`abilities.ts:425`), add:
 ```typescript
     /** D-PR14 Bulwark: this reactive applies at most once per round per (owner, ability).
      *  Gated executor-side via IntentExecContext.oncePerRoundConsumed (check BEFORE the
-     *  proc draw, mark only on a successful proc). Absent → no per-round limit. */
+     *  proc draw, mark only on a successful proc). Absent → no per-round limit.
+     *  NOTE: distinct from the `oncePerRound` flag on the extra-action / incoming-block
+     *  AbilityConfig variants — this is the top-level Ability flag (read via
+     *  `intent.ability.oncePerRound`), honoring the spec's "no AbilityConfig change". */
     oncePerRound?: boolean;
     /** D-PR14 Bulwark: an on-ally-attacked reactive fires only when the DAMAGED ally is
      *  adjacent to this owner (board neighbours; non-positional → any living same-side ally).
@@ -470,13 +473,14 @@ In the `case 'on-ally-attacked':` listener (`triggers.ts:391`), after the `roleF
 
 - [ ] **Step 3: Pass `adjacentAllyIdsFor` from BOTH engine call sites**
 
-There are TWO `registerReactiveListeners({ ... })` calls (player ~`engine.ts:2028`, enemy ~`engine.ts:2049`; confirm via `grep -n "registerReactiveListeners" src/utils/combat/engine.ts`). Add to BOTH args objects:
+There are TWO `registerReactiveListeners({ ... })` calls (player ~`engine.ts:2028`, enemy ~`engine.ts:2049`; confirm via `grep -n "registerReactiveListeners" src/utils/combat/engine.ts`). Add to BOTH args objects, using the side-resolving per-side helper:
 
 ```typescript
-            adjacentAllyIdsFor: (ownerId: string) => adjacentAllyIds(ownerId, actors),
+            adjacentAllyIdsFor: (ownerId: string) =>
+                bySide(isEnemySide(ownerId) ? 'enemy' : 'player').adjacentAllyIdsFor(ownerId),
 ```
 
-`adjacentAllyIds` is already imported (`engine.ts:83`) and is side-correct (returns same-side allies of `ownerId` regardless of which team's listeners are registered), so the same line works for both. (The per-side `bySide(...).adjacentAllyIdsFor` helper at `engine.ts:1795` is equivalent if you prefer reusing it.)
+**Do NOT write `adjacentAllyIds(ownerId, actors)` here:** `actors` is a local inside `buildSideContext` (`engine.ts:1765`) and is OUT OF SCOPE at the call sites; and the raw `adjacentAllyIds` (`adjacency.ts:21-30`) does NO side filtering — passing a full roster would make enemy actors count as "adjacent allies" and defeat the restriction. The per-side `buildSideContext(...).adjacentAllyIdsFor` (`engine.ts:1795`) passes the correct same-side roster. `bySide` / `isEnemySide` are in scope at the call sites (`engine.ts:1799-1801`). The listener owner can be on either side, so the `isEnemySide` resolution is required.
 
 - [ ] **Step 4: tsc + combat regression**
 

--- a/docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr14-design.md
+++ b/docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr14-design.md
@@ -45,8 +45,8 @@ single-ship DPS calculator — so **no DPS-page wiring** (unlike D-PR2's outgoin
 - `end-of-round` reactive trigger (live; `events.ts`, Rhodium/C2b-2 precedent).
 - `adjacentAllyIds(ownerId, actors)` (`adjacency.ts:21`) — degrades to all-living-allies in
   non-positional combat.
-- `rollRateGate(gates, key, chance)` (`calculators/rateAccumulator.ts:31`) +
-  `makeRateGate` deterministic proc accumulators.
+- `rollRateGate(gates, key, chance)` (`src/utils/calculators/rateAccumulator.ts:31`) +
+  `makeRateGate` (`:17`) deterministic proc accumulators.
 - Once-per-round pattern from D-PR3 `incoming-block`: `cfg.oncePerRound` flag + a consumed
   `Set` keyed `${ownerId}:${abilityId}`, with the **invariant**: check-consumed BEFORE
   drawing the gate, and mark consumed ONLY on a successful proc (engine.ts ~2607–2625).
@@ -134,7 +134,8 @@ check/roll/mark all happen executor-side, NOT in the listener.
 1. During the round the engine sets `firstActivatorId` once (first real turn).
 2. At `end-of-round`, Doomsayer's listener (owner) checks:
    a. **gate:** `ownerId === firstActivatorId` → else stop.
-   b. **proc roll:** per-rarity chance via `rollRateGate`.
+   b. **proc roll:** per-rarity chance via the executor's `passesProcChanceGate` (the
+      `end-of-round` listener only enqueues; gating is handled at drain, same as Bulwark).
 3. On success → `highestEffectiveAttackAmong(opposingRoster)`; no living enemy → no-op.
 4. Apply **Concentrate Fire** (1 turn, `casterId = ownerId`) to that enemy's per-target
    store.
@@ -196,7 +197,6 @@ timing change in this PR.
 ## Files touched
 
 - `src/constants/implants.ts` — (read-only; data already present, lines ~1428–1609).
-- `src/utils/abilities/buildEquipmentAbilities.ts` — 2 registry entries + 2 proc tables.
 - `src/utils/combat/engine.ts` — `firstActivatorId` round-state field + set-site (before
   `runPlayerTurn`, after all skip branches); `highestEffectiveAttackAmong` selector; bind
   `enemyWithHighestAttack` into `IntentExecContext` at both drain seams; Bulwark

--- a/docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr14-design.md
+++ b/docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr14-design.md
@@ -24,8 +24,8 @@ single-ship DPS calculator — so **no DPS-page wiring** (unlike D-PR2's outgoin
 ## Goals / non-goals
 
 **Goals**
-- Faithfully apply Provoke (Bulwark) and Concentrate Fire (Doomsayer) via the existing
-  reactive debuff-applier executor.
+- Faithfully apply Provoke (Bulwark, via the existing `counterTargetId` route) and
+  Concentrate Fire (Doomsayer, via a new `enemy-highest-attack` global-selector route).
 - Reuse existing machinery wherever it exists; add the smallest possible net-new
   primitives (Approach A — narrow, ad-hoc, no generalized condition primitives).
 - Byte-identical combat goldens (no existing fixture equips either implant).
@@ -53,45 +53,82 @@ single-ship DPS calculator — so **no DPS-page wiring** (unlike D-PR2's outgoin
 - `mostBuffsAmong(roster)` selector pattern (engine.ts ~3423) — template for the new
   highest-attack selector.
 - `effectiveStatsOf` for live effective attack.
-- Provoke/CF debuff application: `statusEngine.applyTimedAbilityStatus` to the target's
-  per-target enemy-debuff store; family-overwrite keying on `buffName`.
+- Provoke debuff application via `eventCtx.counterTargetId`: the debuff executor
+  (`triggers.ts` ~1161–1204) routes to `counterTargetId` (the attacker), exactly like
+  Martyrdom's on-destroyed Disable. **Bulwark reuses this path verbatim** — its
+  `on-ally-attacked` listener sets `counterTargetId = attackerId`.
+- `statusEngine.applyTimedAbilityStatus` to the target's per-target enemy-debuff store;
+  family-overwrite keying on `buffName`.
 - Registry: `IMPLANT_ABILITIES` in `buildEquipmentAbilities.ts` + per-rarity proc tables +
   `mkNamedDebuff` helper (Martyrdom's on-destroyed Disable applier is the precedent).
+  **Proc values come from the hardcoded `*_PROC` tables, not the description text**
+  (Doomsayer's legendary text has a "change"/"chance" typo — harmless since we never parse
+  the percentage).
+
+### NOT reusable as-is (the blocker the executor doesn't cover)
+The debuff executor routes ONLY via `counterTargetId`, falling back to the singular default
+`ctx.enemy.id`. It has **no global-selector branch** — the only global-selector executor is
+the *purge* path (`target === 'enemy-most-buffs'`, `triggers.ts` ~1410), which a debuff
+cannot use. So Doomsayer's "CF to the highest-attack enemy" is **net-new routing**, not
+reuse (see Net-new #2 below). `mkNamedDebuff` also hardcodes `target:'enemy'`
+(`buildEquipmentAbilities.ts` ~370) and cannot be reused as-is for Doomsayer.
 
 ### Net-new (this PR)
 1. **`firstActivatorId`** — a round-state field on the engine, reset at round start, set
    once to the id of the **first actor to take a real (non-skipped) turn**. Skipped turns
-   (Stasis / Disable / focus-skip) do NOT count as activating. Set at the turn-commit site
-   inside the round's `selectNext` loop, after the skip determination, guarded to write
-   only when still unset.
-2. **`highestEffectiveAttackAmong(roster)`** — selector mirroring `mostBuffsAmong`,
-   returning the id of the living actor with the greatest live effective attack
-   (`effectiveStatsOf`); ties → first in roster order; `undefined` if no living candidate.
-   Runs over the **opposing** roster for the firing owner.
-3. **Bulwark adjacency filter + once-per-round gate** on the `on-ally-attacked` path.
-4. **Two `IMPLANT_ABILITIES` registry entries** + `BULWARK_PROC` / `DOOMSAYER_PROC` tables.
-
-Whether the once-per-round gate and first-activator gate are expressed as a small
-`AbilityConfig` flag (`oncePerRound`, reusing D-PR3's flag) vs. pure engine-side wiring is
-a planning-level decision; if a new config field is introduced, the editor-exhaustiveness
-stubs (AbilityCard / AbilityTypePicker / abilityDefaults) get the same trivial additions
-D-PR4 made. Preference: reuse D-PR3's existing `oncePerRound` flag for Bulwark; keep the
-first-activator gate engine-side.
+   (Stasis / Disable / focus-skip) do NOT count as activating. **Set-site: immediately
+   before the `runPlayerTurn` call, AFTER all skip branches resolve** (dead-target skip
+   `~3552`, dead-actor `continue` `~3585`, AND the deeper Stasis/Disable/focus-skip
+   branches inside the turn body) — `firstActivatorId ??= actor.id`. Placing it merely after
+   the dead-actor skip would wrongly count a Stasis-skipped actor (contradicting the
+   first-activator edge case below).
+2. **Doomsayer CF routing — `target: 'enemy-highest-attack'` (the real net-new seam).**
+   - New `AbilityTarget` value `'enemy-highest-attack'` (`types/abilities.ts` ~29–38).
+   - New `IntentExecContext` field `enemyWithHighestAttack?: (ownerId: string) => string |
+     undefined`, mirroring the existing `enemyWithMostBuffs` (`triggers.ts` ~634).
+   - New branch in the **debuff** executor (`triggers.ts` ~1161): when
+     `intent.ability.target === 'enemy-highest-attack'`, resolve the recipient via
+     `ctx.enemyWithHighestAttack?.(intent.ownerId)` and pass it as the `counterTargetId`
+     argument to `applyTimedAbilityStatus`; no living candidate → no-op (skip apply).
+   - Bind at **both** drain seams (`engine.ts` ~3445 `drainIntents`, ~3467
+     `drainEnemyIntents`): `highestEffectiveAttackAmong(enemyAttackerActors)` for player
+     owners, `highestEffectiveAttackAmong(allPlayerActors)` for enemy owners — identical
+     per-side pattern to `enemyWithMostBuffs`.
+   - A `mkNamedDebuff` variant (or an `opts.target` param) emitting the new target, since
+     the base helper hardcodes `target:'enemy'`.
+3. **`highestEffectiveAttackAmong(roster)`** — selector mirroring `mostBuffsAmong`
+   (`engine.ts` ~3423), returning the id of the living actor with the greatest live
+   effective attack (`effectiveStatsOf`); ties → first in roster order; `undefined` if no
+   living candidate. Bound per-side over the opposing roster (see #2).
+4. **Bulwark once-per-round gate — executor-side, no config flag.** The
+   `incoming-block` config's `oncePerRound` flag is NOT reusable (it lives only on that
+   config variant, and `engine.ts` ~2614 keys the consume on `cfg.type ===
+   'incoming-block'`). Instead: a fresh consumed-`Set` keyed `${ownerId}:${abilityId}` in
+   the Bulwark drain path, decided by the ability id alone — **no `AbilityConfig` change,
+   therefore no editor-exhaustiveness stubs**. Invariant preserved (check-consumed BEFORE
+   the proc draw, mark consumed ONLY on a successful proc).
+5. **Two `IMPLANT_ABILITIES` registry entries** + `BULWARK_PROC` / `DOOMSAYER_PROC` tables.
 
 ## Data flow
 
 ### Bulwark (reactive, per damaging hit on an adjacent ally)
+Listeners are PURE (`triggers.ts` ~154 — they `enqueue` only, never mutate state; the proc
+gate is drawn in the executor at drain time via `passesProcChanceGate`). So the gate
+check/roll/mark all happen executor-side, NOT in the listener.
 1. Enemy directly damages an ally → `on-ally-attacked` event (`attackerId`,
    `damagedAllyId`).
-2. Bulwark's listener (owner) checks, in order:
-   a. **once-per-round consumed?** for `(ownerId, abilityId)` → if yes, early-out (before
-      RNG — keeps the proc accumulator sequence undisturbed).
-   b. **adjacency:** `damagedAllyId ∈ adjacentAllyIds(ownerId, actors)`.
-   c. **proc roll:** per-rarity chance via `rollRateGate`.
-3. On success → enqueue a `debuff` Intent with `eventCtx.counterTargetId = attackerId`;
-   mark the once-per-round gate consumed.
-4. Drain → existing debuff executor applies **Provoke** (1 turn, `application:'apply'`,
-   `casterId = ownerId`) to the attacker's per-target enemy-debuff store.
+2. Bulwark's listener (owner) does a **pure** adjacency filter — `damagedAllyId ∈
+   adjacentAllyIds(ownerId, actors)` (state read, no mutation) — and, if adjacent, enqueues
+   a `debuff` Intent with `eventCtx.counterTargetId = attackerId`. Non-adjacent → no
+   enqueue.
+3. At drain, the executor for this intent:
+   a. **once-per-round consumed?** for `(ownerId, abilityId)` → if yes, early-out BEFORE
+      drawing the gate (keeps the proc accumulator sequence undisturbed — same ordering
+      discipline as D-PR3's block path).
+   b. **proc roll:** per-rarity chance via the proc gate.
+   c. on success → mark the consumed-`Set`, then apply.
+4. Apply **Provoke** (1 turn, `application:'apply'`, `casterId = ownerId`) to the
+   attacker's per-target enemy-debuff store via the existing `counterTargetId` route.
 
 ### Doomsayer (end-of-round, global selector)
 1. During the round the engine sets `firstActivatorId` once (first real turn).
@@ -149,8 +186,10 @@ timing change in this PR.
 - **Integration — Doomsayer:** end-of-round, owner is first activator + proc forced on →
   Concentrate Fire lands on the highest-effective-attack enemy; owner NOT first activator →
   no application; owner skipped all round → not first activator.
-- **Coverage tracker:** add `BULWARK`, `DOOMSAYER` to the implemented-implants set in
-  `equipmentCoverage.test.ts` + per-rarity `>= 1 ability` assertions; they leave the
+- **Coverage tracker:** add `BULWARK`, `DOOMSAYER` to the implemented-implants assertion in
+  `equipmentCoverage.test.ts` + per-rarity `>= 1 ability` assertions. NOTE: that assertion
+  is an **ordered** `toEqual` array tracking `Object.keys(IMPLANTS)` declaration order —
+  insert the two names at their declaration-order positions, do not append. They leave the
   unimplemented assertions for everything else intact.
 - **Goldens:** full suite green with ZERO golden/.snap movement.
 
@@ -158,15 +197,25 @@ timing change in this PR.
 
 - `src/constants/implants.ts` — (read-only; data already present, lines ~1428–1609).
 - `src/utils/abilities/buildEquipmentAbilities.ts` — 2 registry entries + 2 proc tables.
-- `src/utils/combat/engine.ts` — `firstActivatorId` round-state field + set-site;
-  `highestEffectiveAttackAmong` selector; wire Doomsayer end-of-round selection + Bulwark
-  once-per-round gate into `IntentExecContext`.
-- `src/utils/combat/triggers.ts` — Bulwark adjacency filter + once-per-round consume on the
-  `on-ally-attacked` enqueue; Doomsayer CF routing to the selected enemy.
-- `src/types/abilities.ts` — reuse existing `oncePerRound` flag if applied to Bulwark's
-  config; no new trigger expected.
-- `src/utils/abilities/__tests__/equipmentCoverage.test.ts` — add the two implants.
-- Editor-exhaustiveness stubs ONLY if a new `AbilityConfig` field is introduced.
+- `src/utils/combat/engine.ts` — `firstActivatorId` round-state field + set-site (before
+  `runPlayerTurn`, after all skip branches); `highestEffectiveAttackAmong` selector; bind
+  `enemyWithHighestAttack` into `IntentExecContext` at both drain seams; Bulwark
+  once-per-round consumed-`Set` in the drain path.
+- `src/utils/combat/triggers.ts` — Bulwark pure adjacency filter + `counterTargetId` enqueue
+  on `on-ally-attacked`; executor-side once-per-round gate + proc roll; new
+  `enemy-highest-attack` branch in the debuff executor; `enemyWithHighestAttack` field on
+  `IntentExecContext`.
+- `src/types/abilities.ts` — new `AbilityTarget` value `'enemy-highest-attack'`. No new
+  trigger. No new `AbilityConfig` field (Bulwark's gate is engine-side, keyed by ability
+  id).
+- `src/utils/abilities/buildEquipmentAbilities.ts` — 2 registry entries + 2 proc tables; a
+  `mkNamedDebuff` variant (or `opts.target`) for Doomsayer's `enemy-highest-attack` target.
+- `src/utils/abilities/__tests__/equipmentCoverage.test.ts` — add the two implants at their
+  declaration-order positions.
+- **Editor-exhaustiveness stubs** (AbilityCard / AbilityTypePicker / abilityDefaults) — only
+  for the new `AbilityTarget` value if those switches are target-exhaustive; confirm during
+  planning (the new value is a *target*, not a config type, so a default-case may already
+  cover it).
 
 ## Out of scope / next D buckets
 

--- a/docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr14-design.md
+++ b/docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr14-design.md
@@ -1,0 +1,179 @@
+# D-PR14 — CF / Provoke applier implants (Bulwark + Doomsayer)
+
+**Date:** 2026-06-22
+**Epic:** Combat-realism — sub-project D (implant + gear-set abilities)
+**Stacks on:** D-PR13 tip (`feat/combat-d-pr13-disable-turn-skip`, `642594a8`)
+**Branch:** `feat/combat-d-pr14-cf-provoke-appliers`
+
+## Summary
+
+Model two implant special-effects that **apply** targeting-control debuffs the engine
+already honors. This PR adds only the *applier* side — Concentrate Fire and Provoke are
+already force-targeted by `positionalBinding.ts` / `buildForcedTargetingStatus` /
+`provokerOf`; nothing about targeting changes.
+
+- **Bulwark** — *"There is a {X}% chance, when an adjacent ally is directly damaged, to
+  apply Provoke to that enemy for 1 turn, once per round."* (proc 5/7/9/12/16% by rarity)
+- **Doomsayer** — *"At the end of the round, if this unit was the first to activate, there
+  is a {X}% chance to apply Concentrate Fire to the enemy with the highest attack for 1
+  turn."* (proc 7/9/12/16% by rarity, uncommon→legendary)
+
+Both effects matter only in the battle simulator (they alter targeting), not the
+single-ship DPS calculator — so **no DPS-page wiring** (unlike D-PR2's outgoing-damage).
+
+## Goals / non-goals
+
+**Goals**
+- Faithfully apply Provoke (Bulwark) and Concentrate Fire (Doomsayer) via the existing
+  reactive debuff-applier executor.
+- Reuse existing machinery wherever it exists; add the smallest possible net-new
+  primitives (Approach A — narrow, ad-hoc, no generalized condition primitives).
+- Byte-identical combat goldens (no existing fixture equips either implant).
+
+**Non-goals**
+- No new targeting behavior; no changes to how Provoke/CF are *consumed*.
+- No generalized `first-to-activate` ConditionSubject or declarative `oncePerRound`
+  condition system (that is Approach B, explicitly rejected).
+- No fix to the locked buff-duration decrement-timing behavior (see Known interactions).
+
+## Architecture
+
+### Reuse (already exists)
+- `on-ally-attacked` reactive trigger + `eventCtx.counterTargetId` routing — Guardian's
+  ally-Provoke counter-infliction is the direct precedent (`triggers.ts` ~387–417, debuff
+  executor ~1161–1204).
+- `end-of-round` reactive trigger (live; `events.ts`, Rhodium/C2b-2 precedent).
+- `adjacentAllyIds(ownerId, actors)` (`adjacency.ts:21`) — degrades to all-living-allies in
+  non-positional combat.
+- `rollRateGate(gates, key, chance)` (`calculators/rateAccumulator.ts:31`) +
+  `makeRateGate` deterministic proc accumulators.
+- Once-per-round pattern from D-PR3 `incoming-block`: `cfg.oncePerRound` flag + a consumed
+  `Set` keyed `${ownerId}:${abilityId}`, with the **invariant**: check-consumed BEFORE
+  drawing the gate, and mark consumed ONLY on a successful proc (engine.ts ~2607–2625).
+- `mostBuffsAmong(roster)` selector pattern (engine.ts ~3423) — template for the new
+  highest-attack selector.
+- `effectiveStatsOf` for live effective attack.
+- Provoke/CF debuff application: `statusEngine.applyTimedAbilityStatus` to the target's
+  per-target enemy-debuff store; family-overwrite keying on `buffName`.
+- Registry: `IMPLANT_ABILITIES` in `buildEquipmentAbilities.ts` + per-rarity proc tables +
+  `mkNamedDebuff` helper (Martyrdom's on-destroyed Disable applier is the precedent).
+
+### Net-new (this PR)
+1. **`firstActivatorId`** — a round-state field on the engine, reset at round start, set
+   once to the id of the **first actor to take a real (non-skipped) turn**. Skipped turns
+   (Stasis / Disable / focus-skip) do NOT count as activating. Set at the turn-commit site
+   inside the round's `selectNext` loop, after the skip determination, guarded to write
+   only when still unset.
+2. **`highestEffectiveAttackAmong(roster)`** — selector mirroring `mostBuffsAmong`,
+   returning the id of the living actor with the greatest live effective attack
+   (`effectiveStatsOf`); ties → first in roster order; `undefined` if no living candidate.
+   Runs over the **opposing** roster for the firing owner.
+3. **Bulwark adjacency filter + once-per-round gate** on the `on-ally-attacked` path.
+4. **Two `IMPLANT_ABILITIES` registry entries** + `BULWARK_PROC` / `DOOMSAYER_PROC` tables.
+
+Whether the once-per-round gate and first-activator gate are expressed as a small
+`AbilityConfig` flag (`oncePerRound`, reusing D-PR3's flag) vs. pure engine-side wiring is
+a planning-level decision; if a new config field is introduced, the editor-exhaustiveness
+stubs (AbilityCard / AbilityTypePicker / abilityDefaults) get the same trivial additions
+D-PR4 made. Preference: reuse D-PR3's existing `oncePerRound` flag for Bulwark; keep the
+first-activator gate engine-side.
+
+## Data flow
+
+### Bulwark (reactive, per damaging hit on an adjacent ally)
+1. Enemy directly damages an ally → `on-ally-attacked` event (`attackerId`,
+   `damagedAllyId`).
+2. Bulwark's listener (owner) checks, in order:
+   a. **once-per-round consumed?** for `(ownerId, abilityId)` → if yes, early-out (before
+      RNG — keeps the proc accumulator sequence undisturbed).
+   b. **adjacency:** `damagedAllyId ∈ adjacentAllyIds(ownerId, actors)`.
+   c. **proc roll:** per-rarity chance via `rollRateGate`.
+3. On success → enqueue a `debuff` Intent with `eventCtx.counterTargetId = attackerId`;
+   mark the once-per-round gate consumed.
+4. Drain → existing debuff executor applies **Provoke** (1 turn, `application:'apply'`,
+   `casterId = ownerId`) to the attacker's per-target enemy-debuff store.
+
+### Doomsayer (end-of-round, global selector)
+1. During the round the engine sets `firstActivatorId` once (first real turn).
+2. At `end-of-round`, Doomsayer's listener (owner) checks:
+   a. **gate:** `ownerId === firstActivatorId` → else stop.
+   b. **proc roll:** per-rarity chance via `rollRateGate`.
+3. On success → `highestEffectiveAttackAmong(opposingRoster)`; no living enemy → no-op.
+4. Apply **Concentrate Fire** (1 turn, `casterId = ownerId`) to that enemy's per-target
+   store.
+
+### Determinism / goldens
+Both effects touch the proc accumulators only when an effect-bearing piece is equipped. No
+existing combat fixture equips Bulwark or Doomsayer → **byte-identical goldens / .snap**.
+
+## Edge cases & faithfulness decisions
+
+- **"First to activate" = first real turn.** A turn skipped by Stasis/Disable/focus-skip
+  does not set `firstActivatorId`. If Doomsayer's owner is skipped all round, it never
+  becomes first activator → no proc (correct).
+- **Highest attack = live effective attack** at end-of-round (buffs/debuffs/shred folded),
+  consistent with engine-wide effective-stat reads. Ties → roster order (deterministic).
+  Self is never a candidate (selector runs over the opposing roster).
+- **Bulwark adjacency in non-positional combat:** `adjacentAllyIds` returns all living
+  allies, so Bulwark fires for any damaged ally — faithful to how adjacency degrades
+  elsewhere. No special-casing.
+- **Once-per-round scope:** the proc roll happens BEFORE marking consumed, so a *failed*
+  roll does not lock the round — Bulwark keeps rolling on later adjacent-ally hits until it
+  lands, then is locked for the round ("{X}% chance … once per round"). Matches the D-PR3
+  invariant exactly.
+- **Multiple adjacent allies hit in one round:** first successful proc locks the gate;
+  later hits early-out.
+- **Provoke onto an attacker that died in the same hit / CF when only dead enemies remain:**
+  selectors skip dead actors; a harmless Provoke on a dead provoker has no effect. Mirrors
+  existing reader null-tolerance — no crashes.
+
+## Known interactions (flagged, not fixed)
+
+Per the locked buff-duration decrement-timing behavior (see D-PR13's Disable note), a
+"1 turn" debuff applied reactively / at end-of-round may expire after a single observable
+enemy turn. This is consistent with how Provoke / Concentrate Fire / Stasis already behave;
+we model faithful *application* and let existing duration semantics govern lifetime. No
+timing change in this PR.
+
+## Testing
+
+- **Unit — selector:** `highestEffectiveAttackAmong` picks the live-highest-attack living
+  enemy; tie → roster order; empty/all-dead → `undefined`.
+- **Unit — registry:** `buildEquipmentAbilities` produces one ability each for Bulwark and
+  Doomsayer at every rarity with the correct trigger / target / procChance / config; absent
+  description → no ability (graceful skip).
+- **Integration — Bulwark:** in a positional two-team sim, a hit on an adjacent ally applies
+  Provoke to the attacker (read via `provokerOf`); proc forced on; once-per-round verified
+  (second adjacent-ally hit same round does not re-apply / re-roll); non-adjacent ally hit
+  does not trigger.
+- **Integration — Doomsayer:** end-of-round, owner is first activator + proc forced on →
+  Concentrate Fire lands on the highest-effective-attack enemy; owner NOT first activator →
+  no application; owner skipped all round → not first activator.
+- **Coverage tracker:** add `BULWARK`, `DOOMSAYER` to the implemented-implants set in
+  `equipmentCoverage.test.ts` + per-rarity `>= 1 ability` assertions; they leave the
+  unimplemented assertions for everything else intact.
+- **Goldens:** full suite green with ZERO golden/.snap movement.
+
+## Files touched
+
+- `src/constants/implants.ts` — (read-only; data already present, lines ~1428–1609).
+- `src/utils/abilities/buildEquipmentAbilities.ts` — 2 registry entries + 2 proc tables.
+- `src/utils/combat/engine.ts` — `firstActivatorId` round-state field + set-site;
+  `highestEffectiveAttackAmong` selector; wire Doomsayer end-of-round selection + Bulwark
+  once-per-round gate into `IntentExecContext`.
+- `src/utils/combat/triggers.ts` — Bulwark adjacency filter + once-per-round consume on the
+  `on-ally-attacked` enqueue; Doomsayer CF routing to the selected enemy.
+- `src/types/abilities.ts` — reuse existing `oncePerRound` flag if applied to Bulwark's
+  config; no new trigger expected.
+- `src/utils/abilities/__tests__/equipmentCoverage.test.ts` — add the two implants.
+- Editor-exhaustiveness stubs ONLY if a new `AbilityConfig` field is introduced.
+
+## Out of scope / next D buckets
+
+Remaining special-effect implants after this PR: Block/Protection reactive buffs
+(Firewall/Last Stand/Lockdown/Tenacity — need a Block-Debuff/Block-Damage/Buff-Protection
+control primitive); shield-grant family (dormant on sub-project H); cleanse-reactive
+(Reactive Ward) + Warpstrike duration half; charge generation (Chrono Reaver); detonation
+(Voidfire Catalyst); plus the trivial Code Guard leftover (crit-by-stealthed
+incoming-reduction — D-PR3's condition already exists, just unregistered). Special-effect
+gear sets still open: Boost / Burner / Decimation / Reflect / Shield / Cloaking.

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -23,6 +23,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat simulator: the Font of Power implant's Power Infused Nanobots buff now grants the repaired ally flat attack equal to 100% of the caster's attack at the time of the repair (previously this attack bonus had no effect).",
     'Combat simulator now models the Fortifying Shroud implant — a chance each turn to grant adjacent allies a Defense Up buff.',
     "Combat simulator: the Disable control now skips the affected ship's turn and locks out its reactions, so effects that apply Disable — like the Martyrdom implant and Disable-inflicting skills — now take effect in the simulation.",
+    'Combat simulator: Bulwark implants now apply Provoke to an enemy that damages a nearby ally, and Doomsayer implants apply Concentrate Fire to the strongest enemy at the end of the round.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -35,7 +35,9 @@ export type AbilityTarget =
     // IntentExecContext.adjacentAllyIdsFor.
     | 'enemy'
     | 'all-enemies'
-    | 'enemy-most-buffs';
+    | 'enemy-most-buffs'
+    | 'enemy-highest-attack'; // D-PR14 Doomsayer: living opposing actor with the greatest
+    //                           live effective attack (global selector, resolved at drain).
 
 // NOTE on the live subset: `round-started` is the engine event key for the
 // `start-of-round` trigger (a deviation from the Phase 1 contract's `turn-started`
@@ -167,7 +169,9 @@ export type ConditionSubject =
     // a direct attack that landed damage on shield or HP; DoT ticks and fully-Barrier-blocked
     // attacks do not count). Live-derived (ConditionContext.wasHitThisRound); defaults false
     // (DPS / not-yet-hit → "not hit" ⇒ met). Used by the Alacrity implant.
-    | 'not-hit-this-round';
+    | 'not-hit-this-round'
+    | 'first-activator'; // D-PR14 Doomsayer: this owner was the first actor to take a REAL
+    //                      (non-Stasis/Disable-skipped) turn this round.
 
 export interface Condition {
     subject: ConditionSubject;
@@ -423,6 +427,18 @@ export interface Ability {
      *  ShipTypeName — 'DEBUFFER' matches every DEBUFFER_* variant). Absent → any
      *  ally. A filter with an UNKNOWN ally role never matches (conservative). */
     roleFilter?: ShipRoleCategory[];
+    /** D-PR14 Bulwark: this reactive applies at most once per round per (owner, ability).
+     *  Gated executor-side via IntentExecContext.oncePerRoundConsumed (check BEFORE the
+     *  proc draw, mark only on a successful proc). Absent → no per-round limit.
+     *  NOTE: distinct from the `oncePerRound` flag on the extra-action / incoming-block
+     *  AbilityConfig variants — this is the top-level Ability flag (read via
+     *  `intent.ability.oncePerRound`), honoring the spec's "no AbilityConfig change". */
+    oncePerRound?: boolean;
+    /** D-PR14 Bulwark: an on-ally-attacked reactive fires only when the DAMAGED ally is
+     *  adjacent to this owner (board neighbours; non-positional → any living same-side ally).
+     *  Filtered in the listener via registerReactiveListeners' adjacentAllyIdsFor. Absent →
+     *  any ally (existing behavior). */
+    requireDamagedAllyAdjacent?: boolean;
     /** Probabilistic proc gate for equipment-sourced reactive abilities ("N% chance to …").
      *  A value in (0,1) means the ability fires at that rate via a combat-lifetime per-(owner,
      *  ability) RateGate (deterministic accumulator, like crit/landing). Absent or out of (0,1)

--- a/src/utils/abilities/__tests__/cfProvokeRegistry.test.ts
+++ b/src/utils/abilities/__tests__/cfProvokeRegistry.test.ts
@@ -1,0 +1,141 @@
+/**
+ * cfProvokeRegistry.test.ts
+ *
+ * D-PR14: Bulwark (Provoke debuff) + Doomsayer (Concentrate Fire debuff) registry entries.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildEquipmentAbilities } from '../buildEquipmentAbilities';
+import { GearPiece } from '../../../types/gear';
+import { Ship } from '../../../types/ship';
+import { Ability } from '../../../types/abilities';
+
+// ---------------------------------------------------------------------------
+// Minimal fixture helpers (copied from equipmentCoverage.test.ts)
+// ---------------------------------------------------------------------------
+
+function makeShip(over: Partial<Ship>): Ship {
+    return {
+        id: 'registry-ship',
+        name: 'Registry Ship',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'ATTACKER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        ...over,
+    } as Ship;
+}
+
+function makePiece(over: Partial<GearPiece>): GearPiece {
+    return {
+        id: 'piece',
+        slot: 'implant_major',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: null,
+        ...over,
+    } as GearPiece;
+}
+
+/**
+ * Build a ship with the given implant at the given rarity and return the single
+ * produced ability (throws if not exactly one ability).
+ */
+function buildImplant(implantKey: string, rarity: GearPiece['rarity']): Ability {
+    const id = `${implantKey}-piece`;
+    const pieceMap: Record<string, GearPiece> = {
+        [id]: makePiece({ id, slot: 'implant_major', rarity, setBonus: implantKey }),
+    };
+    const ship = makeShip({ implants: { implant_major: id } });
+    const abilities = buildEquipmentAbilities(ship, (gearId) => pieceMap[gearId]);
+    if (abilities.length !== 1) {
+        throw new Error(
+            `Expected exactly 1 ability for ${implantKey} (${rarity}), got ${abilities.length}`
+        );
+    }
+    return abilities[0];
+}
+
+function buildBulwark(rarity: GearPiece['rarity']): Ability {
+    return buildImplant('BULWARK', rarity);
+}
+
+function buildDoomsayer(rarity: GearPiece['rarity']): Ability {
+    return buildImplant('DOOMSAYER', rarity);
+}
+
+// ---------------------------------------------------------------------------
+// D-PR14 registry — Bulwark
+// ---------------------------------------------------------------------------
+
+describe('D-PR14 registry — Bulwark', () => {
+    it('produces a Provoke debuff: on-ally-attacked, target enemy, oncePerRound, adjacency-required, procChance per rarity', () => {
+        const ab = buildBulwark('epic');
+        expect(ab.config.type).toBe('debuff');
+        expect((ab.config as { buffName: string }).buffName).toBe('Provoke');
+        expect(ab.trigger).toBe('on-ally-attacked');
+        expect(ab.target).toBe('enemy');
+        expect(ab.oncePerRound).toBe(true);
+        expect(ab.requireDamagedAllyAdjacent).toBe(true);
+        expect(ab.procChance).toBeCloseTo(0.12);
+        expect((ab.config as { duration: number }).duration).toBe(1);
+    });
+
+    it('common rarity: procChance 5%', () => {
+        const ab = buildBulwark('common');
+        expect(ab.procChance).toBeCloseTo(0.05);
+    });
+
+    it('uncommon rarity: procChance 7%', () => {
+        const ab = buildBulwark('uncommon');
+        expect(ab.procChance).toBeCloseTo(0.07);
+    });
+
+    it('rare rarity: procChance 9%', () => {
+        const ab = buildBulwark('rare');
+        expect(ab.procChance).toBeCloseTo(0.09);
+    });
+
+    it('legendary rarity: procChance 16%', () => {
+        const ab = buildBulwark('legendary');
+        expect(ab.procChance).toBeCloseTo(0.16);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// D-PR14 registry — Doomsayer
+// ---------------------------------------------------------------------------
+
+describe('D-PR14 registry — Doomsayer', () => {
+    it('produces a Concentrate Fire debuff: end-of-round, target enemy-highest-attack, first-activator gate, procChance per rarity', () => {
+        const ab = buildDoomsayer('legendary');
+        expect(ab.config.type).toBe('debuff');
+        expect((ab.config as { buffName: string }).buffName).toBe('Concentrate Fire');
+        expect(ab.trigger).toBe('end-of-round');
+        expect(ab.target).toBe('enemy-highest-attack');
+        expect(ab.conditions).toContainEqual({ subject: 'first-activator', derivable: true });
+        expect(ab.procChance).toBeCloseTo(0.16);
+        expect((ab.config as { duration: number }).duration).toBe(1);
+    });
+
+    it('uncommon rarity: procChance 7%', () => {
+        const ab = buildDoomsayer('uncommon');
+        expect(ab.procChance).toBeCloseTo(0.07);
+    });
+
+    it('rare rarity: procChance 9%', () => {
+        const ab = buildDoomsayer('rare');
+        expect(ab.procChance).toBeCloseTo(0.09);
+    });
+
+    it('epic rarity: procChance 12%', () => {
+        const ab = buildDoomsayer('epic');
+        expect(ab.procChance).toBeCloseTo(0.12);
+    });
+});

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -18,6 +18,7 @@
  * D-PR8 added reactive self-buffs (SYNAPTIC_RESONANCE, ALACRITY, AMBUSH).
  * D-PR9 added ally-wide / new-trigger buff grants (SPEARHEAD, FONT_OF_POWER).
  * D-PR11 added adjacent-ally buff grant (FORTIFYING_SHROUD).
+ * D-PR14 added Provoke/Concentrate Fire debuff grants (BULWARK, DOOMSAYER).
  *
  * Assertions are plain `expect` calls — no snapshot files.
  */
@@ -105,7 +106,7 @@ function implantAbilityCount(implantKey: string, rarity: GearPiece['rarity']): n
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { LEECH + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + EXUBERANCE + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + MENACE + SECOND_WIND + SHADOWGUARD + SPEARHEAD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
+    it('exactly { LEECH + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + MENACE + SECOND_WIND + SHADOWGUARD + SPEARHEAD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -133,6 +134,8 @@ describe('equipmentCoverage — implemented effects registry', () => {
             'AMBUSH',
             'BATTLECRY',
             'BLOODTHIRST',
+            'BULWARK',
+            'DOOMSAYER',
             'EXUBERANCE',
             'FONT_OF_POWER',
             'FORTIFYING_SHROUD',
@@ -196,6 +199,7 @@ describe('equipmentCoverage — implants', () => {
     // D-PR6: EXUBERANCE added (repair-amplification on-repair chance).
     // D-PR7: LAST_WISH, BATTLECRY, MARTYRDOM added (on-death repair / buff to allies / disable killer).
     // D-PR8: SYNAPTIC_RESONANCE, ALACRITY, AMBUSH added (reactive self-buff grants).
+    // D-PR14: BULWARK, DOOMSAYER added (Provoke / Concentrate Fire debuff grants).
     const implementedImplants = new Set([
         'BLOODTHIRST',
         'INTRUSION',
@@ -223,6 +227,8 @@ describe('equipmentCoverage — implants', () => {
         'SPEARHEAD',
         'FONT_OF_POWER',
         'FORTIFYING_SHROUD',
+        'BULWARK',
+        'DOOMSAYER',
     ]);
 
     it('INTRUSION produces 1 ability per rarity (outgoingDamage modifier with scaling)', () => {
@@ -423,6 +429,23 @@ describe('equipmentCoverage — implants', () => {
         const SUPPORTED = new Set(['uncommon', 'rare', 'epic', 'legendary']);
         for (const v of IMPLANTS['FORTIFYING_SHROUD'].variants) {
             expect(implantAbilityCount('FORTIFYING_SHROUD', v.rarity)).toBe(
+                SUPPORTED.has(v.rarity) ? 1 : 0
+            );
+        }
+    });
+
+    // D-PR14: Provoke / Concentrate Fire debuff grants
+    it('BULWARK produces 1 ability per rarity (on-ally-attacked Provoke debuff, oncePerRound, adjacency-required)', () => {
+        for (const v of IMPLANTS['BULWARK'].variants) {
+            expect(implantAbilityCount('BULWARK', v.rarity)).toBe(1);
+        }
+    });
+
+    it('DOOMSAYER produces 1 ability for uncommon/rare/epic/legendary (end-of-round Concentrate Fire debuff, first-activator gate); no common variant', () => {
+        expect(implantAbilityCount('DOOMSAYER', 'common')).toBe(0);
+        const SUPPORTED = new Set(['uncommon', 'rare', 'epic', 'legendary']);
+        for (const v of IMPLANTS['DOOMSAYER'].variants) {
+            expect(implantAbilityCount('DOOMSAYER', v.rarity)).toBe(
                 SUPPORTED.has(v.rarity) ? 1 : 0
             );
         }

--- a/src/utils/abilities/__tests__/firstActivatorCondition.test.ts
+++ b/src/utils/abilities/__tests__/firstActivatorCondition.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { conditionsMet } from '../evaluateConditions';
+import { makeConditionContext } from './conditionContextFixture';
+
+describe('first-activator condition', () => {
+    it('is met when firstActivator is true', () => {
+        const ctx = makeConditionContext({ firstActivator: true });
+        expect(conditionsMet([{ subject: 'first-activator', derivable: true }], ctx)).toBe(true);
+    });
+    it('is NOT met when firstActivator is false/absent', () => {
+        const ctx = makeConditionContext({ firstActivator: false });
+        expect(conditionsMet([{ subject: 'first-activator', derivable: true }], ctx)).toBe(false);
+    });
+});

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -28,6 +28,7 @@ import { parseBuffEffects, isStackable } from '../calculators/buffParser';
 import { GearPiece } from '../../types/gear';
 import {
     Ability,
+    AbilityTarget,
     AbilityTrigger,
     Condition,
     HealAmpCondition,
@@ -256,6 +257,24 @@ const FORTIFYING_SHROUD_PROC_CHANCE: Record<string, number> = {
     legendary: 0.32,
 };
 
+// D-PR14: Bulwark — X% chance, when an adjacent ally is directly damaged, apply Provoke 1 turn, once per round.
+const BULWARK_PROC: Record<string, number> = {
+    common: 0.05,
+    uncommon: 0.07,
+    rare: 0.09,
+    epic: 0.12,
+    legendary: 0.16,
+};
+// D-PR14: Doomsayer — at end of round, if first to activate, X% chance to apply Concentrate Fire
+// to the highest-attack enemy 1 turn. No common variant. (Proc from THIS table, not the
+// description text — Doomsayer's legendary text has a "change"/"chance" typo.)
+const DOOMSAYER_PROC: Record<string, number> = {
+    uncommon: 0.07,
+    rare: 0.09,
+    epic: 0.12,
+    legendary: 0.16,
+};
+
 // D-PR6: incoming-heal-amplification implant value tables
 // No common rarity for Exuberance
 const EXUBERANCE_PROC: Record<string, number> = {
@@ -356,10 +375,13 @@ function mkNamedBuffGrant(
 // D-PR7: build a reactive named-debuff application (Martyrdom's on-death "Disable" on the killer).
 // application:'apply' → lands unless affinity disadvantage (no landing roll), matching "Applies".
 // Killer routing is supplied by the on-destroyed listener via eventCtx.counterTargetId.
+// D-PR14: generalised with optional `opts` for target / procChance / conditions
+// (Martyrdom call is byte-identical — all three opts default away).
 function mkNamedDebuff(
     buffName: string,
     trigger: AbilityTrigger,
-    duration: number | undefined
+    duration: number | undefined,
+    opts?: { target?: AbilityTarget; procChance?: number; conditions?: Condition[] }
 ): Omit<Ability, 'id'> | undefined {
     if (duration === undefined) return undefined;
     const buff = BUFFS.find((b) => b.name === buffName);
@@ -367,9 +389,10 @@ function mkNamedDebuff(
     const { stackable, maxStacks } = isStackable(buff.description);
     return {
         type: 'debuff',
-        target: 'enemy',
+        target: opts?.target ?? 'enemy',
         trigger,
-        conditions: [],
+        conditions: opts?.conditions ?? [],
+        ...(opts?.procChance !== undefined ? { procChance: opts.procChance } : {}),
         config: {
             type: 'debuff',
             buffName,
@@ -661,6 +684,27 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
         if (procChance === undefined) return undefined;
         return mkNamedBuffGrant('Defense Up I', 'adjacent-allies', 'start-of-turn', 1, {
             procChance,
+        });
+    },
+    // D-PR14: Bulwark — X% chance, when an adjacent ally is directly damaged, apply Provoke
+    // to that enemy for 1 turn, once per round. requireDamagedAllyAdjacent gates the trigger
+    // to the specific case where the attacked ally is adjacent to the owner.
+    BULWARK: (rarity) => {
+        const procChance = BULWARK_PROC[rarity];
+        if (procChance === undefined) return undefined;
+        const base = mkNamedDebuff('Provoke', 'on-ally-attacked', 1, { procChance });
+        if (!base) return undefined;
+        return { ...base, oncePerRound: true, requireDamagedAllyAdjacent: true };
+    },
+    // D-PR14: Doomsayer — at end of round, if first to activate, X% chance to apply
+    // Concentrate Fire to the enemy with highest attack for 1 turn. No common variant.
+    DOOMSAYER: (rarity) => {
+        const procChance = DOOMSAYER_PROC[rarity];
+        if (procChance === undefined) return undefined;
+        return mkNamedDebuff('Concentrate Fire', 'end-of-round', 1, {
+            procChance,
+            target: 'enemy-highest-attack',
+            conditions: [{ subject: 'first-activator', derivable: true }],
         });
     },
 };

--- a/src/utils/abilities/evaluateConditions.ts
+++ b/src/utils/abilities/evaluateConditions.ts
@@ -32,6 +32,9 @@ export interface ConditionContext {
     /** True when the condition owner was hit by a direct attack this round (damage landed
      *  on shield or HP). Live-derived by the engine; defaults false (DPS / not-yet-hit). */
     wasHitThisRound?: boolean;
+    /** D-PR14: this owner took the round's first real turn. Live-derived by the engine;
+     *  defaults false. Used by the Doomsayer implant. */
+    firstActivator?: boolean;
 }
 
 /** Resolve one condition to a count (>= 0). 0 means "not met". */
@@ -85,6 +88,8 @@ export function evaluateCondition(cond: Condition, ctx: ConditionContext): numbe
             return ctx.selfShielded ? 1 : 0;
         case 'not-hit-this-round':
             return ctx.wasHitThisRound ? 0 : 1;
+        case 'first-activator':
+            return ctx.firstActivator ? 1 : 0;
         default:
             return 0;
     }

--- a/src/utils/abilities/roundContext.ts
+++ b/src/utils/abilities/roundContext.ts
@@ -40,6 +40,8 @@ export function buildRoundContext(state: {
     selfShielded?: boolean;
     /** True when the acting unit was hit by a direct attack this round. Default false. */
     wasHitThisRound?: boolean;
+    /** True when the acting unit took the round's first real turn. Default false. */
+    firstActivator?: boolean;
 }): ConditionContext {
     return {
         selfBuffNames: state.selfBuffNames,
@@ -63,6 +65,7 @@ export function buildRoundContext(state: {
         targetRepairedThisRound: state.targetRepairedThisRound ?? false,
         selfShielded: state.selfShielded ?? false,
         wasHitThisRound: state.wasHitThisRound ?? false,
+        firstActivator: state.firstActivator ?? false,
         ...(state.roundCrit !== undefined ? { roundCrit: state.roundCrit } : {}),
     };
 }

--- a/src/utils/combat/__tests__/cfProvokeAppliers.integration.test.ts
+++ b/src/utils/combat/__tests__/cfProvokeAppliers.integration.test.ts
@@ -251,8 +251,8 @@ describe('D-PR14 Bulwark (Provoke on adjacent-ally damage)', () => {
                 position: 'M2',
                 teamActors: [ally('ally-T2', 'T2'), ally('ally-M3', 'M3')],
                 healTargetId: 'ally-T2',
-                // Two positioned enemies in row M each select a player → both adjacent allies get
-                // hit in the same round, producing two `attacked` events on adjacent allies.
+                // Two enemies both hit the adjacent heal target T2 in the same round → two
+                // `attacked` events on an adjacent ally, so the listener enqueues twice.
                 enemyAttackers: [
                     enemyHitter('enemy-1'),
                     enemyHitter('enemy-2'),

--- a/src/utils/combat/__tests__/cfProvokeAppliers.integration.test.ts
+++ b/src/utils/combat/__tests__/cfProvokeAppliers.integration.test.ts
@@ -164,7 +164,8 @@ function debuffApplied(
     const bus = createEventBus();
     const out: Array<{ sourceId: string; targetId: string; round: number }> = [];
     bus.on('debuff-applied', (e) => {
-        if (e.buffName === buffName) out.push({ sourceId: e.sourceId, targetId: e.targetId, round: e.round });
+        if (e.buffName === buffName)
+            out.push({ sourceId: e.sourceId, targetId: e.targetId, round: e.round });
     });
     runCombat({ ...input, bus });
     return out;
@@ -241,10 +242,10 @@ describe('D-PR14 Bulwark (Provoke on adjacent-ally damage)', () => {
     });
 
     it('applies at most once per round', () => {
-        // Two adjacent allies (T2, M3) are BOTH hit in one round (two enemy attackers, each
-        // hitting a different adjacent ally). The owner's on-ally-attacked listener fires twice,
-        // but oncePerRound consumes after the first successful proc → exactly one Provoke applied.
-        // healTargetId is T2; a second enemy is positioned to hit M3 via positional targeting.
+        // Two enemy attackers BOTH hit the same adjacent ally (T2) in one round. The owner's
+        // on-ally-attacked listener fires twice, but oncePerRound consumes after the first
+        // successful proc → exactly one Provoke applied. healTargetId is T2; both enemies are
+        // non-positional, so both land on T2.
         const events = debuffApplied(
             BASE({
                 numRounds: 1,
@@ -253,10 +254,7 @@ describe('D-PR14 Bulwark (Provoke on adjacent-ally damage)', () => {
                 healTargetId: 'ally-T2',
                 // Two enemies both hit the adjacent heal target T2 in the same round → two
                 // `attacked` events on an adjacent ally, so the listener enqueues twice.
-                enemyAttackers: [
-                    enemyHitter('enemy-1'),
-                    enemyHitter('enemy-2'),
-                ],
+                enemyAttackers: [enemyHitter('enemy-1'), enemyHitter('enemy-2')],
             }),
             'Provoke'
         );
@@ -413,7 +411,14 @@ describe('D-PR14 Doomsayer (Concentrate Fire on highest-attack enemy at end of r
 
         const doomEnemy: EnemyAttacker = {
             id: 'enemy-doom',
-            stats: { attack: 1, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 5000 },
+            stats: {
+                attack: 1,
+                crit: 0,
+                critDamage: 0,
+                defence: 0,
+                hp: 1_000_000_000,
+                speed: 5000,
+            },
             chargeCount: 0,
             startCharged: false,
             shipSkills: { slots: [noopActive, { slot: 'passive', abilities: [doomsayerAbility] }] },

--- a/src/utils/combat/__tests__/cfProvokeAppliers.integration.test.ts
+++ b/src/utils/combat/__tests__/cfProvokeAppliers.integration.test.ts
@@ -1,0 +1,439 @@
+/**
+ * D-PR14 — Bulwark (Provoke) + Doomsayer (Concentrate Fire) ENGINE-LEVEL integration tests.
+ *
+ * These prove the full reactive/end-of-round debuff-applier chain works END TO END through
+ * `runCombat` with REAL board positions and turn order — the threading hops the per-task unit
+ * tests cannot catch: listener registration → adjacency / first-activator gate → proc gate →
+ * once-per-round gate → target resolution (counterTargetId / enemy-highest-attack) → debuff
+ * landing → `debuff-applied` emit.
+ *
+ * Read mechanism: the engine emits a `debuff-applied` event the moment a reactive/end-of-round
+ * debuff LANDS, carrying `sourceId` (the applier/owner) and `targetId` (the victim). This is the
+ * codebase-exposed observable for the whole chain — strictly stronger than `provokerOf`, which
+ * reads the status engine directly (runCombat does not expose its statusEngine). `provokerOf`'s
+ * read path is covered by forcedTargetingStatus.test.ts; here we assert the same fact the engine
+ * persists (Provoke on the attacker, applied by the Bulwark owner) via the public event stream.
+ *
+ * Forcing procs deterministically: `passesProcChanceGate` (triggers.ts) PASSES UNCONDITIONALLY
+ * when `procChance >= 1`. So the abilities are injected directly into the owner's passive slot
+ * with `procChance: 1` — every other field (trigger, target, oncePerRound, requireDamagedAllyAdjacent,
+ * the `first-activator` condition, the 'Provoke'/'Concentrate Fire' buff names, 1-turn duration)
+ * matches the registry exactly (buildEquipmentAbilities.ts BULWARK/DOOMSAYER). This is the same
+ * determinism device the sibling integration suites use (Fortifying Shroud drops procChance;
+ * Second Wind / Insidiousness inject a known procChance). The registry's exact per-rarity proc
+ * tables + ability shape are covered by cfProvokeRegistry.test.ts.
+ *
+ * Board geometry (matches board.ts: M2 ↔ T1,T2,M1,M3,B1,B2):
+ *   Bulwark owner at M2 → adjacent = T2, M3; NON-adjacent = B4.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { createEventBus } from '../events';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { Position } from '../../../types/encounters';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+// ---------------------------------------------------------------------------
+// Shared ability shapes (match the registry, procChance forced to 1)
+// ---------------------------------------------------------------------------
+
+/** Bulwark: on-ally-attacked Provoke (1 turn), once-per-round, adjacency-required. proc forced. */
+const bulwarkAbility: Ability = {
+    id: 'equip-implant-BULWARK',
+    type: 'debuff',
+    target: 'enemy',
+    trigger: 'on-ally-attacked',
+    conditions: [],
+    procChance: 1, // >= 1 → passesProcChanceGate is unconditional (deterministic)
+    oncePerRound: true,
+    requireDamagedAllyAdjacent: true,
+    config: {
+        type: 'debuff',
+        buffName: 'Provoke',
+        parsedEffects: {},
+        stacks: 1,
+        isStackable: false,
+        application: 'inflict',
+        duration: 1,
+    } as Ability['config'],
+    autoFilled: true,
+};
+
+/** Doomsayer: end-of-round Concentrate Fire (1 turn) on the highest-attack enemy, gated by
+ *  first-activator. proc forced. */
+const doomsayerAbility: Ability = {
+    id: 'equip-implant-DOOMSAYER',
+    type: 'debuff',
+    target: 'enemy-highest-attack',
+    trigger: 'end-of-round',
+    conditions: [{ subject: 'first-activator', derivable: true }],
+    procChance: 1,
+    config: {
+        type: 'debuff',
+        buffName: 'Concentrate Fire',
+        parsedEffects: {},
+        stacks: 1,
+        isStackable: false,
+        application: 'inflict',
+        duration: 1,
+    } as Ability['config'],
+    autoFilled: true,
+};
+
+/** A 100% / 1-hit basic attack active slot. */
+const basicAttack = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: 'basic-atk',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 100, hits: 1 },
+        },
+    ],
+});
+
+/** A no-op (0-damage) active so the owner takes a turn without killing anything. */
+const noopActive: ShipSkills['slots'][number] = {
+    slot: 'active',
+    abilities: [
+        {
+            id: 'noop-atk',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0 },
+        },
+    ],
+};
+
+// ---------------------------------------------------------------------------
+// Harness builders
+// ---------------------------------------------------------------------------
+
+/** A positioned, inert team ally (no skills, big HP, no real damage). */
+function ally(id: string, position: Position): TeamActorEngineInput {
+    return {
+        id,
+        speed: 10, // slower than the focus / enemy so it never acts first
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        walk: {
+            shipSkills: { slots: [] },
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp: 1_000_000_000,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    };
+}
+
+/** A non-positional enemy attacker that hits the heal target each round (real damage). */
+const enemyHitter = (id: string, speed = 5): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 5_000, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: { slots: [basicAttack()] },
+    }) as EnemyAttacker;
+
+/** Collect every `debuff-applied` event matching the given buffName. */
+function debuffApplied(
+    input: CombatEngineInput,
+    buffName: string
+): Array<{ sourceId: string; targetId: string; round: number }> {
+    const bus = createEventBus();
+    const out: Array<{ sourceId: string; targetId: string; round: number }> = [];
+    bus.on('debuff-applied', (e) => {
+        if (e.buffName === buffName) out.push({ sourceId: e.sourceId, targetId: e.targetId, round: e.round });
+    });
+    runCombat({ ...input, bus });
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// D-PR14 Bulwark — Provoke on adjacent-ally damage
+// ---------------------------------------------------------------------------
+
+describe('D-PR14 Bulwark (Provoke on adjacent-ally damage)', () => {
+    /** Base input: focus 'attacker' (Bulwark owner) at M2; healing mode; the heal target is the
+     *  ally that the enemy hits, so the `attacked` event names that ally as the damaged target. */
+    const BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+        attack: 1,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: { slots: [noopActive, { slot: 'passive', abilities: [bulwarkAbility] }] },
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 100, // owner acts first; its passive listens for the ally hit
+        position: 'M2',
+        ...overrides,
+    });
+
+    const FOCUS = 'attacker';
+
+    it('applies Provoke to the attacker when an adjacent ally is directly damaged', () => {
+        // Adjacent ally 'ally-T2' at T2 is the heal target → the enemy hits it → owner at M2 is
+        // adjacent → Bulwark fires → Provoke lands on the attacking enemy.
+        const events = debuffApplied(
+            BASE({
+                teamActors: [ally('ally-T2', 'T2'), ally('ally-B4', 'B4')],
+                healTargetId: 'ally-T2',
+                enemyAttackers: [enemyHitter('enemy-atk')],
+            }),
+            'Provoke'
+        );
+
+        expect(events.length).toBeGreaterThan(0);
+        // Applied BY the Bulwark owner (focus), ONTO the attacking enemy.
+        expect(events.every((e) => e.sourceId === FOCUS)).toBe(true);
+        expect(events.every((e) => e.targetId === 'enemy-atk')).toBe(true);
+    });
+
+    it('does NOT fire when the damaged ally is not adjacent (positional)', () => {
+        // The heal target is 'ally-B4' at B4 (NON-adjacent to the M2 owner). The enemy hits B4;
+        // the owner's on-ally-attacked listener runs but the requireDamagedAllyAdjacent gate
+        // rejects it → no Bulwark Provoke. (Adjacent ally-T2 still present so the geometry is
+        // positional, not the all-allies fallback — proving the adjacency gate, not vacuity.)
+        const events = debuffApplied(
+            BASE({
+                teamActors: [ally('ally-T2', 'T2'), ally('ally-B4', 'B4')],
+                healTargetId: 'ally-B4',
+                enemyAttackers: [enemyHitter('enemy-atk')],
+            }),
+            'Provoke'
+        );
+
+        expect(events.length).toBe(0);
+    });
+
+    it('applies at most once per round', () => {
+        // Two adjacent allies (T2, M3) are BOTH hit in one round (two enemy attackers, each
+        // hitting a different adjacent ally). The owner's on-ally-attacked listener fires twice,
+        // but oncePerRound consumes after the first successful proc → exactly one Provoke applied.
+        // healTargetId is T2; a second enemy is positioned to hit M3 via positional targeting.
+        const events = debuffApplied(
+            BASE({
+                numRounds: 1,
+                position: 'M2',
+                teamActors: [ally('ally-T2', 'T2'), ally('ally-M3', 'M3')],
+                healTargetId: 'ally-T2',
+                // Two positioned enemies in row M each select a player → both adjacent allies get
+                // hit in the same round, producing two `attacked` events on adjacent allies.
+                enemyAttackers: [
+                    enemyHitter('enemy-1'),
+                    enemyHitter('enemy-2'),
+                ],
+            }),
+            'Provoke'
+        );
+
+        // oncePerRound: at most one Provoke per round regardless of how many adjacent allies
+        // were hit. (Both enemies hit the heal target T2 — both adjacent — so the listener
+        // enqueues at least twice; the gate still yields exactly one application.)
+        expect(events.filter((e) => e.round === 1).length).toBe(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// D-PR14 Doomsayer — Concentrate Fire on the highest-attack enemy at end of round
+// ---------------------------------------------------------------------------
+
+describe('D-PR14 Doomsayer (Concentrate Fire on highest-attack enemy at end of round)', () => {
+    const CF = 'Concentrate Fire';
+
+    /** Base input: focus 'attacker' (Doomsayer owner); healing mode; two enemies with DIFFERENT
+     *  attack so the highest-attack selection is unambiguous. */
+    const BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+        attack: 1,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: { slots: [noopActive, { slot: 'passive', abilities: [doomsayerAbility] }] },
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        healTargetId: 'attacker',
+        ...overrides,
+    });
+
+    /** A pure-target enemy with a fixed attack (no skills → never acts as first activator). */
+    const enemyWithAttack = (id: string, attack: number, speed = 5): EnemyAttacker =>
+        ({
+            id,
+            stats: { attack, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: { slots: [] },
+        }) as EnemyAttacker;
+
+    it('applies Concentrate Fire to the highest-attack enemy when the owner is first activator', () => {
+        // Owner speed 1000 → it is the FIRST real activator of the round → first-activator gate
+        // passes. Two enemies: low (3000 attack) and high (9000 attack). At end of round the
+        // enemy-highest-attack selector picks the 9000-attack enemy → CF lands there.
+        const events = debuffApplied(
+            BASE({
+                speed: 1000,
+                enemyAttackers: [
+                    enemyWithAttack('enemy-low', 3_000),
+                    enemyWithAttack('enemy-high', 9_000),
+                ],
+            }),
+            CF
+        );
+
+        expect(events.length).toBeGreaterThan(0);
+        // Applied BY the Doomsayer owner, ONTO the highest-attack enemy.
+        expect(events.every((e) => e.sourceId === 'attacker')).toBe(true);
+        expect(events.every((e) => e.targetId === 'enemy-high')).toBe(true);
+    });
+
+    it('does NOT apply when the owner is not the first activator', () => {
+        // A faster TEAM ally activates first → firstActivatorId is the ally, NOT the Doomsayer
+        // owner → the first-activator condition fails at drain time → no CF applied.
+        const fastAlly: TeamActorEngineInput = {
+            id: 'fast-ally',
+            speed: 5000, // strictly faster than the owner (1000) → activates first
+            chargeCount: 0,
+            startCharged: false,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            walk: {
+                shipSkills: { slots: [basicAttack()] }, // a real action so it counts as an activator
+                stats: {
+                    attack: 1,
+                    crit: 0,
+                    critDamage: 0,
+                    defensePenetration: 0,
+                    hacking: 0,
+                    defence: 0,
+                    hp: 1_000_000_000,
+                },
+                selfDotModifier: 0,
+                defensePenetrationBuff: 0,
+                affinityDamageModifier: 0,
+                affinityCritCap: 100,
+                affinityCritPenalty: 0,
+                hasChargedSkill: false,
+            },
+        };
+
+        const events = debuffApplied(
+            BASE({
+                speed: 1000,
+                teamActors: [fastAlly],
+                enemyAttackers: [
+                    enemyWithAttack('enemy-low', 3_000),
+                    enemyWithAttack('enemy-high', 9_000),
+                ],
+            }),
+            CF
+        );
+
+        expect(events.length).toBe(0);
+    });
+
+    it('enemy-side mirror: an enemy Doomsayer first-activator applies CF to the highest-attack PLAYER', () => {
+        // Team-agnosticism: the Doomsayer owner is an ENEMY attacker that activates first (speed
+        // 5000 > the focus 100). firstActivatorId is shared across the player/enemy drains, and
+        // the enemy-side enemyWithHighestAttack resolves against the PLAYER roster. The player
+        // team has two actors with different attack → CF lands on the higher one.
+        // Exercises the real enemy set-site + drainEnemyIntents seam.
+        const highAttackAlly: TeamActorEngineInput = {
+            id: 'player-high',
+            speed: 10,
+            chargeCount: 0,
+            startCharged: false,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            walk: {
+                shipSkills: { slots: [] },
+                stats: {
+                    attack: 9_000, // highest-attack player → CF target
+                    crit: 0,
+                    critDamage: 0,
+                    defensePenetration: 0,
+                    hacking: 0,
+                    defence: 0,
+                    hp: 1_000_000_000,
+                },
+                selfDotModifier: 0,
+                defensePenetrationBuff: 0,
+                affinityDamageModifier: 0,
+                affinityCritCap: 100,
+                affinityCritPenalty: 0,
+                hasChargedSkill: false,
+            },
+        };
+
+        const doomEnemy: EnemyAttacker = {
+            id: 'enemy-doom',
+            stats: { attack: 1, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 5000 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: { slots: [noopActive, { slot: 'passive', abilities: [doomsayerAbility] }] },
+        } as EnemyAttacker;
+
+        const events = debuffApplied(
+            BASE({
+                // Focus 'attacker' = low-attack player (3000); team ally = high-attack (9000).
+                attack: 3_000,
+                speed: 100, // slower than the enemy Doomsayer (5000) → enemy is first activator
+                teamActors: [highAttackAlly],
+                healTargetId: 'attacker',
+                enemyAttackers: [doomEnemy],
+            }),
+            CF
+        );
+
+        expect(events.length).toBeGreaterThan(0);
+        // Applied BY the enemy Doomsayer, ONTO the highest-attack PLAYER actor.
+        expect(events.every((e) => e.sourceId === 'enemy-doom')).toBe(true);
+        expect(events.every((e) => e.targetId === 'player-high')).toBe(true);
+    });
+});

--- a/src/utils/combat/__tests__/highestAttack.test.ts
+++ b/src/utils/combat/__tests__/highestAttack.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { highestAttackAmong } from '../highestAttack';
+
+describe('highestAttackAmong', () => {
+    const attackOf = (id: string) => ({ a: 100, b: 250, c: 250, d: 50 })[id] ?? 0;
+    const living = (dead: string[]) => (id: string) => !dead.includes(id);
+
+    it('returns the id with the greatest attack', () => {
+        expect(highestAttackAmong(['a', 'b', 'd'], attackOf, living([]))).toBe('b');
+    });
+
+    it('breaks ties by roster order (first wins)', () => {
+        expect(highestAttackAmong(['a', 'b', 'c'], attackOf, living([]))).toBe('b');
+    });
+
+    it('skips dead actors', () => {
+        expect(highestAttackAmong(['b', 'c'], attackOf, living(['b']))).toBe('c');
+    });
+
+    it('returns undefined when no living candidate', () => {
+        expect(highestAttackAmong(['a', 'b'], attackOf, living(['a', 'b']))).toBeUndefined();
+        expect(highestAttackAmong([], attackOf, living([]))).toBeUndefined();
+    });
+});

--- a/src/utils/combat/abilityStatusGating.ts
+++ b/src/utils/combat/abilityStatusGating.ts
@@ -26,6 +26,7 @@ const LIVE_SUBJECTS: ReadonlySet<ConditionSubject> = new Set([
     'lowest-speed-ally',
     'target-repaired-this-round',
     'not-hit-this-round',
+    'first-activator',
 ]);
 
 /**

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2038,6 +2038,8 @@ export function runCombat(input: CombatEngineInput): {
         enqueue: (intent) => intentQueue.push(intent),
         isOpposing: isEnemySide,
         roleOf: (id) => roleByActorId.get(id),
+        adjacentAllyIdsFor: (ownerId: string) =>
+            bySide(isEnemySide(ownerId) ? 'enemy' : 'player').adjacentAllyIdsFor(ownerId),
     });
 
     // Enemy-side reactive registration (enemy-team PR1). A SEPARATE intent queue + a second
@@ -2062,6 +2064,8 @@ export function runCombat(input: CombatEngineInput): {
             // (bySide PR2 — fixes the enemy reactive-routing bug).
             isOpposing: (id: string) => !isEnemySide(id),
             roleOf: (id) => roleByActorId.get(id),
+            adjacentAllyIdsFor: (ownerId: string) =>
+                bySide(isEnemySide(ownerId) ? 'enemy' : 'player').adjacentAllyIdsFor(ownerId),
         });
     }
 

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -56,6 +56,7 @@ import { CHEAT_DEATH_BUFFS } from './cheatDeathBuffs';
 import { BARRIER_BUFFS } from './barrierBuffs';
 import { isStasis, STASIS_BUFFS } from './stasisBuffs';
 import { isDisable } from './disableBuffs';
+import { highestAttackAmong } from './highestAttack';
 import { CombatEventBus, createEventBus } from './events';
 import { normalizeTeamActorsToWalked } from './teamActorWalk';
 import {
@@ -1037,6 +1038,12 @@ interface ReactiveSideCtx {
     selfHpPctFor?: (ownerId: string) => number;
     /** Per-side most-buffs opposing-actor resolver (Rhodium). See IntentExecContext. */
     enemyWithMostBuffs?: (ownerId: string) => string | undefined;
+    /** D-PR14 Doomsayer: per-side highest-attack opposing-actor resolver. See IntentExecContext. */
+    enemyWithHighestAttack?: (ownerId: string) => string | undefined;
+    /** D-PR14: id of the round's first real activator (live value at drain-build time). */
+    firstActivatorId?: string;
+    /** D-PR14 Bulwark: per-round once-per-(owner,ability) consume set (shared across both sides). */
+    oncePerRoundConsumed?: Set<string>;
     /** Per-side adjacent-allies resolver (Fortifying Shroud). See IntentExecContext. */
     adjacentAllyIdsFor: (ownerId: string) => string[];
 }
@@ -3404,6 +3411,12 @@ export function runCombat(input: CombatEngineInput): {
                         // side: 100 for every owner until PR5. byte-identical to the old inline spread.
                         selfHpPctFor: sideCtx.selfHpPctFor,
                         enemyWithMostBuffs: sideCtx.enemyWithMostBuffs,
+                        // D-PR14: Doomsayer enemy-highest-attack resolver, the round's first
+                        // real activator id, and the shared once-per-round consume set. All
+                        // inert today — only consumed by the next task's executor branch.
+                        enemyWithHighestAttack: sideCtx.enemyWithHighestAttack,
+                        firstActivatorId: sideCtx.firstActivatorId,
+                        oncePerRoundConsumed: sideCtx.oncePerRoundConsumed,
                         // D-PR8: live not-hit-this-round gate (Alacrity). hitThisRound is a single
                         // combat-wide Set, so the SAME closure serves both sides (team-agnostic) —
                         // no per-side sideCtx field needed (unlike isLowestSpeedAllyFor).
@@ -3415,6 +3428,10 @@ export function runCombat(input: CombatEngineInput): {
                 }
             }
         };
+
+        // D-PR14: per-round state — reset each round (declared inside the round loop).
+        let firstActivatorId: string | undefined;
+        const oncePerRoundConsumed = new Set<string>();
 
         // C2b-2: opposing actor with the most buffs (Rhodium's enemy-most-buffs purge). Buff
         // count via selfBuffNamesForOwners (incl. unremovable — fine for SELECTION; removal still
@@ -3433,6 +3450,18 @@ export function runCombat(input: CombatEngineInput): {
             return bestCount > 0 ? best : undefined; // no buffs anywhere → no most-buffs target
         };
 
+        // D-PR14: living opposing actor with the greatest LIVE effective attack
+        // (Doomsayer's enemy-highest-attack target). Ties → roster order.
+        const highestAttackInRoster = (roster: CombatActor[]): string | undefined =>
+            highestAttackAmong(
+                roster.map((a) => a.id),
+                (id) => {
+                    const a = roster.find((x) => x.id === id);
+                    return a ? effectiveStatsOf(statusEngine, selfBuffLookup, a).attack : 0;
+                },
+                (id) => roster.find((a) => a.id === id)?.destroyedRound === undefined
+            );
+
         // Player drain — binds the player queue + player-side ctx. Behaviourally identical to
         // the pre-refactor drainIntents (same runtimes/playerIds/lowest-speed/grantAllyCharges).
         const drainIntents = (): void =>
@@ -3443,6 +3472,9 @@ export function runCombat(input: CombatEngineInput): {
                 grantAllyCharges: bySide('player').grantAllyCharges,
                 selfHpPctFor: bySide('player').selfHpPctFor,
                 enemyWithMostBuffs: () => mostBuffsAmong(enemyAttackerActors),
+                enemyWithHighestAttack: () => highestAttackInRoster(enemyAttackerActors),
+                firstActivatorId,
+                oncePerRoundConsumed,
                 adjacentAllyIdsFor: bySide('player').adjacentAllyIdsFor,
             });
 
@@ -3465,6 +3497,9 @@ export function runCombat(input: CombatEngineInput): {
                 grantAllyCharges: bySide('enemy').grantAllyCharges,
                 selfHpPctFor: bySide('enemy').selfHpPctFor,
                 enemyWithMostBuffs: () => mostBuffsAmong(allPlayerActors),
+                enemyWithHighestAttack: () => highestAttackInRoster(allPlayerActors),
+                firstActivatorId,
+                oncePerRoundConsumed,
                 adjacentAllyIdsFor: bySide('enemy').adjacentAllyIdsFor,
             });
         };
@@ -3696,6 +3731,9 @@ export function runCombat(input: CombatEngineInput): {
                     // A stasised FOCUS actor must push a synthesized focus turn so the
                     // post-round `focusTurns.length` guard does not throw.
                     if (!isTurnBlocked(actor.id)) {
+                        // D-PR14: first REAL activation of the round (Stasis/Disable-skipped
+                        // actors never enter these blocks). ??= writes once.
+                        firstActivatorId ??= actor.id;
                         const target = parsedTargetFor(actor);
                         const pattern = parsedPatternFor(actor);
                         // Positional target selection (Task C1, GATED). When the focus attacker
@@ -3884,6 +3922,9 @@ export function runCombat(input: CombatEngineInput): {
                     // (below) still run. A walked team actor is never the focus → no focusTurns
                     // synthesis needed (no-else). §4.3 deviation: skip action, decrement preserved.
                     if (!isTurnBlocked(actor.id)) {
+                        // D-PR14: first REAL activation of the round (Stasis/Disable-skipped
+                        // actors never enter these blocks). ??= writes once.
+                        firstActivatorId ??= actor.id;
                         // Positional target selection (Task C2, GATED). Mirrors the focus-turn
                         // branch (C1) but keyed to THIS team actor's own board position
                         // (`actor.position`) and parsed target (`teamTargetById` lookup), not the
@@ -4096,6 +4137,9 @@ export function runCombat(input: CombatEngineInput): {
                     // generate while stasised"). §4.3 deviation: skip action, decrement
                     // preserved. No cadence-advance in the skip path.
                     if (!isTurnBlocked(actor.id)) {
+                        // D-PR14: first REAL activation of the round (Stasis/Disable-skipped
+                        // actors never enter these blocks). ??= writes once.
+                        firstActivatorId ??= actor.id;
                         const enemyRuntime = runtimeFor(actor);
                         // Positional target selection (Task C3, side-symmetric, GATED). Mirrors the
                         // focus-turn (C1) and team-turn (C2) branches, but the OPPOSING roster from the

--- a/src/utils/combat/highestAttack.ts
+++ b/src/utils/combat/highestAttack.ts
@@ -1,0 +1,24 @@
+/**
+ * D-PR14: pick the living actor id with the greatest (live, effective) attack from `ids`.
+ * Ties resolve to the FIRST in `ids` order (deterministic for goldens). Returns undefined
+ * when no living candidate exists. Pure — the caller supplies live attack + liveness, so the
+ * engine wires effectiveStatsOf / destroyedRound and this stays unit-testable (mirrors
+ * incomingEffects.ts / outgoingEffects.ts).
+ */
+export function highestAttackAmong(
+    ids: string[],
+    attackOf: (id: string) => number,
+    isLiving: (id: string) => boolean
+): string | undefined {
+    let best: string | undefined;
+    let bestAtk = -Infinity;
+    for (const id of ids) {
+        if (!isLiving(id)) continue;
+        const atk = attackOf(id);
+        if (atk > bestAtk) {
+            bestAtk = atk;
+            best = id;
+        }
+    }
+    return best;
+}

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1172,6 +1172,17 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
     }
 
     if (cfg.type === 'debuff') {
+        // D-PR14: once-per-round gate (Bulwark) — check consumed BEFORE drawing the proc gate,
+        // so a failed roll never locks the round (mirrors D-PR3 incoming-block invariant).
+        const onceKey = `${intent.ownerId}:${intent.ability.id}`;
+        if (intent.ability.oncePerRound && ctx.oncePerRoundConsumed?.has(onceKey)) return;
+        // D-PR14: proc-chance gate for reactive debuff appliers (Bulwark). Pass-through when
+        // procChance is undefined → BYTE-IDENTICAL for every existing debuff applier (Martyrdom/Warden).
+        if (!passesProcChanceGate(intent, ctx)) return;
+        // Mark consumed ONLY after a successful proc (before the landing roll — "once per round"
+        // is per attempt, matching the spec's read).
+        if (intent.ability.oncePerRound) ctx.oncePerRoundConsumed?.add(onceKey);
+
         const status: Extract<RegisteredAbilityStatus, { kind: 'timed' }> = {
             payload: payloadFromConfig(cfg),
             side: 'enemy',
@@ -1184,7 +1195,14 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
         // Counter-infliction routing (Phase 4c PR 1): an intent whose eventCtx names the
         // attacking enemy ("on that enemy" — Warden) lands on THAT enemy's per-target
         // store. Default (no eventCtx) → the singular default enemy store, byte-identical.
-        const counterTargetId = intent.eventCtx?.counterTargetId;
+        // D-PR14: target resolution — enemy-highest-attack global selector (Doomsayer) else the
+        // counter-infliction route (Bulwark/Warden). Existing appliers use counterTargetId → identical.
+        const counterTargetId =
+            intent.ability.target === 'enemy-highest-attack'
+                ? ctx.enemyWithHighestAttack?.(intent.ownerId)
+                : intent.eventCtx?.counterTargetId;
+        // No living highest-attack enemy → no-op (don't fall back to the default enemy).
+        if (intent.ability.target === 'enemy-highest-attack' && counterTargetId === undefined) return;
         // Draw the OWNER's landing gate (its hacking-vs-security / affinity disadvantage),
         // NOT a global one — a team ship's debuff lands at ITS landing chance.
         if (owner.landsTimedEnemyApplication(cfg.application)) {

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1193,7 +1193,11 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
         // procChance is undefined → BYTE-IDENTICAL for every existing debuff applier (Martyrdom/Warden).
         if (!passesProcChanceGate(intent, ctx)) return;
         // Mark consumed ONLY after a successful proc (before the landing roll — "once per round"
-        // is per attempt, matching the spec's read).
+        // is per attempt, matching the spec's read). NOTE: marked before the enemy-highest-attack
+        // no-target no-op below; harmless today because no ability is both `oncePerRound` AND
+        // `enemy-highest-attack` (Bulwark is oncePerRound+counterTarget; Doomsayer is neither). If
+        // a future ability combines them, move this mark below the target-resolution guard so a
+        // no-living-target round doesn't burn the charge.
         if (intent.ability.oncePerRound) ctx.oncePerRoundConsumed?.add(onceKey);
 
         const status: Extract<RegisteredAbilityStatus, { kind: 'timed' }> = {

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -634,6 +634,10 @@ export interface IntentExecContext {
     enemyWithMostBuffs?: (ownerId: string) => string | undefined;
     /** D-PR14: id of the round's first real (non-Stasis/Disable-skipped) activator. */
     firstActivatorId?: string;
+    /** D-PR14 Doomsayer: living opposing actor with the greatest live effective attack. */
+    enemyWithHighestAttack?: (ownerId: string) => string | undefined;
+    /** D-PR14 Bulwark: per-(owner,ability) once-per-round consume set (reset each round in engine). */
+    oncePerRoundConsumed?: Set<string>;
 }
 
 /** Build the drain-time condition context from CURRENT engine state. This is a

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -632,6 +632,8 @@ export interface IntentExecContext {
      *  Returns undefined when no opposing actor exists (DPS dummy) → executor falls back to
      *  ctx.enemyId. Optional — absent in unit-test ctxs that don't drive most-buffs purges. */
     enemyWithMostBuffs?: (ownerId: string) => string | undefined;
+    /** D-PR14: id of the round's first real (non-Stasis/Disable-skipped) activator. */
+    firstActivatorId?: string;
 }
 
 /** Build the drain-time condition context from CURRENT engine state. This is a
@@ -690,6 +692,9 @@ export function buildActorConditionContext(
         /** Owner was hit by a direct attack this round. Default false. Populated by
          *  buildDrainContext (D-PR8). */
         wasHitThisRound?: boolean;
+        /** Owner took the round's first real turn. Default false. Populated by
+         *  buildDrainContext (D-PR14). */
+        firstActivator?: boolean;
     }
 ) {
     const snap = statusEngine.snapshot(ownerId);
@@ -717,6 +722,7 @@ export function buildActorConditionContext(
         selfDebuffNames: shared.selfDebuffNames,
         isLowestSpeedAlly: shared.isLowestSpeedAlly,
         wasHitThisRound: shared.wasHitThisRound,
+        firstActivator: shared.firstActivator,
     });
 }
 
@@ -751,6 +757,9 @@ function buildDrainContext(ctx: IntentExecContext, ownerId: string) {
         // D-PR8: live not-hit-this-round gate (Alacrity). Default false → DPS / no-delegate
         // paths read "not hit" ⇒ met and stay byte-identical.
         wasHitThisRound: ctx.wasHitThisRoundFor?.(ownerId) ?? false,
+        // D-PR14: live first-activator gate (Doomsayer). Default false → DPS / no-delegate
+        // paths read "not first" ⇒ not met and stay byte-identical.
+        firstActivator: ctx.firstActivatorId === ownerId,
     });
 }
 

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -229,8 +229,12 @@ export function registerReactiveListeners(args: {
      *  Returns the actor's ShipTypeName or undefined (manual actor / no ship picked).
      *  Optional: DPS-mode runs and unit fixtures omit it. */
     roleOf?: (actorId: string) => ShipTypeName | undefined;
+    /** D-PR14 Bulwark: same-side ids adjacent to an owner (living, owner excluded; non-positional
+     *  → all living same-side allies). Used to gate requireDamagedAllyAdjacent reactions. Optional:
+     *  DPS/unit fixtures omit it (→ treat any ally as adjacent). */
+    adjacentAllyIdsFor?: (ownerId: string) => string[];
 }): void {
-    const { bus, perOwner, enqueue, isOpposing, roleOf } = args;
+    const { bus, perOwner, enqueue, isOpposing, roleOf, adjacentAllyIdsFor } = args;
     // Same-side ally = NOT opposing AND not the owner itself (own events route to the
     // self-scoped triggers). For the player registration (opposing = enemy-side) this
     // is byte-identical to the old pattern.
@@ -404,6 +408,15 @@ export function registerReactiveListeners(args: {
                             roles &&
                             roles.length > 0 &&
                             !matchesRoleCategory(roleOf?.(e.targetId), roles)
+                        ) {
+                            return;
+                        }
+                        // D-PR14 Bulwark: fire only when the DAMAGED ally is adjacent to this
+                        // owner. Pure read (listener stays enqueue-only). Helper absent → allow.
+                        if (
+                            ra.ability.requireDamagedAllyAdjacent &&
+                            adjacentAllyIdsFor &&
+                            !adjacentAllyIdsFor(ownerId).includes(e.targetId)
                         ) {
                             return;
                         }


### PR DESCRIPTION
## Summary

Adds two implant special-effects that **apply** targeting-control debuffs the combat engine already honors (this PR is the applier side only — no targeting changes):

- **Bulwark** — when an **adjacent** same-side ally is directly damaged, apply **Provoke** (1 turn) to the attacker, at a per-rarity proc chance (5/7/9/12/16%), **once per round**. Rides the existing `on-ally-attacked` + `counterTargetId` path; adds a pure listener-level adjacency filter + an executor-side once-per-round gate, and makes the reactive debuff executor honor `procChance`.
- **Doomsayer** — at **end of round**, if this unit was the **first to take a real (non-Stasis/Disable-skipped) turn**, apply **Concentrate Fire** (1 turn) to the living enemy with the highest live effective attack, at a per-rarity proc chance (7/9/12/16%). New `first-activator` condition + new `enemy-highest-attack` global-selector target.

Both effects matter only in the battle simulator (targeting), so the DPS calculator is intentionally not wired.

## Implementation notes

- New primitives: pure `highestAttackAmong` selector; `enemy-highest-attack` `AbilityTarget`; `oncePerRound` / `requireDamagedAllyAdjacent` ability fields; `first-activator` condition (threaded through `roundContext` + added to `LIVE_SUBJECTS`); engine round-state `firstActivatorId` (set at all three `!isTurnBlocked` turn-body sites) + per-round `oncePerRoundConsumed`; `enemyWithHighestAttack` selector bound per-side at both drain seams (incl. the `ReactiveSideCtx` forwarding).
- **Byte-identical goldens:** every executor/listener change is gated behind a new optional field absent on all existing abilities; no fixture equips these implants. Confirmed zero `.snap`/golden drift.

## Test plan

- [x] Unit: `highestAttackAmong` selector, `first-activator` condition, registry build (every rarity)
- [x] Integration (`cfProvokeAppliers.integration.test.ts`, 6 tests): Bulwark Provoke-on-adjacent-ally, non-adjacent no-fire, once-per-round (non-vacuous), Doomsayer CF-on-highest-attack when first activator, no-fire when not first activator, **enemy-side Doomsayer mirror**
- [x] Full suite green (zero assertion failures), `tsc` + lint clean, zero golden drift
- [x] Spec + plan each passed two review rounds; final holistic review approved

Spec: `docs/superpowers/specs/2026-06-22-implant-gearset-abilities-D-pr14-design.md`
Plan: `docs/superpowers/plans/2026-06-22-implant-gearset-abilities-D-pr14.md`

> Stacked on D-PR13 (#143). Retarget to main as the lower D-stack PRs merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)