### PR TITLE
feat(combat): Lifeline implant — once-per-battle pre-hit threshold shield

### DIFF
--- a/docs/superpowers/plans/2026-06-26-lifeline-shield.md
+++ b/docs/superpowers/plans/2026-06-26-lifeline-shield.md
@@ -1,0 +1,517 @@
+# Lifeline Shield Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the Lifeline implant — a once-per-battle pre-hit shield grant that fires when a pure direct hit would cross the carrier's HP below 30% of max HP, granting `flatAmount + 100%·attack` (capped at max HP) before the triggering hit's shield-absorb step.
+
+**Architecture:** A victim-side intercept in `applyVictimDamage` (engine.ts), mirroring the D-PR3 `incoming-block`/`incoming-reduction` pattern that already modifies a hit before `shieldAbsorb`. A new `incoming-shield-grant` ability config carries the parameters; a pure helper (`thresholdShield.ts`) decides whether/how much to grant; the engine applies it to `victim.shieldPool` before running the existing `shieldAbsorb` against the boosted pool, then the rest of the hit eats shield→HP per the H1 penetration rules. Once-per-battle via a combat-lifetime Set. Dormant (byte-identical) for any actor without the ability.
+
+**Tech Stack:** TypeScript, Vitest. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-06-26-lifeline-shield-design.md`
+
+**Branch:** Work on `feat/combat-shield-system-h2-h3` (stacks on the open H2/H3 PR #157, same as H3 stacked on H1). Retarget to `main` once the H stack merges. Subagents MUST NOT run `git checkout` / `git switch` (a prior session left a detached HEAD this way).
+
+---
+
+## File Structure
+
+- **Modify** `src/types/abilities.ts` — add `'incoming-shield-grant'` to the `AbilityType` union (~line 23) and a new variant to the `AbilityConfig` union (~line 440, beside `incoming-block`).
+- **Modify** `src/components/skills/AbilityTypePicker.tsx`, `src/components/skills/AbilityCard.tsx`, `src/components/skills/abilityDefaults.ts` — editor exhaustiveness stubs (only where tsc forces them).
+- **Create** `src/utils/combat/thresholdShield.ts` — pure `thresholdShieldForHit()` helper.
+- **Create** `src/utils/combat/__tests__/thresholdShield.test.ts` — helper unit tests.
+- **Modify** `src/utils/combat/engine.ts` — combat-lifetime `thresholdShieldFired` Set (~line 1935 beside `cheatDeathConsumed`); extend the `incomingAbilitiesById` filter (~line 2251); the intercept block in `applyVictimDamage` after `shieldBefore` (~line 2775).
+- **Modify** `src/utils/abilities/buildEquipmentAbilities.ts` — `LIFELINE` value table + `IMPLANT_ABILITIES.LIFELINE` builder.
+- **Modify** `src/utils/abilities/__tests__/equipmentCoverage.test.ts` — add `LIFELINE` to the three coverage spots + a shape test.
+- **Modify** `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts` — end-to-end runCombat scenarios.
+- **Modify** `src/constants/changelog.ts` + `src/pages/DocumentationPage.tsx` — user-facing docs.
+
+---
+
+## Task 1: Add the `incoming-shield-grant` ability config type
+
+**Files:**
+- Modify: `src/types/abilities.ts`
+- Modify: `src/components/skills/AbilityTypePicker.tsx`, `src/components/skills/AbilityCard.tsx`, `src/components/skills/abilityDefaults.ts`
+
+- [ ] **Step 1: Add to the `AbilityType` union**
+
+In `src/types/abilities.ts`, in the `AbilityType` union (the one ending `… | 'incoming-block' | 'outgoing-amplification' | …`), add a new member after `'incoming-block'`:
+
+```ts
+    | 'incoming-shield-grant'
+```
+
+- [ ] **Step 2: Add the `AbilityConfig` variant**
+
+In the `AbilityConfig` union (beside the `incoming-block` variant ~line 451), add:
+
+```ts
+    | {
+          /** Lifeline: a PRE-hit threshold shield. When a pure direct hit would cross the
+           *  carrier's HP below `hpThresholdPct`% of max HP, grant `flatAmount` + `attackPct`%
+           *  of the carrier's own effective attack to the shield pool (capped at max HP) BEFORE
+           *  the hit's absorb step — so the rest of the same hit drains shield→HP per the H1 pen
+           *  rules (the unit can still die). Victim-side / self-scoped; consumed in
+           *  applyVictimDamage, NOT via the reactive executor. Once per battle. */
+          type: 'incoming-shield-grant';
+          hpThresholdPct: number;
+          flatAmount: number;
+          attackPct: number;
+          oncePerCombat: boolean;
+      }
+```
+
+- [ ] **Step 3: Run tsc to find the exhaustiveness gaps**
+
+Run: `npx tsc --noEmit`
+Expected: errors in `AbilityTypePicker.tsx`, `AbilityCard.tsx`, `abilityDefaults.ts` (and possibly others) for the now-missing `'incoming-shield-grant'` case. Note each file/line.
+
+- [ ] **Step 4: Add minimal editor stubs**
+
+For each file tsc flags, add a minimal stub mirroring the existing `incoming-block` entry (a label/option in `AbilityTypePicker`, a render fallback in `AbilityCard`, a default config object in `abilityDefaults`). Use the existing `incoming-block` entry in each file as the template; keep it minimal — these are not user-authored (Lifeline comes from the implant registry). Example default config for `abilityDefaults.ts`:
+
+```ts
+case 'incoming-shield-grant':
+    return { type: 'incoming-shield-grant', hpThresholdPct: 30, flatAmount: 0, attackPct: 100, oncePerCombat: true };
+```
+
+- [ ] **Step 5: Verify tsc clean**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types/abilities.ts src/components/skills/AbilityTypePicker.tsx src/components/skills/AbilityCard.tsx src/components/skills/abilityDefaults.ts
+git commit -m "feat(combat): add incoming-shield-grant ability config (Lifeline)"
+```
+
+---
+
+## Task 2: Pure helper `thresholdShieldForHit()`
+
+**Files:**
+- Create: `src/utils/combat/thresholdShield.ts`
+- Test: `src/utils/combat/__tests__/thresholdShield.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/utils/combat/__tests__/thresholdShield.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { thresholdShieldForHit } from '../thresholdShield';
+import type { Ability } from '../../../types/abilities';
+
+const ability = (overrides: Partial<{ flatAmount: number; attackPct: number; hpThresholdPct: number }> = {}): Ability => ({
+    id: 'lifeline-1',
+    type: 'incoming-shield-grant',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: {
+        type: 'incoming-shield-grant',
+        hpThresholdPct: overrides.hpThresholdPct ?? 30,
+        flatAmount: overrides.flatAmount ?? 8000,
+        attackPct: overrides.attackPct ?? 100,
+        oncePerCombat: true,
+    },
+});
+
+const base = {
+    abilities: [ability()],
+    maxHp: 10000,
+    effectiveAttack: 2000,
+    isDirect: true,
+    alreadyFired: () => false,
+};
+
+describe('thresholdShieldForHit', () => {
+    it('fires on a downward crossing below the threshold', () => {
+        // currentHp 4000 (40% >= 30%), hit deals 2000 to HP -> 2000 (20% < 30%) => crossing
+        const r = thresholdShieldForHit({ ...base, currentHp: 4000, provisionalHpDamage: 2000 });
+        expect(r).not.toBeNull();
+        expect(r!.grant).toBe(8000 + 2000); // flat + 100% attack
+        expect(r!.abilityId).toBe('lifeline-1');
+    });
+
+    it('does not fire when already below the threshold pre-hit', () => {
+        // currentHp 2500 (25% < 30%) -> not a downward crossing
+        const r = thresholdShieldForHit({ ...base, currentHp: 2500, provisionalHpDamage: 1000 });
+        expect(r).toBeNull();
+    });
+
+    it('does not fire when the hit does not cross the threshold', () => {
+        // currentHp 8000 -> 6000 (60% >= 30%)
+        const r = thresholdShieldForHit({ ...base, currentHp: 8000, provisionalHpDamage: 2000 });
+        expect(r).toBeNull();
+    });
+
+    it('does not fire for non-direct damage (DoT / bomb)', () => {
+        const r = thresholdShieldForHit({ ...base, currentHp: 4000, provisionalHpDamage: 2000, isDirect: false });
+        expect(r).toBeNull();
+    });
+
+    it('does not fire when already fired this battle', () => {
+        const r = thresholdShieldForHit({ ...base, currentHp: 4000, provisionalHpDamage: 2000, alreadyFired: () => true });
+        expect(r).toBeNull();
+    });
+
+    it('returns the raw (uncapped) grant — the engine applies the maxHP cap', () => {
+        const r = thresholdShieldForHit({ ...base, currentHp: 4000, provisionalHpDamage: 2000, effectiveAttack: 50000 });
+        expect(r!.grant).toBe(8000 + 50000); // uncapped; cap is applied at the engine seam
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/utils/combat/__tests__/thresholdShield.test.ts`
+Expected: FAIL — module not found / `thresholdShieldForHit` not defined.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `src/utils/combat/thresholdShield.ts`:
+
+```ts
+import type { Ability } from '../../types/abilities';
+
+/**
+ * Lifeline (incoming-shield-grant) — pre-hit threshold shield decision.
+ *
+ * Returns the FIRST `incoming-shield-grant` ability that should fire on this hit and the raw
+ * (uncapped) shield amount to grant, or null if none fires. Pure — no engine state. The caller
+ * applies the max-HP pool cap and records the once-per-battle fired flag.
+ *
+ * Fires when ALL hold:
+ *   (a) the hit is a pure direct hit (no DoT, no bomb portion) — `isDirect`;
+ *   (b) the ability has not yet fired this battle — `!alreadyFired(ability.id)`;
+ *   (c) a downward crossing of the threshold: pre-hit HP >= T AND would-be HP < T,
+ *       where T = hpThresholdPct/100 * maxHp and would-be HP = currentHp - provisionalHpDamage.
+ *
+ * `provisionalHpDamage` is the HP damage the hit would deal computed against the CURRENT shield
+ * pool (a shieldAbsorb run before any Lifeline grant). The grant = flatAmount + effectiveAttack
+ * * attackPct/100.
+ */
+export function thresholdShieldForHit(args: {
+    abilities: Ability[];
+    currentHp: number;
+    maxHp: number;
+    provisionalHpDamage: number;
+    effectiveAttack: number;
+    isDirect: boolean;
+    alreadyFired: (abilityId: string) => boolean;
+}): { abilityId: string; grant: number } | null {
+    const { abilities, currentHp, maxHp, provisionalHpDamage, effectiveAttack, isDirect, alreadyFired } = args;
+    if (!isDirect) return null;
+    for (const ability of abilities) {
+        const cfg = ability.config;
+        if (cfg.type !== 'incoming-shield-grant') continue;
+        if (alreadyFired(ability.id)) continue;
+        const threshold = (cfg.hpThresholdPct / 100) * maxHp;
+        const wouldBeHp = currentHp - provisionalHpDamage;
+        if (currentHp >= threshold && wouldBeHp < threshold) {
+            return {
+                abilityId: ability.id,
+                grant: cfg.flatAmount + effectiveAttack * (cfg.attackPct / 100),
+            };
+        }
+    }
+    return null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/utils/combat/__tests__/thresholdShield.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/thresholdShield.ts src/utils/combat/__tests__/thresholdShield.test.ts
+git commit -m "feat(combat): pure thresholdShieldForHit helper (Lifeline)"
+```
+
+---
+
+## Task 3: Engine intercept in `applyVictimDamage`
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts`
+
+This task wires the helper into the damage path. There is no isolated unit test for the wiring — correctness is locked by the helper's unit tests (Task 2) plus the end-to-end integration tests (Task 5). The verification gate for this task is: full suite green + production goldens/snapshots **byte-identical** (no `-u`).
+
+- [ ] **Step 1: Add the import**
+
+At the top of `engine.ts`, beside the `shieldAbsorb` import, add:
+
+```ts
+import { thresholdShieldForHit } from './thresholdShield';
+```
+
+- [ ] **Step 2: Declare the combat-lifetime fired Set**
+
+Next to `const cheatDeathConsumed = new Set<string>();` (~line 1935), add:
+
+```ts
+// Lifeline (incoming-shield-grant): once-per-BATTLE fired flags, keyed `${victimId}:${abilityId}`.
+// Combat-lifetime (NOT reset per round) — the shield grant occurs at most once per combat.
+const thresholdShieldFired = new Set<string>();
+```
+
+- [ ] **Step 3: Extend the `incomingAbilitiesById` filter**
+
+In the loop that builds `incomingAbilitiesById` (~line 2251), extend the condition:
+
+```ts
+if (
+    a.config.type === 'incoming-reduction' ||
+    a.config.type === 'incoming-block' ||
+    a.config.type === 'incoming-shield-grant'
+) {
+    incoming.push(a);
+}
+```
+
+(Confirmed: implant abilities are appended to the `passive` slot by `buildShipAbilitiesWithEquipment`, and this loop only scans `slot.slot === 'passive'` — so Lifeline is collected.)
+
+- [ ] **Step 4: Add the intercept block in `applyVictimDamage`**
+
+Immediately after `const shieldBefore = victim.shieldPool;` (~line 2775) and BEFORE the existing `const { absorbed, hpDamage } = shieldAbsorb({ … });` call, insert:
+
+```ts
+// Lifeline (incoming-shield-grant): a PRE-hit threshold shield. When a PURE direct hit
+// (no DoT, no bomb portion) would cross this victim's HP below the configured % of max HP,
+// grant flat + %-of-attack to the pool BEFORE absorbing, so the rest of THIS hit drains
+// shield→HP per the H1 pen rules (the unit can still die). Once per battle. Fully inert
+// (no provisional absorb, no helper call) when the victim carries no such ability →
+// byte-identical for every existing fixture.
+const thresholdShieldAbilities = incomingAbilitiesOf(victim.id).filter(
+    (a) => a.config.type === 'incoming-shield-grant'
+);
+if (thresholdShieldAbilities.length > 0) {
+    // Provisional absorb against the CURRENT pool → the HP damage the hit would deal pre-Lifeline.
+    const provisional = shieldAbsorb({
+        damage,
+        shieldPool: victim.shieldPool,
+        isDot: cause?.byDirectDamage === false,
+        penPct: cause?.shieldPenetrationPct ?? 0,
+        bombPortion: cause?.bombPortion ?? 0,
+    });
+    const grant = thresholdShieldForHit({
+        abilities: thresholdShieldAbilities,
+        currentHp: victim.currentHp,
+        maxHp,
+        provisionalHpDamage: provisional.hpDamage,
+        effectiveAttack: effectiveStatsOf(statusEngine, selfBuffLookup, victim).attack,
+        isDirect: cause?.byDirectDamage === true && (cause?.bombPortion ?? 0) === 0,
+        alreadyFired: (abilityId) => thresholdShieldFired.has(`${victim.id}:${abilityId}`),
+    });
+    if (grant) {
+        const newPool = Math.min(maxHp, shieldBefore + grant.grant);
+        const granted = newPool - shieldBefore;
+        victim.shieldPool = newPool;
+        thresholdShieldFired.add(`${victim.id}:${grant.abilityId}`);
+        // Surface the real pool growth on the H1 granted accumulator (StatCard).
+        perActorShieldGranted.set(victim.id, (perActorShieldGranted.get(victim.id) ?? 0) + granted);
+    }
+}
+```
+
+NOTE: verify `effectiveStatsOf`, `statusEngine`, `selfBuffLookup`, and `perActorShieldGranted` are all in lexical scope at this point (they are declared in `runCombat`, which encloses `applyVictimDamage`). If the `effectiveStatsOf(statusEngine, selfBuffLookup, victim)` call signature differs, match the existing call site used by `highestAttackInRoster` / the tank-side effective-stat reads in this file.
+
+- [ ] **Step 5: Run the full suite — expect byte-identical goldens**
+
+Run: `npm test`
+Expected: all tests pass with NO golden/snapshot changes (no actor carries `incoming-shield-grant` yet → the block is never entered). If any `.snap` or golden moves, STOP — the intercept is not inert; do not run `vitest -u`.
+
+- [ ] **Step 6: tsc + lint**
+
+Run: `npx tsc --noEmit && npm run lint`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/utils/combat/engine.ts
+git commit -m "feat(combat): Lifeline pre-hit threshold shield intercept in applyVictimDamage"
+```
+
+---
+
+## Task 4: Registry entry + coverage tracker
+
+**Files:**
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts`
+- Modify: `src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+
+- [ ] **Step 1: Add the value table**
+
+In `buildEquipmentAbilities.ts`, beside the other implant value tables (e.g. after `ABUNDANT_RENEWAL_PCT`), add:
+
+```ts
+// Lifeline: once-per-battle, when a direct hit would drop HP below 30%, gain a shield equal to
+// FLAT + 100% of this unit's attack (capped at max HP). Per-rarity = the flat component only.
+const LIFELINE_FLAT: Record<string, number> = {
+    common: 4000,
+    uncommon: 6000,
+    rare: 8000,
+    epic: 10000,
+    legendary: 12000,
+};
+```
+
+- [ ] **Step 2: Add the builder**
+
+In the `IMPLANT_ABILITIES` object (after `ADAPTIVE_PLATING`), add:
+
+```ts
+// Lifeline: PRE-hit threshold shield (incoming-shield-grant). Consumed victim-side in
+// applyVictimDamage, NOT via the reactive executor — the trigger/target wrapper is nominal
+// (mirrors SHADOWGUARD's incoming-block). All five rarities present.
+LIFELINE: (rarity) => {
+    const flatAmount = LIFELINE_FLAT[rarity];
+    if (flatAmount === undefined) return undefined;
+    return {
+        type: 'incoming-shield-grant',
+        target: 'self',
+        trigger: 'on-cast',
+        conditions: [],
+        config: {
+            type: 'incoming-shield-grant',
+            hpThresholdPct: 30,
+            flatAmount,
+            attackPct: 100,
+            oncePerCombat: true,
+        },
+        autoFilled: true,
+    };
+},
+```
+
+- [ ] **Step 3: Add a shape test**
+
+In `equipmentCoverage.test.ts`, add (near the ADAPTIVE_PLATING/ABUNDANT_RENEWAL shape tests):
+
+```ts
+it('LIFELINE produces 1 ability per rarity (incoming-shield-grant, flat by rarity, 100% attack, threshold 30, once per battle)', () => {
+    const flat: Record<string, number> = { common: 4000, uncommon: 6000, rare: 8000, epic: 10000, legendary: 12000 };
+    for (const v of IMPLANTS['LIFELINE'].variants) {
+        expect(implantAbilityCount('LIFELINE', v.rarity)).toBe(1);
+        const abs = implantAbilities('LIFELINE', v.rarity);
+        expect(abs[0].config).toMatchObject({
+            type: 'incoming-shield-grant',
+            hpThresholdPct: 30,
+            flatAmount: flat[v.rarity],
+            attackPct: 100,
+            oncePerCombat: true,
+        });
+    }
+});
+```
+
+- [ ] **Step 4: Add `LIFELINE` to the three coverage spots**
+
+In `equipmentCoverage.test.ts`:
+1. The `it('exactly { … } are currently implemented', …)` prose string — add `LIFELINE` to the implants list.
+2. The `implementedImplants` array passed to `.toEqual([...])` (~line 143) — insert `'LIFELINE'` in IMPLANTS declaration order (LIFELINE is declared at implants.ts:215, near the top — place it accordingly relative to the existing entries).
+3. The `implementedImplants` `new Set([...])` (~line 314) — add `'LIFELINE'`.
+
+Determine LIFELINE's position in `Object.keys(IMPLANTS)` order by checking `src/constants/implants.ts` and place it consistently in both the array and (order-independent) Set.
+
+- [ ] **Step 5: Run the coverage + shape tests**
+
+Run: `npx vitest run src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/equipmentCoverage.test.ts
+git commit -m "feat(combat): register Lifeline implant (incoming-shield-grant) + coverage"
+```
+
+---
+
+## Task 5: End-to-end integration tests
+
+**Files:**
+- Modify: `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts`
+
+Build the ship through the REAL registry (`buildShipAbilitiesWithEquipment` with a gear piece whose `setBonus`/implant name resolves to `LIFELINE`) so a mutation that breaks the trigger/config actually fails the test — do NOT hand-roll the ability. Use the existing ADAPTIVE_PLATING / Cloaking integration tests in this file as the template for wiring `getGearPiece` and running `runCombat`.
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Add a `describe('Lifeline (incoming-shield-grant)', …)` block with three cases:
+
+1. **Crossing grants a shield that soaks the remainder.** A carrier at >30% HP takes a direct hit that would cross below 30%. Assert: after the hit the unit is alive, its shield pool reflects the granted amount minus what the hit drained (i.e. `flatAmount + attack` was added and the hit was partially/fully absorbed), and HP did not fall as far as it would have without Lifeline. Compare against a control run (same setup, no Lifeline implant) to prove the divergence.
+2. **Lifeline does not prevent death from an overwhelming hit.** A direct hit large enough to exceed `shield grant + remaining HP` still destroys the unit (assert destroyed). This locks "not a death-save".
+3. **Once per battle.** Two qualifying direct hits across the battle → the shield is granted only once (the second qualifying hit adds nothing; assert via shield-granted surfacing or a second-hit HP/shield delta consistent with no new grant).
+
+Pick concrete numbers so the threshold math is unambiguous (e.g. maxHp 10000, attack 2000, legendary flat 12000 → grant 14000 capped to 10000; start HP 4000; hit 3000 direct → crosses 30%, grants, pool 10000 absorbs 3000 → HP stays 4000).
+
+- [ ] **Step 2: Run to verify they fail (or pass) appropriately**
+
+Run: `npx vitest run src/utils/combat/__tests__/equipmentAbilities.integration.test.ts`
+Expected: the new cases pass (the implementation from Tasks 1–4 is complete). If a case fails, debug the wiring — do NOT weaken the assertion.
+
+- [ ] **Step 3: Sanity-check the assertions bite**
+
+Temporarily comment out the intercept block (Task 3 Step 4) and re-run: the crossing/once-per-battle cases MUST fail. Restore the block. (This is the mutation check — confirm the tests are non-vacuous.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+git commit -m "test(combat): Lifeline end-to-end via real registry + runCombat"
+```
+
+---
+
+## Task 6: Changelog, docs, final verification, PR
+
+**Files:**
+- Modify: `src/constants/changelog.ts`
+- Modify: `src/pages/DocumentationPage.tsx`
+
+- [ ] **Step 1: Changelog entry**
+
+Add a plain-English line to `UNRELEASED_CHANGES` in `src/constants/changelog.ts`, e.g.:
+
+> Combat sim now models the Lifeline implant: when a direct hit would drop a ship below 30% HP, it gains a shield (a flat amount plus 100% of its attack, capped at max HP) before the hit lands — once per battle.
+
+- [ ] **Step 2: Documentation**
+
+If the simulator/implant docs in `DocumentationPage.tsx` enumerate modeled implants or shield sources, add Lifeline there to keep in-app docs in sync.
+
+- [ ] **Step 3: Full verification gate**
+
+Run each and confirm output:
+- `npm test` → all green, NO golden/snapshot drift (no `-u`).
+- `npx tsc --noEmit` → clean.
+- `npm run lint` → clean (max-warnings 0).
+- `npm run audit:skills` → 141 ships, 0 findings (unchanged).
+
+- [ ] **Step 4: Commit docs**
+
+```bash
+git add src/constants/changelog.ts src/pages/DocumentationPage.tsx
+git commit -m "docs(combat): changelog + docs for Lifeline shield implant"
+```
+
+- [ ] **Step 5: Push + open the PR**
+
+Run `gh auth switch --user TheSusort` first (required before `gh` in this repo). Push the branch and open a PR with base `feat/combat-shield-system-h2-h3` (the H stack); note in the body that it should be retargeted to `main` after the H stack merges. End the PR body with the Claude Code attribution footer.
+
+---
+
+## Verification Summary (definition of done)
+
+- [ ] `thresholdShieldForHit` unit tests pass (Task 2).
+- [ ] Engine intercept added; full suite green with byte-identical production goldens (Task 3).
+- [ ] `LIFELINE` registered; coverage tracker + shape test pass (Task 4).
+- [ ] Integration tests pass and bite under mutation (Task 5).
+- [ ] Changelog + docs updated; tsc / lint / audit:skills clean (Task 6).

--- a/docs/superpowers/specs/2026-06-26-lifeline-shield-design.md
+++ b/docs/superpowers/specs/2026-06-26-lifeline-shield-design.md
@@ -1,0 +1,122 @@
+# Lifeline Shield — Design Spec
+
+**Date:** 2026-06-26
+**Sub-project:** H (shield system) follow-up — the last remaining shield-grant implant.
+**Branch base:** stacks on `feat/combat-shield-system-h2-h3` (H2/H3 PR #157), the same way H3 stacked on H1. Retarget to `main` once the H stack merges.
+
+## Context
+
+The shield system (sub-project H) shipped H1 (penetration / DoT bypass / sim surfacing), H2 (Shield gear set), and H3 (reactive implants: Adaptive Plating, Abundant Renewal, Resonating Fury). The shield-grant family was tracked as `Abundant Renewal / Adaptive Plating / Strike / Lifeline / Resonating Fury`.
+
+Two corrections found during exploration:
+
+- **Strike is NOT a shield implant.** It is a stat-only flat-attack implant (`attack +30/71/115/182/289` by rarity), like Barrier/Citadel/Devastation — already modeled in combat stats, needs no engine work. Its inclusion in the shield-grant family was a mislabel.
+- **Lifeline is the only remaining shield-grant source.** It is a genuinely new shape, not just another registry entry.
+
+## The implant
+
+> *"When direct damage would cause HP to drop below 30%, gain a Shield equal to [4000/6000/8000/10000/12000] plus 100% of this unit's Attack stat (capped at max HP). This can occur once per battle."*
+
+Per-rarity flat amount: `common 4000, uncommon 6000, rare 8000, epic 10000, legendary 12000`. Attack component: 100% of the carrier's own effective attack. Cap: max HP. Frequency: once per battle.
+
+### Locked game behavior (user-ratified 2026-06-26)
+
+The shield goes up **mid-hit, before the triggering damage finishes applying**:
+
+> "if incoming damage makes hp go below 30% → gain shield → continue applying the incoming damage"
+
+The ship can still die if the incoming damage exceeds the new shield + remaining HP. This is **not** Cheat Death (a dedicated 0%-HP death-intercept that floors HP at 1) — Lifeline is a 30%-threshold buffer that explicitly still allows death.
+
+**Locked semantics:**
+
+1. **Pre-hit / mid-hit timing.** The shield is granted *before* the triggering hit's shield-absorb step, so the rest of that same hit eats through shield→HP per the H1 penetration rules.
+2. **Downward crossing.** Fires only when pre-hit HP ≥ 30% of max HP *and* the hit would bring it below 30%. If the unit is already below 30% (e.g. chipped by a shield-bypassing DoT), a subsequent hit does not "cause it to drop below 30%" → no fire. (Once-per-battle makes the crossing the natural reading.)
+3. **Direct damage only.** Eligibility requires a *pure* direct hit: `cause.byDirectDamage === true && (cause.bombPortion ?? 0) === 0`. DoTs (which bypass shields) and any detonation/bomb-bearing hit do not arm Lifeline. A mixed direct+detonation aggregate hit does not trigger (approximation, consistent with "only direct damage triggers it").
+4. **Once per battle.** Fires at most once per combat, tracked by a combat-lifetime Set keyed `${victimId}:${abilityId}` (mirrors Cheat Death / Yazid once-per-combat).
+5. **Cap at max HP.** The shield *pool* (total, not just the grant) is capped at max HP, consistent with the H1 locked rule. `newPool = min(maxHp, shieldBefore + grant)`.
+
+## Architecture
+
+### Why the victim-side damage path
+
+The existing reactive `on-hp-threshold-crossed` trigger fires on the `hp-changed` event, which is emitted *after* the hit fully resolves — too late to soak the triggering blow. So Lifeline lives in the **victim-side damage-application path** (`applyVictimDamage` in `engine.ts`), which already hosts a near-identical pattern: D-PR3's `incoming-block` / `incoming-reduction` look up `incomingAbilitiesOf(victim.id)` and modify the hit *before* the `shieldAbsorb` step. Lifeline slots in between capturing `shieldBefore` and calling `shieldAbsorb`.
+
+This reuses the established victim-side-intercept machinery (per-actor `incomingAbilitiesById` map, pure testable helper, once-per-combat Set) rather than inventing a new seam.
+
+### 1. Data model — `types/abilities.ts`
+
+New victim-side ability config in the `AbilityConfig` union:
+
+```ts
+| {
+    type: 'incoming-shield-grant';
+    hpThresholdPct: number;   // 30 — fire when a direct hit crosses HP below this % of max HP
+    flatAmount: number;       // 4000/6000/8000/10000/12000 by rarity
+    attackPct: number;        // 100 — % of the carrier's own effective attack
+    oncePerCombat: boolean;   // true
+  }
+```
+
+Self-scoped by construction (the carrier *is* the victim). No `condition` / `procChance` fields — Lifeline is deterministic and unconditional beyond the threshold crossing. Editor exhaustiveness stubs added where the union forces them (AbilityCard / AbilityTypePicker / abilityDefaults), consistent with prior config-type additions.
+
+### 2. Pure helper — `src/utils/combat/thresholdShield.ts`
+
+Fully unit-tested in isolation:
+
+```
+thresholdShieldForHit({
+  abilities,            // Ability[] — the victim's incoming-shield-grant abilities
+  currentHp,
+  maxHp,
+  provisionalHpDamage,  // HP damage from a shieldAbsorb computed with the CURRENT pool
+  effectiveAttack,      // victim's effective attack
+  isDirect,             // cause.byDirectDamage === true && (cause.bombPortion ?? 0) === 0
+  alreadyFired,         // (abilityId: string) => boolean
+}) => { abilityId: string; grant: number } | null
+```
+
+Logic — pick the first `incoming-shield-grant` ability that is:
+
+- (a) `isDirect`,
+- (b) not yet fired (`!alreadyFired(ability.id)`),
+- (c) a downward crossing: `threshold = hpThresholdPct/100 * maxHp`; `currentHp >= threshold && (currentHp - provisionalHpDamage) < threshold`.
+
+Returns `grant = flatAmount + effectiveAttack * attackPct / 100` (raw, **uncapped** — the pool cap is applied at the engine seam against the live pool), plus the `abilityId` for once-fired bookkeeping. Returns `null` otherwise.
+
+### 3. Engine intercept — `applyVictimDamage`, before `shieldAbsorb`
+
+1. **Collect** `incoming-shield-grant` abilities into the existing `incomingAbilitiesById` map (extend the filter at engine.ts ~2251 alongside `incoming-reduction` / `incoming-block`).
+2. After `const shieldBefore = victim.shieldPool`, compute a **provisional** `shieldAbsorb` with the *current* pool to get `hpDamage0` (the HP damage the hit would deal pre-Lifeline).
+3. Call `thresholdShieldForHit(...)` with `isDirect = cause?.byDirectDamage === true && (cause?.bombPortion ?? 0) === 0`. If it returns a grant:
+   - `newPool = Math.min(maxHp, shieldBefore + grant)`; `victim.shieldPool = newPool`.
+   - Mark fired: `thresholdShieldFired.add(`${victim.id}:${abilityId}`)` — a combat-lifetime `Set<string>` declared next to `oncePerCombatFired`.
+   - Surface the granted delta `newPool - shieldBefore` into the H1 `perActorShield.granted` accumulator so the sim StatCard reflects it.
+4. Run the **real** `shieldAbsorb` against `victim.shieldPool` (now boosted) — the existing line, unchanged. The rest of the hit eats shield→HP per the H1 pen rules; the ship can still die.
+
+### 4. Registry — `buildEquipmentAbilities.ts`
+
+`IMPLANT_ABILITIES.LIFELINE`: per-rarity `flatAmount` table `{ common: 4000, uncommon: 6000, rare: 8000, epic: 10000, legendary: 12000 }`, `attackPct: 100`, `hpThresholdPct: 30`, `oncePerCombat: true`. All 5 rarities present. Stable id `equip-implant-LIFELINE-${gearId}` per the existing implant id scheme.
+
+## Byte-identical guarantee
+
+No existing combat fixture equips Lifeline, and no ship skill parses to `incoming-shield-grant`. The `incomingAbilitiesById` filter only adds entries for actors carrying the new config → the map stays empty for every current actor → the provisional-absorb / intercept block is never entered → production goldens/snapshots are byte-identical. Same dormancy guarantee as D-PR3 and the H stack. New behavior is locked with hand-written integration scenarios.
+
+## Testing
+
+- **Helper unit tests** (`thresholdShield.test.ts`): crossing fires; pre-hit already below 30% → no fire; non-direct (DoT) → no fire; bomb-bearing hit → no fire; once-per-battle (second qualifying hit → null after fired); cap-at-maxHP delta; `grant === flatAmount + attack` (varying attack to prove the attack component).
+- **Coverage tracker** (`equipmentCoverage.test.ts`): add `LIFELINE` to the three spots — the `toEqual` array in IMPLANTS decl order, the implemented Set, and the `exactly{}` prose — plus a shape test (1 ability per rarity, correct config fields).
+- **Integration** (`equipmentAbilities.integration.test.ts`) via real `buildShipAbilitiesWithEquipment` + `runCombat`:
+  - a direct hit that crosses 30% grants the shield and soaks the remainder — the unit survives a hit it otherwise would not, with shield left over;
+  - a large enough direct hit still kills *through* shield + remaining HP (Lifeline is not a death-save);
+  - fires at most once per battle (a second qualifying hit grants nothing).
+
+## Scope notes
+
+- **DPS calculator not wired** — defensive-only effect, like every shield/defensive D PR.
+- **Per-hit granularity** — the intercept runs per `applyVictimDamage` call, which is the actual HP-application seam (not an aggregate approximation).
+- **Surfacing** — the granted delta feeds the existing H1 `perActorShield.granted` so the simulator's shield-granted StatCard is accurate; no new surface needed.
+
+## Out of scope / deferred
+
+- Pre-emptive absorb of the *triggering hit itself* beyond the shield (i.e. Lifeline does not reduce or cap the incoming hit — it only adds a pool the hit then drains). This matches the locked behavior.
+- Strike (stat-only, no work).

--- a/src/components/skills/AbilityCard.tsx
+++ b/src/components/skills/AbilityCard.tsx
@@ -56,6 +56,7 @@ const ABILITY_TYPE_LABELS: Record<Ability['type'], string> = {
     control: 'Control',
     'incoming-reduction': 'Incoming Reduction',
     'incoming-block': 'Incoming Block',
+    'incoming-shield-grant': 'Incoming Shield Grant',
     'outgoing-amplification': 'Outgoing Amplification',
     'heal-amplification': 'Heal Amplification',
     'incoming-heal-amplification': 'Incoming Heal Amplification',

--- a/src/components/skills/AbilityTypePicker.tsx
+++ b/src/components/skills/AbilityTypePicker.tsx
@@ -26,6 +26,7 @@ const TYPE_LABELS: Record<AbilityType, string> = {
     control: 'Control',
     'incoming-reduction': 'Incoming Reduction',
     'incoming-block': 'Incoming Block',
+    'incoming-shield-grant': 'Incoming Shield Grant',
     'outgoing-amplification': 'Outgoing Amplification',
     'heal-amplification': 'Heal Amplification',
     'incoming-heal-amplification': 'Incoming Heal Amplification',

--- a/src/components/skills/abilityDefaults.ts
+++ b/src/components/skills/abilityDefaults.ts
@@ -66,6 +66,14 @@ const makeDefaultConfig = (type: AbilityType): AbilityConfig => {
                 blockPct: 1,
                 oncePerRound: false,
             };
+        case 'incoming-shield-grant':
+            return {
+                type: 'incoming-shield-grant',
+                hpThresholdPct: 30,
+                flatAmount: 0,
+                attackPct: 100,
+                oncePerCombat: true,
+            };
         case 'outgoing-amplification':
             return {
                 type: 'outgoing-amplification',
@@ -99,6 +107,7 @@ const DEFAULT_TARGETS: Record<AbilityType, AbilityTarget> = {
     control: 'enemy',
     'incoming-reduction': 'self',
     'incoming-block': 'self',
+    'incoming-shield-grant': 'self',
     'outgoing-amplification': 'self',
     'heal-amplification': 'self',
     'incoming-heal-amplification': 'self',

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -36,6 +36,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator now models Block Buff — a unit affected by Block Buff can no longer gain new buffs while it lasts.',
     'Combat & DPS simulators now model two damage-over-time gear sets: Burner (applies Inferno for 2 turns when the ship attacks) and Decimation (+10% DoT damage per equipped set, up to +30%). Decimation now boosts your ship’s Inferno and Corrosion ticks in both the combat simulator and the DPS calculator.',
     'Combat simulator now models four shield sources: the Shield gear set grants the equipped ship a shield each turn (4% of its max HP), the Adaptive Plating implant grants the ship a shield from the damage it takes (once per round), the Abundant Renewal implant turns over-healing on an ally into a shield for that ally, and the Resonating Fury implant gives a chance to grant Crit Power Up to allies it shields.',
+    'Combat simulator now models the Lifeline implant: when a direct hit would drop a ship below 30% HP, it gains a shield (a flat amount plus 100% of its attack, capped at max HP) before the hit lands, so the rest of the hit drains shield then HP — once per battle.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/implants.ts
+++ b/src/constants/implants.ts
@@ -220,13 +220,13 @@ export const IMPLANTS: Record<string, ImplantData> = {
                 rarity: 'common',
                 stats: [],
                 description:
-                    "When direct damage would cause HP to drop below 30%, gain a shield equal to 4000 plus 100% of this unit's attack stat. This can occur once per battle",
+                    "When direct damage would cause HP to drop below 30%, gain a shield equal to 4000 plus 100% of this unit's attack stat (capped at max HP). This can occur once per battle.",
             },
             {
                 rarity: 'uncommon',
                 stats: [],
                 description:
-                    "When direct damage would cause HP to drop below 30%, gain a shield equal to 6000 plus 100% of this unit's attack stat. This can occur once per battle",
+                    "When direct damage would cause HP to drop below 30%, gain a shield equal to 6000 plus 100% of this unit's attack stat (capped at max HP). This can occur once per battle.",
             },
             {
                 rarity: 'rare',

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3124,7 +3124,7 @@ const DocumentationPage: React.FC = () => {
                                     Inferno for 2 turns when the ship attacks) and{' '}
                                     <strong>Decimation</strong> (+10% DoT damage per equipped set,
                                     up to +30%, boosting your Inferno and Corrosion ticks in both
-                                    the combat simulator and the DPS calculator). Four shield
+                                    the combat simulator and the DPS calculator). Five shield
                                     sources are also modeled: the <strong>Shield</strong> gear set
                                     (grants the equipped ship a shield each turn, 4% of its max HP),{' '}
                                     <strong>Adaptive Plating</strong> (grants the ship a shield from
@@ -3132,8 +3132,11 @@ const DocumentationPage: React.FC = () => {
                                     <strong>Abundant Renewal</strong> (turns over-healing on an ally
                                     into a shield for that ally), and{' '}
                                     <strong>Resonating Fury</strong> (a chance to grant Crit Power
-                                    Up to allies it shields). More implant and gear-set effects will
-                                    be added in future updates.
+                                    Up to allies it shields), and <strong>Lifeline</strong> (when a
+                                    direct hit would drop the ship below 30% HP, it gains a shield —
+                                    a flat amount plus 100% of its attack, capped at max HP — before
+                                    the hit lands, once per battle). More implant and gear-set
+                                    effects will be added in future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -22,6 +22,7 @@ export type AbilityType =
     | 'control'
     | 'incoming-reduction'
     | 'incoming-block'
+    | 'incoming-shield-grant'
     | 'outgoing-amplification'
     | 'heal-amplification'
     | 'incoming-heal-amplification';
@@ -455,6 +456,19 @@ export type AbilityConfig =
           /** 0..1 fraction of the hit blocked (1.0 = full block). */
           blockPct: number;
           oncePerRound: boolean;
+      }
+    | {
+          /** Lifeline: a PRE-hit threshold shield. When a pure direct hit would cross the
+           *  carrier's HP below `hpThresholdPct`% of max HP, grant `flatAmount` + `attackPct`%
+           *  of the carrier's own effective attack to the shield pool (capped at max HP) BEFORE
+           *  the hit's absorb step — so the rest of the same hit drains shield→HP per the H1 pen
+           *  rules (the unit can still die). Victim-side / self-scoped; consumed in
+           *  applyVictimDamage, NOT via the reactive executor. Once per battle. */
+          type: 'incoming-shield-grant';
+          hpThresholdPct: number;
+          flatAmount: number;
+          attackPct: number;
+          oncePerCombat: boolean;
       }
     // D-PR4 attacker-side outgoing-damage amplification (folded at the per-hit seam before victim apply).
     | {

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -120,7 +120,7 @@ function implantAbilities(implantKey: string, rarity: string) {
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { BURNER + DECIMATION + LEECH + CLOAKING + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + CHRONO_REAVER + HYPERION_GAZE + INTRUSION + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_STAND + LAST_WISH + LOCKDOWN + MENACE + REACTIVE_WARD + SECOND_WIND + SHADOWGUARD + SPEARHEAD + TENACITY + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
+    it('exactly { BURNER + DECIMATION + LEECH + CLOAKING + HARDENED (gear sets), MARTYRDOM + ARCANE_SIEGE + CHRONO_REAVER + HYPERION_GAZE + INTRUSION + LIFELINE + NEBULA_NULLIFIER + NOURISHMENT + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_STAND + LAST_WISH + LOCKDOWN + MENACE + REACTIVE_WARD + SECOND_WIND + SHADOWGUARD + SPEARHEAD + TENACITY + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -147,6 +147,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
             'CHRONO_REAVER',
             'HYPERION_GAZE',
             'INTRUSION',
+            'LIFELINE',
             'NEBULA_NULLIFIER',
             'NOURISHMENT',
             'SYNAPTIC_RESONANCE',
@@ -314,6 +315,7 @@ describe('equipmentCoverage — implants', () => {
     const implementedImplants = new Set([
         'ABUNDANT_RENEWAL',
         'ADAPTIVE_PLATING',
+        'LIFELINE',
         'FIREWALL',
         'LOCKDOWN',
         'TENACITY',
@@ -728,6 +730,28 @@ describe('equipmentCoverage — implants', () => {
             buffName: 'Crit Power Up III',
             duration: 1,
         });
+    });
+
+    // Lifeline: PRE-hit threshold shield (incoming-shield-grant), all five rarities.
+    it('LIFELINE produces 1 ability per rarity (incoming-shield-grant, flat by rarity, 100% attack, threshold 30, once per battle)', () => {
+        const flat: Record<string, number> = {
+            common: 4000,
+            uncommon: 6000,
+            rare: 8000,
+            epic: 10000,
+            legendary: 12000,
+        };
+        for (const v of IMPLANTS['LIFELINE'].variants) {
+            expect(implantAbilityCount('LIFELINE', v.rarity)).toBe(1);
+            const abs = implantAbilities('LIFELINE', v.rarity);
+            expect(abs[0].config).toMatchObject({
+                type: 'incoming-shield-grant',
+                hpThresholdPct: 30,
+                flatAmount: flat[v.rarity],
+                attackPct: 100,
+                oncePerCombat: true,
+            });
+        }
     });
 
     const unimplementedImplants = Object.keys(IMPLANTS).filter((k) => !implementedImplants.has(k));

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -263,6 +263,16 @@ const ADAPTIVE_PLATING_PCT: Record<string, number> = { uncommon: 21, epic: 34, l
 // threaded by the on-own-repair-to-ally listener in H3.3).
 const ABUNDANT_RENEWAL_PCT: Record<string, number> = { epic: 20, legendary: 30 };
 
+// Lifeline: once-per-battle, when a direct hit would drop HP below 30%, gain a shield equal to
+// FLAT + 100% of this unit's attack (capped at max HP). Per-rarity = the flat component only.
+const LIFELINE_FLAT: Record<string, number> = {
+    common: 4000,
+    uncommon: 6000,
+    rare: 8000,
+    epic: 10000,
+    legendary: 12000,
+};
+
 // D-PR5: Second Wind reactive self-heal on crit-received value table
 const SECOND_WIND_PROC: Record<string, number> = {
     uncommon: 0.07,
@@ -771,6 +781,27 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
             procChance,
             oncePerRound: true,
             config: { type: 'shield', pct, basis: 'damage-taken' },
+            autoFilled: true,
+        };
+    },
+    // Lifeline: PRE-hit threshold shield (incoming-shield-grant). Consumed victim-side in
+    // applyVictimDamage, NOT via the reactive executor — the trigger/target wrapper is nominal
+    // (mirrors SHADOWGUARD's incoming-block). All five rarities present.
+    LIFELINE: (rarity) => {
+        const flatAmount = LIFELINE_FLAT[rarity];
+        if (flatAmount === undefined) return undefined;
+        return {
+            type: 'incoming-shield-grant',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [],
+            config: {
+                type: 'incoming-shield-grant',
+                hpThresholdPct: 30,
+                flatAmount,
+                attackPct: 100,
+                oncePerCombat: true,
+            },
             autoFilled: true,
         };
     },

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -5527,3 +5527,253 @@ describe('H3.8 integration — Resonating Fury grants Crit Power Up III to shiel
         expect(fires.every((f) => f.actorId === 'attacker')).toBe(true);
     });
 });
+
+// ---------------------------------------------------------------------------
+// Lifeline (incoming-shield-grant) — once-per-battle PRE-hit threshold shield
+// ---------------------------------------------------------------------------
+//
+// Lifeline (legendary) resolves through the registry (IMPLANT_ABILITIES.LIFELINE) into a
+// nominal-trigger ability:
+//   { type:'incoming-shield-grant', target:'self', trigger:'on-cast',
+//     config:{ type:'incoming-shield-grant', hpThresholdPct:30, flatAmount:12000,
+//              attackPct:100, oncePerCombat:true } }
+// It is NOT routed via the reactive executor; it is consumed victim-side in applyVictimDamage
+// (engine.ts ~2784). When a PURE direct hit (byDirectDamage && no bomb portion) would carry the
+// carrier from >=30% to <30% of max HP, the engine grants flatAmount + 100%·attack to the shield
+// pool (capped at max HP) BEFORE the hit's absorb step, so the rest of THAT hit drains shield→HP.
+// The unit can still die. Once per battle, keyed `${victimId}:${abilityId}` in thresholdShieldFired.
+//
+// Concrete setup pinned across all three cases (no mitigation arithmetic):
+//   carrier maxHp 10000, attack 2000, legendary Lifeline → grant = 12000 + 2000 = 14000,
+//   capped to maxHp 10000. Threshold T = 30% × 10000 = 3000. Carrier starts at full HP (100%).
+//   Enemy hits are pure single-hit direct attacks (no crit/defence/pen on either side), carrier
+//   is slow (speed 1) so the enemy hits land at the top of each round, before the carrier acts.
+//   The grant surfaces on the H1 per-round accumulator: RoundData.perActorShield['attacker'].granted.
+const lifelinePiece = makePiece({
+    id: 'lifeline-legendary',
+    slot: 'implant_major',
+    rarity: 'legendary',
+    setBonus: 'LIFELINE',
+});
+
+describe('Lifeline (incoming-shield-grant)', () => {
+    /** No-op active for the carrier (focus) — deals no damage, just keeps the round cadence. */
+    const noopActive: Ability = {
+        id: 'noop-active',
+        type: 'damage',
+        target: 'enemy',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'damage', multiplier: 0 },
+    };
+
+    /** Build the carrier's ship skills via the REAL registry: no-op active + the Lifeline passive.
+     *  Returns both the ShipSkills and the resolved ability id so callers can assert the registry
+     *  shape landed (pre-condition). */
+    function buildLifelineCarrier(): { shipSkills: ShipSkills; lifelineId: string } {
+        const ship = makeShip({ implants: { implant_major: 'lifeline-legendary' } });
+        const getGearPiece = makeGetGearPiece({ 'lifeline-legendary': lifelinePiece });
+        const baseSkills = buildShipAbilitiesWithEquipment(ship, getGearPiece);
+        const passive = baseSkills.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        const lifeline = passive!.abilities.find((a) => a.id.startsWith('equip-implant-LIFELINE'));
+        // Pre-condition: the Lifeline ability resolved through the registry with the spec shape.
+        expect(lifeline).toBeDefined();
+        expect(lifeline!.config).toMatchObject({
+            type: 'incoming-shield-grant',
+            hpThresholdPct: 30,
+            flatAmount: 12000,
+            attackPct: 100,
+            oncePerCombat: true,
+        });
+        return {
+            shipSkills: {
+                slots: [
+                    { slot: 'active', abilities: [noopActive] },
+                    ...(passive ? [{ slot: passive.slot, abilities: passive.abilities }] : []),
+                ],
+            },
+            lifelineId: lifeline!.id,
+        };
+    }
+
+    /** Carrier WITHOUT Lifeline (control) — just the no-op active. */
+    const carrierNoLifeline: ShipSkills = {
+        slots: [{ slot: 'active', abilities: [noopActive] }],
+    };
+
+    /** A fast enemy that lands ONE pure direct hit of `dmg` on the carrier each round.
+     *  attack = dmg, multiplier 100, single hit, no crit → per-round direct damage taken = dmg. */
+    function directHitter(dmg: number) {
+        return {
+            id: 'lifeline-enemy',
+            stats: {
+                attack: dmg,
+                crit: 0,
+                critDamage: 0,
+                speed: 1000, // acts before the slow (speed 1) carrier
+                defence: 0,
+                hp: 1_000_000_000,
+            },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active' as const,
+                        abilities: [
+                            {
+                                id: 'lifeline-enemy-hit',
+                                type: 'damage' as const,
+                                target: 'enemy' as const,
+                                trigger: 'on-cast' as const,
+                                conditions: [],
+                                config: { type: 'damage' as const, multiplier: 100, hits: 1 },
+                            },
+                        ],
+                    },
+                ],
+            } as ShipSkills,
+        };
+    }
+
+    /** Base engine input for the carrier ('attacker'): healing mode, maxHp 10000, attack 2000,
+     *  slow so the enemy hit lands first. No mitigation so damage taken == nominal hit. */
+    const LIFELINE_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput =>
+        BASE({
+            attack: 2000, // → Lifeline grant = 12000 + 100%·2000 = 14000 (capped to maxHp)
+            crit: 0,
+            critDamage: 0,
+            defence: 0,
+            hp: 10_000,
+            speed: 1,
+            enemyHp: 1_000_000_000,
+            healTargetId: 'attacker',
+            ...overrides,
+        });
+
+    /** Sum the carrier's per-round granted-shield surface across the whole battle. */
+    function totalGranted(result: ReturnType<typeof runCombat>): number {
+        return result.rounds.reduce(
+            (sum, rd) => sum + (rd.perActorShield?.['attacker']?.granted ?? 0),
+            0
+        );
+    }
+
+    /** Did the carrier ('attacker') die? Read the heal target's destroyed round. */
+    function carrierDied(result: ReturnType<typeof runCombat>): boolean {
+        return result.healing?.destroyedRound !== undefined;
+    }
+
+    // ── Case 1: crossing grants a shield that soaks the remainder ─────────────────
+    //
+    // Per-hit 4000 over 3 rounds. maxHp 10000, T = 3000.
+    //   R1: HP 10000 → 6000 (pool 0, no crossing; 6000 >= 3000).
+    //   R2: HP 6000, would-be 6000 − 4000 = 2000 < 3000, currentHp 6000 >= 3000 → CROSS.
+    //       Grant 14000 capped to 10000 → pool 10000 (before absorb). Absorb 4000 → pool 6000,
+    //       HP stays 6000.
+    //   R3: HP 6000, pool 6000. The 4000 hit is fully absorbed (would-be HP 6000, no crossing,
+    //       and already fired) → pool 2000, HP 6000. Carrier SURVIVES all three rounds.
+    // Control (no Lifeline): R1 6000, R2 2000, R3 2000 − 4000 → DEAD at round 3.
+    it(
+        'Case 1: a direct hit crossing below 30% grants a maxHP-capped shield that soaks the ' +
+            'remainder — the carrier SURVIVES a hit that kills the no-Lifeline control',
+        () => {
+            const { shipSkills } = buildLifelineCarrier();
+            const result = runCombat(
+                LIFELINE_BASE({
+                    numRounds: 3,
+                    shipSkills,
+                    enemyAttackers: [directHitter(4000)],
+                })
+            );
+
+            // The carrier survived the full battle.
+            expect(carrierDied(result)).toBe(false);
+
+            // EXACTLY one capped grant fired across the battle: pool jumped from 0 to maxHp 10000.
+            expect(totalGranted(result)).toBeCloseTo(10_000, 6);
+
+            // The grant landed on the carrier's pool and it still carries shield at end of battle
+            // (proving the pool soaked hits that would otherwise have hit HP).
+            const lastRound = result.rounds[result.rounds.length - 1];
+            expect(lastRound.perActorShield?.['attacker']?.pool).toBeGreaterThan(0);
+
+            // CONTROL — identical setup WITHOUT Lifeline: the carrier takes the same hits to HP
+            // with no shield and DIES at round 3. This is the divergence Lifeline prevents above.
+            const controlResult = runCombat(
+                LIFELINE_BASE({
+                    numRounds: 3,
+                    shipSkills: carrierNoLifeline,
+                    enemyAttackers: [directHitter(4000)],
+                })
+            );
+            expect(carrierDied(controlResult)).toBe(true);
+            // The control never granted any shield (no Lifeline).
+            expect(totalGranted(controlResult)).toBeCloseTo(0, 6);
+        }
+    );
+
+    // ── Case 2: Lifeline is NOT a death-save ──────────────────────────────────────
+    //
+    // A single overwhelming direct hit. maxHp 10000, full HP, T = 3000.
+    //   Provisional (pool 0): hpDamage 25000, would-be 10000 − 25000 < 3000, currentHp 10000 >=
+    //   3000 → CROSS → grant 14000 capped to 10000 → pool 10000. Total soak capacity = pool 10000
+    //   + HP 10000 = 20000 < 25000 → absorb 10000, remaining 15000 to HP → HP 0. Carrier DESTROYED.
+    it(
+        'Case 2: a hit exceeding (shield grant + remaining HP) still DESTROYS the carrier — ' +
+            'Lifeline is not a death-save',
+        () => {
+            const { shipSkills } = buildLifelineCarrier();
+            const result = runCombat(
+                LIFELINE_BASE({
+                    numRounds: 1,
+                    shipSkills,
+                    enemyAttackers: [directHitter(25_000)],
+                })
+            );
+
+            // The shield DID fire (the crossing condition was met) — non-vacuous: this is a
+            // genuine Lifeline grant, not "the hit just missed the threshold".
+            expect(totalGranted(result)).toBeCloseTo(10_000, 6);
+
+            // …yet the carrier still died: 25000 overwhelmed pool 10000 + HP 10000.
+            expect(carrierDied(result)).toBe(true);
+        }
+    );
+
+    // ── Case 3: once per battle ───────────────────────────────────────────────────
+    //
+    // Per-hit 4000 over 5 rounds. maxHp 10000, attack 2000, T = 3000.
+    //   R1: HP 10000 → 6000 (pool 0).
+    //   R2: HP 6000, would-be 2000 < 3000 → CROSS → GRANT #1 (capped 10000) → pool 10000;
+    //       absorb 4000 → pool 6000, HP 6000.
+    //   R3: HP 6000, pool 6000 → fully absorbs 4000 → pool 2000, HP 6000 (no crossing).
+    //   R4: HP 6000, pool 2000 → absorb 2000, hpDmg 2000 → pool 0, HP 4000 (would-be 4000, no cross).
+    //   R5: HP 4000, pool 0 → would-be 0 < 3000, currentHp 4000 >= 3000 → a SECOND qualifying
+    //       crossing, but Lifeline ALREADY FIRED → NO new grant → HP → 0, carrier DIES.
+    // If once-per-battle were broken, R5 would re-grant (pool → 10000) and the carrier would
+    // SURVIVE — so the carrier's death at R5 + total granted == one grant is the non-vacuous proof.
+    it(
+        'Case 3: two qualifying direct crossings across the battle grant the shield only ONCE — ' +
+            'the second qualifying hit gets no grant and the carrier dies',
+        () => {
+            const { shipSkills } = buildLifelineCarrier();
+            const result = runCombat(
+                LIFELINE_BASE({
+                    numRounds: 5,
+                    shipSkills,
+                    enemyAttackers: [directHitter(4000)],
+                })
+            );
+
+            // Exactly ONE grant across the entire battle (the R2 capped grant of 10000). A second
+            // grant at R5 would double this to 20000.
+            expect(totalGranted(result)).toBeCloseTo(10_000, 6);
+
+            // The carrier dies at R5: the second qualifying crossing produced NO shield. With a
+            // second grant the carrier would have survived — this asserts the once-per-battle gate.
+            expect(carrierDied(result)).toBe(true);
+        }
+    );
+});

--- a/src/utils/combat/__tests__/thresholdShield.test.ts
+++ b/src/utils/combat/__tests__/thresholdShield.test.ts
@@ -48,6 +48,18 @@ describe('thresholdShieldForHit', () => {
         expect(r).toBeNull();
     });
 
+    it('fires when pre-hit HP sits exactly on the threshold (>= is inclusive)', () => {
+        // currentHp 3000 (exactly 30%), hit drops it to 2999 (< 30%) => crossing
+        const r = thresholdShieldForHit({ ...base, currentHp: 3000, provisionalHpDamage: 1 });
+        expect(r).not.toBeNull();
+    });
+
+    it('does not fire when the hit lands HP exactly on the threshold (< is exclusive)', () => {
+        // currentHp 5000 -> 3000 (exactly 30%): "at" 30% has not "crossed below"
+        const r = thresholdShieldForHit({ ...base, currentHp: 5000, provisionalHpDamage: 2000 });
+        expect(r).toBeNull();
+    });
+
     it('does not fire for non-direct damage (DoT / bomb)', () => {
         const r = thresholdShieldForHit({
             ...base,

--- a/src/utils/combat/__tests__/thresholdShield.test.ts
+++ b/src/utils/combat/__tests__/thresholdShield.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { thresholdShieldForHit } from '../thresholdShield';
+import type { Ability } from '../../../types/abilities';
+
+const ability = (
+    overrides: Partial<{ flatAmount: number; attackPct: number; hpThresholdPct: number }> = {}
+): Ability => ({
+    id: 'lifeline-1',
+    type: 'incoming-shield-grant',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: {
+        type: 'incoming-shield-grant',
+        hpThresholdPct: overrides.hpThresholdPct ?? 30,
+        flatAmount: overrides.flatAmount ?? 8000,
+        attackPct: overrides.attackPct ?? 100,
+        oncePerCombat: true,
+    },
+});
+
+const base = {
+    abilities: [ability()],
+    maxHp: 10000,
+    effectiveAttack: 2000,
+    isDirect: true,
+    alreadyFired: () => false,
+};
+
+describe('thresholdShieldForHit', () => {
+    it('fires on a downward crossing below the threshold', () => {
+        // currentHp 4000 (40% >= 30%), hit deals 2000 to HP -> 2000 (20% < 30%) => crossing
+        const r = thresholdShieldForHit({ ...base, currentHp: 4000, provisionalHpDamage: 2000 });
+        expect(r).not.toBeNull();
+        expect(r!.grant).toBe(8000 + 2000); // flat + 100% attack
+        expect(r!.abilityId).toBe('lifeline-1');
+    });
+
+    it('does not fire when already below the threshold pre-hit', () => {
+        // currentHp 2500 (25% < 30%) -> not a downward crossing
+        const r = thresholdShieldForHit({ ...base, currentHp: 2500, provisionalHpDamage: 1000 });
+        expect(r).toBeNull();
+    });
+
+    it('does not fire when the hit does not cross the threshold', () => {
+        // currentHp 8000 -> 6000 (60% >= 30%)
+        const r = thresholdShieldForHit({ ...base, currentHp: 8000, provisionalHpDamage: 2000 });
+        expect(r).toBeNull();
+    });
+
+    it('does not fire for non-direct damage (DoT / bomb)', () => {
+        const r = thresholdShieldForHit({
+            ...base,
+            currentHp: 4000,
+            provisionalHpDamage: 2000,
+            isDirect: false,
+        });
+        expect(r).toBeNull();
+    });
+
+    it('does not fire when already fired this battle', () => {
+        const r = thresholdShieldForHit({
+            ...base,
+            currentHp: 4000,
+            provisionalHpDamage: 2000,
+            alreadyFired: () => true,
+        });
+        expect(r).toBeNull();
+    });
+
+    it('returns the raw (uncapped) grant — the engine applies the maxHP cap', () => {
+        const r = thresholdShieldForHit({
+            ...base,
+            currentHp: 4000,
+            provisionalHpDamage: 2000,
+            effectiveAttack: 50000,
+        });
+        expect(r!.grant).toBe(8000 + 50000); // uncapped; cap is applied at the engine seam
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2810,8 +2810,15 @@ export function runCombat(input: CombatEngineInput): {
                         thresholdShieldFired.has(`${victim.id}:${abilityId}`),
                 });
                 if (grant) {
-                    const newPool = Math.min(maxHp, shieldBefore + grant.grant);
-                    const granted = newPool - shieldBefore;
+                    // Only ever ADD shield — never shrink a pre-hit pool that already
+                    // sits above the current effective max HP (e.g. an HP-down debuff
+                    // lowered maxHp after the pool was granted). Clamping the sum alone
+                    // would make `granted` negative and could turn a survivable hit lethal.
+                    const newPool =
+                        shieldBefore >= maxHp
+                            ? shieldBefore
+                            : Math.min(maxHp, shieldBefore + grant.grant);
+                    const granted = Math.max(0, newPool - shieldBefore);
                     victim.shieldPool = newPool;
                     thresholdShieldFired.add(`${victim.id}:${grant.abilityId}`);
                     // Surface the real pool growth on the H1 granted accumulator (StatCard).

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -55,6 +55,7 @@ import { incomingHealAmpForRecipient } from './healAmplification';
 import { CHEAT_DEATH_BUFFS } from './cheatDeathBuffs';
 import { BARRIER_BUFFS } from './barrierBuffs';
 import { shieldAbsorb } from './shieldAbsorb';
+import { thresholdShieldForHit } from './thresholdShield';
 import { isStasis, STASIS_BUFFS } from './stasisBuffs';
 import { isDisable } from './disableBuffs';
 import { highestAttackAmong } from './highestAttack';
@@ -1933,6 +1934,9 @@ export function runCombat(input: CombatEngineInput): {
     // its id lands here and a SECOND lethal hit destroys it normally even though the recurring
     // buff is still in the snapshot. Declared OUTSIDE the round loop → persists across rounds.
     const cheatDeathConsumed = new Set<string>();
+    // Lifeline (incoming-shield-grant): once-per-BATTLE fired flags, keyed `${victimId}:${abilityId}`.
+    // Combat-lifetime (NOT reset per round) — the shield grant occurs at most once per combat.
+    const thresholdShieldFired = new Set<string>();
     // Display-only (Phase 4c): a spent Cheat Death keeps reappearing in the displayed buff list
     // for two reasons, depending on how it was granted. (1) Passive/aura grants (Tycho) are
     // re-derived from the persistent aura store every round and clearRemovable leaves auras
@@ -2248,7 +2252,11 @@ export function runCombat(input: CombatEngineInput): {
         for (const slot of rt.castSkills.slots) {
             if (slot.slot !== 'passive') continue;
             for (const a of slot.abilities) {
-                if (a.config.type === 'incoming-reduction' || a.config.type === 'incoming-block') {
+                if (
+                    a.config.type === 'incoming-reduction' ||
+                    a.config.type === 'incoming-block' ||
+                    a.config.type === 'incoming-shield-grant'
+                ) {
                     incoming.push(a);
                 }
             }
@@ -2773,6 +2781,46 @@ export function runCombat(input: CombatEngineInput): {
                 return { shieldBefore: victim.shieldPool, hpDamage: 0, barriered: true };
             }
             const shieldBefore = victim.shieldPool;
+            // Lifeline (incoming-shield-grant): a PRE-hit threshold shield. When a PURE direct hit
+            // (no DoT, no bomb portion) would cross this victim's HP below the configured % of max HP,
+            // grant flat + %-of-attack to the pool BEFORE absorbing, so the rest of THIS hit drains
+            // shield→HP per the H1 pen rules (the unit can still die). Once per battle. Fully inert
+            // (no provisional absorb, no helper call) when the victim carries no such ability →
+            // byte-identical for every existing fixture.
+            const thresholdShieldAbilities = incomingAbilitiesOf(victim.id).filter(
+                (a) => a.config.type === 'incoming-shield-grant'
+            );
+            if (thresholdShieldAbilities.length > 0) {
+                // Provisional absorb against the CURRENT pool → the HP damage the hit would deal pre-Lifeline.
+                const provisional = shieldAbsorb({
+                    damage,
+                    shieldPool: victim.shieldPool,
+                    isDot: cause?.byDirectDamage === false,
+                    penPct: cause?.shieldPenetrationPct ?? 0,
+                    bombPortion: cause?.bombPortion ?? 0,
+                });
+                const grant = thresholdShieldForHit({
+                    abilities: thresholdShieldAbilities,
+                    currentHp: victim.currentHp,
+                    maxHp,
+                    provisionalHpDamage: provisional.hpDamage,
+                    effectiveAttack: effectiveStatsOf(statusEngine, selfBuffLookup, victim).attack,
+                    isDirect: cause?.byDirectDamage === true && (cause?.bombPortion ?? 0) === 0,
+                    alreadyFired: (abilityId) =>
+                        thresholdShieldFired.has(`${victim.id}:${abilityId}`),
+                });
+                if (grant) {
+                    const newPool = Math.min(maxHp, shieldBefore + grant.grant);
+                    const granted = newPool - shieldBefore;
+                    victim.shieldPool = newPool;
+                    thresholdShieldFired.add(`${victim.id}:${grant.abilityId}`);
+                    // Surface the real pool growth on the H1 granted accumulator (StatCard).
+                    perActorShieldGranted.set(
+                        victim.id,
+                        (perActorShieldGranted.get(victim.id) ?? 0) + granted
+                    );
+                }
+            }
             const { absorbed, hpDamage } = shieldAbsorb({
                 damage,
                 shieldPool: victim.shieldPool,

--- a/src/utils/combat/thresholdShield.ts
+++ b/src/utils/combat/thresholdShield.ts
@@ -1,0 +1,53 @@
+import type { Ability } from '../../types/abilities';
+
+/**
+ * Lifeline (incoming-shield-grant) — pre-hit threshold shield decision.
+ *
+ * Returns the FIRST `incoming-shield-grant` ability that should fire on this hit and the raw
+ * (uncapped) shield amount to grant, or null if none fires. Pure — no engine state. The caller
+ * applies the max-HP pool cap and records the once-per-battle fired flag.
+ *
+ * Fires when ALL hold:
+ *   (a) the hit is a pure direct hit (no DoT, no bomb portion) — `isDirect`;
+ *   (b) the ability has not yet fired this battle — `!alreadyFired(ability.id)`;
+ *   (c) a downward crossing of the threshold: pre-hit HP >= T AND would-be HP < T,
+ *       where T = hpThresholdPct/100 * maxHp and would-be HP = currentHp - provisionalHpDamage.
+ *
+ * `provisionalHpDamage` is the HP damage the hit would deal computed against the CURRENT shield
+ * pool (a shieldAbsorb run before any Lifeline grant). The grant = flatAmount + effectiveAttack
+ * * attackPct/100.
+ */
+export function thresholdShieldForHit(args: {
+    abilities: Ability[];
+    currentHp: number;
+    maxHp: number;
+    provisionalHpDamage: number;
+    effectiveAttack: number;
+    isDirect: boolean;
+    alreadyFired: (abilityId: string) => boolean;
+}): { abilityId: string; grant: number } | null {
+    const {
+        abilities,
+        currentHp,
+        maxHp,
+        provisionalHpDamage,
+        effectiveAttack,
+        isDirect,
+        alreadyFired,
+    } = args;
+    if (!isDirect) return null;
+    for (const ability of abilities) {
+        const cfg = ability.config;
+        if (cfg.type !== 'incoming-shield-grant') continue;
+        if (alreadyFired(ability.id)) continue;
+        const threshold = (cfg.hpThresholdPct / 100) * maxHp;
+        const wouldBeHp = currentHp - provisionalHpDamage;
+        if (currentHp >= threshold && wouldBeHp < threshold) {
+            return {
+                abilityId: ability.id,
+                grant: cfg.flatAmount + effectiveAttack * (cfg.attackPct / 100),
+            };
+        }
+    }
+    return null;
+}


### PR DESCRIPTION
> Supersedes #158, which GitHub auto-closed when the H2/H3 base branch was deleted on merge. Rebased onto `main` (H1 #156 + H2/H3 #157 are now merged); content unchanged.

## Summary

Implements the **Lifeline** implant — the last remaining shield-grant source in sub-project H. When a *pure direct hit* would drop the carrier's HP below 30% of max HP, Lifeline grants a shield of `flatAmount(rarity) + 100% of the unit's attack` (capped at max HP) **before** the triggering hit's absorb step, so the rest of that hit drains shield→HP. The ship can still die if the hit exceeds the new shield + remaining HP. Once per battle.

Per-rarity flat amount: common 4000 / uncommon 6000 / rare 8000 / epic 10000 / legendary 12000.

### Mechanics (user-ratified)
- **Pre-hit / mid-hit timing** — shield goes up before the absorb, then the rest of the hit drains shield→HP (not a death-save; distinct from Cheat Death).
- **Downward crossing** — fires only when pre-hit HP ≥ 30% and the hit would bring it below 30%.
- **Direct damage only** — `byDirectDamage === true && bombPortion === 0`. DoTs (bypass shields) and bomb/detonation hits do **not** trigger it.
- **Once per battle** — combat-lifetime fired Set keyed `${victimId}:${abilityId}`.
- **Cap at max HP** — the total shield pool is capped at max HP.

### Implementation
- New `incoming-shield-grant` `AbilityConfig` type (+ minimal editor exhaustiveness stubs).
- Pure helper `src/utils/combat/thresholdShield.ts` (`thresholdShieldForHit`) — fully unit-tested incl. exact-boundary semantics.
- Engine intercept in `applyVictimDamage` (the single victim-side damage seam — covers both the aggregate/tank and positional paths), mirroring the D-PR3 `incoming-block` pattern; surfaces the granted delta to the H1 `perActorShield.granted` accumulator.
- `LIFELINE` registry entry + coverage tracker (3 spots + shape test).
- End-to-end integration tests through the real registry + `runCombat`.

### Architecture notes
- **Byte-identical** — no fixture equips Lifeline and no ship skill parses to `incoming-shield-grant`, so the intercept is inert for every existing actor; production goldens/snapshots are unchanged.
- Spec: `docs/superpowers/specs/2026-06-26-lifeline-shield-design.md`. Plan: `docs/superpowers/plans/2026-06-26-lifeline-shield.md`.
- **Strike correction:** the implant previously grouped with the shield-grant family is stat-only (flat attack) — no engine work; Lifeline is the only remaining shield-grant source.

> **Stacking:** based on `feat/combat-shield-system-h2-h3` (H2/H3 PR #157), which itself stacks on H1 PR #156. **Retarget this PR to `main` once the H stack (#156 → #157) merges.**

## Test Plan
- [x] Full suite green (3315 tests), goldens byte-identical (no `-u`)
- [x] `tsc --noEmit` clean, `npm run lint` clean (max-warnings 0)
- [x] `npm run audit:skills` → 141 ships, 0 findings (unchanged)
- [x] Helper unit tests incl. exact-boundary cases
- [x] Integration tests bite under mutation (intercept disabled → cases fail; restored → pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
