### PR TITLE
feat(combat): charge Phase 2+3 — periodic (Chrono Reaver) & conditional (Cobalt) self-charge

### DIFF
--- a/src/components/skills/AbilityCard.tsx
+++ b/src/components/skills/AbilityCard.tsx
@@ -127,6 +127,7 @@ const ROLE_FILTER_OPTIONS: { value: ShipRoleCategory; label: string }[] = [
 const TRIGGER_OPTIONS: { value: AbilityTrigger; label: string }[] = [
     { value: 'on-cast', label: 'On cast (default)' },
     { value: 'start-of-turn', label: 'Start of own turn' },
+    { value: 'end-of-turn', label: 'End of own turn' },
     { value: 'start-of-round', label: 'Start of round' },
     { value: 'on-crit', label: 'On critical hit' },
     { value: 'on-deal-damage', label: 'On dealing direct damage' },

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -29,6 +29,8 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator now models two cleanse-related implants: Reactive Ward (when the carrier is directly hit, a chance to cleanse one of its own debuffs — two if the hit was a critical) and the second half of Warpstrike (when the carrier deals direct damage while debuffed, it shortens one of its own debuffs by a turn). Chance-based procs are modeled at their true average frequency.',
     'Combat simulator now models the Cloaking gear set: at the start of combat the equipped ship gains Stealth for 2 turns, becoming untargetable while any un-stealthed target is available. This also activates effects that key off being stealthed — the Ambush implant and stealth-based incoming-damage reduction now trigger when the ship is cloaked.',
     "Combat sim now models enemy charge removal — ships like Opal, Provider, Sefuba (on cast), Demolisher (when a bomb explodes), and Zosimos (every second enemy repair) now drain the enemy's Charged Skill, with charge-loss-immune ships unaffected.",
+    "Combat simulator now models the Chrono Reaver implant — it grants a bonus charge to the carrier's charged skill every 2nd turn (legendary) or every 3rd turn (epic). Units in Stasis bank no charge on skipped turns.",
+    "Combat simulator now models Cobalt's passive — at the start of each of its turns while at full HP, Cobalt gains a bonus charge toward its charged skill.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3096,8 +3096,12 @@ const DocumentationPage: React.FC = () => {
                                     (stronger repairs on allies with less HP than the healer), and{' '}
                                     <strong>Vivacious Repair</strong> (chance to double a repair on
                                     an ally below 25% HP), and <strong>Exuberance</strong> (chance
-                                    to increase the amount of a repair this unit receives). More
-                                    implant and gear-set effects will be added in future updates.
+                                    to increase the amount of a repair this unit receives). Charge
+                                    manipulation is also modeled: <strong>Chrono Reaver</strong>{' '}
+                                    (grants a bonus charge to the carrier&apos;s charged skill every
+                                    2nd turn at legendary rarity or every 3rd turn at epic; units in
+                                    Stasis bank no charge on skipped turns). More implant and
+                                    gear-set effects will be added in future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/types/calculator.ts
+++ b/src/types/calculator.ts
@@ -1,6 +1,6 @@
 import type { ShipTypeName } from '../constants/shipTypes';
 import { AffinityName } from './ship';
-import type { ShipSkills } from './abilities';
+import type { Condition, ShipSkills } from './abilities';
 
 export type StackTrigger = 'per-round' | 'per-active' | 'per-charge';
 
@@ -42,7 +42,18 @@ export interface ChargeGain {
     // Reactive event the charge gain fires on (set for inflict-driven charge gains).
     // When present, the gain is per-event (+amount each fire) rather than a per-standing
     // count condition, and `condition` is 'always'.
-    trigger?: 'on-debuff-inflicted' | 'on-ally-debuff-inflicted' | 'on-enemy-repaired';
+    // start-of-turn is a periodic self-charge (Cobalt) that ALSO carries a gate via
+    // `conditions` below — unlike the inflict/repair triggers, which fire per-event
+    // with no gate.
+    trigger?:
+        | 'on-debuff-inflicted'
+        | 'on-ally-debuff-inflicted'
+        | 'on-enemy-repaired'
+        | 'start-of-turn';
+    // Explicit gate conditions applied alongside `trigger` (start-of-turn + full-HP, Cobalt).
+    // When present, buildShipAbilities uses these verbatim instead of deriving a single
+    // condition from `condition`, and they coexist with a (non-reactive-event) trigger.
+    conditions?: Condition[];
 }
 
 export const CONDITIONAL_CONDITION_LABELS: Record<ConditionalCondition, string> = {

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -1178,14 +1178,51 @@ describe('parseChargeGain', () => {
         });
     });
 
