### PR TITLE
feat(combat): D-PR15 — Block Debuff + Buff Protection control primitives

### DIFF
--- a/docs/superpowers/plans/2026-06-22-block-control-primitives.md
+++ b/docs/superpowers/plans/2026-06-22-block-control-primitives.md
@@ -25,11 +25,11 @@
 - **Buff corpus:** `src/constants/buffs.ts` (`BUFFS: Buff[]`, `type: 'buff'|'debuff'|'effect'`); regen-preserve list `MANUAL_BUFFS` in `src/utils/dataUpdate/updateBuffsData.ts:21` (merged only-if-absent, mirrors `Power Infused Nanobots`).
 - **Purge:** `statusEngine.purge(actorId, count)` (`statusEngine.ts:993`) → `removeNewestFirst(actorId,'buffs',count)`; **cleanse** is the separate `removeNewestFirst(actorId,'debuffs',count)` (`:987`). statusEngine internal reads available to `purge`: `snapshot(ownerId)` closure (`:743`) returning `activeSelfBuffs`, and `timedAbilityStatuses('self', ownerId)`.
 - **Cast-side landing decision:** `landsTimedEnemyApplicationLive(application)` (`playerTurn.ts:750`) — drives BOTH the cast timed loop (`:928`) and the scheduled path via `statusEngine.setLandsTimedEnemyApplication(...)` (`:758`). Turn target = `enemy` (id `enemy.id`, also `targetId`).
-- **Cast-side DoT gate:** `roundDebuffLanded()` (`playerTurn.ts:809`) consumed at `:1425` (`dotsLanded`), applied via `applyNewDoTs(...)` at `:1430`; DoT target = `enemy.id`; each `dotsConfig` entry has `{ dotType, tier, ... }`.
+- **Cast-side DoT gate:** `roundDebuffLanded()` (`playerTurn.ts:809`) consumed at `:1425` (`dotsLanded`), applied via `applyNewDoTs(...)` at `:1430`; DoT target = `enemy.id`. Cast-side `dotsConfig` is `DoTApplicationEntry[]` (`src/types/calculator.ts:81`) whose kind field is **`type`** (`dot.type === 'corrosion'`, consumed `playerTurn.ts:568`) — NOT `dotType`. (The REACTIVE DoT config in `triggers.ts` uses `cfg.dotType` — different shape; do not confuse them.)
 - **Reactive timed debuff:** `triggers.ts:1177` (`if (owner.landsTimedEnemyApplication(...)) {apply} else {recordResisted + debuff-resisted}`); target = `intent.eventCtx?.counterTargetId ?? ctx.enemy.id`.
 - **Reactive DoT:** `triggers.ts:1214` (`if (!owner.debuffLandingGate(liveLanding)) return;` — silent); target = `ctx.enemy.id`.
 - **Buff-name read idiom:** `selfBuffNamesForOwners(statusEngine, [id])` (`triggers.ts:795`) — reads `snapshot(id).activeSelfBuffs` + self ability statuses; Barrier uses it at `engine.ts:2578`.
