### PR TITLE
feat(combat): shield system H2+H3 — Shield gear set + reactive shield implants

### DIFF
--- a/docs/superpowers/plans/2026-06-25-shield-system-h2-h3.md
+++ b/docs/superpowers/plans/2026-06-25-shield-system-h2-h3.md
@@ -1,0 +1,487 @@
+# Shield System H2 + H3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Light up the dormant Shield gear set and three reactive shield implants (Adaptive Plating, Abundant Renewal, Resonating Fury) in the combat engine, shipped as one PR with H2 (gear set) and H3 (implants + a new `on-shield-applied` trigger) as ordered phases.
+
+**Architecture:** All four are data-driven equipment abilities registered in `buildEquipmentAbilities.ts`, flowing through the existing reactive trigger machinery. A single foundation fix — routing reactive shield grants per-recipient via `recipientActor(rid)` instead of heal-target-only — enables every new source. Two new reactive bases (`damage-taken` via the on-attacked hit damage, `overheal` via a new `heal-performed.overheal` field) scale the implant shields off runtime amounts. A new `shield-applied` event + `on-shield-applied` trigger, emitted once per shield-application cast carrying the granter + recipient set, drives Resonating Fury.
+
+**Tech Stack:** React 18, TypeScript, Vite, Vitest. Combat engine in `src/utils/combat/`, equipment-ability registry in `src/utils/abilities/`, ability/event types in `src/types/`.
+
+---
+
+## Pre-flight (read once, do not skip)
+
+- **`.env` required for the full suite.** This repo's `.tsx` test files need the gitignored `.env`. If working in a worktree, `cp` the main repo's `.env` in first or ~14 test files fail to collect ("supabaseUrl is required"). The pre-commit (husky) hook runs the FULL vitest suite — a missing `.env` will fail the commit.
+- **NEVER run `vitest -u`** (blanket golden update). H2/H3 are designed byte-identical; if a golden drifts, STOP and audit — do not rebaseline.
+- **Goldens to watch after the Phase 0 foundation fix:** any battle-sim/healing golden exercising an existing reactive shield (FrontLine `on-enemy-charged-cast`, Defiant `on-stasis-applied`). Expected byte-identical (fixtures run owner==focus==healTarget). If one drifts, confirm the drift is a previously-dropped grant now landing on a non-focus owner (intended) before accepting; otherwise it's a bug.
+- **Gates per task/PR:** `npm test` (full suite green), `npm run lint` (max-warnings 0), `tsc` (via build or editor), `npm run audit:skills` unchanged (141/0). 
+- **Commits:** feature commits run the pre-commit hook (full vitest) — let it run. Use `gh auth switch --user TheSusort` before any `gh pr create`.
+- **Subagents share the main working dir** on branch `feat/combat-shield-system`. Forbid `git checkout`/`git switch` in any dispatched subagent (a prior run left a detached HEAD).
+
+## Reference: exact game data (already in the repo, do not re-derive)
+
+- `src/constants/gearSets.ts:111` `SHIELD` = `{ name:'Shield', stats:[{name:'shield',value:4,type:'percentage'}], description:'Generate 4% shield each turn' }`.
+- `src/constants/implants.ts`:
+  - `ADAPTIVE_PLATING` (`:1089`, type `major`): "When directly damaged, X% chance to gain a Shield equal to Y% of the damage taken, limited to once per round." Rarities: `uncommon` 12%/.21, `epic` 16%/.34, `legendary` 19%/.42.
+  - `ABUNDANT_RENEWAL` (`:37`, type `ultimate`): "Grants a shield equal to X% of the overrepaired amount on the target when overrepairing an ally." Rarities: `epic` 20%, `legendary` 30%. No proc (deterministic).
+  - `RESONATING_FURY` (`:2556`, type `major`): "When applying a shield, X% chance to grant Crit Power Up 3 for 1 turn." Rarities: `common` 5%, `uncommon` 7%, `rare` 9%, `epic` 12%, `legendary` 16%.
+- `'Crit Power Up 3'` is an existing named buff in `BUFFS` (used by Stealth crit implants) — `mkNamedBuffGrant` resolves it.
+
+## Locked behavior (from the spec — do not relitigate)
+
+- Resonating Fury: **one proc roll per shield-application cast**; on success Crit Power Up 3 (1 turn) goes to **every recipient that gained shield on that cast** (caster included if among them). NOT per-recipient, NOT carrier-only.
+- `on-shield-applied` is emitted **once per cast** carrying `granterId` + `recipientIds` (only recipients with `actualGranted > 0`); if none gained shield, no event.
+- Adaptive Plating: `on-attacked` (direct only — DoTs route through `dot-applied`, never `on-attacked`), `oncePerRound: true`.
+- Abundant Renewal: `on-own-repair-to-ally`, ally overheals only, deterministic, shield to the over-repaired ally.
+- Emission scope: `on-shield-applied` is emitted from the **cast path** (`playerTurn.ts`) and the **reactive executor** (`triggers.ts`) only — these cover all H2/H3 sources. The standing damage-leech shield sites (`engine.ts` 2337/2415/2475/4686) are **out of scope** for emission (document in-code; no H2/H3 source uses them, and they're per-recipient not per-cast).
+
+---
+
+## File Structure
+
+**Modify:**
+- `src/types/abilities.ts` — add `'on-shield-applied'` to `AbilityTrigger` + `LIVE_TRIGGERS`; add `'overheal'` to the `heal|shield` config `basis` union.
+- `src/utils/combat/events.ts` — add `shield-applied` event variant; add `overheal?` to `heal-performed`.
+- `src/utils/combat/playerTurn.ts` — accumulate `overheal` in the cast heal loop, attach to `heal-performed`; emit `shield-applied` once per cast in the shield loop.
+- `src/utils/combat/triggers.ts` — Phase 0 per-recipient shield routing; `damage-taken` + `overheal` basis arms; stamp `triggerDamage` on `on-attacked`; thread `overheal` on `on-own-repair-to-ally`; emit `shield-applied` from the reactive shield branch; new `eventCtx.shieldRecipientIds`; new `on-shield-applied` listener; RF recipient routing in the buff executor.
+- `src/utils/abilities/buildEquipmentAbilities.ts` — `SHIELD` gear set entry + `ADAPTIVE_PLATING`/`ABUNDANT_RENEWAL`/`RESONATING_FURY` implant entries + rarity tables.
+- `src/utils/abilities/__tests__/equipmentCoverage.test.ts` — register the 4 new abilities in the coverage matrix.
+- `src/constants/changelog.ts` — `UNRELEASED_CHANGES` entry.
+- `src/pages/DocumentationPage.tsx` — note the new shield sources if a relevant section exists.
+
+**Create (tests):**
+- `src/utils/combat/__tests__/reactiveShieldRouting.test.ts` — Phase 0.
+- Extend `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts` — one integration test per new source.
+
+---
+
+## Phase 0 — Foundation: reactive shield per-recipient routing
+
+This is the enabler for every new source. Today the reactive heal/shield executor only lands a pool when `rid === ctx.healing.targetId`.
+
+### Task 0.1: Reactive shield grants land on any same-side recipient
+
+**Files:**
+- Modify: `src/utils/combat/triggers.ts:1614-1617`
+- Test: `src/utils/combat/__tests__/reactiveShieldRouting.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test.** Build a battle-sim scenario (use the `simulateBattle` / `runCombat` + `createEventBus` harness from `equipmentAbilities.integration.test.ts`) with a focus ship A (the heal target) and an ally ship B, where B has a reactive shield ability targeting `self` that fires (e.g. a hand-built `start-of-turn` `{type:'shield', pct:10, basis:'hp'}` ability on B). Assert B's shield pool / `shieldGranted` becomes `0.10 × Bmaxhp` even though B is NOT the focus.
+
+```ts
+// reactiveShieldRouting.test.ts — sketch; adapt to the integration harness BASE()/makeShip
+it('reactive self-shield lands a pool on a non-focus ally', () => {
+    // ship B (ally, not focus) carries a start-of-turn self-shield ability
+    // run simulateBattle with focus = A
+    // expect B's currentShieldPool ≈ 0.10 * B.maxHp
+});
+```
+
+- [ ] **Step 2: Run to verify it fails.** `npm test -- reactiveShieldRouting` → FAIL (B's pool stays 0; only the focus gets a pool).
+
+- [ ] **Step 3: Implement.** Replace the heal-target-only guard with per-recipient routing mirroring the cast path (`playerTurn.ts:1907-1910`):
+
+```ts
+// triggers.ts ~1614-1617, the `else` (shield) branch of the heal/shield executor
+} else {
+    ctx.healing.credit(intent.ownerId, 'shield', raw);
+    const recipientActor = ctx.healing.recipientActor(rid);
+    if (recipientActor) ctx.healing.grantShieldToTarget(raw, recipientActor);
+}
+```
+
+- [ ] **Step 4: Run the new test + the full suite.** `npm test -- reactiveShieldRouting` → PASS. Then `npm test` (full). Goldens MUST stay byte-identical. If any reactive-shield golden drifts, STOP and audit per Pre-flight before continuing.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add src/utils/combat/triggers.ts src/utils/combat/__tests__/reactiveShieldRouting.test.ts
+git commit -m "feat(combat): route reactive shield grants per-recipient via recipientActor (H2/H3 foundation)"
+```
+
+---
+
+## Phase H2 — Shield gear set
+
+### Task H2.1: SHIELD gear-set ability entry
+
+**Files:**
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (the `GEAR_SET_ABILITIES` object, `:44-112`)
+- Test: `src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+
+- [ ] **Step 1: Write the failing shape test** in `equipmentCoverage.test.ts`, modeled on the CLOAKING shape test (`:202-227`):
+
+```ts
+it('SHIELD produces a start-of-turn self shield of 4% caster max HP', () => {
+    const minPieces = GEAR_SETS['SHIELD']?.minPieces ?? 2;
+    const slots = ['weapon', 'hull', 'sensor', 'engine', 'shield', 'computer'] as const;
+    const equipment: Record<string, string> = {};
+    const pieceMap: Record<string, GearPiece> = {};
+    for (let i = 0; i < minPieces; i++) {
+        const id = `SHIELD-piece-${i}`;
+        equipment[slots[i % slots.length]] = id;
+        pieceMap[id] = makePiece({ id, slot: slots[i % slots.length], setBonus: 'SHIELD' });
+    }
+    const ship = makeShip({ equipment });
+    const abilities = buildEquipmentAbilities(ship, (id) => pieceMap[id]);
+    const sh = abilities.find((a) => a.id === 'equip-set-SHIELD');
+    expect(sh).toBeDefined();
+    expect(sh!.type).toBe('shield');
+    expect(sh!.target).toBe('self');
+    expect(sh!.trigger).toBe('start-of-turn');
+    expect(sh!.config.type).toBe('shield');
+    // @ts-expect-error shield config
+    expect(sh!.config.pct).toBe(4);
+    // @ts-expect-error shield config
+    expect(sh!.config.basis).toBe('hp');
+});
+```
+Also update the implemented-sets list (`:128`) and the `IMPLEMENTED_SETS` Set (`:179`) to include `'SHIELD'`.
+
+- [ ] **Step 2: Run to verify it fails.** `npm test -- equipmentCoverage` → FAIL (no SHIELD entry).
+
+- [ ] **Step 3: Implement the entry** in `GEAR_SET_ABILITIES` (hand-written literal, no shield helper exists; model on inline LEECH/HARDENED):
+
+```ts
+// Shield gear set: "Generate 4% shield each turn" → start-of-turn self shield of 4% caster max HP.
+// start-of-turn is a LIVE trigger → partitions to the reactive path; lands via the Phase 0
+// per-recipient routing fix.
+SHIELD: () => ({
+    type: 'shield',
+    target: 'self',
+    trigger: 'start-of-turn',
+    conditions: [],
+    config: { type: 'shield', pct: 4, basis: 'hp' },
+    autoFilled: true,
+}),
+```
+
+- [ ] **Step 4: Run to verify it passes.** `npm test -- equipmentCoverage` → PASS.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/equipmentCoverage.test.ts
+git commit -m "feat(combat): Shield gear set — start-of-turn 4% maxHP self shield (H2)"
+```
+
+### Task H2.2: Shield gear-set integration test (full build→engine path)
+
+**Files:**
+- Test: `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts`
+
+- [ ] **Step 1: Write the integration test.** Equip a ship with 2 SHIELD pieces, build via `buildShipAbilitiesWithEquipment`, run `simulateBattle` (focus = that ship so its `ShipRoundState` surfaces), assert `shieldGranted` / `currentShieldPool` ≈ `0.04 × maxHp` after its first turn. Model on the LEECH integration test (`:135-210`) for the build path and the H1 surfacing fields (`ShipRoundState.shieldGranted`, `currentShieldPool`).
+
+- [ ] **Step 2: Run to verify it fails first if written before H2.1** (skip if H2.1 already merged) — otherwise run to confirm PASS.
+
+- [ ] **Step 3: Run.** `npm test -- equipmentAbilities.integration` → PASS.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+git commit -m "test(combat): Shield gear set grants 4% maxHP pool via full build→sim path (H2)"
+```
+
+---
+
+## Phase H3 — Reactive shield implants + on-shield-applied
+
+### Task H3.1: `damage-taken` reactive basis (Adaptive Plating foundation)
+
+**Files:**
+- Modify: `src/utils/combat/triggers.ts` (on-attacked listener `:446-449`; basis ternary `:1561-1572`)
+- Test: `src/utils/combat/__tests__/reactiveShieldRouting.test.ts` (extend) or a focused new test
+
+- [ ] **Step 1: Write the failing test.** A ship with a hand-built `on-attacked` `{type:'shield', basis:'damage-taken', pct:50}` ability; when it takes a direct hit of D damage, assert its shield pool grows by `0.50 × D`.
+
+- [ ] **Step 2: Run to verify it fails.** The basis falls through to `effectiveMaxHp` today → pool wrong/huge. → FAIL.
+
+- [ ] **Step 3: Implement two edits.**
+(a) Stamp the hit damage into eventCtx in the `on-attacked` listener (`triggers.ts:446-449`):
+```ts
+enqueue({
+    ...intent,
+    eventCtx: { counterTargetId: e.attackerId, didCrit: e.didCrit, triggerDamage: e.damage },
+});
+```
+(b) Add a `damage-taken` arm to the `nonTargetHpBasis` ternary (`triggers.ts:1561-1572`) reading `eventCtx.triggerDamage` (same source the `damage-dealt` arm uses):
+```ts
+const nonTargetHpBasis =
+    cfg.basis === 'attack'
+        ? (ownerCtx?.effectiveAttack ?? owner.attack)
+        : cfg.basis === 'defense'
+          ? (ownerCtx?.effectiveDefence ?? owner.defence)
+          : cfg.basis === 'damage-dealt' || cfg.basis === 'damage-taken'
+            ? (intent.eventCtx?.triggerDamage ?? 0)
+            : (ownerCtx?.effectiveMaxHp ?? owner.hp);
+```
+
+- [ ] **Step 4: Run the new test + full suite.** PASS; goldens byte-identical (no existing reactive shield uses `damage-taken`; the standing `damage-taken` leech path is untouched because reactive partitioning strips on-attacked abilities from `castSkills`).
+
+- [ ] **Step 5: Commit.**
+```bash
+git add src/utils/combat/triggers.ts src/utils/combat/__tests__/reactiveShieldRouting.test.ts
+git commit -m "feat(combat): reactive damage-taken shield basis via on-attacked hit damage (H3)"
+```
+
+### Task H3.2: Adaptive Plating implant entry + integration test
+
+**Files:**
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (`IMPLANT_ABILITIES`)
+- Test: `equipmentCoverage.test.ts` + `equipmentAbilities.integration.test.ts`
+
+- [ ] **Step 1: Write the failing coverage test** asserting the entry's shape (model on SECOND_WIND `:685-698` for an on-attacked reactive shield). Add `'ADAPTIVE_PLATING'` to the implemented-implants list (`:136-171`) and Set (`:269-304`).
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement** the rarity tables + entry:
+```ts
+const ADAPTIVE_PLATING_PROC: Record<string, number> = { uncommon: 0.12, epic: 0.16, legendary: 0.19 };
+const ADAPTIVE_PLATING_PCT: Record<string, number> = { uncommon: 21, epic: 34, legendary: 42 };
+// ...
+ADAPTIVE_PLATING: (rarity) => {
+    const procChance = ADAPTIVE_PLATING_PROC[rarity];
+    const pct = ADAPTIVE_PLATING_PCT[rarity];
+    if (procChance === undefined || pct === undefined) return undefined;
+    return {
+        type: 'shield',
+        target: 'self',
+        trigger: 'on-attacked', // direct only — DoTs use dot-applied, never on-attacked
+        conditions: [],
+        procChance,
+        oncePerRound: true,
+        config: { type: 'shield', pct, basis: 'damage-taken' },
+        autoFilled: true,
+    };
+},
+```
+
+- [ ] **Step 4: Run coverage → PASS.**
+
+- [ ] **Step 5: Write integration test** — equip a legendary Adaptive Plating implant, run a sim where the ship takes a direct hit, force the proc (set proc to fire — see how existing reactive tests drive procChance, e.g. via a deterministic rate-gate at 1.0 or a high-probability fixture), assert shield pool ≈ `0.42 × damageTaken` and that it fires at most once per round. Model on the integration harness.
+
+- [ ] **Step 6: Run full suite → PASS, goldens byte-identical.**
+
+- [ ] **Step 7: Commit.**
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/equipmentCoverage.test.ts src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+git commit -m "feat(combat): Adaptive Plating — once-per-round shield on direct hit (H3)"
+```
+
+### Task H3.3: `overheal` basis + `heal-performed.overheal` plumbing (Abundant Renewal foundation)
+
+**Files:**
+- Modify: `src/types/abilities.ts:384` (basis union); `src/utils/combat/events.ts:98-105` (heal-performed); `src/utils/combat/playerTurn.ts` (cast heal loop `:1868-1890`, emit `:1936`); `src/utils/combat/triggers.ts` (on-own-repair-to-ally listener `:369-382`, basis ternary)
+- Test: focused new test
+
+- [ ] **Step 1: Write the failing test.** A ship with a hand-built `on-own-repair-to-ally` `{type:'shield', basis:'overheal', pct:50}` ability that heals an ally for more than its missing HP; assert the over-repaired ally's shield pool grows by `0.50 × overheal`.
+
+- [ ] **Step 2: Run → FAIL** (`overheal` basis not in the type / not threaded).
+
+- [ ] **Step 3: Implement, in order:**
+(a) `abilities.ts:384` — add `'overheal'`:
+```ts
+basis: 'hp' | 'attack' | 'defense' | 'target-hp' | 'damage-dealt' | 'damage-taken' | 'overheal';
+```
+(b) `events.ts` `heal-performed` payload (`:98-105`) — add `overheal?: number`.
+(c) `playerTurn.ts` cast heal loop (`:1868-1890`) — accumulate overheal:
+```ts
+let overhealSum = 0; // declare alongside healRawSum
+// inside the rid === healing.targetId block, after computing { consumed, overheal }:
+overhealSum += overheal;
+```
+and at the emit (`:1936`) attach `...(overhealSum > 0 ? { overheal: overhealSum } : {})`.
+(d) `triggers.ts` on-own-repair-to-ally listener (`:369-382`) — thread it:
+```ts
+eventCtx: { ...intent.eventCtx, repairedAllyIds: repaired, triggerDamage: e.overheal ?? 0 },
+```
+Add a dedicated `overhealAmount?: number` to the eventCtx type (`triggers.ts:104-123`) — `damage-taken` and `overheal` never share an event, so reusing `triggerDamage` would be safe, but a dedicated field keeps the eventCtx self-documenting (preferred).
+(e) `triggers.ts` basis ternary — add an `overheal` arm reading the same magnitude field as chosen in (d).
+
+- [ ] **Step 4: Run the new test + full suite → PASS, goldens byte-identical** (no existing ability uses `overheal` basis; the new `heal-performed.overheal` field is additive and ignored by existing listeners).
+
+- [ ] **Step 5: Commit.**
+```bash
+git add src/types/abilities.ts src/utils/combat/events.ts src/utils/combat/playerTurn.ts src/utils/combat/triggers.ts <test>
+git commit -m "feat(combat): overheal shield basis + heal-performed.overheal field (H3)"
+```
+
+### Task H3.4: Abundant Renewal implant entry + integration test
+
+**Files:** `buildEquipmentAbilities.ts`, `equipmentCoverage.test.ts`, `equipmentAbilities.integration.test.ts`
+
+- [ ] **Step 1: Coverage test** (shape; model on FONT_OF_POWER `:812-818` for on-own-repair-to-ally). Add `'ABUNDANT_RENEWAL'` to the implant lists.
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement.** Target `ally` (reactive recipients fall back to the focus heal target = the over-repaired ally). Deterministic (no procChance):
+```ts
+const ABUNDANT_RENEWAL_PCT: Record<string, number> = { epic: 20, legendary: 30 };
+// ...
+ABUNDANT_RENEWAL: (rarity) => {
+    const pct = ABUNDANT_RENEWAL_PCT[rarity];
+    if (pct === undefined) return undefined;
+    return {
+        type: 'shield',
+        target: 'ally',
+        trigger: 'on-own-repair-to-ally',
+        conditions: [],
+        config: { type: 'shield', pct, basis: 'overheal' },
+        autoFilled: true,
+    };
+},
+```
+
+- [ ] **Step 4: Coverage → PASS.**
+
+- [ ] **Step 5: Integration test** — a healer with legendary Abundant Renewal overheals an ally; assert the ally's shield pool ≈ `0.30 × overheal`. Verify the over-repaired ally (heal target) is the recipient.
+
+- [ ] **Step 6: Full suite → PASS, byte-identical. Commit.**
+```bash
+git commit -m "feat(combat): Abundant Renewal — overheal→shield to the over-repaired ally (H3)"
+```
+
+### Task H3.5: `shield-applied` event + `on-shield-applied` trigger (definitions)
+
+**Files:** `src/types/abilities.ts` (AbilityTrigger + LIVE_TRIGGERS), `src/utils/combat/events.ts`
+
+- [ ] **Step 1: Write a failing test** asserting `'on-shield-applied'` is in `LIVE_TRIGGERS` and that a `shield-applied` event can be emitted/consumed via `createEventBus`.
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement.**
+(a) `abilities.ts` — add `'on-shield-applied'` to the `AbilityTrigger` union (with a doc comment: "fired once per shield-application cast; reaction keyed on the granter, targets the shield recipients — Resonating Fury") AND to `LIVE_TRIGGERS`.
+(b) `events.ts` — add the variant (model on `heal-performed` `:98-105`):
+```ts
+| {
+      type: 'shield-applied';
+      granterId: string;
+      recipientIds: string[]; // only recipients with actualGranted > 0
+      round: number;
+      amount: number; // total shield actually granted this cast
+  }
+```
+
+- [ ] **Step 4: Run → PASS.**
+
+- [ ] **Step 5: Commit.**
+```bash
+git commit -m "feat(combat): add shield-applied event + on-shield-applied trigger (H3)"
+```
+
+### Task H3.6: Emit `shield-applied` once per cast (cast path + reactive executor)
+
+**Files:** `src/utils/combat/playerTurn.ts` (shield loop `:1891-1911`), `src/utils/combat/triggers.ts` (reactive shield branch, after the recipient loop)
+
+- [ ] **Step 1: Write the failing test.** Two scenarios via `createEventBus` + `bus.on('shield-applied', …)`:
+  1. A cast shield to self + one ally emits ONE `shield-applied` with both recipientIds (those that gained shield) and the granter.
+  2. The Shield gear set (`start-of-turn`, reactive) emits ONE `shield-applied` with `[ownerId]`.
+Assert exactly one event per cast and that fully-capped (0-grant) recipients are excluded.
+
+- [ ] **Step 2: Run → FAIL** (no emission yet).
+
+- [ ] **Step 3: Implement.** In each grant loop, track recipients whose `grantShieldToTarget` produced `actualGranted > 0`. `grantShieldToTarget` doesn't return the delta today — either (a) have it return `actualGranted`, or (b) read the pool before/after at the call site. Prefer (a): change the closure signature to `grantShieldToTarget: (raw, victim?) => number` returning `actualGranted` (update the `HealingRuntimeCtx` interface at `playerTurn.ts:116` and the impl at `engine.ts:2062-2079`; all existing callers ignore the return — non-breaking). Then:
+  - Cast path (`playerTurn.ts:1891-1911`): collect `{rid, granted}` per recipient; after the loop, if any `granted > 0`, `bus.emit({ type:'shield-applied', granterId: actor.id, recipientIds: granted>0 ones, round: r, amount: sum })`.
+  - Reactive executor (`triggers.ts`, shield branch): same — after the recipient loop, emit one `shield-applied` keyed on `intent.ownerId`. Add a clear comment: this is intentional (unlike heal-performed which is deliberately NOT re-emitted) — `shield-applied` drives Resonating Fury (a buff, not a shield → terminates, no chain). 
+  - Document in-code at the `engine.ts` standing-leech shield sites that they are intentionally NOT emitting `shield-applied` (out of H3 scope; per-recipient, no H2/H3 source uses them).
+
+- [ ] **Step 4: Run new test + full suite → PASS, byte-identical** (emission is additive; no existing listener consumes `shield-applied`).
+
+- [ ] **Step 5: Commit.**
+```bash
+git commit -m "feat(combat): emit shield-applied once per cast (cast path + reactive executor) (H3)"
+```
+
+### Task H3.7: `on-shield-applied` listener + RF recipient routing
+
+**Files:** `src/utils/combat/triggers.ts` (eventCtx type `:104-123`; `registerReactiveListeners` `:232-633`; buff-executor recipient resolution)
+
+- [ ] **Step 1: Write the failing test.** A ship with a hand-built `on-shield-applied` buff ability (Crit Power Up 3, target the shield recipients) that, when it grants a shield to an ally, applies Crit Power Up 3 to that ally (and to all recipients of a multi-recipient cast on a single proc). Use `bus.on('buff-applied', …)` to assert recipients.
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement.**
+(a) Add `shieldRecipientIds?: string[]` to the `eventCtx` type (`:104-123`).
+(b) Add an `on-shield-applied` case in `registerReactiveListeners` keyed on the granter (model on `on-own-repair-to-ally` `:369-382`):
+```ts
+case 'on-shield-applied':
+    bus.on('shield-applied', (e) => {
+        if (e.granterId !== ownerId) return;
+        if (e.recipientIds.length === 0) return;
+        enqueue({ ...intent, eventCtx: { ...intent.eventCtx, shieldRecipientIds: e.recipientIds } });
+    });
+    break;
+```
+(c) Route the buff executor's recipients to `eventCtx.shieldRecipientIds` when present. Find where the buff branch resolves recipients (mirrors how `on-own-repair-to-ally` buffs use `repairedAllyIds`, and `reactiveRecipients` consumes eventCtx). Add `shieldRecipientIds` as the recipient source for an `on-shield-applied` reaction (a "shield-recipient" resolution). The proc roll (`passesProcChanceGate`) happens ONCE per enqueued intent = once per cast → correct single-roll-per-cast semantics.
+
+- [ ] **Step 4: Run new test + full suite → PASS, byte-identical.**
+
+- [ ] **Step 5: Commit.**
+```bash
+git commit -m "feat(combat): on-shield-applied listener — reaction targets shield recipients (H3)"
+```
+
+### Task H3.8: Resonating Fury implant entry + integration test (incl. reactive→reactive hop)
+
+**Files:** `buildEquipmentAbilities.ts`, `equipmentCoverage.test.ts`, `equipmentAbilities.integration.test.ts`
+
+- [ ] **Step 1: Coverage test** (shape; `mkNamedBuffGrant('Crit Power Up 3', target, 'on-shield-applied', 1, { procChance })`). Add `'RESONATING_FURY'` to the implant lists. The `target` for the buff must resolve to the shield recipients via the H3.7 routing — confirm the chosen `AbilityTarget` (likely `'ally'` or a dedicated value) maps to `shieldRecipientIds`.
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement:**
+```ts
+const RESONATING_FURY_PROC: Record<string, number> = {
+    common: 0.05, uncommon: 0.07, rare: 0.09, epic: 0.12, legendary: 0.16,
+};
+// ...
+RESONATING_FURY: (rarity) => {
+    const procChance = RESONATING_FURY_PROC[rarity];
+    if (procChance === undefined) return undefined;
+    return mkNamedBuffGrant('Crit Power Up 3', /* recipient-routed target */, 'on-shield-applied', 1, { procChance });
+},
+```
+(If `mkNamedBuffGrant`'s target union doesn't include a recipient-routed value, either extend it or hand-write the buff Ability literal — match the H3.7 recipient resolution.)
+
+- [ ] **Step 4: Coverage → PASS.**
+
+- [ ] **Step 5: Integration tests** (force the proc deterministically):
+  1. A ship with Resonating Fury that shields an ally → that ally gets Crit Power Up 3.
+  2. **Reactive→reactive hop:** a ship with BOTH Adaptive Plating + Resonating Fury takes a direct hit → Adaptive Plating self-shield fires → `shield-applied` → Resonating Fury grants Crit Power Up 3 to self. Assert the buff lands (proves the single safe hop terminates). If the intent queue does NOT drain intents enqueued mid-drain, this test surfaces it — if so, fix by ensuring the drain loop processes newly-enqueued intents (verify the `enqueue`/drain mechanism in `triggers.ts`).
+  3. Gear set + Resonating Fury: start-of-turn self shield → Crit Power Up 3 on self.
+
+- [ ] **Step 6: Full suite → PASS, byte-identical. Commit.**
+```bash
+git commit -m "feat(combat): Resonating Fury — Crit Power Up 3 to shield recipients on shield-applied (H3)"
+```
+
+---
+
+## Phase F — Finalize
+
+### Task F.1: Changelog + docs
+
+- [ ] Add an `UNRELEASED_CHANGES` entry to `src/constants/changelog.ts` (plain English): Shield gear set and the three reactive shield implants now function in the battle simulator. 
+- [ ] If `DocumentationPage.tsx` has a combat/gear-set/implant section, note the new working sources.
+- [ ] Commit: `git commit -m "docs(combat): changelog + docs for Shield gear set and reactive shield implants (H2/H3)"` (this is user-facing; do NOT `--no-verify` unless docs-only with no code — changelog.ts is code, let the hook run).
+
+### Task F.2: Full verification gate
+
+- [ ] `npm test` — full suite green (note pass count vs baseline 3281+; new tests add to it).
+- [ ] `npm run lint` — 0 warnings.
+- [ ] `tsc` clean (build or editor diagnostics).
+- [ ] `npm run audit:skills` — unchanged (141/0).
+- [ ] Confirm goldens byte-identical across the whole PR (NO `vitest -u`). If anything drifted, it must be explained and accepted (only the Phase 0 reactive-shield routing could plausibly drift, and only if a fixture ran a reactive shield on a non-focus owner — audit and document).
+
+### Task F.3: PR
+
+- [ ] `gh auth switch --user TheSusort`
+- [ ] Push `feat/combat-shield-system`, open the PR summarizing H2 + H3, link the spec, and note: byte-identical goldens, the Phase 0 enabler, and the documented out-of-scope items (standing-leech shield sites don't emit `shield-applied`; dynamic shieldPenetration buff-folding remains out of scope from H1).
+
+---
+
+## Risks & open verification points (resolve during execution, not by guessing)
+
+1. **Intent queue drains mid-drain enqueues** (Task H3.8 hop). Verified during plan review: `drainQueue` (`engine.ts:~3447-3457`) is a multi-generation `while (queue.length > 0)` loop re-snapshotting via `splice` each pass, so a `shield-applied` emitted mid-drain gets its `on-shield-applied` intent processed in the next generation within the same drain. The hop terminates (RF emits a buff, not a shield). The H3.8 #2 integration test remains the guard — keep it.
+2. **`mkNamedBuffGrant` target union** may not include a recipient-routed target for RF — extend or hand-write (Task H3.8).
+3. **`grantShieldToTarget` return value** — adding a return is non-breaking (callers ignore it), but verify no caller destructures/spreads its result (Task H3.6).
+4. **Golden drift from Phase 0** — expected none; audit if any (Pre-flight).
+5. **Adaptive Plating slot** — confirm equipment implants land where `on-attacked` reactive partitioning picks them up (passive slot per Leech precedent); the integration test confirms end-to-end.

--- a/docs/superpowers/specs/2026-06-25-shield-system-design.md
+++ b/docs/superpowers/specs/2026-06-25-shield-system-design.md
@@ -138,24 +138,40 @@ synthetic fixture equips them). Each source: registry entry + `equipmentCoverage
 mutation-resistant integration test through the real `buildShipAbilitiesWithEquipment` path, per the
 established D-PR convention.
 
-#### Reactive shield magnitude — two new bases (shared H3 foundation)
+#### Shared foundation (verified against code 2026-06-25)
 
-The reactive shield executor (`triggers.ts:~1610`) already computes `raw = basisValue × pct/100`
-(FrontLine is precedent for a shield scaled off a runtime amount). Adaptive Plating and Abundant
-Renewal each scale off a **triggering-event magnitude**, so H3 adds two basis types that read that
-magnitude from the reactive context:
-
-- `damage-taken` — the HP+shield damage of the triggering `on-attacked` hit (Adaptive Plating).
-- `overheal-amount` — the clipped overheal of the triggering `on-own-repair-to-ally` event
-  (Abundant Renewal). Overheal is already captured at the heal-apply site (`applyHealToTarget`
-  returns `{consumed, overheal}`).
+- **Reactive shield per-recipient routing (the key enabler).** The reactive heal/shield executor
+  (`triggers.ts:1614-1617`) only lands a pool when `rid === ctx.healing.targetId`, so a reactive
+  shield to a `self`/`ally` recipient who isn't the focus grants *nothing* today. Fix: route
+  per-recipient via `ctx.healing.recipientActor(rid)` (the member already exists; the cast path at
+  `playerTurn.ts:1907-1910` already does exactly this). This single change lights up **all** new
+  reactive shield sources (the `start-of-turn` self gear set, Adaptive Plating self-shield, Abundant
+  Renewal ally-shield). Golden risk: existing reactive shields (FrontLine, Defiant) granted only
+  when owner==focus before; expect byte-identical (synthetic fixtures run owner==focus) but audit.
+- **Reactive shield magnitude — two bases.** Adaptive Plating and Abundant Renewal each scale off a
+  **triggering-event magnitude**, read from the reactive `eventCtx`:
+  - `damage-taken` (Adaptive Plating) — reuse the existing `damage-taken` basis string. The reactive
+    executor doesn't special-case it (falls to maxHP), so add a `damage-taken` arm to the
+    `nonTargetHpBasis` ternary (`triggers.ts:1561-1572`) reading `eventCtx.triggerDamage`, and stamp
+    `triggerDamage: e.damage` in the `on-attacked` listener (`triggers.ts:448`). Safe from the
+    `damage-taken` leech collector: `on-attacked` is a LIVE trigger → `partitionReactiveAbilities`
+    strips it from `castSkills` before the leech scan (`engine.ts:2214-2233`), so no double-apply.
+  - `overheal` (Abundant Renewal) — a NEW basis string added to the `heal|shield` config union
+    (`abilities.ts:384`). Requires: an `overheal` accumulator in the cast heal loop
+    (`playerTurn.ts:1868-1890`), a new `overheal?: number` field on the `heal-performed` event
+    (`events.ts:98-105`) attached at emit (`playerTurn.ts:1936`), threaded into the
+    `on-own-repair-to-ally` listener `eventCtx` (`triggers.ts:369-382`), and an `overheal` arm in the
+    reactive basis ternary. Granted to the over-repaired ally (the focus heal target, the only actor
+    that accrues overheal in-sim).
 
 #### H2 — Shield gear set
 
 `gearSets.ts:SHIELD` ("Generate 4% shield each turn") → a new `GEAR_SET_ABILITIES.SHIELD` entry: a
-`start-of-turn`, `self`, **shield-config** grant (`type:'shield'`, `basis:'self-max-hp'`, `pct:4`)
-→ `floor(0.04 × maxHP)` each owner turn. Follows the Fortifying Shroud `start-of-turn` registry
-shape but emits a shield config (not a named buff). No proc, no gate.
+`start-of-turn`, `self`, **shield-config** grant (`type:'shield'`, `basis:'hp'`, `pct:4`) →
+`0.04 × maxHP` each owner turn (`basis:'hp'` = caster max HP; there is no `self-max-hp` basis). A
+hand-written Ability literal (no shield-builder helper exists), modeled on the inline LEECH/HARDENED
+gear-set entries. No proc, no gate. As a `start-of-turn` (LIVE) trigger it partitions to the reactive
+path and lands via the per-recipient routing fix above.
 
 #### H3 — Reactive shield implants
 

--- a/docs/superpowers/specs/2026-06-25-shield-system-design.md
+++ b/docs/superpowers/specs/2026-06-25-shield-system-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-25
 **Epic:** Combat-realism (`project_combat_realism_epic`). Sub-project H.
-**Status:** Approved design → ready for plan (H1 first PR).
+**Status:** H1 SHIPPED (PR #156). H2+H3 refined & approved 2026-06-25 → combined plan next (one PR).
 
 ## Goal
 
@@ -130,30 +130,70 @@ direct-vs-bomb split rides the separated portions, not a flag.
 shield), with documented per-scenario numeric justification; **never** blind `vitest -u`. New
 battle-sim integration tests for each matrix row + per-actor grant + surfacing fields.
 
-### H2 — Standing shield sources
+### H2 + H3 — combined PR (shield sources)
 
-**Shield gear set** = "generate 4% shield each turn" → a `start-of-turn` equipment ability granting
-`floor(0.04 × maxHP)` shield, via `GEAR_SET_ABILITIES` (the Cloaking start-of-round / Fortifying
-Shroud start-of-turn registry pattern). Byte-identical (no fixture equips it). Registry + coverage
-tracker + mutation-resistant integration test through `buildShipAbilitiesWithEquipment`.
+**H2 and H3 ship together in one PR** (user decision 2026-06-25), with H2 (gear set) and H3 (three
+implants + the new trigger) as ordered phases inside one plan. All sources are byte-identical (no
+synthetic fixture equips them). Each source: registry entry + `equipmentCoverage` guard +
+mutation-resistant integration test through the real `buildShipAbilitiesWithEquipment` path, per the
+established D-PR convention.
 
-### H3 — Reactive shield mechanics
+#### Reactive shield magnitude — two new bases (shared H3 foundation)
 
-- **Abundant Renewal** — overheal → shield (% of the over-repaired amount). Heals already clamp at
-  max HP; the clipped excess is the overheal signal. Needs an overheal hook at the heal-apply site.
-- **Adaptive Plating** — damage-taken → shield (% of damage taken, capped **once per round**).
-  Reuses the `oncePerRound` gate (D-PR3/D-PR16 precedent) + a damage-taken hook.
-- **Resonating Fury** — new `on-shield-applied` trigger emitted at the grant site; its effect rides
-  the existing reactive executor.
+The reactive shield executor (`triggers.ts:~1610`) already computes `raw = basisValue × pct/100`
+(FrontLine is precedent for a shield scaled off a runtime amount). Adaptive Plating and Abundant
+Renewal each scale off a **triggering-event magnitude**, so H3 adds two basis types that read that
+magnitude from the reactive context:
 
-All three byte-identical (no fixture equips them); registry + coverage + integration tests.
+- `damage-taken` — the HP+shield damage of the triggering `on-attacked` hit (Adaptive Plating).
+- `overheal-amount` — the clipped overheal of the triggering `on-own-repair-to-ally` event
+  (Abundant Renewal). Overheal is already captured at the heal-apply site (`applyHealToTarget`
+  returns `{consumed, overheal}`).
+
+#### H2 — Shield gear set
+
+`gearSets.ts:SHIELD` ("Generate 4% shield each turn") → a new `GEAR_SET_ABILITIES.SHIELD` entry: a
+`start-of-turn`, `self`, **shield-config** grant (`type:'shield'`, `basis:'self-max-hp'`, `pct:4`)
+→ `floor(0.04 × maxHP)` each owner turn. Follows the Fortifying Shroud `start-of-turn` registry
+shape but emits a shield config (not a named buff). No proc, no gate.
+
+#### H3 — Reactive shield implants
+
+All percent values below are **percentages applied as `× value/100`** (e.g. `damagePct` 34 means
+34% of damage taken). `procChance` values are decimal probabilities (e.g. .16 = 16%).
+
+- **Adaptive Plating** (`on-attacked`, direct-only — DoTs already route through `dot-applied`):
+  self-shield = `(damagePct/100) × damage-taken`, **`oncePerRound: true`** (text: "limited to once
+  per round"; D-PR precedent). Rarity tables: `procChance` {uncommon .12, epic .16, legendary .19},
+  `damagePct` {uncommon 21, epic 34, legendary 42}.
+- **Abundant Renewal** (`on-own-repair-to-ally`, **ally overheals only** per text "when
+  overrepairing an ally"): shield to the **healed ally** = `(pct/100) × overheal-amount`. Rarity:
+  {epic 20, legendary 30}. No proc roll (deterministic), no per-round cap.
+- **Resonating Fury** (new `on-shield-applied` trigger): grants **Crit Power Up 3** (existing named
+  buff) to self for 1 turn. `procChance` {common .05, uncommon .07, rare .09, epic .12,
+  legendary .16}, rolled **per shield-application event** with **NO `oncePerRound` cap** — the game
+  text omits the "once per round" clause that Adaptive Plating carries, so it may proc repeatedly in
+  a round across multiple shield grants.
+
+#### New `on-shield-applied` trigger
+
+Emitted from `grantShieldToTarget` (the single grant chokepoint), keyed on the **granter** (acting
+actor), **only when `actualGranted > 0`** (a fully-capped 0-grant does not proc). Per user decision,
+this fires for **any shield the carrier applies**: skill casts, the H2 gear-set start-of-turn grant,
+Abundant Renewal, and Adaptive Plating's own self-grant. Requires threading a `granterId` into
+`grantShieldToTarget` (currently recipient-only). No shield→shield chain exists (Resonating Fury
+grants a buff, not a shield), so there is no re-trigger / infinite-loop risk; the executor's existing
+heal/shield no-re-emit guard still applies.
 
 ## Components / boundaries
 
 - **`applyVictimDamage` absorb step** (engine) — the only place shield drains; gains damage-kind +
   pen awareness. Single chokepoint, independently testable via the apply path.
 - **`grantShieldToTarget`** (engine) — the only place shields are added; H3 emits
-  `on-shield-applied` from here. Unchanged signature.
+  `on-shield-applied` from here (only when post-cap `actualGranted > 0`). H3 adds a `granterId`
+  parameter (today `(raw, victim)`) so the event is keyed on the acting actor, not the recipient.
+  Cross-source note: a wearer with both the H2 Shield gear set and Resonating Fury will roll
+  Resonating Fury off the gear-set's own start-of-turn grant — an intended, tested interaction.
 - **Equipment-ability registry** (`buildEquipmentAbilities.ts`) — H2/H3 sources as data entries.
 - **`battleSimulator` adapter** — translates engine round data into `ShipRoundState` shield fields;
   the surfacing boundary. UI components consume `ShipRoundState` only.

--- a/docs/superpowers/specs/2026-06-25-shield-system-design.md
+++ b/docs/superpowers/specs/2026-06-25-shield-system-design.md
@@ -170,27 +170,38 @@ All percent values below are **percentages applied as `× value/100`** (e.g. `da
   overrepairing an ally"): shield to the **healed ally** = `(pct/100) × overheal-amount`. Rarity:
   {epic 20, legendary 30}. No proc roll (deterministic), no per-round cap.
 - **Resonating Fury** (new `on-shield-applied` trigger): on proc, grants **Crit Power Up 3**