-    it('parses full-HP self gain as always-true — Cobalt', () => {
+    it('parses start-of-turn full-HP self gain as start-of-turn + hp-threshold gate — Cobalt 1st passive', () => {
         const text =
             'This Unit <unit-aid>adds 1 charge</unit-aid> to its charged skill at the start of the turn if it is at full HP.';
         expect(parseChargeGain(text)).toEqual({
             amount: 1,
             condition: 'always',
             derivable: true,
+            trigger: 'start-of-turn',
+            conditions: [
+                {
+                    subject: 'hp-threshold',
+                    derivable: true,
+                    hpComparator: 'above',
+                    hpPercent: 99,
+                    hpSubject: 'self',
+                },
+            ],
         });
+    });
+
+    it('parses start-of-turn full-HP self gain (with separate buff clause) — Cobalt 2nd passive', () => {
+        const text =
+            'This Unit <unit-aid>adds 1 charge</unit-aid> to its charged skill and gains <unit-aid>Out. Damage Up II</unit-aid> for 1 turn at the start of the turn if it is at full HP.';
+        expect(parseChargeGain(text)).toMatchObject({
+            amount: 1,
+            trigger: 'start-of-turn',
+            conditions: [{ subject: 'hp-threshold' }],
+        });
+    });
+
+    it('parses "each turn" phrasing as start-of-turn trigger (widened regex)', () => {
+        const text =
+            'This Unit <unit-aid>adds 1 charge</unit-aid> to its charged skill at the start of each turn if it is at full HP.';
+        expect(parseChargeGain(text)).toMatchObject({
+            amount: 1,
+            trigger: 'start-of-turn',
+            conditions: [{ subject: 'hp-threshold' }],
+        });
+    });
+
+    it('leaves a plain unconditional self-charge unchanged (no trigger) — regression', () => {
+        const result = parseChargeGain(
+            'This Unit <unit-aid>adds 1 charge</unit-aid> to its charged skill.'
+        );
+        expect(result?.trigger).toBeUndefined();
     });
 
     it('parses enemy-buff threshold gain (manual) — Nuqtu', () => {

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -798,3 +798,46 @@ describe('Power Infused Nanobots buff (D-PR9 + D-PR10 — Font of Power, flat at
         expect(effects.attackFlat).toBeUndefined();
     });
 });
+
+// ---------------------------------------------------------------------------
+// Chrono Reaver implant (periodic self-charge, end-of-turn)
+// ---------------------------------------------------------------------------
+describe('Chrono Reaver implant', () => {
+    it('legendary → charge/self/end-of-turn, every-n-turns period 2, offset 0', () => {
+        const abilities = buildForImplant('CHRONO_REAVER', 'legendary');
+        expect(abilities).toHaveLength(1);
+        const ab = abilities[0];
+        expect(ab.type).toBe('charge');
+        expect(ab.target).toBe('self');
+        expect(ab.trigger).toBe('end-of-turn');
+        expect(ab.conditions).toEqual([
+            { subject: 'every-n-turns', derivable: true, period: 2, offset: 0 },
+        ]);
+        expect(ab.config).toEqual({ type: 'charge', amount: 1 });
+        expect(ab.autoFilled).toBe(true);
+    });
+
+    it('epic → period 3', () => {
+        const abilities = buildForImplant('CHRONO_REAVER', 'epic');
+        expect(abilities).toHaveLength(1);
+        const ab = abilities[0];
+        expect(ab.type).toBe('charge');
+        expect(ab.trigger).toBe('end-of-turn');
+        expect(ab.conditions).toEqual([
+            { subject: 'every-n-turns', derivable: true, period: 3, offset: 0 },
+        ]);
+        expect(ab.config).toEqual({ type: 'charge', amount: 1 });
+    });
+
+    it('common → no ability (only epic + legendary variants exist)', () => {
+        expect(buildForImplant('CHRONO_REAVER', 'common')).toEqual([]);
+    });
+
+    it('uncommon → no ability', () => {
+        expect(buildForImplant('CHRONO_REAVER', 'uncommon')).toEqual([]);
+    });
+
+    it('rare → no ability', () => {
+        expect(buildForImplant('CHRONO_REAVER', 'rare')).toEqual([]);
+    });
+});

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -85,6 +85,34 @@ describe('buildShipAbilities', () => {
         expect(charge!.conditions[0]).toMatchObject({ subject: 'always', derivable: true });
     });
 
+    it('Cobalt passive: start-of-turn self-charge gated by full HP (Phase 3)', () => {
+        // Build abilities from Cobalt's first-passive text; find the charge ability.
+        // R0 passive (refits: []) so firstPassiveSkillText is the active row.
+        const chargeAbilityFrom = (text: string): Ability | undefined => {
+            const s = ship({ refits: [], firstPassiveSkillText: text, chargeSkillCharge: 4 });
+            const passive = slot(buildShipAbilities(s).slots, 'passive');
+            return abilityOfType(passive?.abilities ?? [], 'charge');
+        };
+
+        const charge = chargeAbilityFrom(
+            'This Unit adds 1 charge to its charged skill at the start of the turn if it is at full HP.'
+        );
+        expect(charge).toMatchObject({
+            type: 'charge',
+            target: 'self',
+            trigger: 'start-of-turn',
+            conditions: [
+                {
+                    subject: 'hp-threshold',
+                    hpComparator: 'above',
+                    hpPercent: 99,
+                    hpSubject: 'self',
+                },
+            ],
+            config: { type: 'charge', amount: 1 },
+        });
+    });
+
     it('Panguan active: damage(145) with conditional scaling (perUnit 30) attached to base', () => {
         const s = ship({
             activeSkillText:

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -119,7 +119,7 @@ function implantAbilities(implantKey: string, rarity: string) {
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { LEECH + CLOAKING + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_STAND + LAST_WISH + LOCKDOWN + MENACE + REACTIVE_WARD + SECOND_WIND + SHADOWGUARD + SPEARHEAD + TENACITY + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
+    it('exactly { LEECH + CLOAKING + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + CHRONO_REAVER + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_STAND + LAST_WISH + LOCKDOWN + MENACE + REACTIVE_WARD + SECOND_WIND + SHADOWGUARD + SPEARHEAD + TENACITY + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -135,6 +135,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
         expect(implementedImplants).toEqual([
             'MARTYRDOM',
             'ARCANE_SIEGE',
+            'CHRONO_REAVER',
             'HYPERION_GAZE',
             'INTRUSION',
             'NEBULA_NULLIFIER',
@@ -255,6 +256,7 @@ describe('equipmentCoverage — implants', () => {
     // D-PR16: LAST_STAND added (on-ally-destroyed + last-standing → self Barrier + Block Debuff co-grant).
     // Reactive cleanse PR: REACTIVE_WARD added (reactive cleanse on-attacked, crit-count branch).
     //         WARPSTRIKE gains a second ability (reduce-duration cleanse on-deal-damage).
+    // Phase 2-3: CHRONO_REAVER added (end-of-turn periodic self-charge; epic=every 3rd, legendary=every 2nd).
     const implementedImplants = new Set([
         'FIREWALL',
         'LOCKDOWN',
@@ -263,6 +265,7 @@ describe('equipmentCoverage — implants', () => {
         'BLOODTHIRST',
         'INTRUSION',
         'ARCANE_SIEGE',
+        'CHRONO_REAVER',
         'WARPSTRIKE',
         'VOIDSHADE',
         'NEBULA_NULLIFIER',
@@ -303,6 +306,13 @@ describe('equipmentCoverage — implants', () => {
         for (const v of variants) {
             expect(implantAbilityCount('ARCANE_SIEGE', v.rarity)).toBe(1);
         }
+    });
+
+    // Phase 2-3: periodic self-charge (end-of-turn + every-n-turns gate)
+    it('CHRONO_REAVER produces 1 ability for epic + legendary (periodic self-charge); 0 for other rarities', () => {
+        // Only epic and legendary variants exist in implants.ts — no common/uncommon/rare.
+        expect(implantAbilityCount('CHRONO_REAVER', 'epic')).toBe(1);
+        expect(implantAbilityCount('CHRONO_REAVER', 'legendary')).toBe(1);
     });
 
     it('WARPSTRIKE produces 2 abilities per rarity (outgoingDamage modifier + reduce-duration cleanse, gated on self-debuff)', () => {

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -850,6 +850,24 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
             alsoGrantBuffNames: ['Block Debuff'],
         });
     },
+    // Chrono Reaver: periodic self-charge. Epic = every 3rd own turn, Legendary = every 2nd.
+    // Rides end-of-turn (turn-ended) + the every-n-turns gate on the live turnsTaken counter
+    // (offset 0 → procs when turnsTaken % period === 0, i.e. the actor's Nth own turn). The
+    // proc is dropped for a turn-blocked owner by the §4.4 reactive-suppression filter
+    // (engine.ts ~3403), so a stasised/disabled unit banks no periodic charge.
+    // Only epic/legendary variants exist (implants.ts) — other rarities emit nothing.
+    CHRONO_REAVER: (rarity) => {
+        const period = rarity === 'legendary' ? 2 : rarity === 'epic' ? 3 : undefined;
+        if (period === undefined) return undefined;
+        return {
+            type: 'charge',
+            target: 'self',
+            trigger: 'end-of-turn',
+            conditions: [{ subject: 'every-n-turns', derivable: true, period, offset: 0 }],
+            config: { type: 'charge', amount: 1 },
+            autoFilled: true,
+        };
+    },
 };
 
 // ---------------------------------------------------------------------------

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -1169,23 +1169,29 @@ function abilitiesFromText(
         // condition. parseChargeGain's own trigger (inflict-driven) takes precedence when present.
         const allyCritChargeTrigger = detectAllyCritTrigger(text, chargePos);
         const reactiveTrigger = charge.trigger ?? allyCritChargeTrigger;
+        // Phase 3: an explicit conditions array (start-of-turn + full-HP, Cobalt) carries BOTH a
+        // trigger and a gate, overriding the "trigger ⇒ no condition" rule used by the inflict/repair
+        // reactive gains (whose trigger IS the gate).
+        const conditions = charge.conditions
+            ? charge.conditions
+            : reactiveTrigger
+              ? []
+              : [
+                    toCondition(
+                        charge.condition,
+                        charge.derivable,
+                        charge.manualCount,
+                        charge.requiredEnemyType,
+                        text
+                    ),
+                ];
         out.push({
             ability: {
                 id: nextId(),
                 type: 'charge',
                 target: 'self',
                 trigger: reactiveTrigger ?? 'on-cast',
-                conditions: reactiveTrigger
-                    ? []
-                    : [
-                          toCondition(
-                              charge.condition,
-                              charge.derivable,
-                              charge.manualCount,
-                              charge.requiredEnemyType,
-                              text
-                          ),
-                      ],
+                conditions,
                 config: { type: 'charge', amount: charge.amount },
                 autoFilled: true,
             },

--- a/src/utils/combat/__tests__/chronoReaverCharge.integration.test.ts
+++ b/src/utils/combat/__tests__/chronoReaverCharge.integration.test.ts
@@ -1,0 +1,707 @@
+/**
+ * Integration: Chrono Reaver periodic self-charge (Charge Phase 2/3 Task 2).
+ *
+ * Chrono Reaver is an IMPLANT that emits a reactive `{ type:'charge', target:'self',
+ * trigger:'end-of-turn' }` ability gated by an `every-n-turns` condition (LEGENDARY → period 2,
+ * EPIC → period 3, offset 0). The ability under test is RESOLVED FROM THE REAL IMPLANT PATH
+ * (`buildEquipmentAbilities(ship, getGearPiece)` against a Ship carrying a `setBonus:'CHRONO_REAVER'`
+ * gear piece) — exactly what `simulateBattle(placements, getGearPiece)` feeds the engine via
+ * `buildShipAbilitiesWithEquipment`. We then run the resolved ability through `runCombat` (the
+ * battle-sim engine) with a two-side roster (a charged player focus vs. a dummy/sink enemy) and
+ * read the focus's per-round charge counts from `result.rounds[].charges` (RoundData — the focus's
+ * END-OF-ROUND live charge counter) and `result.rounds[].action` ('active' | 'charged').
+ *
+ * Why runCombat (not simulateBattle directly): `simulateBattle`'s `BattleResult`/`ShipRoundState`
+ * surfaces damage/healing/HP/buffs but NOT charge counts, so it cannot pin the exact per-round
+ * charge ledger this task requires. `runCombat` exposes the focus's `rounds[].charges` directly
+ * (the Phase-1 charge goldens use the same entry point). We still exercise the genuine implant→
+ * ability resolution by building the ability via `buildEquipmentAbilities` from a real GearPiece +
+ * Ship, so the ability shape under test is the implant's actual output, not a hand-written copy.
+ *
+ * ─── CRITICAL TIMING (baked into every ledger below) ──────────────────────────────────────────
+ * There is NO pre-action drain between the focus's `turn-started` and its action body. The focus's
+ * own per-action drain (engine.ts ~4639) runs BEFORE its `turn-ended` emit (~4667), which is where
+ * the `end-of-turn` Chrono Reaver intent is ENQUEUED. So the CR intent does NOT drain within the
+ * focus's own post-action drain — it banks at the NEXT drain pass (the dummy enemy's post-action
+ * drain ~4639, or the round-end drain ~4795). BOTH of those passes still fall WITHIN THE SAME ROUND,
+ * and `rounds[].charges` is captured at row assembly AFTER the round-end drain — so the CR proc that
+ * fires on the focus's turn IS reflected in that SAME round's reported `charges`. Charges carry
+ * forward across rounds (like start-of-round self-buffs), so accrual is correct.
+ *
+ * The CR gate evaluates `actor.turnsTaken % period === 0` at DRAIN time. `turnsTaken` is bumped at
+ * the focus's turn-start (engine.ts ~3742) and the focus takes exactly ONE turn per round, so on
+ * round r the focus's `turnsTaken === r`. Hence the proc banks +1 whenever `r % period === 0`.
+ *
+ * Per-turn cast-path cadence (runPlayerTurn): on a turn where `charges >= chargeCount` the focus
+ * fires its CHARGED skill and `advanceChargeCadence` RESETS charges to 0; otherwise it fires ACTIVE
+ * and `advanceChargeCadence` adds the +1/turn BASELINE. The CR proc (when it fires that round) adds
+ * a further +1, all capped at `chargeCount`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { buildEquipmentAbilities } from '../../abilities/buildEquipmentAbilities';
+import { simulateChronoReaver } from '../../calculators/chronoReaver';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { GearPiece } from '../../../types/gear';
+import type { Ship } from '../../../types/ship';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
+
+// ─── Real implant resolution ──────────────────────────────────────────────────────
+// Resolve the Chrono Reaver ability from the SAME path simulateBattle uses: a Ship with a
+// CHRONO_REAVER implant gear piece, through buildEquipmentAbilities. This is the genuine
+// implant→ability output (Task 1), not a hand-rolled duplicate.
+
+function makeShip(over: Partial<Ship>): Ship {
+    return {
+        id: 'cr-ship',
+        name: 'Chrono Reaver Carrier',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'ATTACKER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        ...over,
+    } as Ship;
+}
+
+function makePiece(over: Partial<GearPiece>): GearPiece {
+    return {
+        id: 'piece-1',
+        slot: 'weapon',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: null,
+        ...over,
+    } as GearPiece;
+}
+
+/** Build the Chrono Reaver ability for a rarity via the real implant resolution path. */
+function resolveChronoReaver(rarity: 'epic' | 'legendary'): Ability {
+    const piece = makePiece({ id: 'cr-implant', rarity, setBonus: 'CHRONO_REAVER' });
+    const ship = makeShip({ implants: { implant_major: 'cr-implant' } });
+    const abilities = buildEquipmentAbilities(ship, (id) =>
+        id === 'cr-implant' ? piece : undefined
+    );
+    if (abilities.length !== 1) {
+        throw new Error(
+            `expected exactly 1 resolved Chrono Reaver ability, got ${abilities.length}`
+        );
+    }
+    return abilities[0];
+}
+
+// ─── Ability + enemy fixtures ───────────────────────────────────────────────────────
+
+const damage = (multiplier: number, id: string): Ability => ({
+    id,
+    type: 'damage',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'damage', multiplier },
+});
+
+/** A cast-path self-charge gain: fires on-cast (active turn) so it MUST ride the active slot via
+ *  `activeExtra`. Models a native +amount/active-turn source layered ON TOP of the +1/turn baseline. */
+const castPathSelfChargeGain = (amount: number, id: string): Ability => ({
+    id,
+    type: 'charge',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'charge', amount },
+});
+
+/** A passive, charge-less dummy/sink enemy: slow (speed 40, acts AFTER the focus), tiny attack,
+ *  no charged slot → it just basic-attacks each turn. It carries no every-n-turns ability, so its
+ *  own turnsTaken bump is inert. Present only so the run is a real two-side battle (the focus's CR
+ *  end-of-turn intent banks at a later drain within the round, per the timing note above). */
+const dummySink = (): EnemyAttacker => ({
+    id: 'e-sink',
+    stats: { attack: 1, crit: 0, critDamage: 0, speed: 40 },
+    chargeCount: 0,
+    startCharged: false,
+    shipSkills: {
+        slots: [{ slot: 'active', abilities: [damage(1, 'es-a')] }],
+    } as ShipSkills,
+});
+
+// ─── Player / engine input ────────────────────────────────────────────────────────
+
+/** A charged player focus (id 'attacker', speed 100 → acts BEFORE the sink). active 50% / charged
+ *  400% so a charged cast is plainly distinguishable from an active one. Huge HP pools so nothing
+ *  dies and every round is observable. The under-test charge ability(ies) ride the passive slot. */
+const buildInput = (opts: {
+    chargeCount: number;
+    numRounds: number;
+    startCharged?: boolean;
+    passiveAbilities?: Ability[];
+    activeExtra?: Ability[];
+}): CombatEngineInput => {
+    const slots: ShipSkills['slots'] = [
+        { slot: 'active', abilities: [damage(50, 'p-a'), ...(opts.activeExtra ?? [])] },
+        { slot: 'charged', abilities: [damage(400, 'p-c')] },
+    ];
+    if (opts.passiveAbilities && opts.passiveAbilities.length) {
+        slots.push({ slot: 'passive', abilities: opts.passiveAbilities });
+    }
+    return {
+        attack: 1000,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: opts.chargeCount,
+        shipSkills: { slots },
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: opts.numRounds,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: true,
+        startCharged: opts.startCharged ?? false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 100,
+        healTargetId: 'attacker',
+        enemyAttackers: [dummySink()],
+    };
+};
+
+/** Convenience: the per-round (action-initial, charges) ledger for the focus. */
+const ledger = (r: ReturnType<typeof runCombat>): Array<[string, number]> =>
+    r.rounds.map((x) => [x.action, x.charges]);
+
+// ─── 1. Legendary cadence (period 2) ────────────────────────────────────────────────
+
+describe('Chrono Reaver — legendary cadence (every 2nd own turn)', () => {
+    it('procs on turnsTaken % 2 === 0 (rounds 2,4,6); pins the exact per-round charge ledger', () => {
+        // chargeCount 8 so the bar fills slowly and the cadence is visible across 8 rounds.
+        // Baseline = +1 each ACTIVE turn (advanceChargeCadence); CR adds a further +1 when r%2===0.
+        //
+        // Per-round ledger (focus turnsTaken === round; CR banks within the SAME round per the
+        // timing note — the end-of-turn intent drains at the sink's post-action drain / round-end):
+        //   R1 (t1): active, adv 0→1, CR? 1%2≠0 no            → charges 1
+        //   R2 (t2): active, adv 1→2, CR? 2%2=0 +1            → charges 3
+        //   R3 (t3): active, adv 3→4, CR? no                  → charges 4
+        //   R4 (t4): active, adv 4→5, CR? +1                  → charges 6
+        //   R5 (t5): active, adv 6→7, CR? no                  → charges 7
+        //   R6 (t6): active, adv 7→8 (=cap), CR? +1 capped    → charges 8  (proc wasted by cap)
+        //   R7 (t7): charges 8≥8 → CHARGED, reset 0, CR? no   → charges 0
+        //   R8 (t8): active, adv 0→1, CR? +1                  → charges 2
+        const cr = resolveChronoReaver('legendary');
+        const result = runCombat(
+            buildInput({ chargeCount: 8, numRounds: 8, passiveAbilities: [cr] })
+        );
+
+        expect(ledger(result)).toEqual([
+            ['active', 1],
+            ['active', 3],
+            ['active', 4],
+            ['active', 6],
+            ['active', 7],
+            ['active', 8],
+            ['charged', 0],
+            ['active', 2],
+        ]);
+
+        // No-implant baseline: pure +1/turn cadence — charged fires one round LATER (R8 vs R7).
+        // The CR proc count by R6 (3 procs: R2,R4,R6) advances the bar 3 ahead of baseline, pulling
+        // the first charged cast from round 9 (baseline would reach 8 at R8 → charged R9) to round 7.
+        const baseline = runCombat(buildInput({ chargeCount: 8, numRounds: 8 }));
+        expect(ledger(baseline)).toEqual([
+            ['active', 1],
+            ['active', 2],
+            ['active', 3],
+            ['active', 4],
+            ['active', 5],
+            ['active', 6],
+            ['active', 7],
+            ['active', 8],
+        ]);
+
+        // Direct cadence-advantage signal: the CR focus has fired its charged skill by R8; the
+        // no-implant baseline has NOT yet (it only reaches a full bar at R8 → charged on R9).
+        const crChargedRounds = result.rounds
+            .filter((x) => x.action === 'charged')
+            .map((x) => x.round);
+        const baseChargedRounds = baseline.rounds
+            .filter((x) => x.action === 'charged')
+            .map((x) => x.round);
+        expect(crChargedRounds).toEqual([7]);
+        expect(baseChargedRounds).toEqual([]); // baseline never reaches the cap within 8 rounds
+    });
+});
+
+// ─── 2. Epic cadence (period 3) ──────────────────────────────────────────────────────
+
+describe('Chrono Reaver — epic cadence (every 3rd own turn)', () => {
+    it('procs on turnsTaken % 3 === 0 (rounds 3,6); pins the exact per-round charge ledger', () => {
+        // chargeCount 8, baseline +1/active turn, CR +1 when r%3===0.
+        //   R1 (t1): active, adv 0→1, CR? 1%3≠0 no   → 1
+        //   R2 (t2): active, adv 1→2, CR? no         → 2
+        //   R3 (t3): active, adv 2→3, CR? 3%3=0 +1   → 4
+        //   R4 (t4): active, adv 4→5, CR? no         → 5
+        //   R5 (t5): active, adv 5→6, CR? no         → 6
+        //   R6 (t6): active, adv 6→7, CR? 6%3=0 +1   → 8
+        //   R7 (t7): charges 8≥8 → CHARGED, reset 0  → 0
+        //   R8 (t8): active, adv 0→1, CR? no         → 1
+        const cr = resolveChronoReaver('epic');
+        const result = runCombat(
+            buildInput({ chargeCount: 8, numRounds: 8, passiveAbilities: [cr] })
+        );
+
+        expect(ledger(result)).toEqual([
+            ['active', 1],
+            ['active', 2],
+            ['active', 4],
+            ['active', 5],
+            ['active', 6],
+            ['active', 8],
+            ['charged', 0],
+            ['active', 1],
+        ]);
+
+        // Epic procs less often than legendary (2 procs by R6 vs 3) → its first charged cast is
+        // still pulled forward of the no-implant baseline (R7 vs R9), but one round LATER than the
+        // legendary fixture would be at the same chargeCount — the only difference is the period.
+        const chargedRounds = result.rounds
+            .filter((x) => x.action === 'charged')
+            .map((x) => x.round);
+        expect(chargedRounds).toEqual([7]);
+    });
+});
+
+// ─── 3. Wasted proc at full charge ───────────────────────────────────────────────────
+
+describe('Chrono Reaver — wasted proc at full charge', () => {
+    it('a proc on an already-full bar is dropped by the cap (no extra cast, no negative effect)', () => {
+        // chargeCount 2, period 2 (legendary). The cap exposes a wasted proc cleanly:
+        //   R1 (t1): active, adv 0→1, CR? 1%2≠0 no              → 1
+        //   R2 (t2): active 1<2, adv 1→2 (=cap), CR? 2%2=0 +1   → 2  ← capped: PROC WASTED
+        //   R3 (t3): charges 2≥2 → CHARGED, reset 0, CR? no     → 0
+        //   R4 (t4): active, adv 0→1, CR? 4%2=0 +1              → 2  ← proc on a NON-full bar lands
+        const cr = resolveChronoReaver('legendary');
+        const result = runCombat(
+            buildInput({ chargeCount: 2, numRounds: 4, passiveAbilities: [cr] })
+        );
+
+        expect(ledger(result)).toEqual([
+            ['active', 1],
+            ['active', 2], // R2 proc fires on a full (2/2) bar → dropped by the min(.., chargeCount) cap
+            ['charged', 0],
+            ['active', 2],
+        ]);
+
+        // Proof the R2 proc was a NO-OP: the no-implant baseline reaches the SAME R2 value (2) and
+        // fires its charged skill on the SAME round (R3). The wasted proc neither advanced the bar
+        // past the cap (no negative / no overflow) nor pulled the charged cast earlier than baseline.
+        const baseline = runCombat(buildInput({ chargeCount: 2, numRounds: 4 }));
+        expect(ledger(baseline)).toEqual([
+            ['active', 1],
+            ['active', 2], // identical to CR at R2 → R2 proc had zero net effect
+            ['charged', 0], // both fire charged on R3 → CR caused no extra/earlier cast
+            ['active', 1], // baseline R4 = 1 (no proc); CR R4 = 2 → the R4 proc (non-full bar) DID land
+        ]);
+
+        // The two runs DIVERGE only at R4 (CR 2 vs baseline 1): the R4 proc lands because the bar is
+        // not full there, confirming the implant otherwise works — it is ONLY the full-bar R2 proc
+        // that is wasted. Charges never go negative or exceed the cap in either run.
+        expect(result.rounds[1].charges).toBe(baseline.rounds[1].charges); // R2: wasted proc → equal
+        expect(result.rounds[3].charges).toBeGreaterThan(baseline.rounds[3].charges); // R4: effective
+        for (const row of result.rounds) {
+            expect(row.charges).toBeGreaterThanOrEqual(0); // never negative
+            expect(row.charges).toBeLessThanOrEqual(2); // never exceeds the cap
+        }
+    });
+});
+
+// ─── 4. Stacking with the ship's own parsed self-charge source ────────────────────────
+
+describe('Chrono Reaver — stacking with a parsed self-charge source', () => {
+    it('layers additively atop baseline + own-source (Phase-0 guard prevents baseline double-count)', () => {
+        // The focus ALSO carries a native +1/active-turn self-charge gain (cast path) PLUS Chrono
+        // Reaver (legendary, period 2). Per ACTIVE turn the bar advances by:
+        //   baseline +1 (advanceChargeCadence) + own-source +1 = +2, and a further +1 on CR procs.
+        // The Phase-0 baseline-double-count guard ensures the +1/turn baseline is applied ONCE
+        // (advanceChargeCadence), so own-source adds +1 (not +2) on top of it.
+        //
+        // chargeCount 8, period 2:
+        //   R1 (t1): active, adv 0→1, own +1 →2, CR? 1%2≠0 no    → 2
+        //   R2 (t2): active 2<8, adv 2→3, own +1 →4, CR? +1      → 5
+        //   R3 (t3): active 5<8, adv 5→6, own +1 →7, CR? no      → 7
+        //   R4 (t4): active 7<8, adv 7→8, own +1 →8(cap), CR? +1 capped → 8
+        //   R5 (t5): charges 8≥8 → CHARGED, reset 0, CR? no      → 0
+        //   R6 (t6): active, adv 0→1, own +1 →2, CR? +1          → 3
+        //   R7 (t7): active 3<8, adv 3→4, own +1 →5, CR? no      → 5
+        //   R8 (t8): active 5<8, adv 5→6, own +1 →7, CR? +1      → 8
+        const cr = resolveChronoReaver('legendary');
+        const own = castPathSelfChargeGain(1, 'p-own-charge');
+        const stacked = runCombat(
+            // activeExtra: cast-path charge must ride the active slot so it fires on each active turn.
+            buildInput({ chargeCount: 8, numRounds: 8, passiveAbilities: [cr], activeExtra: [own] })
+        );
+
+        expect(ledger(stacked)).toEqual([
+            ['active', 2],
+            ['active', 5],
+            ['active', 7],
+            ['active', 8],
+            ['charged', 0],
+            ['active', 3],
+            ['active', 5],
+            ['active', 8],
+        ]);
+
+        // ADDITIVITY PROOF: a control with the SAME own-source but NO Chrono Reaver advances by
+        // baseline+own = +2/active turn (NO double-counted baseline → 2,4,6,8 not 3,6,...). On each
+        // CR proc round (R2,R4,R6,R8) the stacked run is exactly +1 ahead of this control, until the
+        // cap clamps both — i.e. CR layers additively on top of baseline+own.
+        // activeExtra: same cast-path placement, no CR — isolates the baseline+own contribution.
+        const ownOnly = runCombat(buildInput({ chargeCount: 8, numRounds: 8, activeExtra: [own] }));
+        expect(ledger(ownOnly)).toEqual([
+            ['active', 2], // +2/turn: baseline+own (NOT +3 — baseline counted once)
+            ['active', 4],
+            ['active', 6],
+            ['active', 8],
+            ['charged', 0], // bar full at R4 → charged on R5 (same as stacked)
+            ['active', 2],
+            ['active', 4],
+            ['active', 6],
+        ]);
+
+        // Per-proc-round additive layering (stacked = ownOnly + 1 on proc rounds, until cap):
+        //   R2: ownOnly 4 + CR 1 = 5 ✓   R6: ownOnly 2 + CR 1 = 3 ✓   R8: ownOnly 6 + CR 1 = ... 8 (capped)
+        expect(stacked.rounds[1].charges).toBe(ownOnly.rounds[1].charges + 1); // R2 proc: +1
+        expect(stacked.rounds[5].charges).toBe(ownOnly.rounds[5].charges + 1); // R6 proc: +1
+        // R8 proc: ownOnly 6 + 1 = 7 would be the uncapped value, but the stacked run's earlier
+        // procs put it at 8 (the cap) — additive then clamped. Assert it is the cap and ≥ ownOnly+1.
+        expect(stacked.rounds[7].charges).toBe(8);
+        expect(stacked.rounds[7].charges).toBeGreaterThanOrEqual(ownOnly.rounds[7].charges + 1);
+
+        // Non-proc rounds: stacked equals ownOnly + (accumulated CR lead carried forward). The
+        // baseline-double-count guard is what keeps ownOnly at +2/turn (not +3) — if the baseline
+        // were double-applied, ownOnly R1 would be 3, not 2.
+        expect(ownOnly.rounds[0].charges).toBe(2); // guard: baseline applied exactly once
+    });
+});
+
+// ─── 5. Parity vs the standalone single-ship chronoReaver calculator ───────────────────
+
+describe('Chrono Reaver — parity vs standalone chronoReaver calc', () => {
+    /**
+     * The standalone `simulateChronoReaver` (src/utils/calculators/chronoReaver.ts) is a single-ship
+     * loop with NO enemy/targeting/crit — it models exactly the +1/turn baseline + the CR proc
+     * schedule. The engine models a full battle, so absolute damage is NOT comparable. What IS
+     * comparable is the CHARGED-CAST CADENCE: both bank +1/active-turn and add +1 on the same proc
+     * schedule (legendary → every 2nd, epic → every 3rd), so the set of rounds on which the bar is
+     * full and a charged skill fires must be IDENTICAL.
+     *
+     * Alignment of the two clocks:
+     *  - standalone: 1-based `round`, proc on `round % period === 0`.
+     *  - engine: focus takes one turn per round; `turnsTaken` is bumped at turn-start so on round r
+     *    `turnsTaken === r`, and the CR gate `turnsTaken % period === 0` fires on the same rounds.
+     *  - standalone per-round order (cast-then-proc) matches the engine's per-turn order
+     *    (advanceChargeCadence baseline / charged-reset, THEN the end-of-turn CR proc banked within
+     *    the same round) — see the CRITICAL TIMING note at the top of this file.
+     */
+
+    /** Engine: 1-based rounds where the focus fired its CHARGED skill. */
+    const engineChargedRounds = (r: ReturnType<typeof runCombat>): number[] =>
+        r.rounds.filter((x) => x.action === 'charged').map((x) => x.round);
+
+    /** Standalone: 1-based rounds where the loop chose the charged action. */
+    const standaloneChargedRounds = (res: ReturnType<typeof simulateChronoReaver>): number[] =>
+        res.rounds.filter((x) => x.action === 'charged').map((x) => x.round);
+
+    const RARITIES: Array<'epic' | 'legendary'> = ['epic', 'legendary'];
+    const CHARGES_REQUIRED = [2, 3, 4];
+    const NUM_ROUNDS = 12; // long enough that every matrix cell reaches at least one charged cast.
+
+    const matrix = RARITIES.flatMap((crRarity) =>
+        CHARGES_REQUIRED.map((chargesRequired) => ({ crRarity, chargesRequired }))
+    );
+
+    it.each(matrix)(
+        'charged-cast cadence matches standalone (rarity=$crRarity, chargesRequired=$chargesRequired)',
+        ({ crRarity, chargesRequired }) => {
+            const standalone = simulateChronoReaver({
+                chargesRequired,
+                crRarity,
+                activeSkillPercent: 50,
+                chargedSkillPercent: 400,
+                rounds: NUM_ROUNDS,
+            });
+            const cr = resolveChronoReaver(crRarity);
+            const engine = runCombat(
+                buildInput({
+                    chargeCount: chargesRequired,
+                    numRounds: NUM_ROUNDS,
+                    passiveAbilities: [cr],
+                })
+            );
+
+            const expected = standaloneChargedRounds(standalone);
+            const actual = engineChargedRounds(engine);
+
+            // Sanity: the matrix is chosen so at least one charged cast occurs in each cell — if this
+            // ever trips, the comparison would be vacuously true and must be revisited.
+            expect(expected.length).toBeGreaterThan(0);
+            expect(actual).toEqual(expected);
+        }
+    );
+});
+
+// ─── 6. Stasis suppression (Charge Phase 2/3 Task 4) ─────────────────────────────────
+//
+// Full-fidelity decision (LOCKED): a unit that is turn-blocked (Stasis OR Disable) on a
+// periodic-proc turn banks NO periodic charge for that turn — matching the +1/turn baseline,
+// which is itself gated behind `!isTurnBlocked` (advanceChargeCadence). This is ALREADY
+// structural — NO new gating code is needed. The Chrono Reaver `end-of-turn` charge is a
+// REACTIVE intent carrying `intent.ownerId`; on a blocked owner's turn the §4.4 reactive-intent
+// drain filter (engine.ts ~3403: `if (isTurnBlocked(intent.ownerId)) continue;`) DROPS that
+// intent before `executeIntent` ever applies the charge. Listeners only enqueue (pure), so a
+// dropped intent leaves no partial state. Meanwhile `turnsTaken` stays MONOTONIC (bumped even on
+// skipped turns, engine.ts ~3742), so the cadence does not spuriously re-fire on the frozen value
+// — the periodic proc loses the skipped tick and resumes on the original residue (the next
+// even own-turn for a legendary, period-2 unit).
+describe('Chrono Reaver — stasis suppression (periodic proc dropped on turn-blocked turns)', () => {
+    // A board-positioned, killable stasis bot: speed 300 → acts BEFORE the killer (200) and the
+    // focus (100), so it lands Stasis(3) on the front player (the focus at M4) at the very head of
+    // round 1. hp 1 → the killer destroys it the SAME round, so Stasis is applied EXACTLY ONCE and
+    // is NOT re-applied (the focus recovers naturally once the duration expires). hacking 200 vs the
+    // focus's default security → landing chance 1.0 (mirrors stasis.test.ts).
+    const POS_FRONT: Position = 'M4';
+    const parsedFront: ParsedTarget = { raw: 'front', side: 'enemy', selection: 'front' };
+    const basePattern: ParsedPattern = { raw: 'base', shape: 'base', range: 0, modifiers: {} };
+
+    const stasisBot = (turns: number): EnemyAttacker =>
+        ({
+            id: 'stasis-bot',
+            position: POS_FRONT,
+            target: parsedFront,
+            pattern: basePattern,
+            stats: {
+                attack: 1,
+                crit: 0,
+                critDamage: 0,
+                defence: 0,
+                hp: 1, // killed by the killer in round 1 → Stasis applied once, never re-applied
+                speed: 300, // acts before killer (200) and focus (100)
+                security: 0,
+                hacking: 200, // vs focus default security → Stasis lands (chance 1.0)
+            },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active',
+                        abilities: [
+                            damage(1, 'sb-dmg'),
+                            {
+                                id: 'sb-stasis',
+                                type: 'debuff',
+                                target: 'enemy',
+                                trigger: 'on-cast',
+                                conditions: [],
+                                config: {
+                                    type: 'debuff',
+                                    buffName: 'Stasis',
+                                    application: 'inflict',
+                                    duration: turns,
+                                    stacks: 1,
+                                    isStackable: false,
+                                    parsedEffects: {},
+                                },
+                            } as Ability,
+                        ],
+                    },
+                ],
+            } as ShipSkills,
+        }) as EnemyAttacker;
+
+    // A walked team ally that one-shots the stasis bot in round 1 (speed 200 → after the bot,
+    // before the focus; attack 10000 >> bot hp 1). Mirrors the `killer` pattern in stasis.test.ts.
+    const killer = (): TeamActor => ({
+        id: 'killer',
+        speed: 200,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position: 'M3',
+        target: parsedFront,
+        pattern: basePattern,
+        walk: {
+            shipSkills: { slots: [{ slot: 'active', abilities: [damage(100, 'k-dmg')] }] },
+            stats: {
+                attack: 10000,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp: 1_000_000_000,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    });
+
+    // The focus (legendary CR, period 2, chargeCount 8) positioned at M4 so the stasis bot's
+    // `front` target resolves to it. Mirrors buildInput but adds board position + the
+    // killer ally + the stasis bot (buildInput hardcodes a non-positional dummy sink, so this
+    // block builds its own input around the same shared damage/CR/runCombat/ledger helpers).
+    const buildStasisInput = (opts: {
+        passiveAbilities: Ability[];
+        enemyAttackers: EnemyAttacker[];
+        teamActors?: TeamActor[];
+    }): CombatEngineInput => ({
+        attack: 1000,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 8,
+        shipSkills: {
+            slots: [
+                { slot: 'active', abilities: [damage(50, 'p-a')] },
+                { slot: 'charged', abilities: [damage(400, 'p-c')] },
+                { slot: 'passive', abilities: opts.passiveAbilities },
+            ],
+        },
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 8,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: true,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 100,
+        healTargetId: 'attacker',
+        position: POS_FRONT,
+        target: parsedFront,
+        pattern: basePattern,
+        ...(opts.teamActors ? { teamActors: opts.teamActors } : {}),
+        enemyAttackers: opts.enemyAttackers,
+    });
+
+    it('banks NO periodic charge on the turn-blocked proc turn; the next proc lands on the original residue', () => {
+        // Legendary CR (period 2, chargeCount 8). A Stasis(3) lands on the focus at the head of
+        // round 1 (the speed-300 bot acts first), so the focus is turn-blocked across rounds 1–3 —
+        // spanning the round-2 proc turn (t2, 2 % 2 === 0). The bot is killed in round 1, so Stasis
+        // is never re-applied and the focus recovers from round 4.
+        //
+        // Per-turn ledger (turnsTaken bumps UNCONDITIONALLY at turn-start, even on skipped turns →
+        // turnsTaken === round; advanceChargeCadence's +1 baseline AND the CR proc are BOTH gated on
+        // !isTurnBlocked / the §4.4 drain filter, so a blocked turn banks neither):
+        //   R1 (t1): turnsTaken 0→1. Stasis(3) → turn-blocked → SKIP. No baseline. Not a proc turn.
+        //            Post-Turn: Stasis 3→2.                                          → charges 0
+        //   R2 (t2): turnsTaken 1→2. Stasis(2) → turn-blocked → SKIP. No baseline.
+        //            PROC TURN (2%2=0): the end-of-turn CR intent is enqueued by the turn-ended bus
+        //            event. Within the actor's OWN turn, drainIntents/drainEnemyIntents fire BEFORE
+        //            turn-ended is emitted, so the queue was empty at that mid-turn drain and nothing
+        //            was dropped then. The intent is instead dropped by a SUBSEQUENT drain pass (the
+        //            next actor's post-action drain, or the round-end drain) — at that point Stasis has
+        //            already decremented (3→2→1 here) but is still ≥1, so the owner remains
+        //            turn-blocked and the §4.4 filter drops it.
+        //            // ~engine.ts:3403
+        //            Post-Turn: 2→1.
+        //                                                                              → charges 0  ← proc SUPPRESSED
+        //   R3 (t3): turnsTaken 2→3. Stasis(1) → turn-blocked → SKIP. Not a proc turn.
+        //            Post-Turn: Stasis 1→0 → EXPIRED.                                  → charges 0
+        //   R4 (t4): turnsTaken 3→4. NOT blocked → acts. baseline 0→1. PROC (4%2=0) +1 → charges 2
+        //   R5 (t5): active, adv 2→3, no proc                                          → charges 3
+        //   R6 (t6): active, adv 3→4, PROC +1                                          → charges 5
+        //   R7 (t7): active, adv 5→6, no proc                                          → charges 6
+        //   R8 (t8): active, adv 6→7, PROC +1                                          → charges 8
+        const cr = resolveChronoReaver('legendary');
+        let isStasisedTap: ((id: string) => boolean) | undefined;
+        const stasised = runCombat({
+            ...buildStasisInput({
+                passiveAbilities: [cr],
+                teamActors: [killer()],
+                enemyAttackers: [stasisBot(3)],
+            }),
+            __testTapIsStasised: (fn) => {
+                isStasisedTap = fn;
+            },
+        });
+
+        expect(ledger(stasised)).toEqual([
+            ['active', 0], // R1: turn-blocked skip
+            ['active', 0], // R2: turn-blocked skip — PROC SUPPRESSED (intent dropped at drain)
+            ['active', 0], // R3: turn-blocked skip
+            ['active', 2], // R4: recovered — proc lands on the ORIGINAL even-turn residue (t4)
+            ['active', 3],
+            ['active', 5], // R6: proc (t6)
+            ['active', 6],
+            ['active', 8], // R8: proc (t8)
+        ]);
+
+        // Stasis expired by the end of the run (applied once, never re-applied).
+        expect(isStasisedTap?.('attacker')).toBe(false);
+
+        // CONTROL: the SAME legendary CR with NO stasis (the un-stasised legendary run). Its proc
+        // fires on every even turn from t2, so by R2 it is already AHEAD of the stasised run.
+        const control = runCombat(
+            buildInput({ chargeCount: 8, numRounds: 8, passiveAbilities: [cr] })
+        );
+        expect(ledger(control)).toEqual([
+            ['active', 1],
+            ['active', 3], // R2 proc LANDED (control) vs 0 (stasised) — the suppressed proc
+            ['active', 4],
+            ['active', 6],
+            ['active', 7],
+            ['active', 8],
+            ['charged', 0],
+            ['active', 2],
+        ]);
+
+        // SUPPRESSION SIGNAL: from the skipped proc turn (R2) up to — but not including — the round
+        // the control fires its charged skill (R7, where it RESETS to 0), the stasised run has
+        // STRICTLY FEWER charges than the control. The dropped R2 proc plus the two surrounding
+        // skipped baselines (R1,R3) put it behind and it never recovers the lost ticks. (After the
+        // control's R7 reset the raw counts cross — the control banks from 0 again — so the window
+        // is the pre-reset rounds R2–R6, which is where the suppression is observable.)
+        for (let i = 1; i <= 5; i++) {
+            expect(stasised.rounds[i].charges).toBeLessThan(control.rounds[i].charges);
+        }
+        // Specifically the skipped proc turn R2: control banked the proc (3), stasised banked nothing (0).
+        expect(stasised.rounds[1].charges).toBe(0);
+        expect(control.rounds[1].charges).toBe(3);
+
+        // MONOTONIC CADENCE: the next proc after the suppressed R2 lands on R4 (t4 — the next even
+        // own-turn = the ORIGINAL residue), NOT shifted earlier to R3. turnsTaken stayed monotonic
+        // through the skips (1,2,3,4), so the every-2nd-turn gate did not re-fire on a frozen value.
+        // R3 (odd t3) banks 0 (skip + non-proc); R4 (even t4) is the first post-recovery proc (0→1
+        // baseline +1 proc = 2).
+        expect(stasised.rounds[2].charges).toBe(0); // R3: no early proc
+        expect(stasised.rounds[3].charges).toBe(2); // R4: proc on the original even-turn residue
+    });
+});

--- a/src/utils/combat/__tests__/cobaltStartOfTurnCharge.integration.test.ts
+++ b/src/utils/combat/__tests__/cobaltStartOfTurnCharge.integration.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Integration: Cobalt start-of-turn full-HP self-charge (Charge Phase 2/3 Task 9).
+ *
+ * Cobalt's passive text "adds 1 charge to its charged skill at the start of the turn if it is at
+ * full HP" is parsed (Tasks 6-8) into a charge ability:
+ *   { type:'charge', target:'self', trigger:'start-of-turn',
+ *     conditions:[{ subject:'hp-threshold', derivable:true, hpComparator:'above',
+ *                   hpPercent:99, hpSubject:'self' }],
+ *     config:{ type:'charge', amount:1 } }
+ *
+ * The ability under test is RESOLVED FROM THE REAL PARSER PATH: we hand `buildShipAbilities` a Ship
+ * whose `firstPassiveSkillText` is Cobalt's real corpus string and pull the start-of-turn charge
+ * ability out of the built passive slot — so the shape the engine runs is the parser's genuine
+ * output, not a hand-rolled copy (mirrors the Chrono Reaver goldens' implant-resolution discipline).
+ *
+ * We then run that ability through `runCombat` (the battle-sim engine) with a two-side roster (the
+ * Cobalt focus vs. an enemy attacker) and read the focus's per-round charge counts from
+ * `result.rounds[].charges` (the focus's END-OF-ROUND live charge counter) and
+ * `result.rounds[].action` ('active' | 'charged'). `simulateBattle`'s result surfaces damage/HP but
+ * NOT charge counts, so `runCombat` is the only entry point that can pin the per-round charge ledger
+ * (same reason the Chrono Reaver / Phase-1 charge goldens use it).
+ *
+ * ─── CRITICAL TIMING (baked into the Part 1 ledger) ───────────────────────────────────────────
+ * There is NO pre-action drain between the focus's `turn-started` and its action body. The
+ * `start-of-turn` charge intent is ENQUEUED on `turn-started` (triggers.ts) but DRAINS at the
+ * post-action point (~engine.ts:4648 / round-end). So Cobalt's +1 proc lands AFTER its own turn's
+ * cast decision (one-turn alignment) — within the SAME round, reflected in that round's reported
+ * `charges`. Charges carry forward across rounds, so accrual is correct. Net effect at full HP: the
+ * bar advances by +2 each active turn (baseline +1 from advanceChargeCadence, plus Cobalt's +1
+ * proc), so the charged skill fills ~twice as fast as a no-passive baseline.
+ *
+ * ─── SELF-HP LIVENESS (drives Part 2's approach) ──────────────────────────────────────────────
+ * The drain-time `hpSubject:'self'` gate reads `selfHpPctFor(ownerId)`. On the player side that
+ * closure returns LIVE HP (currentHp / maxHp * 100) ONLY for the heal-target actor, and 100 for
+ * every other owner (engine.ts ~1836). Because `buildInput` sets `healTargetId:'attacker'` (the
+ * focus IS the heal target), the focus's live HP IS threaded into its own gate — so a damaged focus
+ * genuinely flips the gate false. Part 2 therefore uses the PREFERRED live-HP approach (a): an
+ * enemy attacker that acts BEFORE the focus dents it below 99% every turn, and the proc is
+ * suppressed on every round (NOT the Arcane-Siege-style always-100 fallback (b)).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import { parseChargeGain } from '../../skillTextParser';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { Ship } from '../../../types/ship';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+// Cobalt's two real corpus passive strings. Buff names are wrapped in <unit-skill> tags exactly as
+// the game CSV stores them (the buff/effect parser reads buff names from those tags — an untagged
+// "Out. Damage Up II" is invisible to parseAllSkillEffects, so the corpus-faithful tagged form is
+// required for Part 3 to exercise the real swallow hazard).
+const COBALT_P1 =
+    'This Unit adds 1 charge to its <unit-skill>charged skill</unit-skill> at the start of the turn if it is at full HP.';
+const COBALT_P2 =
+    'This Unit adds 1 charge to its <unit-skill>charged skill</unit-skill> and gains ' +
+    '<unit-skill>Out. Damage Up II</unit-skill> for 1 turn at the start of the turn if it is at full HP.';
+
+// ─── Real parser resolution ───────────────────────────────────────────────────────
+// Resolve Cobalt's abilities from the SAME path production uses: a Ship carrying the passive text,
+// through buildShipAbilities. This is the genuine parser output (Tasks 6-8), not a hand-rolled copy.
+
+function makeShip(passiveText: string): Ship {
+    return {
+        id: 'cobalt',
+        name: 'Cobalt',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'ATTACKER',
+        baseStats: {} as Ship['baseStats'],
+        stats: [],
+        equipment: {},
+        implants: {},
+        refits: [],
+        firstPassiveSkillText: passiveText,
+    } as Ship;
+}
+
+/** Pull the passive-slot abilities buildShipAbilities produces from a Cobalt passive string. */
+function resolvePassiveAbilities(passiveText: string): Ability[] {
+    const skills = buildShipAbilities(makeShip(passiveText));
+    return skills.slots.find((s) => s.slot === 'passive')?.abilities ?? [];
+}
+
+/** The start-of-turn self-charge ability, resolved from the real parser path. */
+function resolveCobaltCharge(passiveText: string): Ability {
+    const charge = resolvePassiveAbilities(passiveText).find(
+        (a) => a.type === 'charge' && a.trigger === 'start-of-turn'
+    );
+    if (!charge) throw new Error('expected a start-of-turn charge ability from the Cobalt passive');
+    return charge;
+}
+
+// ─── Ability + enemy fixtures ───────────────────────────────────────────────────────
+
+const damage = (multiplier: number, id: string): Ability => ({
+    id,
+    type: 'damage',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'damage', multiplier },
+});
+
+/** A passive, charge-less dummy/sink enemy: slow (speed 40, acts AFTER the focus), tiny attack
+ *  (1) so it never meaningfully dents a 1e9-HP focus → the focus stays at full HP and Cobalt's
+ *  gate stays true. Present only so the run is a real two-side battle. */
+const dummySink = (): EnemyAttacker => ({
+    id: 'e-sink',
+    stats: { attack: 1, crit: 0, critDamage: 0, speed: 40 },
+    chargeCount: 0,
+    startCharged: false,
+    shipSkills: {
+        slots: [{ slot: 'active', abilities: [damage(1, 'es-a')] }],
+    } as ShipSkills,
+});
+
+/** A heavy hitter that acts BEFORE the focus (speed 200 > 100) and dents it below 99% every turn,
+ *  but never kills it: vs a 1,000,000-HP focus a 100% hit of attack 100000 removes ~100000/turn, so
+ *  over 6 rounds the focus drops to ~40% and lives the whole run. Drives Part 2's live-HP gate flip. */
+const heavyHitter = (): EnemyAttacker => ({
+    id: 'heavy',
+    stats: { attack: 100000, crit: 0, critDamage: 0, speed: 200, defence: 0, hp: 1_000_000_000 },
+    chargeCount: 0,
+    startCharged: false,
+    shipSkills: {
+        slots: [{ slot: 'active', abilities: [damage(100, 'hv-a')] }],
+    } as ShipSkills,
+});
+
+// ─── Player / engine input ────────────────────────────────────────────────────────
+
+/** A charged player focus (id 'attacker', speed 100). active 50% / charged 400% so a charged cast
+ *  is plainly distinguishable from an active one. `healTargetId:'attacker'` makes the focus its own
+ *  heal target so its live HP feeds the drain-time self hp-threshold gate. The under-test charge
+ *  ability rides the passive slot; `hp` and `enemyAttackers` are caller-tunable so the same builder
+ *  serves the full-HP (Part 1) and damaged (Part 2) scenarios. */
+const buildInput = (opts: {
+    chargeCount: number;
+    numRounds: number;
+    passiveAbilities?: Ability[];
+    hp?: number;
+    enemyAttackers?: EnemyAttacker[];
+}): CombatEngineInput => {
+    const slots: ShipSkills['slots'] = [
+        { slot: 'active', abilities: [damage(50, 'p-a')] },
+        { slot: 'charged', abilities: [damage(400, 'p-c')] },
+    ];
+    if (opts.passiveAbilities && opts.passiveAbilities.length) {
+        slots.push({ slot: 'passive', abilities: opts.passiveAbilities });
+    }
+    return {
+        attack: 1000,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: opts.chargeCount,
+        shipSkills: { slots },
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: opts.numRounds,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: true,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: opts.hp ?? 1_000_000_000,
+        speed: 100,
+        healTargetId: 'attacker',
+        enemyAttackers: opts.enemyAttackers ?? [dummySink()],
+    };
+};
+
+/** Convenience: the per-round (action, charges) ledger for the focus. */
+const ledger = (r: ReturnType<typeof runCombat>): Array<[string, number]> =>
+    r.rounds.map((x) => [x.action, x.charges]);
+
+// ─── Part 1: full-HP proc ─────────────────────────────────────────────────────────
+
+describe('Cobalt start-of-turn charge — full-HP proc', () => {
+    it('banks an EXTRA +1/turn beyond baseline; charged fills ~twice as fast', () => {
+        // chargeCount 8 so the cadence is visible across 8 rounds. At full HP the gate is always
+        // true, so the bar advances by +2 each active turn: baseline +1 (advanceChargeCadence) PLUS
+        // Cobalt's +1 proc (banked within the same round per the one-turn-alignment timing note).
+        //
+        // Per-round ledger (focus turnsTaken === round; proc banks within the SAME round):
+        //   R1 (t1): active, baseline 0→1, proc +1            → charges 2
+        //   R2 (t2): active 2<8, baseline 2→3, proc +1        → charges 4
+        //   R3 (t3): active 4<8, baseline 4→5, proc +1        → charges 6
+        //   R4 (t4): active 6<8, baseline 6→7, proc +1 (= cap, fills bar exactly)  → charges 8
+        //   R5 (t5): charges 8≥8 → CHARGED, reset 0, proc +1  → charges 1
+        //   R6 (t6): active 1<8, baseline 1→2, proc +1        → charges 3
+        //   R7 (t7): active 3<8, baseline 3→4, proc +1        → charges 5
+        //   R8 (t8): active 5<8, baseline 5→6, proc +1        → charges 7
+        const charge = resolveCobaltCharge(COBALT_P1);
+        const proc = runCombat(
+            buildInput({ chargeCount: 8, numRounds: 8, passiveAbilities: [charge] })
+        );
+
+        expect(ledger(proc)).toEqual([
+            ['active', 2],
+            ['active', 4],
+            ['active', 6],
+            ['active', 8],
+            ['charged', 1],
+            ['active', 3],
+            ['active', 5],
+            ['active', 7],
+        ]);
+
+        // No-passive baseline: pure +1/turn cadence — it only just reaches the cap on R8 (→ charged
+        // R9, outside the window), so it NEVER fires a charged cast in 8 rounds.
+        const base = runCombat(buildInput({ chargeCount: 8, numRounds: 8 }));
+        expect(ledger(base)).toEqual([
+            ['active', 1],
+            ['active', 2],
+            ['active', 3],
+            ['active', 4],
+            ['active', 5],
+            ['active', 6],
+            ['active', 7],
+            ['active', 8],
+        ]);
+
+        // Differential: Cobalt fires its charged skill by R5 (the +2/turn fill reaches 8 at R4 →
+        // charged R5); the no-passive baseline fires none within 8 rounds. The proc roughly doubles
+        // the fill rate, exactly as the parsed start-of-turn +1 should.
+        const procCharged = proc.rounds.filter((x) => x.action === 'charged').map((x) => x.round);
+        const baseCharged = base.rounds.filter((x) => x.action === 'charged').map((x) => x.round);
+        expect(procCharged).toEqual([5]);
+        expect(baseCharged).toEqual([]);
+    });
+});
+
+// ─── Part 2: damaged → no proc (PREFERRED live-HP approach (a)) ──────────────────────
+
+describe('Cobalt start-of-turn charge — damaged focus suppresses the proc (live-HP)', () => {
+    it('a focus below 99% HP banks only the +1/turn baseline (the full-HP gate flips false)', () => {
+        // APPROACH (a), the PREFERRED live-HP path. The focus is its own heal target
+        // (healTargetId:'attacker'), so selfHpPctFor returns its LIVE HP% to the drain-time
+        // hp-threshold gate. A heavy enemy attacker (speed 200) acts BEFORE the focus (speed 100)
+        // each round, so by the focus's turn-start its HP is already < 99% — INCLUDING round 1 (the
+        // attacker's round-1 hit lands before the focus's first turn). The gate (hp-threshold ABOVE
+        // 99 self) is therefore false on EVERY turn, so Cobalt's +1 proc never fires and the bar
+        // advances by only the +1/turn baseline (which is NOT HP-gated):
+        //   R1..R6: active, baseline +1 each, proc SUPPRESSED → 1,2,3,4,5,6
+        // (vs the full-HP control's 2,4,6,... — the +1 proc is exactly the missing increment.)
+        const charge = resolveCobaltCharge(COBALT_P1);
+        const damaged = runCombat(
+            buildInput({
+                chargeCount: 8,
+                numRounds: 6,
+                passiveAbilities: [charge],
+                hp: 1_000_000, // large pool: dented below 99% but never killed across 6 rounds
+                enemyAttackers: [heavyHitter()],
+            })
+        );
+
+        expect(ledger(damaged)).toEqual([
+            ['active', 1],
+            ['active', 2],
+            ['active', 3],
+            ['active', 4],
+            ['active', 5],
+            ['active', 6],
+        ]);
+
+        // The proc is missing on EVERY round: a full-HP control (same charge, same chargeCount, but
+        // the harmless dummy sink) banks +2/turn from R1. The damaged run is strictly behind from R1
+        // onward — the gap is exactly the suppressed +1/turn proc.
+        const control = runCombat(
+            buildInput({ chargeCount: 8, numRounds: 6, passiveAbilities: [charge] })
+        );
+        expect(ledger(control)).toEqual([
+            ['active', 2],
+            ['active', 4],
+            ['active', 6],
+            ['active', 8],
+            ['charged', 1],
+            ['active', 3],
+        ]);
+        for (let i = 0; i < 4; i++) {
+            // R1..R4 (pre-control-reset window): damaged strictly fewer charges than the full-HP run.
+            expect(damaged.rounds[i].charges).toBeLessThan(control.rounds[i].charges);
+        }
+
+        // Structural sanity: the resolved ability really carries the full-HP self gate that drives
+        // the suppression (so the differential above is the gate flipping, not some unrelated effect).
+        expect(charge.conditions).toEqual([
+            {
+                subject: 'hp-threshold',
+                derivable: true,
+                hpComparator: 'above',
+                hpPercent: 99,
+                hpSubject: 'self',
+            },
+        ]);
+    });
+});
+
+// ─── Direct parse assertion ────────────────────────────────────────────────────────
+// Complements the integration-path assertions above: confirms the PARSER OUTPUT shape for
+// the 2nd-passive string directly, independent of buildShipAbilities / the engine path.
+
+describe('Cobalt second passive — parseChargeGain direct parse assertion', () => {
+    it('parseChargeGain returns start-of-turn + full-HP gate for the 2nd-passive string', () => {
+        const result = parseChargeGain(COBALT_P2);
+        expect(result).toEqual({
+            amount: 1,
+            condition: 'always',
+            derivable: true,
+            trigger: 'start-of-turn',
+            conditions: [
+                {
+                    subject: 'hp-threshold',
+                    derivable: true,
+                    hpComparator: 'above',
+                    hpPercent: 99,
+                    hpSubject: 'self',
+                },
+            ],
+        });
+    });
+});
+
+// ─── Part 3: second-passive co-buff coexistence ─────────────────────────────────────
+
+describe('Cobalt second passive — charge AND Out. Damage Up II coexist (no clause swallow)', () => {
+    it('buildShipAbilities yields BOTH the start-of-turn charge AND the Out. Damage Up II buff', () => {
+        // The 2nd-passive text joins the charge clause and the buff clause with "and", and the buff
+        // name carries the "Out." abbreviation period — a known clause-scoping hazard (abbreviation
+        // periods must be masked before sentence-splitting in BOTH skillTextParser and auditSkills,
+        // or the period reads as a sentence boundary and the buff clause is swallowed). This asserts
+        // the buff SURVIVES: the parser emits a charge ability AND a buff ability for the SAME passive.
+        const abilities = resolvePassiveAbilities(COBALT_P2);
+
+        const charge = abilities.find((a) => a.type === 'charge' && a.trigger === 'start-of-turn');
+        expect(charge, 'start-of-turn charge ability present').toBeDefined();
+
+        const buff = abilities.find(
+            (a) =>
+                a.type === 'buff' &&
+                a.config.type === 'buff' &&
+                a.config.buffName === 'Out. Damage Up II'
+        );
+        expect(
+            buff,
+            'Out. Damage Up II buff ability present (not swallowed by the "Out." period)'
+        ).toBeDefined();
+
+        // The buff is self-targeted and inherits the same full-HP gate as the charge (both are
+        // gained "at the start of the turn if it is at full HP").
+        expect(buff!.target).toBe('self');
+        expect(buff!.conditions).toEqual([
+            {
+                subject: 'hp-threshold',
+                derivable: true,
+                hpComparator: 'above',
+                hpPercent: 99,
+                hpSubject: 'self',
+            },
+        ]);
+
+        // KNOWN LIMITATION: only the charge half is parsed as start-of-turn (Task 7); the buff
+        // parser has no start-of-turn detection, so the co-buff is emitted as on-cast. In-game it
+        // is granted at start-of-turn alongside the charge. Asserting the current behavior so a
+        // future buff-trigger fix surfaces here rather than silently changing.
+        expect(buff!.trigger).toBe('on-cast');
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3729,15 +3729,24 @@ export function runCombat(input: CombatEngineInput): {
                 // (turn-ended) reactive drains — which run later — read the correct N. 1-based
                 // (turnsTaken=1 on the first own turn) matches the evaluator's `t % period === offset`.
                 //
-                // STASIS/DISABLE (deferred to Phase 2 / Chrono Reaver): this increment is
-                // UNCONDITIONAL — it bumps even on a turn the actor skips under Stasis/Disable,
-                // unlike advanceChargeCadence (~4172/4233) which is gated behind !isTurnBlocked.
-                // Keeping it monotonic is deliberate: turn-ended (~4595) and the reactive drains
-                // (~4567) fire on skipped turns too, so freezing the counter on a skip would let an
-                // every-n-turns gate spuriously re-fire against the frozen value. Fully suppressing
-                // the every-n-turns proc on a skipped turn (so a stasised unit banks no periodic
-                // charge, matching advanceChargeCadence) is Phase 2 work and will get its own
-                // stasis golden when Chrono Reaver attaches the first every-n-turns ability.
+                // STASIS/DISABLE: this increment is UNCONDITIONAL — it bumps even on a turn the
+                // actor skips under Stasis/Disable, unlike advanceChargeCadence (~4249/4314) which
+                // is gated behind !isTurnBlocked. Keeping it monotonic is DELIBERATE: turn-ended
+                // (~4595) and the reactive drains (~4567) fire on skipped turns too, so freezing the
+                // counter on a skip would let an every-n-turns gate spuriously re-fire against the
+                // frozen value — instead the cadence loses the skipped tick and resumes on the
+                // original residue (the next own-turn that satisfies `t % period === offset`).
+                //
+                // The every-n-turns periodic proc IS already fully suppressed on a turn-blocked turn
+                // — NO gating is needed HERE. A periodic charge (e.g. Chrono Reaver's `end-of-turn`
+                // charge) is a REACTIVE intent carrying intent.ownerId; on a blocked owner's turn the
+                // §4.4 reactive-intent drain filter (~3403: `if (isTurnBlocked(intent.ownerId)) continue;`)
+                // DROPS it before executeIntent applies the charge. So a stasised/disabled unit banks
+                // NO periodic charge, matching the +1/turn baseline. Golden: chronoReaverCharge.integration.test.ts
+                // ("stasis suppression"). NOTE: the suppression relies on the owner being STILL
+                // turn-blocked at the drain pass — for a 1-turn block the Post-Turn decrement (~4651)
+                // can clear the block before the deferred end-of-turn intent drains, so that golden
+                // uses a ≥2-turn block spanning a proc turn.
                 // The dummy-sink enemy is also bumped here; harmless (no every-n-turns ability on it).
                 actor.turnsTaken += 1;
 

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -386,6 +386,12 @@ const EVERY_SECOND_REPAIR_RE = /every second repair/i;
 // A team-dependent trigger: manual (non-derivable) since the single-ship sim has no allies.
 const ALLY_INFLICTS_DEBUFF_RE = /\ball(?:y|ies)\b[^.]*\b(?:appl|inflict)\w*\s+a\s+debuff\b/i;
 
+// Cobalt: "adds N charge ... at the start of the turn if it is at full HP" — a periodic
+// self-charge gated on full HP. The two halves are detected together so the start-of-turn
+// trigger and the hp-threshold gate ride as a pair.
+const START_OF_TURN_CHARGE_RE = /\bat the start of (?:the|its|each|every)\s+turn\b/i;
+const AT_FULL_HP_RE = /\bat full (?:hp|health)\b/i; // reused phrasing (cf. classifier ~line 647)
+
 function classifyChargeCondition(
     text: string // already tag-stripped, any case
 ): { condition: ConditionalCondition; derivable: boolean; requiredEnemyType?: EnemyBaseClass } {
@@ -1574,6 +1580,28 @@ export function parseChargeGain(text: string | null | undefined): ChargeGain | n
     }
     if (low.includes('inflict') && low.includes('debuff')) {
         return { amount, condition: 'always', derivable: true, trigger: 'on-debuff-inflicted' };
+    }
+
+    // Phase 3 (Cobalt): start-of-turn self-charge gated on full HP. Placed after the
+    // inflict/repair reactive branches (those event triggers win if a text somehow carries
+    // both; no corpus ship does). condition 'always' is a placeholder — the real gate is in
+    // `conditions`.
+    if (START_OF_TURN_CHARGE_RE.test(low) && AT_FULL_HP_RE.test(low)) {
+        return {
+            amount,
+            condition: 'always',
+            derivable: true,
+            trigger: 'start-of-turn',
+            conditions: [
+                {
+                    subject: 'hp-threshold',
+                    derivable: true,
+                    hpComparator: 'above',
+                    hpPercent: 99,
+                    hpSubject: 'self',
+                },
+            ],
+        };
     }
 
     const { condition, derivable, requiredEnemyType } = classifyChargeCondition(plain);


### PR DESCRIPTION
## Summary

Merged **Phase 2 + Phase 3** of the charge generation/manipulation epic — both are self-target charge generation gated by a self-condition on a turn boundary, so they ship as one PR. Builds on the Phase 0 foundation (#151) and Phase 1 enemy-removal (#152); **stacked on #152** — retarget to `main` after the #151→#152 stack merges.

**Phase 2 — Chrono Reaver implant** (periodic charge)
- `IMPLANT_ABILITIES['CHRONO_REAVER']`: a `charge`/`self`/`end-of-turn` ability with an `every-n-turns` gate (legendary → every 2nd turn, epic → every 3rd; offset 0). Pure registry, no parser work.
- Goldens: cadence (epic/legendary), wasted-proc-at-full, stacking with a ship's own charge source, a 6-cell parity matrix vs the standalone `chronoReaver.ts`, and a stasis-suppression golden.
- **Stasis = full fidelity, for free:** a turn-blocked unit banks no periodic charge. This is already structural — the §4.4 reactive-intent drain filter (`engine.ts:~3403`) drops the blocked owner's end-of-turn charge intent; `turnsTaken` stays monotonic so cadence resumes on the original residue. The only `engine.ts` change is **comment-only** (the deferred Phase-0 decision, now resolved + documented). Added an `end-of-turn` editor option.

**Phase 3 — Cobalt** (conditional start-of-turn charge)
- `ChargeGain` gains a `start-of-turn` trigger + an optional `conditions?: Condition[]`.
- `parseChargeGain` detects "at the start of (the|its|each|every) turn … at full HP" → a `start-of-turn` charge with a reused `hp-threshold` self-gate (double-gated; reclassifies **only** Cobalt).
- `buildShipAbilities` honors the explicit `conditions` (overriding the "trigger ⇒ no condition" rule; byte-identical for inflict/repair gains).
- Goldens: full-HP proc differential, live-HP damaged-suppression (genuine HP-gate flip via heal-target threading), and 2nd-passive co-buff coexistence.

## Known limitations (documented in-code)
- Start-of-turn charge lands post-action / end-of-turn banks at the next drain (one-turn alignment) — intentional, no pre-action drain added.
- Self-HP gate is only live in heal-target sim contexts (defaults to 100 elsewhere — same as Arcane Siege's self-shield).
- Cobalt's 2nd-passive co-buff ("Out. Damage Up II") is emitted as `on-cast`, not `start-of-turn` (the buff parser has no start-of-turn detection — charge half only). Asserted explicitly as current behavior; a follow-up if buff timing is ever needed.

## Test plan
- [x] Full suite green (3158 tests), lint clean (max-warnings 0), `tsc --noEmit` clean
- [x] `audit:skills` 0 findings / 141 ships (parser reclassifies only Cobalt)
- [x] Zero golden/.snap drift (no fixture equips Chrono Reaver or runs Cobalt today)
- [x] Per-task spec + quality review + final holistic review (READY TO MERGE)

Spec: `docs/superpowers/specs/2026-06-23-charge-generation-manipulation-design.md` (Phases 2-3)
Plan: `docs/superpowers/plans/2026-06-24-charge-phase2-3-periodic-conditional-self-charge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)