### PR TITLE
feat(combat): reactive cleanse — Reactive Ward + Warpstrike duration-reduction

### DIFF
--- a/docs/superpowers/plans/2026-06-23-reactive-cleanse.md
+++ b/docs/superpowers/plans/2026-06-23-reactive-cleanse.md
@@ -1,0 +1,635 @@
+# Reactive Cleanse (Reactive Ward + Warpstrike duration-reduction) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two cleanse-family reactive implant effects to the battle sim — Reactive Ward (on directly-damaged → proc-gated cleanse of 1 debuff, or 2 on a crit) and Warpstrike's deferred duration-reduction half (on dealing direct damage while self-debuffed → shave 1 turn off the newest self-debuff).
+
+**Architecture:** Both flow through the single existing reactive `cleanse` executor branch (`triggers.ts` ~1407), distinguished by a new `mode: 'remove' | 'reduce-duration'` field — no turn-loop special-casing. Reactive Ward rides the existing `on-attacked` trigger; Warpstrike rides a new `on-deal-damage` trigger (which rides `ability-performed`, emitted exactly once per damage-dealing turn). A new status-engine primitive `reduceNewestDebuffDuration` does the partial-duration work. Both are registered as equipment abilities in `buildEquipmentAbilities.ts`.
+
+**Tech Stack:** TypeScript, Vitest. Combat engine in `src/utils/combat/`; equipment-ability registry in `src/utils/abilities/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-23-reactive-cleanse-design.md`
+
+**Branch:** `feat/combat-d-pr-reactive-cleanse` (off `main` @ D-PR15).
+
+---
+
+## Pre-flight grounding (read before starting)
+
+- Reactive `cleanse` executor branch: `src/utils/combat/triggers.ts` ~1407.
+- `on-attacked` listener: `src/utils/combat/triggers.ts` ~382 (already builds `eventCtx: { counterTargetId }`).
+- Trigger-listener `switch (ra.ability.trigger)`: `src/utils/combat/triggers.ts` ~251.
+- `passesProcChanceGate` + **its doc-comment gate-desync rule**: `src/utils/combat/triggers.ts` ~1016-1023. The `!ctx.healing` early-return MUST precede the proc gate in remove-mode.
+- `reactiveRecipients`: `src/utils/combat/triggers.ts` ~1004 — `self` target → `[ownerId]`.
+- `cleanse` / `removeNewestFirst` / `isUnremovable`: `src/utils/combat/statusEngine.ts` ~899-989.
+- `cleanse` AbilityConfig member: `src/types/abilities.ts` ~347-356 (shared with `purge`).
+- `Intent.eventCtx`: `src/utils/combat/triggers.ts` ~102.
+- `ability-performed` emit (once per turn): `src/utils/combat/playerTurn.ts` ~1404; positional path relies on it (`engine.ts` ~2887).
+- Registry consumer / id-stamping: `src/utils/abilities/buildEquipmentAbilities.ts` ~769-780.
+
+**Verified facts driving this plan:**
+- `ability-performed` fires exactly once per damage-dealing turn (aggregate event; positional path emits none) → Warpstrike needs **no** once-per-turn guard.
+- `reactiveRecipients` maps `target: 'self'` → `[ownerId]`.
+- `passesProcChanceGate` is pass-through (returns `true` without touching the gate) when `procChance` is undefined → Warpstrike (no procChance) never advances the accumulator.
+- No combat golden fixture equips Reactive Ward or Warpstrike → zero golden/.snap drift expected.
+
+---
+
+## Task 1: Status-engine primitive `reduceNewestDebuffDuration`
+
+**Files:**
+- Modify: `src/utils/combat/statusEngine.ts` (add to the `StatusEngine` interface ~163 near `cleanse`; add the implementation near `removeNewestFirst`/`cleanse` ~954-989; expose it on the returned object near the `cleanse,` entry ~1204)
+- Test: `src/utils/combat/__tests__/statusEngine.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a `describe('reduceNewestDebuffDuration', ...)` block. Use the existing test file's helpers to apply timed enemy-side debuffs to an actor (mirror how `cleanseRemoval`/`statusEngine` tests apply debuffs — apply two timed debuffs with different durations and application order so newest-first is observable). Cover:
+
+```ts
+// 1. Reduces the NEWEST-applied debuff's duration by `turns`, leaves others untouched.
+//    Apply debuff A (3 turns) then debuff B (3 turns); reduceNewestDebuffDuration(id, 1)
+//    → B has 2 turns remaining, A still 3. Returns 1.
+// 2. Expires (removes) a debuff reduced to <= 0.
+//    Apply a 1-turn debuff; reduceNewestDebuffDuration(id, 1) → debuff gone. Returns 1.
+// 3. Skips non-numeric durations ('recurring'/'permanent') and UNREMOVABLE_STATUSES —
+//    if the ONLY debuff is unremovable/recurring, returns 0 and nothing changes.
+// 4. Unknown actor id (no debuffs) → returns 0, no throw.
+// 5. turns > 1 reduces by that many (e.g. 2-turn debuff, reduce by 2 → expires).
+```
+
+Assert via `snapshot(id)` / the engine's existing read API for active debuffs + their remaining turns (match whatever `statusEngine.test.ts` already uses to read durations).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest --run src/utils/combat/__tests__/statusEngine.test.ts -t "reduceNewestDebuffDuration"`
+Expected: FAIL — `reduceNewestDebuffDuration is not a function`.
+
+- [ ] **Step 3: Add the interface method**
+
+In the `StatusEngine` interface (near `cleanse(actorId, count): number;`):
+
+```ts
+/** Reduce the duration of ONE timed debuff on `actorId` by `turns`, newest-applied first
+ *  (highest appliedSeq). Reduced to <= 0 → the debuff is removed (expired). Only timed
+ *  debuffs are eligible (accumulating/persistent have no finite duration); 'recurring'/
+ *  'permanent' and UNREMOVABLE_STATUSES are skipped (consistent with cleanse). Returns 1
+ *  if a debuff was affected, else 0. Unknown id → 0. */
+reduceNewestDebuffDuration(actorId: string, turns: number): number;
+```
+
+- [ ] **Step 4: Implement the primitive**
+
+Near `cleanse` (~988):
+
+```ts
+/** See interface doc. Mirrors removeNewestFirst's candidate gathering/skip rules over the
+ *  per-victim TIMED enemy store only, then decrements-or-deletes the newest candidate. */
+const reduceNewestDebuffDuration = (actorId: string, turns: number): number => {
+    const timedMap = enemyMaps.get(actorId);
+    if (!timedMap) return 0;
+    let best: { seq: number; key: string; s: BuffState } | undefined;
+    for (const [key, s] of timedMap) {
+        // Only timed entries carry a numeric duration; 'recurring'/'permanent' are not reducible.
+        if (typeof s.turnsRemaining !== 'number') continue;
+        if (isUnremovable(s.buffName, s.turnsRemaining)) continue;
+        if (!best || s.appliedSeq > best.seq) best = { seq: s.appliedSeq, key, s };
+    }
+    if (!best) return 0;
+    best.s.turnsRemaining = (best.s.turnsRemaining as number) - turns;
+    if ((best.s.turnsRemaining as number) <= 0) timedMap.delete(best.key);
+    return 1;
+};
+```
+
+Expose it on the returned engine object (near `cleanse,` ~1204): add `reduceNewestDebuffDuration,`.
+
+(Confirm `BuffState` is the in-scope type name used by `enemyMaps`; if the local alias differs, match it. `turnsRemaining` is `number | 'recurring' | 'permanent'`, so the `as number` narrowing after the `typeof` guard is safe and may be unnecessary if TS already narrows — drop the casts if lint complains.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest --run src/utils/combat/__tests__/statusEngine.test.ts -t "reduceNewestDebuffDuration"`
+Expected: PASS (all 5).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/combat/statusEngine.ts src/utils/combat/__tests__/statusEngine.test.ts
+git commit -m "feat(combat): reduceNewestDebuffDuration status-engine primitive"
+```
+
+---
+
+## Task 2: Extend cleanse AbilityConfig + Intent.eventCtx.didCrit (types)
+
+**Files:**
+- Modify: `src/types/abilities.ts` (the `cleanse | purge` config member ~347)
+- Modify: `src/utils/combat/triggers.ts` (`Intent.eventCtx` ~102)
+
+- [ ] **Step 1: Add cleanse config fields**
+
+In the `{ type: 'cleanse' | 'purge'; count; countScaling? }` member, add (cleanse-only — document that purge never sets these):
+
+```ts
+/** Reactive Ward: debuffs to cleanse when the triggering hit was a crit (else `count`).
+ *  Read from intent.eventCtx.didCrit by the reactive cleanse executor. cleanse-only. */
+critCount?: number;
+/** D-PR(reactive-cleanse): 'remove' (default) deletes whole debuffs (cleanse);
+ *  'reduce-duration' shaves `durationTurns` off the newest debuff (Warpstrike). cleanse-only. */
+mode?: 'remove' | 'reduce-duration';
+/** Turns to reduce in 'reduce-duration' mode (default 1). cleanse-only. */
+durationTurns?: number;
+```
+
+- [ ] **Step 2: Add `didCrit` to Intent.eventCtx**
+
+In `Intent.eventCtx` (after `triggerDamage?`):
+
+```ts
+/** The triggering hit's crit outcome (on-attacked → attacked.didCrit), read by the
+ *  reactive cleanse executor to pick `critCount` over `count` (Reactive Ward). */
+didCrit?: boolean;
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: PASS (additive optional fields — no call sites break).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types/abilities.ts src/utils/combat/triggers.ts
+git commit -m "feat(combat): cleanse config (critCount/mode/durationTurns) + eventCtx.didCrit"
+```
+
+---
+
+## Task 3: on-attacked threads didCrit + cleanse executor remove-mode (proc gate + crit-count)
+
+**Files:**
+- Modify: `src/utils/combat/triggers.ts` (`on-attacked` listener ~393; cleanse executor branch ~1407)
+- Test: `src/utils/combat/__tests__/cleanseReactivePath.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add cases to `cleanseReactivePath.test.ts` (follow the file's existing harness for building an Intent + IntentExecContext with a healing ctx and a real status engine carrying debuffs):
+
+```ts
+// A. remove-mode, no procChance: cleanses `count` debuffs (existing behavior preserved).
+// B. remove-mode, didCrit true + critCount set: cleanses critCount (2), not count (1).
+// C. remove-mode, didCrit false + critCount set: cleanses count (1).
+// D. remove-mode, procChance present + gate FAILS (procChance very low, or drive the gate
+//    so it doesn't fire): cleanses 0. (Mirror reactiveDamageProcGate.test.ts's gate-driving.)
+// E. gate-desync guard: in a NON-healing ctx (ctx.healing undefined), remove-mode returns
+//    early WITHOUT consulting the proc gate (assert the gate accumulator is untouched —
+//    or at minimum that no throw and no cleanse occurs).
+```
+
+Set `intent.eventCtx = { didCrit: true/false }` for B/C. Build the cleanse config with `mode: 'remove'`, `count: 1`, `critCount: 2`, and a `procChance` for D.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest --run src/utils/combat/__tests__/cleanseReactivePath.test.ts`
+Expected: FAIL (crit-count not honored; proc gate not applied).
+
+- [ ] **Step 3: Thread didCrit in the on-attacked listener**
+
+At `triggers.ts` ~393, change the enqueue to also carry `didCrit`:
+
+```ts
+enqueue({ ...intent, eventCtx: { counterTargetId: e.attackerId, didCrit: e.didCrit } });
+```
+
+- [ ] **Step 4: Rewrite the cleanse executor branch (remove-mode portion)**
+
+Replace the branch at ~1407. **CRITICAL ORDERING (see `passesProcChanceGate` doc ~1019):** in remove-mode the `!ctx.healing` early-return MUST come *before* the proc gate, or the rate accumulator desyncs between healing/non-healing passes.
+
+```ts
+if (cfg.type === 'cleanse') {
+    const mode = cfg.mode ?? 'remove';
+    // reduce-duration handled in Task 4; for now keep remove-mode correct.
+    // remove mode — keep the !ctx.healing return BEFORE the proc gate (gate-desync rule).
+    if (!ctx.healing) return;
+    if (!passesProcChanceGate(intent, ctx)) return;
+    const recipients = reactiveRecipients(intent, ctx, ctx.healing.targetId);
+    const count =
+        intent.eventCtx?.didCrit && cfg.critCount != null ? cfg.critCount : cfg.count;
+    let removed = 0;
+    for (const rid of recipients) removed += ctx.statusEngine.cleanse(rid, count);
+    // Credit the ACTUAL removed count.
+    ctx.healing.credit(intent.ownerId, 'cleanseCount', removed);
+    return;
+}
+```
+
+(Task 4 inserts the `reduce-duration` branch before the `!ctx.healing` remove-mode block. The `const mode` line is added now so the diff in Task 4 is small.)
+
+- [ ] **Step 5: Run to verify they pass**
+
+Run: `npx vitest --run src/utils/combat/__tests__/cleanseReactivePath.test.ts`
+Expected: PASS. Also run the existing on-cast cleanse tests to confirm no regression:
+`npx vitest --run src/utils/combat/__tests__/cleanseCastPath.test.ts src/utils/combat/__tests__/cleanseAll.test.ts src/utils/combat/__tests__/cleanseRemoval.test.ts`
+Expected: PASS (byte-identical — `mode` defaults to remove, `critCount`/`didCrit` absent → `count`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/combat/triggers.ts src/utils/combat/__tests__/cleanseReactivePath.test.ts
+git commit -m "feat(combat): reactive cleanse honors procChance + crit-count (Reactive Ward executor)"
+```
+
+---
+
+## Task 4: cleanse executor reduce-duration mode
+
+**Files:**
+- Modify: `src/utils/combat/triggers.ts` (cleanse executor branch from Task 3)
+- Test: `src/utils/combat/__tests__/cleanseReactivePath.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// F. reduce-duration mode reduces the newest self-debuff by durationTurns (default 1)
+//    and credits cleanseCount = number affected (1). Use a self-target intent + an actor
+//    carrying two timed debuffs; assert the newest lost a turn, the other unchanged.
+// G. reduce-duration mode works WITHOUT ctx.healing (pure status mutation): build a ctx
+//    with healing undefined → still calls reduceNewestDebuffDuration, no throw, no credit.
+// H. reduce-duration with no eligible debuff → affected 0, no throw.
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest --run src/utils/combat/__tests__/cleanseReactivePath.test.ts -t "reduce-duration"`
+Expected: FAIL (mode ignored → falls into remove path / requires healing).
+
+- [ ] **Step 3: Insert the reduce-duration branch**
+
+In the cleanse branch, immediately after `const mode = cfg.mode ?? 'remove';` and BEFORE the `if (!ctx.healing) return;` remove block:
+
+```ts
+if (mode === 'reduce-duration') {
+    // No shipped duration-reduction ability sets procChance (deterministic), so the gate is
+    // pass-through and never advances — safe to consult regardless of healing mode.
+    if (!passesProcChanceGate(intent, ctx)) return;
+    // Pure status mutation — does NOT require healing mode. Self-target → [ownerId].
+    const fallback = ctx.healing?.targetId ?? intent.ownerId;
+    const recipients = reactiveRecipients(intent, ctx, fallback);
+    let affected = 0;
+    for (const rid of recipients)
+        affected += ctx.statusEngine.reduceNewestDebuffDuration(rid, cfg.durationTurns ?? 1);
+    ctx.healing?.credit(intent.ownerId, 'cleanseCount', affected);
+    return;
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `npx vitest --run src/utils/combat/__tests__/cleanseReactivePath.test.ts`
+Expected: PASS (F/G/H + all Task 3 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/triggers.ts src/utils/combat/__tests__/cleanseReactivePath.test.ts
+git commit -m "feat(combat): reactive cleanse reduce-duration mode (Warpstrike half)"
+```
+
+---
+
+## Task 5: New trigger `on-deal-damage`
+
+**Files:**
+- Modify: `src/types/abilities.ts` (`AbilityTrigger` union + runtime trigger array, ~49/~99)
+- Modify: `src/utils/combat/triggers.ts` (listener switch ~251)
+- Test: `src/utils/combat/__tests__/triggers.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `triggers.test.ts`, register an ability with `trigger: 'on-deal-damage'` via `registerReactiveListeners`, emit `ability-performed` events on the bus, and assert enqueue behavior:
+
+```ts
+// - emits enqueue when actorId === ownerId AND damage > 0
+// - does NOT enqueue when actorId !== ownerId
+// - does NOT enqueue when damage is 0 / undefined
+```
+
+Follow the file's existing pattern for the `on-crit` / `on-attacked` listener tests (build the bus, register, emit, assert the intent queue).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest --run src/utils/combat/__tests__/triggers.test.ts -t "on-deal-damage"`
+Expected: FAIL — `'on-deal-damage'` not assignable to `AbilityTrigger` (and no listener).
+
+- [ ] **Step 3: Add the trigger to the type + runtime array**
+
+`src/types/abilities.ts`: add `| 'on-deal-damage'` to the `AbilityTrigger` union (group it near `on-crit`/`on-debuff-inflicted` with a comment), **and `'on-deal-damage',` to the `LIVE_TRIGGERS` array (~line 98)**. The `LIVE_TRIGGERS` membership is load-bearing: `isReactiveAbility` (`triggers.ts` ~123) gates on `LIVE_TRIGGERS.has(trigger)`, so without it the ability is never partitioned as reactive and the listener never registers. Adding it only to the union is NOT enough.
+
+- [ ] **Step 4: Add the listener**
+
+In the `switch (ra.ability.trigger)` (`triggers.ts` ~251), add:
+
+```ts
+case 'on-deal-damage':
+    bus.on('ability-performed', (e) => {
+        // Warpstrike duration-reduction: fires on the OWNER's own damage-dealing turn.
+        // runPlayerTurn emits exactly ONE aggregate ability-performed per turn (positional
+        // path emits none — engine.ts ~2887), so this is once-per-turn for single- and
+        // multi-hit/AoE alike — no guard needed. The while-debuffed requirement is an
+        // ability condition (self-debuff), enforced at drain via gateConditions.
+        if (e.actorId !== ownerId) return;
+        // ability-performed.damage is optional (events.ts) and tsconfig is strict — guard with
+        // ?? 0 (the codebase pattern for optional numeric event fields, cf. e.critHits ?? 0).
+        if ((e.damage ?? 0) <= 0) return;
+        enqueue(intent);
+    });
+    break;
+```
+
+- [ ] **Step 5: Run to verify it passes + tsc**
+
+Run: `npx vitest --run src/utils/combat/__tests__/triggers.test.ts -t "on-deal-damage"` → PASS
+Run: `npx tsc --noEmit` → PASS (any exhaustiveness switch over triggers now needs `on-deal-damage`; the editor stub in Task 7 covers the UI one — if tsc flags an editor switch here, add the stub now).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types/abilities.ts src/utils/combat/triggers.ts src/utils/combat/__tests__/triggers.test.ts
+git commit -m "feat(combat): on-deal-damage reactive trigger (rides ability-performed)"
+```
+
+---
+
+## Task 6: Registry — multi-ability builder + REACTIVE_WARD + WARPSTRIKE second ability
+
+**Files:**
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (builder type ~77; consumer ~769; add REACTIVE_WARD + a WARPSTRIKE proc/const table + the WARPSTRIKE builder ~468)
+- Test: a unit test for the registry — extend `src/utils/abilities/__tests__/equipmentCoverage.test.ts` or add `buildEquipmentAbilities.test.ts` if one exists; otherwise put the ability-shape assertions in `equipmentCoverage.test.ts` (it already calls `implantAbilityCount`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// REACTIVE_WARD: produces 1 ability per rarity; trigger 'on-attacked', type 'cleanse',
+//   mode 'remove', target 'self', count 1, critCount 2, procChance == rarity table
+//   (common .05 / uncommon .07 / epic .12 / legendary .16; rare → no ability/undefined).
+// WARPSTRIKE: produces 2 abilities per rarity — one modifier (existing, outgoingDamage,
+//   self-debuff gate) AND one cleanse (mode 'reduce-duration', durationTurns 1, target
+//   'self', trigger 'on-deal-damage', self-debuff condition, NO procChance).
+```
+
+Use `implantAbilityCount('REACTIVE_WARD', rarity)` and `('WARPSTRIKE', rarity)` plus a shape inspection of the built abilities (call `buildEquipmentAbilities` with a fake `getGearPiece` returning a piece whose `setBonus` is the implant name + the rarity, like the existing integration setup).
+
+**Explicit edit:** the existing WARPSTRIKE assertion at `equipmentCoverage.test.ts` ~line 251 — `expect(implantAbilityCount('WARPSTRIKE', v.rarity)).toBe(1)` — must change to `.toBe(2)`, and its test title from "1 ability" to "2 abilities". Do NOT leave it at `.toBe(1)` (it will fail once WARPSTRIKE returns two abilities).
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest --run src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+Expected: FAIL (REACTIVE_WARD not in registry → 0 abilities; WARPSTRIKE still 1).
+
+- [ ] **Step 3: Allow builders to return an array**
+
+Change the builder type (~77):
+
+```ts
+type ImplantAbilityBuilder = (
+    rarity: string
+) => Omit<Ability, 'id'> | Omit<Ability, 'id'>[] | undefined;
+```
+
+Update the consumer (~769-780) to normalize + stamp ids (single → existing id byte-identical; array → index-suffixed):
+
+```ts
+const builder = IMPLANT_ABILITIES[implantName];
+if (builder) {
+    const res = builder(piece.rarity);
+    if (!res) continue;
+    const partials = Array.isArray(res) ? res : [res];
+    partials.forEach((partial, i) => {
+        abilities.push({
+            ...partial,
+            // Single-ability implants keep their exact id (byte-identical). Multi-ability
+            // implants (Warpstrike) index-suffix so each gets a unique, stable id; proc-rate
+            // gates key on (owner, ability.id), so ids must be distinct per ability.
+            id:
+                partials.length === 1
+                    ? `equip-implant-${implantName}-${gearId}`
+                    : `equip-implant-${implantName}-${gearId}-${i}`,
+        });
+    });
+    continue;
+}
+```
+
+- [ ] **Step 4: Add the REACTIVE_WARD rarity table + builder**
+
+Near the other proc tables (top of file):
+
+```ts
+const REACTIVE_WARD_PROC: Record<string, number> = {
+    common: 0.05,
+    uncommon: 0.07,
+    epic: 0.12,
+    legendary: 0.16,
+};
+```
+
+In `IMPLANT_ABILITIES`:
+
+```ts
+// Reactive cleanse: when directly damaged, X% chance to cleanse 1 debuff (2 if the hit
+// was a crit). No rare variant exists in implants.ts.
+REACTIVE_WARD: (rarity) => {
+    const pc = REACTIVE_WARD_PROC[rarity];
+    if (pc === undefined) return undefined;
+    return {
+        type: 'cleanse',
+        target: 'self',
+        trigger: 'on-attacked',
+        conditions: [],
+        procChance: pc,
+        config: { type: 'cleanse', count: 1, critCount: 2, mode: 'remove' },
+        autoFilled: true,
+    };
+},
+```
+
+- [ ] **Step 5: Make WARPSTRIKE return both abilities**
+
+Rewrite the WARPSTRIKE builder (~468) to return an array: the existing modifier object PLUS the duration-reduction cleanse. Keep the existing modifier object verbatim. Add:
+
+```ts
+WARPSTRIKE: (rarity) => {
+    const value = WARPSTRIKE_PCT[rarity];
+    if (value === undefined) return undefined;
+    const selfDebuffGate = {
+        subject: 'self-debuff' as const,
+        derivable: true,
+        countComparator: 'gte' as const,
+        countThreshold: 1,
+    };
+    return [
+        // Damage half (D-PR2, unchanged): +X% outgoing direct damage while self-debuffed.
+        {
+            type: 'modifier',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [selfDebuffGate],
+            config: { type: 'modifier', channel: 'outgoingDamage', value, isMultiplicative: false },
+            autoFilled: true,
+        },
+        // Duration-reduction half: on dealing direct damage while self-debuffed, reduce the
+        // newest self-debuff by 1 turn. Deterministic (no procChance).
+        {
+            type: 'cleanse',
+            target: 'self',
+            trigger: 'on-deal-damage',
+            conditions: [selfDebuffGate],
+            config: { type: 'cleanse', count: 0, mode: 'reduce-duration', durationTurns: 1 },
+            autoFilled: true,
+        },
+    ];
+},
+```
+
+(Confirm the `conditions`/config object literal types match the existing modifier entry — reuse the exact `subject: 'self-debuff'` shape already in the file. `count: 0` is an inert placeholder for the cleanse union's required `count`; reduce-duration mode ignores it. If the `cleanse` config type makes `count` required and `0` reads oddly, that's fine — it is never consulted in reduce-duration mode.)
+
+- [ ] **Step 6: Run to verify they pass + tsc**
+
+Run: `npx vitest --run src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+Run: `npx tsc --noEmit`
+Expected: PASS (REACTIVE_WARD shape; WARPSTRIKE 2 abilities; ids index-suffixed for Warpstrike, unchanged for all single-ability implants).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/equipmentCoverage.test.ts
+git commit -m "feat(combat): register Reactive Ward + Warpstrike duration-reduction (multi-ability builder)"
+```
+
+---
+
+## Task 7: Editor stubs + coverage tracker
+
+**Files:**
+- Modify: `src/components/.../AbilityCard.tsx` (the `TRIGGER_OPTIONS` list — find via `grep -rn "TRIGGER_OPTIONS" src/components`)
+- Modify: `src/utils/abilities/__tests__/equipmentCoverage.test.ts` (implemented-implants set)
+
+- [ ] **Step 1: Add the `on-deal-damage` editor stub**
+
+Add an `on-deal-damage` entry to `TRIGGER_OPTIONS` (mirror the existing trigger entries, e.g. label "On dealing damage"). This keeps the manual ability editor's trigger dropdown exhaustive. (No `ConditionRow` change — `self-debuff` already exists.)
+
+- [ ] **Step 2: Update the coverage tracker**
+
+In `equipmentCoverage.test.ts`, add `REACTIVE_WARD` to the implemented-implants set in **all three** spots (the `.toEqual([...])` decl-order array, the `Set`, and the `it('exactly {…}')` string). The `.toEqual([...])` array and the `it` title follow `Object.keys(IMPLANTS)` order — REACTIVE_WARD lives at ~line 2468 of `implants.ts`, so insert it at the matching position (not appended). WARPSTRIKE is already in the set; its `implantAbilityCount` assertion was changed to `.toBe(2)` in Task 6.
+
+- [ ] **Step 3: Run to verify**
+
+Run: `npx vitest --run src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+Run: `npx tsc --noEmit && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components src/utils/abilities/__tests__/equipmentCoverage.test.ts
+git commit -m "chore(combat): editor trigger stub + coverage tracker for reactive cleanse"
+```
+
+---
+
+## Task 8: Engine integration tests (real registry)
+
+**Files:**
+- Test: `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts`
+
+Route everything through the REAL registry (`buildShipAbilitiesWithEquipment` + a ship whose equipped piece has `setBonus = 'REACTIVE_WARD' / 'WARPSTRIKE'` and the chosen rarity), overriding only `procChance: 1` for single-event determinism where needed — the D-PR16 Last Stand mutation-probe lesson: a hand-rolled ability can pass even when the wiring is broken, so assert the registry shape too.
+
+- [ ] **Step 1: Write the Reactive Ward integration test**
+
+```ts
+// Build a battle where the Reactive-Ward carrier holds 2 timed debuffs and is directly hit.
+// procChance forced to 1 (or assert statistically via the gate). 
+// - Non-crit hit → exactly 1 debuff cleansed.
+// - Crit hit → exactly 2 debuffs cleansed.
+// Assert via the post-round status snapshot / cleanse credit on the result.
+```
+
+- [ ] **Step 2: Write the Warpstrike integration test**
+
+```ts
+// Build a battle where the Warpstrike carrier is itself debuffed (2 timed debuffs) and takes
+// a damage-dealing turn against an enemy.
+// - The newest self-debuff loses ONE EXTRA turn beyond the normal post-turn decrement
+//   (i.e. -2 net this turn vs -1 for a non-Warpstrike control), OR is removed if it had 1 left.
+//   (Account for the same-turn post-turn decrement — assert the DELTA vs a no-Warpstrike control
+//   ship in the same setup, mirroring how D-PR13's Martyrdom/Disable test isolates the extra tick.)
+// - The D-PR2 damage half still applies (outgoing damage is boosted while self-debuffed) — assert
+//   both abilities are present from the registry and the damage modifier still fires.
+```
+
+Use a no-Warpstrike control ship in an otherwise identical setup to isolate the extra duration tick from the normal decrement (this avoids baking the decrement-timing quirk into the assertion).
+
+- [ ] **Step 3: Add a registry-shape assertion**
+
+Assert `buildShipAbilitiesWithEquipment` for a WARPSTRIKE-equipped ship yields both the `outgoingDamage` modifier and the `reduce-duration` cleanse (trigger `on-deal-damage`), and for REACTIVE_WARD yields the `on-attacked` cleanse with `critCount: 2`. This makes the mutation-probe bite.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `npx vitest --run src/utils/combat/__tests__/equipmentAbilities.integration.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+git commit -m "test(combat): engine integration for Reactive Ward + Warpstrike duration-reduction"
+```
+
+---
+
+## Task 9: Full verification + changelog
+
+**Files:**
+- Modify: `src/constants/changelog.ts` (`UNRELEASED_CHANGES`)
+
+- [ ] **Step 1: Add a changelog entry**
+
+Add a plain-English entry to `UNRELEASED_CHANGES` (match the existing entry style), e.g.:
+"Battle simulator now models the Reactive Ward implant (chance to cleanse a debuff when hit, doubled on crits) and the duration-reduction half of Warpstrike (shaves a turn off one of your debuffs when you attack while debuffed)."
+
+- [ ] **Step 2: Full test suite**
+
+Run: `npm test`
+Expected: All pass except the known pre-existing env-failing FILES (missing Supabase URL + gitignored `docs/*.csv`). Confirm no NEW failures and **zero golden/.snap drift** (no `-u`, ever — if any golden moved, STOP and investigate; the spec predicts zero movement).
+
+- [ ] **Step 3: tsc + lint + skills audit**
+
+Run: `npx tsc --noEmit && npm run lint && npm run audit:skills`
+Expected: tsc clean; lint clean (max-warnings 0); `audit:skills` 141/0 unchanged.
+
+- [ ] **Step 4: Confirm zero golden drift explicitly**
+
+Run: `git status --porcelain` after the suite — expect no modified `*.snap` / golden fixture files. If any appear, investigate before proceeding (do NOT commit a golden change for this PR).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/constants/changelog.ts
+git commit -m "docs(combat): changelog for reactive cleanse (Reactive Ward + Warpstrike)"
+```
+
+- [ ] **Step 6: Final review handoff**
+
+Dispatch a holistic code review (the campaign's per-PR final-review step) and address findings before opening the PR.
+
+---
+
+## Definition of Done
+
+- `reduceNewestDebuffDuration` primitive + unit tests.
+- Reactive cleanse executor honors `procChance` (remove-mode, `!ctx.healing` before the gate) and `critCount`; supports `reduce-duration` mode (no healing dependency).
+- `on-attacked` threads `didCrit`; new `on-deal-damage` trigger.
+- REACTIVE_WARD registered (1 ability/rarity, no rare); WARPSTRIKE returns both halves (multi-ability builder; single-ability implant ids unchanged).
+- Editor trigger stub + coverage tracker updated.
+- Engine integration tests via the real registry (mutation-probe-resistant).
+- Full suite green, tsc/lint clean, `audit:skills` 141/0, **zero golden/.snap drift**, changelog entry added.
+- DPS page intentionally NOT wired (defensive/status-only effects).

--- a/docs/superpowers/specs/2026-06-23-reactive-cleanse-design.md
+++ b/docs/superpowers/specs/2026-06-23-reactive-cleanse-design.md
@@ -67,7 +67,7 @@ Reactive `cleanse` executor branch (`triggers.ts` ~1407):
   ```
   bus.on('ability-performed', (e) => {
       if (e.actorId !== ownerId) return;
-      if (!(e.damage > 0)) return;   // "directly damaging an enemy"
+      if ((e.damage ?? 0) <= 0) return;   // "directly damaging an enemy" (damage is optional → ?? 0)
       enqueue(intent);
   });
   ```

--- a/docs/superpowers/specs/2026-06-23-reactive-cleanse-design.md
+++ b/docs/superpowers/specs/2026-06-23-reactive-cleanse-design.md
@@ -30,7 +30,7 @@ The reactive `cleanse` executor branch is the common seam. Reactive Ward uses `m
 
 New method on the status engine (interface + implementation in `src/utils/combat/statusEngine.ts`, beside `cleanse` / `removeNewestFirst`):
 
-```
+```ts
 reduceNewestDebuffDuration(actorId: string, turns: number): number
 ```
 
@@ -64,7 +64,7 @@ Reactive `cleanse` executor branch (`triggers.ts` ~1407):
 
 - Added to the `AbilityTrigger` union and the runtime trigger array (`src/types/abilities.ts`).
 - Listener (`triggers.ts`): rides `ability-performed` —
-  ```
+  ```ts
   bus.on('ability-performed', (e) => {
       if (e.actorId !== ownerId) return;
       if ((e.damage ?? 0) <= 0) return;   // "directly damaging an enemy" (damage is optional → ?? 0)

--- a/docs/superpowers/specs/2026-06-23-reactive-cleanse-design.md
+++ b/docs/superpowers/specs/2026-06-23-reactive-cleanse-design.md
@@ -1,0 +1,114 @@
+# D-PR — Reactive Cleanse (Reactive Ward + Warpstrike duration-reduction)
+
+**Date:** 2026-06-23
+**Sub-project:** D (implants + gear-set abilities), combat-realism epic
+**Status:** Design — approved, pre-spec-review
+
+## Summary
+
+Adds the two cleanse-family reactive effects from the implant corpus:
+
+1. **Reactive Ward** — "When directly damaged, there is an X% chance to cleanse 1 debuff, but if the hit was a critical, 2 debuffs are cleansed instead." A victim-side reaction: on being directly hit, a proc-gated full-cleanse of self debuffs, with the count doubling on a critical hit.
+2. **Warpstrike (duration-reduction half)** — the deferred half of the Warpstrike implant. Full text: "Increases damage by 1% when directly damaging an enemy while debuffed, **and reduces a random active debuff's duration by 1 turn**." The damage half shipped in D-PR2 (a passive `outgoingDamage` modifier gated on self-debuff). This spec adds only the duration-reduction half: an attacker-side reaction that, when the carrier deals direct damage while itself debuffed, shaves one turn off one of its own debuffs.
+
+Both are modeled as cleanse-family reactive abilities flowing through the **single existing reactive `cleanse` executor branch** (`triggers.ts` ~1407), distinguished by a new `mode` field. This keeps both effects inside the registry/trigger system the rest of sub-project D uses — no turn-loop special-casing.
+
+## Unifying design
+
+The reactive `cleanse` executor branch is the common seam. Reactive Ward uses `mode: 'remove'` (whole-debuff removal, the existing behavior). Warpstrike uses `mode: 'reduce-duration'` (partial duration reduction, new). Both resolve recipients via the existing `reactiveRecipients` helper and (for these two) target `self`.
+
+## Decisions (locked with the user)
+
+- **Scope:** both effects ship in one PR.
+- **"Random" debuff pick (Warpstrike):** deterministic **newest-applied first** — consistent with the existing cleanse/purge `removeNewestFirst` convention. Documented as a deterministic approximation of the game's "random".
+- **Warpstrike trigger seam:** a **new reactive trigger** (`on-deal-damage`), riding `ability-performed`, gated on the self-debuff condition reused from Warpstrike's D-PR2 damage half. Chosen over a turn-loop fold to stay consistent with the campaign's reactive/registry architecture.
+- **Warpstrike cadence:** once per turn (one debuff reduced per damage-dealing turn), not per AoE victim.
+
+## Components
+
+### 1. Status-engine primitive — `reduceNewestDebuffDuration`
+
+New method on the status engine (interface + implementation in `src/utils/combat/statusEngine.ts`, beside `cleanse` / `removeNewestFirst`):
+
+```
+reduceNewestDebuffDuration(actorId: string, turns: number): number
+```
+
+- Gathers **timed** debuff candidates from `enemyMaps.get(actorId)` only. Accumulating (`accumEnemyMaps`) and persistent-stacking maps have no finite duration → not visited.
+- Skips entries whose `turnsRemaining` is non-numeric (`'recurring'` / `'permanent'`) and entries whose `buffName ∈ UNREMOVABLE_STATUSES` (consistent with cleanse — duration-reduction must not affect debuffs cleanse can't touch).
+- Picks the candidate with the highest `appliedSeq` (newest-applied first).
+- Reduces that entry's `turnsRemaining` by `turns`. If the result is ≤ 0, deletes the entry (it has expired).
+- Returns `1` if it acted on a debuff, else `0`. Unknown actor id / no eligible candidate → `0` (lazy-empty, safe no-op).
+
+Mirrors `removeNewestFirst`'s candidate-gathering and skip rules; differs only in the terminal action (decrement-or-delete vs delete).
+
+### 2. Cleanse AbilityConfig + reactive executor extensions
+
+`cleanse` AbilityConfig (`src/types/abilities.ts`) gains:
+
+- `critCount?: number` — count to cleanse when the triggering hit was a crit (Reactive Ward).
+- `mode?: 'remove' | 'reduce-duration'` — defaults to `'remove'`.
+- `durationTurns?: number` — turns to reduce in `'reduce-duration'` mode (default 1).
+
+Reactive `cleanse` executor branch (`triggers.ts` ~1407):
+
+- Adds `if (!passesProcChanceGate(intent, ctx)) return;` at the top. Pass-through when `procChance` is undefined/≤0/≥1 → **existing reactive cleanses byte-identical** (verify no shipped reactive cleanse sets `procChance`; if any do, the gate is still a pass-through for the undefined case).
+- `mode === 'remove'` (default): `count = intent.eventCtx?.didCrit && cfg.critCount != null ? cfg.critCount : cfg.count`; for each recipient `removed += statusEngine.cleanse(rid, count)`; credit `cleanseCount` (unchanged behavior when `critCount`/`didCrit` absent).
+- `mode === 'reduce-duration'`: for each recipient `affected += statusEngine.reduceNewestDebuffDuration(rid, cfg.durationTurns ?? 1)`. This path needs only `statusEngine` (always present in the drain), so it must **not** sit behind the branch's `if (!ctx.healing) return` heal-credit guard — restructure so the early-return guards only the credit emission, with credit emitted only when `ctx.healing` is present.
+
+### 3. `didCrit` threading (Reactive Ward crit-count)
+
+`Intent.eventCtx` gains `didCrit?: boolean`. The `on-attacked` listener (`triggers.ts` ~393) already enqueues `eventCtx: { counterTargetId: e.attackerId }` — add `didCrit: e.didCrit`. The executor reads `intent.eventCtx?.didCrit` to choose `critCount` over `count`.
+
+### 4. New trigger — `on-deal-damage` (Warpstrike)
+
+- Added to the `AbilityTrigger` union and the runtime trigger array (`src/types/abilities.ts`).
+- Listener (`triggers.ts`): rides `ability-performed` —
+  ```
+  bus.on('ability-performed', (e) => {
+      if (e.actorId !== ownerId) return;
+      if (!(e.damage > 0)) return;   // "directly damaging an enemy"
+      enqueue(intent);
+  });
+  ```
+- Self-scoped, direct-damage-gated. The **while-debuffed** requirement is an ability *condition* (the self-debuff condition reused from Warpstrike's D-PR2 damage half), evaluated at drain via `gateConditions` — the listener stays enqueue-only.
+- **Verification item (resolve as an explicit early step in the plan):** confirm `ability-performed` fires once per cast (carrying aggregate `damage`/`critHits`), not once per AoE victim. `on-crit` reads `e.critHits` (aggregate per cast), which suggests once-per-cast. The answer determines whether the once-per-turn guard is built or skipped, which in turn shapes the Warpstrike integration test — so it must be settled before the executor/test tasks. If it can fire per-victim, add a once-per-turn guard so Warpstrike reduces exactly one debuff per damage-dealing turn.
+
+### 5. Registry (`src/utils/abilities/buildEquipmentAbilities.ts`)
+
+- **REACTIVE_WARD** (new entry): `trigger: 'on-attacked'`, `type: 'cleanse'`, `mode: 'remove'`, `target: 'self'`, `count: 1`, `critCount: 2`, `procChance` per rarity — **common 0.05 / uncommon 0.07 / epic 0.12 / legendary 0.16**. (No rare variant exists in `implants.ts`.) Note: `on-attacked` is per-hit, so the proc **rolls per incoming hit** (each hit independently rolls the cleanse), consistent with the existing per-event proc-gate model. The crit-count applies to whichever hit procs.
+- **WARPSTRIKE**: builder now returns **two** abilities —
+  1. the existing damage-half `outgoingDamage` modifier (untouched, byte-identical), and
+  2. the new duration-reduction reactive: `trigger: 'on-deal-damage'`, `type: 'cleanse'`, `mode: 'reduce-duration'`, `durationTurns: 1`, `target: 'self'`, self-debuff condition, **no `procChance`** (deterministic), all rarities.
+
+  Requires extending the registry builder return type to allow `Omit<Ability,'id'> | Omit<Ability,'id'>[]` so one implant can contribute multiple abilities. Stable ids stay unique per ability (the `equip-implant-${name}-${gearId}` scheme; the two Warpstrike abilities need distinguishable ids — append an ability-role suffix or index).
+
+### 6. Editor stubs + coverage tracker
+
+- `on-deal-damage` → `TRIGGER_OPTIONS` stub in `AbilityCard.tsx` (switch exhaustiveness); the new cleanse `mode` field handled where the config editor switches on cleanse fields.
+- `equipmentCoverage.test.ts`: add `REACTIVE_WARD` to the implemented-implants set (three spots — `.toEqual` decl-order array, the `Set`, and the `it('exactly {…}')` string). WARPSTRIKE is already in the set (D-PR2); update its per-implant ability-count assertion from 1 to 2.
+
+### 7. DPS calculator page
+
+Not wired. Both effects are defensive/status-only and do not affect single-ship DPS — consistent with the other defensive implants (Reactive Ward = cleanse; Warpstrike's duration-reduction shortens self-debuffs, irrelevant to the single-ship DPS model). Warpstrike's *damage* half remains wired from D-PR2.
+
+## Testing
+
+- **Unit — `reduceNewestDebuffDuration`:** newest-first selection; expiry/delete when reduced to ≤0; skips `'recurring'`/`'permanent'`/accumulating/unremovable; unknown id → 0; multi-turn reduction.
+- **Unit — reactive cleanse executor:** proc-chance gate (proc vs no-proc); crit-count (`didCrit` → `critCount`, else `count`); `reduce-duration` mode routes to the primitive.
+- **Integration (engine), routed through the real registry** (`buildShipAbilitiesWithEquipment` + `setBonus`, `procChance: 1` for determinism — the mutation-probe lesson from D-PR16 Last Stand; assert the registry shape so a hand-rolled ability can't pass):
+  - Reactive Ward: on-attacked **crit** → 2 debuffs cleansed; **non-crit** → 1.
+  - Warpstrike: carrier deals direct damage while self-debuffed → the newest self-debuff loses one extra turn (and the D-PR2 damage-half modifier still applies on the same turn).
+
+## Gates
+
+- Full test suite green (excluding the pre-existing env-failing files — missing Supabase URL + gitignored `docs/*.csv`).
+- `tsc` + lint clean.
+- `npm run audit:skills` unchanged (141/0).
+- **Zero golden / `.snap` drift** — no combat fixture equips Reactive Ward or Warpstrike, so neither effect fires in any golden run.
+
+## Out of scope / follow-ups
+
+- Truly randomized debuff selection (engine is deterministic by design).
+- Warpstrike duration-reduction in the DPS calculator (no single-ship debuff model).
+- Any other cleanse-family corpus effects beyond these two.

--- a/src/components/skills/AbilityCard.tsx
+++ b/src/components/skills/AbilityCard.tsx
@@ -129,6 +129,7 @@ const TRIGGER_OPTIONS: { value: AbilityTrigger; label: string }[] = [
     { value: 'start-of-turn', label: 'Start of own turn' },
     { value: 'start-of-round', label: 'Start of round' },
     { value: 'on-crit', label: 'On critical hit' },
+    { value: 'on-deal-damage', label: 'On dealing direct damage' },
     { value: 'on-attacked', label: 'When attacked' },
     { value: 'on-debuffed', label: 'On debuffed (self)' },
     { value: 'on-debuff-resisted', label: 'On debuff resisted (self)' },

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -26,6 +26,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator: Bulwark implants now apply Provoke to an enemy that damages a nearby ally, and Doomsayer implants apply Concentrate Fire to the strongest enemy at the end of the round.',
     "Combat simulator now models two control primitives: Block Debuff (a unit immune to debuffs auto-resists every incoming debuff — timed, persistent, control such as Stasis or Disable, and damage-over-time — shown in the log as resisted) and Buff Protection (a unit's buffs can no longer be stripped by enemy purge). These back upcoming implant effects.",
     'Combat simulator now models four reactive defensive-control implants: Firewall (when the carrier is debuffed, a chance to gain Block Debuff so it briefly auto-resists incoming debuffs), Lockdown (when the carrier resists a debuff, grants the team Buff Protection so their buffs can no longer be purged), Tenacity (when the carrier takes a hit over 25% of its max HP, grants the team Buff Protection), and Last Stand (when the carrier becomes the last unit standing, grants itself Barrier and Block Debuff).',
+    "Combat simulator now models two cleanse-related implants: Reactive Ward (when the carrier is directly hit, a chance to cleanse one of its own debuffs — two if the hit was a critical) and the second half of Warpstrike (when the carrier deals direct damage while debuffed, it shortens one of its own debuffs by a turn). Chance-based procs are modeled at their true average frequency.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -82,6 +82,10 @@ export type AbilityTrigger =
     // event's slot discriminator). Self-scoped: the listener matches actorId === ownerId
     // && slot === 'charged'. Used by the Spearhead implant (all-allies Attack Up grant).
     | 'on-charged-cast'
+    // Warpstrike: owner dealt direct damage on its turn. Rides the aggregate
+    // ability-performed event emitted once per damage-dealing turn (runPlayerTurn
+    // emits exactly one; positional path emits none — engine.ts ~2887).
+    | 'on-deal-damage'
     // Fired when the owner applies repair to at least one OTHER ally (own heal-performed
     // event with a non-self recipient). Used by the Font of Power implant (grants the
     // repaired allies a buff). Distinct from on-ally-critically-repaired (no crit filter).
@@ -135,6 +139,8 @@ export const LIVE_TRIGGERS = new Set<AbilityTrigger>([
     'on-debuffed',
     // D-PR16 Lockdown: self-scoped reaction to RESISTING an incoming debuff.
     'on-debuff-resisted',
+    // Warpstrike: owner dealt direct damage on its turn.
+    'on-deal-damage',
 ]);
 
 export type ConditionSubject =

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -380,6 +380,14 @@ export type AbilityConfig =
            *  used today (Amartya: "purges 1 buff … for every 50% crit power").
            *  Absent → static `count`. cleanse never sets this. */
           countScaling?: { stat: 'critDamage'; per: number };
+          /** Reactive Ward: debuffs to cleanse when the triggering hit was a crit (else `count`).
+           *  Read from intent.eventCtx.didCrit by the reactive cleanse executor. cleanse-only. */
+          critCount?: number;
+          /** 'remove' (default) deletes whole debuffs (cleanse); 'reduce-duration' shaves
+           *  `durationTurns` off the newest debuff (Warpstrike). cleanse-only. */
+          mode?: 'remove' | 'reduce-duration';
+          /** Turns to reduce in 'reduce-duration' mode (default 1). cleanse-only. */
+          durationTurns?: number;
       }
     | {
           type: 'control';

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -100,13 +100,26 @@ function implantAbilityCount(implantKey: string, rarity: GearPiece['rarity']): n
     return buildEquipmentAbilities(ship, (gearId) => pieceMap[gearId]).length;
 }
 
+/**
+ * Build a minimal ship equipping one implant piece (at the given rarity) and
+ * return the built abilities produced by buildEquipmentAbilities (for shape assertions).
+ */
+function implantAbilities(implantKey: string, rarity: string) {
+    const id = `${implantKey}-piece`;
+    const pieceMap: Record<string, GearPiece> = {
+        [id]: makePiece({ id, slot: 'implant_major', rarity, setBonus: implantKey }),
+    };
+    const ship = makeShip({ implants: { implant_major: id } });
+    return buildEquipmentAbilities(ship, (gearId) => pieceMap[gearId]);
+}
+
 // ---------------------------------------------------------------------------
 // Regression guard: implemented effect names must equal exactly this set.
 // Update deliberately when new effects are added.
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { LEECH + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_STAND + LAST_WISH + LOCKDOWN + MENACE + SECOND_WIND + SHADOWGUARD + SPEARHEAD + TENACITY + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
+    it('exactly { LEECH + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_STAND + LAST_WISH + LOCKDOWN + MENACE + REACTIVE_WARD + SECOND_WIND + SHADOWGUARD + SPEARHEAD + TENACITY + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -147,6 +160,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
             'LAST_WISH',
             'LOCKDOWN',
             'MENACE',
+            'REACTIVE_WARD',
             'SECOND_WIND',
             'SHADOWGUARD',
             'SPEARHEAD',
@@ -208,6 +222,8 @@ describe('equipmentCoverage — implants', () => {
     // D-PR16: LOCKDOWN added (on-debuff-resisted → all-ally Buff Protection grant).
     // D-PR16: TENACITY added (on-attacked >25%-max-HP → all-ally Buff Protection grant).
     // D-PR16: LAST_STAND added (on-ally-destroyed + last-standing → self Barrier + Block Debuff co-grant).
+    // Reactive cleanse PR: REACTIVE_WARD added (reactive cleanse on-attacked, crit-count branch).
+    //         WARPSTRIKE gains a second ability (reduce-duration cleanse on-deal-damage).
     const implementedImplants = new Set([
         'FIREWALL',
         'LOCKDOWN',
@@ -241,6 +257,7 @@ describe('equipmentCoverage — implants', () => {
         'FORTIFYING_SHROUD',
         'BULWARK',
         'DOOMSAYER',
+        'REACTIVE_WARD',
     ]);
 
     it('INTRUSION produces 1 ability per rarity (outgoingDamage modifier with scaling)', () => {
@@ -257,10 +274,10 @@ describe('equipmentCoverage — implants', () => {
         }
     });
 
-    it('WARPSTRIKE produces 1 ability per rarity (outgoingDamage modifier gated on self-debuff)', () => {
+    it('WARPSTRIKE produces 2 abilities per rarity (outgoingDamage modifier + reduce-duration cleanse, gated on self-debuff)', () => {
         const variants = IMPLANTS['WARPSTRIKE'].variants;
         for (const v of variants) {
-            expect(implantAbilityCount('WARPSTRIKE', v.rarity)).toBe(1);
+            expect(implantAbilityCount('WARPSTRIKE', v.rarity)).toBe(2);
         }
     });
 
@@ -460,6 +477,74 @@ describe('equipmentCoverage — implants', () => {
             expect(implantAbilityCount('DOOMSAYER', v.rarity)).toBe(
                 SUPPORTED.has(v.rarity) ? 1 : 0
             );
+        }
+    });
+
+    // D-PR16: WARPSTRIKE shape — two abilities, correct trigger + config each
+    it('WARPSTRIKE ability[0] is the outgoingDamage modifier (on-cast, self-debuff condition)', () => {
+        const abs = implantAbilities('WARPSTRIKE', 'legendary');
+        expect(abs).toHaveLength(2);
+        const mod = abs[0];
+        expect(mod.type).toBe('modifier');
+        expect(mod.trigger).toBe('on-cast');
+        expect(mod.config).toMatchObject({ type: 'modifier', channel: 'outgoingDamage' });
+        // self-debuff condition must be present
+        expect(mod.conditions.some((c) => c.subject === 'self-debuff')).toBe(true);
+    });
+
+    it('WARPSTRIKE ability[1] is the reduce-duration cleanse (on-deal-damage, self-debuff condition, durationTurns 1)', () => {
+        const abs = implantAbilities('WARPSTRIKE', 'legendary');
+        expect(abs).toHaveLength(2);
+        const cleanse = abs[1];
+        expect(cleanse.type).toBe('cleanse');
+        expect(cleanse.trigger).toBe('on-deal-damage');
+        expect(cleanse.config).toMatchObject({
+            type: 'cleanse',
+            mode: 'reduce-duration',
+            durationTurns: 1,
+        });
+        // self-debuff condition must be present
+        expect(cleanse.conditions.some((c) => c.subject === 'self-debuff')).toBe(true);
+        // deterministic — no procChance
+        expect(cleanse.procChance).toBeUndefined();
+    });
+
+    it('WARPSTRIKE ids are suffixed with -0 / -1 (multi-ability builder indexing)', () => {
+        const abs = implantAbilities('WARPSTRIKE', 'common');
+        expect(abs[0].id).toBe('equip-implant-WARPSTRIKE-WARPSTRIKE-piece-0');
+        expect(abs[1].id).toBe('equip-implant-WARPSTRIKE-WARPSTRIKE-piece-1');
+    });
+
+    // D-PR16: REACTIVE_WARD — 1 ability for common/uncommon/epic/legendary; 0 for rare
+    it('REACTIVE_WARD produces 1 ability for common/uncommon/epic/legendary, 0 for rare (no rare variant)', () => {
+        expect(implantAbilityCount('REACTIVE_WARD', 'common')).toBe(1);
+        expect(implantAbilityCount('REACTIVE_WARD', 'uncommon')).toBe(1);
+        expect(implantAbilityCount('REACTIVE_WARD', 'rare')).toBe(0);
+        expect(implantAbilityCount('REACTIVE_WARD', 'epic')).toBe(1);
+        expect(implantAbilityCount('REACTIVE_WARD', 'legendary')).toBe(1);
+    });
+
+    it('REACTIVE_WARD ability shape: trigger on-attacked, cleanse mode remove, count 1, critCount 2, correct procChance per rarity', () => {
+        const PROC: Record<string, number> = {
+            common: 0.05,
+            uncommon: 0.07,
+            epic: 0.12,
+            legendary: 0.16,
+        };
+        for (const [rarity, expectedPc] of Object.entries(PROC)) {
+            const abs = implantAbilities('REACTIVE_WARD', rarity);
+            expect(abs).toHaveLength(1);
+            const ab = abs[0];
+            expect(ab.type).toBe('cleanse');
+            expect(ab.trigger).toBe('on-attacked');
+            expect(ab.target).toBe('self');
+            expect(ab.procChance).toBeCloseTo(expectedPc);
+            expect(ab.config).toMatchObject({
+                type: 'cleanse',
+                count: 1,
+                critCount: 2,
+                mode: 'remove',
+            });
         }
     });
 

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -515,7 +515,7 @@ describe('equipmentCoverage — implants', () => {
         expect(abs[1].id).toBe('equip-implant-WARPSTRIKE-WARPSTRIKE-piece-1');
     });
 
-    // D-PR16: REACTIVE_WARD — 1 ability for common/uncommon/epic/legendary; 0 for rare
+    // Reactive cleanse PR: REACTIVE_WARD — 1 ability for common/uncommon/epic/legendary; 0 for rare
     it('REACTIVE_WARD produces 1 ability for common/uncommon/epic/legendary, 0 for rare (no rare variant)', () => {
         expect(implantAbilityCount('REACTIVE_WARD', 'common')).toBe(1);
         expect(implantAbilityCount('REACTIVE_WARD', 'uncommon')).toBe(1);

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -74,7 +74,9 @@ const GEAR_SET_ABILITIES: Partial<Record<string, () => Omit<Ability, 'id'>>> = {
 // Each entry maps an implant name to a per-rarity builder.  A builder returns
 // an Ability (minus `id`) or undefined when the rarity is unsupported.
 
-type ImplantAbilityBuilder = (rarity: string) => Omit<Ability, 'id'> | undefined;
+type ImplantAbilityBuilder = (
+    rarity: string
+) => Omit<Ability, 'id'> | Omit<Ability, 'id'>[] | undefined;
 
 const BLOODTHIRST_HEAL_PCT: Record<string, number> = {
     uncommon: 12,
@@ -298,6 +300,15 @@ const LAST_STAND_PROC: Record<string, number> = {
     legendary: 0.32,
 };
 
+// D-PR16: Reactive Ward — X% chance, when directly damaged, to cleanse 1 debuff (2 if crit).
+// No rare variant exists in implants.ts.
+const REACTIVE_WARD_PROC: Record<string, number> = {
+    common: 0.05,
+    uncommon: 0.07,
+    epic: 0.12,
+    legendary: 0.16,
+};
+
 // D-PR6: incoming-heal-amplification implant value tables
 // No common rarity for Exuberance
 const EXUBERANCE_PROC: Record<string, number> = {
@@ -507,26 +518,60 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
             autoFilled: true,
         };
     },
-    // Warpstrike (damage half only): +X% outgoing direct damage while self-debuffed. Flat
-    // value + a >=1 self-debuff gate (NOT scaling — scaledBonus uses the raw debuff count and
-    // would over-apply for multiple debuffs). The "reduce a random debuff's duration by 1
-    // turn" half is DEFERRED (self-debuff-mitigation / cleanse-family).
+    // Warpstrike: +X% outgoing direct damage while self-debuffed (damage half), AND reduces
+    // a random active debuff's duration by 1 turn on each damage-dealing turn (duration-reduction
+    // half). Both halves are gated on the same self-debuff condition (>=1 debuff required).
+    // Returns an array so the consumer stamps distinct ids (-0 / -1) for each half.
     WARPSTRIKE: (rarity) => {
         const value = WARPSTRIKE_PCT[rarity];
         if (value === undefined) return undefined;
-        return {
-            type: 'modifier',
-            target: 'self',
-            trigger: 'on-cast',
-            conditions: [
-                {
-                    subject: 'self-debuff',
-                    derivable: true,
-                    countComparator: 'gte',
-                    countThreshold: 1,
+        const selfDebuffGate = {
+            subject: 'self-debuff' as const,
+            derivable: true,
+            countComparator: 'gte' as const,
+            countThreshold: 1,
+        };
+        return [
+            {
+                type: 'modifier' as const,
+                target: 'self' as const,
+                trigger: 'on-cast' as const,
+                conditions: [selfDebuffGate],
+                config: {
+                    type: 'modifier' as const,
+                    channel: 'outgoingDamage' as const,
+                    value,
+                    isMultiplicative: false,
                 },
-            ],
-            config: { type: 'modifier', channel: 'outgoingDamage', value, isMultiplicative: false },
+                autoFilled: true,
+            },
+            {
+                type: 'cleanse' as const,
+                target: 'self' as const,
+                trigger: 'on-deal-damage' as const,
+                conditions: [selfDebuffGate],
+                config: {
+                    type: 'cleanse' as const,
+                    count: 0,
+                    mode: 'reduce-duration' as const,
+                    durationTurns: 1,
+                },
+                autoFilled: true,
+            },
+        ];
+    },
+    // Reactive Ward: X% chance, when directly damaged, to cleanse 1 debuff (2 if the hit was
+    // a critical). No rare variant exists in implants.ts.
+    REACTIVE_WARD: (rarity) => {
+        const pc = REACTIVE_WARD_PROC[rarity];
+        if (pc === undefined) return undefined;
+        return {
+            type: 'cleanse' as const,
+            target: 'self' as const,
+            trigger: 'on-attacked' as const,
+            conditions: [],
+            procChance: pc,
+            config: { type: 'cleanse' as const, count: 1, critCount: 2, mode: 'remove' as const },
             autoFilled: true,
         };
     },
@@ -853,14 +898,24 @@ export function buildEquipmentAbilities(
             // Try the per-implant builder first (handles cases the text parser can't).
             const builder = IMPLANT_ABILITIES[implantName];
             if (builder) {
-                const partial = builder(piece.rarity);
-                if (!partial) continue;
-                abilities.push({
-                    ...partial,
-                    // Suffix the unique gear-piece id so two copies of the same implant get
-                    // distinct ability ids — the proc-rate gate keys on (owner, ability.id),
-                    // so a shared id would collapse independent procs into one gate.
-                    id: `equip-implant-${implantName}-${gearId}`,
+                const res = builder(piece.rarity);
+                if (!res) continue;
+                const partials = Array.isArray(res) ? res : [res];
+                partials.forEach((partial, i) => {
+                    abilities.push({
+                        ...partial,
+                        // For single-ability implants, preserve the original id byte-exactly
+                        // (suffix the unique gear-piece id so two copies of the same implant
+                        // get distinct ability ids — the proc-rate gate keys on
+                        // (owner, ability.id), so a shared id would collapse independent
+                        // procs into one gate).
+                        // For multi-ability implants (e.g. Warpstrike), append an index
+                        // suffix so the two halves also get distinct ids.
+                        id:
+                            partials.length === 1
+                                ? `equip-implant-${implantName}-${gearId}`
+                                : `equip-implant-${implantName}-${gearId}-${i}`,
+                    });
                 });
                 continue;
             }

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -552,7 +552,7 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
                 conditions: [selfDebuffGate],
                 config: {
                     type: 'cleanse' as const,
-                    count: 0,
+                    count: 0, // inert in reduce-duration mode (required by the cleanse config type)
                     mode: 'reduce-duration' as const,
                     durationTurns: 1,
                 },

--- a/src/utils/combat/__tests__/cleanseReactivePath.test.ts
+++ b/src/utils/combat/__tests__/cleanseReactivePath.test.ts
@@ -1,7 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { runCombat, CombatEngineInput } from '../engine';
 import { createEventBus, CombatEvent } from '../events';
 import { Ability, ShipSkills } from '../../../types/abilities';
+import { executeIntent, Intent, IntentExecContext } from '../triggers';
+import { createStatusEngine, RegisteredAbilityStatus } from '../statusEngine';
+import { makeRateGate } from '../../calculators/rateAccumulator';
+import type { CombatActor } from '../state';
 
 type CleansePerformed = Extract<CombatEvent, { type: 'cleanse-performed' }>;
 
@@ -129,5 +133,225 @@ describe('C1 Task 4: reactive-path cleanse removes debuffs (player-side)', () =>
             0
         );
         expect(totalCleanse).toBe(2);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Task 3: reactive cleanse honors procChance + crit-count (Reactive Ward executor)
+//
+// These tests drive executeIntent directly (no full runCombat) to isolate the
+// cleanse executor branch. Pattern mirrors reactiveDamageProcGate.test.ts.
+// ---------------------------------------------------------------------------
+
+const OWNER_ID = 'owner1';
+// For 'self'-target cleanse, reactiveRecipients returns [ownerId]; seed debuffs on OWNER_ID.
+const TARGET_ID = OWNER_ID;
+
+// A minimal timed enemy debuff seeded into the status engine (enemy-side, per-victim).
+const mkTimed = (
+    buffName: string,
+    duration = 3
+): Extract<RegisteredAbilityStatus, { kind: 'timed' }> => ({
+    kind: 'timed',
+    side: 'enemy',
+    sourceSlot: 'active',
+    conditions: [],
+    duration,
+    payload: { buffName, stacks: 1, parsedEffects: {} },
+});
+
+/** Build a reactive cleanse Intent for the test owner. */
+function makeCleanseIntent(opts: {
+    count?: number;
+    critCount?: number;
+    procChance?: number;
+    didCrit?: boolean;
+}): Intent {
+    return {
+        ownerId: OWNER_ID,
+        sourceSlot: 'passive',
+        ability: {
+            id: 'reactive-cleanse-ab',
+            type: 'cleanse',
+            target: 'self',
+            trigger: 'on-attacked',
+            conditions: [],
+            ...(opts.procChance !== undefined ? { procChance: opts.procChance } : {}),
+            config: {
+                type: 'cleanse',
+                count: opts.count ?? 1,
+                ...(opts.critCount !== undefined ? { critCount: opts.critCount } : {}),
+            },
+        },
+        ...(opts.didCrit !== undefined ? { eventCtx: { didCrit: opts.didCrit } } : {}),
+    } as unknown as Intent;
+}
+
+/**
+ * Build a minimal IntentExecContext for the cleanse branch.
+ *
+ * The cleanse branch reads:
+ *   - ctx.healing  → must be truthy to not short-circuit
+ *   - ctx.statusEngine  → for cleanse() calls
+ *   - ctx.procChanceGates  → provided when testing the gate
+ *
+ * `healing.targetId` is the recipient to cleanse (TARGET_ID, same as owner for 'self').
+ * `healing.credit` is the spy tracking cleanseCount credits.
+ */
+function makeCtx(opts?: {
+    procChanceGates?: Map<string, ReturnType<typeof makeRateGate>>;
+    creditSpy?: ReturnType<typeof vi.fn>;
+    statusEngine?: ReturnType<typeof createStatusEngine>;
+}): IntentExecContext {
+    const bus = createEventBus();
+    const se = opts?.statusEngine ?? createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+    const creditSpy = opts?.creditSpy ?? vi.fn();
+
+    return {
+        round: 1,
+        enemy: { id: 'enemy1', currentHp: 100000 } as CombatActor,
+        enemyId: 'enemy1',
+        statusEngine: se,
+        bus,
+        corrosionEntries: [],
+        infernoEntries: [],
+        pendingBombs: [],
+        runtimes: new Map([
+            [
+                OWNER_ID,
+                {
+                    actor: { id: OWNER_ID, chargeCount: 0, charges: 0 } as unknown as CombatActor,
+                    attack: 10000,
+                    defence: 0,
+                    hp: 10000,
+                    healModifier: 0,
+                    selfDotModifier: 0,
+                    defensePenetrationBuff: 0,
+                    affinityDamageModifier: 0,
+                    affinityCritCap: 100,
+                    affinityCritPenalty: 0,
+                    affinityDisadvantage: false,
+                    selfBuffLookup: new Map(),
+                    enemyDebuffLookup: new Map(),
+                } as never,
+            ],
+        ]),
+        grantAllyCharges: () => {},
+        grantExtraAction: () => {},
+        playerIds: [OWNER_ID],
+        lastTurnCtxByActor: new Map(),
+        enemyHp: 100000,
+        cumulativeDamage: 0,
+        recordResisted: () => {},
+        procChanceGates: opts?.procChanceGates,
+        // Minimal healing ctx: targetId = TARGET_ID (same as owner for 'self'),
+        // credit is the spy, stubs for unused methods.
+        healing: {
+            targetId: TARGET_ID,
+            credit: creditSpy,
+            recipientMaxHp: () => 10000,
+            recipientIncomingHealPct: () => 0,
+            applierMaxHp: () => undefined,
+            applyHealToTarget: () => ({ consumed: 0, overheal: 0 }),
+            grantShieldToTarget: () => {},
+            playerIds: [OWNER_ID],
+            enemyIds: [],
+            recipientActor: () => undefined,
+        },
+    } as unknown as IntentExecContext;
+}
+
+/** Seed `count` distinct debuffs onto TARGET_ID in the given status engine. */
+function seedDebuffs(se: ReturnType<typeof createStatusEngine>, count: number): void {
+    se.beginRound(1);
+    for (let i = 0; i < count; i++) {
+        se.applyTimedAbilityStatus(1, mkTimed(`Debuff-${i}`), 'attacker', TARGET_ID);
+    }
+}
+
+describe('Task 3: reactive cleanse executor — procChance + crit-count', () => {
+    it('A. remove-mode, no procChance: cleanses cfg.count debuffs (preserved behavior)', () => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        seedDebuffs(se, 3);
+        const creditSpy = vi.fn();
+        const ctx = makeCtx({ statusEngine: se, creditSpy });
+        const intent = makeCleanseIntent({ count: 2 });
+        executeIntent(intent, ctx);
+        // Should have removed 2 debuffs and credited that count.
+        expect(creditSpy).toHaveBeenCalledWith(OWNER_ID, 'cleanseCount', 2);
+    });
+
+    it('B. didCrit=true + critCount=2: cleanses critCount (2), not count (1)', () => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        seedDebuffs(se, 3);
+        const creditSpy = vi.fn();
+        const ctx = makeCtx({ statusEngine: se, creditSpy });
+        const intent = makeCleanseIntent({ count: 1, critCount: 2, didCrit: true });
+        executeIntent(intent, ctx);
+        expect(creditSpy).toHaveBeenCalledWith(OWNER_ID, 'cleanseCount', 2);
+    });
+
+    it('C. didCrit=false + critCount=2: cleanses count (1), NOT critCount (2)', () => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        seedDebuffs(se, 3);
+        const creditSpy = vi.fn();
+        const ctx = makeCtx({ statusEngine: se, creditSpy });
+        const intent = makeCleanseIntent({ count: 1, critCount: 2, didCrit: false });
+        executeIntent(intent, ctx);
+        expect(creditSpy).toHaveBeenCalledWith(OWNER_ID, 'cleanseCount', 1);
+    });
+
+    it('D. procChance gate does NOT fire: cleanses 0, credit not called', () => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        seedDebuffs(se, 3);
+        const creditSpy = vi.fn();
+        // A gate with procChance 0.5 over the makeRateGate accumulator: fires on calls 2,4,6...
+        // Drive the gate 1 time first (call 1 = no fire), then our executeIntent is call 2 (fires).
+        // To get a non-fire: pre-drain the gate so the NEXT call is a fire, then test the FIRST call.
+        // Actually: gate fires on calls where floor(n*rate) > floor((n-1)*rate).
+        // rate=0.5: fires on even calls (2,4,6,...), not odd calls (1,3,5,...).
+        // So call 1 → no fire. We just call executeIntent once (first call = odd = no fire).
+        const procChanceGates = new Map<string, ReturnType<typeof makeRateGate>>();
+        const intent = makeCleanseIntent({ count: 1, procChance: 0.5 });
+        const ctx = makeCtx({ statusEngine: se, creditSpy, procChanceGates });
+        executeIntent(intent, ctx);
+        // Call 1 with rate 0.5: floor(1*0.5)=0 > floor(0*0.5)=0 → false → gate rejects.
+        expect(creditSpy).not.toHaveBeenCalled();
+    });
+
+    it('E. ctx.healing undefined: returns early (no throw, no cleanse, gate NOT consumed)', () => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        seedDebuffs(se, 2);
+        const creditSpy = vi.fn();
+        // Use a shared gate map with a procChance so we can verify gate is not consumed.
+        const procChanceGates = new Map<string, ReturnType<typeof makeRateGate>>();
+        const intent = makeCleanseIntent({ count: 1, procChance: 0.5 });
+        const ctx = makeCtx({ statusEngine: se, creditSpy, procChanceGates });
+        // Remove the healing ctx to simulate non-healing mode.
+        (ctx as unknown as Record<string, unknown>).healing = undefined;
+
+        // Should not throw.
+        expect(() => executeIntent(intent, ctx)).not.toThrow();
+        // Should not credit anything.
+        expect(creditSpy).not.toHaveBeenCalled();
+        // Gate should NOT have been touched: re-run WITH healing and expect it fires on call 2
+        // (even-call fire), confirming call 1 was never consumed.
+        // If the early-return was correct (before gate), gate call 1 is still unused.
+        // Restore healing and call again (this is call 1 to the gate — should NOT fire).
+        (ctx as unknown as Record<string, unknown>).healing = {
+            targetId: TARGET_ID,
+            credit: creditSpy,
+            recipientMaxHp: () => 10000,
+            recipientIncomingHealPct: () => 0,
+            applierMaxHp: () => undefined,
+            applyHealToTarget: () => ({ consumed: 0, overheal: 0 }),
+            grantShieldToTarget: () => {},
+            playerIds: [OWNER_ID],
+            enemyIds: [],
+            recipientActor: () => undefined,
+        };
+        executeIntent(intent, ctx);
+        // This is still call 1 to the gate (early-return did NOT consume it) → should not fire.
+        expect(creditSpy).not.toHaveBeenCalled();
     });
 });

--- a/src/utils/combat/__tests__/cleanseReactivePath.test.ts
+++ b/src/utils/combat/__tests__/cleanseReactivePath.test.ts
@@ -269,6 +269,92 @@ function seedDebuffs(se: ReturnType<typeof createStatusEngine>, count: number): 
     }
 }
 
+/** Build a reactive reduce-duration Intent for the test owner. */
+function makeReduceDurationIntent(opts: { durationTurns?: number; procChance?: number }): Intent {
+    return {
+        ownerId: OWNER_ID,
+        sourceSlot: 'passive',
+        ability: {
+            id: 'reactive-reduce-dur-ab',
+            type: 'cleanse',
+            target: 'self',
+            trigger: 'on-attacked',
+            conditions: [],
+            ...(opts.procChance !== undefined ? { procChance: opts.procChance } : {}),
+            config: {
+                type: 'cleanse',
+                mode: 'reduce-duration',
+                count: 1, // unused in reduce-duration mode but required by type
+                ...(opts.durationTurns !== undefined ? { durationTurns: opts.durationTurns } : {}),
+            },
+        },
+    } as unknown as Intent;
+}
+
+describe('Task 4: reactive cleanse executor — reduce-duration mode', () => {
+    it('F. reduce-duration: newest debuff loses 1 turn; older debuff unchanged; credits cleanseCount:1', () => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        se.beginRound(1);
+        // Seed two debuffs in sequence: Debuff-0 first (older, seq=1), Debuff-1 second (newer, seq=2).
+        se.applyTimedAbilityStatus(1, mkTimed('Debuff-0', 3), 'attacker', TARGET_ID);
+        se.applyTimedAbilityStatus(1, mkTimed('Debuff-1', 5), 'attacker', TARGET_ID);
+
+        const creditSpy = vi.fn();
+        const ctx = makeCtx({ statusEngine: se, creditSpy });
+        const intent = makeReduceDurationIntent({ durationTurns: 1 });
+        executeIntent(intent, ctx);
+
+        // Credit should be called with cleanseCount = 1 (one debuff had its duration reduced).
+        expect(creditSpy).toHaveBeenCalledWith(OWNER_ID, 'cleanseCount', 1);
+
+        // Inspect remaining durations via timedAbilityStatuses('enemy', ownerId, targetId).
+        // TARGET_ID = OWNER_ID so both arguments are the same string.
+        const statuses = se.timedAbilityStatuses('enemy', OWNER_ID, TARGET_ID);
+        const byName = new Map(statuses.map((s) => [s.active.buffName, s.active.turnsRemaining]));
+
+        // Debuff-1 is the newest (higher appliedSeq) → its duration was reduced by 1 (5→4).
+        expect(byName.get('Debuff-1')).toBe(4);
+        // Debuff-0 is older → unchanged (still 3).
+        expect(byName.get('Debuff-0')).toBe(3);
+    });
+
+    it('G. reduce-duration without healing ctx: still reduces debuff, no throw, no credit attempted', () => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        se.beginRound(1);
+        se.applyTimedAbilityStatus(1, mkTimed('Debuff-X', 4), 'attacker', TARGET_ID);
+
+        const creditSpy = vi.fn();
+        const ctx = makeCtx({ statusEngine: se, creditSpy });
+        // Remove healing ctx entirely.
+        (ctx as unknown as Record<string, unknown>).healing = undefined;
+
+        const intent = makeReduceDurationIntent({ durationTurns: 1 });
+        // Must not throw even without healing.
+        expect(() => executeIntent(intent, ctx)).not.toThrow();
+
+        // The debuff duration must have been reduced (4 → 3).
+        const statuses = se.timedAbilityStatuses('enemy', OWNER_ID, TARGET_ID);
+        const debuffX = statuses.find((s) => s.active.buffName === 'Debuff-X');
+        expect(debuffX?.active.turnsRemaining).toBe(3);
+
+        // No credit should be called (ctx.healing is absent).
+        expect(creditSpy).not.toHaveBeenCalled();
+    });
+
+    it('H. reduce-duration with no eligible debuff: affected 0, no throw, credit 0 when healing present', () => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        // No debuffs seeded — actor is clean.
+
+        const creditSpy = vi.fn();
+        const ctx = makeCtx({ statusEngine: se, creditSpy });
+        const intent = makeReduceDurationIntent({ durationTurns: 1 });
+
+        expect(() => executeIntent(intent, ctx)).not.toThrow();
+        // affected = 0, so credit called with 0.
+        expect(creditSpy).toHaveBeenCalledWith(OWNER_ID, 'cleanseCount', 0);
+    });
+});
+
 describe('Task 3: reactive cleanse executor — procChance + crit-count', () => {
     it('A. remove-mode, no procChance: cleanses cfg.count debuffs (preserved behavior)', () => {
         const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -3596,3 +3596,472 @@ describe('D-PR11 integration — Fortifying Shroud: enemy-side mirror (team-agno
         expect(buffGrantedTo.size).toBe(2);
     });
 });
+
+// ---------------------------------------------------------------------------
+// D-PR (reactive cleanse) — Reactive Ward + Warpstrike duration-reduction
+// ---------------------------------------------------------------------------
+//
+// Two implants resolve through the REAL equipment registry
+// (buildShipAbilitiesWithEquipment / simulateBattle's getGearPiece arg):
+//
+//   Reactive Ward (REACTIVE_WARD): on-attacked reactive cleanse — when the carrier is
+//     directly damaged, an X% chance (per rarity) to REMOVE 1 of the carrier's OWN debuffs,
+//     or 2 if the triggering hit CRIT. Registry shape: trigger 'on-attacked', cleanse config
+//     { mode:'remove', count:1, critCount:2, procChance:<rarity> }.
+//
+//   Warpstrike (WARPSTRIKE): TWO abilities —
+//     (1) D-PR2 +X% outgoing-damage modifier while self-debuffed (on-cast modifier), and
+//     (2) NEW: on-deal-damage reactive cleanse in 'reduce-duration' mode — each damage-dealing
+//         turn while self-debuffed reduces the carrier's NEWEST own debuff by 1 turn
+//         (durationTurns 1, DETERMINISTIC — no procChance).
+//
+// DETERMINISM THROUGH THE REAL REGISTRY (the D-PR16 lesson): the abilities below are built
+// by `buildShipAbilitiesWithEquipment(makeShip({ setBonus }), getGearPiece)` and read out of
+// the passive slot — NOT hand-rolled. For Reactive Ward (procChance < 1) we override the
+// built ability's `procChance` to 1 for single-event determinism WHILE keeping every other
+// field the registry produced (mode/count/critCount/trigger), so a registry mutation still
+// fails a test. Warpstrike's reduce-duration half is already deterministic (no procChance).
+//
+// CARRIER SELF-DEBUFFS: a player carrier's OWN debuffs live in its per-target debuff store
+// (statusEngine.enemyMaps[carrierId]), populated when an ENEMY applies a debuff to it
+// (application:'apply' → always lands). Both implants act on / gate off that store. Healing
+// mode (healTargetId='attacker') is required so the carrier is a heal-target whose
+// cleanseCount credit is recorded per round.
+
+describe('D-PR reactive cleanse — Reactive Ward (on-attacked) cleanses 1 / 2-on-crit', () => {
+    const CARRIER_HP = 10_000;
+
+    /** Legendary Reactive Ward implant piece (procChance 0.16 per registry). */
+    const reactiveWardPiece = makePiece({
+        id: 'rw-legendary',
+        slot: 'implant_major',
+        rarity: 'legendary',
+        setBonus: 'REACTIVE_WARD',
+    });
+
+    /**
+     * Build the Reactive Ward passive slot through the REAL registry, then override the built
+     * ability's procChance to 1 for single-event determinism. The mode/count/critCount fields
+     * stay exactly as the registry produced them, so a registry mutation (e.g. critCount→1)
+     * still changes test behaviour.
+     */
+    function buildReactiveWardSlots(): ShipSkills['slots'] {
+        const ship = makeShip({ implants: { implant_major: 'rw-legendary' } });
+        const getGearPiece = makeGetGearPiece({ 'rw-legendary': reactiveWardPiece });
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        const ward = passive!.abilities.find((a) => a.id.startsWith('equip-implant-REACTIVE_WARD'));
+        // Pre-condition: the registry produced the on-attacked remove cleanse with crit-count 2.
+        expect(ward).toBeDefined();
+        expect(ward!.trigger).toBe('on-attacked');
+        expect(ward!.config.type).toBe('cleanse');
+        if (ward!.config.type === 'cleanse') {
+            expect(ward!.config.mode ?? 'remove').toBe('remove');
+            expect(ward!.config.count).toBe(1);
+            expect(ward!.config.critCount).toBe(2);
+        }
+        // Force determinism for the single-hit assertion WITHOUT leaving the registry path:
+        // mutate only procChance on the built ability (keeps mode/count/critCount/trigger).
+        const determinized: Ability = { ...ward!, procChance: 1 };
+        return [
+            { slot: 'active', abilities: [noopWardActive] },
+            { slot: 'passive', abilities: [determinized] },
+        ];
+    }
+
+    /** No-op active so the carrier takes a turn (the cleanse itself fires reactively to the hit). */
+    const noopWardActive: Ability = {
+        id: 'noop-ward-active',
+        type: 'damage',
+        target: 'enemy',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'damage', multiplier: 0 },
+    };
+
+    /**
+     * A FAST enemy that, in one turn, applies THREE distinct removable debuffs to the carrier
+     * (apply → always lands, distinct families so they coexist) AND lands one damaging hit.
+     * `crit` controls whether that hit crits (→ critCount path). attack > 0 so the `attacked`
+     * event is emitted and the on-attacked cleanse enqueues.
+     */
+    function debufferHitter(crit: number) {
+        const debuff = (name: string): Ability => ({
+            id: `rw-debuff-${name}`,
+            type: 'debuff',
+            target: 'enemy', // from the enemy's view the carrier is its enemy
+            trigger: 'on-cast',
+            conditions: [],
+            config: {
+                type: 'debuff',
+                buffName: name,
+                parsedEffects: {},
+                stacks: 1,
+                isStackable: false,
+                application: 'apply',
+                duration: 9, // long enough to outlive the single round
+            },
+        });
+        return {
+            id: 'rw-enemy',
+            stats: {
+                attack: 200, // > 0 → attacked event emitted; small so it never kills the carrier
+                crit,
+                critDamage: 0,
+                speed: 1_000, // faster than the carrier (acts first)
+                defence: 0,
+                hp: 1_000_000_000,
+            },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active' as const,
+                        abilities: [
+                            // Three distinct debuffs (≥2 so the crit path can remove 2).
+                            debuff('Attack Down'),
+                            debuff('Defense Down'),
+                            debuff('Speed Down'),
+                            // A damaging hit that emits `attacked` (with didCrit per `crit`).
+                            {
+                                id: 'rw-enemy-hit',
+                                type: 'damage' as const,
+                                target: 'enemy' as const,
+                                trigger: 'on-cast' as const,
+                                conditions: [],
+                                config: { type: 'damage' as const, multiplier: 100, hits: 1 },
+                            },
+                        ],
+                    },
+                ],
+            },
+        };
+    }
+
+    /** Healing-mode base for the Reactive Ward carrier ('attacker' is the heal target). */
+    const WARD_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+        attack: 0,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: { slots: [] },
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: CARRIER_HP,
+        healTargetId: 'attacker',
+        speed: 1,
+        ...overrides,
+    });
+
+    /** Sum the round-1 cleanseCount credited to the carrier ('attacker'). */
+    function round1Cleanse(result: ReturnType<typeof runCombat>): number {
+        return result.healing?.rounds[0]?.perActor.get('attacker')?.cleanseCount ?? 0;
+    }
+
+    it('NON-crit incoming hit cleanses exactly 1 of the carrier’s own debuffs', () => {
+        const result = runCombat(
+            WARD_BASE({
+                shipSkills: { slots: buildReactiveWardSlots() },
+                enemyAttackers: [debufferHitter(0)], // crit 0 → didCrit:false → count path (1)
+            })
+        );
+        expect(result.healing).toBeDefined();
+        // procChance forced to 1 → the on-attacked cleanse fires; non-crit → removes count=1.
+        expect(round1Cleanse(result)).toBe(1);
+    });
+
+    it('CRIT incoming hit cleanses exactly 2 of the carrier’s own debuffs (critCount path)', () => {
+        const result = runCombat(
+            WARD_BASE({
+                shipSkills: { slots: buildReactiveWardSlots() },
+                enemyAttackers: [debufferHitter(100)], // crit 100 → didCrit:true → critCount path (2)
+            })
+        );
+        expect(result.healing).toBeDefined();
+        // CRIT → removes critCount=2 (not count=1). This is the load-bearing crit-count assertion:
+        // if the registry's critCount were mutated to 1, this would read 1 and fail.
+        expect(round1Cleanse(result)).toBe(2);
+    });
+});
+
+describe('D-PR reactive cleanse — Warpstrike duration-reduction + damage half', () => {
+    const CARRIER_HP = 1_000_000_000;
+    const ATTACK = 10_000;
+    const NUM_ROUNDS = 4;
+
+    /** Legendary Warpstrike implant piece (outgoingDamage +5% half; reduce-duration half). */
+    const warpstrikeLegendaryPiece = makePiece({
+        id: 'ws-legendary',
+        slot: 'implant_major',
+        rarity: 'legendary',
+        setBonus: 'WARPSTRIKE',
+    });
+
+    /**
+     * Build the Warpstrike passive slot through the REAL registry (BOTH halves) and return the
+     * full passive abilities. No procChance override is needed — the reduce-duration half is
+     * deterministic, and the modifier half is unconditional-once per self-debuffed cast.
+     */
+    function buildWarpstrikePassive(): Ability[] {
+        const ship = makeShip({ implants: { implant_major: 'ws-legendary' } });
+        const getGearPiece = makeGetGearPiece({ 'ws-legendary': warpstrikeLegendaryPiece });
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        return passive!.abilities;
+    }
+
+    /** A single-hit 100% damage active so the carrier deals direct damage each turn. */
+    const dmgActive: Ability = {
+        id: 'ws-dmg-active',
+        type: 'damage',
+        target: 'enemy',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'damage', multiplier: 100, hits: 1 },
+    };
+
+    /**
+     * Carrier ship skills: the damage active + (optionally) the Warpstrike passive halves.
+     * The control omits the passive entirely (no implant) so the delta isolates Warpstrike.
+     */
+    function carrierSkills(withWarpstrike: boolean): ShipSkills {
+        return {
+            slots: [
+                { slot: 'active', abilities: [dmgActive] },
+                ...(withWarpstrike
+                    ? [{ slot: 'passive' as const, abilities: buildWarpstrikePassive() }]
+                    : []),
+            ],
+        };
+    }
+
+    /**
+     * A FAST enemy that lands TWO distinct self-debuffs on the carrier each round (apply →
+     * always lands) and a token hit. It acts BEFORE the carrier so the carrier is already
+     * self-debuffed when it deals its damage (gating both Warpstrike halves). The two debuffs
+     * are applied in a fixed order ('Older' then 'Newer') so 'Newer' is the newest → the one
+     * Warpstrike's reduce-duration half targets.
+     */
+    function selfDebuffer() {
+        const debuff = (name: string): Ability => ({
+            id: `ws-debuff-${name}`,
+            type: 'debuff',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: {
+                type: 'debuff',
+                buffName: name,
+                parsedEffects: {},
+                stacks: 1,
+                isStackable: false,
+                application: 'apply',
+                duration: 9,
+            },
+        });
+        return {
+            id: 'ws-enemy',
+            stats: {
+                attack: 1, // token damage → never kills the fat carrier
+                crit: 0,
+                critDamage: 0,
+                speed: 1_000, // acts before the carrier each round
+                defence: 0,
+                hp: 1_000_000_000,
+            },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active' as const,
+                        abilities: [debuff('Older'), debuff('Newer')],
+                    },
+                ],
+            },
+        };
+    }
+
+    /** Healing-mode base: the carrier 'attacker' is the heal target (so cleanseCount is recorded). */
+    const WS_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+        attack: ATTACK,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: { slots: [] },
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: NUM_ROUNDS,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: CARRIER_HP,
+        healTargetId: 'attacker',
+        speed: 1,
+        ...overrides,
+    });
+
+    /** Total cleanseCount credited to the carrier across all rounds (= count of newest-debuff
+     *  duration reductions Warpstrike performed). */
+    function totalCleanse(result: ReturnType<typeof runCombat>): number {
+        return (result.healing?.rounds ?? []).reduce(
+            (sum, rd) => sum + (rd.perActor.get('attacker')?.cleanseCount ?? 0),
+            0
+        );
+    }
+
+    it(
+        'reduce-duration half fires once per self-debuffed damage turn (control credits 0); ' +
+            'the credited reduction count = Warpstrike’s extra ticks on the newest debuff',
+        () => {
+            const withWarp = runCombat(
+                WS_BASE({
+                    shipSkills: carrierSkills(true),
+                    enemyAttackers: [selfDebuffer()],
+                })
+            );
+            const control = runCombat(
+                WS_BASE({
+                    shipSkills: carrierSkills(false),
+                    enemyAttackers: [selfDebuffer()],
+                })
+            );
+
+            expect(withWarp.healing).toBeDefined();
+            // Control (no Warpstrike) → no duration reductions credited.
+            expect(totalCleanse(control)).toBe(0);
+
+            // Warpstrike: each round the carrier is already self-debuffed (enemy acts first) and
+            // deals direct damage → on-deal-damage reduce-duration fires once, reducing the NEWEST
+            // debuff by 1 turn → cleanseCount += 1 each round. reduceNewestDebuffDuration returns 1
+            // per fire (a SINGLE debuff — the newest — is reduced, never bulk). Over NUM_ROUNDS
+            // self-debuffed damage turns the total extra ticks = NUM_ROUNDS.
+            expect(totalCleanse(withWarp)).toBe(NUM_ROUNDS);
+
+            // Per-round shape: exactly 1 reduction per round (one debuff — the newest — reduced),
+            // never 0 (would mean the reduce half never fired) and never >1 (would mean it bulk-
+            // reduced rather than targeting only the newest).
+            for (let r = 0; r < NUM_ROUNDS; r++) {
+                expect(withWarp.healing!.rounds[r]?.perActor.get('attacker')?.cleanseCount).toBe(1);
+            }
+        }
+    );
+
+    it('D-PR2 damage half is STILL live: outgoing damage is boosted while self-debuffed', () => {
+        // Same self-debuffer setup; compare total direct damage WITH vs WITHOUT Warpstrike.
+        // Warpstrike legendary = +5% outgoingDamage while self-debuffed. crit=0 → per-round damage
+        // is otherwise constant, so the +5% modifier can only ADD → withWarp strictly exceeds the
+        // control. This proves BOTH halves are live (the reduce-duration test above proves the 2nd).
+        const withWarp = runCombat(
+            WS_BASE({
+                shipSkills: carrierSkills(true),
+                enemyAttackers: [selfDebuffer()],
+            })
+        );
+        const control = runCombat(
+            WS_BASE({
+                shipSkills: carrierSkills(false),
+                enemyAttackers: [selfDebuffer()],
+            })
+        );
+        expect(withWarp.rawTotals.direct).toBeGreaterThan(control.rawTotals.direct);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Registry-shape assertions (mutation-probe defense) — REACTIVE_WARD + WARPSTRIKE
+// ---------------------------------------------------------------------------
+//
+// These assert the SHAPE the registry produces, independent of any engine run, so a mutation
+// that drops/changes a wire (e.g. removing WARPSTRIKE's 2nd ability, or flipping REACTIVE_WARD
+// critCount) fails here even if the engine integration runs happened to still pass.
+
+describe('D-PR reactive cleanse — registry shape (buildShipAbilitiesWithEquipment)', () => {
+    it('WARPSTRIKE yields BOTH the on-cast outgoingDamage modifier AND the on-deal-damage reduce-duration cleanse', () => {
+        const ship = makeShip({ implants: { implant_major: 'ws-shape' } });
+        const piece = makePiece({
+            id: 'ws-shape',
+            slot: 'implant_major',
+            rarity: 'legendary',
+            setBonus: 'WARPSTRIKE',
+        });
+        const baseSkills = buildShipAbilitiesWithEquipment(
+            ship,
+            makeGetGearPiece({ 'ws-shape': piece })
+        );
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        const warps = passive!.abilities.filter((a) => a.id.startsWith('equip-implant-WARPSTRIKE'));
+        // BOTH halves present.
+        expect(warps).toHaveLength(2);
+
+        // Half 1: the D-PR2 outgoing-damage modifier (on-cast).
+        const modifier = warps.find((a) => a.config.type === 'modifier');
+        expect(modifier).toBeDefined();
+        expect(modifier!.trigger).toBe('on-cast');
+        if (modifier!.config.type === 'modifier') {
+            expect(modifier!.config.channel).toBe('outgoingDamage');
+            expect(modifier!.config.value).toBe(5); // legendary WARPSTRIKE_PCT
+        }
+
+        // Half 2: the NEW on-deal-damage reduce-duration cleanse (deterministic, no procChance).
+        const cleanse = warps.find((a) => a.config.type === 'cleanse');
+        expect(cleanse).toBeDefined();
+        expect(cleanse!.trigger).toBe('on-deal-damage');
+        expect(cleanse!.procChance).toBeUndefined();
+        if (cleanse!.config.type === 'cleanse') {
+            expect(cleanse!.config.mode).toBe('reduce-duration');
+            expect(cleanse!.config.durationTurns).toBe(1);
+        }
+    });
+
+    it('REACTIVE_WARD yields the on-attacked remove cleanse with count 1, critCount 2, and a per-rarity procChance', () => {
+        const ship = makeShip({ implants: { implant_major: 'rw-shape' } });
+        const piece = makePiece({
+            id: 'rw-shape',
+            slot: 'implant_major',
+            rarity: 'legendary',
+            setBonus: 'REACTIVE_WARD',
+        });
+        const baseSkills = buildShipAbilitiesWithEquipment(
+            ship,
+            makeGetGearPiece({ 'rw-shape': piece })
+        );
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        const ward = passive!.abilities.find((a) => a.id.startsWith('equip-implant-REACTIVE_WARD'));
+        expect(ward).toBeDefined();
+        expect(ward!.trigger).toBe('on-attacked');
+        // procChance is the legendary rarity value (0.16) — present and < 1 (real-registry proc).
+        expect(ward!.procChance).toBeCloseTo(0.16);
+        expect(ward!.config.type).toBe('cleanse');
+        if (ward!.config.type === 'cleanse') {
+            expect(ward!.config.mode).toBe('remove');
+            expect(ward!.config.count).toBe(1);
+            expect(ward!.config.critCount).toBe(2);
+        }
+    });
+});

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -3851,11 +3851,13 @@ describe('D-PR reactive cleanse — Warpstrike duration-reduction + damage half'
     }
 
     /**
-     * A FAST enemy that lands TWO distinct self-debuffs on the carrier each round (apply →
-     * always lands) and a token hit. It acts BEFORE the carrier so the carrier is already
-     * self-debuffed when it deals its damage (gating both Warpstrike halves). The two debuffs
-     * are applied in a fixed order ('Older' then 'Newer') so 'Newer' is the newest → the one
-     * Warpstrike's reduce-duration half targets.
+     * A FAST enemy whose only job is to keep the carrier self-debuffed: it lands TWO distinct
+     * self-debuffs on the carrier each round (apply → always lands) and acts BEFORE the carrier
+     * so the carrier is already self-debuffed when it deals its OWN damage (which is what gates
+     * both Warpstrike halves — the duration-reduction rides the carrier's on-deal-damage, not the
+     * enemy's hit). attack:1 keeps any incidental damage from killing the fat carrier. The two
+     * debuffs are applied in a fixed order ('Older' then 'Newer') so 'Newer' is the newest → the
+     * one Warpstrike's reduce-duration half targets.
      */
     function selfDebuffer() {
         const debuff = (name: string): Ability => ({

--- a/src/utils/combat/__tests__/statusEngine.test.ts
+++ b/src/utils/combat/__tests__/statusEngine.test.ts
@@ -1524,6 +1524,32 @@ describe('reduceNewestDebuffDuration', () => {
         // A throw would fail the test; a wrong return value fails the assertion.
         expect(eng.reduceNewestDebuffDuration('no-such-actor', 1)).toBe(0);
     });
+
+    it.each([0, -1, NaN, Infinity, 1.5])(
+        'rejects a non-positive / non-finite / fractional turns (%s) → returns 0, debuff untouched',
+        (turns) => {
+            const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+            eng.beginRound(1);
+            eng.applyTimedAbilityStatus(1, timedEnemyStatus('Defense Down', 3));
+
+            // 1.5 truncates to 1 → it WOULD reduce; assert the guard rejects only <= 0 / non-finite
+            // and that a fractional value is floored (truncated) rather than corrupting state.
+            const result = eng.reduceNewestDebuffDuration(DEFAULT_ENEMY_TARGET, turns);
+            const remaining = eng
+                .timedAbilityStatuses('enemy')
+                .find((s) => s.payload.buffName === 'Defense Down')?.active.turnsRemaining;
+
+            if (turns === 1.5) {
+                // Math.trunc(1.5) = 1 → a normal one-turn reduction.
+                expect(result).toBe(1);
+                expect(remaining).toBe(2);
+            } else {
+                // 0 / negative / NaN / Infinity rejected — no mutation, no false success.
+                expect(result).toBe(0);
+                expect(remaining).toBe(3);
+            }
+        }
+    );
 });
 
 describe('clearRemovable', () => {

--- a/src/utils/combat/__tests__/statusEngine.test.ts
+++ b/src/utils/combat/__tests__/statusEngine.test.ts
@@ -1521,7 +1521,7 @@ describe('reduceNewestDebuffDuration', () => {
         const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
         eng.beginRound(1);
 
-        expect(() => eng.reduceNewestDebuffDuration('no-such-actor', 1)).not.toThrow();
+        // A throw would fail the test; a wrong return value fails the assertion.
         expect(eng.reduceNewestDebuffDuration('no-such-actor', 1)).toBe(0);
     });
 });

--- a/src/utils/combat/__tests__/statusEngine.test.ts
+++ b/src/utils/combat/__tests__/statusEngine.test.ts
@@ -1492,30 +1492,29 @@ describe('reduceNewestDebuffDuration', () => {
         expect(timed[0].active.turnsRemaining).toBe(3);
     });
 
-    it('skips a non-numeric (recurring) duration and returns 0', () => {
-        // We cannot inject a 'recurring' duration via applyTimedAbilityStatus (duration is
-        // guaranteed numeric). Use a persistent-stacking debuff — its turnsRemaining sentinel
-        // is 'permanent', which is also non-numeric and must be skipped.
-        const persistentShred = (): Extract<RegisteredAbilityStatus, { kind: 'timed' }> => ({
-            kind: 'timed',
-            side: 'enemy',
-            sourceSlot: 'active',
-            conditions: [],
-            duration: 2, // ignored — name routes to the persistent map
-            payload: {
-                buffName: 'Defense Shred',
-                stacks: 1,
-                parsedEffects: { defense: -2 },
-                application: 'inflict',
-            },
-        });
+    it('skips the newest UNREMOVABLE debuff and reduces the newest REMOVABLE one instead', () => {
+        // Scenario: actor has two timed debuffs — a removable one applied first, then an
+        // unremovable one (Acidic Decay, a real UNREMOVABLE_STATUSES member) applied second
+        // (higher appliedSeq = technically "newer"). The function must skip the unremovable
+        // entry and reduce the removable one, proving the skip logic executes on reachable state.
         const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
         eng.beginRound(1);
-        eng.applyTimedAbilityStatus(1, persistentShred());
+        // Apply removable debuff first (lower seq).
+        eng.applyTimedAbilityStatus(1, timedEnemyStatus('Defense Down', 3));
+        // Apply unremovable debuff second (higher seq — it IS the "newest" by sequence).
+        eng.applyTimedAbilityStatus(1, timedEnemyStatus('Acidic Decay', 3));
 
-        // The 'permanent' sentinel must be skipped.
         const result = eng.reduceNewestDebuffDuration(DEFAULT_ENEMY_TARGET, 1);
-        expect(result).toBe(0);
+
+        // Should have found a target (the removable Defense Down).
+        expect(result).toBe(1);
+        const timed = eng.timedAbilityStatuses('enemy');
+        const removable = timed.find((s) => s.payload.buffName === 'Defense Down');
+        const unremovable = timed.find((s) => s.payload.buffName === 'Acidic Decay');
+        // Removable was reduced.
+        expect(removable?.active.turnsRemaining).toBe(2);
+        // Unremovable was skipped — completely untouched.
+        expect(unremovable?.active.turnsRemaining).toBe(3);
     });
 
     it('returns 0 for an unknown actor id without throwing', () => {

--- a/src/utils/combat/__tests__/statusEngine.test.ts
+++ b/src/utils/combat/__tests__/statusEngine.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createStatusEngine, RegisteredAbilityStatus } from '../statusEngine';
+import { createStatusEngine, DEFAULT_ENEMY_TARGET, RegisteredAbilityStatus } from '../statusEngine';
 import { SelectedGameBuff } from '../../../types/calculator';
 import { ConditionContext } from '../../abilities/evaluateConditions';
 
@@ -1421,6 +1421,109 @@ describe('per-target debuff stores (Task 1)', () => {
             const defaultActive = eng.activeAbilityStatuses('enemy', () => baseCtx);
             expect(defaultActive.find((s) => s.payload.buffName === 'TankAura')).toBeUndefined();
         });
+    });
+});
+
+describe('reduceNewestDebuffDuration', () => {
+    // Timed enemy-side debuff fixture.
+    const timedEnemyStatus = (
+        buffName: string,
+        duration: number
+    ): Extract<RegisteredAbilityStatus, { kind: 'timed' }> => ({
+        kind: 'timed',
+        side: 'enemy',
+        sourceSlot: 'active',
+        conditions: [],
+        duration,
+        payload: { buffName, stacks: 1, parsedEffects: { defense: -5 } },
+    });
+
+    it('reduces the newest-applied debuff by `turns`, leaves others untouched', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.beginRound(1);
+        // Apply debuff A first (seq lower), then debuff B (seq higher → newest).
+        eng.applyTimedAbilityStatus(1, timedEnemyStatus('Armor Break', 3));
+        eng.applyTimedAbilityStatus(1, timedEnemyStatus('Defense Down', 3));
+
+        const result = eng.reduceNewestDebuffDuration(DEFAULT_ENEMY_TARGET, 1);
+
+        expect(result).toBe(1);
+        const timed = eng.timedAbilityStatuses('enemy');
+        const a = timed.find((s) => s.payload.buffName === 'Armor Break');
+        const b = timed.find((s) => s.payload.buffName === 'Defense Down');
+        expect(a?.active.turnsRemaining).toBe(3); // untouched
+        expect(b?.active.turnsRemaining).toBe(2); // reduced by 1
+    });
+
+    it('removes a debuff whose duration is reduced to exactly 0', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.beginRound(1);
+        eng.applyTimedAbilityStatus(1, timedEnemyStatus('Defense Down', 1));
+
+        const result = eng.reduceNewestDebuffDuration(DEFAULT_ENEMY_TARGET, 1);
+
+        expect(result).toBe(1);
+        expect(eng.timedAbilityStatuses('enemy')).toHaveLength(0);
+    });
+
+    it('removes a debuff whose duration is reduced below 0 (turns > remaining)', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.beginRound(1);
+        eng.applyTimedAbilityStatus(1, timedEnemyStatus('Defense Down', 2));
+
+        const result = eng.reduceNewestDebuffDuration(DEFAULT_ENEMY_TARGET, 2);
+
+        expect(result).toBe(1);
+        expect(eng.timedAbilityStatuses('enemy')).toHaveLength(0);
+    });
+
+    it('skips UNREMOVABLE_STATUSES and returns 0 when that is the only debuff', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.beginRound(1);
+        // 'Acidic Decay' is a real member of UNREMOVABLE_STATUSES.
+        eng.applyTimedAbilityStatus(1, timedEnemyStatus('Acidic Decay', 3));
+
+        const result = eng.reduceNewestDebuffDuration(DEFAULT_ENEMY_TARGET, 1);
+
+        expect(result).toBe(0);
+        // The debuff must be untouched.
+        const timed = eng.timedAbilityStatuses('enemy');
+        expect(timed).toHaveLength(1);
+        expect(timed[0].active.turnsRemaining).toBe(3);
+    });
+
+    it('skips a non-numeric (recurring) duration and returns 0', () => {
+        // We cannot inject a 'recurring' duration via applyTimedAbilityStatus (duration is
+        // guaranteed numeric). Use a persistent-stacking debuff — its turnsRemaining sentinel
+        // is 'permanent', which is also non-numeric and must be skipped.
+        const persistentShred = (): Extract<RegisteredAbilityStatus, { kind: 'timed' }> => ({
+            kind: 'timed',
+            side: 'enemy',
+            sourceSlot: 'active',
+            conditions: [],
+            duration: 2, // ignored — name routes to the persistent map
+            payload: {
+                buffName: 'Defense Shred',
+                stacks: 1,
+                parsedEffects: { defense: -2 },
+                application: 'inflict',
+            },
+        });
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.beginRound(1);
+        eng.applyTimedAbilityStatus(1, persistentShred());
+
+        // The 'permanent' sentinel must be skipped.
+        const result = eng.reduceNewestDebuffDuration(DEFAULT_ENEMY_TARGET, 1);
+        expect(result).toBe(0);
+    });
+
+    it('returns 0 for an unknown actor id without throwing', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.beginRound(1);
+
+        expect(() => eng.reduceNewestDebuffDuration('no-such-actor', 1)).not.toThrow();
+        expect(eng.reduceNewestDebuffDuration('no-such-actor', 1)).toBe(0);
     });
 });
 