-  (existing named buff, 1 turn) to **the recipient of the triggering shield** — i.e. the buff
-  follows the shield, NOT the carrier (user decision 2026-06-25). A self-shield buffs self; an
-  ally-shield buffs that ally. `procChance` {common .05, uncommon .07, rare .09, epic .12,
-  legendary .16}, rolled **per shield-application event** with **NO `oncePerRound` cap** — the game
-  text omits the "once per round" clause that Adaptive Plating carries, so it may proc repeatedly in
-  a round. Because `grantShieldToTarget` fires once per recipient, a multi-ally shield grant emits
-  one event (and one independent proc roll) per recipient, each buffing only that recipient.
+  (existing named buff, 1 turn) to **every recipient of the triggering shield cast** — the buff
+  follows the shield, NOT (only) the carrier (user decision 2026-06-25). A multi-recipient shield
+  cast gets a **single proc roll**; on success **all** recipients that gained shield are buffed
+  (the caster included if it was among them). `procChance` {common .05, uncommon .07, rare .09,
+  epic .12, legendary .16}, rolled **once per shield-application cast** with **NO `oncePerRound`
+  cap** — the game text omits the "once per round" clause that Adaptive Plating carries, so it may
+  proc on multiple separate casts within a round.
 
 #### New `on-shield-applied` trigger
 
