### PR TITLE
feat(combat): D-PR16 — Block/Protection appliers (Firewall/Lockdown/Tenacity/Last Stand)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-block-protection-appliers.md
+++ b/docs/superpowers/plans/2026-06-23-block-protection-appliers.md
@@ -102,7 +102,7 @@ In `src/utils/combat/triggers.ts` `registerReactiveListeners`, add a `case` next
                     break;
 ```
 
-Also add `'on-debuffed'` to the `REACTIVE_ABILITY_TYPES`/`LIVE_TRIGGERS` membership ONLY if required for the listener to be registered — check how `on-attacked` is gated into `registerReactiveListeners` (search `LIVE_TRIGGERS` in `triggers.ts`/`abilityStatusGating.ts`). Add it wherever `on-attacked` appears so the partition treats it as a reactive (not on-cast) trigger.
+**REQUIRED:** add `'on-debuffed'` to `LIVE_TRIGGERS` in `src/types/abilities.ts` (line ~110, alongside `'on-attacked'`). `triggers.ts:123` does `if (!LIVE_TRIGGERS.has(ability.trigger)) return false;` — a trigger absent from this set is never classified reactive, so the new `switch` case is unreachable and the applier silently does nothing. Do NOT touch `REACTIVE_ABILITY_TYPES` (the ability `type` is `'buff'`, already present).
 
 - [ ] **Step 6: Add the registry entry + proc map**
 
@@ -206,7 +206,7 @@ In `triggers.ts` `registerReactiveListeners`:
                     break;
 ```
 
-Add `'on-debuff-resisted'` to the same reactive-trigger membership list as in Task 1 Step 5.
+**REQUIRED:** add `'on-debuff-resisted'` to `LIVE_TRIGGERS` in `src/types/abilities.ts` (alongside `'on-attacked'`), same as Task 1 Step 5 — without it the listener case is unreachable and Lockdown silently does nothing.
 
 - [ ] **Step 6: Registry entry + proc map**
 
@@ -349,7 +349,7 @@ In `engine.ts`, both `registerReactiveListeners(...)` call sites (player + enemy
         },
 ```
 
-Use whatever roster map + effective-stats helper is already in engine scope (mirror how `highestAttackInRoster` resolves `effectiveStatsOf(...).attack`). If `effectiveStatsOf` exposes max HP under a different key, use that. Add to BOTH call sites (same closure is fine — it's side-agnostic by id).
+The engine's existing idiom for effective max HP is `lastTurnCtxByActor.get(id)?.effectiveMaxHp ?? <base HP for id>` (see engine.ts ~1834 / the `triggers.ts:1378` pattern `ownerCtx?.effectiveMaxHp ?? owner.hp`) — prefer that over re-deriving via `effectiveStatsOf(...)`. Whichever source you use, add to BOTH `registerReactiveListeners` call sites (same closure is fine — it's side-agnostic by id).
 
 - [ ] **Step 8: Registry entry + proc map**
 
@@ -623,7 +623,7 @@ In `triggers.ts`, in the `cfg.type === 'buff'` branch, AFTER the existing per-re
         }
 ```
 
-(Verify `payloadFromConfig` accepts a `{ type:'buff', buffName, parsedEffects, stacks, isStackable, maxStacks, duration }` shape — it consumes the primary `buffCfg` of that shape today. The co-buffs intentionally skip the `attackFlatPctOfCaster` pin — Block Debuff/Barrier carry no such sentinel.)
+(`payloadFromConfig` reads only `{ buffName, stacks, parsedEffects, application? }` from its argument — spreading `{ type:'buff', ...extra }` type-checks (variable spread bypasses excess-property checks) and yields the correct payload. The co-buffs intentionally skip the `attackFlatPctOfCaster` pin — Block Debuff/Barrier carry no such sentinel.)
 
 - [ ] **Step 6: Run tests + tsc + lint.**
 