-- **Test patterns:** sim-level synthetic buff via `enemyAttacker(id, selfBuffSkills('Barrier'))` (`applyOutgoingToEnemy.test.ts:194`); statusEngine-level seeding via `eng.applyTimedAbilityStatus(1, mkTimed('X'), 'attacker', 'v1')` (`cleanseRemoval.test.ts:240`).
+- **Test patterns:** engine entry point is **`runCombat(input)`** (`engine.ts:1109`) — there is NO `simulateBattle`. Sim-level synthetic buff via `enemyAttacker(id, selfBuffSkills('Barrier'))` (`applyOutgoingToEnemy.test.ts:194`). statusEngine **self-store** seeding (the store `purge` reads) via `mkTimedBuff` with **`side: 'self'`** + `eng.applyTimedAbilityStatus(1, mkTimedBuff('X'), 'e1')` — see **`purgeRemoval.test.ts`** (this is the correct purge-test model; `cleanseRemoval.test.ts`'s `mkTimed` is `side:'enemy'` = the DEBUFF store, WRONG for purge). Note: `selfBuffSkills`/`enemyAttacker`/`mkTimedBuff` are local consts in their test files (not exported) → copy them into the new test files, don't import.
 
 ---
 
@@ -108,19 +108,19 @@ export const BUFF_PROTECTION_BUFFS: ReadonlySet<string> = new Set(['Buff Protect
 export const isBuffProtection = (name: string): boolean => BUFF_PROTECTION_BUFFS.has(name);
 ```
 
-- [ ] **Step 2: Write the failing test** in `buffProtection.test.ts`. Mirror `cleanseRemoval.test.ts` for statusEngine setup (`mkTimed`, `applyTimedAbilityStatus`). Cover:
-  1. Apply `Buff Protection` + another buff (e.g. `Attack Up I`) to `'attacker'`; `purge('attacker', 'all')` returns `0` and the other buff survives.
-  2. Without `Buff Protection`, the same purge removes the buff (control — proves the guard is the cause).
-  3. A debuff on the same actor is still removable by `cleanse(actorId,'all')` (purge-only scope intact).
+- [ ] **Step 2: Write the failing test** in `buffProtection.test.ts`. Model setup on **`purgeRemoval.test.ts`** (`mkTimedBuff` with `side: 'self'` — the self/buffs store `purge` reads; do NOT use `cleanseRemoval`'s `side:'enemy'` `mkTimed`, which seeds the debuff store and would make BOTH the main and control cases trivially return 0). Cover:
+  1. Apply `Buff Protection` + another buff (e.g. `Attack Up I`) as **self** statuses on an actor id (e.g. `'e1'`); `purge('e1', 'all')` returns `0` and the other buff survives.
+  2. Without `Buff Protection` (only `Attack Up I`), the same purge removes the buff (control — `> 0`).
+  3. Cleanse is unaffected: seed a removable **debuff** (`side:'enemy'`) on a Buff-Protection holder and assert `cleanse(id,'all') > 0` (purge-only scope intact).
 
 ```ts
-// sketch
+// sketch — mkTimedBuff is the side:'self' helper copied from purgeRemoval.test.ts
 const eng = createStatusEngine(/* per existing test helper */);
 eng.beginRound(1);
-eng.applyTimedAbilityStatus(1, mkTimed('Buff Protection'), 'attacker');
-eng.applyTimedAbilityStatus(1, mkTimed('Attack Up I'), 'attacker');
-expect(eng.purge('attacker', 'all')).toBe(0);
-// control test: a second engine without Buff Protection → purge removes > 0
+eng.applyTimedAbilityStatus(1, mkTimedBuff('Buff Protection'), 'e1'); // 3-arg: recipient = self id
+eng.applyTimedAbilityStatus(1, mkTimedBuff('Attack Up I'), 'e1');
+expect(eng.purge('e1', 'all')).toBe(0);
+// control: a second engine seeded with ONLY 'Attack Up I' → purge('e1','all') > 0
 ```
 
 - [ ] **Step 3: Run → fails** (`npm test -- src/utils/combat/__tests__/buffProtection.test.ts`): purge currently returns > 0.
@@ -136,11 +136,14 @@ const purge = (actorId: string, count: number | 'all'): number => {
         if (ab.stacks === undefined || ab.stacks > 0) selfBuffNames.add(ab.buffName);
     }
     for (const s of timedAbilityStatuses('self', actorId)) selfBuffNames.add(s.active.buffName);
+    // NOTE: deliberately omits the aura/accum channel (`activeAbilityStatuses('self', …)`) that
+    // `selfBuffNamesForOwners` also reads — Buff Protection is only ever granted as a TIMED buff,
+    // so the timed + scheduled channels cover every real grant. Revisit if an aura grant appears.
     if ([...selfBuffNames].some(isBuffProtection)) return 0;
     return removeNewestFirst(actorId, 'buffs', count);
 };
 ```
-Import `isBuffProtection` at the top of `statusEngine.ts`. (Confirm `snapshot` and `timedAbilityStatuses` are in-closure consts declared before `purge`; both are.)
+Import `isBuffProtection` from `./buffProtectionBuffs` at the top of `statusEngine.ts`. (Confirm `snapshot` and `timedAbilityStatuses` are in-closure consts declared before `purge`; both are.)
 
 - [ ] **Step 5: Run → passes.** Then `npm test -- src/utils/combat/__tests__/cleanseRemoval.test.ts` to confirm cleanse/purge characterization tests still pass.
 
@@ -219,9 +222,9 @@ Fold immunity into `landsTimedEnemyApplicationLive` so an immune turn-target aut
 
 **Files:**
 - Modify: `src/utils/combat/playerTurn.ts:750` (and add the per-turn immunity flag near `:744`)
-- Test: `blockDebuff.test.ts` (engine-level, `simulateBattle`)
+- Test: `blockDebuff.test.ts` (engine-level, `runCombat`)
 
-- [ ] **Step 1: Write the failing test.** Set up a two-side sim where the player (or enemy) attacker casts a **timed** debuff (e.g. `Attack Down II`) at a target carrying `Block Debuff` (seed via `selfBuffSkills('Block Debuff')` on the target ship, per `applyOutgoingToEnemy.test.ts:194`). Assert: the debuff is NOT applied (target's debuff list has no `Attack Down`) and a `debuff-resisted` event for it is emitted. Add a second case for a **persistent-stacking** debuff (e.g. `Defense Shred`) → resisted, no stack added.
+- [ ] **Step 1: Write the failing test.** Set up a two-side `runCombat` sim where the player (or enemy) attacker casts a **timed** debuff (e.g. `Attack Down II`) at a target carrying `Block Debuff` (seed via `selfBuffSkills('Block Debuff')` on the target ship, per `applyOutgoingToEnemy.test.ts:194`). Assert: the debuff is NOT applied (target's debuff list has no `Attack Down`) and a `debuff-resisted` event for it is emitted. Add a second case for a **persistent-stacking** debuff (e.g. `Defense Shred`) → resisted, no stack added.
 
 - [ ] **Step 2: Run → fails** (debuff currently lands).
 
@@ -312,14 +315,16 @@ if (dotsConfig.length > 0 && targetImmuneToDebuffs) {
     // Block Debuff: blocked DoTs are recorded as resists (block-path only — normal landing
     // failures below stay silent / byte-identical).
     for (const dot of dotsConfig) {
-        emitBlockDebuffResist(bus, enemy.id, r, dotResistLabel(dot.dotType, dot.tier));
+        emitBlockDebuffResist(bus, enemy.id, r, dotResistLabel(dot.type, dot.tier));
     }
 } else {
     const dotsLanded = dotsConfig.length > 0 ? roundDebuffLanded() : true;
-    // ... existing corrosionEntriesBefore/infernoEntriesBefore capture + if (dotsLanded) applyNewDoTs(...) + inflicted-scope extension block UNCHANGED, moved inside this else ...
+    // ... ALL existing cast-DoT code UNCHANGED, moved inside this else ...
 }
 ```
-Verify the exact `dotsConfig` field names (`dotType`, `tier`) against the local shape; keep the existing `corrosionEntriesBefore`/`infernoEntriesBefore` capture and the `if (dotsLanded)` extension block (`:1457`) on the non-immune branch. When not immune, the original code path is unchanged → byte-identical.
+**Field name:** cast-side `dotsConfig` entries use **`dot.type`** (`'corrosion'|'inferno'|'bomb'`) and `dot.tier` — NOT `dotType` (that's the reactive config in Task 7). Using `dot.dotType` here → `undefined` label + TS error.
+
+**Which code moves into the `else`:** there are **three** consecutive `if (dotsLanded)`-gated blocks in this region — `applyNewDoTs` (`:1430`), the inflicted-scope DoT extension (`:1457`), and `applyAccumulators` (`:1470`) — plus the `corrosionEntriesBefore`/`infernoEntriesBefore` capture (`:1428`). All of them (and the `const dotsLanded = …` line) go on the **non-immune `else` branch** together; the immune branch does ONLY the resist-event loop and applies no DoTs/accumulators/extensions. When not immune, the original code path is byte-for-byte unchanged.
 
 - [ ] **Step 4: Run → passes** (both the block case and the silent-normal-failure case).
 
@@ -377,7 +382,7 @@ git commit -m "feat(combat): D-PR15 — Block Debuff reactive DoT block + resist
 - Test: `src/utils/combat/__tests__/blockDebuff.test.ts` (integration describe)
 - Modify: `src/constants/changelog.ts`
 
-- [ ] **Step 1: Write the integration test(s).** In a two-team `simulateBattle`, give one actor a `Block Debuff` buff and have the opposing side attempt, across a few rounds, each debuff family — (a) timed, (b) persistent-stacking, (c) DoT, (d) control-as-named-debuff (`Stasis`/`Disable`). Assert all are resisted / not applied. Add a case proving an **already-landed** debuff (applied before Block Debuff goes up) is NOT removed when Block Debuff becomes active (Block Debuff blocks new applications only). Add an **immunity-beats-landing** case (a would-otherwise-land application is still blocked).
+- [ ] **Step 1: Write the integration test(s).** In a two-team `runCombat`, give one actor a `Block Debuff` buff (`selfBuffSkills('Block Debuff')` — copy the local helper) and have the opposing side attempt, across a few rounds, each debuff family — (a) timed, (b) persistent-stacking, (c) DoT, (d) control-as-named-debuff (`Stasis`/`Disable`). Assert all are resisted / not applied. Add a case proving an **already-landed** debuff (applied before Block Debuff goes up) is NOT removed when Block Debuff becomes active (Block Debuff blocks new applications only). Add an **immunity-beats-landing** case (a would-otherwise-land application is still blocked).
 
 - [ ] **Step 2: Run the targeted suites** → pass:
   - `npm test -- src/utils/combat/__tests__/blockDebuff.test.ts`

--- a/docs/superpowers/plans/2026-06-22-block-control-primitives.md
+++ b/docs/superpowers/plans/2026-06-22-block-control-primitives.md
@@ -1,0 +1,408 @@
+# Block / Protection Control Primitives — Implementation Plan (D-PR15)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make two currently-inert defensive control buffs do something in the combat engine — **Block Debuff** (incoming debuffs are blocked and recorded as resists) and **Buff Protection** (the holder's buffs cannot be removed by purge) — tested synthetically, with zero golden/fixture drift.
+
+**Architecture:** Both are buff-name-driven primitives in the established style of `barrierBuffs.ts` / `stasisBuffs.ts` (a `ReadonlySet<string>` of buff names + predicate; the engine reads an actor's active buff names and short-circuits). Buff Protection is a single holder-state guard inside `statusEngine.purge()`. Block Debuff is modeled as "the target auto-resists": folded into the **landing decision** so timed/persistent paths reuse existing resist plumbing for free, plus two thin DoT call sites (DoT landing-failures are silent today, so blocked DoTs get a resist event emitted **only on the block path** to preserve byte-identity).
+
+**Tech Stack:** TypeScript, Vitest. All work under `src/utils/combat/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-22-block-control-primitives-design.md`
+
+**Branch / worktree:** `feat/combat-d-pr15-block-control-primitives` (off `main`), worktree `.worktrees/d-pr15-block-control-primitives`.
+
+**Commands:**
+- Single test file: `npm test -- src/utils/combat/__tests__/<file>.ts`
+- Full suite: `npm test`
+- Lint/types: `npm run lint`
+- Pre-existing failing FILES unrelated to this work: 16 files fail from a missing Supabase URL env + gitignored `docs/*.csv` (see prior D-PR notes). These are NOT regressions — judge our tests by the targeted files and by zero NEW failures / zero golden+`.snap` drift.
+
+---
+
+## Key grounding (verified file:line in this worktree)
+
+- **Buff corpus:** `src/constants/buffs.ts` (`BUFFS: Buff[]`, `type: 'buff'|'debuff'|'effect'`); regen-preserve list `MANUAL_BUFFS` in `src/utils/dataUpdate/updateBuffsData.ts:21` (merged only-if-absent, mirrors `Power Infused Nanobots`).
+- **Purge:** `statusEngine.purge(actorId, count)` (`statusEngine.ts:993`) → `removeNewestFirst(actorId,'buffs',count)`; **cleanse** is the separate `removeNewestFirst(actorId,'debuffs',count)` (`:987`). statusEngine internal reads available to `purge`: `snapshot(ownerId)` closure (`:743`) returning `activeSelfBuffs`, and `timedAbilityStatuses('self', ownerId)`.
+- **Cast-side landing decision:** `landsTimedEnemyApplicationLive(application)` (`playerTurn.ts:750`) — drives BOTH the cast timed loop (`:928`) and the scheduled path via `statusEngine.setLandsTimedEnemyApplication(...)` (`:758`). Turn target = `enemy` (id `enemy.id`, also `targetId`).
+- **Cast-side DoT gate:** `roundDebuffLanded()` (`playerTurn.ts:809`) consumed at `:1425` (`dotsLanded`), applied via `applyNewDoTs(...)` at `:1430`; DoT target = `enemy.id`; each `dotsConfig` entry has `{ dotType, tier, ... }`.
+- **Reactive timed debuff:** `triggers.ts:1177` (`if (owner.landsTimedEnemyApplication(...)) {apply} else {recordResisted + debuff-resisted}`); target = `intent.eventCtx?.counterTargetId ?? ctx.enemy.id`.
+- **Reactive DoT:** `triggers.ts:1214` (`if (!owner.debuffLandingGate(liveLanding)) return;` — silent); target = `ctx.enemy.id`.
+- **Buff-name read idiom:** `selfBuffNamesForOwners(statusEngine, [id])` (`triggers.ts:795`) — reads `snapshot(id).activeSelfBuffs` + self ability statuses; Barrier uses it at `engine.ts:2578`.
+- **Test patterns:** sim-level synthetic buff via `enemyAttacker(id, selfBuffSkills('Barrier'))` (`applyOutgoingToEnemy.test.ts:194`); statusEngine-level seeding via `eng.applyTimedAbilityStatus(1, mkTimed('X'), 'attacker', 'v1')` (`cleanseRemoval.test.ts:240`).
+
+---
+
+## File structure
+
+**Create:**
+- `src/utils/combat/buffProtectionBuffs.ts` — `BUFF_PROTECTION_BUFFS` set + `isBuffProtection`.
+- `src/utils/combat/debuffImmunity.ts` — `BLOCK_DEBUFF_BUFFS` set, `isBlockDebuff`, `targetCarriesBlockDebuff(statusEngine, targetId)`, `dotResistLabel(dotType, tier)`, `emitBlockDebuffResist(bus, targetId, round, buffName)`.
+- `src/utils/combat/__tests__/buffProtection.test.ts`
+- `src/utils/combat/__tests__/blockDebuff.test.ts`
+
+**Modify:**
+- `src/constants/buffs.ts` — add `Block Debuff`, `Buff Protection` buff entries.
+- `src/utils/dataUpdate/updateBuffsData.ts` — add both to `MANUAL_BUFFS`.
+- `src/utils/combat/statusEngine.ts` — Buff Protection guard inside `purge()`.
+- `src/utils/combat/playerTurn.ts` — Block Debuff: fold into `landsTimedEnemyApplicationLive`; cast-DoT block branch.
+- `src/utils/combat/triggers.ts` — Block Debuff: reactive timed fold (`:1177`); reactive DoT block branch (`:1214`).
+- `src/constants/changelog.ts` — `UNRELEASED_CHANGES` entry.
+
+---
+
+## Task 1: Buff corpus additions
+
+Add the two behavioral buffs so their names resolve everywhere and survive `fetch-buffs`.
+
+**Files:**
+- Modify: `src/constants/buffs.ts`
+- Modify: `src/utils/dataUpdate/updateBuffsData.ts:21` (`MANUAL_BUFFS`)
+
+- [ ] **Step 1:** In `src/constants/buffs.ts`, add two entries to the `BUFFS` array (near `Power Infused Nanobots`):
+
+```ts
+{
+    name: 'Block Debuff',
+    description: 'Is immune to receiving debuffs',
+    type: 'buff',
+},
+{
+    name: 'Buff Protection',
+    description: "Protects this unit's buffs from being removed",
+    type: 'buff',
+},
+```
+
+- [ ] **Step 2:** In `src/utils/dataUpdate/updateBuffsData.ts`, add the same two `{name, description, type:'buff'}` objects to `MANUAL_BUFFS` so regeneration preserves them.
+
+- [ ] **Step 3:** Verify types/lint: `npm run lint` → clean. (No test yet; these are data rows consumed by later tasks.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/constants/buffs.ts src/utils/dataUpdate/updateBuffsData.ts
+git commit -m "feat(combat): D-PR15 — add Block Debuff + Buff Protection to buff corpus"
+```
+
+---
+
+## Task 2: Buff Protection module + purge guard
+
+A purge against a holder of `Buff Protection` removes 0 buffs (whole purge blocked). Cleanse (debuff removal) is untouched.
+
+**Files:**
+- Create: `src/utils/combat/buffProtectionBuffs.ts`
+- Modify: `src/utils/combat/statusEngine.ts` (`purge`, `:993`)
+- Test: `src/utils/combat/__tests__/buffProtection.test.ts`
+
+- [ ] **Step 1: Write the module**
+
+```ts
+// src/utils/combat/buffProtectionBuffs.ts
+/** Named buffs that make the holder's buffs UNREMOVABLE BY PURGE for the buff's duration.
+ *  A purge against a Buff-Protection holder removes 0 buffs (the whole purge is blocked).
+ *  Purge-only: cleanse (debuff removal) and buff-steal are unaffected. Holder-state guard,
+ *  NOT a per-buff property (cf. UNREMOVABLE_STATUSES). Extend from game data as identified. */
+export const BUFF_PROTECTION_BUFFS: ReadonlySet<string> = new Set(['Buff Protection']);
+export const isBuffProtection = (name: string): boolean => BUFF_PROTECTION_BUFFS.has(name);
+```
+
+- [ ] **Step 2: Write the failing test** in `buffProtection.test.ts`. Mirror `cleanseRemoval.test.ts` for statusEngine setup (`mkTimed`, `applyTimedAbilityStatus`). Cover:
+  1. Apply `Buff Protection` + another buff (e.g. `Attack Up I`) to `'attacker'`; `purge('attacker', 'all')` returns `0` and the other buff survives.
+  2. Without `Buff Protection`, the same purge removes the buff (control — proves the guard is the cause).
+  3. A debuff on the same actor is still removable by `cleanse(actorId,'all')` (purge-only scope intact).
+
+```ts
+// sketch
+const eng = createStatusEngine(/* per existing test helper */);
+eng.beginRound(1);
+eng.applyTimedAbilityStatus(1, mkTimed('Buff Protection'), 'attacker');
+eng.applyTimedAbilityStatus(1, mkTimed('Attack Up I'), 'attacker');
+expect(eng.purge('attacker', 'all')).toBe(0);
+// control test: a second engine without Buff Protection → purge removes > 0
+```
+
+- [ ] **Step 3: Run → fails** (`npm test -- src/utils/combat/__tests__/buffProtection.test.ts`): purge currently returns > 0.
+
+- [ ] **Step 4: Implement the guard** inside `purge` (`statusEngine.ts:993`). Read the holder's active self-buff names using statusEngine's own internal `snapshot(actorId).activeSelfBuffs` + `timedAbilityStatuses('self', actorId)` (mirrors `selfBuffNamesForOwners`; no circular import). Short-circuit before removal:
+
+```ts
+const purge = (actorId: string, count: number | 'all'): number => {
+    // Holder-state guard: a unit carrying Buff Protection cannot have its buffs purged.
+    // Purge-only — `cleanse` (removeNewestFirst(_, 'debuffs', _)) does NOT call this.
+    const selfBuffNames = new Set<string>();
+    for (const ab of snapshot(actorId).activeSelfBuffs) {
+        if (ab.stacks === undefined || ab.stacks > 0) selfBuffNames.add(ab.buffName);
+    }
+    for (const s of timedAbilityStatuses('self', actorId)) selfBuffNames.add(s.active.buffName);
+    if ([...selfBuffNames].some(isBuffProtection)) return 0;
+    return removeNewestFirst(actorId, 'buffs', count);
+};
+```
+Import `isBuffProtection` at the top of `statusEngine.ts`. (Confirm `snapshot` and `timedAbilityStatuses` are in-closure consts declared before `purge`; both are.)
+
+- [ ] **Step 5: Run → passes.** Then `npm test -- src/utils/combat/__tests__/cleanseRemoval.test.ts` to confirm cleanse/purge characterization tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/combat/buffProtectionBuffs.ts src/utils/combat/statusEngine.ts src/utils/combat/__tests__/buffProtection.test.ts
+git commit -m "feat(combat): D-PR15 — Buff Protection purge-immunity primitive"
+```
+
+---
+
+## Task 3: Block Debuff module (pure helpers)
+
+**Files:**
+- Create: `src/utils/combat/debuffImmunity.ts`
+- Test: add a `describe('debuffImmunity helpers')` block to `src/utils/combat/__tests__/blockDebuff.test.ts`
+
+- [ ] **Step 1: Write the module**
+
+```ts
+// src/utils/combat/debuffImmunity.ts
+import type { StatusEngine } from './statusEngine';
+import type { CombatEventBus } from './events'; // adjust to the bus type used by emit sites
+import { selfBuffNamesForOwners } from './triggers';
+
+/** Named buffs that make the holder IMMUNE to receiving debuffs. While active, every incoming
+ *  debuff application (timed, persistent-stacking, DoT, control-as-named-debuff) is blocked and
+ *  recorded as a RESIST. Already-landed debuffs are untouched. Extend from game data. */
+export const BLOCK_DEBUFF_BUFFS: ReadonlySet<string> = new Set(['Block Debuff']);
+export const isBlockDebuff = (name: string): boolean => BLOCK_DEBUFF_BUFFS.has(name);
+
+/** True if `targetId` currently carries a Block Debuff buff (reads its self-buff names). */
+export function targetCarriesBlockDebuff(statusEngine: StatusEngine, targetId: string): boolean {
+    return selfBuffNamesForOwners(statusEngine, [targetId]).some(isBlockDebuff);
+}
+
+const ROMAN = ['', 'I', 'II', 'III', 'IV', 'V'];
+/** Single source of truth for the resisted-debuff label of a blocked DoT, so the emit site and
+ *  the test assertion agree. e.g. ('inferno', 3) → 'Inferno III'; ('bomb', 0) → 'Bomb'. */
+export function dotResistLabel(dotType: 'corrosion' | 'inferno' | 'bomb', tier: number): string {
+    const kind = dotType.charAt(0).toUpperCase() + dotType.slice(1);
+    const numeral = tier > 0 && tier < ROMAN.length ? ` ${ROMAN[tier]}` : '';
+    return dotType === 'bomb' ? kind : `${kind}${numeral}`;
+}
+
+/** Emit a debuff-resisted event for a Block-Debuff-blocked DoT. Call ONLY on the block path —
+ *  normal DoT landing-roll failures stay silent (byte-identical). */
+export function emitBlockDebuffResist(
+    bus: CombatEventBus,
+    targetId: string,
+    round: number,
+    buffName: string
+): void {
+    bus.emit({ type: 'debuff-resisted', targetId, round, buffName });
+}
+```
+Adjust the `bus` / event-bus type import to match the actual type used at the emit sites in `triggers.ts`/`playerTurn.ts` (grep `bus.emit({ type: 'debuff-resisted'`).
+
+- [ ] **Step 2: Write failing unit tests** for `dotResistLabel` (`'Inferno III'`, `'Corrosion II'`, `'Bomb'`) and `isBlockDebuff`. (Pure — no engine.)
+
+- [ ] **Step 3: Run → label test fails until module exists; then passes.**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/combat/debuffImmunity.ts src/utils/combat/__tests__/blockDebuff.test.ts
+git commit -m "feat(combat): D-PR15 — debuffImmunity module (Block Debuff predicate + DoT label)"
+```
+
+---
+
+## Task 4: Block Debuff — cast-side timed + persistent (landing fold)
+
+Fold immunity into `landsTimedEnemyApplicationLive` so an immune turn-target auto-resists every cast/scheduled timed + persistent debuff via existing resist plumbing.
+
+**Files:**
+- Modify: `src/utils/combat/playerTurn.ts:750` (and add the per-turn immunity flag near `:744`)
+- Test: `blockDebuff.test.ts` (engine-level, `simulateBattle`)
+
+- [ ] **Step 1: Write the failing test.** Set up a two-side sim where the player (or enemy) attacker casts a **timed** debuff (e.g. `Attack Down II`) at a target carrying `Block Debuff` (seed via `selfBuffSkills('Block Debuff')` on the target ship, per `applyOutgoingToEnemy.test.ts:194`). Assert: the debuff is NOT applied (target's debuff list has no `Attack Down`) and a `debuff-resisted` event for it is emitted. Add a second case for a **persistent-stacking** debuff (e.g. `Defense Shred`) → resisted, no stack added.
+
+- [ ] **Step 2: Run → fails** (debuff currently lands).
+
+- [ ] **Step 3: Implement the fold.** Near the `liveLandingChance` computation (`playerTurn.ts:~744`), add:
+
+```ts
+import { targetCarriesBlockDebuff } from './debuffImmunity';
+// ...
+// Block Debuff: an immune turn-target auto-resists every timed/persistent application.
+const targetImmuneToDebuffs = targetCarriesBlockDebuff(statusEngine, enemy.id);
+```
+Then guard the landing decision (`:750`):
+
+```ts
+const landsTimedEnemyApplicationLive = (application?: 'inflict' | 'apply'): boolean =>
+    targetImmuneToDebuffs
+        ? false
+        : application === 'apply'
+          ? !affinityDisadvantage
+          : debuffLandingGate(liveLandingChance);
+```
+This routes both the cast timed loop (`:928`) and the scheduled `sourceFired` hook (`:758`) to their existing resist branches. Immune path returns `false` WITHOUT drawing `debuffLandingGate` — fine, no fixture has immune targets, so byte-identical.
+
+- [ ] **Step 4: Run → passes.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/playerTurn.ts src/utils/combat/__tests__/blockDebuff.test.ts
+git commit -m "feat(combat): D-PR15 — Block Debuff cast-side timed/persistent landing fold"
+```
+
+---
+
+## Task 5: Block Debuff — reactive timed debuff
+
+**Files:**
+- Modify: `src/utils/combat/triggers.ts:1177`
+- Test: `blockDebuff.test.ts`
+
+- [ ] **Step 1: Write the failing test.** Drive a reactive `debuff` ability (e.g. an on-attacked debuff) firing at a target carrying `Block Debuff`; assert resisted (no apply, `debuff-resisted` emitted). If a self-contained reactive setup is heavy, assert via the `executeIntent`/drain path used by existing trigger tests.
+
+- [ ] **Step 2: Run → fails.**
+
+- [ ] **Step 3: Implement.** At `:1174`-`:1177`, compute the target and gate immunity into the landing condition so the existing `else` (resist) branch handles it:
+
+```ts
+import { targetCarriesBlockDebuff } from './debuffImmunity';
+// ...
+const counterTargetId = intent.eventCtx?.counterTargetId;
+const debuffTargetId = counterTargetId ?? ctx.enemy.id;
+const blocked = targetCarriesBlockDebuff(ctx.statusEngine, debuffTargetId);
+if (!blocked && owner.landsTimedEnemyApplication(cfg.application)) {
+    // ... existing apply branch unchanged ...
+} else {
+    // ... existing recordResisted + debuff-resisted branch unchanged ...
+}
+```
+Immune → `else` branch → `recordResisted` + `debuff-resisted` (persistent-name → `'permanent'` row, already handled). Byte-identical when `blocked === false`.
+
+- [ ] **Step 4: Run → passes.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/triggers.ts src/utils/combat/__tests__/blockDebuff.test.ts
+git commit -m "feat(combat): D-PR15 — Block Debuff reactive timed-debuff fold"
+```
+
+---
+
+## Task 6: Block Debuff — cast-side DoT block + resist event
+
+**Files:**
+- Modify: `src/utils/combat/playerTurn.ts:~1425`
+- Test: `blockDebuff.test.ts`
+
+- [ ] **Step 1: Write the failing test.** Player casts a DoT skill (e.g. inflicts `Inferno III`) at a `Block Debuff` target. Assert: no DoT entry added (target takes no DoT ticks over subsequent rounds) AND a `debuff-resisted` event with buffName `'Inferno III'` is emitted. Also assert a normal landing-roll failure (no Block Debuff, low landing chance) emits NO `debuff-resisted` (byte-identical silent-fail preserved).
+
+- [ ] **Step 2: Run → fails** (DoT lands; no resist event).
+
+- [ ] **Step 3: Implement.** Reuse `targetImmuneToDebuffs` (from Task 4) at the DoT application site (`:1425`-`:1450`):
+
+```ts
+import { emitBlockDebuffResist, dotResistLabel } from './debuffImmunity';
+// ...
+if (dotsConfig.length > 0 && targetImmuneToDebuffs) {
+    // Block Debuff: blocked DoTs are recorded as resists (block-path only — normal landing
+    // failures below stay silent / byte-identical).
+    for (const dot of dotsConfig) {
+        emitBlockDebuffResist(bus, enemy.id, r, dotResistLabel(dot.dotType, dot.tier));
+    }
+} else {
+    const dotsLanded = dotsConfig.length > 0 ? roundDebuffLanded() : true;
+    // ... existing corrosionEntriesBefore/infernoEntriesBefore capture + if (dotsLanded) applyNewDoTs(...) + inflicted-scope extension block UNCHANGED, moved inside this else ...
+}
+```
+Verify the exact `dotsConfig` field names (`dotType`, `tier`) against the local shape; keep the existing `corrosionEntriesBefore`/`infernoEntriesBefore` capture and the `if (dotsLanded)` extension block (`:1457`) on the non-immune branch. When not immune, the original code path is unchanged → byte-identical.
+
+- [ ] **Step 4: Run → passes** (both the block case and the silent-normal-failure case).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/playerTurn.ts src/utils/combat/__tests__/blockDebuff.test.ts
+git commit -m "feat(combat): D-PR15 — Block Debuff cast-side DoT block + resist event"
+```
+
+---
+
+## Task 7: Block Debuff — reactive DoT block + resist event
+
+**Files:**
+- Modify: `src/utils/combat/triggers.ts:~1214`
+- Test: `blockDebuff.test.ts`
+
+- [ ] **Step 1: Write the failing test.** Reactive DoT ability firing at a `Block Debuff` target → no DoT entry, `debuff-resisted` emitted with the `dotResistLabel`. Plus a control: reactive DoT landing-failure (no Block Debuff) emits no event (silent preserved).
+
+- [ ] **Step 2: Run → fails.**
+
+- [ ] **Step 3: Implement.** Before the landing gate at `:1213`-`:1214`:
+
+```ts
+import { targetCarriesBlockDebuff, emitBlockDebuffResist, dotResistLabel } from './debuffImmunity';
+// ...
+if (cfg.type === 'dot') {
+    if (cfg.stacks <= 0 || cfg.tier <= 0) return;
+    if (targetCarriesBlockDebuff(ctx.statusEngine, ctx.enemy.id)) {
+        emitBlockDebuffResist(ctx.bus, ctx.enemy.id, ctx.round, dotResistLabel(cfg.dotType, cfg.tier));
+        return;
+    }
+    const liveLanding = owner.liveDebuffLandingChance ?? 1;
+    if (!owner.debuffLandingGate(liveLanding)) return; // unchanged silent failure
+    // ... existing corrosion/inferno/bomb append + dot-applied UNCHANGED ...
+}
+```
+Byte-identical when target is not immune (guard is a no-op).
+
+- [ ] **Step 4: Run → passes.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/triggers.ts src/utils/combat/__tests__/blockDebuff.test.ts
+git commit -m "feat(combat): D-PR15 — Block Debuff reactive DoT block + resist event"
+```
+
+---
+
+## Task 8: End-to-end integration, byte-identity, changelog
+
+**Files:**
+- Test: `src/utils/combat/__tests__/blockDebuff.test.ts` (integration describe)
+- Modify: `src/constants/changelog.ts`
+
+- [ ] **Step 1: Write the integration test(s).** In a two-team `simulateBattle`, give one actor a `Block Debuff` buff and have the opposing side attempt, across a few rounds, each debuff family — (a) timed, (b) persistent-stacking, (c) DoT, (d) control-as-named-debuff (`Stasis`/`Disable`). Assert all are resisted / not applied. Add a case proving an **already-landed** debuff (applied before Block Debuff goes up) is NOT removed when Block Debuff becomes active (Block Debuff blocks new applications only). Add an **immunity-beats-landing** case (a would-otherwise-land application is still blocked).
+
+- [ ] **Step 2: Run the targeted suites** → pass:
+  - `npm test -- src/utils/combat/__tests__/blockDebuff.test.ts`
+  - `npm test -- src/utils/combat/__tests__/buffProtection.test.ts`
+
+- [ ] **Step 3: Byte-identity gate — run the full suite** `npm test` and confirm: zero NEW failures vs the pre-existing 16 env-failing files, and **zero golden / `.snap` drift** (no `.snap` files modified; `git status` shows none changed). If any golden moved, STOP — a non-immune fixture changed behavior, which violates the design; investigate before proceeding.
+
+- [ ] **Step 4: Lint/types** `npm run lint` → clean.
+
+- [ ] **Step 5: Changelog.** Add to `UNRELEASED_CHANGES` in `src/constants/changelog.ts` a plain-English line, e.g.: "Combat sim now models Block Debuff (incoming debuffs are blocked and shown as resisted) and Buff Protection (a unit's buffs can't be purged) — used by upcoming implant effects."
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/combat/__tests__/blockDebuff.test.ts src/constants/changelog.ts
+git commit -m "test(combat): D-PR15 — Block Debuff/Buff Protection integration + changelog"
+```
+
+---
+
+## Out of scope (follow-up applier PRs)
+Firewall (on-self-debuffed → Block Debuff), Last Stand (last-standing → Barrier + Block Debuff), Lockdown (on-debuff-resisted → all-ally Buff Protection), Tenacity (>25% hit → all-ally Buff Protection); the `Block Buff` primitive (golden-moving, 4 ships); buff-steal immunity. No DPS-calculator wiring (these effects don't affect DPS). No equipment-coverage-tracker change (no implant implemented this PR).
+
+## Definition of done
+- Both primitives live and unit+integration tested; `dotResistLabel` is the single label source shared by emit + assertions.
+- Buff Protection is purge-only (cleanse verified intact).
+- Block Debuff blocks all incoming debuff families and records resists; already-landed debuffs untouched; DoT resist events fire only on the block path.
+- Full suite: zero new failures, zero golden/`.snap` drift. Lint/types clean. Changelog updated.

--- a/docs/superpowers/plans/2026-06-22-block-control-primitives.md
+++ b/docs/superpowers/plans/2026-06-22-block-control-primitives.md
@@ -143,7 +143,7 @@ const purge = (actorId: string, count: number | 'all'): number => {
     return removeNewestFirst(actorId, 'buffs', count);
 };
 ```
-Import `isBuffProtection` from `./buffProtectionBuffs` at the top of `statusEngine.ts`. (Confirm `snapshot` and `timedAbilityStatuses` are in-closure consts declared before `purge`; both are.)
+Import `isBuffProtection` from `./buffProtectionBuffs` at the top of `statusEngine.ts`. (`snapshot` and `timedAbilityStatuses` are `const` arrow functions in the same factory body; `timedAbilityStatuses` is actually declared AFTER `purge` lexically, but that's fine — both resolve at call-time via the closure, and `purge` only runs post-construction, so no TDZ.)
 
 - [ ] **Step 5: Run → passes.** Then `npm test -- src/utils/combat/__tests__/cleanseRemoval.test.ts` to confirm cleanse/purge characterization tests still pass.
 

--- a/docs/superpowers/specs/2026-06-22-block-control-primitives-design.md
+++ b/docs/superpowers/specs/2026-06-22-block-control-primitives-design.md
@@ -145,8 +145,11 @@ The seams collapse into three things:
    `if (targetCarriesBlockDebuff) { emitBlockDebuffResist(...); skip; }` — checked *before* the
    normal landing gate. Call sites: cast DoT gate (playerTurn.ts ~811 / `applyNewDoTs`) and
    reactive DoT gate (triggers.ts ~1214). The synthesized `buffName` for the event reflects the
-   DoT kind + tier (e.g. `'Inferno III'`, `'Corrosion II'`) — exact label is an implementation
-   detail.
+   DoT kind + tier as a single shared convention — capitalized kind + Roman-numeral tier
+   (`'Inferno III'`, `'Corrosion II'`; `'Bomb'` has no tier). Define this label in **one place**
+   (in `debuffImmunity.ts`, reusing any existing DoT-naming helper if present) so the
+   `emitBlockDebuffResist` call and the test assertion reference the same source — this is the
+   one spot in the PR where two pieces must agree on a string.
 
 3. **One shared predicate** `targetCarriesBlockDebuff` (via `selfBuffNamesForOwners`) used by
    both the landing-fold checks and the DoT call sites.

--- a/docs/superpowers/specs/2026-06-22-block-control-primitives-design.md
+++ b/docs/superpowers/specs/2026-06-22-block-control-primitives-design.md
@@ -1,0 +1,216 @@
+# Block / Protection Control Primitives — Design (D-PR15)
+
+**Date:** 2026-06-22
+**Epic:** Combat-realism epic (sub-project D — implants + gear-set abilities)
+**Status:** Approved (brainstorm), pending spec review
+
+## Context
+
+The "Block/Protection" D bucket covers four implants — Firewall, Last Stand, Lockdown,
+Tenacity — that grant defensive **control buffs** to the holder or its allies. Those buff
+*types* are inert in the combat engine today: the grant machinery (reactive self / all-ally
+buff grants) already exists from D-PR8/D-PR9, but the granted buffs do nothing.
+
+This PR is the **primitives-first** slice: make the underlying buff *types* actually do
+something in the engine, tested synthetically (buffs applied directly to actors in tests, no
+implant triggers). The four implant **appliers** ship in follow-up PRs (see Out of Scope).
+
+### Scope correction discovered during brainstorm
+
+The four implants reference three control buffs: **Block Damage**, **Block Debuff**, and
+**Buff Protection**.
+
+- **Block Damage is already modeled** — it is the old name for **Barrier**, which the engine
+  fully implements (`src/utils/combat/barrierBuffs.ts`: full damage immunity, blocks direct +
+  DoT, a fully-blocked hit deals 0, with leech/positional carve-outs). The user renamed the
+  Last Stand implant description from "Block Damage" to "Barrier" (committed to main as
+  `2339df92`). **No engine work is needed for Block Damage** — the Last Stand applier PR will
+  simply grant the existing `Barrier` buff.
+
+Therefore this PR ships **two** new primitives:
+
+1. **Block Debuff** — immune to receiving debuffs.
+2. **Buff Protection** — the holder's buffs cannot be removed by purge.
+
+### Byte-identical guarantee
+
+No ship skill and no combat fixture grants `Block Debuff` or `Buff Protection` (verified by
+corpus grep: 0 matches in `docs/ship-skills.csv`). No fixture equips effect-bearing gear that
+grants them. Therefore lighting up both primitives is **byte-identical** to every existing
+golden / `.snap` fixture (zero drift expected).
+
+> Note: the sibling buff **Block Buff** ("immune to receiving buffs") *is* granted by 4 ships
+> (Bizon, Butcher, + two purge ships) and is also inert in-engine. Lighting it up would move
+> goldens, so **Block Buff is explicitly out of scope** for this PR.
+
+## Locked Semantics (from brainstorm)
+
+### Block Debuff
+- Blocks **all** incoming debuff applications while active — every application path: timed
+  debuffs, DoTs (Inferno/Corrosion/Bomb), control-as-named-debuff (Stasis/Disable applied as a
+  named debuff), and persistent-stacking debuffs (Defense Shred/Blast/Overload/Titanite).
+- A blocked debuff is recorded as a **resist** — the same outcome as a failed landing roll
+  (resisted list + `debuff-resisted` event). This is what lets a future Lockdown ("when
+  resisting a debuff") chain off it.
+- **DoTs also fire a resist event when blocked** (user decision). Since DoTs have no resist
+  surface today (a failed DoT landing roll silently does not append, with no event), the
+  `debuff-resisted` event for a DoT is emitted **only on the Block-Debuff block path** — NOT
+  on normal landing-roll failures, which stay silent as today. This preserves the
+  byte-identical guarantee for existing fixtures.
+- Block is checked **before the landing roll** (immunity beats landing — a debuff that would
+  otherwise land is still blocked).
+- **Already-landed debuffs are untouched** — Block Debuff only blocks *new* applications while
+  active; it does not remove or shorten debuffs already on the holder.
+
+### Buff Protection
+- The holder's buffs **cannot be removed by purge**. A purge against a Buff-Protection holder
+  removes **0** buffs (the *entire* purge is blocked, not just "protect one buff").
+- **Purge only.** Cleanse (which removes *debuffs*, not buffs) is untouched. Buff-**steal** is
+  untouched (out of scope; no steal mechanic interacts here today).
+- Buff Protection protects the holder's other active buffs **and itself** while active.
+
+## Engine Design
+
+Both primitives follow the established **buff-name-driven** pattern (mirrors `barrierBuffs.ts`,
+`stasisBuffs.ts`, `disableBuffs.ts`): a small module exporting a `ReadonlySet<string>` of buff
+names + an `is*` predicate; the engine reads the relevant actor's active buff names and
+short-circuits.
+
+Reading an actor's active buff names uses the existing idiom
+`selfBuffNamesForOwners(statusEngine, [actorId])` (the same accessor Barrier uses at the damage
+seam, `engine.ts:2578`), which folds scheduled + ability-timed + ability-aura buff sources.
+
+### Buff Protection (single chokepoint)
+
+New module `src/utils/combat/buffProtectionBuffs.ts`:
+```ts
+export const BUFF_PROTECTION_BUFFS: ReadonlySet<string> = new Set(['Buff Protection']);
+export const isBuffProtection = (name: string): boolean => BUFF_PROTECTION_BUFFS.has(name);
+```
+
+Purge funnels through exactly one removal function: `statusEngine.purge(targetId, count)`
+(`statusEngine.ts` ~993), which delegates to `removeNewestFirst(targetId, 'buffs', count)`.
+There are only two call sites — on-cast (`playerTurn.ts:1515`) and reactive
+(`triggers.ts:1425`) — both already read the real removed count, and `purge-performed` is only
+emitted when `removed > 0`.
+
+**Guard inside `purge()`** (holder-state guard, not per-buff): before removal, read the target's
+active buff names; if any ∈ `BUFF_PROTECTION_BUFFS`, return `0` immediately (skip
+`removeNewestFirst`). This covers both call sites and any future one automatically, and a blocked
+purge naturally emits no `purge-performed` event (removed = 0).
+
+- Cleanse uses `removeNewestFirst(actorId, 'debuffs', count)` — a different store, not touched
+  by this guard. Confirm the guard is scoped to the `'buffs'`/purge path only.
+- This is distinct from the existing **per-buff** `UNREMOVABLE_STATUSES` mechanism
+  (`cheatDeathBuffs.ts`); Buff Protection is a **holder-state** guard (depends on the target
+  having the buff), so it does not belong in `UNREMOVABLE_STATUSES`.
+
+### Block Debuff — model as "immune target auto-resists" (gathered)
+
+**Framing:** Block Debuff is a **landing concern**, not an apply concern. An immune target
+simply *resists* every incoming debuff. Because every timed/persistent debuff path already
+converts a failed landing roll into a correctly-recorded resist (resisted list +
+`debuff-resisted` event), folding the immunity check into the **landing decision** makes those
+paths produce the right resist **for free**, with no per-seam apply/resist duplication.
+
+All immunity logic lives in **one module**, `src/utils/combat/debuffImmunity.ts`:
+```ts
+export const BLOCK_DEBUFF_BUFFS: ReadonlySet<string> = new Set(['Block Debuff']);
+export const isBlockDebuff = (name: string): boolean => BLOCK_DEBUFF_BUFFS.has(name);
+
+// Holder-state predicate (reuses the Barrier idiom via selfBuffNamesForOwners).
+export function targetCarriesBlockDebuff(statusEngine, targetId): boolean;
+
+// Used by the DoT seams (block-path resist event helper).
+export function emitBlockDebuffResist(bus, targetId, round, buffName): void;
+```
+
+The seams collapse into three things:
+
+1. **Timed + persistent debuffs (cast + reactive) — fold into the landing decision.**
+   When the target carries Block Debuff, the landing decision returns *resisted* (the roll is
+   not drawn / its result is ignored — immunity beats landing, including the `application:
+   'apply'` auto-land branch). The existing resist plumbing then records the resist at every
+   one of these paths automatically.
+   - Cast side: `landsTimedEnemyApplicationLive` (playerTurn.ts ~750) — already knows the turn
+     target; one immunity check covers on-cast timed (Path 1), scheduled timed/persistent via
+     the same bound function (Path 2), and ability-persistent (Path 4, which rides this
+     landing).
+   - Reactive side: the landing call in triggers.ts ~1177 — target is
+     `counterTargetId ?? <default>`, available at the seam.
+
+2. **DoTs (cast + reactive) — two thin call sites.** A failed DoT landing roll is **silent**
+   today (no event), and that must stay byte-identical. So the DoT gates get an explicit
+   immunity branch that fires **only on the Block-Debuff block path**:
+   `if (targetCarriesBlockDebuff) { emitBlockDebuffResist(...); skip; }` — checked *before* the
+   normal landing gate. Call sites: cast DoT gate (playerTurn.ts ~811 / `applyNewDoTs`) and
+   reactive DoT gate (triggers.ts ~1214). The synthesized `buffName` for the event reflects the
+   DoT kind + tier (e.g. `'Inferno III'`, `'Corrosion II'`) — exact label is an implementation
+   detail.
+
+3. **One shared predicate** `targetCarriesBlockDebuff` (via `selfBuffNamesForOwners`) used by
+   both the landing-fold checks and the DoT call sites.
+
+Notes:
+- Control inflicts (Stasis, Disable) reach the engine as **named debuffs** (parsed buffName
+  `'Stasis'` / `'Disable'`) routed through the timed paths above — blocked for free by the
+  landing fold; no separate seam. The `control-applied` event is reaction-only.
+- Because the engine is team-agnostic, the landing fold + DoT checks protect player and enemy
+  targets symmetrically (the reactive landing/DoT seams run for both sides).
+- **Implementation note:** verify the cast-side landing fold also covers the `application:
+  'apply'` (auto-land) branch and that the reactive `owner.landsTimedEnemyApplication` seam
+  resolves the correct `counterTargetId`. If threading the target into a bound landing function
+  proves awkward at any single seam, fall back to a thin `targetCarriesBlockDebuff` guard at
+  that one seam (still calling the shared module) — but the default is the landing fold.
+
+## Corpus Additions
+
+`Block Debuff` and `Buff Protection` are not in the buff corpus (`src/constants/buffs.ts`),
+exactly like `Power Infused Nanobots` in D-PR9. Add both via the existing `MANUAL_BUFFS`
+mechanism (`scripts/updateBuffsData.ts`) so `npm run fetch-buffs` preserves them on regen:
+
+- `Block Debuff` — `type: 'buff'`, description "Is immune to receiving debuffs".
+- `Buff Protection` — `type: 'buff'`, description e.g. "Protects this unit's buffs from being
+  removed".
+
+Both are purely behavioral (no stat effects) → `parseBuffEffects` yields empty effects → no fold
+impact. Confirm they render acceptably in any buff picker UI (informational only).
+
+## Testing Strategy
+
+Synthetic engine tests (no implant triggers):
+
+- **Block Debuff:** apply `Block Debuff` directly to a target, then have the opposing side
+  attempt each debuff family — (a) timed debuff, (b) persistent-stacking shred, (c) DoT
+  (inferno/corrosion), (d) control-as-named-debuff (Stasis/Disable) — and assert each is
+  **blocked + recorded as a resist** (resisted list entry + `debuff-resisted` event, including
+  the new DoT resist event). Assert an **already-landed** debuff is NOT removed when Block
+  Debuff is subsequently applied. Assert the block fires even against a would-otherwise-land
+  application (immunity beats landing).
+- **Buff Protection:** apply `Buff Protection` to a target holding ≥1 other buff, run a purge
+  (on-cast and reactive), assert **0 removed** and **no `purge-performed`** event. Assert
+  cleanse of a debuff on a Buff-Protection holder still works (purge-only scope). Assert that
+  without Buff Protection the same purge removes buffs (control case).
+- **Byte-identical:** full suite green, **zero** golden / `.snap` drift.
+
+## Out of Scope (follow-up applier PRs)
+
+Tracked in the epic; not this PR:
+
+- **Firewall** — on self being debuffed → self gains `Block Debuff` (needs an on-self-debuffed
+  trigger).
+- **Last Stand** — on becoming the last unit standing → self gains `Barrier` + `Block Debuff`
+  (needs a last-standing trigger; uses the existing Barrier + this PR's Block Debuff).
+- **Lockdown** — on resisting a debuff → all allies gain `Buff Protection` (needs an
+  on-debuff-resisted trigger; chains off Block Debuff resists or true landing-roll resists).
+- **Tenacity** — on directly receiving damage > 25% max HP → all allies gain `Buff Protection`
+  (needs a big-hit-threshold condition on the on-attacked trigger).
+- **Block Buff** primitive (immune to receiving buffs) — separate, golden-moving (4 ships use
+  it).
+- Buff-**steal** immunity for Buff Protection.
+
+## Decomposition note
+
+Both primitives are independent and could split into two PRs (Buff Protection is a 1-chokepoint
+change; Block Debuff is the multi-seam one). Default: ship both in one PR as two separate tasks,
+since both are byte-identical and share the corpus + synthetic-test harness work.

--- a/src/constants/buffs.ts
+++ b/src/constants/buffs.ts
@@ -13,6 +13,16 @@ export const BUFFS: Buff[] = [
         type: 'buff',
     },
     {
+        name: 'Block Debuff',
+        description: 'Is immune to receiving debuffs',
+        type: 'buff',
+    },
+    {
+        name: 'Buff Protection',
+        description: "Protects this unit's buffs from being removed",
+        type: 'buff',
+    },
+    {
         name: 'Hacking Up II',
         description: '+40 Hacking',
         type: 'buff',

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -24,6 +24,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator now models the Fortifying Shroud implant — a chance each turn to grant adjacent allies a Defense Up buff.',
     "Combat simulator: the Disable control now skips the affected ship's turn and locks out its reactions, so effects that apply Disable — like the Martyrdom implant and Disable-inflicting skills — now take effect in the simulation.",
     'Combat simulator: Bulwark implants now apply Provoke to an enemy that damages a nearby ally, and Doomsayer implants apply Concentrate Fire to the strongest enemy at the end of the round.',
+    'Combat simulator now models two control primitives: Block Debuff (a unit immune to debuffs auto-resists every incoming debuff — timed, persistent, control such as Stasis or Disable, and damage-over-time — shown in the log as resisted) and Buff Protection (a unit\'s buffs can no longer be stripped by enemy purge). These back upcoming implant effects.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/combat/__tests__/blockDebuff.test.ts
+++ b/src/utils/combat/__tests__/blockDebuff.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { dotResistLabel, isBlockDebuff } from '../debuffImmunity';
+
+describe('debuffImmunity helpers', () => {
+    describe('isBlockDebuff', () => {
+        it('returns true for "Block Debuff"', () => {
+            expect(isBlockDebuff('Block Debuff')).toBe(true);
+        });
+
+        it('returns false for unrelated buff names', () => {
+            expect(isBlockDebuff('Attack Up I')).toBe(false);
+        });
+    });
+
+    describe('dotResistLabel', () => {
+        it('formats inferno with roman numeral tier', () => {
+            expect(dotResistLabel('inferno', 3)).toBe('Inferno III');
+        });
+
+        it('formats corrosion with roman numeral tier', () => {
+            expect(dotResistLabel('corrosion', 2)).toBe('Corrosion II');
+        });
+
+        it('formats bomb with no tier suffix', () => {
+            expect(dotResistLabel('bomb', 0)).toBe('Bomb');
+        });
+    });
+});

--- a/src/utils/combat/__tests__/blockDebuff.test.ts
+++ b/src/utils/combat/__tests__/blockDebuff.test.ts
@@ -213,6 +213,106 @@ describe('Block Debuff — cast-side timed/persistent landing fold (engine)', ()
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Task 6: Block Debuff — cast-side DoT block + resist event (engine).
+//
+// A DoT-casting attacker (enemy attacker `e1`, speed 10 — acts AFTER the speed-100
+// focus actor so the focus actor's recurring Block Debuff self-buff is already live)
+// inflicts an `Inferno III` DoT at the focus actor (heal target `attacker`). When that
+// target carries `Block Debuff`, the cast-side DoT region must BLOCK the DoT (no entry
+// appended → no `dot-applied`, the DoT never ticks) AND emit a `debuff-resisted` event
+// labelled `Inferno III` (block-path only — a normal landing failure stays silent).
+// We assert via the emitted events AND the per-enemy round-effects surface
+// (`dots` empty, `resistedDots` carries the blocked Inferno).
+// ─────────────────────────────────────────────────────────────────────────────
+
+// An enemy attacker casting a basic attack + an Inferno III DoT. `hacking` omitted →
+// defaults to 200 → 100% landing, so the ONLY thing that can block the DoT is the
+// Block Debuff immunity branch.
+const infernoIIIEnemy = (): EnemyAttacker =>
+    ({
+        id: 'e1',
+        stats: { attack: 1000, crit: 0, critDamage: 0, speed: 10 },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        enemyAb({ type: 'damage', config: { type: 'damage', multiplier: 100 } }),
+                        enemyAb({
+                            type: 'dot',
+                            config: {
+                                type: 'dot',
+                                dotType: 'inferno',
+                                tier: 3,
+                                stacks: 2,
+                                duration: 3,
+                            },
+                        }),
+                    ],
+                },
+            ],
+        } as ShipSkills,
+    }) as EnemyAttacker;
+
+const runDotWith = (focusSkills: ShipSkills, bus?: ReturnType<typeof createEventBus>) =>
+    runCombat(
+        blockDebuffEngineBase({
+            numRounds: 3,
+            enemyAttackers: [infernoIIIEnemy()],
+            shipSkills: focusSkills,
+            ...(bus ? { bus } : {}),
+        })
+    );
+
+describe('Block Debuff — cast-side DoT block + resist event (engine)', () => {
+    it('immune target BLOCKS an inflicted DoT: no dot-applied, resisted Inferno III event + resistedDots', () => {
+        const bus = createEventBus();
+        const events: CombatEvent[] = [];
+        bus.on('dot-applied', (e) => events.push(e as CombatEvent));
+        bus.on('debuff-resisted', (e) => events.push(e as CombatEvent));
+
+        const result = runDotWith(blockDebuffSelfSkills(), bus);
+
+        // No DoT was applied — the block path never appends an entry.
+        expect(events.some((e) => e.type === 'dot-applied')).toBe(false);
+        // A debuff-resisted event fired, labelled with the blocked DoT's name.
+        const resisted = events.filter((e) => e.type === 'debuff-resisted');
+        expect(resisted.length).toBeGreaterThan(0);
+        expect(
+            resisted.map((e) => (e.type === 'debuff-resisted' ? e.buffName : '')).filter(Boolean)
+        ).toContain('Inferno III');
+
+        // Round-effects surface: the enemy's DoT is blocked → no landed dots, resistedDots
+        // carries the Inferno entry (symmetric with the timed/persistent resist surface).
+        const entry = e1Effects(result);
+        expect(entry).toBeDefined();
+        expect(entry!.dots).toHaveLength(0);
+        expect(entry!.resistedDots).toEqual([{ type: 'inferno', tier: 3, stacks: 2 }]);
+    });
+
+    it('control: WITHOUT Block Debuff the same DoT lands (dot-applied, NO resist event)', () => {
+        const bus = createEventBus();
+        const events: CombatEvent[] = [];
+        bus.on('dot-applied', (e) => events.push(e as CombatEvent));
+        bus.on('debuff-resisted', (e) => events.push(e as CombatEvent));
+
+        const result = runDotWith({ slots: [] }, bus);
+
+        // The DoT lands normally → dot-applied fires, and the resist event is UNIQUE to the
+        // block path (normal successful casts never emit debuff-resisted for DoTs).
+        expect(events.some((e) => e.type === 'dot-applied')).toBe(true);
+        expect(events.some((e) => e.type === 'debuff-resisted')).toBe(false);
+
+        const entry = e1Effects(result);
+        expect(entry).toBeDefined();
+        expect(entry!.dots.map((d) => d.type)).toContain('inferno');
+        expect(entry!.resistedDots).toHaveLength(0);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Task 5: Block Debuff — reactive timed-debuff fold (executeIntent).
 //
 // The REACTIVE debuff executor (triggers.ts `cfg.type === 'debuff'`) applies a

--- a/src/utils/combat/__tests__/blockDebuff.test.ts
+++ b/src/utils/combat/__tests__/blockDebuff.test.ts
@@ -313,6 +313,61 @@ describe('Block Debuff — cast-side DoT block + resist event (engine)', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Block Debuff — cast-side control block + resist event (engine).
+//
+// A control infliction (cfg.type 'control', e.g. Stasis) emits `control-applied` so
+// reactions (on-stasis-applied) can fire. When the target carries `Block Debuff` the
+// control is a blocked debuff: NO `control-applied` (so reactions do NOT fire) and a
+// `debuff-resisted` labelled with the control effect — symmetric with the timed/DoT block.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const controlEnemy = (): EnemyAttacker =>
+    debuffEnemy(enemyAb({ type: 'control', config: { type: 'control', effect: 'stasis' } }));
+
+const runControlWith = (focusSkills: ShipSkills, bus: ReturnType<typeof createEventBus>) =>
+    runCombat(
+        blockDebuffEngineBase({
+            numRounds: 3,
+            enemyAttackers: [controlEnemy()],
+            shipSkills: focusSkills,
+            bus,
+        })
+    );
+
+describe('Block Debuff — cast-side control block + resist event (engine)', () => {
+    it('immune target BLOCKS a control infliction: no control-applied, resisted Stasis event', () => {
+        const bus = createEventBus();
+        const events: CombatEvent[] = [];
+        bus.on('control-applied', (e) => events.push(e as CombatEvent));
+        bus.on('debuff-resisted', (e) => events.push(e as CombatEvent));
+
+        runControlWith(blockDebuffSelfSkills(), bus);
+
+        // The control was blocked → on-stasis-applied reactions never get the signal.
+        expect(events.some((e) => e.type === 'control-applied')).toBe(false);
+        // A debuff-resisted event fired, labelled with the blocked control effect.
+        const resisted = events.filter((e) => e.type === 'debuff-resisted');
+        expect(
+            resisted.map((e) => (e.type === 'debuff-resisted' ? e.buffName : '')).filter(Boolean)
+        ).toContain('Stasis');
+    });
+
+    it('control: WITHOUT Block Debuff the control fires (control-applied, NO resist) — non-vacuity', () => {
+        const bus = createEventBus();
+        const events: CombatEvent[] = [];
+        bus.on('control-applied', (e) => events.push(e as CombatEvent));
+        bus.on('debuff-resisted', (e) => events.push(e as CombatEvent));
+
+        runControlWith({ slots: [] }, bus);
+
+        // The control lands normally → control-applied fires; the resist event is UNIQUE to
+        // the block path (a normal control cast never emits debuff-resisted).
+        expect(events.some((e) => e.type === 'control-applied')).toBe(true);
+        expect(events.some((e) => e.type === 'debuff-resisted')).toBe(false);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Task 5: Block Debuff — reactive timed-debuff fold (executeIntent).
 //
 // The REACTIVE debuff executor (triggers.ts `cfg.type === 'debuff'`) applies a
@@ -643,9 +698,7 @@ describe('Block Debuff — integration (engine)', () => {
     });
 
     it('auto-resists an inflicted Disable (named control debuff): resisted, NOT applied', () => {
-        const entry = e1Effects(
-            runWith(namedControlDebuff('Disable'), blockDebuffSelfSkills())
-        );
+        const entry = e1Effects(runWith(namedControlDebuff('Disable'), blockDebuffSelfSkills()));
         expect(entry).toBeDefined();
         expect(entry!.resistedDebuffs.map((d) => d.buffName)).toContain('Disable');
         expect(entry!.debuffs.map((d) => d.buffName)).not.toContain('Disable');

--- a/src/utils/combat/__tests__/blockDebuff.test.ts
+++ b/src/utils/combat/__tests__/blockDebuff.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { dotResistLabel, isBlockDebuff } from '../debuffImmunity';
 import { runCombat, CombatEngineInput } from '../engine';
 import { ShipSkills, Ability } from '../../../types/abilities';
+import { executeIntent, Intent, IntentExecContext } from '../triggers';
+import { createEventBus, CombatEvent } from '../events';
+import { createStatusEngine } from '../statusEngine';
+import type { RegisteredAbilityStatus, ActiveBuff } from '../statusEngine';
+import type { PlayerActorRuntime } from '../playerTurn';
+import type { CombatActor } from '../state';
 
 describe('debuffImmunity helpers', () => {
     describe('isBlockDebuff', () => {
@@ -203,5 +209,132 @@ describe('Block Debuff — cast-side timed/persistent landing fold (engine)', ()
         expect(entry).toBeDefined();
         expect(entry!.debuffs.map((d) => d.buffName)).toContain('Defense Shred');
         expect(entry!.resistedDebuffs).toHaveLength(0);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 5: Block Debuff — reactive timed-debuff fold (executeIntent).
+//
+// The REACTIVE debuff executor (triggers.ts `cfg.type === 'debuff'`) applies a
+// timed debuff to a target on a triggered event (on-attacked / on-crit, etc).
+// When that target carries `Block Debuff`, the immunity fold must route the
+// application into the EXISTING resist branch: the debuff is NOT applied to the
+// target store, `recordResisted` is called, and a `debuff-resisted` event is
+// emitted. We drive the executor directly (a full runCombat reactive setup is
+// heavy) and seed `Block Debuff` onto the counter target's self-buff store via
+// a timed self-status — exactly the read `targetCarriesBlockDebuff` performs.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Block Debuff — reactive timed-debuff fold (engine)', () => {
+    const makeRuntime = (): PlayerActorRuntime =>
+        ({
+            actor: { id: 'attacker' } as CombatActor,
+            // Always lands → the ONLY thing that can resist is the Block Debuff fold.
+            landsTimedEnemyApplication: () => true,
+            debuffLandingGate: (_rate: number) => true,
+        }) as unknown as PlayerActorRuntime;
+
+    // A reactive (on-attacked) timed debuff inflicted at a chosen counter target.
+    const makeReactiveDebuffIntent = (counterTargetId?: string): Intent => ({
+        ownerId: 'attacker',
+        sourceSlot: 'passive',
+        ability: {
+            id: 'reactive-debuff',
+            type: 'debuff',
+            target: 'enemy',
+            trigger: 'on-attacked',
+            conditions: [],
+            config: {
+                type: 'debuff',
+                buffName: 'Attack Down II',
+                stacks: 1,
+                parsedEffects: { attack: -50 },
+                isStackable: false,
+                application: 'inflict',
+                duration: 3,
+            },
+        },
+        ...(counterTargetId !== undefined ? { eventCtx: { counterTargetId } } : {}),
+    });
+
+    // Seed a `Block Debuff` self-buff onto `targetId`'s store (the read
+    // `targetCarriesBlockDebuff` performs: a timed self-status on that owner).
+    const seedBlockDebuff = (
+        statusEngine: ReturnType<typeof createStatusEngine>,
+        round: number,
+        targetId: string
+    ): void => {
+        const status: Extract<RegisteredAbilityStatus, { kind: 'timed' }> = {
+            payload: { buffName: 'Block Debuff', stacks: 1, parsedEffects: {} },
+            side: 'self',
+            sourceSlot: 'passive',
+            conditions: [],
+            casterId: targetId,
+            recipients: [targetId],
+            kind: 'timed',
+            duration: 5,
+        };
+        statusEngine.applyTimedAbilityStatus(round, status, targetId);
+    };
+
+    const buildCtx = (
+        immuneTargetId?: string
+    ): { ctx: IntentExecContext; resisted: ActiveBuff[] } => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        se.beginRound(1);
+        if (immuneTargetId) seedBlockDebuff(se, 1, immuneTargetId);
+        const resisted: ActiveBuff[] = [];
+        const ctx: IntentExecContext = {
+            round: 1,
+            enemy: { id: 'enemy-default' } as CombatActor,
+            enemyId: 'enemy-default',
+            statusEngine: se,
+            bus: createEventBus(),
+            corrosionEntries: [],
+            infernoEntries: [],
+            pendingBombs: [],
+            runtimes: new Map([['attacker', makeRuntime()]]),
+            grantAllyCharges: () => {},
+            grantExtraAction: () => {},
+            playerIds: ['attacker'],
+            lastTurnCtxByActor: new Map(),
+            enemyHp: 100000,
+            cumulativeDamage: 0,
+            recordResisted: (r: ActiveBuff) => resisted.push(r),
+        } as unknown as IntentExecContext;
+        return { ctx, resisted };
+    };
+
+    it('immune counter target auto-resists a reactive TIMED debuff: not applied, resisted + event', () => {
+        const { ctx, resisted } = buildCtx('enemy-1');
+        const events: CombatEvent[] = [];
+        ctx.bus.on('debuff-resisted', (e) => events.push(e as CombatEvent));
+        ctx.bus.on('debuff-applied', (e) => events.push(e as CombatEvent));
+
+        executeIntent(makeReactiveDebuffIntent('enemy-1'), ctx);
+
+        // NOT applied to the immune target's store.
+        const timedEnemy1 = ctx.statusEngine.timedAbilityStatuses('enemy', undefined, 'enemy-1');
+        expect(timedEnemy1.some((s) => s.active.buffName === 'Attack Down II')).toBe(false);
+        // Recorded as a resist.
+        expect(resisted.map((r) => r.buffName)).toContain('Attack Down II');
+        // A debuff-resisted event fired; no debuff-applied event.
+        expect(events.some((e) => e.type === 'debuff-resisted')).toBe(true);
+        expect(events.some((e) => e.type === 'debuff-applied')).toBe(false);
+    });
+
+    it('control: WITHOUT Block Debuff the same reactive TIMED debuff lands (non-vacuity)', () => {
+        const { ctx, resisted } = buildCtx(); // no immunity seeded
+        const events: CombatEvent[] = [];
+        ctx.bus.on('debuff-resisted', (e) => events.push(e as CombatEvent));
+        ctx.bus.on('debuff-applied', (e) => events.push(e as CombatEvent));
+
+        executeIntent(makeReactiveDebuffIntent('enemy-1'), ctx);
+
+        const timedEnemy1 = ctx.statusEngine.timedAbilityStatuses('enemy', undefined, 'enemy-1');
+        expect(timedEnemy1.some((s) => s.active.buffName === 'Attack Down II')).toBe(true);
+        expect(resisted).toHaveLength(0);
+        expect(events.some((e) => e.type === 'debuff-applied')).toBe(true);
+        expect(events.some((e) => e.type === 'debuff-resisted')).toBe(false);
     });
 });

--- a/src/utils/combat/__tests__/blockDebuff.test.ts
+++ b/src/utils/combat/__tests__/blockDebuff.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { dotResistLabel, isBlockDebuff } from '../debuffImmunity';
+import { runCombat, CombatEngineInput } from '../engine';
+import { ShipSkills, Ability } from '../../../types/abilities';
 
 describe('debuffImmunity helpers', () => {
     describe('isBlockDebuff', () => {
@@ -24,5 +26,182 @@ describe('debuffImmunity helpers', () => {
         it('formats bomb with no tier suffix', () => {
             expect(dotResistLabel('bomb', 0)).toBe('Bomb');
         });
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 4: Block Debuff — cast-side timed + persistent landing fold.
+//
+// A target carrying `Block Debuff` auto-resists EVERY incoming timed and
+// persistent-stacking debuff. We drive the engine via `runCombat` with an enemy
+// attacker (the opposing caster) inflicting a TIMED debuff (`Attack Down II`) and a
+// PERSISTENT-STACKING debuff (`Defense Shred`) at the heal target. The heal target —
+// the focus actor `attacker` — carries `Block Debuff` (a recurring self-buff), so
+// when the enemy casts, the turn target is immune. The fold returns `false` from the
+// landing decision → the existing resist plumbing records the resist: the debuff
+// surfaces in that enemy's `resistedDebuffs` (display) and NOT in `debuffs`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+let idCounter = 0;
+
+const blockDebuffEngineBase = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 5000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [] },
+    enemyDefense: 0,
+    enemyHp: 10_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000,
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+const enemyAb = (partial: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `bdka${++idCounter}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...partial,
+});
+
+/**
+ * An enemy attacker (speed 10 — acts AFTER the speed-100 focus actor each round, so the
+ * focus actor's Block Debuff self-buff is already active when this enemy casts) whose kit
+ * inflicts a basic attack + ONE timed/persistent debuff at the heal target. `hacking`
+ * omitted → defaults to 200 → 100% landing (so the ONLY thing that can resist is the
+ * Block Debuff immunity fold).
+ */
+const debuffEnemy = (debuff: Ability): EnemyAttacker =>
+    ({
+        id: 'e1',
+        stats: { attack: 1000, crit: 0, critDamage: 0, speed: 10 },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        enemyAb({ type: 'damage', config: { type: 'damage', multiplier: 100 } }),
+                        debuff,
+                    ],
+                },
+            ],
+        } as ShipSkills,
+    }) as EnemyAttacker;
+
+/** Focus actor (heal target) shipSkills granting a recurring `Block Debuff` self-buff. */
+const blockDebuffSelfSkills = (): ShipSkills => ({
+    slots: [
+        {
+            slot: 'passive',
+            abilities: [
+                {
+                    id: 'block-debuff-self',
+                    type: 'buff',
+                    target: 'self',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config: {
+                        type: 'buff',
+                        buffName: 'Block Debuff',
+                        stacks: 1,
+                        isStackable: false,
+                        duration: 'recurring',
+                        parsedEffects: {},
+                    },
+                },
+            ],
+        },
+    ],
+});
+
+const runWith = (debuff: Ability, focusSkills: ShipSkills) =>
+    runCombat(
+        blockDebuffEngineBase({
+            enemyAttackers: [debuffEnemy(debuff)],
+            shipSkills: focusSkills,
+        })
+    );
+
+const e1Effects = (result: ReturnType<typeof runCombat>) =>
+    result.healing?.rounds?.[0]?.enemyEffects.find((e) => e.enemyId === 'e1');
+
+const timedAttackDown: Ability = {
+    id: 'ad2',
+    type: 'debuff',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: {
+        type: 'debuff',
+        buffName: 'Attack Down II',
+        parsedEffects: { attack: -50 },
+        stacks: 1,
+        isStackable: false,
+        application: 'inflict',
+        duration: 3,
+    },
+};
+
+const persistentDefenseShred: Ability = {
+    id: 'dshred',
+    type: 'debuff',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: {
+        type: 'debuff',
+        buffName: 'Defense Shred',
+        parsedEffects: { defense: -2 },
+        stacks: 1,
+        isStackable: true,
+        application: 'inflict',
+        duration: 3,
+    },
+};
+
+describe('Block Debuff — cast-side timed/persistent landing fold (engine)', () => {
+    it('immune target auto-resists a TIMED debuff: it is in resistedDebuffs, NOT debuffs', () => {
+        const entry = e1Effects(runWith(timedAttackDown, blockDebuffSelfSkills()));
+        expect(entry).toBeDefined();
+        expect(entry!.resistedDebuffs.map((d) => d.buffName)).toContain('Attack Down II');
+        expect(entry!.debuffs.map((d) => d.buffName)).not.toContain('Attack Down II');
+    });
+
+    it('control: WITHOUT Block Debuff the same TIMED debuff lands (non-vacuity)', () => {
+        const entry = e1Effects(runWith(timedAttackDown, { slots: [] }));
+        expect(entry).toBeDefined();
+        expect(entry!.debuffs.map((d) => d.buffName)).toContain('Attack Down II');
+        expect(entry!.resistedDebuffs).toHaveLength(0);
+    });
+
+    it('immune target auto-resists a PERSISTENT-STACKING debuff: resisted, no stack added', () => {
+        const entry = e1Effects(runWith(persistentDefenseShred, blockDebuffSelfSkills()));
+        expect(entry).toBeDefined();
+        expect(entry!.resistedDebuffs.map((d) => d.buffName)).toContain('Defense Shred');
+        expect(entry!.debuffs.map((d) => d.buffName)).not.toContain('Defense Shred');
+    });
+
+    it('control: WITHOUT Block Debuff the same PERSISTENT-STACKING debuff lands (non-vacuity)', () => {
+        const entry = e1Effects(runWith(persistentDefenseShred, { slots: [] }));
+        expect(entry).toBeDefined();
+        expect(entry!.debuffs.map((d) => d.buffName)).toContain('Defense Shred');
+        expect(entry!.resistedDebuffs).toHaveLength(0);
     });
 });