-Emitted from `grantShieldToTarget` (the single grant chokepoint), **only when `actualGranted > 0`**
-(a fully-capped 0-grant does not proc). The event carries **both** the **granter** (acting actor —
-the key the carrier's Resonating Fury listens on) and the **recipient** (the actor whose shield pool
-grew — Resonating Fury's buff target). Per user decision, this fires for **any shield the carrier
-applies**: skill casts, the H2 gear-set start-of-turn grant, Abundant Renewal, and Adaptive
-Plating's own self-grant. Requires threading a `granterId` into `grantShieldToTarget` (today
-`(raw, victim)` — recipient-only); the listener ownership keys on `granterId` while the reactive
-effect targets the event's recipient (a "shield-recipient" target resolution, distinct from the
-usual self/ally/all-allies target types). No shield→shield chain exists (Resonating Fury grants a
-buff, not a shield), so there is no re-trigger / infinite-loop risk; the executor's existing
-heal/shield no-re-emit guard still applies.
+Emitted **once per shield-application cast** (NOT once per recipient — so a single cast yields a
+single Resonating Fury proc roll). `grantShieldToTarget` is per-recipient and already accumulates
+`actualGranted`; each grant **site** (skill-cast multi-recipient loop ~engine.ts:2415, single-target
+casts ~2339/2475, the standing/passive grant ~4686, the H2 gear-set start-of-turn grant, and the
+reactive shield executor in triggers.ts ~1610) collects the recipients that gained shield
+(`actualGranted > 0`) and emits **one** `on-shield-applied` carrying the **granter** (acting actor —
+the key the carrier's Resonating Fury listens on) and the **recipient set** (Resonating Fury's buff
+targets). Sites that grant to a single recipient emit a one-element set; if no recipient gained
+shield, no event fires. Per user decision, this covers **any shield the carrier applies**: skill
+casts, the gear-set start-of-turn grant, Abundant Renewal, and Adaptive Plating's own self-grant.
+Requires threading a `granterId` (today `grantShieldToTarget` is `(raw, victim)` — recipient-only).
+The listener ownership keys on `granterId`; the reactive effect targets the event's recipient set (a
+"shield-recipient" target resolution, distinct from the usual self/ally/all-allies target types).
+
+**Reactive→reactive hop:** because Abundant Renewal and Adaptive Plating grant shields from inside
+the reactive executor, their grants must also emit `on-shield-applied` so a carrier holding both
+(e.g. Adaptive Plating + Resonating Fury) procs RF off its own reactive shield — consistent with the
+"any grant by carrier" decision. This is a single safe hop: RF emits a **buff**, not a shield, so it
+produces no further `on-shield-applied` and cannot recurse. No shield→shield chain exists, so there
+is no infinite-loop risk; the executor's existing heal/shield no-re-emit guard (which only suppresses
+heal/shield re-triggering heal/shield) is unaffected. The plan must confirm the engine's reactive
+dispatch permits this one cross-type hop (emit `on-shield-applied` from within a reactive grant).
 
 ## Components / boundaries
 