--- a/docs/superpowers/plans/2026-06-23-block-protection-appliers.md
+++ b/docs/superpowers/plans/2026-06-23-block-protection-appliers.md
@@ -1,0 +1,746 @@
+# D-PR16 — Block/Protection appliers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add four implant appliers (Firewall, Lockdown, Tenacity, Last Stand) that reactively grant the Block Debuff / Buff Protection / Barrier control buffs shipped by D-PR15.
+
+**Architecture:** All *effects* ride the existing reactive-buff executor + `procChance` gates + all-allies routing. The new work is three trigger seams (`on-debuffed`, `on-debuff-resisted`, a damage-fraction filter on `on-attacked`), one new condition subject (`last-standing`), and a small multi-buff co-grant extension (Last Stand grants Barrier + Block Debuff on one roll). No production caller equips these implants in any fixture → all DPS/healing goldens stay byte-identical (the load-bearing safety invariant).
+
+**Tech Stack:** TypeScript, Vitest. Combat engine in `src/utils/combat/`, equipment ability registry in `src/utils/abilities/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-23-block-protection-appliers-design.md`
+
+---
+
+## Environment notes (read first)
+
+- **Worktree:** `.worktrees/d-pr16-block-protection-appliers` (branch `feat/combat-d-pr16-block-protection-appliers`, based on D-PR15 tip + cherry-picked Last Stand data fix). `.env` and `docs/*.csv` are symlinked from the main checkout — do NOT delete them (tests need them).
+- **Pre-commit hook runs the FULL vitest suite.** For code commits let it run. For docs-only commits use `--no-verify`.
+- **Goldens:** NEVER run `vitest -u`. If a golden snapshot file (`*.snap`, `healingGoldenParity`/DPS golden files) changes, a gate leaked — fix the gate, do not regenerate. Verify byte-identical via `git status` showing no snapshot files modified.
+- **Verification commands** (run from the worktree root):
+  - `npm test` — full suite
+  - `npm run lint` — ESLint (max-warnings 0)
+  - `npx tsc --noEmit` — type check
+  - `npm test -- equipmentCoverage` — coverage tracker
+- **Per-rarity proc data** is already in `src/constants/implants.ts` (verified): Firewall unc .08/rare .10/epic .12/leg .15; Lockdown com .05/unc .07/rare .09/epic .12/leg .16; Tenacity rare .10/epic .12/leg .16; Last Stand unc .18/rare .21/epic .26/leg .32.
+- **Buffs exist:** D-PR15 added `Block Debuff` and `Buff Protection` to `BUFFS` (`src/constants/buffs.ts`) + `MANUAL_BUFFS`; `Barrier` predates them. So `mkNamedBuffGrant('Block Debuff'|'Buff Protection'|'Barrier', …)` resolves.
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/types/abilities.ts` | Ability/Condition types | += `on-debuffed`, `on-debuff-resisted` triggers; `last-standing` subject; `requireIncomingDamageFracOfMaxHp?` Ability field; `additionalBuffs?` on buff config |
+| `src/utils/combat/events.ts` | Combat event union | `attacked` event += optional `damage?: number` |
+| `src/utils/combat/engine.ts` | Engine loop | emit aggregate `damage` on `attacked`; `soleSurvivorOf` helper + `lastStandingId` in both drain literals + ctx literal |
+| `src/utils/combat/triggers.ts` | Reactive listeners + executor | 3 listener arms; Tenacity filter; co-grant loop; `last-standing` thread + `maxHpOf` resolver |
+| `src/utils/combat/abilityStatusGating.ts` | LIVE_SUBJECTS | += `last-standing` |
+| `src/utils/abilities/evaluateConditions.ts` | Condition eval | `isLastStanding` ctx field + `last-standing` case |
+| `src/utils/abilities/roundContext.ts` | Round context | `lastStanding` state field + builder pass-through |
+| `src/utils/abilities/buildEquipmentAbilities.ts` | Implant registry | 4 proc maps + 4 registry entries; `mkNamedBuffGrant` `alsoGrantBuffNames` opt |
+| `src/components/skills/AbilityCard.tsx` | Editor | TRIGGER_OPTIONS += 2 |
+| `src/components/skills/ConditionRow.tsx` | Editor | SUBJECT_VALUES += `last-standing` |
+| `src/utils/abilities/__tests__/equipmentCoverage.test.ts` | Coverage gate | += 4 implants (array + Set) |
+| `src/constants/changelog.ts` | Changelog | UNRELEASED_CHANGES entry |
+| test files (see tasks) | Behavior | per-applier integration + unit |
+
+---
+
+## Task 1: Firewall — `on-debuffed` trigger (self → Block Debuff)
+
+**Files:**
+- Modify: `src/types/abilities.ts` (AbilityTrigger union)
+- Modify: `src/components/skills/AbilityCard.tsx` (TRIGGER_OPTIONS)
+- Modify: `src/utils/combat/triggers.ts` (listener arm, ~after the `on-attacked` case)
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (FIREWALL_PROC + FIREWALL entry)
+- Modify: `src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+- Test: `src/utils/combat/__tests__/firewallApplier.test.ts` (new)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `src/utils/combat/__tests__/firewallApplier.test.ts`. Model it on an existing equipment-applier engine test (e.g. find one that uses `buildShipAbilitiesWithEquipment` + `simulateBattle`/`runCombat` with a `getGearPiece` stub — search `grep -rln "buildShipAbilitiesWithEquipment" src/utils/combat/__tests__`). The test: a player carrier equips a legendary Firewall implant (procChance forced to fire — set the rate-gate to certainty by using a high-enough accumulated rate, i.e. give the implant via a gear stub whose implant `setBonus='Firewall'`/`rarity='legendary'`, and ensure an enemy lands a timed debuff on the carrier). Assert that after the debuff lands, the carrier carries a `Block Debuff` self-buff (query via the same status read the other tests use — `selfBuffNamesForOwners` or the round buff display).
+
+Note: procChance .15 is not deterministic per single event. Use the established test approach for forcing a proc — search how `BLOODTHIRST`/`BULWARK` tests force their gate (`grep -rln "procChance\|makeRateGate\|rollRateGate" src/utils/combat/__tests__`); reuse that mechanism (typically multiple qualifying events or a seeded/forced gate). If no forcing hook exists, assert the *capability* (over enough debuff events the buff appears) or use the deterministic-accumulator property (a gate at rate r fires on the ceil(1/r)-th event).
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `npm test -- firewallApplier`
+Expected: FAIL — `on-debuffed` is not a valid trigger / no Block Debuff granted.
+
+- [ ] **Step 3: Add the `on-debuffed` trigger to the union**
+
+In `src/types/abilities.ts` AbilityTrigger union, add after `'on-charged-cast'` (or near the other `on-*` values):
+
+```ts
+    // D-PR16 Firewall: fires when THIS unit receives a timed debuff (rides the existing
+    // `debuff-applied` event, self-scoped on targetId === ownerId). Does NOT fire for DoTs
+    // (separate `dot-applied` event) — matches "when debuffed".
+    | 'on-debuffed'
+```
+
+- [ ] **Step 4: Add the editor TRIGGER_OPTIONS stub**
+
+In `src/components/skills/AbilityCard.tsx` TRIGGER_OPTIONS array (line ~127), add:
+
+```ts
+    { value: 'on-debuffed', label: 'On debuffed (self)' },
+```
+
+- [ ] **Step 5: Register the listener arm**
+
+In `src/utils/combat/triggers.ts` `registerReactiveListeners`, add a `case` next to `on-attacked` (~line 394):
+
+```ts
+                case 'on-debuffed':
+                    bus.on('debuff-applied', (e) => {
+                        // Self-scoped: fires when THIS owner receives a timed debuff. Mirrors
+                        // on-attacked's targetId === ownerId scoping. DoTs use dot-applied (not
+                        // this event) → Firewall does not fire on DoT application, by design.
+                        if (e.targetId === ownerId) enqueue(intent);
+                    });
+                    break;
+```
+
+Also add `'on-debuffed'` to the `REACTIVE_ABILITY_TYPES`/`LIVE_TRIGGERS` membership ONLY if required for the listener to be registered — check how `on-attacked` is gated into `registerReactiveListeners` (search `LIVE_TRIGGERS` in `triggers.ts`/`abilityStatusGating.ts`). Add it wherever `on-attacked` appears so the partition treats it as a reactive (not on-cast) trigger.
+
+- [ ] **Step 6: Add the registry entry + proc map**
+
+In `src/utils/abilities/buildEquipmentAbilities.ts`, add a proc map near the others (~line 280):
+
+```ts
+const FIREWALL_PROC: Record<string, number> = {
+    uncommon: 0.08,
+    rare: 0.1,
+    epic: 0.12,
+    legendary: 0.15,
+};
+```
+
+Add to `IMPLANT_ABILITIES` (near BULWARK/DOOMSAYER):
+
+```ts
+    // D-PR16: Firewall — when debuffed, X% chance to gain Block Debuff (self) for 1 turn.
+    FIREWALL: (rarity) => {
+        const procChance = FIREWALL_PROC[rarity];
+        if (procChance === undefined) return undefined;
+        return mkNamedBuffGrant('Block Debuff', 'self', 'on-debuffed', 1, { procChance });
+    },
+```
+
+- [ ] **Step 7: Update the coverage tracker**
+
+In `src/utils/abilities/__tests__/equipmentCoverage.test.ts`, add `'FIREWALL'` to BOTH the `.toEqual([...])` decl-order array (line ~122 — insert in `IMPLANTS` declaration order) AND the `implementedImplants` Set (line ~203). Update the `it('exactly {...}')` description string if it enumerates names. Run `npm test -- equipmentCoverage` and fix ordering until green.
+
+- [ ] **Step 8: Run the tests**
+
+Run: `npm test -- firewallApplier equipmentCoverage` then `npx tsc --noEmit` and `npm run lint`.
+Expected: PASS, clean.
+
+- [ ] **Step 9: Confirm goldens byte-identical**
+
+Run: `npm test` then `git status --short`.
+Expected: full suite green; NO `*.snap`/golden files modified.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add -A
+git commit -m "feat(combat): D-PR16 Firewall — on-debuffed trigger grants self Block Debuff"
+```
+
+---
+
+## Task 2: Lockdown — `on-debuff-resisted` trigger (all-allies → Buff Protection)
+
+**Files:**
+- Modify: `src/types/abilities.ts`, `src/components/skills/AbilityCard.tsx`
+- Modify: `src/utils/combat/triggers.ts` (listener arm)
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (LOCKDOWN_PROC + entry)
+- Modify: `src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+- Test: `src/utils/combat/__tests__/lockdownApplier.test.ts` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/utils/combat/__tests__/lockdownApplier.test.ts` with TWO cases:
+1. **Direct:** a Lockdown carrier resists an incoming enemy debuff (force the resist via high tank security / hacking-disadvantage so the landing roll fails — search how existing tests force a resist, e.g. the PR#100 `resistedDebuffs` tests). Assert all same-side allies carry `Buff Protection` after the resist (forced proc). Optionally assert an enemy purge against an ally is then a no-op (purge-immunity, D-PR15 primitive).
+2. **Synergy (the headline test):** a carrier holding `Block Debuff` (grant it directly via the test setup, or via a Firewall on a prior event) auto-resists an incoming debuff → `debuff-resisted` fires → a *same-side* Lockdown carrier grants the team `Buff Protection`. This proves the chain across D-PR15's Block-Debuff resist emission.
+
+- [ ] **Step 2: Run to confirm fail**
+
+Run: `npm test -- lockdownApplier`
+Expected: FAIL — `on-debuff-resisted` invalid / no Buff Protection.
+
+- [ ] **Step 3: Add the trigger to the union**
+
+`src/types/abilities.ts`:
+
+```ts
+    // D-PR16 Lockdown: fires when THIS unit resists an incoming debuff (rides the existing
+    // `debuff-resisted` event, self-scoped on targetId === ownerId). Chains off D-PR15's
+    // Block-Debuff auto-resist emission AND normal hacking/affinity resists.
+    | 'on-debuff-resisted'
+```
+
+- [ ] **Step 4: Editor stub**
+
+`AbilityCard.tsx` TRIGGER_OPTIONS:
+
+```ts
+    { value: 'on-debuff-resisted', label: 'On debuff resisted (self)' },
+```
+
+- [ ] **Step 5: Register the listener arm**
+
+In `triggers.ts` `registerReactiveListeners`:
+
+```ts
+                case 'on-debuff-resisted':
+                    bus.on('debuff-resisted', (e) => {
+                        // Self-scoped on the RESISTER. `debuff-resisted` carries targetId = the
+                        // unit that resisted (either side: cast-side, reactive-side, and the
+                        // D-PR15 Block-Debuff auto-resist all emit it). all-allies recipient
+                        // routing happens in the buff executor.
+                        if (e.targetId === ownerId) enqueue(intent);
+                    });
+                    break;
+```
+
+Add `'on-debuff-resisted'` to the same reactive-trigger membership list as in Task 1 Step 5.
+
+- [ ] **Step 6: Registry entry + proc map**
+
+```ts
+const LOCKDOWN_PROC: Record<string, number> = {
+    common: 0.05,
+    uncommon: 0.07,
+    rare: 0.09,
+    epic: 0.12,
+    legendary: 0.16,
+};
+```
+
+```ts
+    // D-PR16: Lockdown — when resisting a debuff, X% chance to grant Buff Protection to
+    // all allies for 1 turn.
+    LOCKDOWN: (rarity) => {
+        const procChance = LOCKDOWN_PROC[rarity];
+        if (procChance === undefined) return undefined;
+        return mkNamedBuffGrant('Buff Protection', 'all-allies', 'on-debuff-resisted', 1, {
+            procChance,
+        });
+    },
+```
+
+- [ ] **Step 7: Coverage tracker** — add `'LOCKDOWN'` to both the array and the Set.
+
+- [ ] **Step 8: Run tests + tsc + lint** (`npm test -- lockdownApplier equipmentCoverage`).
+
+- [ ] **Step 9: Goldens byte-identical** (`npm test` + `git status --short`).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add -A
+git commit -m "feat(combat): D-PR16 Lockdown — on-debuff-resisted grants all-ally Buff Protection (chains off Block Debuff)"
+```
+
+---
+
+## Task 3: Tenacity — `on-attacked` + >25%-max-HP filter (all-allies → Buff Protection)
+
+**Files:**
+- Modify: `src/utils/combat/events.ts` (`attacked` event += `damage?`)
+- Modify: `src/utils/combat/engine.ts` (emit aggregate `damage` ~line 4510)
+- Modify: `src/types/abilities.ts` (`requireIncomingDamageFracOfMaxHp?` Ability field)
+- Modify: `src/utils/combat/triggers.ts` (thread `maxHpOf` resolver + filter in `on-attacked` arm)
+- Modify: `src/utils/combat/engine.ts` (pass `maxHpOf` into `registerReactiveListeners` — both call sites)
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (TENACITY_PROC + entry)
+- Modify: `src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+- Test: `src/utils/combat/__tests__/tenacityApplier.test.ts` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tenacityApplier.test.ts` with three cases:
+1. A single direct attack dealing > 25% of the carrier's max HP → all allies gain `Buff Protection` (2 turns), proc forced.
+2. An attack dealing ≤ 25% → no grant.
+3. A DoT batch exceeding 25% → no grant (DoT ticks emit no `attacked` event).
+
+- [ ] **Step 2: Run to confirm fail** (`npm test -- tenacityApplier`).
+
+- [ ] **Step 3: Add `damage?` to the `attacked` event**
+
+`src/utils/combat/events.ts`, in the `attacked` event member (~line 173):
+
+```ts
+    | {
+          type: 'attacked';
+          targetId: string;
+          attackerId: string;
+          round: number;
+          didCrit?: boolean;
+          /** D-PR16: per-ATTACK aggregate direct damage dealt this turn (identical across the
+           *  turn's per-hit events — per-hit damage is not tracked, same approximation as
+           *  Bloodthirst's triggerDamage). Present only when a damage aggregate is in scope.
+           *  Tenacity's >25%-max-HP filter reads this. */
+          damage?: number;
+      };
+```
+
+- [ ] **Step 4: Emit the aggregate damage**
+
+In `src/utils/combat/engine.ts` at the `attacked` emission (~line 4510), add `damage` to the emitted object using the per-attack `damage` aggregate already in scope (used at line ~4476):
+
+```ts
+                                bus.emit({
+                                    type: 'attacked',
+                                    targetId: tgt.id,
+                                    attackerId: actor.id,
+                                    round: r,
+                                    ...(hitCrit ? { didCrit: true } : {}),
+                                    ...(damage > 0 ? { damage } : {}),
+                                });
+```
+
+(Verify the in-scope binding name is `damage` at this point; if it's named differently, use that. Conditional spread keeps the event byte-shape unchanged when damage is 0/absent.)
+
+- [ ] **Step 5: Add the Ability filter field**
+
+`src/types/abilities.ts`, on the `Ability` interface (near `triggerCritFilter`/`requireDamagedAllyAdjacent`):
+
+```ts
+    /** D-PR16 Tenacity: gate an `on-attacked` reaction on the per-attack aggregate damage
+     *  exceeding this fraction of the owner's effective max HP (e.g. 0.25). Absent → no gate
+     *  (byte-identical for every existing on-attacked ability). */
+    requireIncomingDamageFracOfMaxHp?: number;
+```
+
+- [ ] **Step 6: Thread a `maxHpOf` resolver into the listeners**
+
+In `triggers.ts` `registerReactiveListeners` args object (~line 223, next to `adjacentAllyIdsFor`):
+
+```ts
+    /** D-PR16: owner effective max HP resolver — gates Tenacity's incoming-damage-fraction
+     *  filter. Optional: absent → the filter is skipped (no Tenacity in scope). */
+    maxHpOf?: (ownerId: string) => number;
+```
+
+Destructure it (`const { …, maxHpOf } = args;`).
+
+In the `on-attacked` case, after the existing crit-filter checks and before `enqueue`, add:
+
+```ts
+                        const fracGate = ra.ability.requireIncomingDamageFracOfMaxHp;
+                        if (fracGate !== undefined) {
+                            const maxHp = maxHpOf?.(ownerId);
+                            if (e.damage === undefined || !maxHp || e.damage <= fracGate * maxHp)
+                                return;
+                        }
+```
+
+- [ ] **Step 7: Provide `maxHpOf` from the engine**
+
+In `engine.ts`, both `registerReactiveListeners(...)` call sites (player + enemy — search `registerReactiveListeners(`), pass a resolver that returns the actor's effective max HP. Reuse the same effective-max-HP source the engine already uses (search `effectiveMaxHp` — `triggers.ts:1378` shows `ownerCtx?.effectiveMaxHp ?? owner.hp` as the pattern; the engine has an `effectiveStatsOf`/per-actor HP lookup). Implement:
+
+```ts
+        maxHpOf: (id) => {
+            const a = allActorsById.get(id); // or the existing roster map in scope
+            return a ? effectiveStatsOf(statusEngine, selfBuffLookup, a).hp : 0;
+        },
+```
+
+Use whatever roster map + effective-stats helper is already in engine scope (mirror how `highestAttackInRoster` resolves `effectiveStatsOf(...).attack`). If `effectiveStatsOf` exposes max HP under a different key, use that. Add to BOTH call sites (same closure is fine — it's side-agnostic by id).
+
+- [ ] **Step 8: Registry entry + proc map**
+
+```ts
+const TENACITY_PROC: Record<string, number> = { rare: 0.1, epic: 0.12, legendary: 0.16 };
+```
+
+```ts
+    // D-PR16: Tenacity — upon directly receiving damage > 25% of max HP, X% chance to grant
+    // Buff Protection to all allies for 2 turns. Models the per-ATTACK aggregate (the
+    // `attacked` event excludes DoT/bomb → "directly receiving").
+    TENACITY: (rarity) => {
+        const procChance = TENACITY_PROC[rarity];
+        if (procChance === undefined) return undefined;
+        const base = mkNamedBuffGrant('Buff Protection', 'all-allies', 'on-attacked', 2, {
+            procChance,
+        });
+        if (!base) return undefined;
+        return { ...base, requireIncomingDamageFracOfMaxHp: 0.25 };
+    },
+```
+
+- [ ] **Step 9: Coverage tracker** — add `'TENACITY'` to array + Set.
+
+- [ ] **Step 10: Run tests + tsc + lint** (`npm test -- tenacityApplier equipmentCoverage`).
+
+- [ ] **Step 11: Goldens byte-identical** (`npm test` + `git status --short` — the `attacked` `damage` field is conditionally spread, so no golden should move; if one does, the conditional spread or a healing-mode `attacked` consumer leaked — investigate, do NOT `-u`).
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add -A
+git commit -m "feat(combat): D-PR16 Tenacity — on-attacked >25% max-HP filter grants all-ally Buff Protection"
+```
+
+---
+
+## Task 4: `last-standing` condition subject (infrastructure)
+
+Mirror the D-PR14 `first-activator` threading exactly (11 sites — see `grep -rn "first-activator\|firstActivator" src/`). The ONLY behavioral difference: `last-standing` is derived liveness (recomputed each drain), not a monotonic id.
+
+**Files:**
+- Modify: `src/types/abilities.ts` (ConditionSubject union)
+- Modify: `src/utils/combat/abilityStatusGating.ts` (LIVE_SUBJECTS, ~line 29)
+- Modify: `src/utils/abilities/evaluateConditions.ts` (ctx field + case, ~lines 37/91)
+- Modify: `src/utils/abilities/roundContext.ts` (state field + builder, ~lines 44/68)
+- Modify: `src/utils/combat/triggers.ts` (IntentExecContext field ~654, buildDrainContext shared bag ~719/747/784)
+- Modify: `src/utils/combat/engine.ts` (`soleSurvivorOf` helper; ReactiveSideCtx field ~1044; ctx literal ~3422; both drain literals ~3480/3505)
+- Modify: `src/components/skills/ConditionRow.tsx` (SUBJECT_VALUES)
+- Test: `src/utils/abilities/__tests__/evaluateConditions.test.ts` (extend) + `src/utils/combat/__tests__/lastStandingSubject.test.ts` (new, engine-level)
+
+- [ ] **Step 1: Write the failing unit test (pure evaluator)**
+
+In `evaluateConditions.test.ts` (or co-located), assert `last-standing` evaluates to 1 when `ctx.isLastStanding === true` and 0 otherwise. Follow the existing `first-activator` test if present.
+
+- [ ] **Step 2: Write the failing engine wiring test**
+
+Create `lastStandingSubject.test.ts`: build a 2-actor player team where one actor carries a buff-grant ability gated on `{ subject: 'last-standing', derivable: true }` triggered by `on-ally-destroyed`. Kill the other ally; assert the survivor's gate evaluates true and the buff is granted. Add a control: with both alive, an unrelated `on-ally-destroyed` does NOT grant (gate false). (This task does not add a co-grant yet — use a single-buff grant like `Defense Up I` to prove the subject; Last Stand's real buffs come in Task 6.)
+
+- [ ] **Step 3: Run to confirm fail** (`npm test -- lastStandingSubject evaluateConditions`).
+
+- [ ] **Step 4: Add the subject to the union**
+
+`src/types/abilities.ts` ConditionSubject union (next to `'first-activator'`, ~line 173):
+
+```ts
+    | 'last-standing'; // D-PR16 Last Stand: true iff the owner is the SOLE living same-side actor.
+```
+
+(Adjust the union's trailing `;`/`|` punctuation to keep it valid.)
+
+- [ ] **Step 5: LIVE_SUBJECTS**
+
+`src/utils/combat/abilityStatusGating.ts` (~line 29, where `'first-activator'` is listed):
+
+```ts
+    'last-standing',
+```
+
+- [ ] **Step 6: evaluateConditions**
+
+`src/utils/abilities/evaluateConditions.ts`: add to `ConditionContext` (~line 37, near `firstActivator?`):
+
+```ts
+    isLastStanding?: boolean;
+```
+
+Add the eval case (~line 91, next to `first-activator`):
+
+```ts
+        case 'last-standing':
+            return ctx.isLastStanding ? 1 : 0;
+```
+
+- [ ] **Step 7: roundContext**
+
+`src/utils/abilities/roundContext.ts`: add to the state type (~line 44):
+
+```ts
+    lastStanding?: boolean;
+```
+
+and in `buildRoundContext` output (~line 68, where `firstActivator: state.firstActivator ?? false` is):
+
+```ts
+        isLastStanding: state.lastStanding ?? false,
+```
+
+(Confirm the field name the context forwards to `ConditionContext` — it must match Step 6's `isLastStanding`. `first-activator` forwards as `firstActivator`; for last-standing the context field is `isLastStanding` and the round-context *state* key is `lastStanding`. Keep these consistent across files; pick `isLastStanding` for the ConditionContext key and `lastStanding` for the round-state/sideCtx delegate value to avoid double-negation bugs.)
+
+- [ ] **Step 8: triggers.ts thread**
+
+- IntentExecContext (~line 654, near `firstActivatorId?`):
+
+```ts
+    /** D-PR16: the id of the SOLE living same-side actor for the owner's side this drain, or
+     *  undefined when ≠1 alive. Recomputed per drain (derived liveness). */
+    lastStandingId?: string;
+```
+
+- In `buildDrainContext` shared bag (mirror `firstActivator: ctx.firstActivatorId === ownerId` at ~line 784):
+
+```ts
+        lastStanding: ctx.lastStandingId === ownerId,
+```
+
+and add `lastStanding?: boolean;` to the shared-bag type (~line 719) and forward it into `buildActorConditionContext`/the round context input so it reaches `buildRoundContext` state as `lastStanding`. Follow exactly how `firstActivator` flows from line 747 → roundContext.
+
+- [ ] **Step 9: engine.ts compute + thread**
+
+- Add a helper near `highestAttackInRoster` (~line 3459):
+
+```ts
+        // D-PR16: the id of the sole living actor in a roster, or undefined if ≠1 alive.
+        // Drives the `last-standing` condition (Last Stand). Recomputed each drain so it
+        // reflects deaths recorded before the reactive drain.
+        const soleSurvivorOf = (roster: CombatActor[]): string | undefined => {
+            const living = roster.filter((a) => a.destroyedRound === undefined);
+            return living.length === 1 ? living[0].id : undefined;
+        };
+```
+
+- Add `lastStandingId?: string;` to the ReactiveSideCtx interface (~line 1044, near `firstActivatorId?`).
+- Pass it into the `executeIntent`/ctx literal (~line 3422, next to `firstActivatorId: sideCtx.firstActivatorId`):
+
+```ts
+                        lastStandingId: sideCtx.lastStandingId,
+```
+
+- Set it in BOTH drain literals:
+  - Player drain (~line 3480): `lastStandingId: soleSurvivorOf(allPlayerActors),`
+  - Enemy drain (~line 3505): `lastStandingId: soleSurvivorOf(enemyAttackerActors),`
+
+(These literals rebuild on each drain call → `soleSurvivorOf` reflects current liveness.)
+
+- [ ] **Step 10: Editor stub**
+
+`src/components/skills/ConditionRow.tsx` SUBJECT_VALUES (~line 15):
+
+```ts
+    'last-standing',
+```
+
+Add an `EXTRA_SUBJECT_LABELS` entry (~line 38) if the auto-label is poor:
+
+```ts
+    'last-standing': 'Last one standing (self)',
+```
+
+- [ ] **Step 11: Run tests + tsc + lint** (`npm test -- lastStandingSubject evaluateConditions`, then `npx tsc --noEmit`, `npm run lint`).
+
+- [ ] **Step 12: Goldens byte-identical** (`npm test` + `git status --short`).
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add -A
+git commit -m "feat(combat): D-PR16 last-standing condition subject (mirrors first-activator threading)"
+```
+
+---
+
+## Task 5: multi-buff co-grant extension (`additionalBuffs`)
+
+Lets a single buff-grant ability apply more than one named buff on ONE proc roll (Last Stand: Barrier + Block Debuff). Purely additive — existing single-buff grants are byte-identical (`additionalBuffs` undefined → no-op).
+
+**Files:**
+- Modify: `src/types/abilities.ts` (buff `AbilityConfig` += `additionalBuffs?`)
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (`mkNamedBuffGrant` `alsoGrantBuffNames` opt)
+- Modify: `src/utils/combat/triggers.ts` (co-grant loop in the `cfg.type === 'buff'` branch, ~after line 1189)
+- Test: `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts` (extend or new co-grant test) + reuse an engine test
+
+- [ ] **Step 1: Write the failing test**
+
+Add a unit test: `mkNamedBuffGrant('Barrier', 'self', 'on-ally-destroyed', 1, { procChance: 0.32, alsoGrantBuffNames: ['Block Debuff'] })` returns an ability whose buff config has `buffName: 'Barrier'` and `additionalBuffs` containing a `Block Debuff` config with resolved `parsedEffects`. Plus an engine-level assertion (can fold into Task 6) that applying it grants BOTH buffs to the recipient.
+
+- [ ] **Step 2: Run to confirm fail.**
+
+- [ ] **Step 3: Add `additionalBuffs` to the buff config type**
+
+`src/types/abilities.ts`, on the buff `AbilityConfig` variant (where `buffName`/`parsedEffects`/`stacks`/`duration` live):
+
+```ts
+    /** D-PR16: extra buffs granted ALONGSIDE the primary in the SAME application (one proc
+     *  roll → all of them). Each carries its own resolved effects + duration. Absent → the
+     *  single-buff path is unchanged. */
+    additionalBuffs?: Array<{
+        buffName: string;
+        parsedEffects: ParsedBuffEffects; // same type as the primary config's parsedEffects
+        stacks: number;
+        isStackable: boolean;
+        maxStacks?: number;
+        duration: number;
+    }>;
+```
+
+(Use the exact element type of the primary config's fields — copy the field types from the buff config so they match. `ParsedBuffEffects` is the return type of `parseBuffEffects`; import/reference whatever the primary uses.)
+
+- [ ] **Step 4: Extend `mkNamedBuffGrant`**
+
+In `buildEquipmentAbilities.ts`, add `alsoGrantBuffNames?: string[]` to the `opts` param type, and after building the primary `config`, populate `additionalBuffs`:
+
+```ts
+    const additionalBuffs = (opts?.alsoGrantBuffNames ?? [])
+        .map((n) => {
+            const b = BUFFS.find((x) => x.name === n);
+            if (!b) return undefined;
+            const { stackable, maxStacks } = isStackable(b.description);
+            return {
+                buffName: n,
+                parsedEffects: parseBuffEffects(b.name, b.description),
+                stacks: 1,
+                isStackable: stackable,
+                maxStacks,
+                duration,
+            };
+        })
+        .filter((x): x is NonNullable<typeof x> => x !== undefined);
+```
+
+and add `...(additionalBuffs.length ? { additionalBuffs } : {})` into the returned `config` object.
+
+- [ ] **Step 5: Apply co-buffs in the executor**
+
+In `triggers.ts`, in the `cfg.type === 'buff'` branch, AFTER the existing per-recipient apply+emit loop (after line ~1189, before `return;`), add:
+
+```ts
+        // D-PR16: co-granted buffs (Last Stand's Barrier + Block Debuff) — applied in the
+        // SAME application as the primary (the single proc gate above already passed).
+        for (const extra of cfg.additionalBuffs ?? []) {
+            const extraStatus: Extract<RegisteredAbilityStatus, { kind: 'timed' }> = {
+                payload: payloadFromConfig({ type: 'buff', ...extra }),
+                side: 'self',
+                sourceSlot: intent.sourceSlot,
+                conditions: gateConditions,
+                casterId: intent.ownerId,
+                recipients,
+                kind: 'timed',
+                duration: extra.duration,
+            };
+            for (const rid of recipients) {
+                ctx.statusEngine.applyTimedAbilityStatus(ctx.round, extraStatus, rid);
+                ctx.bus.emit({
+                    type: 'buff-applied',
+                    actorId: rid,
+                    round: ctx.round,
+                    buffName: extra.buffName,
+                    duration: extra.duration,
+                });
+            }
+        }
+```
+
+(Verify `payloadFromConfig` accepts a `{ type:'buff', buffName, parsedEffects, stacks, isStackable, maxStacks, duration }` shape — it consumes the primary `buffCfg` of that shape today. The co-buffs intentionally skip the `attackFlatPctOfCaster` pin — Block Debuff/Barrier carry no such sentinel.)
+
+- [ ] **Step 6: Run tests + tsc + lint.**
+
+- [ ] **Step 7: Goldens byte-identical** (`npm test` + `git status --short`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m "feat(combat): D-PR16 multi-buff co-grant (additionalBuffs) — one proc roll grants several buffs"
+```
+
+---
+
+## Task 6: Last Stand registry entry (combines Tasks 4 + 5)
+
+**Files:**
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (LAST_STAND_PROC + entry)
+- Modify: `src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+- Test: `src/utils/combat/__tests__/lastStandApplier.test.ts` (new)
+
+- [ ] **Step 1: Write the failing integration test**
+
+`lastStandApplier.test.ts`: a player team of 2; the carrier (legendary Last Stand, proc forced) survives while the other ally is killed. Assert the carrier carries BOTH `Barrier` AND `Block Debuff` after the death (one proc → both). Control: with ≥2 allies alive, no grant fires. Enemy-side mirror (optional but recommended for team-agnostic coverage): an enemy carrier becomes last-standing against the player team → gains both.
+
+- [ ] **Step 2: Run to confirm fail.**
+
+- [ ] **Step 3: Registry entry + proc map**
+
+```ts
+const LAST_STAND_PROC: Record<string, number> = {
+    uncommon: 0.18,
+    rare: 0.21,
+    epic: 0.26,
+    legendary: 0.32,
+};
+```
+
+```ts
+    // D-PR16: Last Stand — when this unit becomes the last one standing, X% chance to gain
+    // Barrier AND Block Debuff (self) for 1 turn. Rides on-ally-destroyed gated on last-standing
+    // (fires on the ally death that leaves the owner sole survivor); both buffs on ONE proc roll.
+    LAST_STAND: (rarity) => {
+        const procChance = LAST_STAND_PROC[rarity];
+        if (procChance === undefined) return undefined;
+        return mkNamedBuffGrant('Barrier', 'self', 'on-ally-destroyed', 1, {
+            procChance,
+            conditions: [{ subject: 'last-standing', derivable: true }],
+            alsoGrantBuffNames: ['Block Debuff'],
+        });
+    },
+```
+
+- [ ] **Step 4: Coverage tracker** — add `'LAST_STAND'` to array + Set.
+
+- [ ] **Step 5: Run tests + tsc + lint** (`npm test -- lastStandApplier equipmentCoverage`).
+
+- [ ] **Step 6: Goldens byte-identical** (`npm test` + `git status --short`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat(combat): D-PR16 Last Stand — last-standing grants self Barrier + Block Debuff"
+```
+
+---
+
+## Task 7: Changelog + final holistic verification
+
+**Files:**
+- Modify: `src/constants/changelog.ts`
+
+- [ ] **Step 1: Add the changelog entry**
+
+In `UNRELEASED_CHANGES` (`src/constants/changelog.ts`), add a plain-English line, e.g.:
+
+> "Combat sim: the Firewall, Lockdown, Tenacity, and Last Stand implants now take effect — they reactively grant Block Debuff (auto-resist incoming debuffs), Buff Protection (buffs can't be purged), and Barrier when their conditions are met."
+
+- [ ] **Step 2: Final coverage assertion** — confirm `equipmentCoverage.test.ts` now lists all four (FIREWALL, LOCKDOWN, TENACITY, LAST_STAND) in BOTH the array and the Set, and the `it('exactly {...}')` description string matches. Run `npm test -- equipmentCoverage`.
+
+- [ ] **Step 3: Full verification gate**
+
+```bash
+npm test            # full suite green
+npx tsc --noEmit    # clean
+npm run lint        # 0 warnings
+npm test -- audit   # if an audit:skills test exists; else npm run audit:skills
+git status --short  # NO *.snap / golden files modified
+```
+
+Expected: all green; zero golden/snapshot drift. If any golden moved, STOP and find the leaked gate — never `vitest -u`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "docs(combat): D-PR16 changelog entry for Block/Protection appliers"
+```
+
+- [ ] **Step 5: Push + open PR** (after the holistic review approves)
+
+```bash
+git push -u origin feat/combat-d-pr16-block-protection-appliers 2>&1 | cat
+gh pr create --base feat/combat-d-pr15-block-control-primitives \
+  --title "feat(combat): D-PR16 — Block/Protection appliers (Firewall/Lockdown/Tenacity/Last Stand)" \
+  --body "..."
+```
+
+(Base = the D-PR15 branch since #147 is unmerged; retarget to `main` after #147 merges. Use `gh auth switch --user TheSusort` first if needed.)
+
+---
+
+## Known limitations / notes for reviewers
+
+- **Tenacity damage granularity:** the threshold reads the per-ATTACK aggregate damage, not per-hit (per-hit damage isn't tracked — same accepted approximation as Bloodthirst, D-PR1). DoT/bomb never emit `attacked` → correctly excluded ("directly receiving").
+- **Firewall scope:** fires on timed debuffs received (incl. control-as-named-debuff Stasis/Disable), NOT on DoT application (`dot-applied` is a separate event). Matches "when debuffed".
+- **Last Stand `last-standing`:** evaluated at drain time after deaths are recorded; fires on the ally-death event that leaves the owner sole survivor. Multiple simultaneous deaths → on-ally-destroyed fires per death, gate passes only on the one leaving exactly one alive.
+- **No once-per-round caps** — all four are pure %-chance procs (unlike D-PR14 Bulwark).
+- **Byte-identical invariant:** no fixture equips these implants → all goldens must stay byte-identical. The `attacked.damage` field is conditionally spread to preserve event byte-shape in healing mode.

--- a/docs/superpowers/specs/2026-06-23-block-protection-appliers-design.md
+++ b/docs/superpowers/specs/2026-06-23-block-protection-appliers-design.md
@@ -107,7 +107,7 @@ New `AbilityTrigger` values (`on-debuffed`, `on-debuff-resisted`) and the `last-
 - `src/utils/combat/triggers.ts` — three new listener arms (`on-debuffed`, `on-debuff-resisted` self-scoped; Tenacity damage filter on the `on-attacked` arm); `cfg.type === 'buff'` co-grant loop; `last-standing` thread through `buildDrainContext`.
 - `src/utils/combat/engine.ts` — `attacked` emission += aggregate `damage`; `isLastStandingFor` delegate on the IntentExecContext (both drain seams, side-bound); thread through `ReactiveSideCtx` if needed (D-PR14 lesson — not just the drain literals).
 - `src/utils/combat/roundContext.ts` / condition-context builders — `isLastStanding` plumbing.
-- `src/utils/abilities/abilityStatusGating.ts` — `LIVE_SUBJECTS += 'last-standing'`.
+- `src/utils/combat/abilityStatusGating.ts` — `LIVE_SUBJECTS += 'last-standing'`.
 - `src/utils/combat/evaluateCondition` (wherever it lives) — `last-standing` case.
 - `src/utils/abilities/buildEquipmentAbilities.ts` — `mkNamedBuffGrant` `alsoGrantBuffNames` opt; four registry entries.
 - Editor stubs + `equipmentCoverage.test.ts`.

--- a/docs/superpowers/specs/2026-06-23-block-protection-appliers-design.md
+++ b/docs/superpowers/specs/2026-06-23-block-protection-appliers-design.md
@@ -52,7 +52,7 @@ So the PR's real work is **trigger seams** — three new ones plus one new filte
 
 - **Seam:** rides the existing `on-attacked` trigger (self-scoped `attacked` event). Adds a NEW filter: the hit's damage must exceed 25% of the victim's max HP.
 - **Damage granularity (forced by the engine model):** the `attacked` event is emitted per-hit but carries **no damage amount** — direct damage is applied per-attack as an aggregate (engine.ts ~4476/4510). So the threshold is modeled on the **per-attack aggregate** damage, not per individual hit. This is the same per-hit-vs-aggregate limitation Bloodthirst (D-PR1) documented and accepted. The `attacked` event already excludes DoT ticks and bomb detonations (only direct weapon hits emit it) — which matches "**directly** receiving damage".
-- **Plumbing:** add an optional `damage?: number` field to the `attacked` event (the per-attack aggregate, identical across the turn's hits) so the listener can evaluate `damage / victimMaxHp > 0.25`. The listener resolves the victim's effective max HP (the carrier is the attacked unit = owner). A new `Ability`/config filter field expresses the threshold (e.g. `triggerIncomingDamageFracOfMaxHp?: number` = 0.25) — kept generic, defaulting absent → no filter (byte-identical for every existing on-attacked ability).
+- **Plumbing:** add an optional `damage?: number` field to the `attacked` event (the per-attack aggregate, identical across the turn's hits) so the listener can evaluate `damage / victimMaxHp > 0.25`. The listener resolves the victim's effective max HP (the carrier is the attacked unit = owner). A new `Ability` filter field expresses the threshold (`requireIncomingDamageFracOfMaxHp?: number` = 0.25) — kept generic, defaulting absent → no filter (byte-identical for every existing on-attacked ability).
 - **Effect:** all-allies grant `Buff Protection`, duration 2, procChance per rarity.
 
 ### 3.4 Last Stand — `on-ally-destroyed` + NEW `last-standing` condition subject
@@ -102,7 +102,7 @@ New `AbilityTrigger` values (`on-debuffed`, `on-debuff-resisted`) and the `last-
 
 ## 9. Key file seams (for the plan)
 
-- `src/types/abilities.ts` — `AbilityTrigger` += `on-debuffed`, `on-debuff-resisted`; buff `AbilityConfig` += `alsoGrantBuffNames?`; the Tenacity threshold filter field; `Condition` subject `last-standing`.
+- `src/types/abilities.ts` — `AbilityTrigger` += `on-debuffed`, `on-debuff-resisted`; buff `AbilityConfig` += `additionalBuffs?` (co-grant list, built from `mkNamedBuffGrant`'s `alsoGrantBuffNames` input); the Tenacity threshold filter field `requireIncomingDamageFracOfMaxHp?`; `Condition` subject `last-standing`.
 - `src/utils/combat/events.ts` — `attacked` event += optional `damage?`.
 - `src/utils/combat/triggers.ts` — three new listener arms (`on-debuffed`, `on-debuff-resisted` self-scoped; Tenacity damage filter on the `on-attacked` arm); `cfg.type === 'buff'` co-grant loop; `last-standing` thread through `buildDrainContext`.
 - `src/utils/combat/engine.ts` — `attacked` emission += aggregate `damage`; `isLastStandingFor` delegate on the IntentExecContext (both drain seams, side-bound); thread through `ReactiveSideCtx` if needed (D-PR14 lesson — not just the drain literals).

--- a/docs/superpowers/specs/2026-06-23-block-protection-appliers-design.md
+++ b/docs/superpowers/specs/2026-06-23-block-protection-appliers-design.md
@@ -1,0 +1,114 @@
+# D-PR16 — Block/Protection appliers (Firewall, Last Stand, Lockdown, Tenacity)
+
+**Date:** 2026-06-23
+**Status:** Design (pre-plan)
+**Branch:** `feat/combat-d-pr16-block-protection-appliers` (off D-PR15 tip `ee439ad1` + cherry-picked Last Stand data fix `d47c9980`; retargets to main after #147 merges)
+**Epic:** combat-realism, sub-project D (implants + gear-set abilities). Follows D-PR15 (Block/Protection control PRIMITIVES, PR #147).
+
+## 1. Context & purpose
+
+D-PR15 shipped the two control **primitives** these appliers consume, both currently inert (no ship skill or fixture grants them):
+
+- **Block Debuff** — a holder that carries it AUTO-RESISTS every incoming debuff (modeled as a landing concern in `debuffImmunity.ts`; the resist fires the existing `debuff-resisted` event).
+- **Buff Protection** — purge-immunity (a holder's buffs cannot be purged; guarded inside `statusEngine.purge()`, `buffProtectionBuffs.ts`).
+
+`Barrier` (full damage immunity for its duration) was modeled earlier (`barrierBuffs.ts`).
+
+This PR adds the four implant **appliers** that grant those primitives reactively. The user explicitly chose "primitives first" in D-PR15; this is the unblocked follow-up.
+
+**Corpus (verified against `src/constants/implants.ts`):**
+
+| Implant | Trigger text | Effect | Target | Dur | procChance by rarity |
+|---|---|---|---|---|---|
+| **Firewall** | "When debuffed" | gain **Block Debuff** | self | 1t | unc 8% / rare 10% / epic 12% / leg 15% (no common) |
+| **Last Stand** | "When this unit becomes the last one standing" | gain **Barrier + Block Debuff** | self | 1t | unc 18% / rare 21% / epic 26% / leg 32% (no common) |
+| **Lockdown** | "When resisting a debuff" | grant **Buff Protection** | all allies | 1t | com 5% / unc 7% / rare 9% / epic 12% / leg 16% |
+| **Tenacity** | "Upon directly receiving damage exceeding 25% of max HP" | grant **Buff Protection** | all allies | 2t | rare 10% / epic 12% / leg 16% (no common/uncommon) |
+
+(Last Stand's epic variant was a copy-paste error in the data — corrected by the maintainer to the uniform "last one standing → Barrier + Block Debuff" form before this PR; the cherry-picked fix is on-branch. All four Last Stand rarities are now uniform → single builder, no per-rarity branching.)
+
+## 2. Design principle
+
+The **effects** all ride existing machinery: the reactive-buff executor (`triggers.ts` `cfg.type === 'buff'` branch, line ~1115), `mkNamedBuffGrant` (`buildEquipmentAbilities.ts`), the `procChance` gate (`passesProcChanceGate`, D-PR8), and all-allies recipient routing (`ctx.playerIds`, D-PR7 Battlecry / D-PR14 precedent). Block Debuff, Buff Protection, and Barrier are all real engine buffs now.
+
+So the PR's real work is **trigger seams** — three new ones plus one new filter. Each is scoped to the smallest faithful primitive.
+
+## 3. Per-applier design
+
+### 3.1 Firewall — `on-debuffed` (NEW trigger)
+
+- **Seam:** new `AbilityTrigger` value `on-debuffed`, registered in `triggers.ts` `registerReactiveListeners` to listen on the existing `debuff-applied` bus event, **self-scoped**: enqueue for owner where `e.targetId === ownerId`. Mirrors the `on-attacked` self-scoping pattern (`targetId === ownerId`).
+- **Scope decision:** `debuff-applied` is emitted once per discrete timed-debuff infliction (NOT recurring/aura re-applications, NOT DoTs — DoTs use the separate `dot-applied` event). So Firewall fires on **timed debuffs received**, including control-as-named-debuff (Stasis/Disable land as named debuffs). It does NOT fire on DoT application. This matches the colloquial "when debuffed" and is the cleanest faithful read; documented as a known scope boundary.
+- **Effect:** self-grant `Block Debuff`, duration 1, procChance per rarity. `mkNamedBuffGrant('Block Debuff', 'self', 'on-debuffed', 1, { procChance })`.
+- **No loop risk:** Block Debuff is a *buff* (not a debuff), so granting it does not re-fire `on-debuffed`.
+
+### 3.2 Lockdown — `on-debuff-resisted` (NEW trigger)
+
+- **Seam:** new `AbilityTrigger` value `on-debuff-resisted`, listens on the existing `debuff-resisted` bus event, **self-scoped**: enqueue for owner where `e.targetId === ownerId` (the resister). The `debuff-resisted` event carries `{ targetId, round, buffName }`; `targetId` is the resisting unit on either side (cast-side emission `playerTurn.ts:724`, reactive-side `triggers.ts:1256`, plus the D-PR15 Block-Debuff resist path) — so a player implant fires when the carrier resists an enemy debuff, side-agnostically.
+- **Effect:** all-allies grant `Buff Protection`, duration 1, procChance per rarity. `mkNamedBuffGrant('Buff Protection', 'all-allies', 'on-debuff-resisted', 1, { procChance })`.
+- **Emergent synergy (intended, tested):** a unit carrying Firewall-granted (or otherwise) Block Debuff auto-resists incoming debuffs → emits `debuff-resisted` → a same-side Lockdown carrier grants the team Buff Protection. Chains across D-PR15's primitive. This is a feature, not a coincidence; one integration test pins it.
+
+### 3.3 Tenacity — `on-attacked` + NEW damage-fraction filter
+
+- **Seam:** rides the existing `on-attacked` trigger (self-scoped `attacked` event). Adds a NEW filter: the hit's damage must exceed 25% of the victim's max HP.
+- **Damage granularity (forced by the engine model):** the `attacked` event is emitted per-hit but carries **no damage amount** — direct damage is applied per-attack as an aggregate (engine.ts ~4476/4510). So the threshold is modeled on the **per-attack aggregate** damage, not per individual hit. This is the same per-hit-vs-aggregate limitation Bloodthirst (D-PR1) documented and accepted. The `attacked` event already excludes DoT ticks and bomb detonations (only direct weapon hits emit it) — which matches "**directly** receiving damage".
+- **Plumbing:** add an optional `damage?: number` field to the `attacked` event (the per-attack aggregate, identical across the turn's hits) so the listener can evaluate `damage / victimMaxHp > 0.25`. The listener resolves the victim's effective max HP (the carrier is the attacked unit = owner). A new `Ability`/config filter field expresses the threshold (e.g. `triggerIncomingDamageFracOfMaxHp?: number` = 0.25) — kept generic, defaulting absent → no filter (byte-identical for every existing on-attacked ability).
+- **Effect:** all-allies grant `Buff Protection`, duration 2, procChance per rarity.
+
+### 3.4 Last Stand — `on-ally-destroyed` + NEW `last-standing` condition subject
+
+- **Seam (recommended over a dedicated trigger):** rides the existing `on-ally-destroyed` trigger (fires for each surviving same-side ally when an ally is destroyed) **gated by a NEW `last-standing` ConditionSubject** that is true iff the owner is the *sole living same-side actor*. The transition into "last standing" coincides exactly with the death of the last *other* same-side ally, so on-ally-destroyed + the gate fires precisely on becoming-last-standing. This reuses trigger machinery (lighter than a brand-new trigger and its event wiring).
+  - Edge: if multiple allies die in one batch, `on-ally-destroyed` fires per death; the gate evaluates after each, so it fires only on the death that leaves exactly one survivor. Correct.
+- **New condition subject** (follows the D-PR14 `first-activator` precedent, 6-hop thread):
+  - `ConditionContext.isLastStanding?: boolean` + `evaluateCondition` case (`ctx.isLastStanding ? 1 : 0`).
+  - Engine computes "is this owner the only living same-side actor" via a delegate `IntentExecContext.isLastStandingFor?(ownerId): boolean`, threaded through `buildDrainContext` → `buildActorConditionContext` → `buildRoundContext`. Liveness uses the same `destroyedRound === undefined` test used elsewhere; the same-side roster is the owner's side (player → `allPlayerActors`, enemy → `enemyAttackerActors`), side-bound at the drain seam exactly as D-PR14's `enemyWithHighestAttack`/`firstActivator` are.
+  - **MUST add `last-standing` to `LIVE_SUBJECTS`** (`abilityStatusGating.ts`) — else `liveGateConditions` rewrites it to `always` (the D-PR14 lesson). Buff-grant abilities run through `liveGateConditions`.
+- **Effect (dual buff, single proc roll):** self-grant `Barrier` AND `Block Debuff`, duration 1, on ONE proc roll. `mkNamedBuffGrant` grants a single buff name today; the existing skill parser emits one ability per buff for deterministic "A and B" ship-skill grants, but that gives **independent** proc rolls — unfaithful here ("gain Barrier and Block Debuff" is one chance for both).
+  - **Co-grant extension:** add optional `alsoGrantBuffNames?: string[]` to the buff `AbilityConfig`. In the `cfg.type === 'buff'` executor branch, AFTER the single `passesProcChanceGate` check, build and apply a timed status for the primary `buffName` **plus** each name in `alsoGrantBuffNames`, to the same recipients with the same duration (small loop around the existing single-status hoist). `mkNamedBuffGrant` gains `alsoGrantBuffNames` in `opts` (each resolved via `BUFFS` for `parsedEffects`; unknown name → skip that co-buff, never throw).
+  - Last Stand: `mkNamedBuffGrant('Barrier', 'self', 'on-ally-destroyed', 1, { procChance, conditions: [{ subject: 'last-standing', derivable: true }], alsoGrantBuffNames: ['Block Debuff'] })`.
+  - Byte-identical: `alsoGrantBuffNames` absent → single-buff path unchanged for every existing grant.
+
+## 4. proc model
+
+No once-per-round / once-per-combat caps — all four texts are pure per-event `% chance` procs (unlike D-PR14 Bulwark's "once per round"). Each qualifying event rolls the per-`(owner, ability)` rate gate (`procChanceGates`, deterministic accumulator). Firewall and Lockdown can therefore fire multiple times per round (multiple debuffs received / resisted), each an independent roll — faithful to the text.
+
+## 5. Registry & coverage
+
+- `buildEquipmentAbilities.ts`: four new `IMPLANT_ABILITIES` entries (FIREWALL, LAST_STAND, LOCKDOWN, TENACITY), values from `implants.ts` per-rarity proc chances.
+- `equipmentCoverage.test.ts`: add the four to BOTH the decl-order `.toEqual` array AND the `implementedImplants` Set (known pitfall — must update both).
+- DPS calculator page NOT wired — these are defensive/targeting-adjacent effects that don't affect outgoing DPS (consistent with D-PR14).
+
+## 6. Editor / type stubs
+
+New `AbilityTrigger` values (`on-debuffed`, `on-debuff-resisted`) and the `last-standing` condition subject need the usual exhaustiveness stubs so `tsc` and the ability editor stay complete: `AbilityCard.tsx` TRIGGER_OPTIONS, `ConditionRow.tsx` SUBJECT_VALUES + EXTRA_SUBJECT_LABELS, and any `AbilityTypePicker`/`abilityDefaults` switch arms. The new `attacked.damage` and config-filter / `alsoGrantBuffNames` fields are optional → no UI required beyond exhaustiveness.
+
+## 7. Testing & invariants
+
+- **Byte-identical goldens (load-bearing safety invariant):** no ship skill and no combat fixture grants any of these implants (verified — same posture as D-PR15). All DPS + healing goldens MUST stay byte-identical. If a golden moves, a gate leaked — fix the gate, never `vitest -u`.
+- Per-applier integration tests (engine-level, positional or aggregate as fits):
+  - **Firewall:** a debuff lands on the carrier → (proc forced via a deterministic gate) carrier gains Block Debuff → a subsequent incoming debuff is auto-resisted.
+  - **Lockdown:** carrier resists an incoming debuff → all same-side allies gain Buff Protection → an enemy purge against an ally is no-op.
+  - **Lockdown × Block Debuff synergy:** Block-Debuff holder auto-resists → `debuff-resisted` → same-side Lockdown grants team Buff Protection (the emergent chain).
+  - **Tenacity:** a direct attack > 25% of victim max HP → all allies gain Buff Protection (2t); an attack ≤ 25% does NOT trigger; a DoT batch exceeding 25% does NOT trigger (DoT emits no `attacked`).
+  - **Last Stand:** kill all same-side allies but one → the survivor (proc forced) gains BOTH Barrier and Block Debuff from one roll (assert both present; assert it does not fire while ≥2 allies live).
+  - Enemy-side mirror for at least one applier (team-agnostic: the same effect fires for an enemy carrier against the player team).
+- Pure-unit tests for the new `last-standing` evaluation and the Tenacity damage-fraction filter.
+
+## 8. Out of scope / deferred
+
+- **Block Buff** primitive (immune to RECEIVING buffs) — D-PR15 deferred it as golden-moving; no applier here needs it.
+- Remaining D buckets (shield-grant family DORMANT on sub-project H, Reactive Ward cleanse, Chrono Reaver charge-gen, Voidfire Catalyst detonation, trivial Code Guard, special-effect gear sets) — unchanged, future PRs.
+- No UI beyond editor exhaustiveness stubs; no DPS-page wiring.
+
+## 9. Key file seams (for the plan)
+
+- `src/types/abilities.ts` — `AbilityTrigger` += `on-debuffed`, `on-debuff-resisted`; buff `AbilityConfig` += `alsoGrantBuffNames?`; the Tenacity threshold filter field; `Condition` subject `last-standing`.
+- `src/utils/combat/events.ts` — `attacked` event += optional `damage?`.
+- `src/utils/combat/triggers.ts` — three new listener arms (`on-debuffed`, `on-debuff-resisted` self-scoped; Tenacity damage filter on the `on-attacked` arm); `cfg.type === 'buff'` co-grant loop; `last-standing` thread through `buildDrainContext`.
+- `src/utils/combat/engine.ts` — `attacked` emission += aggregate `damage`; `isLastStandingFor` delegate on the IntentExecContext (both drain seams, side-bound); thread through `ReactiveSideCtx` if needed (D-PR14 lesson — not just the drain literals).
+- `src/utils/combat/roundContext.ts` / condition-context builders — `isLastStanding` plumbing.
+- `src/utils/abilities/abilityStatusGating.ts` — `LIVE_SUBJECTS += 'last-standing'`.
+- `src/utils/combat/evaluateCondition` (wherever it lives) — `last-standing` case.
+- `src/utils/abilities/buildEquipmentAbilities.ts` — `mkNamedBuffGrant` `alsoGrantBuffNames` opt; four registry entries.
+- Editor stubs + `equipmentCoverage.test.ts`.
+- `src/constants/changelog.ts` — `UNRELEASED_CHANGES` entry.

--- a/src/components/skills/AbilityCard.tsx
+++ b/src/components/skills/AbilityCard.tsx
@@ -131,6 +131,7 @@ const TRIGGER_OPTIONS: { value: AbilityTrigger; label: string }[] = [
     { value: 'on-crit', label: 'On critical hit' },
     { value: 'on-attacked', label: 'When attacked' },
     { value: 'on-debuffed', label: 'On debuffed (self)' },
+    { value: 'on-debuff-resisted', label: 'On debuff resisted (self)' },
     { value: 'on-ally-attacked', label: 'When an ally is attacked' },
     { value: 'on-ally-destroyed', label: 'On ally destroyed' },
     { value: 'on-destroyed', label: 'On destroyed' },

--- a/src/components/skills/AbilityCard.tsx
+++ b/src/components/skills/AbilityCard.tsx
@@ -130,6 +130,7 @@ const TRIGGER_OPTIONS: { value: AbilityTrigger; label: string }[] = [
     { value: 'start-of-round', label: 'Start of round' },
     { value: 'on-crit', label: 'On critical hit' },
     { value: 'on-attacked', label: 'When attacked' },
+    { value: 'on-debuffed', label: 'On debuffed (self)' },
     { value: 'on-ally-attacked', label: 'When an ally is attacked' },
     { value: 'on-ally-destroyed', label: 'On ally destroyed' },
     { value: 'on-destroyed', label: 'On destroyed' },

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -24,7 +24,8 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator now models the Fortifying Shroud implant — a chance each turn to grant adjacent allies a Defense Up buff.',
     "Combat simulator: the Disable control now skips the affected ship's turn and locks out its reactions, so effects that apply Disable — like the Martyrdom implant and Disable-inflicting skills — now take effect in the simulation.",
     'Combat simulator: Bulwark implants now apply Provoke to an enemy that damages a nearby ally, and Doomsayer implants apply Concentrate Fire to the strongest enemy at the end of the round.',
-    'Combat simulator now models two control primitives: Block Debuff (a unit immune to debuffs auto-resists every incoming debuff — timed, persistent, control such as Stasis or Disable, and damage-over-time — shown in the log as resisted) and Buff Protection (a unit\'s buffs can no longer be stripped by enemy purge). These back upcoming implant effects.',
+    "Combat simulator now models two control primitives: Block Debuff (a unit immune to debuffs auto-resists every incoming debuff — timed, persistent, control such as Stasis or Disable, and damage-over-time — shown in the log as resisted) and Buff Protection (a unit's buffs can no longer be stripped by enemy purge). These back upcoming implant effects.",
+    'Combat simulator now models the Firewall implant — when the carrier is debuffed, a chance to gain Block Debuff for 1 turn, making it briefly immune to incoming debuffs.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -25,7 +25,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat simulator: the Disable control now skips the affected ship's turn and locks out its reactions, so effects that apply Disable — like the Martyrdom implant and Disable-inflicting skills — now take effect in the simulation.",
     'Combat simulator: Bulwark implants now apply Provoke to an enemy that damages a nearby ally, and Doomsayer implants apply Concentrate Fire to the strongest enemy at the end of the round.',
     "Combat simulator now models two control primitives: Block Debuff (a unit immune to debuffs auto-resists every incoming debuff — timed, persistent, control such as Stasis or Disable, and damage-over-time — shown in the log as resisted) and Buff Protection (a unit's buffs can no longer be stripped by enemy purge). These back upcoming implant effects.",
-    'Combat simulator now models the Firewall implant — when the carrier is debuffed, a chance to gain Block Debuff for 1 turn, making it briefly immune to incoming debuffs.',
+    'Combat simulator now models four reactive defensive-control implants: Firewall (when the carrier is debuffed, a chance to gain Block Debuff so it briefly auto-resists incoming debuffs), Lockdown (when the carrier resists a debuff, grants the team Buff Protection so their buffs can no longer be purged), Tenacity (when the carrier takes a hit over 25% of its max HP, grants the team Buff Protection), and Last Stand (when the carrier becomes the last unit standing, grants itself Barrier and Block Debuff).',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -89,7 +89,11 @@ export type AbilityTrigger =
     // D-PR16 Firewall: fires when THIS unit receives a timed debuff (rides the existing
     // `debuff-applied` event, self-scoped on targetId === ownerId). Does NOT fire for DoTs
     // (separate `dot-applied` event) — matches "when debuffed".
-    | 'on-debuffed';
+    | 'on-debuffed'
+    // D-PR16 Lockdown: fires when THIS unit resists an incoming debuff (rides the existing
+    // `debuff-resisted` event, self-scoped on targetId === ownerId). Chains off D-PR15's
+    // Block-Debuff auto-resist emission AND normal hacking/affinity resists.
+    | 'on-debuff-resisted';
 
 /**
  * Triggers the combat engine consumes via listeners (the machinery lives in
@@ -129,6 +133,8 @@ export const LIVE_TRIGGERS = new Set<AbilityTrigger>([
     'on-own-repair-to-ally',
     // D-PR16 Firewall: self-scoped reaction to receiving a timed debuff.
     'on-debuffed',
+    // D-PR16 Lockdown: self-scoped reaction to RESISTING an incoming debuff.
+    'on-debuff-resisted',
 ]);
 
 export type ConditionSubject =

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -451,6 +451,10 @@ export interface Ability {
      *  Filtered in the listener via registerReactiveListeners' adjacentAllyIdsFor. Absent →
      *  any ally (existing behavior). */
     requireDamagedAllyAdjacent?: boolean;
+    /** D-PR16 Tenacity: gate an `on-attacked` reaction on the per-attack aggregate damage
+     *  exceeding this fraction of the owner's effective max HP (e.g. 0.25). Absent → no gate
+     *  (byte-identical for every existing on-attacked ability). */
+    requireIncomingDamageFracOfMaxHp?: number;
     /** Probabilistic proc gate for equipment-sourced reactive abilities ("N% chance to …").
      *  A value in (0,1) means the ability fires at that rate via a combat-lifetime per-(owner,
      *  ability) RateGate (deterministic accumulator, like crit/landing). Absent or out of (0,1)

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -37,7 +37,7 @@ export type AbilityTarget =
     | 'all-enemies'
     | 'enemy-most-buffs'
     | 'enemy-highest-attack'; // D-PR14 Doomsayer: living opposing actor with the greatest
-    //                           live effective attack (global selector, resolved at drain).
+//                           live effective attack (global selector, resolved at drain).
 
 // NOTE on the live subset: `round-started` is the engine event key for the
 // `start-of-round` trigger (a deviation from the Phase 1 contract's `turn-started`
@@ -85,7 +85,11 @@ export type AbilityTrigger =
     // Fired when the owner applies repair to at least one OTHER ally (own heal-performed
     // event with a non-self recipient). Used by the Font of Power implant (grants the
     // repaired allies a buff). Distinct from on-ally-critically-repaired (no crit filter).
-    | 'on-own-repair-to-ally';
+    | 'on-own-repair-to-ally'
+    // D-PR16 Firewall: fires when THIS unit receives a timed debuff (rides the existing
+    // `debuff-applied` event, self-scoped on targetId === ownerId). Does NOT fire for DoTs
+    // (separate `dot-applied` event) — matches "when debuffed".
+    | 'on-debuffed';
 
 /**
  * Triggers the combat engine consumes via listeners (the machinery lives in
@@ -123,6 +127,8 @@ export const LIVE_TRIGGERS = new Set<AbilityTrigger>([
     'on-charged-cast',
     // Font of Power: buff grant to allies the owner repairs.
     'on-own-repair-to-ally',
+    // D-PR16 Firewall: self-scoped reaction to receiving a timed debuff.
+    'on-debuffed',
 ]);
 
 export type ConditionSubject =
@@ -171,7 +177,7 @@ export type ConditionSubject =
     // (DPS / not-yet-hit → "not hit" ⇒ met). Used by the Alacrity implant.
     | 'not-hit-this-round'
     | 'first-activator'; // D-PR14 Doomsayer: this owner was the first actor to take a REAL
-    //                      (non-Stasis/Disable-skipped) turn this round.
+//                      (non-Stasis/Disable-skipped) turn this round.
 
 export interface Condition {
     subject: ConditionSubject;

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -304,6 +304,17 @@ export type AbilityConfig =
            *  combat-lifetime Set keyed `${ownerId}:${abilityId}` in IntentExecContext.
            *  Absent → unbounded (fires on every qualifying trigger). */
           oncePerCombat?: boolean;
+          /** D-PR16: extra buffs granted ALONGSIDE the primary in the SAME application (one proc
+           *  roll → all of them). Each carries its own resolved effects + duration. Absent → the
+           *  single-buff path is unchanged. */
+          additionalBuffs?: Array<{
+              buffName: string;
+              parsedEffects: ParsedBuffEffects;
+              stacks: number;
+              isStackable: boolean;
+              maxStacks?: number;
+              duration: number;
+          }>;
       }
     | {
           type: 'debuff';

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -182,8 +182,13 @@ export type ConditionSubject =
     // attacks do not count). Live-derived (ConditionContext.wasHitThisRound); defaults false
     // (DPS / not-yet-hit → "not hit" ⇒ met). Used by the Alacrity implant.
     | 'not-hit-this-round'
-    | 'first-activator'; // D-PR14 Doomsayer: this owner was the first actor to take a REAL
-//                      (non-Stasis/Disable-skipped) turn this round.
+    | 'first-activator' // D-PR14 Doomsayer: this owner was the first actor to take a REAL
+    //                      (non-Stasis/Disable-skipped) turn this round.
+    // D-PR16: binary gate — this owner is the SOLE living actor on its own side. Live-derived by
+    // the engine each drain (ConditionContext.isLastStanding); defaults false (DPS / not-alone).
+    // derivable:true — a derivable:false condition would always be met (evaluateConditions.ts:30).
+    // Infrastructure for the Last Stand implant (wired in a later task).
+    | 'last-standing';
 
 export interface Condition {
     subject: ConditionSubject;

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.cogrant.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.cogrant.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { mkNamedBuffGrant } from '../buildEquipmentAbilities';
+
+// D-PR16 Task 5: multi-buff co-grant infrastructure. `mkNamedBuffGrant` can carry extra
+// named buffs (alsoGrantBuffNames) that are granted ALONGSIDE the primary in the SAME
+// application (one proc roll → all of them). No implant uses it yet (Task 6 wires Last
+// Stand) — these tests pin the registry SHAPE.
+describe('mkNamedBuffGrant — additionalBuffs co-grant (D-PR16 Task 5)', () => {
+    it('attaches a populated additionalBuffs array with resolved parsedEffects', () => {
+        const ability = mkNamedBuffGrant('Barrier', 'self', 'on-ally-destroyed', 1, {
+            procChance: 0.32,
+            alsoGrantBuffNames: ['Block Debuff'],
+        });
+
+        expect(ability).toBeDefined();
+        expect(ability!.config.type).toBe('buff');
+        if (ability!.config.type !== 'buff') throw new Error('expected buff config');
+
+        // Primary buff unchanged.
+        expect(ability!.config.buffName).toBe('Barrier');
+        expect(ability!.procChance).toBeCloseTo(0.32);
+
+        // Co-granted buff present with a resolved (non-undefined) parsedEffects.
+        const extras = ability!.config.additionalBuffs;
+        expect(extras).toBeDefined();
+        expect(extras).toHaveLength(1);
+        expect(extras![0].buffName).toBe('Block Debuff');
+        expect(extras![0].parsedEffects).toBeDefined();
+        expect(extras![0].duration).toBe(1);
+    });
+
+    it('omits additionalBuffs entirely when alsoGrantBuffNames is absent (byte-identical)', () => {
+        const ability = mkNamedBuffGrant('Barrier', 'self', 'on-ally-destroyed', 1, {
+            procChance: 0.32,
+        });
+        expect(ability).toBeDefined();
+        if (ability!.config.type !== 'buff') throw new Error('expected buff config');
+        expect('additionalBuffs' in ability!.config).toBe(false);
+    });
+
+    it('omits additionalBuffs when alsoGrantBuffNames is empty', () => {
+        const ability = mkNamedBuffGrant('Barrier', 'self', 'on-ally-destroyed', 1, {
+            procChance: 0.32,
+            alsoGrantBuffNames: [],
+        });
+        if (ability!.config.type !== 'buff') throw new Error('expected buff config');
+        expect('additionalBuffs' in ability!.config).toBe(false);
+    });
+});

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -106,7 +106,7 @@ function implantAbilityCount(implantKey: string, rarity: GearPiece['rarity']): n
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { LEECH + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + LOCKDOWN + MENACE + SECOND_WIND + SHADOWGUARD + SPEARHEAD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
+    it('exactly { LEECH + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + LOCKDOWN + MENACE + SECOND_WIND + SHADOWGUARD + SPEARHEAD + TENACITY + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -149,6 +149,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
             'SECOND_WIND',
             'SHADOWGUARD',
             'SPEARHEAD',
+            'TENACITY',
             'VIVACIOUS_REPAIR',
         ]);
     });
@@ -204,9 +205,11 @@ describe('equipmentCoverage — implants', () => {
     // D-PR14: BULWARK, DOOMSAYER added (Provoke / Concentrate Fire debuff grants).
     // D-PR16: FIREWALL added (on-debuffed → self Block Debuff grant).
     // D-PR16: LOCKDOWN added (on-debuff-resisted → all-ally Buff Protection grant).
+    // D-PR16: TENACITY added (on-attacked >25%-max-HP → all-ally Buff Protection grant).
     const implementedImplants = new Set([
         'FIREWALL',
         'LOCKDOWN',
+        'TENACITY',
         'BLOODTHIRST',
         'INTRUSION',
         'ARCANE_SIEGE',

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -106,7 +106,7 @@ function implantAbilityCount(implantKey: string, rarity: GearPiece['rarity']): n
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { LEECH + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + MENACE + SECOND_WIND + SHADOWGUARD + SPEARHEAD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
+    it('exactly { LEECH + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + MENACE + SECOND_WIND + SHADOWGUARD + SPEARHEAD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -137,6 +137,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
             'BULWARK',
             'DOOMSAYER',
             'EXUBERANCE',
+            'FIREWALL',
             'FONT_OF_POWER',
             'FORTIFYING_SHROUD',
             'GIANT_SLAYER',
@@ -200,7 +201,9 @@ describe('equipmentCoverage — implants', () => {
     // D-PR7: LAST_WISH, BATTLECRY, MARTYRDOM added (on-death repair / buff to allies / disable killer).
     // D-PR8: SYNAPTIC_RESONANCE, ALACRITY, AMBUSH added (reactive self-buff grants).
     // D-PR14: BULWARK, DOOMSAYER added (Provoke / Concentrate Fire debuff grants).
+    // D-PR16: FIREWALL added (on-debuffed → self Block Debuff grant).
     const implementedImplants = new Set([
+        'FIREWALL',
         'BLOODTHIRST',
         'INTRUSION',
         'ARCANE_SIEGE',

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -106,7 +106,7 @@ function implantAbilityCount(implantKey: string, rarity: GearPiece['rarity']): n
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { LEECH + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + MENACE + SECOND_WIND + SHADOWGUARD + SPEARHEAD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
+    it('exactly { LEECH + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + LOCKDOWN + MENACE + SECOND_WIND + SHADOWGUARD + SPEARHEAD + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -144,6 +144,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
             'INSIDIOUSNESS',
             'IRONCLAD',
             'LAST_WISH',
+            'LOCKDOWN',
             'MENACE',
             'SECOND_WIND',
             'SHADOWGUARD',
@@ -202,8 +203,10 @@ describe('equipmentCoverage — implants', () => {
     // D-PR8: SYNAPTIC_RESONANCE, ALACRITY, AMBUSH added (reactive self-buff grants).
     // D-PR14: BULWARK, DOOMSAYER added (Provoke / Concentrate Fire debuff grants).
     // D-PR16: FIREWALL added (on-debuffed → self Block Debuff grant).
+    // D-PR16: LOCKDOWN added (on-debuff-resisted → all-ally Buff Protection grant).
     const implementedImplants = new Set([
         'FIREWALL',
+        'LOCKDOWN',
         'BLOODTHIRST',
         'INTRUSION',
         'ARCANE_SIEGE',

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -106,7 +106,7 @@ function implantAbilityCount(implantKey: string, rarity: GearPiece['rarity']): n
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { LEECH + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_WISH + LOCKDOWN + MENACE + SECOND_WIND + SHADOWGUARD + SPEARHEAD + TENACITY + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
+    it('exactly { LEECH + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_STAND + LAST_WISH + LOCKDOWN + MENACE + SECOND_WIND + SHADOWGUARD + SPEARHEAD + TENACITY + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -143,6 +143,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
             'GIANT_SLAYER',
             'INSIDIOUSNESS',
             'IRONCLAD',
+            'LAST_STAND',
             'LAST_WISH',
             'LOCKDOWN',
             'MENACE',
@@ -206,10 +207,12 @@ describe('equipmentCoverage — implants', () => {
     // D-PR16: FIREWALL added (on-debuffed → self Block Debuff grant).
     // D-PR16: LOCKDOWN added (on-debuff-resisted → all-ally Buff Protection grant).
     // D-PR16: TENACITY added (on-attacked >25%-max-HP → all-ally Buff Protection grant).
+    // D-PR16: LAST_STAND added (on-ally-destroyed + last-standing → self Barrier + Block Debuff co-grant).
     const implementedImplants = new Set([
         'FIREWALL',
         'LOCKDOWN',
         'TENACITY',
+        'LAST_STAND',
         'BLOODTHIRST',
         'INTRUSION',
         'ARCANE_SIEGE',

--- a/src/utils/abilities/__tests__/lastStandingCondition.test.ts
+++ b/src/utils/abilities/__tests__/lastStandingCondition.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { conditionsMet } from '../evaluateConditions';
+import { makeConditionContext } from './conditionContextFixture';
+
+describe('last-standing condition', () => {
+    it('is met when isLastStanding is true', () => {
+        const ctx = makeConditionContext({ isLastStanding: true });
+        expect(conditionsMet([{ subject: 'last-standing', derivable: true }], ctx)).toBe(true);
+    });
+    it('is NOT met when isLastStanding is false/absent', () => {
+        const ctxFalse = makeConditionContext({ isLastStanding: false });
+        expect(conditionsMet([{ subject: 'last-standing', derivable: true }], ctxFalse)).toBe(
+            false
+        );
+        const ctxAbsent = makeConditionContext({});
+        expect(conditionsMet([{ subject: 'last-standing', derivable: true }], ctxAbsent)).toBe(
+            false
+        );
+    });
+});

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -289,6 +289,14 @@ const LOCKDOWN_PROC: Record<string, number> = {
     legendary: 0.16,
 };
 const TENACITY_PROC: Record<string, number> = { rare: 0.1, epic: 0.12, legendary: 0.16 };
+// D-PR16: Last Stand — when this unit becomes the last one standing, X% chance to gain Barrier
+// AND Block Debuff (self) for 1 turn. All four rarities are uniform per the source data.
+const LAST_STAND_PROC: Record<string, number> = {
+    uncommon: 0.18,
+    rare: 0.21,
+    epic: 0.26,
+    legendary: 0.32,
+};
 
 // D-PR6: incoming-heal-amplification implant value tables
 // No common rarity for Exuberance
@@ -771,6 +779,18 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
         });
         if (!base) return undefined;
         return { ...base, requireIncomingDamageFracOfMaxHp: 0.25 };
+    },
+    // D-PR16: Last Stand — when this unit becomes the last one standing, X% chance to gain
+    // Barrier AND Block Debuff (self) for 1 turn. Rides on-ally-destroyed gated on last-standing
+    // (fires on the ally death that leaves the owner sole survivor); both buffs on ONE proc roll.
+    LAST_STAND: (rarity) => {
+        const procChance = LAST_STAND_PROC[rarity];
+        if (procChance === undefined) return undefined;
+        return mkNamedBuffGrant('Barrier', 'self', 'on-ally-destroyed', 1, {
+            procChance,
+            conditions: [{ subject: 'last-standing', derivable: true }],
+            alsoGrantBuffNames: ['Block Debuff'],
+        });
     },
 };
 

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -274,6 +274,13 @@ const DOOMSAYER_PROC: Record<string, number> = {
     epic: 0.12,
     legendary: 0.16,
 };
+// D-PR16: Firewall — when debuffed, X% chance to gain Block Debuff (self) for 1 turn.
+const FIREWALL_PROC: Record<string, number> = {
+    uncommon: 0.08,
+    rare: 0.1,
+    epic: 0.12,
+    legendary: 0.15,
+};
 
 // D-PR6: incoming-heal-amplification implant value tables
 // No common rarity for Exuberance
@@ -706,6 +713,12 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
             target: 'enemy-highest-attack',
             conditions: [{ subject: 'first-activator', derivable: true }],
         });
+    },
+    // D-PR16: Firewall — when debuffed, X% chance to gain Block Debuff (self) for 1 turn.
+    FIREWALL: (rarity) => {
+        const procChance = FIREWALL_PROC[rarity];
+        if (procChance === undefined) return undefined;
+        return mkNamedBuffGrant('Block Debuff', 'self', 'on-debuffed', 1, { procChance });
     },
 };
 

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -357,17 +357,39 @@ function mkHealAmp(
 // effect the engine does not yet fold (self-side incoming-damage buffs) — the status is applied
 // and logged but has no combat effect until that fold exists.
 // D-PR8: generalised with optional `opts` for conditions + procChance (Battlecry call is byte-identical).
-function mkNamedBuffGrant(
+// D-PR16: `alsoGrantBuffNames` (Task 5) lets one ability co-grant extra named buffs ALONGSIDE
+// the primary in the SAME application (one proc roll → all of them; Last Stand's Barrier + Block
+// Debuff). Each extra resolves its own effects/stackability from BUFFS and inherits `duration`.
+// Absent/empty → the `additionalBuffs` field is omitted → the single-buff path is byte-identical.
+// Exported for the co-grant registry-shape test.
+export function mkNamedBuffGrant(
     buffName: string,
     target: 'self' | 'ally' | 'all-allies' | 'adjacent-allies',
     trigger: AbilityTrigger,
     duration: number | undefined,
-    opts?: { conditions?: Condition[]; procChance?: number }
+    opts?: { conditions?: Condition[]; procChance?: number; alsoGrantBuffNames?: string[] }
 ): Omit<Ability, 'id'> | undefined {
     if (duration === undefined) return undefined;
     const buff = BUFFS.find((b) => b.name === buffName);
     if (!buff) return undefined;
     const { stackable, maxStacks } = isStackable(buff.description);
+    const additionalBuffs = (opts?.alsoGrantBuffNames ?? [])
+        .map((n) => {
+            const b = BUFFS.find((x) => x.name === n);
+            if (!b) return undefined;
+            const { stackable: extraStackable, maxStacks: extraMaxStacks } = isStackable(
+                b.description
+            );
+            return {
+                buffName: n,
+                parsedEffects: parseBuffEffects(b.name, b.description),
+                stacks: 1,
+                isStackable: extraStackable,
+                maxStacks: extraMaxStacks,
+                duration,
+            };
+        })
+        .filter((x): x is NonNullable<typeof x> => x !== undefined);
     return {
         type: 'buff',
         target,
@@ -382,6 +404,7 @@ function mkNamedBuffGrant(
             isStackable: stackable,
             maxStacks,
             duration,
+            ...(additionalBuffs.length ? { additionalBuffs } : {}),
         },
         autoFilled: true,
     };

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -281,6 +281,13 @@ const FIREWALL_PROC: Record<string, number> = {
     epic: 0.12,
     legendary: 0.15,
 };
+const LOCKDOWN_PROC: Record<string, number> = {
+    common: 0.05,
+    uncommon: 0.07,
+    rare: 0.09,
+    epic: 0.12,
+    legendary: 0.16,
+};
 
 // D-PR6: incoming-heal-amplification implant value tables
 // No common rarity for Exuberance
@@ -719,6 +726,15 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
         const procChance = FIREWALL_PROC[rarity];
         if (procChance === undefined) return undefined;
         return mkNamedBuffGrant('Block Debuff', 'self', 'on-debuffed', 1, { procChance });
+    },
+    // D-PR16: Lockdown — when resisting a debuff, X% chance to grant Buff Protection to
+    // all allies for 1 turn.
+    LOCKDOWN: (rarity) => {
+        const procChance = LOCKDOWN_PROC[rarity];
+        if (procChance === undefined) return undefined;
+        return mkNamedBuffGrant('Buff Protection', 'all-allies', 'on-debuff-resisted', 1, {
+            procChance,
+        });
     },
 };
 

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -288,6 +288,7 @@ const LOCKDOWN_PROC: Record<string, number> = {
     epic: 0.12,
     legendary: 0.16,
 };
+const TENACITY_PROC: Record<string, number> = { rare: 0.1, epic: 0.12, legendary: 0.16 };
 
 // D-PR6: incoming-heal-amplification implant value tables
 // No common rarity for Exuberance
@@ -735,6 +736,18 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
         return mkNamedBuffGrant('Buff Protection', 'all-allies', 'on-debuff-resisted', 1, {
             procChance,
         });
+    },
+    // D-PR16: Tenacity — upon directly receiving damage > 25% of max HP, X% chance to grant
+    // Buff Protection to all allies for 2 turns. Models the per-ATTACK aggregate (the
+    // `attacked` event excludes DoT/bomb → "directly receiving").
+    TENACITY: (rarity) => {
+        const procChance = TENACITY_PROC[rarity];
+        if (procChance === undefined) return undefined;
+        const base = mkNamedBuffGrant('Buff Protection', 'all-allies', 'on-attacked', 2, {
+            procChance,
+        });
+        if (!base) return undefined;
+        return { ...base, requireIncomingDamageFracOfMaxHp: 0.25 };
     },
 };
 

--- a/src/utils/abilities/evaluateConditions.ts
+++ b/src/utils/abilities/evaluateConditions.ts
@@ -35,6 +35,9 @@ export interface ConditionContext {
     /** D-PR14: this owner took the round's first real turn. Live-derived by the engine;
      *  defaults false. Used by the Doomsayer implant. */
     firstActivator?: boolean;
+    /** D-PR16: this owner is the SOLE living actor on its own side. Live-derived by the engine
+     *  each drain; defaults false. Infrastructure for the Last Stand implant. */
+    isLastStanding?: boolean;
 }
 
 /** Resolve one condition to a count (>= 0). 0 means "not met". */
@@ -90,6 +93,8 @@ export function evaluateCondition(cond: Condition, ctx: ConditionContext): numbe
             return ctx.wasHitThisRound ? 0 : 1;
         case 'first-activator':
             return ctx.firstActivator ? 1 : 0;
+        case 'last-standing':
+            return ctx.isLastStanding ? 1 : 0;
         default:
             return 0;
     }

--- a/src/utils/abilities/roundContext.ts
+++ b/src/utils/abilities/roundContext.ts
@@ -42,6 +42,8 @@ export function buildRoundContext(state: {
     wasHitThisRound?: boolean;
     /** True when the acting unit took the round's first real turn. Default false. */
     firstActivator?: boolean;
+    /** True when the acting unit is the sole living actor on its side. Default false. */
+    lastStanding?: boolean;
 }): ConditionContext {
     return {
         selfBuffNames: state.selfBuffNames,
@@ -66,6 +68,7 @@ export function buildRoundContext(state: {
         selfShielded: state.selfShielded ?? false,
         wasHitThisRound: state.wasHitThisRound ?? false,
         firstActivator: state.firstActivator ?? false,
+        isLastStanding: state.lastStanding ?? false,
         ...(state.roundCrit !== undefined ? { roundCrit: state.roundCrit } : {}),
     };
 }

--- a/src/utils/combat/__tests__/firewallApplier.test.ts
+++ b/src/utils/combat/__tests__/firewallApplier.test.ts
@@ -1,0 +1,201 @@
+/**
+ * D-PR16 — Firewall (Block Debuff) ENGINE-LEVEL integration test.
+ *
+ * Firewall: "When debuffed, there is an X% chance to gain Block Debuff for 1 turn."
+ * It rides the new `on-debuffed` reactive trigger — self-scoped on the `debuff-applied`
+ * event (targetId === ownerId) — and grants the owner a `Block Debuff` self-buff.
+ *
+ * This exercises the FULL registry path (NOT direct ability injection): a player carrier
+ * equips a legendary Firewall implant via a stubbed `getGearPiece` + `setBonus='FIREWALL'`,
+ * `buildShipAbilitiesWithEquipment` merges the reactive buff-grant into the passive slot,
+ * and the engine wires up the `on-debuffed` listener. An enemy attacker lands a timed
+ * (non-DoT) debuff on the carrier every round, emitting `debuff-applied` with
+ * targetId = the carrier → the listener fires → the proc gate (legendary 0.15) accumulates.
+ *
+ * Forcing the proc deterministically: the rate-accumulator gate at rate 0.15 fires on the
+ * ceil(1/0.15)=7th qualifying event. Driving 10 qualifying debuff events guarantees at
+ * least one fire, so the carrier MUST end up carrying `Block Debuff` (buff-applied emitted
+ * with actorId = the carrier). The control (same setup, NO Firewall) proves non-vacuity:
+ * with no Firewall there are ZERO `Block Debuff` self-buffs.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus } from '../events';
+import { ShipSkills } from '../../../types/abilities';
+import { Ship } from '../../../types/ship';
+import { GearPiece } from '../../../types/gear';
+import { buildShipAbilitiesWithEquipment } from '../../abilities/buildShipAbilitiesWithEquipment';
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+function makeShip(over: Partial<Ship>): Ship {
+    return {
+        id: 'test-ship',
+        name: 'Test Ship',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'DEFENDER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        ...over,
+    } as Ship;
+}
+
+function makePiece(over: Partial<GearPiece>): GearPiece {
+    return {
+        id: 'piece-1',
+        slot: 'implant_major',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: null,
+        ...over,
+    } as GearPiece;
+}
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+/** An enemy attacker that lands a timed Def Down debuff on the player focus every round.
+ *  application:'apply' always lands (no affinity disadvantage here) → emits debuff-applied
+ *  with targetId = the carrier ('attacker') every round. */
+const debuffEnemy = (id: string): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 1, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1000 },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'enemy-debuff',
+                            type: 'debuff',
+                            target: 'enemy', // enemy's "enemy" = the player carrier
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: {
+                                type: 'debuff',
+                                buffName: 'Def Down',
+                                parsedEffects: {},
+                                stacks: 1,
+                                isStackable: false,
+                                application: 'apply',
+                                duration: 1,
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+    }) as EnemyAttacker;
+
+/** No-op active so the focus takes a turn without ending the combat early. */
+const noopActive: ShipSkills['slots'][number] = {
+    slot: 'active',
+    abilities: [
+        {
+            id: 'noop-atk',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0 },
+        },
+    ],
+};
+
+const BASE = (
+    shipSkills: ShipSkills,
+    overrides: Partial<CombatEngineInput> = {}
+): CombatEngineInput => ({
+    attack: 1,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills,
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 10,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    speed: 1, // slower than the enemy → enemy debuffs the carrier each round before it acts
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+/** Collect every `buff-applied` event for `buffName` on the given actor. */
+function buffAppliedOn(input: CombatEngineInput, buffName: string, actorId: string): number {
+    const bus = createEventBus();
+    let count = 0;
+    bus.on('buff-applied', (e) => {
+        if (e.buffName === buffName && e.actorId === actorId) count++;
+    });
+    runCombat({ ...input, bus });
+    return count;
+}
+
+// Build the carrier's skills via the REAL registry path: a legendary Firewall implant.
+function buildFirewallSkills(): ShipSkills {
+    const ship = makeShip({ implants: { implant_major: 'firewall-legendary' } });
+    const getGearPiece = (id: string): GearPiece | undefined =>
+        id === 'firewall-legendary'
+            ? makePiece({ id, slot: 'implant_major', rarity: 'legendary', setBonus: 'FIREWALL' })
+            : undefined;
+    const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+    const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+    return {
+        slots: [
+            noopActive,
+            ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+        ],
+    };
+}
+
+describe('D-PR16 Firewall (on-debuffed → self Block Debuff)', () => {
+    it('grants the carrier Block Debuff when an enemy repeatedly debuffs it (registry path)', () => {
+        const firewallSkills = buildFirewallSkills();
+
+        // Pre-condition: the Firewall reactive buff-grant landed in the passive slot.
+        const passive = firewallSkills.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        const fw = passive!.abilities.find((a) => a.id.startsWith('equip-implant-FIREWALL'));
+        expect(fw).toBeDefined();
+
+        // 10 qualifying debuff events; legendary rate 0.15 fires on the 7th → at least one
+        // Block Debuff self-buff applied to the carrier.
+        const count = buffAppliedOn(
+            BASE(firewallSkills, { enemyAttackers: [debuffEnemy('enemy-deb')] }),
+            'Block Debuff',
+            'attacker'
+        );
+        expect(count).toBeGreaterThan(0);
+    });
+
+    it('control: WITHOUT Firewall the carrier never gains Block Debuff (non-vacuity)', () => {
+        const bareSkills: ShipSkills = { slots: [noopActive] };
+        const count = buffAppliedOn(
+            BASE(bareSkills, { enemyAttackers: [debuffEnemy('enemy-deb')] }),
+            'Block Debuff',
+            'attacker'
+        );
+        expect(count).toBe(0);
+    });
+});

--- a/src/utils/combat/__tests__/lastStandApplier.test.ts
+++ b/src/utils/combat/__tests__/lastStandApplier.test.ts
@@ -13,11 +13,14 @@
  * the proc gate — so the proc accumulator only advances on the single qualifying (sole-survivor)
  * event. A fresh rate accumulator at the registry's 0.32 rate does NOT fire on its first event, so
  * the single last-standing event cannot drive a real-rate proc deterministically. We therefore
- * inject the ability with `procChance: 1` (every other field — trigger, target, the `last-standing`
- * condition, the 'Barrier' buff name + `alsoGrantBuffNames: ['Block Debuff']`, 1-turn duration —
- * matches the registry exactly, buildEquipmentAbilities.ts LAST_STAND). This is the same determinism
- * device the sibling integration suites use (cfProvokeAppliers forces procChance: 1). The registry's
- * exact per-rarity proc table + ability shape are covered by equipmentCoverage.test.ts.
+ * resolve the ability from the REAL registry (legendary implant via buildShipAbilitiesWithEquipment)
+ * and override ONLY `procChance` to 1 — every other field (trigger, target, the `last-standing`
+ * condition, the 'Barrier' buff name + co-granted 'Block Debuff', 1-turn duration) is exactly what
+ * buildEquipmentAbilities.ts LAST_STAND produced. This is the same determinism device the sibling
+ * integration suites use (cfProvokeAppliers forces procChance: 1), but routed through the real entry
+ * so a registry typo in any load-bearing field fails a test here. A registry-shape assertion below
+ * additionally pins the exact field values; the per-rarity proc table is covered by
+ * equipmentCoverage.test.ts.
  *
  * Cases:
  *  - GRANT (headline): a 2-actor player team; the carrier becomes sole survivor when the OTHER ally
@@ -33,41 +36,75 @@ import { createEventBus } from '../events';
 import { Ability, ShipSkills } from '../../../types/abilities';
 import type { Position } from '../../../types/encounters';
 import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import { Ship } from '../../../types/ship';
+import { GearPiece } from '../../../types/gear';
+import { buildShipAbilitiesWithEquipment } from '../../abilities/buildShipAbilitiesWithEquipment';
 
 type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
 
 // ---------------------------------------------------------------------------
-// Shared ability shapes (match the registry, procChance forced to 1)
+// Real-registry resolution of the LAST_STAND ability (procChance forced to 1)
 // ---------------------------------------------------------------------------
+//
+// The headline + enemy-mirror cases drive the REAL registry entry end-to-end: we equip a
+// legendary Last Stand implant via a stubbed `getGearPiece` + `setBonus='LAST_STAND'`,
+// `buildShipAbilitiesWithEquipment` merges the reactive buff-grant into the passive slot, and
+// we override ONLY `procChance` to 1 on the resolved ability (so the single sole-survivor event
+// fires deterministically — see header note). Every other field — trigger, target, the
+// `last-standing` condition, the 'Barrier' buff name + co-granted 'Block Debuff', 1-turn duration
+// — is exactly what the registry produced. A registry typo in any of those fields now fails a test.
 
-/** Last Stand: on-ally-destroyed self Barrier (1 turn) + co-granted Block Debuff (1 turn), gated on
- *  `last-standing`. proc forced to 1 → the single sole-survivor event reliably grants both buffs. */
-const lastStandAbility: Ability = {
-    id: 'equip-implant-LAST_STAND',
-    type: 'buff',
-    target: 'self',
-    trigger: 'on-ally-destroyed',
-    conditions: [{ subject: 'last-standing', derivable: true }],
-    procChance: 1, // >= 1 → passesProcChanceGate is unconditional (deterministic)
-    config: {
-        type: 'buff',
-        buffName: 'Barrier',
-        parsedEffects: {},
-        stacks: 1,
-        isStackable: false,
-        duration: 1,
-        additionalBuffs: [
-            {
-                buffName: 'Block Debuff',
-                parsedEffects: {},
-                stacks: 1,
-                isStackable: false,
-                duration: 1,
-            },
-        ],
-    } as Ability['config'],
-    autoFilled: true,
-};
+function makeShip(over: Partial<Ship>): Ship {
+    return {
+        id: 'test-ship',
+        name: 'Test Ship',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'DEFENDER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        ...over,
+    } as Ship;
+}
+
+function makePiece(over: Partial<GearPiece>): GearPiece {
+    return {
+        id: 'piece-1',
+        slot: 'implant_major',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: null,
+        ...over,
+    } as GearPiece;
+}
+
+/**
+ * Resolve the Last Stand passive ability from the REAL registry (legendary implant), then return a
+ * copy with `procChance` forced to 1 so the single qualifying sole-survivor event fires
+ * deterministically. Every other field is left exactly as the registry produced it.
+ */
+function buildLastStandAbility(): Ability {
+    const ship = makeShip({ implants: { implant_major: 'laststand-legendary' } });
+    const getGearPiece = (id: string): GearPiece | undefined =>
+        id === 'laststand-legendary'
+            ? makePiece({ id, slot: 'implant_major', rarity: 'legendary', setBonus: 'LAST_STAND' })
+            : undefined;
+    const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+    const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+    const resolved = passive?.abilities.find((a) => a.id.startsWith('equip-implant-LAST_STAND'));
+    if (!resolved) {
+        throw new Error('LAST_STAND ability was not produced by the registry');
+    }
+    return { ...resolved, procChance: 1 };
+}
+
+/** The real registry's LAST_STAND ability with procChance forced to 1 (deterministic). */
+const lastStandAbility: Ability = buildLastStandAbility();
 
 /** A 100% / 1-hit basic attack active slot (for a killing actor). */
 const basicAttack = (): ShipSkills['slots'][number] => ({
@@ -277,5 +314,34 @@ describe('D-PR16 Last Stand (last-standing → self Barrier + Block Debuff co-gr
 
         expect(buffAppliedOn(input, 'Barrier', 'enemy-carrier')).toBeGreaterThan(0);
         expect(buffAppliedOn(input, 'Block Debuff', 'enemy-carrier')).toBeGreaterThan(0);
+    });
+
+    it('registry shape: the real LAST_STAND entry has the exact load-bearing fields', () => {
+        // Resolve the ability straight from the registry (NO procChance override) and pin every
+        // load-bearing field. A typo in trigger/condition/target/buffName/co-grant/duration fails here.
+        const ship = makeShip({ implants: { implant_major: 'laststand-legendary' } });
+        const getGearPiece = (id: string): GearPiece | undefined =>
+            id === 'laststand-legendary'
+                ? makePiece({
+                      id,
+                      slot: 'implant_major',
+                      rarity: 'legendary',
+                      setBonus: 'LAST_STAND',
+                  })
+                : undefined;
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        const ability = passive?.abilities.find((a) => a.id.startsWith('equip-implant-LAST_STAND'));
+
+        expect(ability).toBeDefined();
+        expect(ability!.trigger).toBe('on-ally-destroyed');
+        expect(ability!.target).toBe('self');
+        expect(ability!.conditions?.[0]?.subject).toBe('last-standing');
+        expect((ability!.procChance ?? 0) > 0 && (ability!.procChance ?? 1) < 1).toBe(true);
+
+        const config = ability!.config as Extract<Ability['config'], { type: 'buff' }>;
+        expect(config.buffName).toBe('Barrier');
+        expect(config.duration).toBe(1);
+        expect(config.additionalBuffs?.[0]?.buffName).toBe('Block Debuff');
     });
 });

--- a/src/utils/combat/__tests__/lastStandApplier.test.ts
+++ b/src/utils/combat/__tests__/lastStandApplier.test.ts
@@ -1,0 +1,281 @@
+/**
+ * D-PR16 — Last Stand (last-standing → self Barrier + Block Debuff co-grant) ENGINE-LEVEL test.
+ *
+ * Last Stand: "When this unit becomes the last one standing, X% chance to gain Barrier AND
+ * Block Debuff (self) for 1 turn." It rides the `on-ally-destroyed` trigger (which fires for each
+ * surviving same-side ally when an ally dies) gated on the `last-standing` condition subject
+ * (true iff the owner is the SOLE living actor on its own side). The gate narrows the trigger to
+ * precisely the ally-death that leaves the owner alone. One proc roll co-grants BOTH buffs via the
+ * Task-5 `alsoGrantBuffNames` → `additionalBuffs` co-grant.
+ *
+ * Forcing the proc deterministically: `passesProcChanceGate` (triggers.ts) PASSES UNCONDITIONALLY
+ * when `procChance >= 1`, AND the engine's drain orders the `last-standing` condition gate BEFORE
+ * the proc gate — so the proc accumulator only advances on the single qualifying (sole-survivor)
+ * event. A fresh rate accumulator at the registry's 0.32 rate does NOT fire on its first event, so
+ * the single last-standing event cannot drive a real-rate proc deterministically. We therefore
+ * inject the ability with `procChance: 1` (every other field — trigger, target, the `last-standing`
+ * condition, the 'Barrier' buff name + `alsoGrantBuffNames: ['Block Debuff']`, 1-turn duration —
+ * matches the registry exactly, buildEquipmentAbilities.ts LAST_STAND). This is the same determinism
+ * device the sibling integration suites use (cfProvokeAppliers forces procChance: 1). The registry's
+ * exact per-rarity proc table + ability shape are covered by equipmentCoverage.test.ts.
+ *
+ * Cases:
+ *  - GRANT (headline): a 2-actor player team; the carrier becomes sole survivor when the OTHER ally
+ *    dies → the carrier carries BOTH Barrier AND Block Debuff (proves the one-roll co-grant).
+ *  - NO-FIRE control: with ≥2 allies still alive, an ally death that does NOT leave the carrier
+ *    alone grants NEITHER buff (proves the last-standing gate, not trigger vacuity).
+ *  - ENEMY-side mirror: an enemy carrier becomes last-standing among the enemy roster → gains both
+ *    buffs (proves team-agnosticism through the real enemy set-site + drain seam).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { createEventBus } from '../events';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { Position } from '../../../types/encounters';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+// ---------------------------------------------------------------------------
+// Shared ability shapes (match the registry, procChance forced to 1)
+// ---------------------------------------------------------------------------
+
+/** Last Stand: on-ally-destroyed self Barrier (1 turn) + co-granted Block Debuff (1 turn), gated on
+ *  `last-standing`. proc forced to 1 → the single sole-survivor event reliably grants both buffs. */
+const lastStandAbility: Ability = {
+    id: 'equip-implant-LAST_STAND',
+    type: 'buff',
+    target: 'self',
+    trigger: 'on-ally-destroyed',
+    conditions: [{ subject: 'last-standing', derivable: true }],
+    procChance: 1, // >= 1 → passesProcChanceGate is unconditional (deterministic)
+    config: {
+        type: 'buff',
+        buffName: 'Barrier',
+        parsedEffects: {},
+        stacks: 1,
+        isStackable: false,
+        duration: 1,
+        additionalBuffs: [
+            {
+                buffName: 'Block Debuff',
+                parsedEffects: {},
+                stacks: 1,
+                isStackable: false,
+                duration: 1,
+            },
+        ],
+    } as Ability['config'],
+    autoFilled: true,
+};
+
+/** A 100% / 1-hit basic attack active slot (for a killing actor). */
+const basicAttack = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: 'basic-atk',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 100, hits: 1 },
+        },
+    ],
+});
+
+/** A no-op (0-damage) active so the owner takes a turn without killing anything. */
+const noopActive: ShipSkills['slots'][number] = {
+    slot: 'active',
+    abilities: [
+        {
+            id: 'noop-atk',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0 },
+        },
+    ],
+};
+
+// ---------------------------------------------------------------------------
+// Harness builders
+// ---------------------------------------------------------------------------
+
+/** A positioned, inert team ally with a fixed HP (so an enemy hit can kill it). */
+function ally(id: string, position: Position, hp: number): TeamActorEngineInput {
+    return {
+        id,
+        speed: 10, // slower than the enemy so the enemy hits (and kills) it before it acts
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        walk: {
+            shipSkills: { slots: [] },
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    };
+}
+
+/** A non-positional enemy attacker that hits the heal target each round (real damage). */
+const enemyHitter = (id: string, attack: number, hp = 1_000_000_000, speed = 1000): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack, crit: 0, critDamage: 0, defence: 0, hp, speed },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: { slots: [basicAttack()] },
+    }) as EnemyAttacker;
+
+const BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 1,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [noopActive, { slot: 'passive', abilities: [lastStandAbility] }] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000, // focus survives
+    speed: 1, // slowest → the enemy kills the ally before the focus acts
+    position: 'M2',
+    ...overrides,
+});
+
+/** Run combat and report how many `buff-applied` events for `buffName` landed on `actorId`. */
+function buffAppliedOn(input: CombatEngineInput, buffName: string, actorId: string): number {
+    const bus = createEventBus();
+    let count = 0;
+    bus.on('buff-applied', (e) => {
+        if (e.buffName === buffName && e.actorId === actorId) count++;
+    });
+    runCombat({ ...input, bus });
+    return count;
+}
+
+describe('D-PR16 Last Stand (last-standing → self Barrier + Block Debuff co-grant)', () => {
+    it('grants BOTH Barrier and Block Debuff to the carrier when it becomes the sole survivor (one roll)', () => {
+        // focus 'attacker' + ONE ally (T2). The enemy hits the heal target (the ally) for lethal
+        // damage → the ally dies → on-ally-destroyed fires on the surviving focus → the focus is
+        // now the only living player → last-standing gate true → the forced proc grants BOTH the
+        // primary Barrier AND the co-granted Block Debuff in the same application.
+        const input = BASE({
+            teamActors: [ally('ally-T2', 'T2', 3_000)],
+            healTargetId: 'ally-T2',
+            enemyAttackers: [enemyHitter('enemy-atk', 5_000)],
+        });
+
+        const barrier = buffAppliedOn(input, 'Barrier', 'attacker');
+        const blockDebuff = buffAppliedOn(input, 'Block Debuff', 'attacker');
+
+        expect(barrier).toBeGreaterThan(0); // primary buff landed
+        expect(blockDebuff).toBeGreaterThan(0); // co-granted buff landed on the SAME roll
+    });
+
+    it('control: does NOT grant either buff when an ally death does not leave the carrier alone', () => {
+        // focus + TWO allies (T2 dies, M3 survives with huge HP). One ally dies → on-ally-destroyed
+        // still fires on the focus, but TWO players remain alive (focus + M3) → focus is NOT the
+        // sole survivor → last-standing gate false → neither buff granted (proves the gate).
+        const input = BASE({
+            teamActors: [ally('ally-T2', 'T2', 3_000), ally('ally-M3', 'M3', 1_000_000_000)],
+            healTargetId: 'ally-T2',
+            enemyAttackers: [enemyHitter('enemy-atk', 5_000)],
+        });
+
+        expect(buffAppliedOn(input, 'Barrier', 'attacker')).toBe(0);
+        expect(buffAppliedOn(input, 'Block Debuff', 'attacker')).toBe(0);
+    });
+
+    it('enemy-side mirror: an enemy carrier becomes last-standing and gains BOTH buffs', () => {
+        // Team-agnosticism through the real positional two-team seam (twoTeamBattle harness). The
+        // player focus fires `front` against the enemy roster and kills the fragile front enemy;
+        // the back enemy carrier (huge HP + Last Stand passive) survives → it is now the sole
+        // living enemy → enemy-side on-ally-destroyed fires on the carrier → last-standing gate
+        // true → the forced proc co-grants Barrier + Block Debuff onto the enemy carrier.
+        const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+            raw: selection,
+            side: 'enemy',
+            selection,
+        });
+        const basePattern = (): ParsedPattern => ({
+            raw: 'base',
+            shape: 'base',
+            range: 0,
+            modifiers: {},
+        });
+
+        // Fragile front enemy: the focus's `front` shot kills it (5000 dmg vs 1 HP).
+        const frontEnemy: EnemyAttacker = {
+            id: 'enemy-front',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1, speed: 1 },
+            chargeCount: 0,
+            startCharged: false,
+            position: 'M4',
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            shipSkills: { slots: [noopActive] },
+        } as EnemyAttacker;
+
+        // Back enemy carrier: huge HP (survives) + the Last Stand passive. When the front enemy
+        // dies it becomes the sole living enemy → its on-ally-destroyed reaction's last-standing
+        // gate passes → forced proc co-grants both buffs.
+        const enemyCarrier: EnemyAttacker = {
+            id: 'enemy-carrier',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1 },
+            chargeCount: 0,
+            startCharged: false,
+            position: 'M1',
+            target: parsedTarget('back'),
+            pattern: basePattern(),
+            shipSkills: {
+                slots: [noopActive, { slot: 'passive', abilities: [lastStandAbility] }],
+            },
+        } as EnemyAttacker;
+
+        const input: CombatEngineInput = {
+            ...BASE(),
+            // Player focus fires `front` with lethal damage and acts first (speed 1000).
+            attack: 5000,
+            speed: 1000,
+            shipSkills: { slots: [basicAttack()] },
+            position: 'M4',
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            healTargetId: 'attacker', // required when enemyAttackers are present
+            teamActors: [], // no positional player ally needed
+            enemyAttackers: [frontEnemy, enemyCarrier],
+            numRounds: 2,
+        };
+
+        expect(buffAppliedOn(input, 'Barrier', 'enemy-carrier')).toBeGreaterThan(0);
+        expect(buffAppliedOn(input, 'Block Debuff', 'enemy-carrier')).toBeGreaterThan(0);
+    });
+});

--- a/src/utils/combat/__tests__/lastStandingSubject.test.ts
+++ b/src/utils/combat/__tests__/lastStandingSubject.test.ts
@@ -1,0 +1,198 @@
+/**
+ * D-PR16 — `last-standing` condition subject ENGINE-LEVEL wiring test (INFRASTRUCTURE).
+ *
+ * `last-standing` is true iff the owner is the SOLE living actor on its own side. No production
+ * implant uses it yet (Task 6 wires Last Stand); this test proves the THREADING: the engine
+ * computes a per-side sole-survivor id fresh each drain (soleSurvivorOf), the drain context maps
+ * `lastStandingId === ownerId` → the `lastStanding` round-context flag → the `last-standing`
+ * condition gate.
+ *
+ * Harness: a player focus 'attacker' carries a SINGLE benign self buff-grant ('Defense Up I')
+ * gated on `last-standing`, triggered by `on-ally-destroyed`. An enemy kills a low-HP ally.
+ *  - SOLE-SURVIVOR case: focus + ONE ally; the ally dies → focus is the only living player →
+ *    gate true → buff granted (buff-applied emitted with actorId = focus).
+ *  - CONTROL: focus + TWO allies; ONE ally dies → another ally still lives → focus is NOT the
+ *    sole survivor → gate false → no buff granted. (The on-ally-destroyed listener still fires —
+ *    a death occurs — so this proves the GATE, not vacuity of the trigger.)
+ *
+ * Buff grants are deterministic (no procChance on the grant). The 'Defense Up I' name is a benign
+ * placeholder — Last Stand's real buffs are Task 6.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { createEventBus } from '../events';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { Position } from '../../../types/encounters';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+// ---------------------------------------------------------------------------
+// Ability shapes
+// ---------------------------------------------------------------------------
+
+/** On an ally's death, IF the owner is the sole living actor on its side, grant itself a benign
+ *  'Defense Up I' (1 turn). No procChance → the grant fires deterministically when the gate passes. */
+const lastStandingGrant: Ability = {
+    id: 'test-last-standing-grant',
+    type: 'buff',
+    target: 'self',
+    trigger: 'on-ally-destroyed',
+    conditions: [{ subject: 'last-standing', derivable: true }],
+    config: {
+        type: 'buff',
+        buffName: 'Defense Up I',
+        parsedEffects: {},
+        stacks: 1,
+        isStackable: false,
+        duration: 1,
+    },
+    autoFilled: true,
+};
+
+/** No-op active so the focus takes a turn without ending combat early / killing anything. */
+const noopActive: ShipSkills['slots'][number] = {
+    slot: 'active',
+    abilities: [
+        {
+            id: 'noop-atk',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0 },
+        },
+    ],
+};
+
+/** A 100% / 1-hit basic attack active slot (for the killing enemy). */
+const basicAttack = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: 'basic-atk',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 100, hits: 1 },
+        },
+    ],
+});
+
+// ---------------------------------------------------------------------------
+// Harness builders
+// ---------------------------------------------------------------------------
+
+/** A positioned, inert team ally with a fixed HP (so an enemy hit can kill it). */
+function ally(id: string, position: Position, hp: number): TeamActorEngineInput {
+    return {
+        id,
+        speed: 10, // slower than the enemy so the enemy hits (and kills) it before it acts
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        walk: {
+            shipSkills: { slots: [] },
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    };
+}
+
+/** A non-positional enemy attacker that hits the heal target each round with real damage. */
+const enemyHitter = (id: string, attack: number, speed = 1000): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: { slots: [basicAttack()] },
+    }) as EnemyAttacker;
+
+const BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 1,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [noopActive, { slot: 'passive', abilities: [lastStandingGrant] }] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000, // focus survives
+    speed: 1, // slowest → the enemy kills the ally before the focus acts
+    position: 'M2',
+    ...overrides,
+});
+
+/** Run combat, returning [ # of buff-applied for buffName on actorId, # of ship-destroyed ]. */
+function run(input: CombatEngineInput): { buffs: number; deaths: string[] } {
+    const bus = createEventBus();
+    let buffs = 0;
+    const deaths: string[] = [];
+    bus.on('buff-applied', (e) => {
+        if (e.buffName === 'Defense Up I' && e.actorId === 'attacker') buffs++;
+    });
+    bus.on('ship-destroyed', (e) => deaths.push(e.actorId));
+    runCombat({ ...input, bus });
+    return { buffs, deaths };
+}
+
+describe('D-PR16 last-standing condition subject (engine wiring)', () => {
+    it('grants the self buff when the owner becomes the sole living actor on its side', () => {
+        // focus + ONE ally (T2). The enemy hits the heal target (the ally) for lethal damage →
+        // the ally dies → on-ally-destroyed fires on the surviving focus → at drain the focus is
+        // the only living player → last-standing gate true → Defense Up I granted to the focus.
+        const { buffs, deaths } = run(
+            BASE({
+                teamActors: [ally('ally-T2', 'T2', 3_000)],
+                healTargetId: 'ally-T2',
+                enemyAttackers: [enemyHitter('enemy-atk', 5_000)],
+            })
+        );
+
+        expect(deaths).toContain('ally-T2'); // the death actually happened (trigger fired)
+        expect(buffs).toBeGreaterThan(0); // sole survivor → gate true → buff granted
+    });
+
+    it('control: does NOT grant when the owner is not the sole survivor (gate false)', () => {
+        // focus + TWO allies (T2 dies, M3 survives). One ally dies → on-ally-destroyed still fires
+        // on the focus, but TWO players remain alive (focus + M3) → focus is NOT the sole survivor
+        // → last-standing gate false → no buff. Proves the gate, not trigger vacuity.
+        const { buffs, deaths } = run(
+            BASE({
+                teamActors: [ally('ally-T2', 'T2', 3_000), ally('ally-M3', 'M3', 1_000_000_000)],
+                healTargetId: 'ally-T2',
+                enemyAttackers: [enemyHitter('enemy-atk', 5_000)],
+            })
+        );
+
+        expect(deaths).toContain('ally-T2'); // the death still happened (trigger fired)
+        expect(buffs).toBe(0); // not sole survivor → gate false → no buff
+    });
+});

--- a/src/utils/combat/__tests__/lockdownApplier.test.ts
+++ b/src/utils/combat/__tests__/lockdownApplier.test.ts
@@ -1,0 +1,272 @@
+/**
+ * D-PR16 — Lockdown (Buff Protection) ENGINE-LEVEL integration test.
+ *
+ * Lockdown: "When this unit RESISTS an incoming debuff, there is an X% chance to grant
+ * Buff Protection to ALL allies for 1 turn." It rides the new `on-debuff-resisted`
+ * reactive trigger — self-scoped on the `debuff-resisted` event (targetId === ownerId,
+ * the RESISTER) — and grants the whole same side a `Buff Protection` buff
+ * (target = 'all-allies' → the reactive buff executor routes to ctx.playerIds).
+ *
+ * The `debuff-resisted` event is emitted on multiple paths, and Lockdown chains off ALL
+ * of them. Two cases cover the two routes that matter:
+ *
+ *   1. DIRECT (normal hacking/affinity resist): an enemy attacker with hacking 0 casts a
+ *      TIMED debuff at the carrier every round. The live landing roll fails → the cast-side
+ *      `emitDebuffResisted` fires with targetId = the carrier. Over enough rounds the proc
+ *      gate (legendary 0.16) accumulates and fires → the team carries Buff Protection.
+ *
+ *   2. SYNERGY (headline — chains off D-PR15's Block-Debuff auto-resist): the carrier holds
+ *      a recurring `Block Debuff` self-buff (D-PR15). A high-hacking enemy WOULD land its
+ *      timed debuff, but the Block-Debuff immunity fold auto-resists it and emits
+ *      `debuff-resisted` from `debuffImmunity.ts`. That same event drives Lockdown → the
+ *      team gains Buff Protection. Proves the full Block-Debuff → resist → Lockdown chain.
+ *
+ * Both exercise the FULL registry path (NOT direct ability injection): a Lockdown implant
+ * is equipped via a stubbed `getGearPiece` + `setBonus='LOCKDOWN'`,
+ * `buildShipAbilitiesWithEquipment` merges the reactive buff-grant into the passive slot,
+ * and the engine wires up the `on-debuff-resisted` listener. The control (same setup, NO
+ * Lockdown) proves non-vacuity: with no Lockdown there are ZERO Buff Protection self-buffs.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus } from '../events';
+import { ShipSkills } from '../../../types/abilities';
+import { Ship } from '../../../types/ship';
+import { GearPiece } from '../../../types/gear';
+import { buildShipAbilitiesWithEquipment } from '../../abilities/buildShipAbilitiesWithEquipment';
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+function makeShip(over: Partial<Ship>): Ship {
+    return {
+        id: 'test-ship',
+        name: 'Test Ship',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'DEFENDER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        ...over,
+    } as Ship;
+}
+
+function makePiece(over: Partial<GearPiece>): GearPiece {
+    return {
+        id: 'piece-1',
+        slot: 'implant_major',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: null,
+        ...over,
+    } as GearPiece;
+}
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+/**
+ * An enemy attacker that casts a timed Def Down debuff at the player carrier each round.
+ * `hacking` drives the live landing roll vs the carrier's default security 100:
+ *   - 0   → landing 0 → the debuff is RESISTED every round (cast-side `debuff-resisted`).
+ *   - 200 → landing 1 → the debuff would LAND (used in the synergy case where the carrier's
+ *           Block Debuff auto-resists it instead).
+ * speed 10 → acts AFTER the speed-100 carrier so the carrier's recurring self-buffs (Block
+ * Debuff in the synergy case) are already live when this enemy casts.
+ */
+const debuffEnemy = (id: string, hacking: number): EnemyAttacker =>
+    ({
+        id,
+        stats: {
+            attack: 1,
+            crit: 0,
+            critDamage: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 10,
+            hacking,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'enemy-debuff',
+                            type: 'debuff',
+                            target: 'enemy', // enemy's "enemy" = the player carrier
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: {
+                                type: 'debuff',
+                                buffName: 'Def Down',
+                                parsedEffects: {},
+                                stacks: 1,
+                                isStackable: false,
+                                application: 'inflict',
+                                duration: 1,
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+    }) as EnemyAttacker;
+
+/** No-op active so the focus takes a turn without ending the combat early. */
+const noopActive: ShipSkills['slots'][number] = {
+    slot: 'active',
+    abilities: [
+        {
+            id: 'noop-atk',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0 },
+        },
+    ],
+};
+
+/** A recurring `Block Debuff` self-buff on the focus actor (D-PR15) — drives the synergy path. */
+const blockDebuffPassive: ShipSkills['slots'][number] = {
+    slot: 'passive',
+    abilities: [
+        {
+            id: 'block-debuff-self',
+            type: 'buff',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [],
+            config: {
+                type: 'buff',
+                buffName: 'Block Debuff',
+                stacks: 1,
+                isStackable: false,
+                duration: 'recurring',
+                parsedEffects: {},
+            },
+        },
+    ],
+};
+
+const BASE = (
+    shipSkills: ShipSkills,
+    overrides: Partial<CombatEngineInput> = {}
+): CombatEngineInput => ({
+    attack: 1,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills,
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 12,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    speed: 100, // faster than the enemy (speed 10) → its recurring self-buffs are live first
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+/** Collect every `buff-applied` event for `buffName` on the given actor. */
+function buffAppliedOn(input: CombatEngineInput, buffName: string, actorId: string): number {
+    const bus = createEventBus();
+    let count = 0;
+    bus.on('buff-applied', (e) => {
+        if (e.buffName === buffName && e.actorId === actorId) count++;
+    });
+    runCombat({ ...input, bus });
+    return count;
+}
+
+// Build the carrier's skills via the REAL registry path: a legendary Lockdown implant,
+// optionally fused with a recurring Block Debuff self-buff (synergy path).
+function buildLockdownSkills(opts: { withBlockDebuff?: boolean } = {}): ShipSkills {
+    const ship = makeShip({ implants: { implant_major: 'lockdown-legendary' } });
+    const getGearPiece = (id: string): GearPiece | undefined =>
+        id === 'lockdown-legendary'
+            ? makePiece({ id, slot: 'implant_major', rarity: 'legendary', setBonus: 'LOCKDOWN' })
+            : undefined;
+    const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+    const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+    // Merge the Lockdown reactive grant with the optional Block Debuff self-buff into one
+    // passive slot (the engine reads all passive abilities from a single passive slot).
+    const passiveAbilities = [
+        ...(opts.withBlockDebuff ? blockDebuffPassive.abilities : []),
+        ...(passive ? passive.abilities : []),
+    ];
+    return {
+        slots: [
+            noopActive,
+            ...(passiveAbilities.length
+                ? [{ slot: 'passive' as const, abilities: passiveAbilities }]
+                : []),
+        ],
+    };
+}
+
+describe('D-PR16 Lockdown (on-debuff-resisted → all-ally Buff Protection)', () => {
+    it('DIRECT: grants the team Buff Protection when the carrier resists incoming debuffs (registry path)', () => {
+        const lockdownSkills = buildLockdownSkills();
+
+        // Pre-condition: the Lockdown reactive buff-grant landed in the passive slot.
+        const passive = lockdownSkills.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        const ld = passive!.abilities.find((a) => a.id.startsWith('equip-implant-LOCKDOWN'));
+        expect(ld).toBeDefined();
+
+        // Enemy hacking 0 → every cast is RESISTED → cast-side `debuff-resisted` fires with
+        // targetId = the carrier every round. 12 rounds; legendary rate 0.16 fires on the
+        // ceil(1/0.16)=7th qualifying event → at least one Buff Protection granted to the team.
+        const count = buffAppliedOn(
+            BASE(lockdownSkills, { enemyAttackers: [debuffEnemy('enemy-deb', 0)] }),
+            'Buff Protection',
+            'attacker'
+        );
+        expect(count).toBeGreaterThan(0);
+    });
+
+    it('SYNERGY: a Block Debuff auto-resist drives Lockdown → team gains Buff Protection (chains off D-PR15)', () => {
+        // Carrier holds a recurring Block Debuff self-buff AND a legendary Lockdown implant.
+        // The enemy (hacking 200) WOULD land its timed debuff, but Block Debuff auto-resists
+        // it and emits `debuff-resisted` (debuffImmunity.ts) with targetId = the carrier →
+        // Lockdown's on-debuff-resisted listener fires → all-allies Buff Protection.
+        const synergySkills = buildLockdownSkills({ withBlockDebuff: true });
+
+        const count = buffAppliedOn(
+            BASE(synergySkills, { enemyAttackers: [debuffEnemy('enemy-deb', 200)] }),
+            'Buff Protection',
+            'attacker'
+        );
+        expect(count).toBeGreaterThan(0);
+    });
+
+    it('control: WITHOUT Lockdown the team never gains Buff Protection (non-vacuity)', () => {
+        // Same Block-Debuff carrier + high-hacking enemy (resists fire), but NO Lockdown implant.
+        const bareSkills: ShipSkills = { slots: [noopActive, blockDebuffPassive] };
+        const count = buffAppliedOn(
+            BASE(bareSkills, { enemyAttackers: [debuffEnemy('enemy-deb', 200)] }),
+            'Buff Protection',
+            'attacker'
+        );
+        expect(count).toBe(0);
+    });
+});

--- a/src/utils/combat/__tests__/tenacityApplier.test.ts
+++ b/src/utils/combat/__tests__/tenacityApplier.test.ts
@@ -1,0 +1,239 @@
+/**
+ * D-PR16 — Tenacity (Buff Protection) ENGINE-LEVEL integration test.
+ *
+ * Tenacity: "Upon directly receiving damage exceeding 25% of max HP, there is an X%
+ * chance to grant Buff Protection to ALL allies for 2 turns." It rides the `on-attacked`
+ * reactive trigger — target-scoped on the per-hit `attacked` event (targetId === ownerId)
+ * — but adds a NEW damage-fraction gate (`requireIncomingDamageFracOfMaxHp: 0.25`): the
+ * per-ATTACK aggregate damage carried on the event must exceed 25% of the carrier's
+ * effective max HP. On a passing hit the proc gate (legendary 0.16) rolls; when it fires
+ * the whole same side gains a `Buff Protection` buff (target = 'all-allies' → routes to
+ * ctx.playerIds).
+ *
+ * Because the `attacked` event is emitted ONLY for direct weapon hits (DoT ticks, bomb
+ * detonations, and accumulators never emit it), filtering on this event naturally means
+ * "directly receiving damage". The DoT negative case below proves it.
+ *
+ * SURVIVAL TRICK (mirrors barrier.test.ts): the carrier also holds an always-active
+ * `Barrier` self-buff so every incoming hit is fully nullified for HP purposes — the
+ * carrier survives all rounds — yet the pre-barrier aggregate `damage` is still computed
+ * and carried on the `attacked` event, so the >25% filter sees the real hit size. This
+ * lets us drive enough qualifying hits to force the 0.16 rate-gate to fire.
+ *
+ * All cases exercise the FULL registry path (NOT direct ability injection): a Tenacity
+ * implant is equipped via a stubbed `getGearPiece` + `setBonus='TENACITY'`,
+ * `buildShipAbilitiesWithEquipment` merges the reactive buff-grant into the passive slot,
+ * and the engine wires up the `on-attacked` listener. The controls (≤25% hit; DoT batch)
+ * prove the new damage-fraction gate and the direct-only scoping respectively.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus } from '../events';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import { Ship } from '../../../types/ship';
+import { GearPiece } from '../../../types/gear';
+import { buildShipAbilitiesWithEquipment } from '../../abilities/buildShipAbilitiesWithEquipment';
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+function makeShip(over: Partial<Ship>): Ship {
+    return {
+        id: 'test-ship',
+        name: 'Test Ship',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'DEFENDER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        ...over,
+    } as Ship;
+}
+
+function makePiece(over: Partial<GearPiece>): GearPiece {
+    return {
+        id: 'piece-1',
+        slot: 'implant_major',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: null,
+        ...over,
+    } as GearPiece;
+}
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+let idCounter = 0;
+const ab = (partial: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `tn${++idCounter}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...partial,
+});
+
+/** A manual flat enemy: one synthesized basic attack of `attack` damage, no skills.
+ *  With the carrier's defence 0, the per-attack aggregate `damage` == `attack`. */
+const manualEnemy = (
+    id: string,
+    attack: number,
+    speed = 50,
+    extra: Partial<EnemyAttacker> = {}
+): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed },
+        chargeCount: 0,
+        startCharged: false,
+        ...extra,
+    }) as EnemyAttacker;
+
+/** An always-active, no-payload Barrier self-buff (same shape as barrier.test.ts) — fully
+ *  nullifies incoming HP damage so the carrier survives every round while the pre-barrier
+ *  aggregate `damage` is still carried on the `attacked` event. */
+const barrierBuff = () => ({
+    id: 'barrier',
+    buffName: 'Barrier',
+    stacks: 1,
+    isStackable: false,
+    parsedEffects: {},
+});
+
+const BASE = (
+    shipSkills: ShipSkills,
+    overrides: Partial<CombatEngineInput> = {}
+): CombatEngineInput => ({
+    attack: 1,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills,
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 14,
+    selfBuffs: [barrierBuff()],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 10_000, // max HP → 25% threshold = 2500
+    speed: 1, // slower than the enemy → the enemy attacks the carrier each round before it acts
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+/** Collect every `buff-applied` event for `buffName` on the given actor. */
+function buffAppliedOn(input: CombatEngineInput, buffName: string, actorId: string): number {
+    const bus = createEventBus();
+    let count = 0;
+    bus.on('buff-applied', (e) => {
+        if (e.buffName === buffName && e.actorId === actorId) count++;
+    });
+    runCombat({ ...input, bus });
+    return count;
+}
+
+/** No-op active so the focus takes a turn without ending the combat early. */
+const noopActive: ShipSkills['slots'][number] = {
+    slot: 'active',
+    abilities: [
+        {
+            id: 'noop-atk',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0 },
+        },
+    ],
+};
+
+// Build the carrier's skills via the REAL registry path: a legendary Tenacity implant.
+function buildTenacitySkills(): ShipSkills {
+    const ship = makeShip({ implants: { implant_major: 'tenacity-legendary' } });
+    const getGearPiece = (id: string): GearPiece | undefined =>
+        id === 'tenacity-legendary'
+            ? makePiece({ id, slot: 'implant_major', rarity: 'legendary', setBonus: 'TENACITY' })
+            : undefined;
+    const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+    const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+    return {
+        slots: [
+            noopActive,
+            ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+        ],
+    };
+}
+
+describe('D-PR16 Tenacity (on-attacked >25% max-HP → all-ally Buff Protection)', () => {
+    beforeEach(() => {
+        idCounter = 0;
+    });
+
+    it('grants the team Buff Protection when a direct hit exceeds 25% of max HP (registry path)', () => {
+        const tenacitySkills = buildTenacitySkills();
+
+        // Pre-condition: the Tenacity reactive buff-grant landed in the passive slot.
+        const passive = tenacitySkills.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        const tn = passive!.abilities.find((a) => a.id.startsWith('equip-implant-TENACITY'));
+        expect(tn).toBeDefined();
+        // …and it carries the new >25%-max-HP gate.
+        expect(tn!.requireIncomingDamageFracOfMaxHp).toBe(0.25);
+
+        // Enemy attack 3000 > 2500 (25% of the 10_000 max HP) → every hit qualifies. 14 rounds
+        // of qualifying hits; legendary rate 0.16 fires on the ceil(1/0.16)=7th qualifying event
+        // → at least one Buff Protection granted to the team. Barrier keeps the carrier alive.
+        const count = buffAppliedOn(
+            BASE(tenacitySkills, { enemyAttackers: [manualEnemy('big-hit', 3000)] }),
+            'Buff Protection',
+            'attacker'
+        );
+        expect(count).toBeGreaterThan(0);
+    });
+
+    it('control: a hit at or below 25% of max HP grants NOTHING (damage-fraction gate)', () => {
+        const tenacitySkills = buildTenacitySkills();
+        // Enemy attack 2000 < 2500 → never exceeds 25% → the gate blocks every event → no proc.
+        const count = buffAppliedOn(
+            BASE(tenacitySkills, { enemyAttackers: [manualEnemy('small-hit', 2000)] }),
+            'Buff Protection',
+            'attacker'
+        );
+        expect(count).toBe(0);
+    });
+
+    it('control: a DoT batch exceeding 25% grants NOTHING (DoT ticks emit no `attacked`)', () => {
+        const tenacitySkills = buildTenacitySkills();
+        // attack 0 → the ONLY incoming damage is a large corrosion DoT batch (well over 25% of
+        // max HP). DoT ticks never emit the `attacked` event, so Tenacity's on-attacked listener
+        // never fires → no Buff Protection, proving the trigger is "directly receiving damage".
+        const corrosionDot = () =>
+            ab({
+                type: 'dot',
+                target: 'enemy',
+                config: { type: 'dot', dotType: 'corrosion', tier: 7, stacks: 10, duration: 14 },
+            });
+        const dotEnemy = manualEnemy('dot-enemy', 0, 50, {
+            shipSkills: { slots: [{ slot: 'active', abilities: [corrosionDot()] }] },
+        });
+        const count = buffAppliedOn(
+            BASE(tenacitySkills, { enemyAttackers: [dotEnemy], selfBuffs: [] }),
+            'Buff Protection',
+            'attacker'
+        );
+        expect(count).toBe(0);
+    });
+});

--- a/src/utils/combat/__tests__/twoTeamBattle.test.ts
+++ b/src/utils/combat/__tests__/twoTeamBattle.test.ts
@@ -303,7 +303,7 @@ describe('Two-team positional battle — characterization spike (Phase 5 PR 1, T
         expect(round0['player-team']).toBe(5000);
     });
 
-    it('`attacked` events carry an attacker + anchor victim but NO damage amount', () => {
+    it('`attacked` events carry an attacker, anchor victim, AND the per-attack aggregate damage', () => {
         idc = 0;
         const { events } = run(
             battle({
@@ -320,8 +320,11 @@ describe('Two-team positional battle — characterization spike (Phase 5 PR 1, T
         // Anchor victims only: enemy attackers struck players (the anchor `tgt`).
         expect(attacked.every((e) => ENEMY_IDS.has(e.attackerId))).toBe(true);
         expect(attacked.every((e) => PLAYER_IDS.has(e.targetId))).toBe(true);
-        // CONTRACT PIN: `attacked` carries NO numeric damage field — it is not a damage source.
-        expect(attacked.every((e) => !('damage' in e))).toBe(true);
+        // CONTRACT (D-PR16): `attacked` now carries the per-ATTACK aggregate damage (5000 here,
+        // enemyAttack with the victim's defence 0) so Tenacity's >25%-max-HP filter can read it.
+        // Added via conditional spread → present only when damage > 0 (healing-mode 0-damage
+        // events stay byte-identical).
+        expect(attacked.every((e) => e.damage === 5000)).toBe(true);
     });
 
     it('ship-destroyed fires for BOTH sides when HP is low enough', () => {

--- a/src/utils/combat/abilityStatusGating.ts
+++ b/src/utils/combat/abilityStatusGating.ts
@@ -27,6 +27,7 @@ const LIVE_SUBJECTS: ReadonlySet<ConditionSubject> = new Set([
     'target-repaired-this-round',
     'not-hit-this-round',
     'first-activator',
+    'last-standing',
 ]);
 
 /**

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2040,6 +2040,9 @@ export function runCombat(input: CombatEngineInput): {
         roleOf: (id) => roleByActorId.get(id),
         adjacentAllyIdsFor: (ownerId: string) =>
             bySide(isEnemySide(ownerId) ? 'enemy' : 'player').adjacentAllyIdsFor(ownerId),
+        // D-PR16: owner effective max HP (live ctx ?? base HP) — gates Tenacity's >25% filter.
+        // id-keyed and side-agnostic, so the same closure serves the enemy registration below.
+        maxHpOf: (ownerId: string) => recipientMaxHp(ownerId),
     });
 
     // Enemy-side reactive registration (enemy-team PR1). A SEPARATE intent queue + a second
@@ -2066,6 +2069,8 @@ export function runCombat(input: CombatEngineInput): {
             roleOf: (id) => roleByActorId.get(id),
             adjacentAllyIdsFor: (ownerId: string) =>
                 bySide(isEnemySide(ownerId) ? 'enemy' : 'player').adjacentAllyIdsFor(ownerId),
+            // D-PR16: same id-keyed effective-max-HP closure as the player registration.
+            maxHpOf: (ownerId: string) => recipientMaxHp(ownerId),
         });
     }
 
@@ -4516,6 +4521,7 @@ export function runCombat(input: CombatEngineInput): {
                                     attackerId: actor.id,
                                     round: r,
                                     ...(hitCrit ? { didCrit: true } : {}),
+                                    ...(damage > 0 ? { damage } : {}),
                                 });
                             }
                         }

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -1042,6 +1042,8 @@ interface ReactiveSideCtx {
     enemyWithHighestAttack?: (ownerId: string) => string | undefined;
     /** D-PR14: id of the round's first real activator (live value at drain-build time). */
     firstActivatorId?: string;
+    /** D-PR16: id of the sole living actor on this side, recomputed each drain (Last Stand). */
+    lastStandingId?: string;
     /** D-PR14 Bulwark: per-round once-per-(owner,ability) consume set (shared across both sides). */
     oncePerRoundConsumed?: Set<string>;
     /** Per-side adjacent-allies resolver (Fortifying Shroud). See IntentExecContext. */
@@ -3425,6 +3427,7 @@ export function runCombat(input: CombatEngineInput): {
                         // inert today — only consumed by the next task's executor branch.
                         enemyWithHighestAttack: sideCtx.enemyWithHighestAttack,
                         firstActivatorId: sideCtx.firstActivatorId,
+                        lastStandingId: sideCtx.lastStandingId,
                         oncePerRoundConsumed: sideCtx.oncePerRoundConsumed,
                         // D-PR8: live not-hit-this-round gate (Alacrity). hitThisRound is a single
                         // combat-wide Set, so the SAME closure serves both sides (team-agnostic) —
@@ -3471,6 +3474,14 @@ export function runCombat(input: CombatEngineInput): {
                 (id) => roster.find((a) => a.id === id)?.destroyedRound === undefined
             );
 
+        // D-PR16: the id of the sole living actor in a roster, or undefined if !=1 alive.
+        // Drives the `last-standing` condition (Last Stand). Recomputed each drain so it
+        // reflects deaths recorded before the reactive drain.
+        const soleSurvivorOf = (roster: CombatActor[]): string | undefined => {
+            const living = roster.filter((a) => a.destroyedRound === undefined);
+            return living.length === 1 ? living[0].id : undefined;
+        };
+
         // Player drain — binds the player queue + player-side ctx. Behaviourally identical to
         // the pre-refactor drainIntents (same runtimes/playerIds/lowest-speed/grantAllyCharges).
         const drainIntents = (): void =>
@@ -3483,6 +3494,7 @@ export function runCombat(input: CombatEngineInput): {
                 enemyWithMostBuffs: () => mostBuffsAmong(enemyAttackerActors),
                 enemyWithHighestAttack: () => highestAttackInRoster(enemyAttackerActors),
                 firstActivatorId,
+                lastStandingId: soleSurvivorOf(allPlayerActors),
                 oncePerRoundConsumed,
                 adjacentAllyIdsFor: bySide('player').adjacentAllyIdsFor,
             });
@@ -3508,6 +3520,7 @@ export function runCombat(input: CombatEngineInput): {
                 enemyWithMostBuffs: () => mostBuffsAmong(allPlayerActors),
                 enemyWithHighestAttack: () => highestAttackInRoster(allPlayerActors),
                 firstActivatorId,
+                lastStandingId: soleSurvivorOf(enemyAttackerActors),
                 oncePerRoundConsumed,
                 adjacentAllyIdsFor: bySide('enemy').adjacentAllyIdsFor,
             });

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -28,11 +28,13 @@ import { DoTType } from '../../types/calculator';
  *    application moment so reactions (Defiant's shield-on-Stasis, on-stasis-applied) can fire.
  */
 export type CombatEvent =
-    | { type: 'round-started'; round: number }
-    | /** Fires once per round at the round TAIL, AFTER all turns + the post-round death drain.
+    | {
+          type: 'round-started';
+          round: number;
+      } /** Fires once per round at the round TAIL, AFTER all turns + the post-round death drain.
      *  Mirror of `round-started`. Drains the end-of-round reactive queue (Rhodium's
      *  end-of-round purge). Carries only the round number. */
-    { type: 'round-ended'; round: number }
+    | { type: 'round-ended'; round: number }
     | { type: 'turn-started'; actorId: string; round: number }
     | { type: 'turn-ended'; actorId: string; round: number }
     | {
@@ -156,7 +158,13 @@ export type CombatEvent =
      *  DIRECT hit (vs a DoT-tick batch, which has no single killer → byDirectDamage:false,
      *  killerId undefined). Optional — only Faust's on-destroyed purge reads them; all other
      *  listeners ignore them (backward-compatible). */
-    | { type: 'ship-destroyed'; actorId: string; round: number; killerId?: string; byDirectDamage?: boolean }
+    | {
+          type: 'ship-destroyed';
+          actorId: string;
+          round: number;
+          killerId?: string;
+          byDirectDamage?: boolean;
+      }
     /** Emitted when a Cheat Death passive intercepts what would have been a lethal
      *  hit, keeping the actor alive at 1 HP. `actorId` is the surviving actor. */
     | { type: 'cheat-death-activated'; actorId: string; round: number }
@@ -176,6 +184,11 @@ export type CombatEvent =
           attackerId: string;
           round: number;
           didCrit?: boolean;
+          /** D-PR16: per-ATTACK aggregate direct damage dealt this turn (identical across the
+           *  turn's per-hit events — per-hit damage is not tracked, same approximation as
+           *  Bloodthirst's triggerDamage). Present only when a damage aggregate is in scope.
+           *  Tenacity's >25%-max-HP filter reads this. */
+          damage?: number;
       };
 
 export type CombatEventType = CombatEvent['type'];

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -238,8 +238,11 @@ export function registerReactiveListeners(args: {
      *  → all living same-side allies). Used to gate requireDamagedAllyAdjacent reactions. Optional:
      *  DPS/unit fixtures omit it (→ treat any ally as adjacent). */
     adjacentAllyIdsFor?: (ownerId: string) => string[];
+    /** D-PR16: owner effective max HP resolver — gates Tenacity's incoming-damage-fraction
+     *  filter. Optional: absent → the filter is skipped (no Tenacity in scope). */
+    maxHpOf?: (ownerId: string) => number;
 }): void {
-    const { bus, perOwner, enqueue, isOpposing, roleOf, adjacentAllyIdsFor } = args;
+    const { bus, perOwner, enqueue, isOpposing, roleOf, adjacentAllyIdsFor, maxHpOf } = args;
     // Same-side ally = NOT opposing AND not the owner itself (own events route to the
     // self-scoped triggers). For the player registration (opposing = enemy-side) this
     // is byte-identical to the old pattern.
@@ -390,6 +393,12 @@ export function registerReactiveListeners(args: {
                         const filter = ra.ability.triggerCritFilter;
                         if (filter === 'crit' && !e.didCrit) return;
                         if (filter === 'non-crit' && e.didCrit) return;
+                        const fracGate = ra.ability.requireIncomingDamageFracOfMaxHp;
+                        if (fracGate !== undefined) {
+                            const maxHp = maxHpOf?.(ownerId);
+                            if (e.damage === undefined || !maxHp || e.damage <= fracGate * maxHp)
+                                return;
+                        }
                         enqueue({ ...intent, eventCtx: { counterTargetId: e.attackerId } });
                     });
                     break;

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -393,6 +393,14 @@ export function registerReactiveListeners(args: {
                         enqueue({ ...intent, eventCtx: { counterTargetId: e.attackerId } });
                     });
                     break;
+                case 'on-debuffed':
+                    bus.on('debuff-applied', (e) => {
+                        // Self-scoped: fires when THIS owner receives a timed debuff. Mirrors
+                        // on-attacked's targetId === ownerId scoping. DoTs use dot-applied (not
+                        // this event) → Firewall does not fire on DoT application, by design.
+                        if (e.targetId === ownerId) enqueue(intent);
+                    });
+                    break;
                 case 'on-ally-attacked':
                     bus.on('attacked', (e) => {
                         // Ally-scoped: fires when ANY OTHER same-side actor is hit — per HIT
@@ -1224,7 +1232,8 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
                 ? ctx.enemyWithHighestAttack?.(intent.ownerId)
                 : intent.eventCtx?.counterTargetId;
         // No living highest-attack enemy → no-op (don't fall back to the default enemy).
-        if (intent.ability.target === 'enemy-highest-attack' && counterTargetId === undefined) return;
+        if (intent.ability.target === 'enemy-highest-attack' && counterTargetId === undefined)
+            return;
         // Block Debuff fold (D-PR15 Task 5): a target carrying Block Debuff auto-resists every
         // incoming timed debuff. Gate immunity into the landing condition so the EXISTING resist
         // `else` handles it (no duplicated resist code). `&&` short-circuits when not immune →

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1223,6 +1223,35 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
                 duration,
             });
         }
+        // D-PR16: co-granted buffs (Last Stand's Barrier + Block Debuff) — applied in the
+        // SAME application as the primary (the single proc gate above already passed). Reuses
+        // the SAME recipients/gate; each extra carries its own duration. Absent → no-op loop.
+        for (const extra of cfg.additionalBuffs ?? []) {
+            const extraStatus: Extract<RegisteredAbilityStatus, { kind: 'timed' }> = {
+                payload: payloadFromConfig({
+                    buffName: extra.buffName,
+                    stacks: extra.stacks,
+                    parsedEffects: extra.parsedEffects,
+                }),
+                side: 'self',
+                sourceSlot: intent.sourceSlot,
+                conditions: gateConditions,
+                casterId: intent.ownerId,
+                recipients,
+                kind: 'timed',
+                duration: extra.duration,
+            };
+            for (const rid of recipients) {
+                ctx.statusEngine.applyTimedAbilityStatus(ctx.round, extraStatus, rid);
+                ctx.bus.emit({
+                    type: 'buff-applied',
+                    actorId: rid,
+                    round: ctx.round,
+                    buffName: extra.buffName,
+                    duration: extra.duration,
+                });
+            }
+        }
         return;
     }
 

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -678,6 +678,9 @@ export interface IntentExecContext {
     enemyWithMostBuffs?: (ownerId: string) => string | undefined;
     /** D-PR14: id of the round's first real (non-Stasis/Disable-skipped) activator. */
     firstActivatorId?: string;
+    /** D-PR16: id of the sole living actor on the drain owner's side (recomputed each drain),
+     *  or undefined when !=1 actor is alive. Drives the `last-standing` gate (Last Stand). */
+    lastStandingId?: string;
     /** D-PR14 Doomsayer: living opposing actor with the greatest live effective attack. */
     enemyWithHighestAttack?: (ownerId: string) => string | undefined;
     /** D-PR14 Bulwark: per-(owner,ability) once-per-round consume set (reset each round in engine). */
@@ -743,6 +746,9 @@ export function buildActorConditionContext(
         /** Owner took the round's first real turn. Default false. Populated by
          *  buildDrainContext (D-PR14). */
         firstActivator?: boolean;
+        /** Owner is the sole living actor on its side. Default false. Populated by
+         *  buildDrainContext (D-PR16). */
+        lastStanding?: boolean;
     }
 ) {
     const snap = statusEngine.snapshot(ownerId);
@@ -771,6 +777,7 @@ export function buildActorConditionContext(
         isLowestSpeedAlly: shared.isLowestSpeedAlly,
         wasHitThisRound: shared.wasHitThisRound,
         firstActivator: shared.firstActivator,
+        lastStanding: shared.lastStanding,
     });
 }
 
@@ -808,6 +815,10 @@ function buildDrainContext(ctx: IntentExecContext, ownerId: string) {
         // D-PR14: live first-activator gate (Doomsayer). Default false → DPS / no-delegate
         // paths read "not first" ⇒ not met and stay byte-identical.
         firstActivator: ctx.firstActivatorId === ownerId,
+        // D-PR16: live last-standing gate (Last Stand). lastStandingId is undefined unless EXACTLY
+        // one same-side actor is alive → DPS / no-delegate paths read "not alone" ⇒ not met and
+        // stay byte-identical.
+        lastStanding: ctx.lastStandingId === ownerId,
     });
 }
 

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1226,6 +1226,9 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
         // D-PR16: co-granted buffs (Last Stand's Barrier + Block Debuff) — applied in the
         // SAME application as the primary (the single proc gate above already passed). Reuses
         // the SAME recipients/gate; each extra carries its own duration. Absent → no-op loop.
+        // NOTE: extras use their raw parsedEffects and do NOT receive the `attackFlatPctOfCaster`
+        // pin applied to the primary above — fine for the current attack-less control buffs
+        // (Barrier/Block Debuff); a future attack-scaled co-buff would need pin handling here.
         for (const extra of cfg.additionalBuffs ?? []) {
             const extraStatus: Extract<RegisteredAbilityStatus, { kind: 'timed' }> = {
                 payload: payloadFromConfig({

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -401,6 +401,15 @@ export function registerReactiveListeners(args: {
                         if (e.targetId === ownerId) enqueue(intent);
                     });
                     break;
+                case 'on-debuff-resisted':
+                    bus.on('debuff-resisted', (e) => {
+                        // Self-scoped on the RESISTER. `debuff-resisted` carries targetId = the
+                        // unit that resisted (either side: cast-side, reactive-side, and the
+                        // D-PR15 Block-Debuff auto-resist all emit it). all-allies recipient
+                        // routing happens in the buff executor.
+                        if (e.targetId === ownerId) enqueue(intent);
+                    });
+                    break;
                 case 'on-ally-attacked':
                     bus.on('attacked', (e) => {
                         // Ally-scoped: fires when ANY OTHER same-side actor is hit — per HIT


### PR DESCRIPTION
## Summary

Wires the four **Block/Protection applier** implants that consume D-PR15's control primitives (previously inert — no implant granted them). Effects ride existing reactive-buff machinery; the new work is the **trigger seams** + two small infra primitives.

| Implant | Trigger | Effect |
|---|---|---|
| **Firewall** | new `on-debuffed` (rides `debuff-applied`, self-scoped) | self **Block Debuff** (1t) |
| **Lockdown** | new `on-debuff-resisted` (rides `debuff-resisted`, self-scoped) | all-ally **Buff Protection** (1t) — chains off D-PR15's Block-Debuff auto-resist |
| **Tenacity** | existing `on-attacked` + new `>25% max-HP` damage filter | all-ally **Buff Protection** (2t) |
| **Last Stand** | existing `on-ally-destroyed` gated on new `last-standing` subject | self **Barrier + Block Debuff** on one roll (1t) |

### Infrastructure added
- **`last-standing` ConditionSubject** — true iff the owner is the sole living same-side actor; threaded across ~8 sites mirroring D-PR14's `first-activator` (incl. `LIVE_SUBJECTS`), recomputed per drain so it reflects deaths.
- **`additionalBuffs` co-grant** — a single reactive buff-grant can apply several named buffs on ONE proc roll (Last Stand's Barrier + Block Debuff).
- **`attacked.damage`** — optional per-attack aggregate added to the event (conditional spread → byte-identical when absent), feeding Tenacity's `requireIncomingDamageFracOfMaxHp` filter via a new `maxHpOf` resolver.

No once-per-round caps (pure %-chance procs). DPS page not wired (defensive/targeting-only effects).

## Test Plan
- [x] Per-applier integration tests through the **real registry** (`buildShipAbilitiesWithEquipment`), incl. the Firewall→resist→Lockdown synergy chain, Tenacity ≤25%/DoT negatives, and the Last Stand enemy-side mirror
- [x] Last Stand registry entry mutation-covered (dropping the co-grant / breaking the trigger now fails a test)
- [x] Full suite **3083 passed / 222 files**; `tsc --noEmit` clean; `lint` 0 warnings; `audit:skills` 0/141
- [x] **Byte-identical goldens** — zero `.snap`/golden drift across the branch (no fixture equips these implants)

Stacked on #147 (D-PR15 primitives); retarget to `main` after it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)