--- a/src/utils/combat/__tests__/blockDebuff.test.ts
+++ b/src/utils/combat/__tests__/blockDebuff.test.ts
@@ -438,3 +438,121 @@ describe('Block Debuff — reactive timed-debuff fold (engine)', () => {
         expect(events.some((e) => e.type === 'debuff-resisted')).toBe(false);
     });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 7: Block Debuff — reactive DoT block + resist event (executeIntent).
+//
+// The REACTIVE DoT executor (triggers.ts `cfg.type === 'dot'`) appends a DoT to
+// the reactive target (`ctx.enemy.id`) on a triggered event, gated by a landing
+// roll that is SILENT on failure. When that target carries `Block Debuff`, the
+// immunity check must BLOCK the DoT (no entry appended → no `dot-applied`) AND
+// emit a `debuff-resisted` event labelled with the blocked DoT (`Inferno III`) —
+// block-path ONLY. Normal landing failures stay silent (byte-identical). We drive
+// the executor directly, reusing the Task 5 harness, with the reactive DoT firing
+// at `ctx.enemy.id` (`enemy-default`).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Block Debuff — reactive DoT block + resist event (engine)', () => {
+    const makeRuntime = (): PlayerActorRuntime =>
+        ({
+            actor: { id: 'attacker' } as CombatActor,
+            // Always lands → the ONLY thing that can block the DoT is the Block Debuff branch.
+            landsTimedEnemyApplication: () => true,
+            debuffLandingGate: (_rate: number) => true,
+            liveDebuffLandingChance: 1,
+        }) as unknown as PlayerActorRuntime;
+
+    // A reactive (on-attacked) Inferno III DoT inflicted at the reactive target (ctx.enemy.id).
+    const makeReactiveDotIntent = (): Intent => ({
+        ownerId: 'attacker',
+        sourceSlot: 'passive',
+        ability: {
+            id: 'reactive-dot',
+            type: 'dot',
+            target: 'enemy',
+            trigger: 'on-attacked',
+            conditions: [],
+            config: {
+                type: 'dot',
+                dotType: 'inferno',
+                tier: 3,
+                stacks: 2,
+                duration: 3,
+            },
+        },
+    });
+
+    const seedBlockDebuff = (
+        statusEngine: ReturnType<typeof createStatusEngine>,
+        round: number,
+        targetId: string
+    ): void => {
+        const status: Extract<RegisteredAbilityStatus, { kind: 'timed' }> = {
+            payload: { buffName: 'Block Debuff', stacks: 1, parsedEffects: {} },
+            side: 'self',
+            sourceSlot: 'passive',
+            conditions: [],
+            casterId: targetId,
+            recipients: [targetId],
+            kind: 'timed',
+            duration: 5,
+        };
+        statusEngine.applyTimedAbilityStatus(round, status, targetId);
+    };
+
+    const buildCtx = (immuneTargetId?: string): IntentExecContext => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        se.beginRound(1);
+        if (immuneTargetId) seedBlockDebuff(se, 1, immuneTargetId);
+        return {
+            round: 1,
+            enemy: { id: 'enemy-default' } as CombatActor,
+            enemyId: 'enemy-default',
+            statusEngine: se,
+            bus: createEventBus(),
+            corrosionEntries: [],
+            infernoEntries: [],
+            pendingBombs: [],
+            runtimes: new Map([['attacker', makeRuntime()]]),
+            grantAllyCharges: () => {},
+            grantExtraAction: () => {},
+            playerIds: ['attacker'],
+            lastTurnCtxByActor: new Map(),
+            enemyHp: 100000,
+            cumulativeDamage: 0,
+            recordResisted: () => {},
+        } as unknown as IntentExecContext;
+    };
+
+    it('immune target BLOCKS a reactive DoT: no dot-applied, resisted Inferno III event, no entry', () => {
+        const ctx = buildCtx('enemy-default');
+        const events: CombatEvent[] = [];
+        ctx.bus.on('dot-applied', (e) => events.push(e as CombatEvent));
+        ctx.bus.on('debuff-resisted', (e) => events.push(e as CombatEvent));
+
+        executeIntent(makeReactiveDotIntent(), ctx);
+
+        // No DoT entry appended → no dot-applied event.
+        expect(ctx.infernoEntries).toHaveLength(0);
+        expect(events.some((e) => e.type === 'dot-applied')).toBe(false);
+        // A debuff-resisted event fired, labelled with the blocked DoT's name.
+        const resisted = events.filter((e) => e.type === 'debuff-resisted');
+        expect(resisted.length).toBeGreaterThan(0);
+        expect(
+            resisted.map((e) => (e.type === 'debuff-resisted' ? e.buffName : '')).filter(Boolean)
+        ).toContain('Inferno III');
+    });
+
+    it('control: WITHOUT Block Debuff the same reactive DoT lands (dot-applied, NO resist event)', () => {
+        const ctx = buildCtx(); // no immunity seeded
+        const events: CombatEvent[] = [];
+        ctx.bus.on('dot-applied', (e) => events.push(e as CombatEvent));
+        ctx.bus.on('debuff-resisted', (e) => events.push(e as CombatEvent));
+
+        executeIntent(makeReactiveDotIntent(), ctx);
+
+        expect(ctx.infernoEntries).toHaveLength(1);
+        expect(events.some((e) => e.type === 'dot-applied')).toBe(true);
+        expect(events.some((e) => e.type === 'debuff-resisted')).toBe(false);
+    });
+});