--- a/src/utils/combat/__tests__/triggers.test.ts
+++ b/src/utils/combat/__tests__/triggers.test.ts
@@ -3418,3 +3418,186 @@ describe('C2b-1: purge partition guard (on-cast stays cast, on-enemy-purged goes
         expect(castIds).not.toContain('pop1');
     });
 });
+
+// ----------------------------------------------------------------------
+// on-deal-damage live trigger: unit-level tests for the pure listener.
+// Models the Warpstrike implant: owner reduces a self-debuff's duration
+// when it deals direct damage on its own turn.
+//
+// The listener rides the aggregate `ability-performed` event emitted once
+// per damage-dealing turn (runPlayerTurn emits exactly one; positional path
+// emits none — engine.ts ~2887). No once-per-turn guard is needed.
+// The while-debuffed condition is enforced at drain (gateConditions), NOT here.
+// ----------------------------------------------------------------------
+describe('on-deal-damage live trigger', () => {
+    // Minimal on-deal-damage ability (Warpstrike shape): a cleanse that
+    // reduces the duration of the oldest self-debuff when the owner deals damage.
+    const onDealDamageAbility = (): Ability =>
+        ab({
+            type: 'cleanse',
+            target: 'self',
+            trigger: 'on-deal-damage',
+            config: {
+                type: 'cleanse',
+                mode: 'reduce-duration',
+                count: 1,
+            },
+        });
+
+    // Helper: wire up the bus, register the owner's listeners, emit an
+    // `ability-performed` event, and return the collected intents.
+    function emitAbilityPerformed(
+        perOwner: { ownerId: string; reactiveAbilities: ReactiveAbility[] }[],
+        event: Extract<CombatEvent, { type: 'ability-performed' }>
+    ): Intent[] {
+        const bus = createEventBus();
+        const intents: Intent[] = [];
+        registerReactiveListeners({
+            bus,
+            perOwner,
+            enqueue: (i) => intents.push(i),
+            isOpposing: (id) => id === 'enemy',
+        });
+        bus.emit(event);
+        return intents;
+    }
+
+    it('enqueues when actorId === ownerId AND damage > 0', () => {
+        const ra: ReactiveAbility = {
+            ability: onDealDamageAbility(),
+            sourceSlot: 'passive',
+        };
+        const intents = emitAbilityPerformed([{ ownerId: 'warpstrike', reactiveAbilities: [ra] }], {
+            type: 'ability-performed',
+            actorId: 'warpstrike',
+            targetId: 'enemy',
+            round: 1,
+            abilityType: 'damage',
+            damage: 5000,
+        });
+        expect(intents).toHaveLength(1);
+        expect(intents[0].ownerId).toBe('warpstrike');
+        expect(intents[0].ability.trigger).toBe('on-deal-damage');
+    });
+
+    it('does NOT enqueue when actorId !== ownerId (another actor dealing damage)', () => {
+        const ra: ReactiveAbility = {
+            ability: onDealDamageAbility(),
+            sourceSlot: 'passive',
+        };
+        const intents = emitAbilityPerformed([{ ownerId: 'warpstrike', reactiveAbilities: [ra] }], {
+            type: 'ability-performed',
+            actorId: 'other-ship',
+            targetId: 'enemy',
+            round: 1,
+            abilityType: 'damage',
+            damage: 5000,
+        });
+        expect(intents).toHaveLength(0);
+    });
+
+    it('does NOT enqueue when damage is 0', () => {
+        const ra: ReactiveAbility = {
+            ability: onDealDamageAbility(),
+            sourceSlot: 'passive',
+        };
+        const intents = emitAbilityPerformed([{ ownerId: 'warpstrike', reactiveAbilities: [ra] }], {
+            type: 'ability-performed',
+            actorId: 'warpstrike',
+            targetId: 'enemy',
+            round: 1,
+            abilityType: 'damage',
+            damage: 0,
+        });
+        expect(intents).toHaveLength(0);
+    });
+
+    it('does NOT enqueue when damage is undefined (non-damage ability event)', () => {
+        const ra: ReactiveAbility = {
+            ability: onDealDamageAbility(),
+            sourceSlot: 'passive',
+        };
+        const intents = emitAbilityPerformed([{ ownerId: 'warpstrike', reactiveAbilities: [ra] }], {
+            type: 'ability-performed',
+            actorId: 'warpstrike',
+            targetId: 'enemy',
+            round: 1,
+            abilityType: 'buff',
+            // damage omitted — optional field, should default via ?? 0
+        });
+        expect(intents).toHaveLength(0);
+    });
+
+    it('fires exactly once per turn regardless of hit count (aggregate event model)', () => {
+        // runPlayerTurn emits ONE ability-performed per turn. Multi-hit and AoE are
+        // already aggregated — this test confirms the listener enqueues exactly once.
+        const ra: ReactiveAbility = {
+            ability: onDealDamageAbility(),
+            sourceSlot: 'passive',
+        };
+        const bus = createEventBus();
+        const intents: Intent[] = [];
+        registerReactiveListeners({
+            bus,
+            perOwner: [{ ownerId: 'warpstrike', reactiveAbilities: [ra] }],
+            enqueue: (i) => intents.push(i),
+            isOpposing: (id) => id === 'enemy',
+        });
+        // Emit ONE aggregate event (as the engine does for a multi-hit turn).
+        bus.emit({
+            type: 'ability-performed',
+            actorId: 'warpstrike',
+            targetId: 'enemy',
+            round: 2,
+            abilityType: 'damage',
+            damage: 12000,
+        });
+        expect(intents).toHaveLength(1);
+    });
+
+    it('fires only the matching owner when multiple owners are registered', () => {
+        const ra: ReactiveAbility = {
+            ability: onDealDamageAbility(),
+            sourceSlot: 'passive',
+        };
+        const raOther: ReactiveAbility = {
+            ability: { ...onDealDamageAbility(), id: 'other-dd' },
+            sourceSlot: 'passive',
+        };
+        const bus = createEventBus();
+        const intents: Intent[] = [];
+        registerReactiveListeners({
+            bus,
+            perOwner: [
+                { ownerId: 'warpstrike', reactiveAbilities: [ra] },
+                { ownerId: 'bystander', reactiveAbilities: [raOther] },
+            ],
+            enqueue: (i) => intents.push(i),
+            isOpposing: (id) => id === 'enemy',
+        });
+        bus.emit({
+            type: 'ability-performed',
+            actorId: 'warpstrike',
+            targetId: 'enemy',
+            round: 1,
+            abilityType: 'damage',
+            damage: 8000,
+        });
+        expect(intents).toHaveLength(1);
+        expect(intents[0].ownerId).toBe('warpstrike');
+    });
+
+    it('on-deal-damage is in LIVE_TRIGGERS (partitions as reactive)', () => {
+        expect(LIVE_TRIGGERS.has('on-deal-damage')).toBe(true);
+        const { reactiveAbilities } = partitionReactiveAbilities({
+            slots: [
+                {
+                    slot: 'passive',
+                    abilities: [onDealDamageAbility()],
+                },
+            ],
+        });
+        expect(reactiveAbilities).toHaveLength(1);
+        expect(reactiveAbilities[0].ability.trigger).toBe('on-deal-damage');
+    });
+});

