### PR TITLE
feat(combat): Burner + Decimation gear-set DoT pair

### DIFF
--- a/docs/superpowers/plans/2026-06-24-gear-set-dot-pair.md
+++ b/docs/superpowers/plans/2026-06-24-gear-set-dot-pair.md
@@ -330,16 +330,19 @@ describe('Burner gear set', () => {
 Run: `npx vitest run src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts -t "Burner"`
 Expected: FAIL — no `equip-set-BURNER` ability.
 
-- [ ] **Step 3: Add the BURNER entry** to `GEAR_SET_ABILITIES`:
+- [ ] **Step 3: Add the BURNER entry** to `GEAR_SET_ABILITIES`. **Trigger = `on-deal-damage`,
+  NOT `on-cast`** — a passive-slot `on-cast` DoT is engine-inert (the cast path only gathers DoTs
+  from the fired skill, and `on-cast` is not a `LIVE_TRIGGER`). `on-deal-damage` is a `LIVE_TRIGGER`
+  that fires once per turn the owner deals direct damage and drains through the reactive DoT executor:
 
 ```typescript
-    // Burner (4pc set): applies Inferno 1 (tier 15) for 2 turns on cast. Reactive on-cast
-    // dot ability — rides the existing reactive DoT executor (triggers.ts), pushing an
-    // inferno entry to the cast target with sourceId = owner.
+    // Burner (4pc set): applies Inferno 1 (tier 15) for 2 turns when the ship attacks.
+    // on-cast is NOT a LIVE_TRIGGER (passive-slot on-cast DoTs are never applied); on-deal-damage
+    // fires once/turn on direct damage and rides the reactive DoT executor → ctx.enemy.id.
     BURNER: () => ({
         type: 'dot',
         target: 'enemy',
-        trigger: 'on-cast',
+        trigger: 'on-deal-damage',
         conditions: [],
         config: { type: 'dot', dotType: 'inferno', tier: 15, stacks: 1, duration: 2 },
         autoFilled: true,

--- a/docs/superpowers/plans/2026-06-24-gear-set-dot-pair.md
+++ b/docs/superpowers/plans/2026-06-24-gear-set-dot-pair.md
@@ -30,8 +30,13 @@
   `modifierAbilities = [...firing, ...passive]` (playerTurn.ts:1129) — passive slot holds equipment abilities.
 - **Fold point:** `src/utils/combat/effectiveStats.ts:214` `selfDotDamageModifier: dotPen.dotDamageModifier`.
 - **Inferno tier scale:** `src/types/calculator.ts:84` — Inferno 1/2/3 = tier 15/30/45 → **Burner = tier 15**.
-- **Gear-set activation loop:** `buildEquipmentAbilities.ts:825-834` — has `count` (pieces) and
-  `minPieces` in scope; builder is currently `() => Omit<Ability,'id'>`.
+- **Gear-set activation loop:** `buildEquipmentAbilities.ts:883-893` — has `count` (pieces) and
+  `minPieces` in scope; the registry type (line 44) is currently
+  `Partial<Record<string, () => Omit<Ability, 'id'> | undefined>>` (the `| undefined` is for
+  CLOAKING, whose `mkNamedBuffGrant` can return undefined). The call site guards with
+  `const partial = builder(); if (!partial) continue;` — **preserve that guard.**
+- **DECIMATION has no `minPieces` field** in `gearSets.ts` — it relies on the loop's `?? 2`
+  default (2pc set). The Decimation builder uses the same `?? 2` fallback.
 
 ---
 
@@ -185,8 +190,8 @@ git commit -m "feat(combat): fold dotDamage modifier into selfDotDamageModifier 
 ## Task 3: Widen gear-set builder signature + Decimation registry entry
 
 **Files:**
-- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (`GEAR_SET_ABILITIES` type ~`:849`,
-  the `DECIMATION` entry, and the call site `:832`)
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (`GEAR_SET_ABILITIES` type at line 44,
+  the `DECIMATION` entry in the registry, and the call site at lines 890-892)
 - Test: `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`
 
 - [ ] **Step 1: Write the failing test** — add to `buildEquipmentAbilities.test.ts` (reuse its
@@ -230,16 +235,18 @@ Run: `npx vitest run src/utils/abilities/__tests__/buildEquipmentAbilities.test.
 Expected: FAIL — no `equip-set-DECIMATION` ability emitted.
 
 - [ ] **Step 3: Widen the builder type + call site.** In `buildEquipmentAbilities.ts`:
-  - Change the registry type from
-    `Partial<Record<string, () => Omit<Ability, 'id'>>>` to
-    `Partial<Record<string, (count: number) => Omit<Ability, 'id'>>>`.
-  - At the call site (line ~832), pass `count`:
+  - Change the registry type (line 44) **from**
+    `Partial<Record<string, () => Omit<Ability, 'id'> | undefined>>` **to**
+    `Partial<Record<string, (count: number) => Omit<Ability, 'id'> | undefined>>`
+    (keep the `| undefined` — CLOAKING returns undefined).
+  - At the call site (lines 890-892), pass `count` and **keep the existing `if (!partial) continue;` guard**:
     ```typescript
         const partial = builder(count);
+        if (!partial) continue;
         abilities.push({ id: `equip-set-${setName}`, ...partial });
     ```
-  - (Existing `LEECH`/`HARDENED` builders take no param — JS ignores the extra arg, byte-identical.
-    Optionally give them `(_count)` signatures for lint cleanliness if ESLint flags arity.)
+  - (Existing `LEECH`/`HARDENED`/`CLOAKING` builders take no param — JS ignores the extra arg,
+    byte-identical. Optionally give them `(_count)` signatures for lint cleanliness if ESLint flags arity.)
 
 - [ ] **Step 4: Add the DECIMATION entry** to `GEAR_SET_ABILITIES` (after `HARDENED`):
 

--- a/docs/superpowers/plans/2026-06-24-gear-set-dot-pair.md
+++ b/docs/superpowers/plans/2026-06-24-gear-set-dot-pair.md
@@ -1,0 +1,548 @@
+# Burner + Decimation Gear-Set DoT Pair — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the two DoT-related special-effect gear sets — Burner (applies Inferno 1 / 2 turns on cast) and Decimation (+10% DoT damage per complete 2pc set) — to the equipment-ability registry, so the battle simulator and DPS calculator honor them.
+
+**Architecture:** Burner rides the existing reactive DoT executor as an `on-cast` `dot` ability. Decimation is a standing passive `modifier` ability feeding a **new `dotDamage` modifier channel** that folds into `dmgStats.selfDotDamageModifier` (effectiveStats.ts) → `dotMult` (playerTurn.ts). Because `runPlayerTurn` is shared by both `simulateBattle` and the DPS calc's `runCombat`, and `modifierAbilities` already includes the passive slot, the single engine fold makes **both** paths honor Decimation — no separate DPS-wiring change. No combat fixture equips either set → byte-identical goldens.
+
+**Tech Stack:** React 18 / TypeScript / Vitest. Registry pattern in `src/utils/abilities/buildEquipmentAbilities.ts` (`GEAR_SET_ABILITIES`). Combat engine in `src/utils/combat/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-24-gear-set-dot-pair-design.md`
+
+**Worktree:** `.worktrees/gear-set-dot-pair`, branch `feat/combat-gear-set-dot-pair` (off main `93a02ad4`; rebase onto final main before PR).
+
+---
+
+## Pre-flight grounding (read before starting)
+
+- **Reactive DoT executor:** `src/utils/combat/triggers.ts` ~1370-1431. A `dot` AbilityConfig
+  pushes `{stacks,tier,remainingRounds,sourceId}` to `ctx.infernoEntries`/`corrosionEntries`
+  (sourceId = owner) after a landing gate, and emits `dot-applied` to `ctx.enemy.id`.
+- **Existing reactive `dot` ability shape:** `src/utils/abilities/buildShipAbilities.ts:1317-1334`
+  (`dotAbility`) — copy this exact shape for Burner.
+- **DoT tick:** `src/utils/combat/engine.ts:767-771` — inferno tick =
+  `stacks × (tier/100) × ctx.effectiveAttack × ctx.dotMult × ctx.affinityMult`, ctx resolved
+  per-entry by `sourceId` (the applier). `dotMult` is the applier's.
+- **`dotMult`:** `src/utils/combat/playerTurn.ts:1207` =
+  `1 + (selfDotModifier + enemyDotMod + dmgStats.selfDotDamageModifier) / 100`.
+- **`dmgStats`:** `playerTurn.ts:1136` `effectiveDamageStatsOf({... modifierAbilities, modifierCtx})`;
+  `modifierAbilities = [...firing, ...passive]` (playerTurn.ts:1129) — passive slot holds equipment abilities.
+- **Fold point:** `src/utils/combat/effectiveStats.ts:214` `selfDotDamageModifier: dotPen.dotDamageModifier`.
+- **Inferno tier scale:** `src/types/calculator.ts:84` — Inferno 1/2/3 = tier 15/30/45 → **Burner = tier 15**.
+- **Gear-set activation loop:** `buildEquipmentAbilities.ts:825-834` — has `count` (pieces) and
+  `minPieces` in scope; builder is currently `() => Omit<Ability,'id'>`.
+
+---
+
+## Task 1: Add `dotDamage` modifier channel (type + fold)
+
+**Files:**
+- Modify: `src/types/abilities.ts:291-300` (`ModifierChannel` union)
+- Modify: `src/utils/abilities/applyAbilities.ts:6-14` (`ModifierTotals`), `:26-34` (init), `:50-73` (switch)
+- Test: `src/utils/abilities/__tests__/applyAbilities.test.ts`
+
+- [ ] **Step 1: Write the failing test** — add to `applyAbilities.test.ts`:
+
+```typescript
+import { Ability } from '../../../types/abilities';
+// (reuse existing makeConditionContext / ctx fixture in this file)
+
+describe('modifierTotalsFromAbilities — dotDamage channel', () => {
+    it('sums a dotDamage modifier into ModifierTotals.dotDamage', () => {
+        const ability: Ability = {
+            id: 'decimation-x',
+            type: 'modifier',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'modifier', channel: 'dotDamage', value: 20, isMultiplicative: false },
+        };
+        const totals = modifierTotalsFromAbilities([ability], makeConditionContext({}));
+        expect(totals.dotDamage).toBe(20);
+        // other channels untouched
+        expect(totals.outgoingDamage).toBe(0);
+        expect(totals.attack).toBe(0);
+    });
+});
+```
+
+(Check the top of `applyAbilities.test.ts` for the existing `makeConditionContext`/ctx helper and
+`modifierTotalsFromAbilities` import; reuse them. If a context fixture lives in
+`src/utils/abilities/__tests__/conditionContextFixture.ts`, import from there.)
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `npx vitest run src/utils/abilities/__tests__/applyAbilities.test.ts -t "dotDamage channel"`
+Expected: FAIL — `totals.dotDamage` is `undefined` (property doesn't exist) / TS error.
+
+- [ ] **Step 3: Add the channel to the type.** In `src/types/abilities.ts`, add `| 'dotDamage'`
+  to the `ModifierChannel` union (after `'outgoingDamage'`):
+
+```typescript
+export type ModifierChannel =
+    | 'attack'
+    | 'defense'
+    | 'defensePenetration'
+    | 'hp'
+    | 'crit'
+    | 'critDamage'
+    | 'outgoingDamage'
+    | 'dotDamage'
+    | 'outgoingHeal'
+    | 'incomingDamage';
+```
+
+- [ ] **Step 4: Add the bucket + case** in `src/utils/abilities/applyAbilities.ts`:
+  - Add `dotDamage: number;` to the `ModifierTotals` interface (after `outgoingDamage`).
+  - Add `dotDamage: 0,` to the `totals` initializer (after `outgoingDamage: 0,`).
+  - Add a case in the `switch (channel)` (after the `'outgoingDamage'` case):
+
+```typescript
+            case 'dotDamage':
+                totals.dotDamage += amount;
+                break;
+```
+
+- [ ] **Step 5: Run test, verify it passes**
+
+Run: `npx vitest run src/utils/abilities/__tests__/applyAbilities.test.ts -t "dotDamage channel"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types/abilities.ts src/utils/abilities/applyAbilities.ts src/utils/abilities/__tests__/applyAbilities.test.ts
+git commit -m "feat(combat): add dotDamage modifier channel"
+```
+
+---
+
+## Task 2: Fold `mod.dotDamage` into `selfDotDamageModifier`
+
+**Files:**
+- Modify: `src/utils/combat/effectiveStats.ts:214`
+- Test: `src/utils/combat/__tests__/effectiveStats.test.ts`
+
+- [ ] **Step 1: Write the failing test** — add to `effectiveStats.test.ts` (mirror an existing
+  `effectiveDamageStatsOf` test in that file for the args shape; the key assertion):
+
+```typescript
+it('includes a dotDamage modifier ability in selfDotDamageModifier', () => {
+    const dotMod: Ability = {
+        id: 'dec',
+        type: 'modifier',
+        target: 'self',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'modifier', channel: 'dotDamage', value: 30, isMultiplicative: false },
+    };
+    const stats = effectiveDamageStatsOf({
+        base: { attack: 100, defence: 50, crit: 0, critDamage: 50, hp: 1000, defensePenetration: 0, defensePenetrationBuff: 0 },
+        scheduledTotals: /* zeroed calculateBuffTotals shape — copy from an existing test */ ZERO_TOTALS,
+        abilitySelfEffects: [],
+        modifierAbilities: [dotMod],
+        modifierCtx: /* a context where conditions [] are met — copy existing helper */ EMPTY_CTX,
+    });
+    expect(stats.selfDotDamageModifier).toBe(30);
+});
+```
+
+(Reuse whatever zeroed-totals/empty-ctx helpers the existing tests in this file already use;
+do not invent new fixture shapes.)
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `npx vitest run src/utils/combat/__tests__/effectiveStats.test.ts -t "dotDamage modifier"`
+Expected: FAIL — `selfDotDamageModifier` is `0` (mod.dotDamage not folded yet).
+
+- [ ] **Step 3: Implement the fold.** In `effectiveStats.ts`, change line 214 from:
+
+```typescript
+        selfDotDamageModifier: dotPen.dotDamageModifier,
+```
+to:
+```typescript
+        selfDotDamageModifier: dotPen.dotDamageModifier + mod.dotDamage,
+```
+
+(`mod = modifierTotalsFromAbilities(...)` is already in scope at line 184.)
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `npx vitest run src/utils/combat/__tests__/effectiveStats.test.ts -t "dotDamage modifier"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/effectiveStats.ts src/utils/combat/__tests__/effectiveStats.test.ts
+git commit -m "feat(combat): fold dotDamage modifier into selfDotDamageModifier (dotMult)"
+```
+
+---
+
+## Task 3: Widen gear-set builder signature + Decimation registry entry
+
+**Files:**
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (`GEAR_SET_ABILITIES` type ~`:849`,
+  the `DECIMATION` entry, and the call site `:832`)
+- Test: `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`
+
+- [ ] **Step 1: Write the failing test** — add to `buildEquipmentAbilities.test.ts` (reuse its
+  `makeShip`/`makePiece`/`getGearPiece` helpers; equip Decimation pieces):
+
+```typescript
+describe('Decimation gear set', () => {
+    function shipWithDecimation(pieces: number) {
+        const equipment: Record<string, string> = {};
+        const map: Record<string, GearPiece> = {};
+        const slots = ['weapon', 'hull', 'generator', 'sensor', 'software', 'thrusters'];
+        for (let i = 0; i < pieces; i++) {
+            const id = `dec-${i}`;
+            equipment[slots[i]] = id;
+            map[id] = makePiece({ id, slot: slots[i] as GearPiece['slot'], setBonus: 'DECIMATION' });
+        }
+        return { ship: makeShip({ equipment }), getGearPiece: (id: string) => map[id] };
+    }
+
+    it('emits a dotDamage modifier scaling 10% per complete 2pc set', () => {
+        for (const [pieces, expected] of [[2, 10], [4, 20], [6, 30]] as const) {
+            const { ship, getGearPiece } = shipWithDecimation(pieces);
+            const abilities = buildEquipmentAbilities(ship, getGearPiece);
+            const dec = abilities.find((a) => a.id === 'equip-set-DECIMATION');
+            expect(dec?.type).toBe('modifier');
+            expect(dec?.config).toMatchObject({ type: 'modifier', channel: 'dotDamage', value: expected });
+        }
+    });
+
+    it('emits nothing below minPieces (1 piece)', () => {
+        const { ship, getGearPiece } = shipWithDecimation(1);
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        expect(abilities.find((a) => a.id === 'equip-set-DECIMATION')).toBeUndefined();
+    });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `npx vitest run src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts -t "Decimation"`
+Expected: FAIL — no `equip-set-DECIMATION` ability emitted.
+
+- [ ] **Step 3: Widen the builder type + call site.** In `buildEquipmentAbilities.ts`:
+  - Change the registry type from
+    `Partial<Record<string, () => Omit<Ability, 'id'>>>` to
+    `Partial<Record<string, (count: number) => Omit<Ability, 'id'>>>`.
+  - At the call site (line ~832), pass `count`:
+    ```typescript
+        const partial = builder(count);
+        abilities.push({ id: `equip-set-${setName}`, ...partial });
+    ```
+  - (Existing `LEECH`/`HARDENED` builders take no param — JS ignores the extra arg, byte-identical.
+    Optionally give them `(_count)` signatures for lint cleanliness if ESLint flags arity.)
+
+- [ ] **Step 4: Add the DECIMATION entry** to `GEAR_SET_ABILITIES` (after `HARDENED`):
+
+```typescript
+    // Decimation (2pc set): +10% DoT damage per complete set, max 3 sets (6 pieces) = +30%.
+    // Standing passive → modeled as a dotDamage modifier that folds into dotMult via
+    // effectiveDamageStatsOf.selfDotDamageModifier (engine + DPS calc both honor it).
+    DECIMATION: (count) => {
+        const minPieces = GEAR_SETS.DECIMATION?.minPieces ?? 2;
+        const sets = Math.floor(count / minPieces); // 1/2/3 at 2/4/6 pieces
+        return {
+            type: 'modifier',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'modifier', channel: 'dotDamage', value: sets * 10, isMultiplicative: false },
+            autoFilled: true,
+        };
+    },
+```
+
+- [ ] **Step 5: Run test, verify it passes**
+
+Run: `npx vitest run src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts -t "Decimation"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+git commit -m "feat(combat): Decimation gear set — +10%/set DoT damage modifier"
+```
+
+---
+
+## Task 4: Burner registry entry
+
+**Files:**
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (`BURNER` entry in `GEAR_SET_ABILITIES`)
+- Test: `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`
+
+- [ ] **Step 1: Write the failing test:**
+
+```typescript
+describe('Burner gear set', () => {
+    it('emits an on-cast inferno DoT (tier 15, 1 stack, 2 turns) at 4 pieces', () => {
+        const equipment: Record<string, string> = {};
+        const map: Record<string, GearPiece> = {};
+        const slots = ['weapon', 'hull', 'generator', 'sensor'];
+        slots.forEach((slot, i) => {
+            const id = `burn-${i}`;
+            equipment[slot] = id;
+            map[id] = makePiece({ id, slot: slot as GearPiece['slot'], setBonus: 'BURNER' });
+        });
+        const abilities = buildEquipmentAbilities(makeShip({ equipment }), (id) => map[id]);
+        const burner = abilities.find((a) => a.id === 'equip-set-BURNER');
+        expect(burner?.type).toBe('dot');
+        expect(burner?.trigger).toBe('on-cast');
+        expect(burner?.target).toBe('enemy');
+        expect(burner?.config).toMatchObject({
+            type: 'dot', dotType: 'inferno', tier: 15, stacks: 1, duration: 2,
+        });
+    });
+
+    it('emits nothing below minPieces (3 pieces, needs 4)', () => {
+        const equipment: Record<string, string> = {};
+        const map: Record<string, GearPiece> = {};
+        ['weapon', 'hull', 'generator'].forEach((slot, i) => {
+            const id = `burn-${i}`;
+            equipment[slot] = id;
+            map[id] = makePiece({ id, slot: slot as GearPiece['slot'], setBonus: 'BURNER' });
+        });
+        const abilities = buildEquipmentAbilities(makeShip({ equipment }), (id) => map[id]);
+        expect(abilities.find((a) => a.id === 'equip-set-BURNER')).toBeUndefined();
+    });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `npx vitest run src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts -t "Burner"`
+Expected: FAIL — no `equip-set-BURNER` ability.
+
+- [ ] **Step 3: Add the BURNER entry** to `GEAR_SET_ABILITIES`:
+
+```typescript
+    // Burner (4pc set): applies Inferno 1 (tier 15) for 2 turns on cast. Reactive on-cast
+    // dot ability — rides the existing reactive DoT executor (triggers.ts), pushing an
+    // inferno entry to the cast target with sourceId = owner.
+    BURNER: () => ({
+        type: 'dot',
+        target: 'enemy',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'dot', dotType: 'inferno', tier: 15, stacks: 1, duration: 2 },
+        autoFilled: true,
+    }),
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `npx vitest run src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts -t "Burner"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+git commit -m "feat(combat): Burner gear set — applies Inferno 1 for 2 turns on cast"
+```
+
+---
+
+## Task 5: Coverage tracker update
+
+**Files:**
+- Modify: `src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+
+The `Object.keys(GEAR_SETS)` declaration order puts BURNER and DECIMATION **before** LEECH
+(gearSets.ts: BURNER `:64`, DECIMATION `:72`, LEECH `:85`, CLOAKING `:118`, HARDENED `:210`).
+
+- [ ] **Step 1: Update the three coverage spots:**
+  - The `exactly {...}` `toEqual` array (line ~127): change `['LEECH', 'CLOAKING', 'HARDENED']`
+    to `['BURNER', 'DECIMATION', 'LEECH', 'CLOAKING', 'HARDENED']`.
+  - The `IMPLEMENTED_SETS` Set (line ~177): add `'BURNER'`, `'DECIMATION'`.
+  - The `it('exactly { ... }')` **title string** (line ~122): add `BURNER + DECIMATION` to the
+    gear-sets list in the description text.
+  - Add a doc-comment line at the top noting this PR (mirror the `D-PRn added …` lines):
+    `* Gear-set DoT pair added BURNER + DECIMATION (gear sets).`
+
+- [ ] **Step 2: Add per-set count assertions** in the `equipmentCoverage — gear sets` describe block:
+
+```typescript
+    it('BURNER produces exactly 1 ability (the on-cast inferno)', () => {
+        expect(gearSetAbilityCount('BURNER')).toBe(1);
+    });
+    it('DECIMATION produces exactly 1 ability (the dotDamage modifier)', () => {
+        expect(gearSetAbilityCount('DECIMATION')).toBe(1);
+    });
+```
+
+- [ ] **Step 3: Run the coverage test, verify it passes**
+
+Run: `npx vitest run src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+Expected: PASS. (If the `toEqual` array order is wrong, the failure message prints the actual
+order — match it exactly.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/abilities/__tests__/equipmentCoverage.test.ts
+git commit -m "test(combat): coverage tracker += Burner, Decimation"
+```
+
+---
+
+## Task 6: Engine integration tests (mutation-resistant, real registry)
+
+**Files:**
+- Create: `src/utils/combat/__tests__/gearSetDotPair.integration.test.ts`
+
+Route through the **real** registry (`buildShipAbilitiesWithEquipment` + a `getGearPiece`
+returning `setBonus:'BURNER'`/`'DECIMATION'`) — NOT hand-rolled abilities — so mutations bite.
+Mirror the setup of an existing equipment integration test
+(e.g. `equipmentAbilities.integration.test.ts` or the D-PR16 Last Stand integration test) for
+how to build a ship, equip gear, and run `simulateBattle`/`runCombat`.
+
+- [ ] **Step 1: Write the tests:**
+  - **Burner applies a 2-turn inferno on cast:** equip a ship with 4 Burner pieces, give it a
+    plain attack skill, run combat against an enemy; assert the enemy takes inferno-tick damage
+    for 2 turns after the cast and none on the 3rd (entry expired). Assert via the `dot-applied`
+    event or the per-round inferno-tick damage in the result.
+  - **Decimation scales DoT ticks by sets×10%:** a ship that applies a known DoT (e.g. via its
+    skill or via Burner), run once with 2 Decimation pieces and once without; assert the
+    Decimation run's DoT-tick damage is exactly `×1.10` the control (within rounding). Use a
+    deterministic setup (fixed attack, no crit variance on DoT) so the ratio is exact.
+  - **Composition:** Burner + Decimation on the same ship → Burner's inferno tick is
+    Decimation-boosted (assert the boosted tick vs a Burner-only control).
+
+- [ ] **Step 2: Run, verify PASS**
+
+Run: `npx vitest run src/utils/combat/__tests__/gearSetDotPair.integration.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Mutation sanity check (manual, do not commit the mutation):** temporarily set
+  Decimation `value` to `0` and confirm the scaling test fails; revert. Confirms the test bites.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/combat/__tests__/gearSetDotPair.integration.test.ts
+git commit -m "test(combat): Burner + Decimation engine integration (real registry)"
+```
+
+---
+
+## Task 7: DPS-calculator verification test
+
+The engine fold (Task 2) should make the DPS calc honor Decimation for free (shared
+`runPlayerTurn`). This task **proves** it — and is the fallback trigger if it doesn't.
+
+**Files:**
+- Create or extend: a DPS-calc test (mirror an existing `dpsSimulator`/DPS-page calc test that
+  builds `shipSkills` via `buildShipAbilitiesWithEquipment` and runs `simulateDPS`/`runCombat`).
+
+- [ ] **Step 1: Write the test** — a ship that applies a DoT, run the DPS sim with vs without 2
+  Decimation pieces (built through `buildShipAbilitiesWithEquipment` so the modifier lands in the
+  passive slot); assert the Decimation run's DoT contribution to DPS is ~10% higher.
+
+- [ ] **Step 2: Run, verify PASS**
+
+Run: `npx vitest run <new test path>`
+Expected: PASS (engine fold flows into DPS).
+
+- [ ] **Step 3 (only if Step 2 FAILS): explicit DPS wiring fallback.** In `dpsSimulator.ts`
+  (~241), the top-level `selfDotModifier` is derived from `selfBuffs` only. If the per-round
+  fold doesn't reach the DPS DoT output, extract the `dotDamage` channel from the passive
+  abilities via `modifierTotalsFromAbilities` and add it into `selfDotModifier`. Add a focused
+  test. (Expectation: NOT needed — documented here only as the contingency the spec flagged.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add <test path>
+git commit -m "test(combat): DPS calc honors Decimation via shared engine fold"
+```
+
+---
+
+## Task 8: Editor option, changelog, docs
+
+**Files:**
+- Modify: `src/components/skills/AbilityCard.tsx:73-83` (`MODIFIER_CHANNEL_OPTIONS`)
+- Modify: `src/constants/changelog.ts` (`UNRELEASED_CHANGES`)
+- Modify: `src/pages/DocumentationPage.tsx` (gear-set / DoT section)
+
+- [ ] **Step 1: Editor channel option.** Add to `MODIFIER_CHANNEL_OPTIONS` (after `outgoingDamage`):
+
+```typescript
+    { value: 'dotDamage', label: 'DoT Damage' },
+```
+
+- [ ] **Step 2: Changelog.** Add to `UNRELEASED_CHANGES` (plain English, user-facing):
+
+```
+'Combat sim now models the Burner gear set (applies Inferno 1 for 2 turns on attack) and the Decimation gear set (+10% DoT damage per set).',
+```
+
+- [ ] **Step 3: Docs.** In `DocumentationPage.tsx`, find the gear-set / DoT-damage section and
+  note that Burner and Decimation special effects are now simulated. Keep it brief, match
+  surrounding prose. (Search for "Decimation" — there's an existing mention at ~:1243.)
+
+- [ ] **Step 4: Run lint + tsc**
+
+Run: `npm run lint && npx tsc --noEmit`
+Expected: clean (0 warnings — `max-warnings: 0`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/skills/AbilityCard.tsx src/constants/changelog.ts src/pages/DocumentationPage.tsx
+git commit -m "feat(combat): editor channel + changelog + docs for Burner/Decimation"
+```
+
+---
+
+## Task 9: Full verification gates
+
+- [ ] **Step 1: Confirm zero combat-fixture usage.** Grep fixtures for the set names:
+
+Run: `grep -rn "BURNER\|DECIMATION" src/utils/combat/__tests__/ src/test/ 2>/dev/null`
+Expected: only the NEW integration test (Task 6) and DPS test (Task 7). Any **pre-existing**
+combat golden/fixture equipping these → the byte-identical premise breaks; STOP and re-derive
+goldens deliberately (never `vitest -u`). Note: `fastScoring`/`fastPotential` autogear scoring
+fixtures may mention the names — those are scoring-only, not combat goldens; ignore them.
+
+- [ ] **Step 2: Full suite**
+
+Run: `npm test`
+Expected: all pass; **zero golden/`.snap` drift** (no fixture equips these sets). Pre-existing
+env-failing files (missing Supabase URL, gitignored `docs/*.csv`) are NOT ours — confirm the
+failing set is unchanged from a clean baseline.
+
+- [ ] **Step 3: Lint, types, skills audit**
+
+Run: `npm run lint && npx tsc --noEmit && npm run audit:skills`
+Expected: lint clean, tsc clean, `audit:skills` 0 failures (unchanged count).
+
+- [ ] **Step 4: Final commit (if any cleanup) + push**
+
+```bash
+git push -u origin feat/combat-gear-set-dot-pair
+```
+
+(Rebase onto the latest `main` first if the charge stack has merged and advanced it — resolve
+in this worktree, do not touch the main checkout.)
+
+---
+
+## Review & PR
+
+- [ ] Run `superpowers:requesting-code-review` (or the `/code-review` skill) on the full diff.
+- [ ] Address findings; re-verify suite green + zero golden drift.
+- [ ] Open PR with `gh pr create` (run `gh auth switch --user TheSusort` first if needed),
+  base `main`, summarizing: Burner (on-cast inferno) + Decimation (dotDamage modifier channel,
+  +10%/set), shared engine fold covers both battle-sim and DPS calc, byte-identical goldens.

--- a/docs/superpowers/specs/2026-06-24-gear-set-dot-pair-design.md
+++ b/docs/superpowers/specs/2026-06-24-gear-set-dot-pair-design.md
@@ -1,0 +1,143 @@
+# Gear-set DoT pair — Burner + Decimation (combat-realism)
+
+**Date:** 2026-06-24
+**Status:** Design — pending plan
+**Epic:** combat-realism (special-effect gear sets bucket)
+**Baseline branch:** `main` (charge epic stack #151–#154 lands separately; this PR is independent of it)
+
+## Summary
+
+Add the two DoT-related special-effect gear sets to the equipment-ability registry:
+
+- **Burner** (4pc) — "Applies Inferno 1 for 2 turns." (stat portion +15% attack already modeled)
+- **Decimation** (2pc) — "+10% DoT damage" per complete set, max 3 sets = +30% (stat portion: none)
+
+Both ride existing machinery. The only genuinely new primitive is a `dotDamage`
+modifier channel for Decimation. No combat fixture equips either set, so the
+expectation is **byte-identical goldens** (to be verified during planning).
+
+This follows the established D-PR gear-set/implant registry pattern: stat portions
+are already folded into combat stats; this PR adds **only** the special effects via
+`GEAR_SET_ABILITIES` in `src/utils/abilities/buildEquipmentAbilities.ts`.
+
+## Background — what already exists
+
+- **DoT model.** `DoTType = 'corrosion' | 'inferno' | 'bomb'` (`types/calculator.ts`).
+  Inferno tiers are 15/30/45 for Inferno 1/2/3 → **"Inferno 1" = tier 15**.
+- **Reactive DoT executor** (`triggers.ts` ~1398): a `dot` AbilityConfig pushes an
+  entry to `ctx.infernoEntries`/`ctx.corrosionEntries` with `sourceId = owner` and
+  emits a `dot-applied` event to `ctx.enemy.id`. Already used by ship-skill reactive DoTs.
+- **DoT tick damage** (`engine.ts` 752/770): each tick =
+  `stacks × (tier/100) × base × ctx.dotMult × ctx.affinityMult`, where `ctx` is the
+  **applier's** snapshotted per-round context (resolved per entry via `sourceId`).
+- **`dotMult`** (`playerTurn.ts` 1234) = `1 + (selfDotModifier + enemyDotMod +
+  dmgStats.selfDotDamageModifier) / 100`. `dmgStats.selfDotDamageModifier`
+  (`effectiveStats.ts` 214) currently = `toDotAndPenModifiers(abilitySelfEffects, []).dotDamageModifier`,
+  i.e. the sum of `parsedEffects.dotDamage` over the applier's timed/gated self-buff statuses
+  (the "Out. DoT Up" buff channel). Bombs are excluded from this multiplier (corrosion + inferno only).
+- **Passive-modifier fold** (`applyAbilities.ts` `modifierTotalsFromAbilities`): sums active
+  `modifier` abilities into stat channels (`attack`/`crit`/`outgoingDamage`/…). Gear-set abilities
+  are merged into the passive slot and the passive slot is already included in `modifierAbilities`
+  (`[...firing, ...passive]`, per D-PR2). There is **no `dotDamage` channel today.**
+- **Existing partial Decimation modeling (display/scoring only, NOT the engine):**
+  `DoTDamage.tsx` stat-line (10% per *piece*) and `priorityScore.ts` autogear (10% per complete
+  *set*). These are inconsistent and neither touches the battle-sim DoT ticks. This PR makes the
+  **engine** honor Decimation for the first time; per-set semantics (below) is authoritative.
+
+## Effect 1 — Burner
+
+**Behaviour:** when the equipped ship casts (attacks), apply Inferno 1 (tier 15), 1 stack,
+2 turns, to the cast target.
+
+**Model:** a reactive `dot` ability in `GEAR_SET_ABILITIES`:
+
+```
+BURNER: () => ({
+    type: 'dot',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'dot', dotType: 'inferno', tier: 15, stacks: 1, duration: 2 },
+    autoFilled: true,
+})
+```
+
+- Rides the **existing** reactive DoT executor (`triggers.ts` ~1398) — pushes an inferno
+  entry (`sourceId = owner`) and emits `dot-applied` to `ctx.enemy.id`. No new application path.
+- The entry ticks with the **applier's** snapshotted `dotMult`/`effectiveAttack`, so a
+  Burner + Decimation ship's inferno is Decimation-boosted automatically.
+- Single target (the cast target), per the design decision. AoE-footprint application is
+  explicitly out of scope.
+
+## Effect 2 — Decimation
+
+**Behaviour:** +10% DoT damage per complete 2pc Decimation set; max 3 sets (6 pieces) = +30%.
+Self-scoped (boosts the equipped ship's own corrosion + inferno ticks; bombs excluded).
+
+**Model:** a passive `modifier` ability feeding a **new `dotDamage` channel** that folds into
+`dotMult`. This is symmetric with how D-PR2 routed conditional outgoing damage through the
+`outgoingDamage` modifier channel.
+
+Changes:
+
+1. **`types/abilities.ts`** — add `'dotDamage'` to `ModifierChannel`.
+2. **`applyAbilities.ts`** — add `dotDamage: number` to `ModifierTotals`; sum the
+   `'dotDamage'` channel in `modifierTotalsFromAbilities` (mirrors the existing channel cases).
+3. **`effectiveStats.ts`** — in `effectiveDamageStatsOf`, include `mod.dotDamage` in the
+   returned `selfDotDamageModifier` (line 214: `dotPen.dotDamageModifier + mod.dotDamage`).
+   This is the single fold point — `dotMult` already consumes `dmgStats.selfDotDamageModifier`,
+   so both the engine cast path and reactive-DoT ticks pick it up with no further wiring.
+4. **`buildEquipmentAbilities.ts`** — Decimation builder emits
+   `{ type:'modifier', target:'self', trigger:'on-cast', conditions:[],
+     config:{ type:'modifier', channel:'dotDamage', value: completeSets*10, isMultiplicative:false } }`.
+
+**Set-count plumbing:** the gear-set builder signature widens from
+`() => Omit<Ability,'id'>` to `(count: number) => Omit<Ability,'id'>`. The activation loop
+already holds `count` (pieces) and `minPieces`; pass `count`, and Decimation computes
+`completeSets = Math.floor(count / minPieces)` (minPieces=2 → 1/2/3 sets at 2/4/6 pieces →
+10/20/30%). Existing builders (Leech, Hardened, Burner) ignore the arg → byte-identical.
+
+## DPS calculator wiring
+
+Decimation affects DoT damage → DPS, so the DPS calculator must honor it. `dpsSimulator.ts`
+computes its own `dotMult` from `toDotAndPenModifiers(...).dotDamageModifier` (self-buffs only)
+and does **not** route through `effectiveDamageStatsOf`. The plan must thread the
+`dotDamage` modifier channel into `dpsSimulator`'s `selfDotModifier` so the DPS page reflects
+Decimation. `buildShipAbilitiesWithEquipment` is already wired into `DPSCalculatorPage` (D-PR2),
+so the Decimation `modifier` ability is already present in the DPS ability set — only the
+fold into the DPS `dotMult` needs adding. The exact seam is a plan-level detail; if it proves
+larger than a small additive change, it may be peeled to a follow-up (the engine fold is the
+primary deliverable).
+
+## Out of scope / explicitly deferred
+
+- AoE-footprint Burner application (single-target only).
+- Bomb DoT scaling from Decimation (matches the existing corrosion+inferno-only channel).
+- Reconciling/removing the legacy per-piece `DoTDamage.tsx` display math (separate cleanup;
+  not this PR's concern unless it visibly contradicts the engine — note for follow-up).
+
+## Testing
+
+- **Registry unit tests** (`buildEquipmentAbilities` test): Burner emits the inferno `dot`
+  ability; Decimation emits a `dotDamage` modifier scaling with complete-set count
+  (2pc→10, 4pc→20, 6pc→30); sub-`minPieces` piece counts emit nothing.
+- **Modifier-fold unit test** (`applyAbilities` test): a `dotDamage` modifier sums into
+  `ModifierTotals.dotDamage`; other channels unaffected.
+- **Mutation-resistant engine integration tests** routed through the **real** registry
+  (`buildShipAbilitiesWithEquipment` + a `getGearPiece` returning `setBonus:'BURNER'`/`'DECIMATION'`,
+  not a hand-rolled ability):
+  - Burner applies a 2-turn Inferno (tier 15, 1 stack) to the target on cast; expires after 2 ticks.
+  - Decimation scales the equipped ship's inferno/corrosion ticks by `sets×10%` (assert the tick
+    delta vs a no-Decimation control).
+  - Composition: Burner + Decimation on the same ship → Burner's inferno is Decimation-boosted.
+- **Coverage tracker** (`equipmentCoverage.test.ts`): add `BURNER` + `DECIMATION` to the
+  implemented gear-set set (decl-order array, Set, and the `exactly{}` string).
+
+## Verification gates
+
+- Full suite green; `npm run lint`, `tsc` clean; `npm run audit:skills` unchanged.
+- **ZERO golden / `.snap` drift** — confirm no combat fixture equips Burner or Decimation
+  (grep fixtures for the set names). If any does, the change is no longer byte-identical and
+  the goldens must be re-derived deliberately, not `-u`'d.
+- DPS-calc numbers: byte-identical for ships without Decimation; correctly increased for ships
+  with it (manual spot-check + the DPS wiring test).

--- a/docs/superpowers/specs/2026-06-24-gear-set-dot-pair-design.md
+++ b/docs/superpowers/specs/2026-06-24-gear-set-dot-pair-design.md
@@ -49,25 +49,35 @@ are already folded into combat stats; this PR adds **only** the special effects 
 **Behaviour:** when the equipped ship casts (attacks), apply Inferno 1 (tier 15), 1 stack,
 2 turns, to the cast target.
 
-**Model:** a reactive `dot` ability in `GEAR_SET_ABILITIES`:
+**Model:** a reactive `dot` ability in `GEAR_SET_ABILITIES`, trigger **`on-deal-damage`**:
 
 ```
 BURNER: () => ({
     type: 'dot',
     target: 'enemy',
-    trigger: 'on-cast',
+    trigger: 'on-deal-damage',
     conditions: [],
     config: { type: 'dot', dotType: 'inferno', tier: 15, stacks: 1, duration: 2 },
     autoFilled: true,
 })
 ```
 
-- Rides the **existing** reactive DoT executor (`triggers.ts` ~1398) — pushes an inferno
-  entry (`sourceId = owner`) and emits `dot-applied` to `ctx.enemy.id`. No new application path.
+- **Trigger correction (found during implementation):** `on-cast` does NOT work for a
+  passive-slot DoT. The cast path only gathers DoTs from the *fired* skill
+  (`dotsFromSkill(gatedSkill)`, playerTurn.ts:1262) — never the passive slot — and `on-cast`
+  is not a `LIVE_TRIGGER`, so the reactive executor never fires it either. (Leech, also an
+  `on-cast` gear-set ability, only works because it has a *dedicated* engine scan,
+  `procStandingLeeches`.) Burner therefore uses **`on-deal-damage`** — a `LIVE_TRIGGER` that
+  fires once per turn the owner deals direct damage (added in the reactive-cleanse PR; the
+  Warpstrike precedent). Faithful to "applies Inferno when it attacks" and golden-safe
+  (no fixture equips Burner).
+- Rides the **existing** reactive DoT executor (`triggers.ts` ~1388) — pushes an inferno
+  entry (`sourceId = owner`) and emits `dot-applied` to `ctx.enemy.id` (the attack target).
+  No new application path.
 - The entry ticks with the **applier's** snapshotted `dotMult`/`effectiveAttack`, so a
   Burner + Decimation ship's inferno is Decimation-boosted automatically.
-- Single target (the cast target), per the design decision. AoE-footprint application is
-  explicitly out of scope.
+- Single target (the attack target), per the design decision. Re-applies each attacking turn
+  (refreshes the 2-turn duration). AoE-footprint application is explicitly out of scope.
 
 ## Effect 2 — Decimation
 

--- a/docs/superpowers/specs/2026-06-24-gear-set-dot-pair-design.md
+++ b/docs/superpowers/specs/2026-06-24-gear-set-dot-pair-design.md
@@ -83,10 +83,12 @@ Changes:
 1. **`types/abilities.ts`** — add `'dotDamage'` to `ModifierChannel`.
 2. **`applyAbilities.ts`** — add `dotDamage: number` to `ModifierTotals`; sum the
    `'dotDamage'` channel in `modifierTotalsFromAbilities` (mirrors the existing channel cases).
-3. **`effectiveStats.ts`** — in `effectiveDamageStatsOf`, include `mod.dotDamage` in the
-   returned `selfDotDamageModifier` (line 214: `dotPen.dotDamageModifier + mod.dotDamage`).
-   This is the single fold point — `dotMult` already consumes `dmgStats.selfDotDamageModifier`,
-   so both the engine cast path and reactive-DoT ticks pick it up with no further wiring.
+3. **`effectiveStats.ts`** — in `effectiveDamageStatsOf`, change the returned
+   `selfDotDamageModifier` (line 214) **from** `dotPen.dotDamageModifier` **to**
+   `dotPen.dotDamageModifier + mod.dotDamage` (`mod = modifierTotalsFromAbilities(...)` is
+   already in scope at line 184). This is the single engine fold point — `dotMult` already
+   consumes `dmgStats.selfDotDamageModifier`, so both the engine cast path and reactive-DoT
+   ticks pick it up with no further wiring.
 4. **`buildEquipmentAbilities.ts`** — Decimation builder emits
    `{ type:'modifier', target:'self', trigger:'on-cast', conditions:[],
      config:{ type:'modifier', channel:'dotDamage', value: completeSets*10, isMultiplicative:false } }`.
@@ -100,14 +102,18 @@ already holds `count` (pieces) and `minPieces`; pass `count`, and Decimation com
 ## DPS calculator wiring
 
 Decimation affects DoT damage → DPS, so the DPS calculator must honor it. `dpsSimulator.ts`
-computes its own `dotMult` from `toDotAndPenModifiers(...).dotDamageModifier` (self-buffs only)
-and does **not** route through `effectiveDamageStatsOf`. The plan must thread the
-`dotDamage` modifier channel into `dpsSimulator`'s `selfDotModifier` so the DPS page reflects
-Decimation. `buildShipAbilitiesWithEquipment` is already wired into `DPSCalculatorPage` (D-PR2),
-so the Decimation `modifier` ability is already present in the DPS ability set — only the
-fold into the DPS `dotMult` needs adding. The exact seam is a plan-level detail; if it proves
-larger than a small additive change, it may be peeled to a follow-up (the engine fold is the
-primary deliverable).
+(line ~241) derives its `selfDotModifier` **solely** from `toDotAndPenModifiers(selfBuffs, [])`
+and never calls `modifierTotalsFromAbilities` on the self side, so the value is **not** sitting
+in an existing variable the way it is on the engine side. Honoring Decimation in the DPS path
+therefore requires the DPS simulator to actually **run** `modifierTotalsFromAbilities` over the
+passive abilities (or otherwise extract the `dotDamage` channel) and add it into `selfDotModifier`
+— a bit more than a one-token change to an existing sum.
+
+`buildShipAbilitiesWithEquipment` is already wired into `DPSCalculatorPage` (verified: it is
+passed as `shipSkills` at `DPSCalculatorPage.tsx:73`), so the Decimation `modifier` ability is
+already present in the DPS ability set — only the fold into the DPS `dotMult` needs adding. The
+exact seam is a plan-level detail; if it proves larger than a small additive change, it may be
+peeled to a follow-up (the engine fold is the primary deliverable).
 
 ## Out of scope / explicitly deferred
 
@@ -138,6 +144,8 @@ primary deliverable).
 - Full suite green; `npm run lint`, `tsc` clean; `npm run audit:skills` unchanged.
 - **ZERO golden / `.snap` drift** — confirm no combat fixture equips Burner or Decimation
   (grep fixtures for the set names). If any does, the change is no longer byte-identical and
-  the goldens must be re-derived deliberately, not `-u`'d.
+  the goldens must be re-derived deliberately, not `-u`'d. Note: grepping `BURNER`/`DECIMATION`
+  turns up **non-combat** hits in the autogear `fastScoring`/`fastPotential` scoring fixtures —
+  those are scoring-only and do not touch combat goldens; don't be alarmed by them.
 - DPS-calc numbers: byte-identical for ships without Decimation; correctly increased for ships
   with it (manual spot-check + the DPS wiring test).

--- a/src/components/skills/AbilityCard.tsx
+++ b/src/components/skills/AbilityCard.tsx
@@ -78,6 +78,7 @@ const MODIFIER_CHANNEL_OPTIONS: { value: ModifierChannel; label: string }[] = [
     { value: 'crit', label: 'Crit' },
     { value: 'critDamage', label: 'Crit Damage' },
     { value: 'outgoingDamage', label: 'Outgoing Damage' },
+    { value: 'dotDamage', label: 'DoT Damage' },
     { value: 'outgoingHeal', label: 'Outgoing Heal' },
     { value: 'incomingDamage', label: 'Incoming Damage' },
 ];

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -31,6 +31,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim now models enemy charge removal — ships like Opal, Provider, Sefuba (on cast), Demolisher (when a bomb explodes), and Zosimos (every second enemy repair) now drain the enemy's Charged Skill, with charge-loss-immune ships unaffected.",
     "Combat simulator now models the Chrono Reaver implant — it grants a bonus charge to the carrier's charged skill every 2nd turn (legendary) or every 3rd turn (epic). Units in Stasis bank no charge on skipped turns.",
     "Combat simulator now models Cobalt's passive — at the start of each of its turns while at full HP, Cobalt gains a bonus charge toward its charged skill.",
+    'Combat & DPS simulators now model two damage-over-time gear sets: Burner (applies Inferno for 2 turns when the ship attacks) and Decimation (+10% DoT damage per equipped set, up to +30%). Decimation now boosts your ship’s Inferno and Corrosion ticks in both the combat simulator and the DPS calculator.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3100,7 +3100,12 @@ const DocumentationPage: React.FC = () => {
                                     manipulation is also modeled: <strong>Chrono Reaver</strong>{' '}
                                     (grants a bonus charge to the carrier&apos;s charged skill every
                                     2nd turn at legendary rarity or every 3rd turn at epic; units in
-                                    Stasis bank no charge on skipped turns). More implant and
+                                    Stasis bank no charge on skipped turns). Two damage-over-time
+                                    gear sets are also modeled: <strong>Burner</strong> (applies
+                                    Inferno for 2 turns when the ship attacks) and{' '}
+                                    <strong>Decimation</strong> (+10% DoT damage per equipped set, up
+                                    to +30%, boosting your Inferno and Corrosion ticks in both the
+                                    combat simulator and the DPS calculator). More implant and
                                     gear-set effects will be added in future updates.
                                 </p>
                             </div>

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -302,6 +302,7 @@ export type ModifierChannel =
     | 'crit'
     | 'critDamage'
     | 'outgoingDamage'
+    | 'dotDamage'
     | 'outgoingHeal'
     | 'incomingDamage';
 

--- a/src/utils/abilities/__tests__/applyAbilities.test.ts
+++ b/src/utils/abilities/__tests__/applyAbilities.test.ts
@@ -86,6 +86,7 @@ describe('modifierTotalsFromAbilities', () => {
         crit: 0,
         critDamage: 0,
         outgoingDamage: 0,
+        dotDamage: 0,
         defence: 0,
         defensePenetration: 0,
         hp: 0,
@@ -183,6 +184,23 @@ describe('modifierTotalsFromAbilities', () => {
                 })
             )
         ).toEqual({ ...zero, defensePenetration: 45 });
+    });
+});
+
+describe('modifierTotalsFromAbilities — dotDamage channel', () => {
+    it('sums a dotDamage modifier into ModifierTotals.dotDamage', () => {
+        const ability: Ability = {
+            id: 'decimation-x',
+            type: 'modifier',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'modifier', channel: 'dotDamage', value: 20, isMultiplicative: false },
+        };
+        const totals = modifierTotalsFromAbilities([ability], makeConditionContext({}));
+        expect(totals.dotDamage).toBe(20);
+        expect(totals.outgoingDamage).toBe(0);
+        expect(totals.attack).toBe(0);
     });
 });
 

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -820,7 +820,7 @@ describe('Decimation gear set', () => {
 // Burner gear set (4pc): applies Inferno 1 (tier 15) for 2 turns on cast
 // ---------------------------------------------------------------------------
 describe('Burner gear set', () => {
-    it('emits an on-cast inferno DoT (tier 15, 1 stack, 2 turns) at 4 pieces', () => {
+    it('emits an on-deal-damage inferno DoT (tier 15, 1 stack, 2 turns) at 4 pieces', () => {
         const equipment: Record<string, string> = {};
         const map: Record<string, GearPiece> = {};
         const slots = ['weapon', 'hull', 'generator', 'sensor'];
@@ -832,7 +832,7 @@ describe('Burner gear set', () => {
         const abilities = buildEquipmentAbilities(makeShip({ equipment }), (id) => map[id]);
         const burner = abilities.find((a) => a.id === 'equip-set-BURNER');
         expect(burner?.type).toBe('dot');
-        expect(burner?.trigger).toBe('on-cast');
+        expect(burner?.trigger).toBe('on-deal-damage');
         expect(burner?.target).toBe('enemy');
         expect(burner?.config).toMatchObject({
             type: 'dot',

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -781,6 +781,41 @@ describe('Fortifying Shroud implant', () => {
     });
 });
 
+// ---------------------------------------------------------------------------
+// Decimation gear set (2pc): +10% DoT damage per complete set, as a dotDamage modifier
+// ---------------------------------------------------------------------------
+describe('Decimation gear set', () => {
+    function shipWithDecimation(pieces: number) {
+        const equipment: Record<string, string> = {};
+        const map: Record<string, GearPiece> = {};
+        const slots = ['weapon', 'hull', 'generator', 'sensor', 'software', 'thrusters'];
+        for (let i = 0; i < pieces; i++) {
+            const id = `dec-${i}`;
+            equipment[slots[i]] = id;
+            map[id] = makePiece({ id, slot: slots[i] as GearPiece['slot'], setBonus: 'DECIMATION' });
+        }
+        return { ship: makeShip({ equipment }), getGearPiece: (id: string) => map[id] };
+    }
+    it('emits a dotDamage modifier scaling 10% per complete 2pc set', () => {
+        for (const [pieces, expected] of [[2, 10], [4, 20], [6, 30]] as const) {
+            const { ship, getGearPiece } = shipWithDecimation(pieces);
+            const abilities = buildEquipmentAbilities(ship, getGearPiece);
+            const dec = abilities.find((a) => a.id === 'equip-set-DECIMATION');
+            expect(dec?.type).toBe('modifier');
+            expect(dec?.config).toMatchObject({
+                type: 'modifier',
+                channel: 'dotDamage',
+                value: expected,
+            });
+        }
+    });
+    it('emits nothing below minPieces (1 piece)', () => {
+        const { ship, getGearPiece } = shipWithDecimation(1);
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        expect(abilities.find((a) => a.id === 'equip-set-DECIMATION')).toBeUndefined();
+    });
+});
+
 describe('Power Infused Nanobots buff (D-PR9 + D-PR10 — Font of Power, flat attack = caster attack)', () => {
     it('exists in the buff corpus as a buff', () => {
         const buff = BUFFS.find((b) => b.name === 'Power Infused Nanobots');

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -792,7 +792,7 @@ describe('Decimation gear set', () => {
         for (let i = 0; i < pieces; i++) {
             const id = `dec-${i}`;
             equipment[slots[i]] = id;
-            map[id] = makePiece({ id, slot: slots[i] as GearPiece['slot'], setBonus: 'DECIMATION' });
+            map[id] = makePiece({ id, slot: slots[i], setBonus: 'DECIMATION' });
         }
         return { ship: makeShip({ equipment }), getGearPiece: (id: string) => map[id] };
     }
@@ -827,7 +827,7 @@ describe('Burner gear set', () => {
         slots.forEach((slot, i) => {
             const id = `burn-${i}`;
             equipment[slot] = id;
-            map[id] = makePiece({ id, slot: slot as GearPiece['slot'], setBonus: 'BURNER' });
+            map[id] = makePiece({ id, slot: slot, setBonus: 'BURNER' });
         });
         const abilities = buildEquipmentAbilities(makeShip({ equipment }), (id) => map[id]);
         const burner = abilities.find((a) => a.id === 'equip-set-BURNER');
@@ -848,7 +848,7 @@ describe('Burner gear set', () => {
         ['weapon', 'hull', 'generator'].forEach((slot, i) => {
             const id = `burn-${i}`;
             equipment[slot] = id;
-            map[id] = makePiece({ id, slot: slot as GearPiece['slot'], setBonus: 'BURNER' });
+            map[id] = makePiece({ id, slot: slot, setBonus: 'BURNER' });
         });
         const abilities = buildEquipmentAbilities(makeShip({ equipment }), (id) => map[id]);
         expect(abilities.find((a) => a.id === 'equip-set-BURNER')).toBeUndefined();

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -816,6 +816,45 @@ describe('Decimation gear set', () => {
     });
 });
 
+// ---------------------------------------------------------------------------
+// Burner gear set (4pc): applies Inferno 1 (tier 15) for 2 turns on cast
+// ---------------------------------------------------------------------------
+describe('Burner gear set', () => {
+    it('emits an on-cast inferno DoT (tier 15, 1 stack, 2 turns) at 4 pieces', () => {
+        const equipment: Record<string, string> = {};
+        const map: Record<string, GearPiece> = {};
+        const slots = ['weapon', 'hull', 'generator', 'sensor'];
+        slots.forEach((slot, i) => {
+            const id = `burn-${i}`;
+            equipment[slot] = id;
+            map[id] = makePiece({ id, slot: slot as GearPiece['slot'], setBonus: 'BURNER' });
+        });
+        const abilities = buildEquipmentAbilities(makeShip({ equipment }), (id) => map[id]);
+        const burner = abilities.find((a) => a.id === 'equip-set-BURNER');
+        expect(burner?.type).toBe('dot');
+        expect(burner?.trigger).toBe('on-cast');
+        expect(burner?.target).toBe('enemy');
+        expect(burner?.config).toMatchObject({
+            type: 'dot',
+            dotType: 'inferno',
+            tier: 15,
+            stacks: 1,
+            duration: 2,
+        });
+    });
+    it('emits nothing below minPieces (3 pieces, needs 4)', () => {
+        const equipment: Record<string, string> = {};
+        const map: Record<string, GearPiece> = {};
+        ['weapon', 'hull', 'generator'].forEach((slot, i) => {
+            const id = `burn-${i}`;
+            equipment[slot] = id;
+            map[id] = makePiece({ id, slot: slot as GearPiece['slot'], setBonus: 'BURNER' });
+        });
+        const abilities = buildEquipmentAbilities(makeShip({ equipment }), (id) => map[id]);
+        expect(abilities.find((a) => a.id === 'equip-set-BURNER')).toBeUndefined();
+    });
+});
+
 describe('Power Infused Nanobots buff (D-PR9 + D-PR10 — Font of Power, flat attack = caster attack)', () => {
     it('exists in the buff corpus as a buff', () => {
         const buff = BUFFS.find((b) => b.name === 'Power Infused Nanobots');

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -19,6 +19,7 @@
  * D-PR9 added ally-wide / new-trigger buff grants (SPEARHEAD, FONT_OF_POWER).
  * D-PR11 added adjacent-ally buff grant (FORTIFYING_SHROUD).
  * D-PR14 added Provoke/Concentrate Fire debuff grants (BULWARK, DOOMSAYER).
+ * Gear-set DoT pair added BURNER (on-cast Inferno) + DECIMATION (dotDamage modifier) gear sets.
  *
  * Assertions are plain `expect` calls — no snapshot files.
  */
@@ -119,12 +120,12 @@ function implantAbilities(implantKey: string, rarity: string) {
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { LEECH + CLOAKING + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + CHRONO_REAVER + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_STAND + LAST_WISH + LOCKDOWN + MENACE + REACTIVE_WARD + SECOND_WIND + SHADOWGUARD + SPEARHEAD + TENACITY + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
+    it('exactly { BURNER + DECIMATION + LEECH + CLOAKING + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + CHRONO_REAVER + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_STAND + LAST_WISH + LOCKDOWN + MENACE + REACTIVE_WARD + SECOND_WIND + SHADOWGUARD + SPEARHEAD + TENACITY + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
         );
-        expect(implementedSets).toEqual(['LEECH', 'CLOAKING', 'HARDENED']);
+        expect(implementedSets).toEqual(['BURNER', 'DECIMATION', 'LEECH', 'CLOAKING', 'HARDENED']);
 
         // Implants with an ability builder (check each implant with a rarity that exists)
         const implementedImplants = Object.keys(IMPLANTS).filter((key) => {
@@ -175,9 +176,17 @@ describe('equipmentCoverage — implemented effects registry', () => {
 // Gear-set coverage: one assertion per set
 // ---------------------------------------------------------------------------
 
-const IMPLEMENTED_SETS = new Set(['LEECH', 'CLOAKING', 'HARDENED']);
+const IMPLEMENTED_SETS = new Set(['BURNER', 'DECIMATION', 'LEECH', 'CLOAKING', 'HARDENED']);
 
 describe('equipmentCoverage — gear sets', () => {
+    it('BURNER produces exactly 1 ability (the on-cast inferno)', () => {
+        expect(gearSetAbilityCount('BURNER')).toBe(1);
+    });
+
+    it('DECIMATION produces exactly 1 ability (the dotDamage modifier)', () => {
+        expect(gearSetAbilityCount('DECIMATION')).toBe(1);
+    });
+
     it('LEECH produces exactly 1 ability (the standing leech)', () => {
         expect(gearSetAbilityCount('LEECH')).toBe(1);
     });

--- a/src/utils/abilities/applyAbilities.ts
+++ b/src/utils/abilities/applyAbilities.ts
@@ -8,6 +8,7 @@ export interface ModifierTotals {
     crit: number;
     critDamage: number;
     outgoingDamage: number;
+    dotDamage: number;
     defence: number;
     defensePenetration: number;
     hp: number;
@@ -28,6 +29,7 @@ export function modifierTotalsFromAbilities(
         crit: 0,
         critDamage: 0,
         outgoingDamage: 0,
+        dotDamage: 0,
         defence: 0,
         defensePenetration: 0,
         hp: 0,
@@ -59,6 +61,9 @@ export function modifierTotalsFromAbilities(
                 break;
             case 'outgoingDamage':
                 totals.outgoingDamage += amount;
+                break;
+            case 'dotDamage':
+                totals.dotDamage += amount;
                 break;
             case 'defense':
                 totals.defence += amount;

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -94,6 +94,17 @@ const GEAR_SET_ABILITIES: Partial<
             autoFilled: true,
         };
     },
+    // Burner (4pc set): applies Inferno 1 (tier 15) for 2 turns on cast. Reactive on-cast
+    // dot ability — rides the existing reactive DoT executor (triggers.ts), pushing an
+    // inferno entry to the cast target with sourceId = owner.
+    BURNER: () => ({
+        type: 'dot',
+        target: 'enemy',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'dot', dotType: 'inferno', tier: 15, stacks: 1, duration: 2 },
+        autoFilled: true,
+    }),
 };
 
 // ---------------------------------------------------------------------------

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -94,13 +94,17 @@ const GEAR_SET_ABILITIES: Partial<
             autoFilled: true,
         };
     },
-    // Burner (4pc set): applies Inferno 1 (tier 15) for 2 turns on cast. Reactive on-cast
-    // dot ability — rides the existing reactive DoT executor (triggers.ts), pushing an
-    // inferno entry to the cast target with sourceId = owner.
+    // Burner (4pc set): applies Inferno 1 (tier 15) for 2 turns when the ship attacks.
+    // `on-cast` is NOT a LIVE_TRIGGER — passive-slot on-cast DoTs are never applied by the
+    // engine (the cast path only gathers DoTs from the FIRED skill, and the reactive executor
+    // only runs for LIVE_TRIGGERS). So Burner rides `on-deal-damage` (a LIVE_TRIGGER that fires
+    // once per turn the owner deals direct damage), draining through the reactive DoT executor
+    // (triggers.ts) which pushes the inferno entry to the attack target (ctx.enemy.id) with
+    // sourceId = owner. Re-applies each attacking turn (refreshes the 2-turn duration).
     BURNER: () => ({
         type: 'dot',
         target: 'enemy',
-        trigger: 'on-cast',
+        trigger: 'on-deal-damage',
         conditions: [],
         config: { type: 'dot', dotType: 'inferno', tier: 15, stacks: 1, duration: 2 },
         autoFilled: true,

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -41,7 +41,9 @@ import { Ship } from '../../types/ship';
 // Gear-set ability registry (D-PR1: Leech; D-PR3: Hardened)
 // ---------------------------------------------------------------------------
 
-const GEAR_SET_ABILITIES: Partial<Record<string, () => Omit<Ability, 'id'> | undefined>> = {
+const GEAR_SET_ABILITIES: Partial<
+    Record<string, (count: number) => Omit<Ability, 'id'> | undefined>
+> = {
     LEECH: () => ({
         type: 'heal',
         target: 'self',
@@ -72,6 +74,26 @@ const GEAR_SET_ABILITIES: Partial<Record<string, () => Omit<Ability, 'id'> | und
     // self-stealth / incoming-crit-by-stealthed conditions, and the D-PR8 Ambush gate.
     CLOAKING: () =>
         mkNamedBuffGrant('Stealth', 'self', 'start-of-round', 2, { oncePerCombat: true }),
+    // Decimation (2pc set): +10% DoT damage per complete set, max 3 sets (6 pieces) = +30%.
+    // Standing passive → modeled as a dotDamage modifier that folds into dotMult via
+    // effectiveDamageStatsOf.selfDotDamageModifier (engine + DPS calc both honor it).
+    DECIMATION: (count) => {
+        const minPieces = GEAR_SETS.DECIMATION?.minPieces ?? 2;
+        const sets = Math.floor(count / minPieces); // 1/2/3 at 2/4/6 pieces
+        return {
+            type: 'modifier',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [],
+            config: {
+                type: 'modifier',
+                channel: 'dotDamage',
+                value: sets * 10,
+                isMultiplicative: false,
+            },
+            autoFilled: true,
+        };
+    },
 };
 
 // ---------------------------------------------------------------------------
@@ -905,7 +927,7 @@ export function buildEquipmentAbilities(
         const builder = GEAR_SET_ABILITIES[setName];
         if (!builder) continue;
 
-        const partial = builder();
+        const partial = builder(count);
         if (!partial) continue;
         abilities.push({ id: `equip-set-${setName}`, ...partial });
     }

--- a/src/utils/calculators/__tests__/decimationDps.test.ts
+++ b/src/utils/calculators/__tests__/decimationDps.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Group E (Task 7): DPS-calculator-level proof that the Decimation gear set raises DoT
+ * damage in the DPS calc — not just the battle-sim engine.
+ *
+ * This test routes through the PUBLIC DPS calculator entry point `simulateDPS`
+ * (src/utils/calculators/dpsSimulator.ts), which the DPS page uses. `simulateDPS` calls
+ * `runCombat` and walks the SAME `runPlayerTurn` as the battle sim, so the
+ * `dotDamage` → `dotMult` fold (effectiveDamageStatsOf.selfDotDamageModifier) applies
+ * here too with no extra wiring.
+ *
+ * The Decimation modifier is NOT hand-rolled: the ship's abilities are built via the REAL
+ * registry (`buildShipAbilitiesWithEquipment(ship, getGearPiece)`) with gear pieces whose
+ * `setBonus` is 'DECIMATION'. The registry emits a passive `modifier` ability
+ * `{channel:'dotDamage', value: floor(pieces/2)*10}`. If someone breaks the DECIMATION
+ * registry entry (e.g. zeroes its value) or the dotDamage fold, this test fails — it is the
+ * DPS-calc trip-wire for the engine fold.
+ *
+ * Setup: a DoT-only ship (active = single-hit inferno DoT, NO direct damage) so the +10%
+ * shows cleanly in `summary.totalInfernoDamage` (the direct/secondary/conditional channels
+ * stay zero and cannot dilute the ratio). The DPS run is executed twice — once with 2
+ * DECIMATION pieces, once without (identical otherwise) — and the boosted run's inferno
+ * total must be exactly ×1.10 the control (affinity neutral → the ratio cancels everything
+ * except the fold factor).
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateDPS } from '../dpsSimulator';
+import { buildShipAbilitiesWithEquipment } from '../../abilities/buildShipAbilitiesWithEquipment';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import { Ship } from '../../../types/ship';
+import { GearPiece } from '../../../types/gear';
+
+// ---------------------------------------------------------------------------
+// Harness helpers (mirrored from gearSetDotPair.integration.test.ts)
+// ---------------------------------------------------------------------------
+
+/** Minimal Ship stub. Equipment is provided by overrides. */
+function makeShip(over: Partial<Ship>): Ship {
+    return {
+        id: 'test-ship',
+        name: 'Test Ship',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'ATTACKER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        ...over,
+    } as Ship;
+}
+
+/** Minimal GearPiece stub. */
+function makePiece(over: Partial<GearPiece>): GearPiece {
+    return {
+        id: 'piece-1',
+        slot: 'weapon',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: null,
+        ...over,
+    } as GearPiece;
+}
+
+/** getGearPiece factory backed by an id→GearPiece map. */
+function makeGetGearPiece(map: Record<string, GearPiece>): (id: string) => GearPiece | undefined {
+    return (id) => map[id];
+}
+
+/**
+ * A DoT-only active skill: a single-hit inferno DoT and NO direct damage. The carrier DoT
+ * whose ticks Decimation scales. Tier 15, 1 stack, 2 turns.
+ */
+const activeInferno: Ability = {
+    id: 'active-inferno',
+    type: 'dot',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'dot', dotType: 'inferno', tier: 15, stacks: 1, duration: 2 },
+};
+
+// 2 DECIMATION pieces (2pc → 1 set → +10% DoT damage).
+const DECIMATION_2PC = [
+    makePiece({ id: 'decim-1', slot: 'software', setBonus: 'DECIMATION' }),
+    makePiece({ id: 'decim-2', slot: 'thruster', setBonus: 'DECIMATION' }),
+];
+
+/**
+ * Build ShipSkills from the REAL registry: equip `pieces`, run buildShipAbilitiesWithEquipment,
+ * then prepend the carrier inferno DoT in the active slot so the ship applies a real DoT each
+ * cast. The registry-built passive slot (carrying the DECIMATION modifier) is carried over verbatim.
+ */
+function skillsWithRegistry(pieces: GearPiece[]): {
+    shipSkills: ShipSkills;
+    passiveAbilityIds: string[];
+} {
+    const equipment: Record<string, string> = {};
+    const map: Record<string, GearPiece> = {};
+    for (const p of pieces) {
+        equipment[p.slot] = p.id;
+        map[p.id] = p;
+    }
+    const ship = makeShip({ equipment: equipment as Ship['equipment'] });
+    const built = buildShipAbilitiesWithEquipment(ship, makeGetGearPiece(map));
+    const passive = built.slots.find((s) => s.slot === 'passive');
+    return {
+        shipSkills: {
+            slots: [
+                { slot: 'active', abilities: [activeInferno] },
+                ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+            ],
+        },
+        passiveAbilityIds: passive?.abilities.map((a) => a.id) ?? [],
+    };
+}
+
+/** Base DPS-calc input: neutral stats, enemy never dies, no crit/affinity variance. */
+const DPS_BASE = {
+    attack: 5000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    rounds: 5,
+    selfBuffs: [],
+    enemyDebuffs: [],
+};
+
+// ---------------------------------------------------------------------------
+// Decimation scales DoT in the DPS calculator (real registry + shared engine fold)
+// ---------------------------------------------------------------------------
+
+describe('DPS calculator — Decimation scales DoT damage (real registry + shared engine fold)', () => {
+    it('2 DECIMATION pieces: DPS-calc inferno total is exactly ×1.10 vs no-Decimation control', () => {
+        // Control: no Decimation — carrier inferno only (no passive slot).
+        const controlSkills: ShipSkills = {
+            slots: [{ slot: 'active', abilities: [activeInferno] }],
+        };
+        // Boosted: same carrier inferno + 2 Decimation pieces via the REAL registry.
+        const boosted = skillsWithRegistry(DECIMATION_2PC);
+
+        // Pre-condition: the DECIMATION modifier landed in the passive slot via the registry.
+        expect(boosted.passiveAbilityIds).toContain('equip-set-DECIMATION');
+
+        const controlResult = simulateDPS({ ...DPS_BASE, shipSkills: controlSkills });
+        const boostedResult = simulateDPS({ ...DPS_BASE, shipSkills: boosted.shipSkills });
+
+        const controlInferno = controlResult.summary.totalInfernoDamage;
+        const boostedInferno = boostedResult.summary.totalInfernoDamage;
+
+        // DoT-only ship: direct/secondary/conditional channels stay zero, so they cannot
+        // dilute the inferno ratio.
+        expect(controlResult.summary.totalDirectDamage).toBe(0);
+        expect(boostedResult.summary.totalDirectDamage).toBe(0);
+
+        expect(controlInferno).toBeGreaterThan(0);
+        // Decimation 2pc → +10% dotDamage → dotMult 1.0→1.1 → boosted = control × 1.10 exactly.
+        // (affinity neutral so the ratio cancels attack/affinity.) Allow rounding tolerance.
+        expect(boostedInferno).toBeCloseTo(controlInferno * 1.1, 3);
+    });
+});

--- a/src/utils/combat/__tests__/effectiveStats.test.ts
+++ b/src/utils/combat/__tests__/effectiveStats.test.ts
@@ -535,6 +535,61 @@ describe('effectiveDamageStatsOf — four-layer fold characterization', () => {
     });
 });
 
+describe('effectiveDamageStatsOf — dotDamage modifier folds into selfDotDamageModifier', () => {
+    const base = {
+        attack: 2000,
+        defence: 500,
+        crit: 15,
+        critDamage: 150,
+        hp: 10000,
+        defensePenetration: 10,
+        defensePenetrationBuff: 5,
+    };
+
+    it('a dotDamage modifier ability raises selfDotDamageModifier (feeds dotMult)', () => {
+        const scheduledTotals = calculateBuffTotals(toSimBuffs([]));
+
+        const modifierAbilities: Ability[] = [
+            {
+                id: 'decimation',
+                type: 'modifier',
+                target: 'self',
+                trigger: 'on-cast',
+                conditions: [],
+                config: {
+                    type: 'modifier',
+                    channel: 'dotDamage',
+                    value: 30,
+                    isMultiplicative: false,
+                },
+            },
+        ];
+
+        const modifierCtx: ConditionContext = {
+            selfBuffNames: [],
+            selfDebuffNames: [],
+            enemyBuffNames: [],
+            enemyDebuffCount: 0,
+            effectiveCritRate: 0,
+            adjacentAllyCount: 0,
+            enemyAdjacentCount: 0,
+            enemyDestroyedCount: 0,
+            selfHpPct: 100,
+            enemyHpPct: 100,
+        };
+
+        const dmg = effectiveDamageStatsOf({
+            base,
+            scheduledTotals,
+            abilitySelfEffects: [],
+            modifierAbilities,
+            modifierCtx,
+        });
+
+        expect(dmg.selfDotDamageModifier).toBe(30);
+    });
+});
+
 describe('liveDebuffLandingChance — reproduces the static landing formula with no buffs (holistic review #3)', () => {
     // The OLD static formula every adapter baked at its input boundary:
     //   clamp(hacking * (1 + affinityDamageModifier/100) - security, 0, 100) / 100

--- a/src/utils/combat/__tests__/gearSetDotPair.integration.test.ts
+++ b/src/utils/combat/__tests__/gearSetDotPair.integration.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Group D (Task 6): Burner + Decimation gear-set DoT pair — mutation-resistant engine
+ * integration tests.
+ *
+ * These tests route through the REAL equipment-ability registry: the ship's abilities are
+ * built via `buildShipAbilitiesWithEquipment(ship, getGearPiece)` with gear pieces whose
+ * `setBonus` is 'BURNER' / 'DECIMATION'. The Decimation modifier is NOT hand-rolled — if
+ * someone breaks the DECIMATION registry entry (e.g. zeroes its value) or the
+ * `dotDamage`→`dotMult` fold (effectiveDamageStatsOf.selfDotDamageModifier), this test fails.
+ *
+ * ── BURNER (now live via on-deal-damage) ─────────────────────────────────────────────────
+ * BURNER's registry entry now rides trigger `on-deal-damage` (a LIVE_TRIGGER that fires once per
+ * turn the owner deals direct damage), NOT `on-cast` (a passive-slot on-cast DoT is engine-inert:
+ * the cast path only gathers DoTs from the FIRED skill). The reactive DoT executor (triggers.ts)
+ * pushes an inferno entry (`{dotType:'inferno',tier:15,stacks:1,duration:2}`, sourceId=owner) onto
+ * the attack target (`ctx.enemy.id`) and emits `dot-applied`. So Burner DOES apply Inferno in
+ * combat — the tests below verify it empirically through the REAL registry (4 BURNER pieces via
+ * `buildShipAbilitiesWithEquipment`, NOT a hand-rolled ability). Because `on-deal-damage` fires
+ * every attacking turn, the 2-turn inferno is RE-APPLIED each turn the ship attacks (overlapping
+ * stacks), so we assert Burner PRODUCES inferno ticks rather than that it expires after 2 turns.
+ *
+ * The composition test proves Burner's reactive inferno is Decimation-boosted via the shared
+ * `dotMult` fold: Burner+Decimation inferno total = Burner-only total × 1.10 exactly (the per-tick
+ * ratio cancels attack/affinity/stacking, leaving only the fold factor).
+ *
+ * Inferno tick formula (engine, tickDoTs):
+ *   damage = stacks × (tier/100) × applierEffectiveAttack × dotMult × affinityMult
+ * affinityMult is neutral (1) here, so the Decimation ratio (boosted/control) is exactly the
+ * fold factor and cancels attack/affinity.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus } from '../events';
+import { ShipSkills, Ability } from '../../../types/abilities';
+import { Ship } from '../../../types/ship';
+import { GearPiece } from '../../../types/gear';
+import { buildShipAbilitiesWithEquipment } from '../../abilities/buildShipAbilitiesWithEquipment';
+
+// ---------------------------------------------------------------------------
+// Harness helpers (mirrored from equipmentAbilities.integration.test.ts)
+// ---------------------------------------------------------------------------
+
+/** Minimal Ship stub. Equipment is provided by overrides. */
+function makeShip(over: Partial<Ship>): Ship {
+    return {
+        id: 'test-ship',
+        name: 'Test Ship',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'ATTACKER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        ...over,
+    } as Ship;
+}
+
+/** Minimal GearPiece stub. */
+function makePiece(over: Partial<GearPiece>): GearPiece {
+    return {
+        id: 'piece-1',
+        slot: 'weapon',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: null,
+        ...over,
+    } as GearPiece;
+}
+
+/** getGearPiece factory backed by an id→GearPiece map. */
+function makeGetGearPiece(map: Record<string, GearPiece>): (id: string) => GearPiece | undefined {
+    return (id) => map[id];
+}
+
+/**
+ * A single-hit inferno DoT in the ACTIVE slot — the carrier DoT whose ticks Decimation scales.
+ * Tier 15, 1 stack, 2 turns mirrors Burner's emitted DoT shape exactly, so the per-tick damage
+ * matches what Burner would inflict once the engine wires passive-slot on-cast DoTs.
+ */
+const activeInferno: Ability = {
+    id: 'active-inferno',
+    type: 'dot',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'dot', dotType: 'inferno', tier: 15, stacks: 1, duration: 2 },
+};
+
+/** Base engine input: neutral stats, enemy never dies, no crit/affinity variance. */
+const BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 5000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 5,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 2000,
+    hp: 10_000,
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+/** Sum inferno tick damage across all rounds for a run. */
+function totalInferno(input: CombatEngineInput): number {
+    const bus = createEventBus();
+    let sum = 0;
+    bus.on('dot-ticked', (e) => {
+        const ev = e;
+        if (ev.dotType === 'inferno') sum += ev.damage;
+    });
+    runCombat({ ...input, bus });
+    return sum;
+}
+
+// ---------------------------------------------------------------------------
+// Gear stubs
+// ---------------------------------------------------------------------------
+
+// 2 DECIMATION pieces (2pc → 1 set → +10% DoT damage).
+const DECIMATION_2PC = [
+    makePiece({ id: 'decim-1', slot: 'software', setBonus: 'DECIMATION' }),
+    makePiece({ id: 'decim-2', slot: 'thruster', setBonus: 'DECIMATION' }),
+];
+
+// 4 BURNER pieces (4pc → activates BURNER's on-deal-damage inferno). Four distinct flat slots.
+const BURNER_4PC = [
+    makePiece({ id: 'burn-1', slot: 'weapon', setBonus: 'BURNER' }),
+    makePiece({ id: 'burn-2', slot: 'hull', setBonus: 'BURNER' }),
+    makePiece({ id: 'burn-3', slot: 'generator', setBonus: 'BURNER' }),
+    makePiece({ id: 'burn-4', slot: 'sensor', setBonus: 'BURNER' }),
+];
+
+/** A plain single-hit damaging active. Burner rides `on-deal-damage`, so the ship must deal
+ *  direct damage each turn for the reactive inferno to fire. Carries no DoT of its own. */
+const plainAttack: Ability = {
+    id: 'plain-attack',
+    type: 'damage',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'damage', multiplier: 100, hits: 1 },
+};
+
+/**
+ * Build ShipSkills from the REAL registry: equip `pieces`, run buildShipAbilitiesWithEquipment,
+ * then prepend a carrier inferno DoT in the active slot so the ship applies a real DoT each cast.
+ * The registry-built passive slot (carrying the DECIMATION modifier) is carried over verbatim.
+ */
+function skillsWithRegistry(pieces: GearPiece[]): {
+    shipSkills: ShipSkills;
+    passiveAbilityIds: string[];
+} {
+    const equipment: Record<string, string> = {};
+    const map: Record<string, GearPiece> = {};
+    for (const p of pieces) {
+        equipment[p.slot] = p.id;
+        map[p.id] = p;
+    }
+    const ship = makeShip({ equipment: equipment as Ship['equipment'] });
+    const built = buildShipAbilitiesWithEquipment(ship, makeGetGearPiece(map));
+    const passive = built.slots.find((s) => s.slot === 'passive');
+    return {
+        shipSkills: {
+            slots: [
+                { slot: 'active', abilities: [activeInferno] },
+                ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+            ],
+        },
+        passiveAbilityIds: passive?.abilities.map((a) => a.id) ?? [],
+    };
+}
+
+/**
+ * Build ShipSkills from the REAL registry with an arbitrary active ability: equip `pieces`, run
+ * buildShipAbilitiesWithEquipment, then prepend `active` in the active slot and carry the
+ * registry-built passive slot (Burner's on-deal-damage DoT + any DECIMATION modifier) verbatim.
+ */
+function skillsWithActive(
+    active: Ability,
+    pieces: GearPiece[]
+): { shipSkills: ShipSkills; passiveAbilityIds: string[] } {
+    const equipment: Record<string, string> = {};
+    const map: Record<string, GearPiece> = {};
+    for (const p of pieces) {
+        equipment[p.slot] = p.id;
+        map[p.id] = p;
+    }
+    const ship = makeShip({ equipment: equipment as Ship['equipment'] });
+    const built = buildShipAbilitiesWithEquipment(ship, makeGetGearPiece(map));
+    const passive = built.slots.find((s) => s.slot === 'passive');
+    return {
+        shipSkills: {
+            slots: [
+                { slot: 'active', abilities: [active] },
+                ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+            ],
+        },
+        passiveAbilityIds: passive?.abilities.map((a) => a.id) ?? [],
+    };
+}
+
+/** Capture inferno `dot-applied` events (sourceId attribution) alongside the inferno tick total. */
+function runWithInfernoCapture(input: CombatEngineInput): {
+    infernoTick: number;
+    infernoApplied: { sourceId: string; targetId: string }[];
+} {
+    const bus = createEventBus();
+    let infernoTick = 0;
+    const infernoApplied: { sourceId: string; targetId: string }[] = [];
+    bus.on('dot-ticked', (e) => {
+        if (e.dotType === 'inferno') infernoTick += e.damage;
+    });
+    bus.on('dot-applied', (e) => {
+        if (e.dotType === 'inferno') infernoApplied.push({ sourceId: e.sourceId, targetId: e.targetId });
+    });
+    runCombat({ ...input, bus });
+    return { infernoTick, infernoApplied };
+}
+
+// ---------------------------------------------------------------------------
+// Burner applies Inferno on attack (real registry, on-deal-damage)
+// ---------------------------------------------------------------------------
+
+describe('Gear-set DoT pair — Burner applies Inferno on attack (real registry)', () => {
+    it('4 BURNER pieces + a plain attack → enemy takes Burner-attributed inferno ticks', () => {
+        const burner = skillsWithActive(plainAttack, BURNER_4PC);
+
+        // Pre-condition: the BURNER on-deal-damage inferno landed in the passive slot via the registry.
+        expect(burner.passiveAbilityIds).toContain('equip-set-BURNER');
+
+        const { infernoTick, infernoApplied } = runWithInfernoCapture(
+            BASE({ numRounds: 5, attack: 5000, crit: 0, critDamage: 0, shipSkills: burner.shipSkills })
+        );
+
+        // Burner fires once per attacking turn → at least one inferno application, attributed to
+        // the Burner ship ('attacker') and landing on the attack target ('enemy').
+        expect(infernoApplied.length).toBeGreaterThan(0);
+        for (const ev of infernoApplied) {
+            expect(ev.sourceId).toBe('attacker');
+            expect(ev.targetId).toBe('enemy');
+        }
+        // And those applications actually tick damage on the enemy.
+        expect(infernoTick).toBeGreaterThan(0);
+    });
+
+    it('re-applies every attacking turn: inferno re-applied each round, ticks ramp to 2 overlapping stacks', () => {
+        // Because Burner rides on-deal-damage and the ship attacks every round, the 2-turn inferno
+        // is RE-APPLIED each round (so it never expires while the ship keeps attacking). We assert
+        // that behaviour directly: an application AND a tick every round, and the per-round tick
+        // damage ramps from a single fresh stack (round 1) to two overlapping stacks (round 2+).
+        const burner = skillsWithActive(plainAttack, BURNER_4PC);
+
+        const bus = createEventBus();
+        const appliesByRound: number[] = [];
+        const tickDmgByRound: number[] = [];
+        bus.on('dot-applied', (e) => {
+            if (e.dotType !== 'inferno') return;
+            appliesByRound[e.round] = (appliesByRound[e.round] ?? 0) + 1;
+        });
+        bus.on('dot-ticked', (e) => {
+            if (e.dotType !== 'inferno') return;
+            tickDmgByRound[e.round] = (tickDmgByRound[e.round] ?? 0) + e.damage;
+        });
+        runCombat(
+            BASE({
+                numRounds: 4,
+                attack: 5000,
+                crit: 0,
+                critDamage: 0,
+                shipSkills: burner.shipSkills,
+                bus,
+            })
+        );
+
+        // Re-applied every round the ship attacks (rounds 1..4).
+        for (let r = 1; r <= 4; r++) {
+            expect(appliesByRound[r]).toBe(1);
+            expect(tickDmgByRound[r]).toBeGreaterThan(0);
+        }
+        // Per-tick stack damage = 5000 × (15/100) × 1 stack × dotMult(1) = 750. Round 1 = one
+        // fresh stack (750); round 2 onward = two overlapping 2-turn stacks (1500). This is the
+        // re-application signature — load-bearing: zeroing BURNER's stacks/tier collapses both.
+        expect(tickDmgByRound[1]).toBeCloseTo(750, 6);
+        expect(tickDmgByRound[2]).toBeCloseTo(1500, 6);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Composition: Burner + Decimation — Burner's inferno is Decimation-boosted ×1.10
+// ---------------------------------------------------------------------------
+
+describe('Gear-set DoT pair — composition (Burner + Decimation)', () => {
+    it("Burner+Decimation inferno total = Burner-only control × 1.10 (shared dotMult fold)", () => {
+        // Control: 4 BURNER only (no Decimation) — Burner's reactive inferno, dotMult 1.0.
+        const burnerOnly = skillsWithActive(plainAttack, BURNER_4PC);
+        // Boosted: identical 4 BURNER + 2 DECIMATION (1 set → +10% DoT damage) via the REAL registry.
+        const burnerDecim = skillsWithActive(plainAttack, [...BURNER_4PC, ...DECIMATION_2PC]);
+
+        // Pre-conditions: both have Burner; only the boosted run carries the Decimation modifier.
+        expect(burnerOnly.passiveAbilityIds).toContain('equip-set-BURNER');
+        expect(burnerOnly.passiveAbilityIds).not.toContain('equip-set-DECIMATION');
+        expect(burnerDecim.passiveAbilityIds).toContain('equip-set-BURNER');
+        expect(burnerDecim.passiveAbilityIds).toContain('equip-set-DECIMATION');
+
+        const env = { numRounds: 5, attack: 5000, crit: 0, critDamage: 0 };
+        const control = runWithInfernoCapture(BASE({ ...env, shipSkills: burnerOnly.shipSkills }));
+        const boosted = runWithInfernoCapture(BASE({ ...env, shipSkills: burnerDecim.shipSkills }));
+
+        // Burner fires identically in both runs (same attack cadence) → the only difference is the
+        // Decimation dotMult fold. Both totals share the same overlapping-stack pattern, so the
+        // ratio is exactly the fold factor.
+        expect(control.infernoTick).toBeGreaterThan(0);
+        expect(boosted.infernoTick).toBeCloseTo(control.infernoTick * 1.1, 3);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Decimation scales DoT ticks by sets × 10% (real registry + real engine fold)
+// ---------------------------------------------------------------------------
+
+describe('Gear-set DoT pair — Decimation scales DoT ticks (real registry + engine fold)', () => {
+    it('2 DECIMATION pieces: inferno ticks are exactly ×1.10 vs no-Decimation control', () => {
+        // Control: no Decimation — carrier inferno only (no passive slot).
+        const controlSkills: ShipSkills = {
+            slots: [{ slot: 'active', abilities: [activeInferno] }],
+        };
+        // Boosted: same carrier inferno + 2 Decimation pieces via the REAL registry.
+        const boosted = skillsWithRegistry(DECIMATION_2PC);
+
+        // Pre-condition: the DECIMATION modifier landed in the passive slot via the registry.
+        expect(boosted.passiveAbilityIds).toContain('equip-set-DECIMATION');
+
+        const env = { numRounds: 5, attack: 5000, crit: 0, critDamage: 0 };
+        const controlInferno = totalInferno(BASE({ ...env, shipSkills: controlSkills }));
+        const boostedInferno = totalInferno(BASE({ ...env, shipSkills: boosted.shipSkills }));
+
+        expect(controlInferno).toBeGreaterThan(0);
+        // Decimation 2pc → +10% dotDamage → dotMult 1.0→1.1 → boosted = control × 1.10 exactly.
+        // (affinityMult is neutral so the ratio cancels attack/affinity.)
+        expect(boostedInferno).toBeCloseTo(controlInferno * 1.1, 3);
+    });
+});

--- a/src/utils/combat/effectiveStats.ts
+++ b/src/utils/combat/effectiveStats.ts
@@ -211,7 +211,7 @@ export function effectiveDamageStatsOf(args: {
             base.defensePenetrationBuff +
             mod.defensePenetration +
             dotPen.defensePenetrationBuff,
-        selfDotDamageModifier: dotPen.dotDamageModifier,
+        selfDotDamageModifier: dotPen.dotDamageModifier + mod.dotDamage,
         totals,
     };
 }


### PR DESCRIPTION
Adds the two DoT-related special-effect gear sets to the combat & DPS simulators via the equipment-ability registry. Stat portions (Burner's +15% attack) were already modeled; this adds **only** the special effects. **No combat fixture equips either set → byte-identical goldens** (verified: zero golden/.snap drift).

## Effects
- **Burner** (4pc): applies **Inferno 1 (tier 15) for 2 turns when the ship attacks**. Reactive `dot` ability on the **`on-deal-damage`** LIVE_TRIGGER (see note below), riding the existing reactive DoT executor → pushes an inferno entry to the attack target (`sourceId = owner`). Re-applies each attacking turn.
- **Decimation** (2pc): **+10% DoT damage per complete set**, max 3 sets (6pc) = +30%. A standing passive `modifier` ability on a **new `dotDamage` ModifierChannel** that folds into `dmgStats.selfDotDamageModifier` (`effectiveStats.ts`) → `dotMult` (`playerTurn.ts`). Boosts the ship's own corrosion + inferno ticks.

## Why one fold covers both simulators
`runPlayerTurn` is shared by `simulateBattle` and the DPS calc's `runCombat`, and `modifierAbilities` already includes the passive slot. So the single `effectiveStats` fold makes **both** the battle sim and the DPS calculator honor Decimation — no separate DPS wiring. (This also makes the *engine* honor Decimation for the first time; previously only the `DoTDamage.tsx` display did.) Proven by a DPS-calc test (`simulateDPS` ×1.10).

## Design correction during implementation
The spec originally specified Burner on **`on-cast`**. Implementation found a passive-slot `on-cast` DoT is **engine-inert**: the cast path only gathers DoTs from the *fired* skill, and `on-cast` is not a `LIVE_TRIGGER` so the reactive executor never fires it. Switched to **`on-deal-damage`** (a LIVE_TRIGGER; Warpstrike precedent) — faithful to "applies Inferno when attacking" and golden-safe. Spec + plan updated to match.

## Tests
- Unit: registry shapes (`buildEquipmentAbilities`), `dotDamage` channel sum (`applyAbilities`), the fold (`effectiveStats`), coverage tracker.
- **Mutation-resistant engine integration** (`gearSetDotPair.integration.test.ts`) via the **real** registry (`buildShipAbilitiesWithEquipment` + `setBonus`): Burner applies inferno on attack (src=attacker, tgt=enemy); Decimation scales ticks ×1.10 exactly; composition (Burner inferno is Decimation-boosted). Mutation-checked (zeroing the registry value/stacks fails the tests).
- DPS-calc test confirms Decimation raises DoT DPS ×1.10.

## Verification
- 3161 tests pass, **0 failures, zero golden/.snap drift**.
- `lint` clean, `tsc` clean, `audit:skills` 0/141.
- Rebased onto current `main` (charge stack #151–#153); conflicts (coverage title, changelog, docs paragraph) resolved keeping both sides.

Spec: `docs/superpowers/specs/2026-06-24-gear-set-dot-pair-design.md` · Plan: `docs/superpowers/plans/2026-06-24-gear-set-dot-pair.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)