--- a/src/utils/combat/__tests__/blockDebuff.test.ts
+++ b/src/utils/combat/__tests__/blockDebuff.test.ts
@@ -556,3 +556,250 @@ describe('Block Debuff — reactive DoT block + resist event (engine)', () => {
         expect(events.some((e) => e.type === 'debuff-resisted')).toBe(false);
     });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 8: Block Debuff — end-to-end integration coverage.
+//
+// The per-family seams (timed/persistent/DoT × cast/reactive) are each unit-tested
+// above (Tasks 4-7). This block covers the cross-cutting cases those seams do not
+// individually assert end-to-end:
+//
+//   1. Control-as-named-debuff: a control inflict (Stasis / Disable) reaches the
+//      engine as an ordinary NAMED timed debuff routed through the same timed
+//      landing fold as `Attack Down II`. So a `Block Debuff` target must auto-resist
+//      it — the target never becomes stasised/disabled. We assert end-to-end via
+//      the enemy round-effects surface AND the engine-local `isStasised` reader tap.
+//   2. Already-landed debuffs survive: Block Debuff only gates NEW applications. A
+//      debuff that landed on a target BEFORE the target gained Block Debuff stays
+//      present and decrements/expires on its normal cadence — the immunity never
+//      retroactively removes it. Staged at the statusEngine level (a real "before"
+//      landed status + a "now" immune target, then a fresh inflict attempt).
+//   3. Immunity beats landing: an attacker with a very high landing chance (would
+//      otherwise definitely land) is still resisted by a Block Debuff target — the
+//      immunity fold short-circuits the landing roll entirely.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Block Debuff — integration (engine)', () => {
+    const namedControlDebuff = (buffName: string): Ability => ({
+        id: `ctrl-${buffName.toLowerCase()}`,
+        type: 'debuff',
+        target: 'enemy',
+        trigger: 'on-cast',
+        conditions: [],
+        config: {
+            type: 'debuff',
+            buffName,
+            // Control inflicts carry no stat effects — they are pure named debuffs
+            // routed through the timed landing path (mirrors stasis.test.ts).
+            parsedEffects: {},
+            stacks: 1,
+            isStackable: false,
+            application: 'inflict',
+            duration: 3,
+        },
+    });
+
+    // (1) Control-as-named-debuff blocked: Stasis & Disable are auto-resisted on a
+    //     Block Debuff target — the target never enters the control state.
+    it('auto-resists an inflicted Stasis: resisted, NOT applied, target never becomes stasised', () => {
+        let isStasisedReader: ((actorId: string) => boolean) | undefined;
+        const result = runCombat(
+            blockDebuffEngineBase({
+                enemyAttackers: [debuffEnemy(namedControlDebuff('Stasis'))],
+                shipSkills: blockDebuffSelfSkills(),
+                __testTapIsStasised: (fn) => {
+                    isStasisedReader = fn;
+                },
+            })
+        );
+
+        const entry = e1Effects(result);
+        expect(entry).toBeDefined();
+        expect(entry!.resistedDebuffs.map((d) => d.buffName)).toContain('Stasis');
+        expect(entry!.debuffs.map((d) => d.buffName)).not.toContain('Stasis');
+        // Behavioral proof: the heal target (the Block Debuff carrier) never enters Stasis.
+        expect(isStasisedReader).toBeDefined();
+        expect(isStasisedReader!('attacker')).toBe(false);
+    });
+
+    it('control: WITHOUT Block Debuff the inflicted Stasis lands and stasises the target (non-vacuity)', () => {
+        let isStasisedReader: ((actorId: string) => boolean) | undefined;
+        const result = runCombat(
+            blockDebuffEngineBase({
+                enemyAttackers: [debuffEnemy(namedControlDebuff('Stasis'))],
+                shipSkills: { slots: [] },
+                __testTapIsStasised: (fn) => {
+                    isStasisedReader = fn;
+                },
+            })
+        );
+
+        const entry = e1Effects(result);
+        expect(entry).toBeDefined();
+        expect(entry!.debuffs.map((d) => d.buffName)).toContain('Stasis');
+        expect(entry!.resistedDebuffs).toHaveLength(0);
+        expect(isStasisedReader).toBeDefined();
+        expect(isStasisedReader!('attacker')).toBe(true);
+    });
+
+    it('auto-resists an inflicted Disable (named control debuff): resisted, NOT applied', () => {
+        const entry = e1Effects(
+            runWith(namedControlDebuff('Disable'), blockDebuffSelfSkills())
+        );
+        expect(entry).toBeDefined();
+        expect(entry!.resistedDebuffs.map((d) => d.buffName)).toContain('Disable');
+        expect(entry!.debuffs.map((d) => d.buffName)).not.toContain('Disable');
+    });
+
+    // (2) Already-landed debuff survives the target later becoming immune.
+    //     Staged at the statusEngine level: apply Attack Down II to enemy-1 while it is
+    //     NOT immune (round 1), THEN seed Block Debuff on enemy-1, THEN fire a fresh
+    //     reactive inflict. The pre-existing debuff must remain and decrement normally;
+    //     only the NEW inflict is blocked.
+    it('already-landed debuff survives when the target later gains Block Debuff (and ticks down normally)', () => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        se.beginRound(1);
+
+        // "Before": Attack Down II lands on enemy-1 (no immunity yet), 2-turn duration.
+        const landed: Extract<RegisteredAbilityStatus, { kind: 'timed' }> = {
+            payload: { buffName: 'Attack Down II', stacks: 1, parsedEffects: { attack: -50 } },
+            side: 'enemy',
+            sourceSlot: 'active',
+            conditions: [],
+            casterId: 'attacker',
+            recipients: ['enemy-1'],
+            kind: 'timed',
+            duration: 2,
+        };
+        se.applyTimedAbilityStatus(1, landed, undefined, 'enemy-1');
+        expect(
+            se
+                .timedAbilityStatuses('enemy', undefined, 'enemy-1')
+                .some((s) => s.active.buffName === 'Attack Down II')
+        ).toBe(true);
+
+        // "Now": enemy-1 gains Block Debuff (self-buff on its own store).
+        const block: Extract<RegisteredAbilityStatus, { kind: 'timed' }> = {
+            payload: { buffName: 'Block Debuff', stacks: 1, parsedEffects: {} },
+            side: 'self',
+            sourceSlot: 'passive',
+            conditions: [],
+            casterId: 'enemy-1',
+            recipients: ['enemy-1'],
+            kind: 'timed',
+            duration: 5,
+        };
+        se.applyTimedAbilityStatus(1, block, 'enemy-1');
+
+        // A fresh inflict attempt against the now-immune enemy-1 is resisted...
+        const resisted: ActiveBuff[] = [];
+        const ctx: IntentExecContext = {
+            round: 1,
+            enemy: { id: 'enemy-1' } as CombatActor,
+            enemyId: 'enemy-1',
+            statusEngine: se,
+            bus: createEventBus(),
+            corrosionEntries: [],
+            infernoEntries: [],
+            pendingBombs: [],
+            runtimes: new Map([
+                [
+                    'attacker',
+                    {
+                        actor: { id: 'attacker' } as CombatActor,
+                        landsTimedEnemyApplication: () => true,
+                        debuffLandingGate: () => true,
+                    } as unknown as PlayerActorRuntime,
+                ],
+            ]),
+            grantAllyCharges: () => {},
+            grantExtraAction: () => {},
+            playerIds: ['attacker'],
+            lastTurnCtxByActor: new Map(),
+            enemyHp: 100000,
+            cumulativeDamage: 0,
+            recordResisted: (r: ActiveBuff) => resisted.push(r),
+        } as unknown as IntentExecContext;
+
+        const freshInflict: Intent = {
+            ownerId: 'attacker',
+            sourceSlot: 'passive',
+            ability: {
+                id: 'fresh-debuff',
+                type: 'debuff',
+                target: 'enemy',
+                trigger: 'on-attacked',
+                conditions: [],
+                config: {
+                    type: 'debuff',
+                    buffName: 'Defense Down',
+                    stacks: 1,
+                    parsedEffects: { defense: -30 },
+                    isStackable: false,
+                    application: 'inflict',
+                    duration: 3,
+                },
+            },
+            eventCtx: { counterTargetId: 'enemy-1' },
+        };
+        executeIntent(freshInflict, ctx);
+
+        // ...the NEW debuff is blocked...
+        expect(resisted.map((r) => r.buffName)).toContain('Defense Down');
+        const afterInflict = se.timedAbilityStatuses('enemy', undefined, 'enemy-1');
+        expect(afterInflict.some((s) => s.active.buffName === 'Defense Down')).toBe(false);
+        // ...but the ALREADY-LANDED debuff is untouched.
+        expect(afterInflict.some((s) => s.active.buffName === 'Attack Down II')).toBe(true);
+
+        // And it ticks down normally: decrement round 1 (1 turn left), round 2 → expires.
+        se.decrementEnemy('enemy-1');
+        expect(
+            se
+                .timedAbilityStatuses('enemy', undefined, 'enemy-1')
+                .some((s) => s.active.buffName === 'Attack Down II')
+        ).toBe(true);
+        se.beginRound(2);
+        se.decrementEnemy('enemy-1');
+        expect(
+            se
+                .timedAbilityStatuses('enemy', undefined, 'enemy-1')
+                .some((s) => s.active.buffName === 'Attack Down II')
+        ).toBe(false);
+    });
+
+    // (3) Immunity beats landing: even a guaranteed-landing attacker is resisted.
+    it('a high-landing-chance attacker is still resisted by a Block Debuff target', () => {
+        // Same Task 4 timed debuff, but the enemy attacker is given a very high base
+        // hacking so its live landing chance is maximal — the ONLY thing that resists
+        // is the Block Debuff immunity fold.
+        const highHackingEnemy: EnemyAttacker = {
+            ...debuffEnemy(timedAttackDown),
+            stats: { attack: 1000, crit: 0, critDamage: 0, speed: 10, hacking: 5000 },
+        } as EnemyAttacker;
+
+        const immune = e1Effects(
+            runCombat(
+                blockDebuffEngineBase({
+                    enemyAttackers: [highHackingEnemy],
+                    shipSkills: blockDebuffSelfSkills(),
+                })
+            )
+        );
+        expect(immune).toBeDefined();
+        expect(immune!.resistedDebuffs.map((d) => d.buffName)).toContain('Attack Down II');
+        expect(immune!.debuffs.map((d) => d.buffName)).not.toContain('Attack Down II');
+
+        // Non-vacuity: the same high-hacking attacker DOES land on a non-immune target.
+        const landed = e1Effects(
+            runCombat(
+                blockDebuffEngineBase({
+                    enemyAttackers: [highHackingEnemy],
+                    shipSkills: { slots: [] },
+                })
+            )
+        );
+        expect(landed).toBeDefined();
+        expect(landed!.debuffs.map((d) => d.buffName)).toContain('Attack Down II');
+        expect(landed!.resistedDebuffs).toHaveLength(0);
+    });
+});