--- a/src/utils/combat/statusEngine.ts
+++ b/src/utils/combat/statusEngine.ts
@@ -1003,6 +1003,9 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
         if (!timedMap) return 0;
         let best: { seq: number; key: string; s: BuffState } | undefined;
         for (const [key, s] of timedMap) {
+            // Defensive: BuffState.turnsRemaining is typed `number` — non-numeric durations
+            // ('recurring'/'permanent') live in separate maps and cannot reach enemyMaps today.
+            // Guard mirrors removeNewestFirst for belt-and-braces safety.
             if (typeof s.turnsRemaining !== 'number') continue;
             if (isUnremovable(s.buffName, s.turnsRemaining)) continue;
             if (!best || s.appliedSeq > best.seq) best = { seq: s.appliedSeq, key, s };

--- a/src/utils/combat/statusEngine.ts
+++ b/src/utils/combat/statusEngine.ts
@@ -998,8 +998,13 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
      *  enemy store is visited — accumulating/persistent maps have no finite duration (so the
      *  "newest" picked here is the newest TIMED debuff, which may differ from cleanse's newest
      *  across all stores). Skips 'recurring'/'permanent' sentinels and UNREMOVABLE_STATUSES (same
-     *  skip rules as cleanse). Returns 1 if a debuff was affected, else 0. Unknown id → 0. */
+     *  skip rules as cleanse). Returns 1 if a debuff was affected, else 0. Unknown id → 0.
+     *  A non-positive / non-finite `turns` is rejected (→ 0): only a positive whole-turn
+     *  reduction is meaningful — 0 would credit a no-op as success, a negative value would
+     *  INCREASE the duration, and NaN would corrupt `turnsRemaining`. */
     const reduceNewestDebuffDuration = (actorId: string, turns: number): number => {
+        const delta = Number.isFinite(turns) ? Math.trunc(turns) : 0;
+        if (delta <= 0) return 0;
         const timedMap = enemyMaps.get(actorId);
         if (!timedMap) return 0;
         let best: { seq: number; key: string; s: BuffState } | undefined;
@@ -1012,7 +1017,7 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
             if (!best || s.appliedSeq > best.seq) best = { seq: s.appliedSeq, key, s };
         }
         if (!best) return 0;