--- a/docs/superpowers/specs/2026-06-25-shield-system-design.md
+++ b/docs/superpowers/specs/2026-06-25-shield-system-design.md
@@ -169,20 +169,27 @@ All percent values below are **percentages applied as `× value/100`** (e.g. `da
 - **Abundant Renewal** (`on-own-repair-to-ally`, **ally overheals only** per text "when
   overrepairing an ally"): shield to the **healed ally** = `(pct/100) × overheal-amount`. Rarity:
   {epic 20, legendary 30}. No proc roll (deterministic), no per-round cap.
-- **Resonating Fury** (new `on-shield-applied` trigger): grants **Crit Power Up 3** (existing named
-  buff) to self for 1 turn. `procChance` {common .05, uncommon .07, rare .09, epic .12,
+- **Resonating Fury** (new `on-shield-applied` trigger): on proc, grants **Crit Power Up 3**
+  (existing named buff, 1 turn) to **the recipient of the triggering shield** — i.e. the buff
+  follows the shield, NOT the carrier (user decision 2026-06-25). A self-shield buffs self; an
+  ally-shield buffs that ally. `procChance` {common .05, uncommon .07, rare .09, epic .12,
   legendary .16}, rolled **per shield-application event** with **NO `oncePerRound` cap** — the game
   text omits the "once per round" clause that Adaptive Plating carries, so it may proc repeatedly in
-  a round across multiple shield grants.
+  a round. Because `grantShieldToTarget` fires once per recipient, a multi-ally shield grant emits
+  one event (and one independent proc roll) per recipient, each buffing only that recipient.
 
 #### New `on-shield-applied` trigger
 
-Emitted from `grantShieldToTarget` (the single grant chokepoint), keyed on the **granter** (acting
-actor), **only when `actualGranted > 0`** (a fully-capped 0-grant does not proc). Per user decision,
-this fires for **any shield the carrier applies**: skill casts, the H2 gear-set start-of-turn grant,
-Abundant Renewal, and Adaptive Plating's own self-grant. Requires threading a `granterId` into
-`grantShieldToTarget` (currently recipient-only). No shield→shield chain exists (Resonating Fury
-grants a buff, not a shield), so there is no re-trigger / infinite-loop risk; the executor's existing
+Emitted from `grantShieldToTarget` (the single grant chokepoint), **only when `actualGranted > 0`**
+(a fully-capped 0-grant does not proc). The event carries **both** the **granter** (acting actor —
+the key the carrier's Resonating Fury listens on) and the **recipient** (the actor whose shield pool
+grew — Resonating Fury's buff target). Per user decision, this fires for **any shield the carrier
+applies**: skill casts, the H2 gear-set start-of-turn grant, Abundant Renewal, and Adaptive
+Plating's own self-grant. Requires threading a `granterId` into `grantShieldToTarget` (today
+`(raw, victim)` — recipient-only); the listener ownership keys on `granterId` while the reactive
+effect targets the event's recipient (a "shield-recipient" target resolution, distinct from the
+usual self/ally/all-allies target types). No shield→shield chain exists (Resonating Fury grants a
+buff, not a shield), so there is no re-trigger / infinite-loop risk; the executor's existing
 heal/shield no-re-emit guard still applies.
 
 ## Components / boundaries

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -35,6 +35,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat simulator: ships now react when an enemy uses its charged skill — Curator purges that enemy's buffs (and at higher refits also blocks it from gaining new buffs), and FrontLine counter-attacks for damage and gains a shield once per round.",
     'Combat simulator now models Block Buff — a unit affected by Block Buff can no longer gain new buffs while it lasts.',
     'Combat & DPS simulators now model two damage-over-time gear sets: Burner (applies Inferno for 2 turns when the ship attacks) and Decimation (+10% DoT damage per equipped set, up to +30%). Decimation now boosts your ship’s Inferno and Corrosion ticks in both the combat simulator and the DPS calculator.',
+    'Combat simulator now models four shield sources: the Shield gear set grants the equipped ship a shield each turn (4% of its max HP), the Adaptive Plating implant grants the ship a shield from the damage it takes (once per round), the Abundant Renewal implant turns over-healing on an ally into a shield for that ally, and the Resonating Fury implant gives a chance to grant Crit Power Up to allies it shields.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3124,8 +3124,16 @@ const DocumentationPage: React.FC = () => {
                                     Inferno for 2 turns when the ship attacks) and{' '}
                                     <strong>Decimation</strong> (+10% DoT damage per equipped set,
                                     up to +30%, boosting your Inferno and Corrosion ticks in both
-                                    the combat simulator and the DPS calculator). More implant and
-                                    gear-set effects will be added in future updates.
+                                    the combat simulator and the DPS calculator). Four shield
+                                    sources are also modeled: the <strong>Shield</strong> gear set
+                                    (grants the equipped ship a shield each turn, 4% of its max HP),{' '}
+                                    <strong>Adaptive Plating</strong> (grants the ship a shield from
+                                    the damage it takes, once per round),{' '}
+                                    <strong>Abundant Renewal</strong> (turns over-healing on an ally
+                                    into a shield for that ally), and{' '}
+                                    <strong>Resonating Fury</strong> (a chance to grant Crit Power
+                                    Up to allies it shields). More implant and gear-set effects will
+                                    be added in future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -380,8 +380,18 @@ export type AbilityConfig =
            *  basis: 'damage-dealt' (X% of damage this actor deals — cast rider on
            *  active/charged slots, standing leech on the passive slot) /
            *  'damage-taken' (X% of an enemy attack's damage on this actor; passive
-           *  slot, procs only while the actor is the heal target). */
-          basis: 'hp' | 'attack' | 'defense' | 'target-hp' | 'damage-dealt' | 'damage-taken';
+           *  slot, procs only while the actor is the heal target) / 'overheal'
+           *  (X% of an over-repair's CLIPPED EXCESS — heal raw minus the HP actually
+           *  consumed — on the over-repaired ally; reactive shield on
+           *  on-own-repair-to-ally; Abundant Renewal). */
+          basis:
+              | 'hp'
+              | 'attack'
+              | 'defense'
+              | 'target-hp'
+              | 'damage-dealt'
+              | 'damage-taken'
+              | 'overheal';
           /** Pallas/Tithonus: "repair cannot critically hit". Shields never crit regardless. */
           noCrit?: boolean;
           /** Passive-slot 'damage-dealt' only: which credited damage procs the leech.

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -104,7 +104,11 @@ export type AbilityTrigger =
     // D-PR16 Lockdown: fires when THIS unit resists an incoming debuff (rides the existing
     // `debuff-resisted` event, self-scoped on targetId === ownerId). Chains off D-PR15's
     // Block-Debuff auto-resist emission AND normal hacking/affinity resists.
-    | 'on-debuff-resisted';
+    | 'on-debuff-resisted'
+    // Fired once per shield-application CAST. Reaction is keyed on the granter (acting actor)
+    // and targets the shield recipient set — used by Resonating Fury to grant Crit Power Up 3
+    // to everyone the carrier just shielded.
+    | 'on-shield-applied';
 
 /**
  * Triggers the combat engine consumes via listeners (the machinery lives in
@@ -151,6 +155,8 @@ export const LIVE_TRIGGERS = new Set<AbilityTrigger>([
     'on-debuff-resisted',
     // Warpstrike: owner dealt direct damage on its turn.
     'on-deal-damage',
+    // Resonating Fury: granter-scoped reaction fired once per shield-application cast.
+    'on-shield-applied',
 ]);
 
 export type ConditionSubject =

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -152,6 +152,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
             'VOIDSHADE',
             'VORTEX_VEIL',
             'WARPSTRIKE',
+            'ADAPTIVE_PLATING',
             'ALACRITY',
             'AMBUSH',
             'BATTLECRY',
@@ -309,6 +310,7 @@ describe('equipmentCoverage — implants', () => {
     //         WARPSTRIKE gains a second ability (reduce-duration cleanse on-deal-damage).
     // Phase 2-3: CHRONO_REAVER added (end-of-turn periodic self-charge; epic=every 3rd, legendary=every 2nd).
     const implementedImplants = new Set([
+        'ADAPTIVE_PLATING',
         'FIREWALL',
         'LOCKDOWN',
         'TENACITY',
@@ -638,6 +640,30 @@ describe('equipmentCoverage — implants', () => {
                 mode: 'remove',
             });
         }
+    });
+
+    // H3.2: Adaptive Plating — reactive once-per-round shield off the damage taken.
+    it('ADAPTIVE_PLATING produces 1 ability for uncommon/epic/legendary, 0 otherwise (no common/rare variant)', () => {
+        expect(implantAbilityCount('ADAPTIVE_PLATING', 'common')).toBe(0);
+        expect(implantAbilityCount('ADAPTIVE_PLATING', 'rare')).toBe(0);
+        const SUPPORTED = new Set(['uncommon', 'epic', 'legendary']);
+        for (const v of IMPLANTS['ADAPTIVE_PLATING'].variants) {
+            expect(implantAbilityCount('ADAPTIVE_PLATING', v.rarity)).toBe(
+                SUPPORTED.has(v.rarity) ? 1 : 0
+            );
+        }
+    });
+
+    it('ADAPTIVE_PLATING (legendary) shape: on-attacked self shield, procChance 0.19, oncePerRound, damage-taken 42%', () => {
+        const abs = implantAbilities('ADAPTIVE_PLATING', 'legendary');
+        expect(abs).toHaveLength(1);
+        const ab = abs[0];
+        expect(ab.type).toBe('shield');
+        expect(ab.target).toBe('self');
+        expect(ab.trigger).toBe('on-attacked');
+        expect(ab.procChance).toBeCloseTo(0.19);
+        expect(ab.oncePerRound).toBe(true);
+        expect(ab.config).toMatchObject({ type: 'shield', pct: 42, basis: 'damage-taken' });
     });
 
     const unimplementedImplants = Object.keys(IMPLANTS).filter((k) => !implementedImplants.has(k));

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -172,6 +172,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
             'LOCKDOWN',
             'MENACE',
             'REACTIVE_WARD',
+            'RESONATING_FURY',
             'SECOND_WIND',
             'SHADOWGUARD',
             'SPEARHEAD',
@@ -347,6 +348,7 @@ describe('equipmentCoverage — implants', () => {
         'BULWARK',
         'DOOMSAYER',
         'REACTIVE_WARD',
+        'RESONATING_FURY',
     ]);
 
     it('INTRUSION produces 1 ability per rarity (outgoingDamage modifier with scaling)', () => {
@@ -692,6 +694,40 @@ describe('equipmentCoverage — implants', () => {
         expect(ab.procChance).toBeCloseTo(0.19);
         expect(ab.oncePerRound).toBe(true);
         expect(ab.config).toMatchObject({ type: 'shield', pct: 42, basis: 'damage-taken' });
+    });
+
+    // H3.8: Resonating Fury — on-shield-applied buff grant to shield recipients.
+    it('RESONATING_FURY produces 1 ability per rarity (all 5 rarities present)', () => {
+        const variants = IMPLANTS['RESONATING_FURY'].variants;
+        // Common/uncommon/rare/epic/legendary all defined.
+        expect(variants.map((v) => v.rarity).sort()).toEqual([
+            'common',
+            'epic',
+            'legendary',
+            'rare',
+            'uncommon',
+        ]);
+        for (const v of variants) {
+            expect(implantAbilityCount('RESONATING_FURY', v.rarity)).toBe(1);
+        }
+    });
+
+    it('RESONATING_FURY (legendary) shape: on-shield-applied all-allies Crit Power Up III buff, duration 1, procChance 0.16', () => {
+        const abs = implantAbilities('RESONATING_FURY', 'legendary');
+        expect(abs).toHaveLength(1);
+        const ab = abs[0];
+        expect(ab.type).toBe('buff');
+        // target 'all-allies' routes to eventCtx.shieldRecipientIds via the H3.7 listener.
+        expect(ab.target).toBe('all-allies');
+        expect(ab.trigger).toBe('on-shield-applied');
+        expect(ab.procChance).toBeCloseTo(0.16);
+        // No per-round cap — one proc roll per cast.
+        expect(ab.oncePerRound).toBeFalsy();
+        expect(ab.config).toMatchObject({
+            type: 'buff',
+            buffName: 'Crit Power Up III',
+            duration: 1,
+        });
     });
 
     const unimplementedImplants = Object.keys(IMPLANTS).filter((k) => !implementedImplants.has(k));

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -125,7 +125,14 @@ describe('equipmentCoverage — implemented effects registry', () => {
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
         );
-        expect(implementedSets).toEqual(['BURNER', 'DECIMATION', 'LEECH', 'CLOAKING', 'HARDENED']);
+        expect(implementedSets).toEqual([
+            'BURNER',
+            'DECIMATION',
+            'LEECH',
+            'SHIELD',
+            'CLOAKING',
+            'HARDENED',
+        ]);
 
         // Implants with an ability builder (check each implant with a rarity that exists)
         const implementedImplants = Object.keys(IMPLANTS).filter((key) => {
@@ -176,7 +183,14 @@ describe('equipmentCoverage — implemented effects registry', () => {
 // Gear-set coverage: one assertion per set
 // ---------------------------------------------------------------------------
 
-const IMPLEMENTED_SETS = new Set(['BURNER', 'DECIMATION', 'LEECH', 'CLOAKING', 'HARDENED']);
+const IMPLEMENTED_SETS = new Set([
+    'BURNER',
+    'DECIMATION',
+    'LEECH',
+    'CLOAKING',
+    'HARDENED',
+    'SHIELD',
+]);
 
 describe('equipmentCoverage — gear sets', () => {
     it('BURNER produces exactly 1 ability (the on-cast inferno)', () => {
@@ -224,6 +238,34 @@ describe('equipmentCoverage — gear sets', () => {
         expect(cloak!.config.duration).toBe(2);
         // @ts-expect-error buff config
         expect(cloak!.config.oncePerCombat).toBe(true);
+    });
+
+    it('SHIELD produces exactly 1 ability (the start-of-turn self shield)', () => {
+        expect(gearSetAbilityCount('SHIELD')).toBe(1);
+    });
+
+    it('SHIELD produces a start-of-turn self shield of 4% caster max HP', () => {
+        const minPieces = GEAR_SETS['SHIELD']?.minPieces ?? 2;
+        const slots = ['weapon', 'hull', 'sensor', 'engine', 'shield', 'computer'] as const;
+        const equipment: Record<string, string> = {};
+        const pieceMap: Record<string, GearPiece> = {};
+        for (let i = 0; i < minPieces; i++) {
+            const id = `SHIELD-piece-${i}`;
+            equipment[slots[i % slots.length]] = id;
+            pieceMap[id] = makePiece({ id, slot: slots[i % slots.length], setBonus: 'SHIELD' });
+        }
+        const ship = makeShip({ equipment });
+        const abilities = buildEquipmentAbilities(ship, (id) => pieceMap[id]);
+        const sh = abilities.find((a) => a.id === 'equip-set-SHIELD');
+        expect(sh).toBeDefined();
+        expect(sh!.type).toBe('shield');
+        expect(sh!.target).toBe('self');
+        expect(sh!.trigger).toBe('start-of-turn');
+        expect(sh!.config.type).toBe('shield');
+        // @ts-expect-error shield config
+        expect(sh!.config.pct).toBe(4);
+        // @ts-expect-error shield config
+        expect(sh!.config.basis).toBe('hp');
     });
 
     const unimplementedSets = Object.keys(GEAR_SETS).filter((k) => !IMPLEMENTED_SETS.has(k));

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -142,6 +142,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
         });
         expect(implementedImplants).toEqual([
             'MARTYRDOM',
+            'ABUNDANT_RENEWAL',
             'ARCANE_SIEGE',
             'CHRONO_REAVER',
             'HYPERION_GAZE',
@@ -310,6 +311,7 @@ describe('equipmentCoverage — implants', () => {
     //         WARPSTRIKE gains a second ability (reduce-duration cleanse on-deal-damage).
     // Phase 2-3: CHRONO_REAVER added (end-of-turn periodic self-charge; epic=every 3rd, legendary=every 2nd).
     const implementedImplants = new Set([
+        'ABUNDANT_RENEWAL',
         'ADAPTIVE_PLATING',
         'FIREWALL',
         'LOCKDOWN',
@@ -640,6 +642,32 @@ describe('equipmentCoverage — implants', () => {
                 mode: 'remove',
             });
         }
+    });
+
+    // H3.4: Abundant Renewal — deterministic overheal→shield to the over-repaired ally.
+    it('ABUNDANT_RENEWAL produces 1 ability for epic/legendary, 0 otherwise (no common/uncommon/rare variant)', () => {
+        expect(implantAbilityCount('ABUNDANT_RENEWAL', 'common')).toBe(0);
+        expect(implantAbilityCount('ABUNDANT_RENEWAL', 'uncommon')).toBe(0);
+        expect(implantAbilityCount('ABUNDANT_RENEWAL', 'rare')).toBe(0);
+        const SUPPORTED = new Set(['epic', 'legendary']);
+        for (const v of IMPLANTS['ABUNDANT_RENEWAL'].variants) {
+            expect(implantAbilityCount('ABUNDANT_RENEWAL', v.rarity)).toBe(
+                SUPPORTED.has(v.rarity) ? 1 : 0
+            );
+        }
+    });
+
+    it('ABUNDANT_RENEWAL (legendary) shape: on-own-repair-to-ally shield to ally, basis overheal 30%, deterministic', () => {
+        const abs = implantAbilities('ABUNDANT_RENEWAL', 'legendary');
+        expect(abs).toHaveLength(1);
+        const ab = abs[0];
+        expect(ab.type).toBe('shield');
+        expect(ab.target).toBe('ally');
+        expect(ab.trigger).toBe('on-own-repair-to-ally');
+        // Deterministic — no proc chance and no once-per-round cap.
+        expect(ab.procChance).toBeUndefined();
+        expect(ab.oncePerRound).toBeFalsy();
+        expect(ab.config).toMatchObject({ type: 'shield', pct: 30, basis: 'overheal' });
     });
 
     // H3.2: Adaptive Plating — reactive once-per-round shield off the damage taken.

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -109,6 +109,17 @@ const GEAR_SET_ABILITIES: Partial<
         config: { type: 'dot', dotType: 'inferno', tier: 15, stacks: 1, duration: 2 },
         autoFilled: true,
     }),
+    // Shield gear set: "Generate 4% shield each turn" → start-of-turn self shield of 4% caster max HP.
+    // start-of-turn is a LIVE trigger → partitions to the reactive path; lands via the per-recipient
+    // routing fix (H2/H3 Task 0.1). basis 'hp' = caster max HP.
+    SHIELD: () => ({
+        type: 'shield',
+        target: 'self',
+        trigger: 'start-of-turn',
+        conditions: [],
+        config: { type: 'shield', pct: 4, basis: 'hp' },
+        autoFilled: true,
+    }),
 };
 
 // ---------------------------------------------------------------------------

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -380,6 +380,18 @@ const REACTIVE_WARD_PROC: Record<string, number> = {
     legendary: 0.16,
 };
 
+// H3.8: Resonating Fury — when applying a shield, X% chance to grant Crit Power Up III for 1 turn
+// to the shield recipients. The in-game text reads "Crit Power Up 3"; "3" is the canonical
+// "III" tier (the Ambush implant carries the same in-game buff and resolves it as the BUFFS
+// entry 'Crit Power Up III'). ONE proc roll per cast, NO oncePerRound cap.
+const RESONATING_FURY_PROC: Record<string, number> = {
+    common: 0.05,
+    uncommon: 0.07,
+    rare: 0.09,
+    epic: 0.12,
+    legendary: 0.16,
+};
+
 // D-PR6: incoming-heal-amplification implant value tables
 // No common rarity for Exuberance
 const EXUBERANCE_PROC: Record<string, number> = {
@@ -951,6 +963,17 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
             procChance,
             conditions: [{ subject: 'last-standing', derivable: true }],
             alsoGrantBuffNames: ['Block Debuff'],
+        });
+    },
+    // H3.8: Resonating Fury — when applying a shield, X% chance to grant Crit Power Up III for 1
+    // turn to the SHIELD RECIPIENTS of the cast (the buff follows the shield, not the carrier).
+    // Rides `on-shield-applied`; target 'all-allies' routes through the H3.7 listener to EXACTLY
+    // eventCtx.shieldRecipientIds (not every ally). ONE proc roll per cast, no oncePerRound cap.
+    RESONATING_FURY: (rarity) => {
+        const procChance = RESONATING_FURY_PROC[rarity];
+        if (procChance === undefined) return undefined;
+        return mkNamedBuffGrant('Crit Power Up III', 'all-allies', 'on-shield-applied', 1, {
+            procChance,
         });
     },
     // Chrono Reaver: periodic self-charge. Epic = every 3rd own turn, Legendary = every 2nd.

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -257,6 +257,12 @@ const ADAPTIVE_PLATING_PROC: Record<string, number> = {
 };
 const ADAPTIVE_PLATING_PCT: Record<string, number> = { uncommon: 21, epic: 34, legendary: 42 };
 
+// H3.4: Abundant Renewal — when over-repairing an ally, grant that ally a Shield equal to X% of
+// the OVER-repaired amount. DETERMINISTIC (no procChance) and no per-round cap. Only epic/legendary
+// variants exist. basis 'overheal' scales off the clipped over-repair (eventCtx.overhealAmount,
+// threaded by the on-own-repair-to-ally listener in H3.3).
+const ABUNDANT_RENEWAL_PCT: Record<string, number> = { epic: 20, legendary: 30 };
+
 // D-PR5: Second Wind reactive self-heal on crit-received value table
 const SECOND_WIND_PROC: Record<string, number> = {
     uncommon: 0.07,
@@ -714,6 +720,24 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
             conditions: [],
             procChance: pc,
             config: { type: 'heal', pct: 10, basis: 'hp' },
+            autoFilled: true,
+        };
+    },
+    // H3.4: Abundant Renewal — when over-repairing an ally, grant the over-repaired ally a Shield
+    // equal to X% of the OVER-repaired amount. DETERMINISTIC (no procChance) and no per-round cap.
+    // Rides `on-own-repair-to-ally` (Font of Power precedent); target 'ally' → the reactive
+    // recipients resolve to the over-repaired ally (falls back to healing.targetId — the engine
+    // only repairs the heal target). basis 'overheal' scales off eventCtx.overhealAmount (H3.3).
+    // No common/uncommon/rare variants.
+    ABUNDANT_RENEWAL: (rarity) => {
+        const pct = ABUNDANT_RENEWAL_PCT[rarity];
+        if (pct === undefined) return undefined;
+        return {
+            type: 'shield',
+            target: 'ally',
+            trigger: 'on-own-repair-to-ally',
+            conditions: [],
+            config: { type: 'shield', pct, basis: 'overheal' },
             autoFilled: true,
         };
     },

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -247,6 +247,16 @@ const GIANT_SLAYER_PROC: Record<string, number> = {
     legendary: 0.2,
 };
 
+// H3.2: Adaptive Plating — when directly damaged, X% chance to gain a Shield equal to Y% of
+// the damage taken, once per round. No common/rare variants. The `damage-taken` basis scales
+// off the triggering hit (eventCtx.triggerDamage, threaded by the on-attacked listener in H3.1).
+const ADAPTIVE_PLATING_PROC: Record<string, number> = {
+    uncommon: 0.12,
+    epic: 0.16,
+    legendary: 0.19,
+};
+const ADAPTIVE_PLATING_PCT: Record<string, number> = { uncommon: 21, epic: 34, legendary: 42 };
+
 // D-PR5: Second Wind reactive self-heal on crit-received value table
 const SECOND_WIND_PROC: Record<string, number> = {
     uncommon: 0.07,
@@ -704,6 +714,27 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
             conditions: [],
             procChance: pc,
             config: { type: 'heal', pct: 10, basis: 'hp' },
+            autoFilled: true,
+        };
+    },
+    // H3.2: Adaptive Plating — when directly damaged, X% chance to gain a Shield equal to Y% of
+    // the damage taken, limited to once per round. `on-attacked` is the "directly damaged" trigger
+    // (DoTs route through dot-applied, never on-attacked). basis 'damage-taken' scales off the
+    // triggering hit's damage (eventCtx.triggerDamage, H3.1). oncePerRound caps the grant to ONE per
+    // round — the `attacked` event's damage is the per-attack aggregate and on-attacked fires once
+    // per hit, so without the gate an N-hit attack would grant N times. No common/rare variants.
+    ADAPTIVE_PLATING: (rarity) => {
+        const procChance = ADAPTIVE_PLATING_PROC[rarity];
+        const pct = ADAPTIVE_PLATING_PCT[rarity];
+        if (procChance === undefined || pct === undefined) return undefined;
+        return {
+            type: 'shield',
+            target: 'self',
+            trigger: 'on-attacked',
+            conditions: [],
+            procChance,
+            oncePerRound: true,
+            config: { type: 'shield', pct, basis: 'damage-taken' },
             autoFilled: true,
         };
     },

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -4765,3 +4765,207 @@ describe('H2.2 integration — Shield gear set grants 4% maxHP shield pool (full
         expect(carrier?.shieldPool).toBeCloseTo(EXPECTED_POOL, 6);
     });
 });
+
+// ---------------------------------------------------------------------------
+// H3 Task H3.2: Adaptive Plating implant — once-per-round shield off the damage taken
+// ---------------------------------------------------------------------------
+//
+// Adaptive Plating (legendary) resolves through the registry (IMPLANT_ABILITIES.ADAPTIVE_PLATING,
+// H3.2) into a reactive ability:
+//   { type:'shield', target:'self', trigger:'on-attacked', procChance:0.19, oncePerRound:true,
+//     config:{ type:'shield', pct:42, basis:'damage-taken' } }
+// 'on-attacked' is a LIVE trigger → it partitions into reactiveAbilities and fires when the carrier
+// is directly hit. basis 'damage-taken' scales the grant off the triggering hit's damage
+// (eventCtx.triggerDamage, threaded by the on-attacked listener in H3.1), landing the pool on the
+// carrier via the per-recipient routing (Phase 0.1).
+//
+// THE KEY INVARIANT (oncePerRound cap): the `attacked` event's `damage` is the per-attack AGGREGATE
+// and on-attacked fires ONCE PER HIT. So for an N-hit attack the on-attacked listener enqueues N
+// shield intents, EACH carrying triggerDamage === the full aggregate. WITHOUT oncePerRound this would
+// grant up to N times per round (one per proc-passing hit). Adaptive Plating's oncePerRound gate must
+// cap it to EXACTLY ONE grant per round.
+//
+// Determinism of the proc: the per-(owner,ability) RateGate accumulates +0.19 per qualifying hit and
+// fires when the accumulator crosses 1. With an 11-hit attack per round (11 × 0.19 = 2.09) the proc
+// gate would pass TWICE within a single round (it crosses 1 at hit ~6 and again at hit ~11) — so the
+// oncePerRound gate (not the proc gate) is the BINDING constraint that caps the round to one grant.
+// We read each round's post-cap `granted` (RoundData.perActorShield[carrier].granted) and assert it
+// is NEVER more than ONE share (0.42 × aggregate), and that at least one round actually fired.
+//
+// Pinning the damage taken D: enemy attack A=1000, multiplier 100%, hits=11, no defence/crit/pen on
+// either side → per-attack aggregate damage D = 1000 × 1.0 × 11 = 11_000. One grant = 0.42 × 11_000
+// = 4_620 (well under the carrier's max HP cap → no clamping).
+
+const adaptivePlatingPiece = makePiece({
+    id: 'ap-legendary',
+    slot: 'implant_major',
+    rarity: 'legendary',
+    setBonus: 'ADAPTIVE_PLATING',
+});
+
+describe('H3.2 integration — Adaptive Plating once-per-round shield off the damage taken', () => {
+    const CARRIER_HP = 100_000_000; // huge: carrier survives every round; shield never caps
+    const NUM_ROUNDS = 10;
+    const ENEMY_ATTACK = 1_000;
+    const ENEMY_HITS = 11; // 11 × 0.19 = 2.09 → proc would pass TWICE/round → oncePerRound is binding
+    const D = ENEMY_ATTACK * ENEMY_HITS; // per-attack aggregate damage taken = 11_000
+    const AP_PCT = 42; // legendary
+    const ONE_GRANT = (AP_PCT / 100) * D; // 4_620 — exactly ONE share
+
+    /** An enemy attacker that hits the carrier (the focus / heal target) with an 11-hit attack
+     *  each round. attack 1000, multiplier 100, no crit → aggregate damage taken = 11_000. */
+    const enemyHitter = () => ({
+        id: 'ap-enemy',
+        stats: {
+            attack: ENEMY_ATTACK,
+            crit: 0,
+            critDamage: 0,
+            speed: 1, // acts before the (slower) carrier so the hit lands at round top
+            defence: 0,
+            hp: 1_000_000_000,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active' as const,
+                    abilities: [
+                        {
+                            id: 'ap-enemy-hit',
+                            type: 'damage' as const,
+                            target: 'enemy' as const,
+                            trigger: 'on-cast' as const,
+                            conditions: [],
+                            config: {
+                                type: 'damage' as const,
+                                multiplier: 100,
+                                hits: ENEMY_HITS,
+                            },
+                        },
+                    ],
+                },
+            ],
+        } as ShipSkills,
+    });
+
+    it(
+        'grants ≈ 0.42 × damageTaken when it fires, and AT MOST ONCE per round (oncePerRound caps ' +
+            'the 11-hit attack to a single grant)',
+        () => {
+            // Carrier = focus (the heal target) equipped with legendary Adaptive Plating via the
+            // real build→merge path. A no-op active keeps the round cadence; the passive slot
+            // carries the reactive Adaptive Plating shield.
+            const ship = makeShip({ implants: { implant_major: 'ap-legendary' } });
+            const getGearPiece = makeGetGearPiece({ 'ap-legendary': adaptivePlatingPiece });
+            const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+
+            // Pre-condition: the Adaptive Plating ability landed in the passive slot.
+            const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+            expect(passive).toBeDefined();
+            const ap = passive!.abilities.find((a) =>
+                a.id.startsWith('equip-implant-ADAPTIVE_PLATING')
+            );
+            expect(ap).toBeDefined();
+            expect(ap!.trigger).toBe('on-attacked');
+            expect(ap!.procChance).toBeCloseTo(0.19);
+            expect(ap!.oncePerRound).toBe(true);
+            expect(ap!.config).toMatchObject({ type: 'shield', pct: 42, basis: 'damage-taken' });
+
+            // Append a no-op active so the focus keeps the round cadence (deals no damage itself).
+            const noopActive: Ability = {
+                id: 'noop-active',
+                type: 'damage',
+                target: 'enemy',
+                trigger: 'on-cast',
+                conditions: [],
+                config: { type: 'damage', multiplier: 0 },
+            };
+            const shipSkills: ShipSkills = {
+                slots: [
+                    { slot: 'active', abilities: [noopActive] },
+                    ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+                ],
+            };
+
+            const result = runCombat(
+                BASE({
+                    attack: 0,
+                    crit: 0,
+                    critDamage: 0,
+                    numRounds: NUM_ROUNDS,
+                    hp: CARRIER_HP,
+                    // No carrier defence → the enemy's 11-hit attack lands its full nominal
+                    // aggregate (1000 × 11 = 11_000) as the damage taken, so the grant pins to
+                    // 0.42 × 11_000 = 4_620 exactly (no mitigation arithmetic in the assertion).
+                    defence: 0,
+                    enemyHp: 1_000_000_000,
+                    healTargetId: 'attacker',
+                    shipSkills,
+                    enemyAttackers: [enemyHitter()],
+                })
+            );
+
+            // Per-round post-cap grant for the carrier (the heal target / focus).
+            const grantedPerRound = result.rounds.map(
+                (rd) => rd.perActorShield?.['attacker']?.granted ?? 0
+            );
+
+            // (1) THE CAP: no round ever grants more than ONE share. WITHOUT oncePerRound, the
+            // 11-hit attack would let the proc gate pass twice in a round → ~2 × ONE_GRANT.
+            for (const granted of grantedPerRound) {
+                expect(granted).toBeLessThanOrEqual(ONE_GRANT + 1e-6);
+            }
+
+            // (2) NON-VACUOUS: the proc actually fired at least once, and every firing round
+            // granted EXACTLY one share (≈ 0.42 × damage taken), proving both the damage-taken
+            // basis and the once-per-round cap.
+            const firingRounds = grantedPerRound.filter((g) => g > 0);
+            expect(firingRounds.length).toBeGreaterThan(0);
+            for (const granted of firingRounds) {
+                expect(granted).toBeCloseTo(ONE_GRANT, 6);
+            }
+
+            // (3) CONTROL — the cap is doing real work (oncePerRound is the BINDING constraint):
+            // an OTHERWISE-IDENTICAL ability WITHOUT oncePerRound, on the same 11-hit attack, lets
+            // the proc gate pass TWICE in a round → that round grants 2 × ONE_GRANT. This proves the
+            // 11-hit setup actually exercises the multi-grant path that oncePerRound suppresses above.
+            const noCapShield: Ability = {
+                id: 'equip-implant-ADAPTIVE_PLATING-nocap',
+                type: 'shield',
+                target: 'self',
+                trigger: 'on-attacked',
+                conditions: [],
+                procChance: 0.19,
+                // oncePerRound deliberately OMITTED.
+                config: { type: 'shield', pct: AP_PCT, basis: 'damage-taken' },
+                autoFilled: true,
+            };
+            const noCapResult = runCombat(
+                BASE({
+                    attack: 0,
+                    crit: 0,
+                    critDamage: 0,
+                    numRounds: NUM_ROUNDS,
+                    hp: CARRIER_HP,
+                    defence: 0,
+                    enemyHp: 1_000_000_000,
+                    healTargetId: 'attacker',
+                    shipSkills: {
+                        slots: [
+                            { slot: 'active', abilities: [noopActive] },
+                            { slot: 'passive', abilities: [noCapShield] },
+                        ],
+                    },
+                    enemyAttackers: [enemyHitter()],
+                })
+            );
+            const noCapGranted = noCapResult.rounds.map(
+                (rd) => rd.perActorShield?.['attacker']?.granted ?? 0
+            );
+            // At least one round grants MORE than a single share (the proc gate passed ≥ 2× that
+            // round) — the exact scenario the real ability's oncePerRound gate caps to one above.
+            expect(noCapGranted.some((g) => g > ONE_GRANT + 1e-6)).toBe(true);
+        }
+    );
+});

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -4969,3 +4969,198 @@ describe('H3.2 integration — Adaptive Plating once-per-round shield off the da
         }
     );
 });
+
+// ---------------------------------------------------------------------------
+// H3 Task H3.4: Abundant Renewal implant — overheal→shield to the over-repaired ally
+// ---------------------------------------------------------------------------
+//
+// Abundant Renewal (legendary) resolves through the registry (IMPLANT_ABILITIES.ABUNDANT_RENEWAL,
+// H3.4) into a DETERMINISTIC reactive ability (no procChance, no oncePerRound):
+//   { type:'shield', target:'ally', trigger:'on-own-repair-to-ally',
+//     config:{ type:'shield', pct:30, basis:'overheal' } }
+// 'on-own-repair-to-ally' is a LIVE trigger → it partitions into reactiveAbilities and fires when
+// the carrier (owner) repairs >= 1 NON-self ally. basis 'overheal' scales the grant off the CLIPPED
+// over-repair (eventCtx.overhealAmount, threaded from heal-performed.overheal by the listener in
+// H3.3). target 'ally' → reactiveRecipients falls back to healing.targetId (the over-repaired ally),
+// so the pool lands on that ally via the per-recipient routing (Phase 0.1).
+//
+// FULL build→sim path (not just the registry):
+//   - The FOCUS actor ('attacker') is the HEALER/carrier — Abundant Renewal merged into its passive
+//     slot via buildShipAbilitiesWithEquipment, plus a hand-built active ally-repair (basis 'hp',
+//     noCrit). It is slow → acts AFTER the enemy each round.
+//   - The over-repaired ally is the heal target ('tank', a team actor set as healTargetId).
+//   - A fast enemy attacker drops the tank to a KNOWN currentHp BEFORE the healer casts, so the
+//     repair clips to a KNOWN overheal.
+//
+// Pinning the overheal exactly (1 round, no folds):
+//   - healer effectiveMaxHp (hp) = 10_000; repair pct 50, basis 'hp', healModifier 0, noCrit →
+//     raw R = 10_000 × 50/100 = 5_000.
+//   - tank maxHp = 10_000; enemy deals G = 2_000 (attack 2000 × mult 100, no defence/crit) →
+//     tank currentHp = 8_000 BEFORE the heal.
+//   - consumed = min(R, maxHp − currentHp) = min(5_000, 2_000) = 2_000;
+//     overheal = R − consumed = 5_000 − 2_000 = 3_000.
+//   - shield granted to the tank = 0.30 × overheal = 0.30 × 3_000 = 900 (well under the tank's max
+//     HP cap → no clamping).
+
+const abundantRenewalPiece = makePiece({
+    id: 'ar-legendary',
+    slot: 'implant_ultimate',
+    rarity: 'legendary',
+    setBonus: 'ABUNDANT_RENEWAL',
+});
+
+describe('H3.4 integration — Abundant Renewal grants overheal→shield to the over-repaired ally (full build→sim path)', () => {
+    const HEALER_HP = 10_000;
+    const TANK_HP = 10_000;
+    const REPAIR_PCT = 50; // raw R = HEALER_HP × 50% = 5_000 (basis 'hp', noCrit, healModifier 0)
+    const RAW_REPAIR = HEALER_HP * (REPAIR_PCT / 100); // 5_000
+    const GAP = 2_000; // enemy damage to the tank before the healer casts
+    const EXPECTED_OVERHEAL = RAW_REPAIR - GAP; // 3_000 (R clips the 2_000 gap, overheals by 3_000)
+    const AR_PCT = 30; // legendary
+    const EXPECTED_SHIELD = (AR_PCT / 100) * EXPECTED_OVERHEAL; // 900
+
+    /** The healer's active repair, targeting an ally (routes to the heal target 'tank').
+     *  basis 'hp' + noCrit so raw = healer effectiveMaxHp × pct with no crit/heal-modifier folds. */
+    const repairAlly: Ability = {
+        id: 'ar-repair-ally',
+        type: 'heal',
+        target: 'ally',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'heal', pct: REPAIR_PCT, basis: 'hp', noCrit: true },
+    };
+
+    /** Team-actor heal target (the tank). Inert skills — it just receives the heal + the enemy hit. */
+    const tankActor = (speed: number): TeamActorEngineInput => ({
+        id: 'tank',
+        speed,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        walk: {
+            shipSkills: { slots: [] },
+            stats: {
+                attack: 1,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp: TANK_HP,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    });
+
+    /** A fast enemy attacker that deals exactly GAP to the heal target ('tank') each round.
+     *  attack === GAP, multiplier 100, no crit/defence → damage taken = GAP. */
+    const enemyHitter = () => ({
+        id: 'ar-enemy',
+        stats: {
+            attack: GAP,
+            crit: 0,
+            critDamage: 0,
+            speed: 1_000, // acts BEFORE the (slow) healer so the gap exists at cast time
+            defence: 0,
+            hp: 1_000_000_000,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active' as const,
+                    abilities: [
+                        {
+                            id: 'ar-enemy-hit',
+                            type: 'damage' as const,
+                            target: 'enemy' as const,
+                            trigger: 'on-cast' as const,
+                            conditions: [],
+                            config: { type: 'damage' as const, multiplier: 100, hits: 1 },
+                        },
+                    ],
+                },
+            ],
+        } as ShipSkills,
+    });
+
+    it('a Abundant-Renewal healer over-repairing the heal target grants that ally a 0.30 × overheal shield', () => {
+        // ── Real resolution+merge path (build→merge): legendary Abundant Renewal implant ──────
+        const ship = makeShip({ implants: { implant_ultimate: 'ar-legendary' } });
+        const getGearPiece = makeGetGearPiece({ 'ar-legendary': abundantRenewalPiece });
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+
+        // Pre-condition: the Abundant Renewal ability landed in the passive slot via the build path.
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        const ar = passive!.abilities.find((a) =>
+            a.id.startsWith('equip-implant-ABUNDANT_RENEWAL')
+        );
+        expect(ar).toBeDefined();
+        expect(ar!.type).toBe('shield');
+        expect(ar!.target).toBe('ally');
+        expect(ar!.trigger).toBe('on-own-repair-to-ally');
+        expect(ar!.procChance).toBeUndefined(); // deterministic — no proc gate
+        expect(ar!.config).toMatchObject({ type: 'shield', pct: 30, basis: 'overheal' });
+
+        // Healer ship skills: active ally-repair + the merged Abundant Renewal passive.
+        const shipSkills: ShipSkills = {
+            slots: [
+                { slot: 'active', abilities: [repairAlly] },
+                ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+            ],
+        };
+
+        // LIVE references — read the tank's shieldPool AFTER the run settles.
+        let captured: CombatActor[] = [];
+        const result = runCombat(
+            BASE({
+                // Focus 'attacker' is the HEALER: slow (acts after the enemy hit), full HP itself,
+                // basis-'hp' repair scales off ITS max HP (10_000).
+                attack: 1,
+                crit: 0,
+                critDamage: 0,
+                healModifier: 0,
+                numRounds: 1,
+                hp: HEALER_HP,
+                speed: 10, // healer is slow → enemy + tank act first
+                enemyHp: 1_000_000_000,
+                healTargetId: 'tank', // the over-repaired ally is a team actor, NOT the focus
+                teamActors: [tankActor(20)], // tank acts before the healer (inert)
+                shipSkills,
+                enemyAttackers: [enemyHitter()],
+                __testTapActors: (actors) => {
+                    captured = actors;
+                },
+            })
+        );
+
+        // ── Pin the overheal: heal-performed.overheal credited to the healer must equal 3_000 ──
+        // The focus 'attacker' is the applier (creditId), so its overheal bucket carries the clip.
+        expect(result.healing).toBeDefined();
+        expect(sumHeal(result, 'overheal', 'attacker')).toBeCloseTo(EXPECTED_OVERHEAL, 6);
+
+        // ── The H3.4 assertion: the over-repaired ally (the tank) accrued 0.30 × overheal ───────
+        // Read both the post-cap per-round `granted` AND the live tank pool — they must agree.
+        const tankGranted = result.rounds.reduce(
+            (sum, rd) => sum + (rd.perActorShield?.['tank']?.granted ?? 0),
+            0
+        );
+        expect(tankGranted).toBeCloseTo(EXPECTED_SHIELD, 6);
+
+        const tank = captured.find((a) => a.id === 'tank');
+        expect(tank?.shieldPool).toBeGreaterThan(0);
+        expect(tank?.shieldPool).toBeCloseTo(EXPECTED_SHIELD, 6);
+
+        // Non-vacuous / routing: the healer (carrier) is NOT the over-repaired ally → no pool on it.
+        const focus = captured.find((a) => a.id === 'attacker');
+        expect(focus?.shieldPool ?? 0).toBe(0);
+    });
+});

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -4726,7 +4726,7 @@ describe('H2.2 integration — Shield gear set grants 4% maxHP shield pool (full
                     critDamage: 0,
                     defensePenetration: 0,
                     shieldPenetration: 0,
-                    hacking: 175,
+                    hacking: 0,
                     defence: 0,
                     hp: ALLY_HP,
                 },

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -23,6 +23,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { CombatActor } from '../state';
 import { createEventBus, CombatEvent } from '../events';
 import { Ability, ShipSkills } from '../../../types/abilities';
 import { Ship } from '../../../types/ship';
@@ -4661,4 +4662,106 @@ describe('H1 Task 10 integration — Arcane Siege activates with a live shield',
             expect(boosted).toBeCloseTo(baseline * (1 + ARCANE_SIEGE_EPIC_PCT / 100), 6);
         }
     );
+});
+
+// ---------------------------------------------------------------------------
+// H2 Task H2.2: Shield gear set — accrues a 4% maxHP shield pool via full build→sim path
+// ---------------------------------------------------------------------------
+//
+// The Shield gear set ("Generate 4% shield each turn") resolves through the registry
+// (GEAR_SET_ABILITIES.SHIELD, H2.1) into an ability:
+//   { type:'shield', target:'self', trigger:'start-of-turn', config:{ type:'shield', pct:4, basis:'hp' } }
+// id `equip-set-SHIELD`. trigger 'start-of-turn' is a LIVE trigger → it partitions into
+// reactiveAbilities and fires via the reactive executor on the carrier's OWN turn, landing the
+// pool on the carrier via the per-recipient routing (Phase 0.1).
+//
+// This test exercises the FULL build→engine path, not just the registry:
+//   1. Equip a ship with the minimum SHIELD-set pieces (2; default minPieces).
+//   2. buildShipAbilitiesWithEquipment merges `equip-set-SHIELD` into the passive slot.
+//      (pre-condition assertion mirrors the LEECH test).
+//   3. Feed those built skills to a NON-focus team ally so its start-of-turn fires within
+//      round 1; read its live shieldPool via __testTapActors after the run settles.
+//
+// grantShieldToTarget does NOT floor: it adds raw and caps at maxHp, with raw = maxHp × 4/100.
+// Ally maxHp = 50_000 → pool = 0.04 × 50_000 = 2_000 exactly (well under the maxHp cap).
+
+const shieldPieceA = makePiece({ id: 'shield-1', slot: 'weapon', setBonus: 'SHIELD' });
+const shieldPieceB = makePiece({ id: 'shield-2', slot: 'hull', setBonus: 'SHIELD' });
+
+describe('H2.2 integration — Shield gear set grants 4% maxHP shield pool (full build→sim path)', () => {
+    it('a Shield-equipped acting ship accrues shieldPool = 0.04 × maxHp after its turn', () => {
+        const ALLY_HP = 50_000;
+        const SHIELD_PCT = 4; // GEAR_SETS.SHIELD stat value
+        const EXPECTED_POOL = (SHIELD_PCT / 100) * ALLY_HP; // 2_000, NOT floored
+
+        // ── 1+2: real resolution+merge path (build→merge) with 2 SHIELD-set pieces ──────────
+        const ship = makeShip({ equipment: { weapon: 'shield-1', hull: 'shield-2' } });
+        const getGearPiece = makeGetGearPiece({
+            'shield-1': shieldPieceA,
+            'shield-2': shieldPieceB,
+        });
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+
+        // Pre-condition: the SHIELD set ability landed in the passive slot via the build path.
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        const shieldAbility = passive!.abilities.find((a) => a.id === 'equip-set-SHIELD');
+        expect(shieldAbility).toBeDefined();
+        expect(shieldAbility!.trigger).toBe('start-of-turn');
+        expect(shieldAbility!.config).toMatchObject({ type: 'shield', pct: 4, basis: 'hp' });
+
+        // ── 3: feed the BUILT skills to a non-focus team ally; it acts within round 1 ────────
+        const teamActors: TeamActorInput[] = [
+            {
+                id: 'shield-carrier',
+                speed: 200, // acts before the focus so its start-of-turn fires within round 1
+                selfBuffs: [],
+                enemyDebuffs: [],
+                chargeCount: 0,
+                startCharged: false,
+                shipSkills: baseSkills,
+                stats: {
+                    attack: 0,
+                    crit: 0,
+                    critDamage: 0,
+                    defensePenetration: 0,
+                    shieldPenetration: 0,
+                    hacking: 175,
+                    defence: 0,
+                    hp: ALLY_HP,
+                },
+            },
+        ];
+        const engineTeam = deriveTeamEngineActors(teamActors, undefined);
+
+        // LIVE references — read shieldPool AFTER the run settles.
+        let captured: CombatActor[] = [];
+        runCombat(
+            BASE({
+                // Focus is inert: no damage, IS the heal target, NOT the shield carrier.
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                numRounds: 1,
+                hp: 40_000,
+                enemyHp: 1_000_000_000,
+                shipSkills: { slots: [{ slot: 'active', abilities: [] }] },
+                teamActors: engineTeam,
+                __testTapActors: (actors) => {
+                    captured = actors;
+                },
+            })
+        );
+
+        const focus = captured.find((a) => a.id === 'attacker');
+        const carrier = captured.find((a) => a.id === 'shield-carrier');
+
+        // Sanity / non-vacuous: the inert focus casts nothing and owns no shield → pool stays 0.
+        expect(focus?.shieldPool ?? 0).toBe(0);
+
+        // The H2 assertion: the Shield-set carrier accrued a 4%-of-maxHP pool on its turn.
+        // Exact (grantShieldToTarget does not floor; raw = maxHp × 4/100, well below the cap).
+        expect(carrier?.shieldPool).toBeGreaterThan(0);
+        expect(carrier?.shieldPool).toBeCloseTo(EXPECTED_POOL, 6);
+    });
 });

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -5164,3 +5164,366 @@ describe('H3.4 integration — Abundant Renewal grants overheal→shield to the 
         expect(focus?.shieldPool ?? 0).toBe(0);
     });
 });
+
+// ---------------------------------------------------------------------------
+// H3 Task H3.8: Resonating Fury implant — Crit Power Up III to shield recipients
+// ---------------------------------------------------------------------------
+//
+// Resonating Fury (legendary) resolves through the registry
+// (IMPLANT_ABILITIES.RESONATING_FURY, H3.8) into a reactive ability:
+//   { type:'buff', target:'all-allies', trigger:'on-shield-applied', procChance:0.16,
+//     config:{ type:'buff', buffName:'Crit Power Up III', duration:1 } }
+// 'on-shield-applied' is a LIVE trigger → it partitions into reactiveAbilities. When the carrier
+// applies a shield (its OWN cast, or a reactive shield off another implant/gear set), H3.6 emits
+// ONE `shield-applied` event keyed on the granter listing the recipients whose pool grew. The
+// H3.7 listener (granter-scoped) threads recipientIds into eventCtx.shieldRecipientIds; the buff
+// executor's 'all-allies' routing fans the grant to EXACTLY those recipients (NOT every ally).
+//
+// Forcing the proc DETERMINISTICALLY: the per-(owner,ability) RateGate accumulates +procChance per
+// qualifying event and fires when it crosses 1. The established device (Ambush/REACTIVE_WARD/Last
+// Stand integration tests) is to mutate ONLY the built ability's `procChance` to 1 — every other
+// field (trigger, buffName, target, duration) comes straight from the registry, so the test still
+// bites if the registry entry breaks. We capture RF firing via 'buff-applied' events filtered to
+// the buff name, exactly as the Ambush integration test does.
+//
+// In-game the implant text reads "Crit Power Up 3"; "3" is the canonical "III" tier — the only
+// matching BUFFS entry is 'Crit Power Up III' (the Ambush implant carries the same in-game buff and
+// the registry resolves both to 'Crit Power Up III'). The buff value, not the literal "3", is what
+// matters.
+
+const resonatingFuryPiece = makePiece({
+    id: 'rf-legendary',
+    slot: 'implant_major',
+    rarity: 'legendary',
+    setBonus: 'RESONATING_FURY',
+});
+
+const RF_BUFF = 'Crit Power Up III';
+
+/**
+ * Build the focus's ship skills with a legendary Resonating Fury merged into the passive slot via
+ * the REAL build→merge path, plus the supplied active. The built RF ability is determinized
+ * (procChance → 1) so every qualifying shield cast fires; all other fields come from the registry.
+ */
+function buildRfShipSkills(active: Ability) {
+    const ship = makeShip({ implants: { implant_major: 'rf-legendary' } });
+    const getGearPiece = makeGetGearPiece({ 'rf-legendary': resonatingFuryPiece });
+    const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+    const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+    expect(passive).toBeDefined();
+
+    const rf = passive!.abilities.find((a) => a.id.startsWith('equip-implant-RESONATING_FURY'));
+    expect(rf).toBeDefined();
+    // Sanity: the registry entry is the on-shield-applied all-allies Crit Power Up III grant.
+    expect(rf!.type).toBe('buff');
+    expect(rf!.target).toBe('all-allies');
+    expect(rf!.trigger).toBe('on-shield-applied');
+    expect(rf!.procChance).toBeCloseTo(0.16);
+    if (rf!.config.type === 'buff') {
+        expect(rf!.config.buffName).toBe(RF_BUFF);
+        expect(rf!.config.duration).toBe(1);
+    }
+
+    // Determinize: mutate ONLY procChance (the established Ambush/REACTIVE_WARD device).
+    const determinizedRf: Ability = { ...rf!, procChance: 1 };
+    const otherPassives = passive!.abilities.filter(
+        (a) => !a.id.startsWith('equip-implant-RESONATING_FURY')
+    );
+    const shipSkills: ShipSkills = {
+        slots: [
+            { slot: 'active', abilities: [active] },
+            { slot: 'passive', abilities: [...otherPassives, determinizedRf] },
+        ],
+    };
+    return shipSkills;
+}
+
+/** Collect RF_BUFF buff-applied events (actorId + round) across a run driven by `input`. */
+function collectRfFires(input: CombatEngineInput): Array<{ actorId: string; round: number }> {
+    const bus = createEventBus();
+    const out: Array<{ actorId: string; round: number }> = [];
+    bus.on('buff-applied', (e) => {
+        if (e.buffName === RF_BUFF) out.push({ actorId: e.actorId, round: e.round });
+    });
+    runCombat({ ...input, bus });
+    return out;
+}
+
+describe('H3.8 integration — Resonating Fury grants Crit Power Up III to shield recipients', () => {
+    /** A team ally that does nothing — just exists to be a shield recipient. */
+    const passiveAlly = (id: string, hp: number): TeamActorEngineInput => ({
+        id,
+        speed: 1, // slow → the focus acts first and casts the shield
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        walk: {
+            shipSkills: { slots: [] },
+            stats: {
+                attack: 1,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    });
+
+    // ── Test 1: the carrier casts a shield → the recipients get Crit Power Up III ───────────
+    it('shield cast → Crit Power Up III lands on every recipient of that cast (one proc roll)', () => {
+        // Focus 'attacker' carries Resonating Fury and casts an `all-allies` shield as its active.
+        // The cast shields the focus + both allies → ONE shield-applied event listing all three →
+        // RF (forced proc) grants Crit Power Up III to all three recipients from that single cast.
+        const shieldActive: Ability = {
+            id: 'rf-shield-cast',
+            type: 'shield',
+            target: 'all-allies',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'shield', pct: 25, basis: 'hp' },
+        };
+        const shipSkills = buildRfShipSkills(shieldActive);
+
+        const fires = collectRfFires(
+            BASE({
+                attack: 1,
+                crit: 0,
+                critDamage: 0,
+                numRounds: 1,
+                hp: 10_000,
+                speed: 100, // focus acts first → casts the shield before allies
+                enemyHp: 1_000_000_000,
+                shipSkills,
+                teamActors: [passiveAlly('rf-ally-1', 10_000), passiveAlly('rf-ally-2', 10_000)],
+            })
+        );
+
+        // Crit Power Up III landed on all three shield recipients (focus + both allies), and the
+        // grants are confined to round 1 (the single cast). Recipients are the shield recipients,
+        // not "every ally" by coincidence — here all three allies are recipients, so the next test
+        // pins the routing with a SELF-only shield.
+        const recipients = new Set(fires.map((f) => f.actorId));
+        expect(recipients).toEqual(new Set(['attacker', 'rf-ally-1', 'rf-ally-2']));
+        expect(fires.every((f) => f.round === 1)).toBe(true);
+    });
+
+    // ── Test 1b: SELF-only shield → buff lands on the granter ONLY (recipient routing, not team) ─
+    it('self-only shield cast → Crit Power Up III lands on the granter ONLY, not the idle allies', () => {
+        // The focus shields ITSELF only → recipientIds === [focus]. RF's all-allies grant must route
+        // to EXACTLY that recipient (shieldRecipientIds), proving it does NOT fan to every ally.
+        const selfShieldActive: Ability = {
+            id: 'rf-self-shield',
+            type: 'shield',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'shield', pct: 25, basis: 'hp' },
+        };
+        const shipSkills = buildRfShipSkills(selfShieldActive);
+
+        const fires = collectRfFires(
+            BASE({
+                attack: 1,
+                crit: 0,
+                critDamage: 0,
+                numRounds: 1,
+                hp: 10_000,
+                speed: 100,
+                enemyHp: 1_000_000_000,
+                shipSkills,
+                teamActors: [passiveAlly('rf-ally-1', 10_000), passiveAlly('rf-ally-2', 10_000)],
+            })
+        );
+
+        expect(fires.length).toBeGreaterThan(0);
+        expect(fires.every((f) => f.actorId === 'attacker')).toBe(true);
+    });
+
+    // ── Test 2 (KEY): reactive → reactive hop ───────────────────────────────────────────────
+    // The focus carries BOTH a legendary Adaptive Plating (on-attacked self shield) AND Resonating
+    // Fury. An enemy directly hits the focus → Adaptive Plating grants a self-shield → H3.6 emits a
+    // `shield-applied` event → RF (forced proc) reacts to it and grants Crit Power Up III to the
+    // shield recipient (the focus). This proves the reactive→reactive hop: a reactive shield re-emits
+    // an event that drives ANOTHER reactive ability, with the second intent enqueued mid-drain and
+    // drained by the same multi-generation `while (queue.length > 0)` loop in drainQueue.
+    it('reactive→reactive hop: Adaptive-Plating self-shield re-fires Resonating Fury onto the carrier', () => {
+        // Build both implants through the real registry; Adaptive Plating in implant_minor so both
+        // resolve. (The build path keys implants by slot; AP determinism comes from its own proc gate
+        // — to make the AP shield reliably land we force AP's procChance to 1 too.)
+        const adaptivePiece = makePiece({
+            id: 'rf-ap-legendary',
+            slot: 'implant_minor',
+            rarity: 'legendary',
+            setBonus: 'ADAPTIVE_PLATING',
+        });
+        const ship = makeShip({
+            implants: { implant_major: 'rf-legendary', implant_minor: 'rf-ap-legendary' },
+        });
+        const getGearPiece = makeGetGearPiece({
+            'rf-legendary': resonatingFuryPiece,
+            'rf-ap-legendary': adaptivePiece,
+        });
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+
+        const rf = passive!.abilities.find((a) => a.id.startsWith('equip-implant-RESONATING_FURY'));
+        const ap = passive!.abilities.find((a) =>
+            a.id.startsWith('equip-implant-ADAPTIVE_PLATING')
+        );
+        expect(rf).toBeDefined();
+        expect(ap).toBeDefined();
+        expect(ap!.trigger).toBe('on-attacked');
+        expect(rf!.trigger).toBe('on-shield-applied');
+
+        // Force BOTH procs to 1 so the chain is deterministic: AP self-shields on the hit, RF reacts
+        // to the resulting shield-applied. Everything else stays from the registry.
+        const determinizedRf: Ability = { ...rf!, procChance: 1 };
+        const determinizedAp: Ability = { ...ap!, procChance: 1 };
+        const otherPassives = passive!.abilities.filter(
+            (a) =>
+                !a.id.startsWith('equip-implant-RESONATING_FURY') &&
+                !a.id.startsWith('equip-implant-ADAPTIVE_PLATING')
+        );
+        // A no-op active keeps the round cadence; the focus deals no damage itself.
+        const noopActive: Ability = {
+            id: 'rf-noop-active',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0 },
+        };
+        const shipSkills: ShipSkills = {
+            slots: [
+                { slot: 'active', abilities: [noopActive] },
+                { slot: 'passive', abilities: [...otherPassives, determinizedAp, determinizedRf] },
+            ],
+        };
+
+        // An enemy that directly hits the focus each round → drives Adaptive Plating's on-attacked.
+        const enemyHitter = () => ({
+            id: 'rf-enemy',
+            stats: {
+                attack: 1_000,
+                crit: 0,
+                critDamage: 0,
+                speed: 1, // acts before the (slower) focus so the hit lands at round top
+                defence: 0,
+                hp: 1_000_000_000,
+            },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active' as const,
+                        abilities: [
+                            {
+                                id: 'rf-enemy-hit',
+                                type: 'damage' as const,
+                                target: 'enemy' as const,
+                                trigger: 'on-cast' as const,
+                                conditions: [],
+                                config: { type: 'damage' as const, multiplier: 100, hits: 1 },
+                            },
+                        ],
+                    },
+                ],
+            } as ShipSkills,
+        });
+
+        const fires = collectRfFires(
+            BASE({
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                numRounds: 3,
+                hp: 100_000_000, // huge → focus survives; the AP shield never caps out
+                defence: 0,
+                speed: 1, // focus acts AFTER the enemy hit so AP fires at round top
+                enemyHp: 1_000_000_000,
+                healTargetId: 'attacker',
+                shipSkills,
+                enemyAttackers: [enemyHitter()],
+            })
+        );
+
+        // THE HOP: AP's reactive self-shield re-emitted shield-applied, RF reacted, and Crit Power Up
+        // III landed on the carrier (the shield recipient). If drainQueue did NOT process intents
+        // enqueued mid-drain, this would be empty.
+        expect(fires.length).toBeGreaterThan(0);
+        expect(fires.every((f) => f.actorId === 'attacker')).toBe(true);
+    });
+
+    // ── Test 3: Shield gear set (start-of-turn self shield) + RF ─────────────────────────────
+    it('Shield gear set start-of-turn self-shield re-fires Resonating Fury onto the carrier', () => {
+        // Focus carries the SHIELD gear set (start-of-turn self shield) + Resonating Fury, both via
+        // the real build path. Each turn the gear set self-shields → shield-applied → RF (forced
+        // proc) grants Crit Power Up III to the self (the shield recipient).
+        const ship = makeShip({
+            equipment: { weapon: 'rf-shield-1', hull: 'rf-shield-2' },
+            implants: { implant_major: 'rf-legendary' },
+        });
+        const shieldPieceA2 = makePiece({ id: 'rf-shield-1', slot: 'weapon', setBonus: 'SHIELD' });
+        const shieldPieceB2 = makePiece({ id: 'rf-shield-2', slot: 'hull', setBonus: 'SHIELD' });
+        const getGearPiece = makeGetGearPiece({
+            'rf-legendary': resonatingFuryPiece,
+            'rf-shield-1': shieldPieceA2,
+            'rf-shield-2': shieldPieceB2,
+        });
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+
+        const setShield = passive!.abilities.find((a) => a.id === 'equip-set-SHIELD');
+        const rf = passive!.abilities.find((a) => a.id.startsWith('equip-implant-RESONATING_FURY'));
+        expect(setShield).toBeDefined();
+        expect(setShield!.trigger).toBe('start-of-turn');
+        expect(rf).toBeDefined();
+
+        const determinizedRf: Ability = { ...rf!, procChance: 1 };
+        const otherPassives = passive!.abilities.filter(
+            (a) => !a.id.startsWith('equip-implant-RESONATING_FURY')
+        );
+        const noopActive: Ability = {
+            id: 'rf-noop-active',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0 },
+        };
+        const shipSkills: ShipSkills = {
+            slots: [
+                { slot: 'active', abilities: [noopActive] },
+                { slot: 'passive', abilities: [...otherPassives, determinizedRf] },
+            ],
+        };
+
+        const fires = collectRfFires(
+            BASE({
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                numRounds: 3,
+                hp: 100_000_000,
+                speed: 100,
+                enemyHp: 1_000_000_000,
+                shipSkills,
+            })
+        );
+
+        expect(fires.length).toBeGreaterThan(0);
+        expect(fires.every((f) => f.actorId === 'attacker')).toBe(true);
+    });
+});

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -5091,7 +5091,7 @@ describe('H3.4 integration — Abundant Renewal grants overheal→shield to the 
         } as ShipSkills,
     });
 
-    it('a Abundant-Renewal healer over-repairing the heal target grants that ally a 0.30 × overheal shield', () => {
+    it('an Abundant-Renewal healer over-repairing the heal target grants that ally a 0.30 × overheal shield', () => {
         // ── Real resolution+merge path (build→merge): legendary Abundant Renewal implant ──────
         const ship = makeShip({ implants: { implant_ultimate: 'ar-legendary' } });
         const getGearPiece = makeGetGearPiece({ 'ar-legendary': abundantRenewalPiece });

--- a/src/utils/combat/__tests__/onShieldAppliedReaction.test.ts
+++ b/src/utils/combat/__tests__/onShieldAppliedReaction.test.ts
@@ -1,0 +1,195 @@
+/**
+ * H3.7 — `on-shield-applied` listener + Resonating-Fury recipient routing.
+ *
+ * Wires the REACTION half of the shield-applied seam (H3.5 defined the event + trigger; H3.6
+ * EMITS it once per cast keyed on the granter). An `on-shield-applied` reactive BUFF ability
+ * owned by the granter must fan its grant out to the SHIELD RECIPIENTS of that cast — exactly
+ * mirroring the `on-own-repair-to-ally` → `repairedAllyIds` precedent (Font of Power), where an
+ * `ally`-target buff lands on the event-derived recipients rather than the owner/whole team.
+ *
+ * This proves BOTH halves as one path:
+ *   (a) the `on-shield-applied` listener is granter-scoped (`e.granterId === ownerId`), skips
+ *       empty-recipient events, and threads `e.recipientIds` into `eventCtx.shieldRecipientIds`;
+ *   (b) the buff executor reads `shieldRecipientIds` (target `ally`/`all-allies`) and grants the
+ *       buff to EXACTLY those recipients — NOT the granter (unless it was itself a recipient).
+ *
+ * Two scenarios:
+ *   1. Single recipient: granter shields one ally → that ally gets the buff; the granter does NOT.
+ *   2. Multi-recipient single roll: granter shields TWO allies in ONE cast (one `shield-applied`
+ *      event listing both) → ONE enqueued intent → BOTH allies get the buff from that single event
+ *      (the proc roll, when present, happens once per cast — here no procChance, always fires).
+ *
+ * PRE-FIX this fails: there is no `on-shield-applied` case in registerReactiveListeners (no intent
+ * enqueued), and even with an enqueued intent the buff executor has no `shieldRecipientIds` hook so
+ * an `ally`-target grant would fall back to the owner/playerIds rather than the shield recipients.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+    registerReactiveListeners,
+    executeIntent,
+    Intent,
+    IntentExecContext,
+    ReactiveAbility,
+} from '../triggers';
+import { createEventBus } from '../events';
+import { createStatusEngine } from '../statusEngine';
+import type { CombatActor } from '../state';
+import type { Ability } from '../../../types/abilities';
+
+const GRANTER_ID = 'granter';
+const ALLY1_ID = 'ally1';
+const ALLY2_ID = 'ally2';
+
+// A reactive buff that grants a known buff to the shield recipients when the owner applies a
+// shield. Target 'ally' routes to eventCtx.shieldRecipientIds (the Resonating-Fury token H3.8
+// will use). No procChance → always fires (proc-gating is covered by reactiveBuffProcGate).
+const resonatingFuryBuff = (): Ability =>
+    ({
+        id: 'resonating-fury',
+        type: 'buff',
+        target: 'ally',
+        trigger: 'on-shield-applied',
+        conditions: [],
+        config: {
+            type: 'buff',
+            buffName: 'Crit Power Up',
+            stacks: 3,
+            duration: 1,
+            parsedEffects: {},
+        },
+    }) as unknown as Ability;
+
+/**
+ * Drive the live on-shield-applied listener and capture every enqueued intent. Mirrors the H3.3
+ * captureIntentForOverheal harness — emits a `shield-applied` event listing `recipientIds` and
+ * returns the intents the listener produced.
+ */
+function captureIntentsForShield(granterId: string, recipientIds: string[]): Intent[] {
+    const bus = createEventBus();
+    const ra: ReactiveAbility = { ability: resonatingFuryBuff(), sourceSlot: 'passive' };
+    const intents: Intent[] = [];
+    registerReactiveListeners({
+        bus,
+        perOwner: [{ ownerId: GRANTER_ID, reactiveAbilities: [ra] }],
+        enqueue: (i) => intents.push(i),
+        isOpposing: (id) => id === 'enemy',
+    });
+    bus.emit({
+        type: 'shield-applied',
+        granterId,
+        recipientIds,
+        round: 1,
+        amount: 5_000,
+    });
+    return intents;
+}
+
+/**
+ * Minimal buff-branch IntentExecContext, modeled on reactiveBuffProcGate's makeCtx. Captures the
+ * recipient ids that actually received the buff (buff-applied.actorId). The full same-side roster
+ * is [GRANTER, ALLY1, ALLY2]; a correct shieldRecipientIds routing lands ONLY on the recipients.
+ */
+function makeBuffCtx(): IntentExecContext & { appliedActorIds: string[] } {
+    const bus = createEventBus();
+    const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+    se.beginRound(1);
+
+    const appliedActorIds: string[] = [];
+    bus.on('buff-applied', (e) => {
+        appliedActorIds.push(e.actorId);
+    });
+
+    const runtimeFor = (id: string) =>
+        [
+            id,
+            {
+                actor: { id, chargeCount: 0, charges: 0 } as unknown as CombatActor,
+                attack: 10000,
+                defence: 0,
+                hp: 10000,
+                healModifier: 0,
+                selfDotModifier: 0,
+                defensePenetrationBuff: 0,
+                affinityDamageModifier: 0,
+                affinityCritCap: 100,
+                affinityCritPenalty: 0,
+                affinityDisadvantage: false,
+                selfBuffLookup: new Map(),
+                enemyDebuffLookup: new Map(),
+            } as never,
+        ] as const;
+
+    const ctx = {
+        round: 1,
+        enemy: { id: 'enemy', currentHp: 100000 } as CombatActor,
+        enemyId: 'enemy',
+        statusEngine: se,
+        bus,
+        corrosionEntries: [],
+        infernoEntries: [],
+        pendingBombs: [],
+        runtimes: new Map([runtimeFor(GRANTER_ID), runtimeFor(ALLY1_ID), runtimeFor(ALLY2_ID)]),
+        grantAllyCharges: () => {},
+        grantExtraAction: () => {},
+        playerIds: [GRANTER_ID, ALLY1_ID, ALLY2_ID],
+        lastTurnCtxByActor: new Map([
+            [GRANTER_ID, { effectiveAttack: 10000, affinityMult: 1 } as never],
+        ]),
+        enemyHp: 100000,
+        cumulativeDamage: 0,
+        recordResisted: () => {},
+    } as unknown as IntentExecContext & { appliedActorIds: string[] };
+
+    (ctx as unknown as Record<string, unknown>).appliedActorIds = appliedActorIds;
+    return ctx;
+}
+
+describe('H3.7 — on-shield-applied reaction routes buff to shield recipients', () => {
+    it('granter-scoped: ignores another granter, skips empty-recipient events', () => {
+        // Wrong granter → no enqueue.
+        expect(captureIntentsForShield('someone-else', [ALLY1_ID])).toHaveLength(0);
+        // Right granter, empty recipients → no enqueue.
+        expect(captureIntentsForShield(GRANTER_ID, [])).toHaveLength(0);
+    });
+
+    it('(1) single recipient: the shielded ally gets the buff; the granter does NOT', () => {
+        // Step 1: the listener threads recipientIds into eventCtx.shieldRecipientIds.
+        const intents = captureIntentsForShield(GRANTER_ID, [ALLY1_ID]);
+        expect(intents).toHaveLength(1);
+        expect(intents[0].eventCtx?.shieldRecipientIds).toEqual([ALLY1_ID]);
+
+        // Step 2: the buff executor routes the grant to that recipient (not the granter).
+        const ctx = makeBuffCtx();
+        executeIntent(intents[0], ctx);
+
+        expect(ctx.appliedActorIds).toEqual([ALLY1_ID]);
+        expect(ctx.appliedActorIds).not.toContain(GRANTER_ID);
+    });
+
+    it('(2) multi-recipient single roll: ONE cast event buffs BOTH recipients', () => {
+        // ONE shield-applied event listing two recipients → exactly ONE enqueued intent
+        // (one proc roll per cast), carrying both recipients.
+        const intents = captureIntentsForShield(GRANTER_ID, [ALLY1_ID, ALLY2_ID]);
+        expect(intents).toHaveLength(1);
+        expect(intents[0].eventCtx?.shieldRecipientIds).toEqual([ALLY1_ID, ALLY2_ID]);
+
+        // Step 2: the single intent fans the buff out to BOTH recipients (and not the granter).
+        const ctx = makeBuffCtx();
+        executeIntent(intents[0], ctx);
+
+        expect(ctx.appliedActorIds).toEqual([ALLY1_ID, ALLY2_ID]);
+        expect(ctx.appliedActorIds).not.toContain(GRANTER_ID);
+    });
+
+    it('(3) granter as its own recipient: buff lands on the granter when it shielded itself', () => {
+        // A self+ally shield cast lists the granter among recipientIds → the buff routes there too.
+        const intents = captureIntentsForShield(GRANTER_ID, [GRANTER_ID, ALLY1_ID]);
+        expect(intents).toHaveLength(1);
+        expect(intents[0].eventCtx?.shieldRecipientIds).toEqual([GRANTER_ID, ALLY1_ID]);
+
+        const ctx = makeBuffCtx();
+        executeIntent(intents[0], ctx);
+
+        expect(ctx.appliedActorIds).toEqual([GRANTER_ID, ALLY1_ID]);
+    });
+});

--- a/src/utils/combat/__tests__/reactiveDamageTakenShield.test.ts
+++ b/src/utils/combat/__tests__/reactiveDamageTakenShield.test.ts
@@ -1,0 +1,156 @@
+/**
+ * H3.1 — reactive `damage-taken` shield basis.
+ *
+ * A reactive `on-attacked` shield whose config basis is `damage-taken` (e.g. the Adaptive
+ * Plating implant: "shield = X% of the damage taken") must scale off the magnitude of the
+ * triggering hit, NOT the owner's Max HP.
+ *
+ * This test exercises BOTH halves of the H3.1 fix as one path:
+ *   (a) the `on-attacked` listener stamps the hit's `e.damage` into `eventCtx.triggerDamage`;
+ *   (b) the heal/shield executor's `damage-taken` basis reads that `triggerDamage`.
+ *
+ * Step 1 drives the live listener (the same `registerReactiveListeners` + bus harness used by
+ * the Task-4 on-attacked tests) and emits an `attacked` event carrying a KNOWN damage D. The
+ * enqueued intent is captured. Step 2 feeds that intent through `executeIntent` with a
+ * `grantShieldToTarget` spy and asserts the granted pool === 0.50 × D.
+ *
+ * PRE-FIX this fails twice over: the listener never threads `e.damage` (so triggerDamage is
+ * undefined), and even if it did the `damage-taken` basis falls through to effectiveMaxHp — so
+ * the grant would be 0.50 × maxHp (50,000 → 25,000), far larger than 0.50 × D (3,000 → 1,500).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+    registerReactiveListeners,
+    executeIntent,
+    Intent,
+    IntentExecContext,
+    ReactiveAbility,
+} from '../triggers';
+import { createEventBus } from '../events';
+import { createStatusEngine } from '../statusEngine';
+import type { CombatActor } from '../state';
+import type { Ability } from '../../../types/abilities';
+
+const OWNER_ID = 'carrier';
+const D = 3_000; // known incoming hit damage
+const MAX_HP = 50_000; // deliberately far from 0.5×D so a maxHp fall-through is unmistakable
+
+// A reactive self-shield that grants 50% of the DAMAGE TAKEN when the owner is attacked.
+// No procChance → always fires.
+const damageTakenShield = (): Ability => ({
+    id: 'adaptive-plating',
+    type: 'shield',
+    target: 'self',
+    trigger: 'on-attacked',
+    conditions: [],
+    config: { type: 'shield', pct: 50, basis: 'damage-taken' },
+});
+
+// Drive the live on-attacked listener and capture the enqueued intent. Mirrors the Task-4
+// emitAttacked harness in triggers.test.ts.
+function captureIntentForAttack(damage: number): Intent {
+    const bus = createEventBus();
+    const ra: ReactiveAbility = { ability: damageTakenShield(), sourceSlot: 'passive' };
+    const intents: Intent[] = [];
+    registerReactiveListeners({
+        bus,
+        perOwner: [{ ownerId: OWNER_ID, reactiveAbilities: [ra] }],
+        enqueue: (i) => intents.push(i),
+        isOpposing: (id) => id === 'enemy',
+    });
+    bus.emit({ type: 'attacked', targetId: OWNER_ID, attackerId: 'enemy', round: 1, damage });
+    expect(intents).toHaveLength(1);
+    return intents[0];
+}
+
+function makeShieldCtx(grantShieldToTarget: (raw: number, actor: CombatActor) => void): {
+    ctx: IntentExecContext;
+} {
+    const bus = createEventBus();
+    const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+
+    const healing: IntentExecContext['healing'] = {
+        targetId: OWNER_ID,
+        credit: () => {},
+        applyHealToTarget: () => ({ consumed: 0, overheal: 0 }),
+        grantShieldToTarget,
+        recipientMaxHp: () => MAX_HP,
+        recipientIncomingHealPct: () => 0,
+        // self-target → recipient is OWNER_ID; resolve it to a truthy actor so the grant fires.
+        recipientActor: (id: string) =>
+            id === OWNER_ID ? ({ id: OWNER_ID } as unknown as CombatActor) : undefined,
+    } as unknown as IntentExecContext['healing'];
+
+    const ctx = {
+        round: 1,
+        enemy: { id: 'enemy', currentHp: 100000 } as CombatActor,
+        enemyId: 'enemy',
+        statusEngine: se,
+        bus,
+        corrosionEntries: [],
+        infernoEntries: [],
+        pendingBombs: [],
+        runtimes: new Map([
+            [
+                OWNER_ID,
+                {
+                    actor: {
+                        id: OWNER_ID,
+                        currentHp: MAX_HP,
+                        chargeCount: 0,
+                        charges: 0,
+                    } as unknown as CombatActor,
+                    attack: 10000,
+                    defence: 0,
+                    hp: MAX_HP,
+                    healModifier: 0,
+                    selfDotModifier: 0,
+                    defensePenetrationBuff: 0,
+                    affinityDamageModifier: 0,
+                    affinityCritCap: 100,
+                    affinityCritPenalty: 0,
+                    affinityDisadvantage: false,
+                    selfBuffLookup: new Map(),
+                    enemyDebuffLookup: new Map(),
+                } as never,
+            ],
+        ]),
+        grantAllyCharges: () => {},
+        removeEnemyCharges: () => {},
+        removeChargesFrom: () => {},
+        grantExtraAction: () => {},
+        playerIds: [OWNER_ID],
+        lastTurnCtxByActor: new Map([
+            [
+                OWNER_ID,
+                { effectiveAttack: 10000, affinityMult: 1, effectiveMaxHp: MAX_HP } as never,
+            ],
+        ]),
+        enemyHp: 100000,
+        cumulativeDamage: 0,
+        recordResisted: () => {},
+        healing,
+    } as IntentExecContext;
+
+    return { ctx };
+}
+
+describe('H3.1 — reactive damage-taken shield basis', () => {
+    it('grants a shield of 50% of the DAMAGE TAKEN (not 50% of Max HP) when attacked', () => {
+        // Step 1: the on-attacked listener must thread the hit damage into eventCtx.
+        const intent = captureIntentForAttack(D);
+        expect(intent.eventCtx?.triggerDamage).toBe(D);
+
+        // Step 2: the executor's damage-taken basis reads triggerDamage.
+        const grantSpy = vi.fn<(raw: number, actor: CombatActor) => void>();
+        const { ctx } = makeShieldCtx(grantSpy);
+        executeIntent(intent, ctx);
+
+        expect(grantSpy).toHaveBeenCalledTimes(1);
+        const grantedRaw = grantSpy.mock.calls[0][0];
+        // 0.50 × D = 1,500. PRE-FIX: triggerDamage is undefined / basis falls through to maxHp
+        // → 0.50 × 50,000 = 25,000.
+        expect(grantedRaw).toBeCloseTo(0.5 * D, 6);
+        expect(grantedRaw).not.toBeCloseTo(0.5 * MAX_HP, 0);
+    });
+});

--- a/src/utils/combat/__tests__/reactiveOncePerRoundGate.test.ts
+++ b/src/utils/combat/__tests__/reactiveOncePerRoundGate.test.ts
@@ -165,6 +165,11 @@ describe('D-PR14: reactive damage/shield branches — passesOncePerRoundGate', (
             grantShieldToTarget: shieldSpy,
             recipientMaxHp: () => 10000,
             recipientIncomingHealPct: () => 0,
+            // Task 0.1: the reactive shield branch now routes per-recipient via recipientActor
+            // (target:'self' → recipient is OWNER_ID). Resolve it to a truthy actor so the
+            // per-recipient grant fires (mirrors the live HealingRuntimeCtx).
+            recipientActor: (id: string) =>
+                id === OWNER_ID ? ({ id: OWNER_ID } as unknown as CombatActor) : undefined,
         } as unknown as IntentExecContext['healing'];
 
         const ctx1 = makeCtx({ round: 1, oncePerRoundConsumed: consumed, healing });
@@ -190,6 +195,10 @@ describe('D-PR14: reactive damage/shield branches — passesOncePerRoundGate', (
             grantShieldToTarget: shieldSpy,
             recipientMaxHp: () => 10000,
             recipientIncomingHealPct: () => 0,
+            // Task 0.1: resolve the self-recipient to a truthy actor so the per-recipient grant
+            // fires (mirrors the live HealingRuntimeCtx).
+            recipientActor: (id: string) =>
+                id === OWNER_ID ? ({ id: OWNER_ID } as unknown as CombatActor) : undefined,
         } as unknown as IntentExecContext['healing'];
 
         const ctx = makeCtx({ oncePerRoundConsumed: consumed, healing });

--- a/src/utils/combat/__tests__/reactiveOverhealShield.test.ts
+++ b/src/utils/combat/__tests__/reactiveOverhealShield.test.ts
@@ -1,0 +1,195 @@
+/**
+ * H3.3 — reactive `overheal` shield basis.
+ *
+ * A reactive `on-own-repair-to-ally` shield whose config basis is `overheal` (e.g. the Abundant
+ * Renewal implant: "shield = X% of the over-repaired amount on the target when overrepairing an
+ * ally") must scale off the CLIPPED EXCESS of the triggering repair (heal raw − HP actually
+ * consumed), NOT the owner's Max HP.
+ *
+ * This test exercises BOTH halves of the H3.3 plumbing as one path:
+ *   (a) the `on-own-repair-to-ally` listener threads the `heal-performed.overheal` into
+ *       `eventCtx.overhealAmount`;
+ *   (b) the heal/shield executor's `overheal` basis reads that `overhealAmount`.
+ *
+ * Step 1 drives the live listener (the same `registerReactiveListeners` + bus harness used by the
+ * H3.1 damage-taken sibling) and emits a `heal-performed` event carrying a KNOWN overheal OH that
+ * reached a non-self ally. The enqueued intent is captured. Step 2 feeds that intent through
+ * `executeIntent` with a `grantShieldToTarget` spy and asserts the granted pool === 0.50 × OH and
+ * that it lands on the OVER-REPAIRED ally (the heal target).
+ *
+ * PRE-FIX this fails twice over: the `heal-performed` payload carries no `overheal` (so the
+ * listener can't thread it and `overhealAmount` is undefined), and even if it did the `overheal`
+ * basis is not in the union and falls through to effectiveMaxHp — so the grant would be
+ * 0.50 × maxHp (50,000 → 25,000), far larger than 0.50 × OH (4,000 → 2,000).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+    registerReactiveListeners,
+    executeIntent,
+    Intent,
+    IntentExecContext,
+    ReactiveAbility,
+} from '../triggers';
+import { createEventBus } from '../events';
+import { createStatusEngine } from '../statusEngine';
+import type { CombatActor } from '../state';
+import type { Ability } from '../../../types/abilities';
+
+const OWNER_ID = 'medic';
+const ALLY_ID = 'ally'; // the over-repaired heal target
+const OH = 4_000; // known overheal (clipped excess of the triggering repair)
+const MAX_HP = 50_000; // deliberately far from 0.5×OH so a maxHp fall-through is unmistakable
+
+// A reactive ally-shield that grants 50% of the OVER-REPAIRED amount when the owner overheals an
+// ally. No procChance → always fires.
+const overhealShield = (): Ability => ({
+    id: 'abundant-renewal',
+    type: 'shield',
+    target: 'ally',
+    trigger: 'on-own-repair-to-ally',
+    conditions: [],
+    config: { type: 'shield', pct: 50, basis: 'overheal' },
+});
+
+// Drive the live on-own-repair-to-ally listener and capture the enqueued intent. Mirrors the H3.1
+// captureIntentForAttack harness.
+function captureIntentForOverheal(overheal: number): Intent {
+    const bus = createEventBus();
+    const ra: ReactiveAbility = { ability: overhealShield(), sourceSlot: 'passive' };
+    const intents: Intent[] = [];
+    registerReactiveListeners({
+        bus,
+        perOwner: [{ ownerId: OWNER_ID, reactiveAbilities: [ra] }],
+        enqueue: (i) => intents.push(i),
+        isOpposing: (id) => id === 'enemy',
+    });
+    // The owner repaired a non-self ally; the cast over-repaired by `overheal`.
+    bus.emit({
+        type: 'heal-performed',
+        casterId: OWNER_ID,
+        targets: [ALLY_ID],
+        round: 1,
+        amount: 10_000,
+        overheal,
+    });
+    expect(intents).toHaveLength(1);
+    return intents[0];
+}
+
+function makeShieldCtx(grantShieldToTarget: (raw: number, actor: CombatActor) => void): {
+    ctx: IntentExecContext;
+} {
+    const bus = createEventBus();
+    const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+
+    const healing: IntentExecContext['healing'] = {
+        // The heal target is the over-repaired ally — an 'ally'-target reactive falls back to
+        // healing.targetId, so the shield must land on ALLY_ID.
+        targetId: ALLY_ID,
+        credit: () => {},
+        applyHealToTarget: () => ({ consumed: 0, overheal: 0 }),
+        grantShieldToTarget,
+        recipientMaxHp: () => MAX_HP,
+        recipientIncomingHealPct: () => 0,
+        // resolve the over-repaired ally to a truthy actor so the grant fires.
+        recipientActor: (id: string) =>
+            id === ALLY_ID ? ({ id: ALLY_ID } as unknown as CombatActor) : undefined,
+    } as unknown as IntentExecContext['healing'];
+
+    const ctx = {
+        round: 1,
+        enemy: { id: 'enemy', currentHp: 100000 } as CombatActor,
+        enemyId: 'enemy',
+        statusEngine: se,
+        bus,
+        corrosionEntries: [],
+        infernoEntries: [],
+        pendingBombs: [],
+        runtimes: new Map([
+            [
+                OWNER_ID,
+                {
+                    actor: {
+                        id: OWNER_ID,
+                        currentHp: MAX_HP,
+                        chargeCount: 0,
+                        charges: 0,
+                    } as unknown as CombatActor,
+                    attack: 10000,
+                    defence: 0,
+                    hp: MAX_HP,
+                    healModifier: 0,
+                    selfDotModifier: 0,
+                    defensePenetrationBuff: 0,
+                    affinityDamageModifier: 0,
+                    affinityCritCap: 100,
+                    affinityCritPenalty: 0,
+                    affinityDisadvantage: false,
+                    selfBuffLookup: new Map(),
+                    enemyDebuffLookup: new Map(),
+                } as never,
+            ],
+            [
+                ALLY_ID,
+                {
+                    actor: {
+                        id: ALLY_ID,
+                        currentHp: MAX_HP,
+                        chargeCount: 0,
+                        charges: 0,
+                    } as unknown as CombatActor,
+                    attack: 10000,
+                    defence: 0,
+                    hp: MAX_HP,
+                    healModifier: 0,
+                    selfDotModifier: 0,
+                    defensePenetrationBuff: 0,
+                    affinityDamageModifier: 0,
+                    affinityCritCap: 100,
+                    affinityCritPenalty: 0,
+                    affinityDisadvantage: false,
+                    selfBuffLookup: new Map(),
+                    enemyDebuffLookup: new Map(),
+                } as never,
+            ],
+        ]),
+        grantAllyCharges: () => {},
+        removeEnemyCharges: () => {},
+        removeChargesFrom: () => {},
+        grantExtraAction: () => {},
+        playerIds: [OWNER_ID, ALLY_ID],
+        lastTurnCtxByActor: new Map([
+            [
+                OWNER_ID,
+                { effectiveAttack: 10000, affinityMult: 1, effectiveMaxHp: MAX_HP } as never,
+            ],
+        ]),
+        enemyHp: 100000,
+        cumulativeDamage: 0,
+        recordResisted: () => {},
+        healing,
+    } as IntentExecContext;
+
+    return { ctx };
+}
+
+describe('H3.3 — reactive overheal shield basis', () => {
+    it('grants a shield of 50% of the OVER-REPAIRED amount (not 50% of Max HP) to the over-repaired ally', () => {
+        // Step 1: the on-own-repair-to-ally listener must thread the overheal into eventCtx.
+        const intent = captureIntentForOverheal(OH);
+        expect(intent.eventCtx?.overhealAmount).toBe(OH);
+
+        // Step 2: the executor's overheal basis reads overhealAmount and lands on the ally.
+        const grantSpy = vi.fn<(raw: number, actor: CombatActor) => void>();
+        const { ctx } = makeShieldCtx(grantSpy);
+        executeIntent(intent, ctx);
+
+        expect(grantSpy).toHaveBeenCalledTimes(1);
+        const [grantedRaw, grantedActor] = grantSpy.mock.calls[0];
+        // 0.50 × OH = 2,000. PRE-FIX: overhealAmount is undefined / basis falls through to maxHp
+        // → 0.50 × 50,000 = 25,000.
+        expect(grantedRaw).toBeCloseTo(0.5 * OH, 6);
+        expect(grantedRaw).not.toBeCloseTo(0.5 * MAX_HP, 0);
+        expect(grantedActor.id).toBe(ALLY_ID);
+    });
+});

--- a/src/utils/combat/__tests__/reactiveShieldRouting.test.ts
+++ b/src/utils/combat/__tests__/reactiveShieldRouting.test.ts
@@ -1,0 +1,124 @@
+/**
+ * H2/H3 FOUNDATION (Task 0.1) — a REACTIVE shield grant lands on its actual recipient,
+ * not just the engine's heal target (the battle-sim focus).
+ *
+ * Background: the cast path (playerTurn.ts) already routes a shield-cast pool to EACH
+ * targeted ally's own actor via `healing.recipientActor(rid)` → `grantShieldToTarget(raw,
+ * recipientActor)` (H1 Task 5). The REACTIVE heal/shield executor (triggers.ts) did NOT —
+ * it only landed a pool when the recipient WAS the heal target (`rid === healing.targetId`).
+ * So a reactive self-shield (or ally-shield) on a NON-focus ship granted NOTHING.
+ *
+ * This test pins the reactive path. Harness mirrors shieldGrantBattleSim.test.ts: a focus
+ * attacker that IS the heal target, plus a SEPARATE non-focus team ally. The ally carries a
+ * hand-built reactive self-shield with trigger 'start-of-turn' (a LIVE trigger → it routes
+ * through the reactive executor, NOT the cast path). We read each actor's `shieldPool` via the
+ * `__testTapActors` seam (LIVE references mutated through the run) AFTER the run settles.
+ *
+ * The ally is NOT the heal target. Pre-fix: its pool stays 0 (the reactive executor skips it
+ * because `rid !== healing.targetId`). Post-fix: it receives 10% × its Max HP.
+ */
+import { describe, it, expect } from 'vitest';
+import { CombatActor } from '../state';
+import { runCombat, CombatEngineInput } from '../engine';
+import { deriveTeamEngineActors } from '../../calculators/dpsSimulator';
+import { ShipSkills } from '../../../types/abilities';
+import { TeamActorInput } from '../../../types/calculator';
+
+// A team actor whose PASSIVE carries a reactive self-shield: on its OWN start-of-turn it gains
+// a Shield equal to 10% of its Max HP. trigger 'start-of-turn' is a LIVE trigger, so this
+// ability is partitioned into reactiveAbilities and fired by the reactive executor — exercising
+// the per-recipient routing under test. target 'self' → reactive recipients = [ownerId].
+const REACTIVE_SELF_SHIELD_SKILLS = (): ShipSkills => ({
+    slots: [
+        { slot: 'active', abilities: [] },
+        {
+            slot: 'passive',
+            abilities: [
+                {
+                    id: 'reactive-self-shield',
+                    type: 'shield',
+                    target: 'self',
+                    trigger: 'start-of-turn',
+                    conditions: [],
+                    config: { type: 'shield', pct: 10, basis: 'hp' },
+                },
+            ],
+        },
+    ],
+});
+
+const baseEngineInput = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    // Focus does NO damage and IS the heal target — it just sits; it is NOT the shield owner.
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [{ slot: 'active', abilities: [] }] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 40_000,
+    // healingCtx requires a heal target; simulateBattle points it at the focus (player[0]).
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+describe('Task 0.1 — a reactive shield grant lands on its NON-focus recipient (battle sim)', () => {
+    it('a reactive self-shield on a non-focus ally grants that ally a pool, even though it is NOT the heal target', () => {
+        const teamActors: TeamActorInput[] = [
+            {
+                id: 'team1',
+                speed: 200, // acts within round 1 so its start-of-turn fires
+                selfBuffs: [],
+                enemyDebuffs: [],
+                chargeCount: 0,
+                startCharged: false,
+                shipSkills: REACTIVE_SELF_SHIELD_SKILLS(),
+                stats: {
+                    attack: 0,
+                    crit: 0,
+                    critDamage: 0,
+                    defensePenetration: 0,
+                    shieldPenetration: 0,
+                    hacking: 175,
+                    defence: 0,
+                    hp: 50_000,
+                },
+            },
+        ];
+        const engineTeam = deriveTeamEngineActors(teamActors, undefined);
+
+        // LIVE references — read shieldPool AFTER the run settles.
+        let captured: CombatActor[] = [];
+        runCombat(
+            baseEngineInput({
+                teamActors: engineTeam,
+                __testTapActors: (actors) => {
+                    captured = actors;
+                },
+            })
+        );
+
+        const focus = captured.find((a) => a.id === 'attacker');
+        const ally = captured.find((a) => a.id === 'team1');
+
+        // The focus is NOT the shield owner and casts nothing → no pool (sanity / non-vacuous).
+        expect(focus?.shieldPool ?? 0).toBe(0);
+
+        // The Task-0.1 assertion: the NON-focus ally's reactive self-shield landed a pool.
+        // 10% of team1's 50k max HP = 5,000. PRE-FIX this is 0 (reactive executor skipped it).
+        expect(ally?.shieldPool).toBeGreaterThan(0);
+        expect(ally?.shieldPool).toBeCloseTo(5_000, 6);
+    });
+});

--- a/src/utils/combat/__tests__/salvationDeadRecipient.test.ts
+++ b/src/utils/combat/__tests__/salvationDeadRecipient.test.ts
@@ -56,7 +56,7 @@ const makeHealing = (
             const consumed = Math.min(raw, 500);
             return { consumed, overheal: raw - consumed };
         },
-        grantShieldToTarget: () => {},
+        grantShieldToTarget: () => 0,
         playerIds,
         // E5 fields (unused on this player-path double — present for type-correctness).
         enemyIds: [],

--- a/src/utils/combat/__tests__/shieldAppliedEvent.test.ts
+++ b/src/utils/combat/__tests__/shieldAppliedEvent.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { LIVE_TRIGGERS } from '../../../types/abilities';
+import { createEventBus, type CombatEvent } from '../events';
+
+describe('shield-applied event + on-shield-applied trigger (H3.5 definitions)', () => {
+    it('includes on-shield-applied in LIVE_TRIGGERS', () => {
+        expect(LIVE_TRIGGERS.has('on-shield-applied')).toBe(true);
+    });
+
+    it('emits and consumes a shield-applied event with the right fields', () => {
+        const bus = createEventBus();
+        const captured: CombatEvent[] = [];
+        bus.on('shield-applied', (e) => captured.push(e));
+
+        bus.emit({
+            type: 'shield-applied',
+            granterId: 'a',
+            recipientIds: ['b', 'c'],
+            round: 1,
+            amount: 500,
+        });
+
+        expect(captured).toHaveLength(1);
+        const event = captured[0];
+        expect(event.type).toBe('shield-applied');
+        if (event.type === 'shield-applied') {
+            expect(event.granterId).toBe('a');
+            expect(event.recipientIds).toEqual(['b', 'c']);
+            expect(event.round).toBe(1);
+            expect(event.amount).toBe(500);
+        }
+    });
+});

--- a/src/utils/combat/__tests__/shieldAppliedEvent.test.ts
+++ b/src/utils/combat/__tests__/shieldAppliedEvent.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { LIVE_TRIGGERS } from '../../../types/abilities';
+import { LIVE_TRIGGERS, ShipSkills } from '../../../types/abilities';
 import { createEventBus, type CombatEvent } from '../events';
+import { CombatActor } from '../state';
+import { runCombat, CombatEngineInput } from '../engine';
+import { deriveTeamEngineActors } from '../../calculators/dpsSimulator';
+import { TeamActorInput } from '../../../types/calculator';
 
 describe('shield-applied event + on-shield-applied trigger (H3.5 definitions)', () => {
     it('includes on-shield-applied in LIVE_TRIGGERS', () => {
@@ -29,5 +33,227 @@ describe('shield-applied event + on-shield-applied trigger (H3.5 definitions)', 
             expect(event.round).toBe(1);
             expect(event.amount).toBe(500);
         }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// H3.6 — emit shield-applied once per shield-application CAST (NOT per recipient).
+// ---------------------------------------------------------------------------
+
+const baseEngineInput = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    // Focus does NO damage and IS the heal target — it just sits and receives shield.
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [{ slot: 'active', abilities: [] }] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 40_000,
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+// A team actor whose active skill grants a Shield equal to 25% of its Max HP to ALL ALLIES.
+// recipientsFor('all-allies') → playerIds = ['attacker', 'team1'].
+const SHIELD_ALL_ALLIES_SKILLS = (): ShipSkills => ({
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                {
+                    id: 'team-shield',
+                    type: 'shield',
+                    target: 'all-allies',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config: { type: 'shield', pct: 25, basis: 'hp' },
+                },
+            ],
+        },
+    ],
+});
+
+describe('H3.6 — shield-applied emitted once per cast', () => {
+    it('cast path: an all-allies shield cast emits EXACTLY ONE shield-applied with both recipients', () => {
+        const teamActors: TeamActorInput[] = [
+            {
+                id: 'team1',
+                speed: 200, // acts before the focus so the grant lands within round 1
+                selfBuffs: [],
+                enemyDebuffs: [],
+                chargeCount: 0,
+                startCharged: false,
+                shipSkills: SHIELD_ALL_ALLIES_SKILLS(),
+                stats: {
+                    attack: 1000,
+                    crit: 0,
+                    critDamage: 0,
+                    defensePenetration: 0,
+                    shieldPenetration: 0,
+                    hacking: 175,
+                    defence: 0,
+                    hp: 50_000,
+                },
+            },
+        ];
+        const engineTeam = deriveTeamEngineActors(teamActors, undefined);
+
+        const bus = createEventBus();
+        const events: Extract<CombatEvent, { type: 'shield-applied' }>[] = [];
+        bus.on('shield-applied', (e) => {
+            if (e.type === 'shield-applied') events.push(e);
+        });
+
+        let captured: CombatActor[] = [];
+        runCombat(
+            baseEngineInput({
+                teamActors: engineTeam,
+                bus,
+                __testTapActors: (actors) => {
+                    captured = actors;
+                },
+            })
+        );
+
+        // Exactly ONE shield-applied for the one all-allies cast.
+        expect(events).toHaveLength(1);
+        const ev = events[0];
+        expect(ev.granterId).toBe('team1');
+        // Both recipients gained shield → both present (order = recipient routing order).
+        expect([...ev.recipientIds].sort()).toEqual(['attacker', 'team1']);
+        // amount = total granted = focus pool + ally pool.
+        const focus = captured.find((a) => a.id === 'attacker');
+        const ally = captured.find((a) => a.id === 'team1');
+        expect(ev.amount).toBeCloseTo((focus?.shieldPool ?? 0) + (ally?.shieldPool ?? 0), 6);
+    });
+
+    it('reactive path: a reactive self-shield (start-of-turn, self — same executor branch as the SHIELD gear set) emits ONE shield-applied keyed on the carrier', () => {
+        // The SHIELD gear set (H2) resolves to { type:'shield', target:'self',
+        // trigger:'start-of-turn' } and fires through the reactive heal/shield executor. This
+        // test hand-builds the identical reactive self-shield passive (mirrors
+        // reactiveShieldRouting.test.ts) so it exercises the SAME executor emission site without
+        // routing through the gear-build path.
+        const REACTIVE_SELF_SHIELD_SKILLS = (): ShipSkills => ({
+            slots: [
+                { slot: 'active', abilities: [] },
+                {
+                    slot: 'passive',
+                    abilities: [
+                        {
+                            id: 'reactive-self-shield',
+                            type: 'shield',
+                            target: 'self',
+                            trigger: 'start-of-turn',
+                            conditions: [],
+                            config: { type: 'shield', pct: 10, basis: 'hp' },
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const teamActors: TeamActorInput[] = [
+            {
+                id: 'team1',
+                speed: 200,
+                selfBuffs: [],
+                enemyDebuffs: [],
+                chargeCount: 0,
+                startCharged: false,
+                shipSkills: REACTIVE_SELF_SHIELD_SKILLS(),
+                stats: {
+                    attack: 0,
+                    crit: 0,
+                    critDamage: 0,
+                    defensePenetration: 0,
+                    shieldPenetration: 0,
+                    hacking: 175,
+                    defence: 0,
+                    hp: 50_000,
+                },
+            },
+        ];
+        const engineTeam = deriveTeamEngineActors(teamActors, undefined);
+
+        const bus = createEventBus();
+        const events: Extract<CombatEvent, { type: 'shield-applied' }>[] = [];
+        bus.on('shield-applied', (e) => {
+            if (e.type === 'shield-applied') events.push(e);
+        });
+
+        let captured: CombatActor[] = [];
+        runCombat(
+            baseEngineInput({
+                teamActors: engineTeam,
+                bus,
+                __testTapActors: (actors) => {
+                    captured = actors;
+                },
+            })
+        );
+
+        const ally = captured.find((a) => a.id === 'team1');
+        // Sanity: the reactive shield landed a pool.
+        expect(ally?.shieldPool ?? 0).toBeGreaterThan(0);
+
+        // Exactly ONE shield-applied for the reactive self-shield, keyed on the carrier.
+        expect(events).toHaveLength(1);
+        const ev = events[0];
+        expect(ev.granterId).toBe('team1');
+        expect(ev.recipientIds).toEqual(['team1']);
+        expect(ev.amount).toBeCloseTo(ally?.shieldPool ?? 0, 6);
+    });
+
+    it('0-grant exclusion: a cast that grants nothing (recipient already at cap) emits NO event', () => {
+        // The focus IS the heal target and casts the shield to SELF. With pct 25% of a tiny
+        // max HP but capped at max HP — to force actualGranted 0 we instead pre-fill via a
+        // first cast then a second. Simpler: a 0% shield grants nothing → no recipient gains.
+        const ZERO_SHIELD_SKILLS = (): ShipSkills => ({
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'zero-shield',
+                            type: 'shield',
+                            target: 'self',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'shield', pct: 0, basis: 'hp' },
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const bus = createEventBus();
+        const events: Extract<CombatEvent, { type: 'shield-applied' }>[] = [];
+        bus.on('shield-applied', (e) => {
+            if (e.type === 'shield-applied') events.push(e);
+        });
+
+        runCombat(
+            baseEngineInput({
+                shipSkills: ZERO_SHIELD_SKILLS(),
+                attack: 0,
+                bus,
+            })
+        );
+
+        // No recipient gained shield → no event.
+        expect(events).toHaveLength(0);
     });
 });

--- a/src/utils/combat/__tests__/triggers.test.ts
+++ b/src/utils/combat/__tests__/triggers.test.ts
@@ -2211,7 +2211,7 @@ describe('once-per-combat repair cap in executeIntent (Task 8)', () => {
                 applied.push(raw);
                 return { consumed: raw, overheal: 0 };
             },
-            grantShieldToTarget: () => {},
+            grantShieldToTarget: () => 0,
             playerIds: ['A'],
             enemyIds: [],
             recipientActor: () => undefined,
@@ -2732,7 +2732,7 @@ describe('Phase 4c Task 6: live drain-time selfHpPct', () => {
                 applied.push(raw);
                 return { consumed: raw, overheal: 0 };
             },
-            grantShieldToTarget: () => {},
+            grantShieldToTarget: () => 0,
             playerIds: ['A'],
             enemyIds: [],
             recipientActor: () => undefined,
@@ -2997,7 +2997,7 @@ describe('Phase 4c PR 2 Task 4: damagedAllyId recipient routing', () => {
                 applied.push(raw);
                 return { consumed: raw, overheal: 0 };
             },
-            grantShieldToTarget: () => {},
+            grantShieldToTarget: () => 0,
             playerIds: PLAYER_IDS,
             enemyIds: [],
             recipientActor: () => undefined,

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2060,7 +2060,7 @@ export function runCombat(input: CombatEngineInput): {
                   return { consumed, overheal: raw - consumed };
               },
               grantShieldToTarget: (raw, victim = healTarget) => {
-                  if (victim.currentHp <= 0) return; // dead → no-op
+                  if (victim.currentHp <= 0) return 0; // dead → no-op
                   const targetMaxHp = recipientMaxHp(victim.id);
                   // Capped at the CURRENT effective max HP. Note: if a max-HP buff later expires
                   // and shrinks targetMaxHp below an already-granted pool, the larger pool simply
@@ -2076,6 +2076,10 @@ export function runCombat(input: CombatEngineInput): {
                       victim.id,
                       (perActorShieldGranted.get(victim.id) ?? 0) + actualGranted
                   );
+                  // H3.6: return the REAL pool growth so the cast path / reactive executor can
+                  // build the shield-applied event's recipientIds (granted > 0) + amount. Existing
+                  // callers ignore the return (non-breaking — call for effect only).
+                  return actualGranted;
               },
               playerIds,
               enemyIds: enemyRecipientIds,
@@ -2472,6 +2476,10 @@ export function runCombat(input: CombatEngineInput): {
                 healingCtx.credit(victim.id, 'overheal', overheal);
             } else {
                 healingCtx.credit(victim.id, 'shield', raw);
+                // H3.6: this engine standing-leech shield site intentionally does NOT emit
+                // shield-applied — it is per-recipient (no shield-application CAST to key on) and
+                // no H2/H3 source routes through it, so it is out of H3 scope. Emission lives only
+                // in the cast path (playerTurn.ts) and the reactive executor (triggers.ts).
                 healingCtx.grantShieldToTarget(raw, victim);
             }
         }

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -102,6 +102,11 @@ export type CombatEvent =
           round: number;
           amount: number;
           critHits?: number;
+          /** Summed CLIPPED EXCESS of this cast's repair on the heal target (heal raw minus
+           *  the HP actually consumed). Present only when > 0. Consumed by the
+           *  on-own-repair-to-ally listener to scale an `overheal`-basis reactive shield
+           *  (Abundant Renewal); ignored by every other heal-performed listener. */
+          overheal?: number;
       }
     /** A cleanse cast resolved. `casterId` is the cleansing actor; `count` is the
      *  number of debuffs actually removed (player-side) or the nominal cfg.count

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -109,16 +109,17 @@ export type CombatEvent =
           overheal?: number;
       }
     /** A shield-application cast resolved (one event per cast, not per recipient).
-     *  `granterId` is the acting actor that applied the shield(s) (Resonating Fury
-     *  listens on this); `recipientIds` are the recipients whose pool actually grew
-     *  (actualGranted > 0) — RF's buff targets; `amount` is the total shield actually
-     *  granted this cast (post-cap). */
+     *  `granterId` is the acting actor that applied the shield(s) — named granter (not
+     *  caster) because Resonating Fury is granter-scoped and listens on this;
+     *  `recipientIds` are the recipients whose pool actually grew (actualGranted > 0) —
+     *  RF's buff targets; `amount` is the total shield actually granted this cast
+     *  (post-cap). */
     | {
           type: 'shield-applied';
-          granterId: string; // the acting actor that applied the shield(s) (Resonating Fury listens on this)
-          recipientIds: string[]; // recipients whose pool actually grew (actualGranted > 0) — RF's buff targets
+          granterId: string;
+          recipientIds: string[];
           round: number;
-          amount: number; // total shield actually granted this cast (post-cap)
+          amount: number;
       }
     /** A cleanse cast resolved. `casterId` is the cleansing actor; `count` is the
      *  number of debuffs actually removed (player-side) or the nominal cfg.count

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -108,6 +108,18 @@ export type CombatEvent =
            *  (Abundant Renewal); ignored by every other heal-performed listener. */
           overheal?: number;
       }
+    /** A shield-application cast resolved (one event per cast, not per recipient).
+     *  `granterId` is the acting actor that applied the shield(s) (Resonating Fury
+     *  listens on this); `recipientIds` are the recipients whose pool actually grew
+     *  (actualGranted > 0) — RF's buff targets; `amount` is the total shield actually
+     *  granted this cast (post-cap). */
+    | {
+          type: 'shield-applied';
+          granterId: string; // the acting actor that applied the shield(s) (Resonating Fury listens on this)
+          recipientIds: string[]; // recipients whose pool actually grew (actualGranted > 0) — RF's buff targets
+          round: number;
+          amount: number; // total shield actually granted this cast (post-cap)
+      }
     /** A cleanse cast resolved. `casterId` is the cleansing actor; `count` is the
      *  number of debuffs actually removed (player-side) or the nominal cfg.count
      *  (enemy-side, event-only path). Asymmetry: player-side performs REAL removal

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1942,7 +1942,9 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 // H3.6: emit ONE shield-applied per shield CAST, keyed on the caster, listing only
                 // recipients whose pool actually grew (granted > 0). Drives Resonating Fury
                 // (on-shield-applied). No recipient gained pool → no event. Mirrors the
-                // heal-performed emit below.
+                // heal-performed emit below. NOTE: enemy event-only shields `continue` above
+                // (healEventOnly) before reaching here, so they never emit — consistent with the
+                // engine not modeling enemy-side shield pools.
                 if (shieldRecipientIds.length > 0) {
                     bus.emit({
                         type: 'shield-applied',

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -111,9 +111,10 @@ export interface HealingRuntimeCtx {
         victim?: CombatActor
     ) => { consumed: number; overheal: number };
     /** Additive pool capped at the victim's max HP; drains before HP (enemy attacks, Task 8).
-     *  Dead victim → no-op. `victim` defaults to the heal target (E2 T1: optional per-victim
-     *  override for positional AoE leech). */
-    grantShieldToTarget: (raw: number, victim?: CombatActor) => void;
+     *  Dead victim → no-op (returns 0). `victim` defaults to the heal target (E2 T1: optional
+     *  per-victim override for positional AoE leech). Returns the REAL pool growth (post-cap
+     *  delta) so the caller can build a shield-applied event (H3.6). */
+    grantShieldToTarget: (raw: number, victim?: CombatActor) => number;
     /** Fixed player-id order for all-allies recipient routing. */
     playerIds: string[];
     /** Fixed enemy-attacker-id order for an ENEMY caster's all-allies routing (E5). */
@@ -1916,6 +1917,10 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 // Shields aren't repairs (documented assumption): NO crit, NO healModifier/
                 // outgoingHeal/incomingHeal channels — raw = basis × pct.
                 const recipients = recipientsFor(ability.target);
+                // H3.6: collect the per-recipient REAL pool growth so we emit ONE shield-applied
+                // per cast (NOT per recipient) carrying only recipients that actually gained pool.
+                const shieldRecipientIds: string[] = [];
+                let shieldGrantedSum = 0;
                 for (const rid of recipients) {
                     const raw = basisValue(cfg.basis, rid) * (cfg.pct / 100);
                     healing.credit(actor.id, 'shield', raw);
@@ -1927,8 +1932,25 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                     // (mirrors the heal-recipient handling for an unwalked legacy team actor).
                     const recipientActor = healing.recipientActor(rid);
                     if (recipientActor) {
-                        healing.grantShieldToTarget(raw, recipientActor);
+                        const granted = healing.grantShieldToTarget(raw, recipientActor);
+                        if (granted > 0) {
+                            shieldRecipientIds.push(rid);
+                            shieldGrantedSum += granted;
+                        }
                     }
+                }
+                // H3.6: emit ONE shield-applied per shield CAST, keyed on the caster, listing only
+                // recipients whose pool actually grew (granted > 0). Drives Resonating Fury
+                // (on-shield-applied). No recipient gained pool → no event. Mirrors the
+                // heal-performed emit below.
+                if (shieldRecipientIds.length > 0) {
+                    bus.emit({
+                        type: 'shield-applied',
+                        granterId: actor.id,
+                        recipientIds: shieldRecipientIds,
+                        round: r,
+                        amount: shieldGrantedSum,
+                    });
                 }
             } else if (cfg.type === 'cleanse') {
                 // Real removal is player-side only (recipientsFor returns player ids; enemy-side

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1874,6 +1874,9 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                         raw *= 1 + (healing.recipientIncomingHealAmpPct?.(rid) ?? 0) / 100;
                         const recipientActor = healing.recipientActor(rid);
                         if (recipientActor) healing.applyHealToTarget(raw, recipientActor);
+                        // overheal intentionally NOT accumulated here — enemy-side reactive
+                        // overheal (overheal-basis shields) is a deferred gap; H3.3 surfaces
+                        // overheal only on the player heal path above.
                         healTargets.push(rid);
                         healRawSum += raw;
                     }

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1700,7 +1700,14 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         };
         // Basis value for a heal/shield ability against recipient `rid`.
         const basisValue = (
-            basis: 'hp' | 'attack' | 'defense' | 'target-hp' | 'damage-dealt' | 'damage-taken',
+            basis:
+                | 'hp'
+                | 'attack'
+                | 'defense'
+                | 'target-hp'
+                | 'damage-dealt'
+                | 'damage-taken'
+                | 'overheal',
             rid: string
         ): number => {
             switch (basis) {
@@ -1721,6 +1728,13 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 case 'damage-taken':
                     throw new Error(
                         'basisValue: damage-taken must not reach the cast path (slot-partition guard owns it)'
+                    );
+                // 'overheal' is a reactive-only basis (on-own-repair-to-ally; Abundant Renewal):
+                // the clipped over-repair is known only at drain time via eventCtx.overhealAmount,
+                // so it never reaches the cast path.
+                case 'overheal':
+                    throw new Error(
+                        'basisValue: overheal must not reach the cast path (reactive-only basis)'
                     );
                 case 'hp':
                 default:
@@ -1829,6 +1843,9 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         const healTargets: string[] = [];
         let healCritCount = 0;
         let healRawSum = 0;
+        // H3.3: summed clipped excess (overheal) across this cast's repairs on the heal target.
+        // Carried on heal-performed.overheal for an `overheal`-basis reactive shield (Abundant Renewal).
+        let overhealSum = 0;
         let cleansePerformedCount = 0;
 
         for (const ability of healAbilities) {
@@ -1884,6 +1901,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                         const { consumed, overheal } = healing.applyHealToTarget(raw);
                         healing.credit(actor.id, 'effectiveHeal', consumed);
                         healing.credit(actor.id, 'overheal', overheal);
+                        overhealSum += overheal;
                     }
                     healTargets.push(rid);
                     healRawSum += raw;
@@ -1940,6 +1958,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 round: r,
                 amount: healRawSum,
                 ...(healCritCount > 0 ? { critHits: healCritCount } : {}),
+                ...(overhealSum > 0 ? { overheal: overhealSum } : {}),
             });
         }
 

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1599,6 +1599,10 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
         // only ever attacks the heal target, so damagedAllyId === healing.targetId in every
         // healing-mode run — but the explicit routing locks the semantics for 4d multi-target.
         const recipients = reactiveRecipients(intent, ctx, healing.targetId);
+        // H3.6: collect the per-recipient REAL pool growth so we emit ONE shield-applied per
+        // reactive shield (NOT per recipient) listing only recipients that actually gained pool.
+        const shieldRecipientIds: string[] = [];
+        let shieldGrantedSum = 0;
         for (const rid of recipients) {
             // Skip DEAD recipients from the gross credit (Phase 4b KNOWN LIMITATION 5):
             // an `all-allies` ON-DESTROYED heal (Salvation) fires when its OWN caster is
@@ -1640,12 +1644,33 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
                 // H2/H3 foundation: route per-recipient (mirrors the cast path in
                 // playerTurn.ts); an unresolvable recipient is credited but not pool-applied.
                 const recipientActor = ctx.healing.recipientActor(rid);
-                if (recipientActor) ctx.healing.grantShieldToTarget(raw, recipientActor);
+                if (recipientActor) {
+                    const granted = ctx.healing.grantShieldToTarget(raw, recipientActor);
+                    if (granted > 0) {
+                        shieldRecipientIds.push(rid);
+                        shieldGrantedSum += granted;
+                    }
+                }
             }
         }
         // Deliberately NO heal-performed emission from the executor (a reactive heal must
         // not re-trigger heal listeners — chain guard; mirrors the drain-time no-crit-outcome
         // conventions). heal/shield therefore never chain.
+        //
+        // H3.6: shield IS the one exception — we DO emit shield-applied here (ONE per reactive
+        // shield, keyed on the owner, listing only recipients whose pool grew). This is
+        // intentional, NOT the deliberate no-heal-performed re-emit above: shield-applied drives
+        // Resonating Fury, which grants a BUFF (not a shield), so it cannot chain back into
+        // another shield-applied. No recipient gained pool → no event.
+        if (cfg.type === 'shield' && shieldRecipientIds.length > 0) {
+            ctx.bus.emit({
+                type: 'shield-applied',
+                granterId: intent.ownerId,
+                recipientIds: shieldRecipientIds,
+                round: ctx.round,
+                amount: shieldGrantedSum,
+            });
+        }
         return;
     }
 

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1613,7 +1613,8 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
                 }
             } else {
                 ctx.healing.credit(intent.ownerId, 'shield', raw);
-                if (rid === ctx.healing.targetId) ctx.healing.grantShieldToTarget(raw);
+                const recipientActor = ctx.healing.recipientActor(rid);
+                if (recipientActor) ctx.healing.grantShieldToTarget(raw, recipientActor);
             }
         }
         // Deliberately NO heal-performed emission from the executor (a reactive heal must

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1636,6 +1636,10 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
         // reaction repairs THAT ally) over the healing target. Identical today — the engine
         // only ever attacks the heal target, so damagedAllyId === healing.targetId in every
         // healing-mode run — but the explicit routing locks the semantics for 4d multi-target.
+        // NOTE (Abundant Renewal / overheal shields): this heal/shield path does NOT consult
+        // eventCtx.repairedAllyIds — it resolves to healing.targetId, which IS the over-repaired
+        // ally because the engine repairs exactly one target today. If 4d multi-target repair
+        // lands, route overheal shields to the repaired ally explicitly here.
         const recipients = reactiveRecipients(intent, ctx, healing.targetId);
         // H3.6: collect the per-recipient REAL pool growth so we emit ONE shield-applied per
         // reactive shield (NOT per recipient) listing only recipients that actually gained pool.

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -128,6 +128,11 @@ export interface Intent {
          *  event, read by an `overheal`-basis reactive shield to scale off the over-repaired
          *  amount rather than the owner's max HP (Abundant Renewal). */
         overhealAmount?: number;
+        /** The recipients of an `on-shield-applied` event (shield-applied.recipientIds — the
+         *  actors whose pool grew). The reaction's buff/effect targets EXACTLY these, mirroring
+         *  repairedAllyIds: an `ally`/`all-allies`-target grant fans out to the shield recipients
+         *  rather than the owner/whole team (Resonating Fury — buff every recipient of the cast). */
+        shieldRecipientIds?: string[];
     };
 }
 
@@ -388,6 +393,25 @@ export function registerReactiveListeners(args: {
                                 ...intent.eventCtx,
                                 repairedAllyIds: repaired,
                                 overhealAmount: e.overheal ?? 0,
+                            },
+                        });
+                    });
+                    break;
+                case 'on-shield-applied':
+                    bus.on('shield-applied', (e) => {
+                        // Granter-scoped (H3.6 keys the event on the acting granter): THIS owner
+                        // applied a shield (Resonating Fury). One enqueue per CAST -> one proc-gate
+                        // roll; the grant fans out to every recipient whose pool grew via
+                        // eventCtx.shieldRecipientIds (mirrors on-own-repair-to-ally/repairedAllyIds).
+                        // An empty recipient list (no pool grew) emits no event by construction, but
+                        // guard defensively so a 0-recipient event never enqueues a no-op intent.
+                        if (e.granterId !== ownerId) return;
+                        if (e.recipientIds.length === 0) return;
+                        enqueue({
+                            ...intent,
+                            eventCtx: {
+                                ...intent.eventCtx,
+                                shieldRecipientIds: e.recipientIds,
                             },
                         });
                     });
@@ -1310,16 +1334,26 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
         // ally/all-allies → every player id (the FIXED playerIds order). The status carries
         // casterId = ownerId so its gate evaluates against the caster's ctx even when it
         // lives on another recipient.
+        const isAllyTarget =
+            intent.ability.target === 'ally' || intent.ability.target === 'all-allies';
         const recipients: string[] =
             intent.ability.target === 'adjacent-allies'
                 ? (ctx.adjacentAllyIdsFor?.(intent.ownerId) ?? ctx.playerIds)
-                : intent.ability.target === 'ally' && intent.eventCtx?.repairedAllyIds?.length
-                  ? intent.eventCtx.repairedAllyIds
-                  : intent.ability.target === 'ally' && intent.eventCtx?.damagedAllyId
-                    ? [intent.eventCtx.damagedAllyId]
-                    : intent.ability.target === 'ally' || intent.ability.target === 'all-allies'
-                      ? ctx.playerIds
-                      : [intent.ownerId];
+                : // H3.7: an on-shield-applied reaction (Resonating Fury) fans an ally/all-allies
+                  // grant out to EXACTLY the recipients of the triggering shield cast — the same
+                  // event-derived recipient routing as repairedAllyIds (Font of Power), keyed on
+                  // eventCtx.shieldRecipientIds. The recipients are same-side by construction (a
+                  // shield to oneself or an ally), so the granter itself appears here iff it
+                  // self-shielded — no extra ally filtering needed.
+                  isAllyTarget && intent.eventCtx?.shieldRecipientIds?.length
+                  ? intent.eventCtx.shieldRecipientIds
+                  : intent.ability.target === 'ally' && intent.eventCtx?.repairedAllyIds?.length
+                    ? intent.eventCtx.repairedAllyIds
+                    : intent.ability.target === 'ally' && intent.eventCtx?.damagedAllyId
+                      ? [intent.eventCtx.damagedAllyId]
+                      : isAllyTarget
+                        ? ctx.playerIds
+                        : [intent.ownerId];
         // D-PR10: dynamic caster-attack snapshot. A buff carrying the `attackFlatPctOfCaster`
         // sentinel ("N% of the caster's attack") freezes a concrete `attackFlat` from the
         // CASTER's effective attack at grant time (the same last-turn ctx value that

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1347,7 +1347,11 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
                   // self-shielded — no extra ally filtering needed.
                   isAllyTarget && intent.eventCtx?.shieldRecipientIds?.length
                   ? intent.eventCtx.shieldRecipientIds
-                  : intent.ability.target === 'ally' && intent.eventCtx?.repairedAllyIds?.length
+                  : // NOTE: repairedAllyIds/damagedAllyId stay scoped to target === 'ally'
+                    // (NOT isAllyTarget) on purpose — only shield routing accepts all-allies.
+                    // Do not "harmonize" these to isAllyTarget; it would broaden Font of Power /
+                    // on-ally-attacked recipients and drift goldens.
+                    intent.ability.target === 'ally' && intent.eventCtx?.repairedAllyIds?.length
                     ? intent.eventCtx.repairedAllyIds
                     : intent.ability.target === 'ally' && intent.eventCtx?.damagedAllyId
                       ? [intent.eventCtx.damagedAllyId]

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -105,9 +105,13 @@ export interface Intent {
         counterTargetId?: string;
         damagedAllyId?: string;
         fromPurgeEvent?: boolean;
-        /** The damage dealt by the triggering event (ability-performed.damage), used by a
-         *  reactive `basis:'damage-dealt'` heal/shield (e.g. Bloodthirst) to scale off the
-         *  triggering hit's damage rather than the owner's max HP. */
+        /** The damage of the triggering event, used by a reactive heal/shield to scale off
+         *  that hit rather than the owner's max HP. Two consumers: `basis:'damage-dealt'`
+         *  (ability-performed.damage — damage the owner DEALT, e.g. Bloodthirst) and
+         *  `basis:'damage-taken'` (attacked.damage — damage the owner TOOK, e.g. Adaptive
+         *  Plating). NOTE: attacked.damage is the per-attack aggregate and on-attacked fires
+         *  once per hit, so a non-oncePerRound damage-taken reactive would grant N times for
+         *  an N-hit attack; Adaptive Plating's oncePerRound gate caps it to one grant/round. */
         triggerDamage?: number;
         /** The triggering hit's crit outcome (on-attacked -> attacked.didCrit), read by the
          *  reactive cleanse executor to pick `critCount` over `count` (Reactive Ward). */

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -445,7 +445,11 @@ export function registerReactiveListeners(args: {
                         }
                         enqueue({
                             ...intent,
-                            eventCtx: { counterTargetId: e.attackerId, didCrit: e.didCrit },
+                            eventCtx: {
+                                counterTargetId: e.attackerId,
+                                didCrit: e.didCrit,
+                                triggerDamage: e.damage,
+                            },
                         });
                     });
                     break;
@@ -1563,11 +1567,13 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
                 ? (ownerCtx?.effectiveAttack ?? owner.attack)
                 : cfg.basis === 'defense'
                   ? (ownerCtx?.effectiveDefence ?? owner.defence)
-                  : cfg.basis === 'damage-dealt'
-                    ? // Reactive damage-dealt (e.g. Bloodthirst on-crit): scale off the triggering
-                      // hit's damage captured in eventCtx.triggerDamage. Falls back to 0 when no
-                      // triggering damage is present (non-crit path or missing context) — a
-                      // damage-dealt reactive heal with no damage context heals nothing.
+                  : cfg.basis === 'damage-dealt' || cfg.basis === 'damage-taken'
+                    ? // Reactive damage-dealt (e.g. Bloodthirst on-crit) / damage-taken (e.g.
+                      // Adaptive Plating on-attacked): scale off the triggering hit's damage
+                      // captured in eventCtx.triggerDamage — the damage DEALT for damage-dealt,
+                      // the damage TAKEN (the on-attacked hit's e.damage) for damage-taken. Falls
+                      // back to 0 when no triggering damage is present (non-crit path or missing
+                      // context) — a damage-scaled reactive with no damage context grants nothing.
                       (intent.eventCtx?.triggerDamage ?? 0)
                     : (ownerCtx?.effectiveMaxHp ?? owner.hp);
         // Recipients: an 'ally'-target heal prefers eventCtx.damagedAllyId (an ally-damage

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -124,6 +124,10 @@ export interface Intent {
          *  listener. Used by the charge branch as the per-source key for an `everyNthEvent` gate
          *  AND as the single-target for "decrease THAT enemy's charge" (Zosimos). */
         repairerId?: string;
+        /** The clipped overheal (heal-performed.overheal) carried from an own-repair-to-ally
+         *  event, read by an `overheal`-basis reactive shield to scale off the over-repaired
+         *  amount rather than the owner's max HP (Abundant Renewal). */
+        overhealAmount?: number;
     };
 }
 
@@ -380,7 +384,11 @@ export function registerReactiveListeners(args: {
                         if (repaired.length === 0) return;
                         enqueue({
                             ...intent,
-                            eventCtx: { ...intent.eventCtx, repairedAllyIds: repaired },
+                            eventCtx: {
+                                ...intent.eventCtx,
+                                repairedAllyIds: repaired,
+                                overhealAmount: e.overheal ?? 0,
+                            },
                         });
                     });
                     break;
@@ -1579,7 +1587,13 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
                       // back to 0 when no triggering damage is present (non-crit path or missing
                       // context) — a damage-scaled reactive with no damage context grants nothing.
                       (intent.eventCtx?.triggerDamage ?? 0)
-                    : (ownerCtx?.effectiveMaxHp ?? owner.hp);
+                    : cfg.basis === 'overheal'
+                      ? // Reactive overheal (Abundant Renewal on-own-repair-to-ally): scale off the
+                        // clipped over-repair captured in eventCtx.overhealAmount by the listener.
+                        // Falls back to 0 when no overheal context is present — an overheal-scaled
+                        // reactive with no over-repair grants nothing.
+                        (intent.eventCtx?.overhealAmount ?? 0)
+                      : (ownerCtx?.effectiveMaxHp ?? owner.hp);
         // Recipients: an 'ally'-target heal prefers eventCtx.damagedAllyId (an ally-damage
         // reaction repairs THAT ally) over the healing target. Identical today — the engine
         // only ever attacks the heal target, so damagedAllyId === healing.targetId in every

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1613,6 +1613,8 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
                 }
             } else {
                 ctx.healing.credit(intent.ownerId, 'shield', raw);
+                // H2/H3 foundation: route per-recipient (mirrors the cast path in
+                // playerTurn.ts); an unresolvable recipient is credited but not pool-applied.
                 const recipientActor = ctx.healing.recipientActor(rid);
                 if (recipientActor) ctx.healing.grantShieldToTarget(raw, recipientActor);
             }


### PR DESCRIPTION
## Shield system H2 + H3 — gear set + reactive implants

**Stacked on #156 (H1).** Base is `feat/combat-shield-system`; retarget to `main` once #156 merges.

Lights up the four dormant shield **sources** on top of the H1 foundation (penetration, DoT bypass, per-actor surfacing). All byte-identical to existing goldens — no synthetic fixture equips these, and the new event/basis plumbing is additive.

### What now works in the battle simulator
- **Shield gear set** — grants the ship a shield each turn (4% of max HP).
- **Adaptive Plating** implant — gain a shield from damage taken, once per round.
- **Abundant Renewal** implant — over-healing an ally grants that ally a shield (% of the over-repair).
- **Resonating Fury** implant — applying a shield has a chance to grant Crit Power Up III to the shielded ally/allies (one roll per cast, buffs all recipients).

### How it's built (phases)
- **Phase 0 (foundation):** reactive shield grants now route per-recipient via `recipientActor(rid)` (mirrors the cast path) — the enabler for every self/ally reactive shield.
- **H2:** `SHIELD` gear-set registry entry (`start-of-turn`, `basis:'hp'`).
- **H3 bases:** `damage-taken` (via the `on-attacked` hit damage) and a new `overheal` basis (new `heal-performed.overheal` field) for reactive-shield magnitudes.
- **H3 implants:** Adaptive Plating, Abundant Renewal, Resonating Fury.
- **New `shield-applied` event + `on-shield-applied` trigger:** `grantShieldToTarget` returns the actual granted amount; one event emitted per shield **cast** (cast path + reactive executor), keyed on the granter, listing only recipients whose pool grew; the listener routes the reaction to those recipients. Resonating Fury rides this, including the reactive→reactive hop (Adaptive Plating self-shield → RF buff), which terminates safely (RF grants a buff, not a shield).

### Out of scope (documented in-code)
- Standing damage-leech shield sites do not emit `shield-applied` (per-recipient, no H2/H3 source uses them).
- Enemy-side overheal shields (consistent with existing enemy-side reactive limitations).
- Dynamic `shieldPenetration` buff-folding (stays static, from H1).

### Verification
- Full suite **3304 passing**, lint 0 warnings, `tsc` clean, `audit:skills` 141/0 unchanged.
- Goldens **byte-identical** (no `vitest -u`).
- Every task was implemented TDD with spec + code-quality review; a final holistic review passed.

Spec: `docs/superpowers/specs/2026-06-25-shield-system-design.md` · Plan: `docs/superpowers/plans/2026-06-25-shield-system-h2-h3.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