--- a/src/utils/combat/__tests__/buffProtection.test.ts
+++ b/src/utils/combat/__tests__/buffProtection.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { createStatusEngine, RegisteredAbilityStatus } from '../statusEngine';
+
+// SELF-SIDE (buff) timed status — side: 'self' routes to selfMaps.get(ownerId) via
+// applyTimedAbilityStatus, the exact store purge() reads (removeNewestFirst with 'buffs').
+// Mirrors purgeRemoval.test.ts's mkTimedBuff.
+const mkTimedBuff = (
+    buffName: string,
+    duration = 3
+): Extract<RegisteredAbilityStatus, { kind: 'timed' }> => ({
+    kind: 'timed',
+    side: 'self',
+    sourceSlot: 'active',
+    conditions: [],
+    duration,
+    payload: { buffName, stacks: 1, parsedEffects: {} },
+});
+
+// ENEMY-SIDE (debuff) timed status — side: 'enemy' routes to enemyMaps (the DEBUFF store),
+// the store cleanse() reads. Mirrors cleanseRemoval.test.ts's mkTimed.
+const mkTimedDebuff = (
+    buffName: string,
+    duration = 3
+): Extract<RegisteredAbilityStatus, { kind: 'timed' }> => ({
+    kind: 'timed',
+    side: 'enemy',
+    sourceSlot: 'active',
+    conditions: [],
+    duration,
+    payload: { buffName, stacks: 1, parsedEffects: {} },
+});
+
+describe('statusEngine.purge — Buff Protection holder-state guard', () => {
+    it('purge returns 0 and leaves all buffs when the holder carries Buff Protection', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.beginRound(1);
+        eng.applyTimedAbilityStatus(1, mkTimedBuff('Buff Protection'), 'e1');
+        eng.applyTimedAbilityStatus(1, mkTimedBuff('Attack Up I'), 'e1');
+
+        const removed = eng.purge('e1', 'all');
+        expect(removed).toBe(0);
+
+        const names = eng.timedAbilityStatuses('self', 'e1').map((s) => s.payload.buffName);
+        expect(names).toContain('Buff Protection');
+        expect(names).toContain('Attack Up I');
+    });
+
+    it('control: without Buff Protection, purge removes buffs (returns > 0)', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.beginRound(1);
+        eng.applyTimedAbilityStatus(1, mkTimedBuff('Attack Up I'), 'e1');
+
+        const removed = eng.purge('e1', 'all');
+        expect(removed).toBeGreaterThan(0);
+
+        const names = eng.timedAbilityStatuses('self', 'e1').map((s) => s.payload.buffName);
+        expect(names).not.toContain('Attack Up I');
+    });
+
+    it('cleanse is unaffected by Buff Protection (purge-only scope)', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.beginRound(1);
+        // Holder carries Buff Protection as a self-buff...
+        eng.applyTimedAbilityStatus(1, mkTimedBuff('Buff Protection'), 'e1');
+        // ...and a removable DEBUFF in the enemy store keyed to the same actor id.
+        eng.applyTimedAbilityStatus(1, mkTimedDebuff('Attack Down'), 'attacker', 'e1');
+
+        const removed = eng.cleanse('e1', 'all');
+        expect(removed).toBeGreaterThan(0);
+
+        const debuffNames = eng
+            .timedAbilityStatuses('enemy', 'attacker', 'e1')
+            .map((s) => s.payload.buffName);
+        expect(debuffNames).not.toContain('Attack Down');
+    });
+});