-        best.s.turnsRemaining -= turns;
+        best.s.turnsRemaining -= delta;
         if (best.s.turnsRemaining <= 0) timedMap.delete(best.key);
         return 1;
     };

--- a/src/utils/combat/statusEngine.ts
+++ b/src/utils/combat/statusEngine.ts
@@ -162,6 +162,11 @@ export interface StatusEngine {
      *  applied first (see removeNewestFirst). `'all'` removes every removable debuff. Returns
      *  the number actually removed. Unknown id → no-op (returns 0). */
     cleanse(actorId: string, count: number | 'all'): number;
+    /** Reduce the duration of ONE timed debuff on `actorId` by `turns`, newest-applied first
+     *  (highest appliedSeq). Reduced to <= 0 → removed (expired). Only timed debuffs are
+     *  eligible; 'recurring'/'permanent' and UNREMOVABLE_STATUSES are skipped (consistent with
+     *  cleanse). Returns 1 if a debuff was affected, else 0. Unknown id → 0. */
+    reduceNewestDebuffDuration(actorId: string, turns: number): number;
     /** Remove up to `count` removable BUFFS from `actorId`'s self store, newest first;
      *  `'all'` = all; respects UNREMOVABLE_STATUSES + 'permanent'; returns count removed. */
     purge(actorId: string, count: number | 'all'): number;
@@ -988,6 +993,26 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
     const cleanse = (actorId: string, count: number | 'all'): number =>
         removeNewestFirst(actorId, 'debuffs', count);
 
+    /** Reduce the duration of ONE timed debuff on `actorId` by `turns`, newest-applied first
+     *  (highest appliedSeq). Reduced to <= 0 → removed (expired). Only the per-victim timed
+     *  enemy store is visited — accumulating/persistent maps have no finite duration. Skips
+     *  'recurring'/'permanent' sentinels and UNREMOVABLE_STATUSES (consistent with cleanse).
+     *  Returns 1 if a debuff was affected, else 0. Unknown id → 0. */
+    const reduceNewestDebuffDuration = (actorId: string, turns: number): number => {
+        const timedMap = enemyMaps.get(actorId);
+        if (!timedMap) return 0;
+        let best: { seq: number; key: string; s: BuffState } | undefined;
+        for (const [key, s] of timedMap) {
+            if (typeof s.turnsRemaining !== 'number') continue;
+            if (isUnremovable(s.buffName, s.turnsRemaining)) continue;
+            if (!best || s.appliedSeq > best.seq) best = { seq: s.appliedSeq, key, s };
+        }
+        if (!best) return 0;
+        best.s.turnsRemaining -= turns;
+        if (best.s.turnsRemaining <= 0) timedMap.delete(best.key);
+        return 1;
+    };
+
     /** Remove up to `count` removable BUFFS from `actorId`'s self store, newest first
      *  (see removeNewestFirst). `'all'` removes every removable buff. Respects
      *  UNREMOVABLE_STATUSES + 'permanent'; returns count removed. Unknown id → no-op (returns 0). */
@@ -1215,6 +1240,7 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
         clearRemovable,
         removeTimedEnemyStatus,
         cleanse,
+        reduceNewestDebuffDuration,
         purge,
         registerAbilityStatuses,
         applyTimedAbilityStatus,

--- a/src/utils/combat/statusEngine.ts
+++ b/src/utils/combat/statusEngine.ts
@@ -995,9 +995,10 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
 
     /** Reduce the duration of ONE timed debuff on `actorId` by `turns`, newest-applied first
      *  (highest appliedSeq). Reduced to <= 0 → removed (expired). Only the per-victim timed
-     *  enemy store is visited — accumulating/persistent maps have no finite duration. Skips
-     *  'recurring'/'permanent' sentinels and UNREMOVABLE_STATUSES (consistent with cleanse).
-     *  Returns 1 if a debuff was affected, else 0. Unknown id → 0. */
+     *  enemy store is visited — accumulating/persistent maps have no finite duration (so the
+     *  "newest" picked here is the newest TIMED debuff, which may differ from cleanse's newest
+     *  across all stores). Skips 'recurring'/'permanent' sentinels and UNREMOVABLE_STATUSES (same
+     *  skip rules as cleanse). Returns 1 if a debuff was affected, else 0. Unknown id → 0. */
     const reduceNewestDebuffDuration = (actorId: string, turns: number): number => {
         const timedMap = enemyMaps.get(actorId);
         if (!timedMap) return 0;

--- a/src/utils/combat/statusEngine.ts
+++ b/src/utils/combat/statusEngine.ts
@@ -1005,7 +1005,7 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
         for (const [key, s] of timedMap) {
             // Defensive: BuffState.turnsRemaining is typed `number` — non-numeric durations
             // ('recurring'/'permanent') live in separate maps and cannot reach enemyMaps today.
-            // Guard mirrors removeNewestFirst for belt-and-braces safety.
+            // Belt-and-braces only (this exact guard is not present in removeNewestFirst).
             if (typeof s.turnsRemaining !== 'number') continue;
             if (isUnremovable(s.buffName, s.turnsRemaining)) continue;
             if (!best || s.appliedSeq > best.seq) best = { seq: s.appliedSeq, key, s };

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -277,6 +277,19 @@ export function registerReactiveListeners(args: {
                         }
                     });
                     break;
+                case 'on-deal-damage':
+                    bus.on('ability-performed', (e) => {
+                        // Warpstrike duration-reduction: fires on the OWNER's own damage-dealing
+                        // turn. runPlayerTurn emits exactly ONE aggregate ability-performed per
+                        // turn (positional path emits none — engine.ts ~2887), so this is
+                        // once-per-turn for single-hit, multi-hit, and AoE alike — no
+                        // once-per-turn guard needed. The while-debuffed requirement is an
+                        // ability condition (self-debuff), enforced at drain via gateConditions.
+                        if (e.actorId !== ownerId) return;
+                        if ((e.damage ?? 0) <= 0) return;
+                        enqueue(intent);
+                    });
+                    break;
                 case 'on-charged-cast':
                     bus.on('skill-fired', (e) => {
                         // Self-scoped: THIS owner performed its CHARGED skill. The skill-fired

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1505,7 +1505,24 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
     }
 
     if (cfg.type === 'cleanse') {
-        // (reduce-duration mode is added in a later task; remove-mode only for now.)
+        const mode = cfg.mode ?? 'remove';
+        if (mode === 'reduce-duration') {
+            // No shipped duration-reduction ability sets procChance (deterministic), so the gate
+            // is pass-through and never advances — safe to consult regardless of healing mode.
+            if (!passesProcChanceGate(intent, ctx)) return;
+            // Pure status mutation — does NOT require healing mode. self-target → [ownerId].
+            // Falls back to ownerId when healing is absent (e.g. Warpstrike in non-healing sim).
+            const fallback = ctx.healing?.targetId ?? intent.ownerId;
+            const recipients = reactiveRecipients(intent, ctx, fallback);
+            let affected = 0;
+            for (const rid of recipients)
+                affected += ctx.statusEngine.reduceNewestDebuffDuration(
+                    rid,
+                    cfg.durationTurns ?? 1
+                );
+            ctx.healing?.credit(intent.ownerId, 'cleanseCount', affected);
+            return;
+        }
         // remove mode — keep the !ctx.healing return BEFORE the proc gate (gate-desync rule;
         // see passesProcChanceGate doc). If reordered, a healing-mode-off pass would consume a
         // gate tick the healing-on pass does not, desynchronizing the proc stream across sims.

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -107,6 +107,9 @@ export interface Intent {
          *  reactive `basis:'damage-dealt'` heal/shield (e.g. Bloodthirst) to scale off the
          *  triggering hit's damage rather than the owner's max HP. */
         triggerDamage?: number;
+        /** The triggering hit's crit outcome (on-attacked -> attacked.didCrit), read by the
+         *  reactive cleanse executor to pick `critCount` over `count` (Reactive Ward). */
+        didCrit?: boolean;
         /** The actor ids of the allies repaired by an on-own-repair-to-ally event
          *  (excludes the caster). The buff branch fans an 'ally'-target grant out to
          *  exactly these recipients (Font of Power -> repaired allies). */

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1507,7 +1507,8 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
     if (cfg.type === 'cleanse') {
         // (reduce-duration mode is added in a later task; remove-mode only for now.)
         // remove mode — keep the !ctx.healing return BEFORE the proc gate (gate-desync rule;
-        // see passesProcChanceGate doc).
+        // see passesProcChanceGate doc). If reordered, a healing-mode-off pass would consume a
+        // gate tick the healing-on pass does not, desynchronizing the proc stream across sims.
         if (!ctx.healing) return; // healing mode off → not-simulated follow-up
         if (!passesProcChanceGate(intent, ctx)) return;
         // ctx.playerIds is the SAME-SIDE ally id order (sideCtx.recipientIds) — side-correct for

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -402,7 +402,10 @@ export function registerReactiveListeners(args: {
                             if (e.damage === undefined || !maxHp || e.damage <= fracGate * maxHp)
                                 return;
                         }
-                        enqueue({ ...intent, eventCtx: { counterTargetId: e.attackerId } });
+                        enqueue({
+                            ...intent,
+                            eventCtx: { counterTargetId: e.attackerId, didCrit: e.didCrit },
+                        });
                     });
                     break;
                 case 'on-debuffed':
@@ -1502,15 +1505,20 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
     }
 
     if (cfg.type === 'cleanse') {
+        // (reduce-duration mode is added in a later task; remove-mode only for now.)
+        // remove mode — keep the !ctx.healing return BEFORE the proc gate (gate-desync rule;
+        // see passesProcChanceGate doc).
         if (!ctx.healing) return; // healing mode off → not-simulated follow-up
+        if (!passesProcChanceGate(intent, ctx)) return;
         // ctx.playerIds is the SAME-SIDE ally id order (sideCtx.recipientIds) — side-correct for
         // both player and enemy reactive drains. ctx.statusEngine is the live store. Mirrors the
         // reactive heal branch's recipient resolution: an 'ally'-target cleanse prefers the
         // eventCtx.damagedAllyId (an ally-damage reaction cleanses THAT ally) over the heal target;
         // 'all-allies' fans out to every same-side id; self → the owner.
         const recipients = reactiveRecipients(intent, ctx, ctx.healing.targetId);
+        const count = intent.eventCtx?.didCrit && cfg.critCount != null ? cfg.critCount : cfg.count;
         let removed = 0;
-        for (const rid of recipients) removed += ctx.statusEngine.cleanse(rid, cfg.count);
+        for (const rid of recipients) removed += ctx.statusEngine.cleanse(rid, count);
         // Credit the ACTUAL removed count (was the nominal cfg.count pre-T4).
         ctx.healing.credit(intent.ownerId, 'cleanseCount', removed);
         return;


### PR DESCRIPTION
## Summary

Adds the cleanse-family reactive implant bucket to the battle simulator (sub-project D of the combat-realism epic):

- **Reactive Ward** — when the carrier is directly hit, an X%-per-rarity chance to cleanse one of its own debuffs, or **two** if the hit was a critical. Rides `on-attacked` (now threads `didCrit` into `eventCtx`) + the reactive `cleanse` executor in a new `mode: 'remove'` with `critCount`.
- **Warpstrike's duration-reduction half** (the damage half shipped in D-PR2) — when the carrier deals direct damage while self-debuffed, shave one turn off its **newest** own debuff. New `on-deal-damage` trigger (rides the single aggregate `ability-performed` per turn → no once-per-turn guard) + reactive `cleanse` executor `mode: 'reduce-duration'` (deterministic, no proc) + a new status-engine primitive `reduceNewestDebuffDuration`.

Both are registered through the equipment registry (`buildEquipmentAbilities`), which now supports multi-ability builders (Warpstrike returns its modifier + the reduce-duration cleanse; single-ability implant ids stay byte-identical). Editor trigger stub + coverage tracker updated. DPS page intentionally not wired (defensive/status-only).

Spec: `docs/superpowers/specs/2026-06-23-reactive-cleanse-design.md`
Plan: `docs/superpowers/plans/2026-06-23-reactive-cleanse.md`

## Test Plan

- [x] Full suite green (3116 tests / 222 files)
- [x] `tsc --noEmit` + `npm run lint` clean (max-warnings 0)
- [x] `npm run audit:skills` 141/0 unchanged
- [x] **Zero golden / `.snap` drift** (no fixture equips these implants)
- [x] New unit tests: `reduceNewestDebuffDuration`, reactive cleanse executor (proc gate, crit-count, reduce-duration mode), `on-deal-damage` trigger + `LIVE_TRIGGERS` partition
- [x] 6 mutation-resistant engine integration tests routed through the real registry (Reactive Ward crit→2/non-crit→1; Warpstrike duration delta vs. no-Warpstrike control + D-PR2 damage half still fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)