--- a/src/utils/combat/buffProtectionBuffs.ts
+++ b/src/utils/combat/buffProtectionBuffs.ts
@@ -1,0 +1,6 @@
+/** Named buffs that make the holder's buffs UNREMOVABLE BY PURGE for the buff's duration.
+ *  A purge against a Buff-Protection holder removes 0 buffs (the whole purge is blocked).
+ *  Purge-only: cleanse (debuff removal) and buff-steal are unaffected. Holder-state guard,
+ *  NOT a per-buff property (cf. UNREMOVABLE_STATUSES). Extend from game data as identified. */
+export const BUFF_PROTECTION_BUFFS: ReadonlySet<string> = new Set(['Buff Protection']);
+export const isBuffProtection = (name: string): boolean => BUFF_PROTECTION_BUFFS.has(name);

--- a/src/utils/combat/debuffImmunity.ts
+++ b/src/utils/combat/debuffImmunity.ts
@@ -1,0 +1,34 @@
+import type { StatusEngine } from './statusEngine';
+import { selfBuffNamesForOwners } from './triggers';
+import type { CombatEventBus } from './events';
+
+/** Named buffs that make the holder IMMUNE to receiving debuffs. While active, every incoming
+ *  debuff application (timed, persistent-stacking, DoT, control-as-named-debuff) is blocked and
+ *  recorded as a RESIST. Already-landed debuffs are untouched. Extend from game data. */
+export const BLOCK_DEBUFF_BUFFS: ReadonlySet<string> = new Set(['Block Debuff']);
+export const isBlockDebuff = (name: string): boolean => BLOCK_DEBUFF_BUFFS.has(name);
+
+/** True if `targetId` currently carries a Block Debuff buff (reads its self-buff names). */
+export function targetCarriesBlockDebuff(statusEngine: StatusEngine, targetId: string): boolean {
+    return selfBuffNamesForOwners(statusEngine, [targetId]).some(isBlockDebuff);
+}
+
+const ROMAN = ['', 'I', 'II', 'III', 'IV', 'V'];
+/** Single source of truth for the resisted-debuff label of a blocked DoT, so the emit site and
+ *  the test assertion agree. e.g. ('inferno', 3) -> 'Inferno III'; ('bomb', 0) -> 'Bomb'. */
+export function dotResistLabel(dotType: 'corrosion' | 'inferno' | 'bomb', tier: number): string {
+    const kind = dotType.charAt(0).toUpperCase() + dotType.slice(1);
+    const numeral = tier > 0 && tier < ROMAN.length ? ` ${ROMAN[tier]}` : '';
+    return dotType === 'bomb' ? kind : `${kind}${numeral}`;
+}
+
+/** Emit a debuff-resisted event for a Block-Debuff-blocked DoT. Call ONLY on the block path —
+ *  normal DoT landing-roll failures stay silent (byte-identical). */
+export function emitBlockDebuffResist(
+    bus: CombatEventBus,
+    targetId: string,
+    round: number,
+    buffName: string
+): void {
+    bus.emit({ type: 'debuff-resisted', targetId, round, buffName });
+}

--- a/src/utils/combat/debuffImmunity.ts
+++ b/src/utils/combat/debuffImmunity.ts
@@ -1,4 +1,8 @@
 import type { StatusEngine } from './statusEngine';
+// Call-time-safe cycle: triggers imports targetCarriesBlockDebuff from this module and we import
+// selfBuffNamesForOwners back. Both are used only inside function bodies (never at top-level
+// evaluation), so there is no initialization-order hazard.
+// eslint-disable-next-line import/no-cycle
 import { selfBuffNamesForOwners } from './triggers';
 import type { CombatEventBus } from './events';
 

--- a/src/utils/combat/debuffImmunity.ts
+++ b/src/utils/combat/debuffImmunity.ts
@@ -1,3 +1,4 @@
+import type { ControlEffect } from '../../types/abilities';
 import type { StatusEngine } from './statusEngine';
 // Call-time-safe cycle: triggers imports targetCarriesBlockDebuff from this module and we import
 // selfBuffNamesForOwners back. Both are used only inside function bodies (never at top-level
@@ -25,6 +26,18 @@ export function dotResistLabel(dotType: 'corrosion' | 'inferno' | 'bomb', tier: 
     const numeral = tier > 0 && tier < ROMAN.length ? ` ${ROMAN[tier]}` : '';
     return dotType === 'bomb' ? kind : `${kind}${numeral}`;
 }
+
+/** Resisted-debuff label for a blocked control infliction, matching the named-debuff buff names
+ *  used elsewhere (Stasis, Provoke, Concentrate Fire). Keeps the control block path's resist row
+ *  consistent with the timed/DoT block rows. */
+const CONTROL_EFFECT_LABEL: Record<ControlEffect, string> = {
+    provoke: 'Provoke',
+    taunt: 'Taunt',
+    stasis: 'Stasis',
+    overload: 'Overload',
+    'concentrate-fire': 'Concentrate Fire',
+};
+export const controlEffectLabel = (effect: ControlEffect): string => CONTROL_EFFECT_LABEL[effect];
 
 /** Emit a debuff-resisted event for a Block-Debuff-blocked DoT. Call ONLY on the block path —
  *  normal DoT landing-roll failures stay silent (byte-identical). */

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1439,6 +1439,9 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     if (dotsConfig.length > 0 && targetImmuneToDebuffs) {
         dotsLanded = false;
         for (const dot of dotsConfig) {
+            // NOTE: a blocked `bomb` DoT emits the resist event but has NO `resistedDots`
+            // row — the engine's resistedDots derivation filters to corrosion/inferno only
+            // (bombs are display-only elsewhere too). Event-yes/surface-no is intentional.
             emitBlockDebuffResist(bus, enemy.id, r, dotResistLabel(dot.type, dot.tier));
         }
     } else {

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -38,6 +38,7 @@ import { synthesizeResisted } from './shared';
 import { buildActorConditionContext, type ReactiveAbility } from './triggers';
 import type { AttackerDamageScalars } from './victimDamage';
 import { effectiveDamageStatsOf, liveDebuffLandingChance } from './effectiveStats';
+import { targetCarriesBlockDebuff } from './debuffImmunity';
 import { outgoingAmplificationForHit } from './outgoingEffects';
 import { healAmplificationForCast } from './healAmplification';
 // Buff-fold leaf helpers. Imported for in-file use and re-exported to preserve the
@@ -742,13 +743,24 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         enemy,
         affinityDamageModifier
     );
-    // Turn-local landing decision: 'apply' (affinity) lands unless at an affinity disadvantage
-    // (UNCHANGED rule); 'inflict' (and unmarked) draws the runtime's deterministic gate against
-    // the LIVE chance. Replaces the runtime's pre-baked `landsTimedEnemyApplication` so every
-    // 'inflict' draw — the playerTurn timed loop, the status-engine sourceFired hook, and the
-    // reactive (triggers.ts) path — uses the live value uniformly.
+    // Block Debuff: an immune turn-target auto-resists every timed/persistent application.
+    // Computed ONCE per turn (the turn target `enemy` is fixed for this turn) — the immune
+    // short-circuit below is only reached when this is true, which no existing fixture triggers,
+    // so the non-immune path stays byte-identical. Task 6 reuses this for the DoT path.
+    const targetImmuneToDebuffs = targetCarriesBlockDebuff(statusEngine, enemy.id);
+    // Turn-local landing decision: an immune target auto-resists (return false WITHOUT drawing
+    // the gate, so the existing resist branches record it); otherwise 'apply' (affinity) lands
+    // unless at an affinity disadvantage (UNCHANGED rule); 'inflict' (and unmarked) draws the
+    // runtime's deterministic gate against the LIVE chance. Replaces the runtime's pre-baked
+    // `landsTimedEnemyApplication` so every 'inflict' draw — the playerTurn timed loop, the
+    // status-engine sourceFired hook, and the reactive (triggers.ts) path — uses the live value
+    // uniformly.
     const landsTimedEnemyApplicationLive = (application?: 'inflict' | 'apply'): boolean =>
-        application === 'apply' ? !affinityDisadvantage : debuffLandingGate(liveLandingChance);
+        targetImmuneToDebuffs
+            ? false
+            : application === 'apply'
+              ? !affinityDisadvantage
+              : debuffLandingGate(liveLandingChance);
     // Publish the live chance onto the runtime so the REACTIVE (triggers.ts) path — which draws
     // the OWNER's landing gate via owner.debuffLandingGate(owner.liveDebuffLandingChance ?? 1) —
     // uses the same live value. Always set now (the live path is unconditional).

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -38,7 +38,12 @@ import { synthesizeResisted } from './shared';
 import { buildActorConditionContext, type ReactiveAbility } from './triggers';
 import type { AttackerDamageScalars } from './victimDamage';
 import { effectiveDamageStatsOf, liveDebuffLandingChance } from './effectiveStats';
-import { targetCarriesBlockDebuff, emitBlockDebuffResist, dotResistLabel } from './debuffImmunity';
+import {
+    targetCarriesBlockDebuff,
+    emitBlockDebuffResist,
+    dotResistLabel,
+    controlEffectLabel,
+} from './debuffImmunity';
 import { outgoingAmplificationForHit } from './outgoingEffects';
 import { healAmplificationForCast } from './healAmplification';
 // Buff-fold leaf helpers. Imported for in-file use and re-exported to preserve the
@@ -1233,8 +1238,15 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     // (on-stasis-applied) can fire. Emission ONLY — the engine does NOT simulate the control's
     // combat effect (Stasis/Taunt stay unmodelled). An emitted-but-unconsumed event changes
     // nothing, so DPS-mode goldens are unaffected.
+    // Block Debuff (D-PR15): a control infliction is a debuff — when the target is immune, BLOCK
+    // it (no `control-applied`, so on-stasis-applied reactions do NOT fire) and record a resist,
+    // symmetric with the timed/persistent/DoT block paths.
     for (const ctrl of controlAbilitiesFromSkill(gatedSkill)) {
         if (ctrl.config.type === 'control') {
+            if (targetImmuneToDebuffs) {
+                emitBlockDebuffResist(bus, enemy.id, r, controlEffectLabel(ctrl.config.effect));
+                continue;
+            }
             bus.emit({
                 type: 'control-applied',
                 casterId: actor.id,

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -38,7 +38,7 @@ import { synthesizeResisted } from './shared';
 import { buildActorConditionContext, type ReactiveAbility } from './triggers';
 import type { AttackerDamageScalars } from './victimDamage';
 import { effectiveDamageStatsOf, liveDebuffLandingChance } from './effectiveStats';
-import { targetCarriesBlockDebuff } from './debuffImmunity';
+import { targetCarriesBlockDebuff, emitBlockDebuffResist, dotResistLabel } from './debuffImmunity';
 import { outgoingAmplificationForHit } from './outgoingEffects';
 import { healAmplificationForCast } from './healAmplification';
 // Buff-fold leaf helpers. Imported for in-file use and re-exported to preserve the
@@ -1430,57 +1430,70 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     });
 
     // Step 3: Apply new DoT stacks from this round's skill (subject to landing roll).
-    // DoTs gate at application: draw the shared per-round roll only when there are
-    // DoTs to apply this round (memoized — shares the recurring partition's single
-    // draw). With nothing to apply, dotsLanded is vacuously true (no draw taken),
-    // preserving the all-landing fixtures where no-DoT rounds report dotsLanded:true.
-    const dotsLanded = dotsConfig.length > 0 ? roundDebuffLanded() : true;
-    // Capture pre-application lengths so 'inflicted'-scope extensions touch only
-    // the entries this cast adds below (the slice from these indices onward).
-    const corrosionEntriesBefore = corrosionEntries.length;
-    const infernoEntriesBefore = infernoEntries.length;
-    if (dotsLanded) {
-        applyNewDoTs({
-            dotsConfig,
-            effectiveAttack,
-            affinityMult,
-            sourceId: actor.id,
-            corrosionEntries,
-            infernoEntries,
-            pendingBombs,
-            emitDotApplied: (dotType, stacks) =>
-                bus.emit({
-                    type: 'dot-applied',
-                    sourceId: actor.id,
-                    targetId: enemy.id,
-                    round: r,
-                    dotType,
-                    stacks,
-                    ...(critHits > 0 ? { viaCrit: true } : {}),
-                }),
-        });
-    }
+    // Block Debuff (Task 6): when the turn target is immune, every cast-side DoT is
+    // BLOCKED and recorded as a resist — and ONLY here. Normal DoT landing-roll
+    // failures (the else branch) stay SILENT (no event), so the non-immune path is
+    // byte-for-byte unchanged. `dotsLanded` is set false so the downstream display
+    // surfaces the blocked DoTs as resisted (symmetric with timed/persistent resists).
+    let dotsLanded: boolean;
+    if (dotsConfig.length > 0 && targetImmuneToDebuffs) {
+        dotsLanded = false;
+        for (const dot of dotsConfig) {
+            emitBlockDebuffResist(bus, enemy.id, r, dotResistLabel(dot.type, dot.tier));
+        }
+    } else {
+        // DoTs gate at application: draw the shared per-round roll only when there are
+        // DoTs to apply this round (memoized — shares the recurring partition's single
+        // draw). With nothing to apply, dotsLanded is vacuously true (no draw taken),
+        // preserving the all-landing fixtures where no-DoT rounds report dotsLanded:true.
+        dotsLanded = dotsConfig.length > 0 ? roundDebuffLanded() : true;
+        // Capture pre-application lengths so 'inflicted'-scope extensions touch only
+        // the entries this cast adds below (the slice from these indices onward).
+        const corrosionEntriesBefore = corrosionEntries.length;
+        const infernoEntriesBefore = infernoEntries.length;
+        if (dotsLanded) {
+            applyNewDoTs({
+                dotsConfig,
+                effectiveAttack,
+                affinityMult,
+                sourceId: actor.id,
+                corrosionEntries,
+                infernoEntries,
+                pendingBombs,
+                emitDotApplied: (dotType, stacks) =>
+                    bus.emit({
+                        type: 'dot-applied',
+                        sourceId: actor.id,
+                        targetId: enemy.id,
+                        round: r,
+                        dotType,
+                        stacks,
+                        ...(critHits > 0 ? { viaCrit: true } : {}),
+                    }),
+            });
+        }
 
-    // Step 3a: 'inflicted'-scope extensions grow ONLY this cast's new DoTs
-    // (Valerian). Sourced from the same firing+passive ability set as Step 2.9.
-    // Guarded by dotsLanded (like applyNewDoTs/applyAccumulators): when the
-    // landing roll failed nothing was appended, and skipping the call keeps
-    // the deterministic extendChanceGate schedule free of phantom draws.
-    if (dotsLanded) {
-        extendInflictedDoTs({
-            abilities: [...(firingSkill?.abilities ?? []), ...(passiveSkill?.abilities ?? [])],
-            ctx,
-            effectiveCritDamage,
-            extendChanceGate,
-            corrosionEntries,
-            infernoEntries,
-            corrosionEntriesBefore,
-            infernoEntriesBefore,
-        });
-    }
+        // Step 3a: 'inflicted'-scope extensions grow ONLY this cast's new DoTs
+        // (Valerian). Sourced from the same firing+passive ability set as Step 2.9.
+        // Guarded by dotsLanded (like applyNewDoTs/applyAccumulators): when the
+        // landing roll failed nothing was appended, and skipping the call keeps
+        // the deterministic extendChanceGate schedule free of phantom draws.
+        if (dotsLanded) {
+            extendInflictedDoTs({
+                abilities: [...(firingSkill?.abilities ?? []), ...(passiveSkill?.abilities ?? [])],
+                ctx,
+                effectiveCritDamage,
+                extendChanceGate,
+                corrosionEntries,
+                infernoEntries,
+                corrosionEntriesBefore,
+                infernoEntriesBefore,
+            });
+        }
 
-    if (dotsLanded) {
-        applyAccumulators({ gatedSkill, pendingAccumulators, sourceId: actor.id });
+        if (dotsLanded) {
+            applyAccumulators({ gatedSkill, pendingAccumulators, sourceId: actor.id });
+        }
     }
 
     // On-cast purge (C2a/C2b-3): remove buffs from the acting actor's target. Keyed off targetId

--- a/src/utils/combat/statusEngine.ts
+++ b/src/utils/combat/statusEngine.ts
@@ -3,6 +3,7 @@ import { Condition, SkillSlot } from '../../types/abilities';
 import { conditionsMet, ConditionContext } from '../abilities/evaluateConditions';
 import { PERSISTENT_STACKING_BUFFS } from '../../constants/persistentStackingBuffs';
 import { UNREMOVABLE_STATUSES } from './cheatDeathBuffs';
+import { isBuffProtection } from './buffProtectionBuffs';
 
 export interface ActiveBuff {
     buffName: string;
@@ -990,8 +991,20 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
     /** Remove up to `count` removable BUFFS from `actorId`'s self store, newest first
      *  (see removeNewestFirst). `'all'` removes every removable buff. Respects
      *  UNREMOVABLE_STATUSES + 'permanent'; returns count removed. Unknown id → no-op (returns 0). */
-    const purge = (actorId: string, count: number | 'all'): number =>
-        removeNewestFirst(actorId, 'buffs', count);
+    const purge = (actorId: string, count: number | 'all'): number => {
+        // Holder-state guard: a unit carrying Buff Protection cannot have its buffs purged.
+        // Purge-only — `cleanse` (removeNewestFirst(_, 'debuffs', _)) does NOT call this.
+        const selfBuffNames = new Set<string>();
+        for (const ab of snapshot(actorId).activeSelfBuffs) {
+            if (ab.stacks === undefined || ab.stacks > 0) selfBuffNames.add(ab.buffName);
+        }
+        for (const s of timedAbilityStatuses('self', actorId)) selfBuffNames.add(s.active.buffName);
+        // NOTE: deliberately omits the aura/accum channel (`activeAbilityStatuses('self', …)`) that
+        // `selfBuffNamesForOwners` also reads — Buff Protection is only ever granted as a TIMED buff,
+        // so the timed + scheduled channels cover every real grant. Revisit if an aura grant appears.
+        if ([...selfBuffNames].some(isBuffProtection)) return 0;
+        return removeNewestFirst(actorId, 'buffs', count);
+    };
 
     // --- Ability-status API (Task 6) ---
 

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -11,7 +11,7 @@ import { expandEnemyDebuffs, payloadToSelectedBuff, expandBuffEntry } from './bu
 // import targetCarriesBlockDebuff back. Both are used only inside function bodies (never at
 // top-level evaluation), so there is no initialization-order hazard.
 // eslint-disable-next-line import/no-cycle
-import { targetCarriesBlockDebuff } from './debuffImmunity';
+import { targetCarriesBlockDebuff, emitBlockDebuffResist, dotResistLabel } from './debuffImmunity';
 import { liveGateConditions } from './abilityStatusGating';
 import { CombatEventBus } from './events';
 import { CombatActor, ActiveDoTStack, PendingBomb } from './state';
@@ -1265,6 +1265,19 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
 
     if (cfg.type === 'dot') {
         if (cfg.stacks <= 0 || cfg.tier <= 0) return;
+        // Block Debuff (D-PR15 Task 7): an immune target auto-resists this reactive DoT — block
+        // it AND emit a resist event (block path ONLY; a normal landing failure below stays
+        // silent → byte-identical when not immune). Placed AFTER the inert-DoT guard above so a
+        // zero-stack/tier DoT doesn't surface a spurious resist.
+        if (targetCarriesBlockDebuff(ctx.statusEngine, ctx.enemy.id)) {
+            emitBlockDebuffResist(
+                ctx.bus,
+                ctx.enemy.id,
+                ctx.round,
+                dotResistLabel(cfg.dotType, cfg.tier)
+            );
+            return;
+        }
         // One landing draw at execution (deterministic queue order) — the OWNER's DoT landing
         // gate + chance (a team ship's DoT lands at ITS hacking-vs-security rate). Reads the
         // LIVE per-target chance (A2 Task 4, set each turn by runPlayerTurn); `?? 1` is a neutral

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -7,6 +7,11 @@ import { conditionsMet } from '../abilities/evaluateConditions';
 import { buildRoundContext } from '../abilities/roundContext';
 import { makeRateGate } from '../calculators/rateAccumulator';
 import { expandEnemyDebuffs, payloadToSelectedBuff, expandBuffEntry } from './buffTotals';
+// Call-time-safe cycle: debuffImmunity imports selfBuffNamesForOwners from this module and we
+// import targetCarriesBlockDebuff back. Both are used only inside function bodies (never at
+// top-level evaluation), so there is no initialization-order hazard.
+// eslint-disable-next-line import/no-cycle
+import { targetCarriesBlockDebuff } from './debuffImmunity';
 import { liveGateConditions } from './abilityStatusGating';
 import { CombatEventBus } from './events';
 import { CombatActor, ActiveDoTStack, PendingBomb } from './state';
@@ -1220,9 +1225,15 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
                 : intent.eventCtx?.counterTargetId;
         // No living highest-attack enemy → no-op (don't fall back to the default enemy).
         if (intent.ability.target === 'enemy-highest-attack' && counterTargetId === undefined) return;
+        // Block Debuff fold (D-PR15 Task 5): a target carrying Block Debuff auto-resists every
+        // incoming timed debuff. Gate immunity into the landing condition so the EXISTING resist
+        // `else` handles it (no duplicated resist code). `&&` short-circuits when not immune →
+        // byte-identical to the original `landsTimedEnemyApplication`-only condition.
+        const debuffTargetId = counterTargetId ?? ctx.enemy.id;
+        const blockedByImmunity = targetCarriesBlockDebuff(ctx.statusEngine, debuffTargetId);
         // Draw the OWNER's landing gate (its hacking-vs-security / affinity disadvantage),
         // NOT a global one — a team ship's debuff lands at ITS landing chance.
-        if (owner.landsTimedEnemyApplication(cfg.application)) {
+        if (!blockedByImmunity && owner.landsTimedEnemyApplication(cfg.application)) {
             ctx.statusEngine.applyTimedAbilityStatus(ctx.round, status, undefined, counterTargetId);
             // Discrete infliction event — sourceId = the owner so the application is chainable.
             ctx.bus.emit({

--- a/src/utils/dataUpdate/updateBuffsData.ts
+++ b/src/utils/dataUpdate/updateBuffsData.ts
@@ -28,6 +28,16 @@ const MANUAL_BUFFS: Array<{
         description: "Grants attack equal to 100% of the caster's attack",
         type: 'buff',
     },
+    {
+        name: 'Block Debuff',
+        description: 'Is immune to receiving debuffs',
+        type: 'buff',
+    },
+    {
+        name: 'Buff Protection',
+        description: "Protects this unit's buffs from being removed",
+        type: 'buff',
+    },
 ];
 
 async function updateBuffsData() {


### PR DESCRIPTION
## Summary
First slice of the **Block/Protection** D bucket — the **primitives-only** slice (the four implant appliers Firewall/Last Stand/Lockdown/Tenacity follow in later PRs). Lights up two control buffs that were inert in the engine:

- **Block Debuff** — an immune target auto-resists **every** incoming debuff (timed, persistent-stacking, control-as-named-debuff like Stasis/Disable, and DoTs). Modeled as "the landing decision returns resisted," so the four seams reuse the existing resist plumbing: cast-side timed/persistent fold (`landsTimedEnemyApplicationLive`), reactive timed fold, cast-side DoT block, reactive DoT block. Blocked DoTs emit a `debuff-resisted` event **only on the block path** (normal landing-roll misses stay silent). All immunity logic lives in one module, `debuffImmunity.ts` (`targetCarriesBlockDebuff`, `dotResistLabel` single-source-of-truth, `emitBlockDebuffResist`).
- **Buff Protection** — a holder's buffs can't be removed by **purge** (a single holder-state guard inside `statusEngine.purge()` returns 0). Purge-only: cleanse and buff-steal untouched.

"Block Damage" turned out to be the old name for **Barrier** (already modeled), so it's not a new primitive — only these two are. `Block Buff` is intentionally **out of scope** (4 ships grant it → would move goldens).

Corpus: `Block Debuff` + `Buff Protection` added to `buffs.ts` + `MANUAL_BUFFS`.

## Byte-identical
No ship skill and no combat fixture grants either buff, so lighting them up is byte-identical: full suite **2931 passing**, **zero golden/`.snap` drift**, tsc + lint clean. Rebased onto current main (D-PR13/D-PR14); the one conflict (reactive debuff executor vs D-PR14's enemy-highest-attack routing) was resolved keeping both.

## Test plan
- [x] `debuffImmunity` unit tests (predicate + DoT label)
- [x] Buff Protection: purge blocked (0 removed) + control + cleanse-unaffected
- [x] Block Debuff per-family engine tests (timed, persistent, cast-DoT, reactive-DoT, reactive-timed) each with non-vacuity control
- [x] Integration: control-as-named-debuff (Stasis/Disable) blocked, already-landed debuff survives, immunity-beats-landing
- [x] Full suite green (only pre-existing env-failing files fail), zero `.snap` drift

Spec: `docs/superpowers/specs/2026-06-22-block-control-primitives-design.md`
Plan: `docs/superpowers/plans/2026-06-22-block-control-primitives.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)