### PR TITLE
feat(combat): Voidfire Catalyst implant + bomb-splash-on-death

### DIFF
--- a/docs/superpowers/plans/2026-06-26-voidfire-catalyst-bomb-splash.md
+++ b/docs/superpowers/plans/2026-06-26-voidfire-catalyst-bomb-splash.md
@@ -1,0 +1,322 @@
+# Voidfire Catalyst + bomb-splash-on-death Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Model the Voidfire Catalyst implant (both halves, all rarities) and add the missing base bomb-splash-on-death combat mechanic that its splash half rides on.
+
+**Architecture:** Three stacked PRs under one spec. PR-1 adds a `detonationDamage` modifier channel (byte-identical) scaling existing detonation bursts. PR-2 adds base bomb-splash-on-death at the shared `recordDestroyed` death seam (the only golden-moving piece; positional-only). PR-3 adds a `bombSplashDamage` channel feeding PR-2's splash, lighting up all Voidfire rarities (byte-identical).
+
+**Tech Stack:** React 18, TypeScript, Vite, Vitest. Combat engine in `src/utils/combat/`; ability/modifier infra in `src/utils/abilities/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-26-voidfire-catalyst-bomb-splash-design.md`
+
+---
+
+## Setup (before Phase 1)
+
+- [ ] **S1: Create a worktree + branch** off `main` per superpowers:using-git-worktrees. Branch: `feat/combat-voidfire-detonation` (PR-1). Copy the gitignored `.env` from the main repo into the worktree (husky runs the full vitest suite on commit; without `.env` ~14 `.tsx` test files fail to collect — see project memory).
+- [ ] **S2: Baseline** — run `npm test` and confirm green; run `npm run lint` (max-warnings 0) and `npx tsc --noEmit` clean. Record the test count.
+
+**Workflow notes (from project memory):**
+- Never run `vitest -u` to bulk-update goldens. In PR-2, validate each moved golden by hand.
+- `gh auth switch --user TheSusort` before `gh pr create`.
+- Commits run husky → full vitest suite; expect commits to take time.
+
+---
+
+# Phase 1 (PR-1): `detonationDamage` modifier channel
+
+**Outcome:** A new modifier channel that scales detonation bursts (bomb/Inferno/Corrosion) on both the skill-triggered and timed paths. Voidfire's detonation half (common/uncommon/epic) lights up. Byte-identical goldens.
+
+### Task 1.1: Add the `detonationDamage` modifier channel to the fold
+
+**Files:**
+- Modify: `src/types/abilities.ts:314-323` (ModifierChannel union)
+- Modify: `src/utils/abilities/applyAbilities.ts:6-15` (ModifierTotals), `:27-36` (init), `:52-78` (switch)
+- Modify: `src/utils/combat/effectiveStats.ts:143-155` (EffectiveDamageStats), `:203-216` (return)
+- Test: `src/utils/abilities/__tests__/applyAbilities.test.ts` (or the nearest existing modifier-fold test)
+
+- [ ] **Step 1: Write the failing test** — a `modifier` ability with `channel: 'detonationDamage', value: 8` produces `totals.detonationDamage === 8`.
+
+```ts
+it('folds a detonationDamage modifier into its own bucket', () => {
+    const ability = mkModifierAbility({ channel: 'detonationDamage', value: 8 });
+    const totals = modifierTotalsFromAbilities([ability], makeConditionContext());
+    expect(totals.detonationDamage).toBe(8);
+});
+```
+(Use the existing test's helpers — `mkModifierAbility`/`makeConditionContext` or equivalents already in the file.)
+
+- [ ] **Step 2: Run test, verify it fails** — `npx vitest run src/utils/abilities/__tests__/applyAbilities.test.ts` → FAIL (`detonationDamage` not on `ModifierTotals`, channel not in union → tsc error).
+
+- [ ] **Step 3: Implement**
+  - `types/abilities.ts`: add `| 'detonationDamage'` to `ModifierChannel`.
+  - `applyAbilities.ts`: add `detonationDamage: number;` to `ModifierTotals`; `detonationDamage: 0,` to the init object; `case 'detonationDamage': totals.detonationDamage += amount; break;` to the switch.
+  - `effectiveStats.ts`: add `detonationDamageModifier: number;` to `EffectiveDamageStats`; in the return object add `detonationDamageModifier: mod.detonationDamage,` (parallel to `selfDotDamageModifier`).
+
+- [ ] **Step 4: Run test, verify it passes.**
+
+- [ ] **Step 5: Commit** — `feat(combat): add detonationDamage modifier channel`
+
+### Task 1.2: Editor exhaustiveness stubs
+
+**Files:**
+- Modify: `src/components/skills/AbilityCard.tsx:82` (DAMAGE_STAT_OPTIONS list) and `:162` (the second channel list)
+- Modify: `src/components/calculator/GameBuffPicker.tsx:29` (label map, e.g. `detonationDamage: 'Detonation'`)
+
+- [ ] **Step 1:** Add `{ value: 'detonationDamage', label: 'Detonation Damage' }` to the AbilityCard option list at ~82, and `'detonationDamage',` to the list at ~162. Add `detonationDamage: 'Detonation',` to GameBuffPicker's label map.
+- [ ] **Step 2:** Run `npx tsc --noEmit` and `npm test` — confirm no exhaustiveness/type errors and goldens unchanged.
+- [ ] **Step 3: Commit** — `chore(skills): editor stubs for detonationDamage channel`
+
+### Task 1.3: Snapshot the applier's detonation modifier onto `PendingBomb` + timed path
+
+**Files:**
+- Modify: `src/utils/combat/state.ts:56-66` (PendingBomb)
+- Modify: `src/utils/combat/playerTurn.ts:587-627` (`applyNewDoTs` — add param + push field) and its call site (~`:1494`+, thread `dmgStats.detonationDamageModifier`)
+- Modify: `src/utils/combat/triggers.ts:1557` (reactive bomb push — set the field, default 0)
+- Modify: `src/utils/combat/engine.ts:695-710` (`processBombs` — scale burst)
+- Test: `src/utils/combat/__tests__/` (a focused processBombs/timed-detonation test, or extend an existing bomb test)
+
+- [ ] **Step 1: Write the failing test** — a timed bomb whose `PendingBomb.detonationDamageModifier = 100` bursts for 2× the unmodified value via `processBombs`.
+
+- [ ] **Step 2: Run, verify fail** (field doesn't exist).
+
+- [ ] **Step 3: Implement**
+  - `state.ts`: add `detonationDamageModifier: number;` to `PendingBomb` (document: applier's, snapshotted at application, like `affinityMult`).
+  - `applyNewDoTs`: add a **new** `detonationDamageModifier: number` field to its args object (it has no `dmgStats` today); set it on the pushed bomb. Thread the applier's value from the call site as `detonationDamageModifier: dmgStats.detonationDamageModifier` (the call site already has `dmgStats` in scope).
+  - `triggers.ts:1557`: set `detonationDamageModifier: 0` on the reactive push (reactive bomb appliers don't carry a live dmgStats here — default 0; document this as a known approximation, mirroring how other reactive snapshots default).
+  - `processBombs`: `burstDamage = bomb.stacks * bomb.damagePerStack * bomb.affinityMult * (1 + bomb.detonationDamageModifier / 100)`.
+  - Update **all** `PendingBomb` literals in tests/fixtures to include `detonationDamageModifier: 0` (grep `pendingBombs: [` and bomb-object literals). tsc will enumerate them.
+
+- [ ] **Step 4: Run test + full suite** — verify the new test passes and goldens are byte-identical (default 0 → mult 1).
+
+- [ ] **Step 5: Commit** — `feat(combat): scale timed bomb detonation by applier's detonation modifier`
+
+### Task 1.4: Apply the detonation modifier in skill-triggered `detonate()`
+
+**Files:**
+- Modify: `src/utils/combat/playerTurn.ts:526-582` (`detonate` — add `detonationMult` param, apply to all 3 branches) and its call site `:1486-1498` (pass `1 + dmgStats.detonationDamageModifier / 100`)
+- Test: existing detonation test (e.g. `engine.events.test.ts` bomb-detonated, or a focused detonate test)
+
+- [ ] **Step 1: Write the failing test** — a skill detonation with the detonating actor carrying `detonationDamageModifier = 50` produces 1.5× the bomb/inferno/corrosion payout.
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement** — add `detonationMult: number` to `detonate`'s args; multiply each branch's contribution (bomb `payout`, inferno sum, corrosion sum) by `args.detonationMult`. At the call site pass `detonationMult: 1 + dmgStats.detonationDamageModifier / 100`. Default modifier 0 → mult 1.
+
+- [ ] **Step 4: Run test + full suite** — new test passes; goldens byte-identical.
+
+- [ ] **Step 5: Commit** — `feat(combat): scale skill-triggered detonation by detonator's modifier`
+
+### Task 1.5: Voidfire Catalyst registry entry (detonation half) + coverage
+
+**Files:**
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (add `VOIDFIRE_CATALYST` to `IMPLANT_ABILITIES` + per-rarity value table)
+- Modify: `src/utils/abilities/__tests__/equipmentCoverage.test.ts` (3 spots: `.toEqual` decl-order array, the Set, the `it('exactly{}')` count string)
+- Test: `src/utils/combat/__tests__/equipmentAbilities.integration.test.ts`
+
+- [ ] **Step 1: Write the failing test** — through the **real registry** (`buildShipAbilitiesWithEquipment` with an implant whose `setBonus = 'VOIDFIRE_CATALYST'`, rarity `epic`), the ship gains a `modifier` ability with `channel: 'detonationDamage', value: 8`. (Also assert `common` → 2, `uncommon` → 4.)
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement** — add value tables:
+```ts
+const VOIDFIRE_DETONATION_PCT: Record<string, number | undefined> = {
+    common: 2, uncommon: 4, rare: undefined, epic: 8, legendary: undefined,
+};
+const VOIDFIRE_SPLASH_PCT: Record<string, number> = {
+    common: 4, uncommon: 8, rare: 24, epic: 16, legendary: 40,
+}; // splash channel wired in Phase 3
+```
+  Add the builder (detonation ability only this phase; returns `undefined` when the detonation value is undefined — but note Phase 3 makes this return an array including the splash ability, so structure it to return an array now with just the detonation entry, or a single ability — keep it simple this phase, expand in 3.3):
+```ts
+VOIDFIRE_CATALYST: (rarity) => {
+    const det = VOIDFIRE_DETONATION_PCT[rarity];
+    if (det === undefined) return undefined; // rare/legendary have no detonation half (splash added in Phase 3)
+    return {
+        type: 'modifier', target: 'self', trigger: 'on-cast', conditions: [],
+        config: { type: 'modifier', channel: 'detonationDamage', value: det, isMultiplicative: false },
+        autoFilled: true,
+    };
+},
+```
+  Update `equipmentCoverage.test.ts`: add `VOIDFIRE_CATALYST` to the implemented-set `.toEqual` array (correct IMPLANTS decl-order position), the Set, and bump the `exactly{N}` count.
+
+- [ ] **Step 4: Run tests** — integration + coverage pass; full suite byte-identical.
+
+- [ ] **Step 5: Commit** — `feat(combat): Voidfire Catalyst detonation half`
+
+### Task 1.6: Phase 1 verification + changelog + PR
+
+- [ ] **Step 1:** Full suite green, `npm run lint`, `npx tsc --noEmit`, `npm run audit:skills` (expect 141/0 unchanged).
+- [ ] **Step 2:** Add a plain-English `UNRELEASED_CHANGES` entry in `src/constants/changelog.ts` (e.g. "Voidfire Catalyst now increases detonation damage").
+- [ ] **Step 3:** Update `src/pages/DocumentationPage.tsx` if it lists implant/combat mechanics.
+- [ ] **Step 4: Commit** docs/changelog; open PR-1 (`gh auth switch --user TheSusort` first).
+
+---
+
+# Phase 2 (PR-2): base bomb-splash-on-death
+
+**Outcome:** Any ship that dies with un-detonated bombs splashes 25/50/75% (by tier) of each bomb's raw burst to its living same-side adjacent allies, chaining recursively. Positional-only. **The one golden-moving phase** — validate each delta by hand.
+
+Branch `feat/combat-bomb-splash-on-death` stacked on PR-1 (or off main if PR-1 merges first).
+
+### Task 2.0: Verify the death seam (research — do first)
+
+- [ ] **Step 1:** Confirm `applyVictimDamage`'s `recordDestroyed` `else` branch (`engine.ts:2895-2902`) is the **sole** real-death seam for positional sims (bySide unification claim). Grep for all `recordDestroyed` call sites; confirm there is no separate positional death path that bypasses `applyVictimDamage`. Document findings as a comment in the plan/PR. If a second death path exists, the splash hook must cover it too — surface before proceeding.
+
+### Task 2.1: `splashPct` pure helper
+
+**Files:**
+- Create: `src/utils/combat/bombSplash.ts`
+- Test: `src/utils/combat/__tests__/bombSplash.test.ts`
+
+- [ ] **Step 1: Write failing tests** — `splashPctForTier(100) === 25`, `(200) === 50`, `(300) === 75` (i.e. `tier / 4`). Also a `splashDamageForBomb({bomb, allyCount?})`-style pure fn if it clarifies the math, returning the per-ally splash for one bomb: `stacks * damagePerStack * splashPct/100 * (1 + splashModifier/100)`.
+- [ ] **Step 2: Run, verify fail.**
+- [ ] **Step 3: Implement** the pure helper(s) in `bombSplash.ts`. No affinity term.
+- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit** — `feat(combat): bomb-splash damage helper`
+
+### Task 2.2: `perActorSplash` surfacing plumbing
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts` (declare `let perActorSplash = new Map<string, number>();` next to `perActorReflected` ~`:1910`; reset per round at the `perActorReflected` reset ~`:3490`; surface in the round-result fold ~`:5149`, the `Object.fromEntries`/spread that emits `perActorReflected`)
+- Modify: `RoundData` type at `src/utils/calculators/dpsSimulator.ts:142` (where `perActorReflected?` is declared) — add `perActorSplash?` with the same shape, plumbed into the round result like `perActorReflected`.
+
+- [ ] **Step 1:** Add the map + per-round reset + RoundData field, mirroring `perActorReflected` exactly. No StatCard.
+- [ ] **Step 2:** `npm test` — byte-identical (nothing writes the map yet).
+- [ ] **Step 3: Commit** — `feat(combat): plumb perActorSplash round surface`
+
+### Task 2.3: Splash-on-death block at the death seam (core)
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts:2895-2902` (immediately after the `recordDestroyed(victim, …)` call in the real-death `else` branch)
+- Test: `src/utils/combat/__tests__/bombSplashOnDeath.integration.test.ts`
+
+- [ ] **Step 1: Write the failing integration test** — a positional 2-team sim where an enemy carrying one Bomb (tier 200, known stacks/damagePerStack) is killed by a direct hit while a living same-side adjacent ally exists. Assert the adjacent ally takes `stacks * damagePerStack * 0.50` splash (full shield drain, no pen, no affinity), and the dead ship's `pendingBombs` is cleared. Use the positional fixture helpers from `positionalDamage.integration.test.ts`.
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement** the splash block. Gate: this call newly destroyed the victim (it's in the `else`/no-cheat-death branch) **and** `victim.pendingBombs.length > 0`. Then, capturing the bombs and clearing them first (to avoid re-entrancy double-fire):
+```ts
+// Bomb-splash-on-death: a ship that dies with un-detonated bombs splashes a
+// tier-scaled fraction of each bomb's raw burst to its LIVING same-side adjacent
+// allies (positional only — adjacentAllyIds returns [] without positions).
+// No affinity (bombs/DoTs are not affinity-scaled). Bomb-like: full shield drain,
+// no penetration. Credited to the bomb applier. Chains: a splash kill re-enters
+// this branch for the new victim's bombs (finite — each ship dies once, bombs cleared).
+const bombs = victim.pendingBombs;
+if (bombs.length > 0) {
+    victim.pendingBombs = []; // consume up-front → no double-fire on chain re-entry
+    const allyIds = adjacentAllyIdsFor(victim.id); // living same-side neighbors
+    for (const allyId of allyIds) {
+        const ally = allActorsById.get(allyId);
+        if (!ally || ally.destroyedRound !== undefined) continue;
+        for (const bomb of bombs) {
+            const splash = splashDamageForBomb(bomb); // stacks*dps*tier/4% *(1+splashMod/100)
+            if (splash <= 0) continue;
+            const splashSink = ally.side === 'player' ? playerSink : enemySink;
+            applyVictimDamage(splash, ally, splashSink, {
+                killerId: bomb.sourceId,
+                byDirectDamage: true,
+                bombPortion: splash,      // full bomb → full shield drain, no reflect
+                shieldPenetrationPct: 0,
+            });
+            perActorSplash.set(ally.id, (perActorSplash.get(ally.id) ?? 0) + splash);
+            roundPerTargetDamage.set(ally.id, (roundPerTargetDamage.get(ally.id) ?? 0) + splash);
+        }
+    }
+}
+```
+  Resolve `adjacentAllyIdsFor` in this closure's scope (the side-aware helper `bySide(isEnemySide(victim.id) ? 'enemy' : 'player').adjacentAllyIdsFor` — confirm the in-scope binding; Reflect's block uses sibling closure-captured helpers). `splashDamageForBomb` is the Task-2.1 helper (reads `bomb.splashModifier`, default 0 until Phase 3).
+
+- [ ] **Step 4: Run the new test** — passes.
+
+- [ ] **Step 5: Run the FULL suite.** Expect some positional goldens to move. For each moved golden, hand-verify the delta equals the splash formula. **Do not** `vitest -u` blindly. Update only validated goldens.
+
+- [ ] **Step 6: Commit** — `feat(combat): bomb-splash-on-death core mechanic`
+
+### Task 2.4: Chaining test
+
+- [ ] **Step 1:** Test: three same-side ships A,B,C adjacent in a line; A and B both carry bombs; killing A splashes B; if that kills B, B splashes C. Assert C takes B's splash (chain) and the whole thing terminates.
+- [ ] **Step 2-4:** Run (should already pass from 2.3's recursion); if not, fix re-entrancy. Commit — `test(combat): bomb-splash chain reaction`.
+
+### Task 2.5: Edge-case guards
+
+- [ ] **Step 1:** Tests: (a) **non-positional** sim with a bombed death → no splash, byte-identical; (b) **cheat-death** survivor (the `if` branch) does **not** splash; (c) **dead applier** (sourceId actor already destroyed) → splash still fires and credits the applier; (d) **no living neighbor** → no splash, bombs still consumed.
+- [ ] **Step 2-4:** Run, fix if needed, commit — `test(combat): bomb-splash edge cases`.
+
+### Task 2.6: Phase 2 verification + changelog + PR
+
+- [ ] Full suite green (with validated golden updates), lint, tsc, audit:skills. Changelog entry ("Bombs now splash to adjacent ships when the carrier dies before they detonate"). DocumentationPage update if relevant. Open PR-2.
+
+---
+
+# Phase 3 (PR-3): `bombSplashDamage` channel + Voidfire splash half
+
+**Outcome:** Voidfire's splash% amplifies Phase-2 splash for all rarities (incl. rare/legendary). Byte-identical (no fixture equips Voidfire).
+
+Branch `feat/combat-voidfire-splash` stacked on PR-2.
+
+### Task 3.1: `bombSplashDamage` modifier channel
+
+**Files:** same set as Task 1.1 + 1.2 (union, ModifierTotals, switch, EffectiveDamageStats field `bombSplashModifier`, editor stubs).
+
+- [ ] **Step 1: Failing test** — modifier `channel: 'bombSplashDamage', value: 40` → `totals.bombSplashDamage === 40`.
+- [ ] **Step 2: Run, fail.**
+- [ ] **Step 3: Implement** — add `'bombSplashDamage'` to union; `bombSplashDamage` to ModifierTotals/init/switch; `bombSplashModifier: mod.bombSplashDamage` on EffectiveDamageStats; editor stubs (AbilityCard ×2, GameBuffPicker label).
+- [ ] **Step 4: Run, pass; full suite byte-identical.**
+- [ ] **Step 5: Commit** — `feat(combat): add bombSplashDamage modifier channel`
+
+### Task 3.2: Snapshot applier's splash modifier onto `PendingBomb` + wire formula
+
+**Files:**
+- Modify: `state.ts` (`PendingBomb.splashModifier`)
+- Modify: `playerTurn.ts` `applyNewDoTs` + call site (thread `dmgStats.bombSplashModifier`), `triggers.ts:1557` (default 0)
+- Modify: `bombSplash.ts` — `splashDamageForBomb` already reads `bomb.splashModifier`; ensure it's wired (it was 0-defaulted in Phase 2)
+- Update all `PendingBomb` literals to add `splashModifier: 0`.
+
+- [ ] **Step 1: Failing test** — a bomb with `splashModifier: 50` splashes 1.5× the Phase-2 amount on death.
+- [ ] **Step 2: Run, fail.**
+- [ ] **Step 3: Implement** the field + snapshot threading.
+- [ ] **Step 4: Run test + full suite** — new test passes; goldens byte-identical (default 0).
+- [ ] **Step 5: Commit** — `feat(combat): snapshot applier bomb-splash modifier onto bombs`
+
+### Task 3.3: Voidfire splash ability (registry array return) + coverage
+
+**Files:** `buildEquipmentAbilities.ts` (expand `VOIDFIRE_CATALYST` to return an array), `equipmentCoverage.test.ts` (count already includes Voidfire from Phase 1; bump the per-builder ability count if asserted).
+
+- [ ] **Step 1: Failing test** — through the real registry, `VOIDFIRE_CATALYST` epic yields **two** modifier abilities (`detonationDamage: 8` + `bombSplashDamage: 16`); rare yields **one** (`bombSplashDamage: 24`, no detonation); legendary → one (`bombSplashDamage: 40`).
+- [ ] **Step 2: Run, fail.**
+- [ ] **Step 3: Implement** — expand the builder to return an array (Warpstrike precedent), pushing the detonation modifier only when its value is defined, always pushing the splash modifier:
+```ts
+VOIDFIRE_CATALYST: (rarity) => {
+    const det = VOIDFIRE_DETONATION_PCT[rarity];
+    const splash = VOIDFIRE_SPLASH_PCT[rarity];
+    if (splash === undefined && det === undefined) return undefined;
+    const abilities: Omit<Ability, 'id'>[] = [];
+    if (det !== undefined) abilities.push({ /* detonationDamage modifier as in 1.5 */ });
+    if (splash !== undefined) abilities.push({
+        type: 'modifier', target: 'self', trigger: 'on-cast', conditions: [],
+        config: { type: 'modifier', channel: 'bombSplashDamage', value: splash, isMultiplicative: false },
+        autoFilled: true,
+    });
+    return abilities;
+},
+```
+  The consumer index-suffixes ids for array returns (Warpstrike precedent).
+- [ ] **Step 4: Run tests** — integration + coverage pass; full suite byte-identical.
+- [ ] **Step 5: Commit** — `feat(combat): Voidfire Catalyst splash half`
+
+### Task 3.4: Phase 3 verification + changelog + PR
+
+- [ ] Full suite green, lint, tsc, audit:skills. Add an integration test that a positional sim where a Voidfire-wearing applier's bomb kills its carrier produces amplified splash vs. an identical no-implant run. Changelog ("Voidfire Catalyst now also increases bomb splash damage"). DocumentationPage. Open PR-3.
+
+---
+
+## Definition of Done
+
+- All three PRs open (stacked), each: full vitest suite green, `npm run lint` clean, `npx tsc --noEmit` clean, `npm run audit:skills` 141/0.
+- PR-1 & PR-3 goldens byte-identical; PR-2 golden deltas each hand-validated against the splash formula.
+- `equipmentCoverage.test.ts` lists `VOIDFIRE_CATALYST` as implemented.
+- Changelog + DocumentationPage updated.

--- a/docs/superpowers/specs/2026-06-26-voidfire-catalyst-bomb-splash-design.md
+++ b/docs/superpowers/specs/2026-06-26-voidfire-catalyst-bomb-splash-design.md
@@ -1,0 +1,210 @@
+# Voidfire Catalyst + bomb-splash-on-death — design
+
+**Date:** 2026-06-26
+**Sub-project:** combat-realism epic, sub-project D (implants + gear-set abilities) — the deferred
+detonation/bomb leftover.
+**Shape:** three stacked PRs (PR-1 detonation channel → PR-2 base splash-on-death → PR-3 Voidfire
+splash modifier). One spec; PR boundaries map to the three Parts below.
+
+## 1. Background
+
+`VOIDFIRE_CATALYST` (`src/constants/implants.ts`) is the last un-modelled implant in the D corpus. Its
+per-rarity descriptions carry **two distinct effects**:
+
+1. **"+X% detonation damage"** — the wearer deals more detonation (bomb/Inferno/Corrosion burst) damage.
+2. **"bombs additionally deal +Y% more splash damage"** — bombs the wearer inflicts splash harder.
+
+It was deferred from D-PR4 because the "splash" half collides with a mechanic the engine does not model
+at all. Clarified in-game behaviour (user-confirmed):
+
+> When a ship carrying **bomb** debuffs **dies before the bombs detonate**, the bombs deal **25% / 50% /
+> 75%** of their damage to **all adjacent ships**, by bomb tier. Voidfire **increases** this splash.
+
+So the splash half rides a **base bomb-splash-on-death mechanic that does not exist yet** — that base
+mechanic is *not* implant-gated (it fires for any bombs). This is the previously-deferred "positional
+per-victim bomb attribution" work (peeled from E5).
+
+### Rarity values (model exactly what each description states)
+
+| Rarity | detonation% | splash% |
+|--------|-------------|---------|
+| common | 2 | 4 |
+| uncommon | 4 | 8 |
+| rare | — (0) | 24 |
+| epic | 8 | 16 |
+| legendary | — (0) | 40 |
+
+Rare/legendary descriptions mention **only** splash → they produce a splash modifier and **no**
+detonation ability.
+
+### Locked mechanic decisions (user-ratified this session)
+
+- **Detonation bonus scope:** applies to **all detonation types** (bomb + Inferno + Corrosion), on
+  **both** the skill-triggered (`detonate()`) and timed-expiry (`processBombs`) paths.
+- **Splash basis:** each adjacent ship takes a **bomb-like** hit — `splashPct × bomb burst`, **full
+  shield drain, no penetration** (mirrors normal bomb damage). **No affinity** is applied — bombs and
+  DoTs are not affinity-scaled in-game (only direct damage is).
+- **Splash targets:** the dying ship's **living same-side adjacent allies** (its own team; cross-side
+  splash is impossible — teams aren't grid-adjacent).
+- **Splash bonus owner:** the **bomb applier** (the wearer who inflicted the bomb) — snapshot the
+  applier's splash modifier onto the bomb at application (like `affinityMult`).
+- **Chaining:** **allowed** — a splash that kills an adjacent bombed ally recursively triggers that
+  ally's splash. Naturally finite (each ship dies once; its bombs are consumed).
+
+## 2. Goals / non-goals
+
+**Goals**
+
+- Fully model Voidfire Catalyst (both halves, all rarities) as a combat-engine effect.
+- Add the missing **base bomb-splash-on-death** core mechanic.
+- Note: the **DPS calculator does not compute detonation damage** (`src/utils/calculators/` has no
+  detonation path — detonation is engine-only). So no DPS wiring is required; the new
+  `detonationDamageModifier` lives in `effectiveDamageStatsOf` (shared by both paths) and the DPS path
+  simply never reads it.
+- Keep DPS / healing / battle-sim goldens **byte-identical** for PR-1 and PR-3 (no fixture equips
+  Voidfire). PR-2 is the *only* golden-moving piece; its deltas are validated by hand.
+
+**Non-goals**
+
+- No UI / autogear / scoring changes (beyond the mandatory editor exhaustiveness stubs).
+- No change to the deterministic chance model (these are passive `modifier` abilities, not procs).
+- No change to how bombs are applied, counted, or normally detonate (PR-1 only *scales* existing
+  bursts; PR-2 only adds a death-time path).
+
+## 3. Architecture
+
+### 3.1 Current bomb model (grounding)
+
+- `PendingBomb` lives **per-actor** (`CombatActor.pendingBombs`, `state.ts:120`) — bombs are already
+  attached to the ship carrying them. Fields: `countdown`, `damagePerStack` (= `effectiveAttack ×
+  tier/100`, **no** affinity), `stacks`, `tier` (100/200/300), `sourceId` (applier), `affinityMult`
+  (snapshotted applier→original-target).
+- Two detonation paths:
+  - **Skill-triggered** — `detonate()` (`playerTurn.ts:526-582`) sums all `pendingBombs` and bursts at
+    the detonating actor's skill power; `payout = Σ(stacks × damagePerStack × affinityMult) × powerPct`.
+    Also handles Inferno/Corrosion detonation. Detonation damage currently bypasses **all** modifier
+    channels.
+  - **Timed expiry** — `processBombs()` (`engine.ts:695-710`) decrements `countdown`, bursts on `≤ 0`,
+    credits the applier (`sourceId`) via `creditDetonation`.
+- Modifier-channel fold: `modifierTotalsFromAbilities` (`src/utils/abilities/applyAbilities.ts:23-81`) → `effectiveStats.ts`
+  fold (`selfDotDamageModifier: dotPen.dotDamageModifier + mod.dotDamage`, line 214). The `dotDamage`
+  channel (Decimation) is the exact template for the two new channels.
+
+### 3.2 PR-1 — `detonationDamage` modifier channel (byte-identical)
+
+New ModifierChannel, mirroring `dotDamage`:
+
+1. **`types/abilities.ts`** — add `'detonationDamage'` to the modifier `channel` union; add the 3 editor
+   exhaustiveness stubs (`AbilityCard` / `AbilityTypePicker` / `abilityDefaults`, per the D-PR4
+   precedent — switches keyed on the channel union).
+2. **`applyAbilities.ts`** — `ModifierTotals.detonationDamage` field + `case 'detonationDamage'`.
+3. **`effectiveStats.ts`** — new `detonationDamageModifier: mod.detonationDamage` on
+   `EffectiveDamageStats` (parallel to `selfDotDamageModifier`).
+4. **`playerTurn.ts` `detonate()`** — thread the detonating actor's `dmgStats.detonationDamageModifier`
+   as a `detonationMult = 1 + mod/100`; multiply the payout of **all three** branches (bomb / inferno /
+   corrosion) by it. Default 0 → mult 1 → byte-identical.
+5. **`state.ts` `PendingBomb`** — new snapshot field `detonationDamageModifier` (the applier's, captured
+   at application alongside `affinityMult`); **`engine.ts` `processBombs`** scales the timed-expiry
+   burst by `(1 + bomb.detonationDamageModifier/100)`.
+6. **Application sites** — `applyNewDoTs` (`playerTurn.ts:587-627`) and the reactive bomb-application
+   path (`triggers.ts:1557`) snapshot the applier's `detonationDamageModifier` onto the new `PendingBomb`
+   field (thread the applier's `dmgStats` value through, defaulting 0).
+7. **DPS calculator** — **no change needed.** The DPS calc has no detonation computation, and its
+   `buildShipAbilities` sites were already routed to `buildShipAbilitiesWithEquipment` in D-PR2. The new
+   field is inert there.
+
+Inert at default 0 everywhere → byte-identical.
+
+### 3.3 PR-2 — base bomb-splash-on-death (golden-moving core mechanic)
+
+Reuses the **Reflect** recursive-`applyVictimDamage` pattern at the shared death seam.
+
+- **Seam:** the shared `applyVictimDamage` real-death branch (`engine.ts:2895-2902`, the `else` that
+  calls `recordDestroyed`). Fires exactly once per death (set-once via `destroyedRound`); the
+  cheat-death branch (`2882-2894`) is **excluded** (it survives at 1 HP and already leaves bombs
+  untouched). This is the sole victim sink (bySide unification), covering player→enemy and
+  enemy→player symmetrically.
+- **Trigger:** the victim is newly destroyed by this call **and** `victim.pendingBombs` is non-empty
+  (un-detonated bombs).
+- **Per bomb × per living same-side adjacent ally** (`adjacentAllyIds(victim.id, actors)` — the helper
+  already used for Bulwark/reactive adjacency; resolve via the side-aware `adjacentAllyIdsFor`):
+
+  ```
+  splashPct(tier) = tier / 4   (%)            // 100→25, 200→50, 300→75
+  splash = (stacks × damagePerStack)          // = stacks × effectiveAttack × tier/100
+         × splashPct/100
+         × (1 + bomb.splashModifier/100)       // PR-3; 0 until then
+  ```
+
+  **No affinity term** — bombs/DoTs are not affinity-scaled in-game (only direct damage is).
+  `damagePerStack` already excludes affinity, so splash is a pure fraction of the bomb's raw burst.
+  (The pre-existing `bomb.affinityMult` snapshot is used only by the *existing* `detonate()` /
+  `processBombs` paths and is left untouched — not in scope to change here.)
+- **Applied like a bomb hit** via recursive
+  `applyVictimDamage(splash, ally, sink-by-ally-side, { killerId: applierId, byDirectDamage: true,
+  bombPortion: splash, shieldPenetrationPct: 0 })` — full shield drain, no pen, credited to the
+  applier's detonation channel.
+- **Applier / credit:** the splash is credited to the bomb's applier (`killerId: bomb.sourceId`); the
+  applier need not be resolved as an actor for the damage value itself (no affinity), only for
+  accounting. Splash fires regardless of applier liveness (bombs are autonomous).
+- **Chaining:** a splash that kills an adjacent bombed ally re-enters the same `applyVictimDamage` death
+  branch → its splash fires recursively. Finite: each ship dies once and its bombs are consumed.
+- **Consume:** clear `victim.pendingBombs` after splashing (so they cannot also time-detonate).
+- **Non-positional safety:** `adjacentAllyIds` returns `[]` without positions → no splash → all
+  non-positional goldens (DPS, healing, single-target sims) stay byte-identical. Only positional sims
+  with a bombed death + a living same-side neighbour change.
+- **Surfacing:** a `perActorSplash` map (reset/round, mirroring Reflect's `perActorReflected`) folded
+  into `roundPerTargetDamage` so splash shows on the victim's HP curve; `RoundData.perActorSplash?`
+  plumbed (no StatCard yet — reserved).
+
+### 3.4 PR-3 — Voidfire `bombSplashDamage` modifier (byte-identical)
+
+- New `'bombSplashDamage'` modifier channel (same fold pattern as §3.2 — union + `ModifierTotals` +
+  `effectiveStats` field `bombSplashModifier` + editor stubs).
+- Snapshot the **applier's** `bombSplashModifier` onto `PendingBomb.splashModifier` at the two
+  application sites (`applyNewDoTs` + `triggers.ts:1557`), alongside the PR-1 detonation snapshot.
+- PR-2's formula already reads `bomb.splashModifier` (default 0 → PR-2 stands alone); PR-3 fills it →
+  Voidfire's splash% amplifies splash for all rarities.
+
+### 3.5 Voidfire registry entry (spans the PRs)
+
+`IMPLANT_ABILITIES.VOIDFIRE_CATALYST = (rarity) => Ability[]` returning up to two `modifier` abilities:
+a `detonationDamage` modifier (value = detonation% — **omitted** when 0, i.e. rare/legendary) and a
+`bombSplashDamage` modifier (value = splash%). The registry builder already supports array returns
+(Warpstrike precedent); consumer index-suffixes ids only for multi-ability builders.
+
+`equipmentCoverage.test.ts` updates per PR (the implemented-set `.toEqual` array decl-order, the Set,
+and the `it('exactly{}')` count string).
+
+## 4. Components & isolation
+
+| Unit | Purpose | Depends on |
+|------|---------|------------|
+| `detonationDamage` channel | scale detonation bursts by a per-actor % | modifier-fold infra |
+| `PendingBomb.detonationDamageModifier` / `.splashModifier` | snapshot the applier's modifiers at application | effectiveStats |
+| splash-on-death block (`engine.ts`) | distribute splash to adjacent allies at death | `adjacentAllyIds`, `applyVictimDamage` (no affinity) |
+| `bombSplashDamage` channel | feed `PendingBomb.splashModifier` | modifier-fold infra |
+| `VOIDFIRE_CATALYST` registry entry | emit the two modifier abilities per rarity | both channels |
+
+## 5. Testing & golden strategy
+
+- **PR-1 / PR-3:** assert goldens **byte-identical**; unit tests for the channel fold + integration
+  tests through the **real registry** (`buildShipAbilitiesWithEquipment` + `setBonus`), per the
+  mutation-resistance lessons from D-PR16.
+- **PR-2:** run the full suite and **expect** positional-bomb-death goldens to move. Validate each delta
+  by hand against the §3.3 formula before accepting (never blanket `vitest -u`). New focused fixtures:
+  (a) single bomb, single adjacent ally — exact splash value; (b) chain (splash kills a bombed
+  neighbour → second splash); (c) non-positional → no splash (byte-identical); (d) multi-bomb,
+  multi-ally; (e) dead applier still splashes; (f) cheat-death survivor does **not** splash.
+
+## 6. Risks
+
+- **Golden churn scope (PR-2):** the splash mechanic is broad. Mitigation: it is positional-only and
+  only fires on a bombed premature death with a living neighbour — a narrow combination; isolate it in
+  its own PR with hand-validated deltas.
+- **Death-path completeness:** the design assumes `applyVictimDamage`'s `recordDestroyed` branch is the
+  sole real-death seam (bySide unification). **Plan-phase verification:** confirm all positional deaths
+  route through it before relying on the single hook.
+- **Chaining recursion:** bounded by "each ship dies once, bombs consumed" — verify no re-entrancy on an
+  already-destroyed victim (the set-once `destroyedRound` guard handles this; the splash trigger must
+  gate on *newly* destroyed + non-empty bombs).

--- a/docs/superpowers/specs/2026-06-26-voidfire-catalyst-bomb-splash-design.md
+++ b/docs/superpowers/specs/2026-06-26-voidfire-catalyst-bomb-splash-design.md
@@ -150,9 +150,13 @@ Reuses the **Reflect** recursive-`applyVictimDamage` pattern at the shared death
 - **Chaining:** a splash that kills an adjacent bombed ally re-enters the same `applyVictimDamage` death
   branch → its splash fires recursively. Finite: each ship dies once and its bombs are consumed.
 - **Consume:** clear `victim.pendingBombs` after splashing (so they cannot also time-detonate).
-- **Non-positional safety:** `adjacentAllyIds` returns `[]` without positions → no splash → all
-  non-positional goldens (DPS, healing, single-target sims) stay byte-identical. Only positional sims
-  with a bombed death + a living same-side neighbour change.
+- **Non-positional safety (code-enforced):** the splash block is gated on the dying victim having a
+  board `position` (positional-only by construction). NOTE: `adjacentAllyIds` does NOT self-gate — it
+  has an all-living-same-side *fallback* when positions are absent, so relying on it returning `[]`
+  would be a latent trap (a future change wiring per-actor bombs onto team actors would splash to ALL
+  same-side allies non-positionally). The explicit `victim.position` gate makes "positional-only"
+  enforced by code, keeping all non-positional goldens (DPS, healing, single-target sims)
+  byte-identical. Only positional sims with a bombed death + a living same-side neighbour change.
 - **Surfacing:** a `perActorSplash` map (reset/round, mirroring Reflect's `perActorReflected`) folded
   into `roundPerTargetDamage` so splash shows on the victim's HP curve; `RoundData.perActorSplash?`
   plumbed (no StatCard yet — reserved).

--- a/src/components/skills/AbilityCard.tsx
+++ b/src/components/skills/AbilityCard.tsx
@@ -80,6 +80,7 @@ const MODIFIER_CHANNEL_OPTIONS: { value: ModifierChannel; label: string }[] = [
     { value: 'critDamage', label: 'Crit Damage' },
     { value: 'outgoingDamage', label: 'Outgoing Damage' },
     { value: 'dotDamage', label: 'DoT Damage' },
+    { value: 'detonationDamage', label: 'Detonation Damage' },
     { value: 'outgoingHeal', label: 'Outgoing Heal' },
     { value: 'incomingDamage', label: 'Incoming Damage' },
 ];

--- a/src/components/skills/AbilityCard.tsx
+++ b/src/components/skills/AbilityCard.tsx
@@ -81,6 +81,7 @@ const MODIFIER_CHANNEL_OPTIONS: { value: ModifierChannel; label: string }[] = [
     { value: 'outgoingDamage', label: 'Outgoing Damage' },
     { value: 'dotDamage', label: 'DoT Damage' },
     { value: 'detonationDamage', label: 'Detonation Damage' },
+    { value: 'bombSplashDamage', label: 'Bomb Splash Damage' },
     { value: 'outgoingHeal', label: 'Outgoing Heal' },
     { value: 'incomingDamage', label: 'Incoming Damage' },
 ];

--- a/src/constants/buffs.ts
+++ b/src/constants/buffs.ts
@@ -459,12 +459,14 @@ export const BUFFS: Buff[] = [
     },
     {
         name: 'Bomb I',
-        description: '100% Attack',
+        description:
+            'Deals 100% Damage upon expiration. If this ship is destroyed before expiring it instead deals 25% damage to all adjacent ships. Detonation damage bypasses defense.',
         type: 'debuff',
     },
     {
         name: 'Bomb II',
-        description: '200% Attack',
+        description:
+            'Deals 200% Damage upon expiration. If this ship is destroyed before expiring it instead deals 50% damage to all adjacent ships. Detonation damage bypasses defense.',
         type: 'debuff',
     },
     {
@@ -595,7 +597,8 @@ export const BUFFS: Buff[] = [
     },
     {
         name: 'Bomb III',
-        description: '300% Attack',
+        description:
+            'Deals 300% Damage upon expiration. If this ship is destroyed before expiring it instead deals 75% damage to all adjacent ships. Detonation damage bypasses defense.',
         type: 'debuff',
     },
     {

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -40,6 +40,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator now models the Reflect gear set: the wearer reflects a portion of damage taken back at the attacker.',
     'Combat simulator now models the Revenge gear set: the wearer deals increasing damage as its HP drops, up to +25% near death.',
     'Combat simulator now models the Smokescreen implant: a chance to gain Stealth when directly hit.',
+    'Voidfire Catalyst implant now increases detonation damage (bomb, Inferno, and Corrosion bursts).',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -41,6 +41,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator now models the Revenge gear set: the wearer deals increasing damage as its HP drops, up to +25% near death.',
     'Combat simulator now models the Smokescreen implant: a chance to gain Stealth when directly hit.',
     'Voidfire Catalyst implant now increases detonation damage (bomb, Inferno, and Corrosion bursts).',
+    "Combat simulator now models bomb splash-on-death: when a ship is destroyed while still carrying un-detonated bombs, each adjacent ally takes a share of every bomb's damage (25% at tier 1, 50% at tier 2, 75% at tier 3). This is positional, so it only applies in battles with board positions.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -42,7 +42,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator now models the Smokescreen implant: a chance to gain Stealth when directly hit.',
     'Voidfire Catalyst implant now increases detonation damage (bomb, Inferno, and Corrosion bursts).',
     "Combat simulator now models bomb splash-on-death: when a ship is destroyed while still carrying un-detonated bombs, each adjacent ally takes a share of every bomb's damage (25% at tier 1, 50% at tier 2, 75% at tier 3). This is positional, so it only applies in battles with board positions.",
-    'Voidfire Catalyst implant now also amplifies bomb splash damage — the splash damage adjacent ships take when a bomb-carrier is destroyed is boosted by the same implant that increases direct detonation damage.',
+    'Voidfire Catalyst implant now also amplifies bomb splash damage — when a bomb-carrier is destroyed, the splash damage dealt to adjacent ships is increased by Voidfire Catalyst, including its rare and legendary splash-only variants.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -42,6 +42,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator now models the Smokescreen implant: a chance to gain Stealth when directly hit.',
     'Voidfire Catalyst implant now increases detonation damage (bomb, Inferno, and Corrosion bursts).',
     "Combat simulator now models bomb splash-on-death: when a ship is destroyed while still carrying un-detonated bombs, each adjacent ally takes a share of every bomb's damage (25% at tier 1, 50% at tier 2, 75% at tier 3). This is positional, so it only applies in battles with board positions.",
+    'Voidfire Catalyst implant now also amplifies bomb splash damage — the splash damage adjacent ships take when a bomb-carrier is destroyed is boosted by the same implant that increases direct detonation damage.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3141,8 +3141,11 @@ const DocumentationPage: React.FC = () => {
                                     the <strong>Revenge</strong> gear set (the wearer deals
                                     increasing damage as its HP drops, up to +25% near death), and
                                     the <strong>Smokescreen</strong> implant (a chance to gain
-                                    Stealth when directly hit). More implant and gear-set effects
-                                    will be added in future updates.
+                                    Stealth when directly hit). The{' '}
+                                    <strong>Voidfire Catalyst</strong> implant is also modeled: it
+                                    increases detonation damage (bomb bursts, Inferno detonations,
+                                    and Corrosion detonations) by a percentage based on rarity. More
+                                    implant and gear-set effects will be added in future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3144,8 +3144,9 @@ const DocumentationPage: React.FC = () => {
                                     Stealth when directly hit). The{' '}
                                     <strong>Voidfire Catalyst</strong> implant is also modeled: it
                                     increases detonation damage (bomb bursts, Inferno detonations,
-                                    and Corrosion detonations) by a percentage based on rarity. More
-                                    implant and gear-set effects will be added in future updates.
+                                    and Corrosion detonations) and bomb splash damage by a
+                                    percentage based on rarity. More implant and gear-set effects
+                                    will be added in future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3145,8 +3145,9 @@ const DocumentationPage: React.FC = () => {
                                     <strong>Voidfire Catalyst</strong> implant is also modeled: it
                                     increases detonation damage (bomb bursts, Inferno detonations,
                                     and Corrosion detonations) and bomb splash damage by a
-                                    percentage based on rarity. More implant and gear-set effects
-                                    will be added in future updates.
+                                    percentage based on rarity — its rare and legendary variants
+                                    amplify bomb splash damage only. More implant and gear-set
+                                    effects will be added in future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -321,6 +321,7 @@ export type ModifierChannel =
     | 'outgoingDamage'
     | 'dotDamage'
     | 'detonationDamage'
+    | 'bombSplashDamage'
     | 'outgoingHeal'
     | 'incomingDamage';
 

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -320,6 +320,7 @@ export type ModifierChannel =
     | 'critDamage'
     | 'outgoingDamage'
     | 'dotDamage'
+    | 'detonationDamage'
     | 'outgoingHeal'
     | 'incomingDamage';
 

--- a/src/utils/abilities/__tests__/applyAbilities.test.ts
+++ b/src/utils/abilities/__tests__/applyAbilities.test.ts
@@ -87,6 +87,7 @@ describe('modifierTotalsFromAbilities', () => {
         critDamage: 0,
         outgoingDamage: 0,
         dotDamage: 0,
+        detonationDamage: 0,
         defence: 0,
         defensePenetration: 0,
         hp: 0,
@@ -199,6 +200,29 @@ describe('modifierTotalsFromAbilities — dotDamage channel', () => {
         };
         const totals = modifierTotalsFromAbilities([ability], makeConditionContext({}));
         expect(totals.dotDamage).toBe(20);
+        expect(totals.outgoingDamage).toBe(0);
+        expect(totals.attack).toBe(0);
+    });
+});
+
+describe('modifierTotalsFromAbilities — detonationDamage channel', () => {
+    it('sums a detonationDamage modifier into ModifierTotals.detonationDamage', () => {
+        const ability: Ability = {
+            id: 'voidfire-x',
+            type: 'modifier',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [],
+            config: {
+                type: 'modifier',
+                channel: 'detonationDamage',
+                value: 8,
+                isMultiplicative: false,
+            },
+        };
+        const totals = modifierTotalsFromAbilities([ability], makeConditionContext({}));
+        expect(totals.detonationDamage).toBe(8);
+        expect(totals.dotDamage).toBe(0);
         expect(totals.outgoingDamage).toBe(0);
         expect(totals.attack).toBe(0);
     });

--- a/src/utils/abilities/__tests__/applyAbilities.test.ts
+++ b/src/utils/abilities/__tests__/applyAbilities.test.ts
@@ -88,6 +88,7 @@ describe('modifierTotalsFromAbilities', () => {
         outgoingDamage: 0,
         dotDamage: 0,
         detonationDamage: 0,
+        bombSplashDamage: 0,
         defence: 0,
         defensePenetration: 0,
         hp: 0,
@@ -222,6 +223,30 @@ describe('modifierTotalsFromAbilities — detonationDamage channel', () => {
         };
         const totals = modifierTotalsFromAbilities([ability], makeConditionContext({}));
         expect(totals.detonationDamage).toBe(8);
+        expect(totals.dotDamage).toBe(0);
+        expect(totals.outgoingDamage).toBe(0);
+        expect(totals.attack).toBe(0);
+    });
+});
+
+describe('modifierTotalsFromAbilities — bombSplashDamage channel', () => {
+    it('sums a bombSplashDamage modifier into ModifierTotals.bombSplashDamage', () => {
+        const ability: Ability = {
+            id: 'voidfire-splash-x',
+            type: 'modifier',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [],
+            config: {
+                type: 'modifier',
+                channel: 'bombSplashDamage',
+                value: 40,
+                isMultiplicative: false,
+            },
+        };
+        const totals = modifierTotalsFromAbilities([ability], makeConditionContext({}));
+        expect(totals.bombSplashDamage).toBe(40);
+        expect(totals.detonationDamage).toBe(0);
         expect(totals.dotDamage).toBe(0);
         expect(totals.outgoingDamage).toBe(0);
         expect(totals.attack).toBe(0);

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -815,14 +815,14 @@ describe('equipmentCoverage — implants', () => {
         }
     });
 
-    // Task 1.5: Voidfire Catalyst — detonationDamage modifier half.
-    // rare/legendary are splash-only → no detonation ability (builder returns undefined).
-    it('VOIDFIRE_CATALYST produces 1 ability for common/uncommon/epic (detonationDamage modifier), 0 for rare/legendary (splash-only)', () => {
-        expect(implantAbilityCount('VOIDFIRE_CATALYST', 'common')).toBe(1);
-        expect(implantAbilityCount('VOIDFIRE_CATALYST', 'uncommon')).toBe(1);
-        expect(implantAbilityCount('VOIDFIRE_CATALYST', 'rare')).toBe(0);
-        expect(implantAbilityCount('VOIDFIRE_CATALYST', 'epic')).toBe(1);
-        expect(implantAbilityCount('VOIDFIRE_CATALYST', 'legendary')).toBe(0);
+    // Tasks 1.5 + 3.3: Voidfire Catalyst — detonationDamage + bombSplashDamage modifier halves.
+    // rare/legendary have no detonation half → 1 ability (bombSplashDamage only).
+    it('VOIDFIRE_CATALYST produces 2 abilities for common/uncommon/epic (detonationDamage + bombSplashDamage), 1 for rare/legendary (bombSplashDamage only)', () => {
+        expect(implantAbilityCount('VOIDFIRE_CATALYST', 'common')).toBe(2);
+        expect(implantAbilityCount('VOIDFIRE_CATALYST', 'uncommon')).toBe(2);
+        expect(implantAbilityCount('VOIDFIRE_CATALYST', 'rare')).toBe(1);
+        expect(implantAbilityCount('VOIDFIRE_CATALYST', 'epic')).toBe(2);
+        expect(implantAbilityCount('VOIDFIRE_CATALYST', 'legendary')).toBe(1);
     });
 
     const unimplementedImplants = Object.keys(IMPLANTS).filter((k) => !implementedImplants.has(k));

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -122,7 +122,7 @@ function implantAbilities(implantKey: string, rarity: string) {
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { BURNER + DECIMATION + LEECH + REFLECT + CLOAKING + HARDENED + REVENGE + SHIELD (gear sets), MARTYRDOM + ARCANE_SIEGE + CHRONO_REAVER + HYPERION_GAZE + INTRUSION + LIFELINE + NEBULA_NULLIFIER + NOURISHMENT + SMOKESCREEN + SYNAPTIC_RESONANCE + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_STAND + LAST_WISH + LOCKDOWN + MENACE + REACTIVE_WARD + SECOND_WIND + SHADOWGUARD + SPEARHEAD + TENACITY + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
+    it('exactly { BURNER + DECIMATION + LEECH + REFLECT + CLOAKING + HARDENED + REVENGE + SHIELD (gear sets), MARTYRDOM + ARCANE_SIEGE + CHRONO_REAVER + HYPERION_GAZE + INTRUSION + LIFELINE + NEBULA_NULLIFIER + NOURISHMENT + SMOKESCREEN + SYNAPTIC_RESONANCE + VOIDFIRE_CATALYST + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_STAND + LAST_WISH + LOCKDOWN + MENACE + REACTIVE_WARD + SECOND_WIND + SHADOWGUARD + SPEARHEAD + TENACITY + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
@@ -155,6 +155,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
             'NEBULA_NULLIFIER',
             'NOURISHMENT',
             'SYNAPTIC_RESONANCE',
+            'VOIDFIRE_CATALYST',
             'VOIDSHADE',
             'VORTEX_VEIL',
             'WARPSTRIKE',
@@ -378,6 +379,7 @@ describe('equipmentCoverage — implants', () => {
         'BATTLECRY',
         'MARTYRDOM',
         'SYNAPTIC_RESONANCE',
+        'VOIDFIRE_CATALYST',
         'ALACRITY',
         'AMBUSH',
         'SPEARHEAD',
@@ -811,6 +813,16 @@ describe('equipmentCoverage — implants', () => {
                 oncePerCombat: true,
             });
         }
+    });
+
+    // Task 1.5: Voidfire Catalyst — detonationDamage modifier half.
+    // rare/legendary are splash-only → no detonation ability (builder returns undefined).
+    it('VOIDFIRE_CATALYST produces 1 ability for common/uncommon/epic (detonationDamage modifier), 0 for rare/legendary (splash-only)', () => {
+        expect(implantAbilityCount('VOIDFIRE_CATALYST', 'common')).toBe(1);
+        expect(implantAbilityCount('VOIDFIRE_CATALYST', 'uncommon')).toBe(1);
+        expect(implantAbilityCount('VOIDFIRE_CATALYST', 'rare')).toBe(0);
+        expect(implantAbilityCount('VOIDFIRE_CATALYST', 'epic')).toBe(1);
+        expect(implantAbilityCount('VOIDFIRE_CATALYST', 'legendary')).toBe(0);
     });
 
     const unimplementedImplants = Object.keys(IMPLANTS).filter((k) => !implementedImplants.has(k));

--- a/src/utils/abilities/applyAbilities.ts
+++ b/src/utils/abilities/applyAbilities.ts
@@ -10,6 +10,7 @@ export interface ModifierTotals {
     outgoingDamage: number;
     dotDamage: number;
     detonationDamage: number;
+    bombSplashDamage: number;
     defence: number;
     defensePenetration: number;
     hp: number;
@@ -32,6 +33,7 @@ export function modifierTotalsFromAbilities(
         outgoingDamage: 0,
         dotDamage: 0,
         detonationDamage: 0,
+        bombSplashDamage: 0,
         defence: 0,
         defensePenetration: 0,
         hp: 0,
@@ -69,6 +71,9 @@ export function modifierTotalsFromAbilities(
                 break;
             case 'detonationDamage':
                 totals.detonationDamage += amount;
+                break;
+            case 'bombSplashDamage':
+                totals.bombSplashDamage += amount;
                 break;
             case 'defense':
                 totals.defence += amount;

--- a/src/utils/abilities/applyAbilities.ts
+++ b/src/utils/abilities/applyAbilities.ts
@@ -9,6 +9,7 @@ export interface ModifierTotals {
     critDamage: number;
     outgoingDamage: number;
     dotDamage: number;
+    detonationDamage: number;
     defence: number;
     defensePenetration: number;
     hp: number;
@@ -30,6 +31,7 @@ export function modifierTotalsFromAbilities(
         critDamage: 0,
         outgoingDamage: 0,
         dotDamage: 0,
+        detonationDamage: 0,
         defence: 0,
         defensePenetration: 0,
         hp: 0,
@@ -64,6 +66,9 @@ export function modifierTotalsFromAbilities(
                 break;
             case 'dotDamage':
                 totals.dotDamage += amount;
+                break;
+            case 'detonationDamage':
+                totals.detonationDamage += amount;
                 break;
             case 'defense':
                 totals.defence += amount;

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -433,9 +433,8 @@ const RESONATING_FURY_PROC: Record<string, number> = {
     legendary: 0.16,
 };
 
-// Task 1.5: Voidfire Catalyst — detonation + splash pct per rarity.
-// rare/legendary have no detonation half → undefined. Splash is wired in a later phase
-// (table defined here for reference; NOT emitted yet).
+// Tasks 1.5 + 3.3: Voidfire Catalyst — detonation + splash pct per rarity.
+// rare/legendary have no detonation half → undefined for detonation. Both halves are now emitted.
 const VOIDFIRE_DETONATION_PCT: Record<string, number | undefined> = {
     common: 2,
     uncommon: 4,
@@ -443,7 +442,7 @@ const VOIDFIRE_DETONATION_PCT: Record<string, number | undefined> = {
     epic: 8,
     legendary: undefined,
 };
-const _VOIDFIRE_SPLASH_PCT: Record<string, number> = {
+const VOIDFIRE_SPLASH_PCT: Record<string, number> = {
     common: 4,
     uncommon: 8,
     rare: 24,
@@ -1064,24 +1063,44 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
             procChance,
         });
     },
-    // Voidfire Catalyst: +X% detonation damage (detonation half). Splash half added in a later phase
-    // (will expand this to return an array). rare/legendary have no detonation half → undefined here.
+    // Voidfire Catalyst: emits both detonationDamage and bombSplashDamage modifier abilities.
+    // rare/legendary have no detonation half → only bombSplashDamage is emitted for those rarities.
     VOIDFIRE_CATALYST: (rarity) => {
         const det = VOIDFIRE_DETONATION_PCT[rarity];
-        if (det === undefined) return undefined;
-        return {
-            type: 'modifier',
-            target: 'self',
-            trigger: 'on-cast',
-            conditions: [],
-            config: {
-                type: 'modifier',
-                channel: 'detonationDamage',
-                value: det,
-                isMultiplicative: false,
-            },
-            autoFilled: true,
-        };
+        const splash = VOIDFIRE_SPLASH_PCT[rarity];
+        if (det === undefined && splash === undefined) return undefined;
+        const abilities: Omit<Ability, 'id'>[] = [];
+        if (det !== undefined) {
+            abilities.push({
+                type: 'modifier' as const,
+                target: 'self' as const,
+                trigger: 'on-cast' as const,
+                conditions: [],
+                config: {
+                    type: 'modifier' as const,
+                    channel: 'detonationDamage' as const,
+                    value: det,
+                    isMultiplicative: false,
+                },
+                autoFilled: true,
+            });
+        }
+        if (splash !== undefined) {
+            abilities.push({
+                type: 'modifier' as const,
+                target: 'self' as const,
+                trigger: 'on-cast' as const,
+                conditions: [],
+                config: {
+                    type: 'modifier' as const,
+                    channel: 'bombSplashDamage' as const,
+                    value: splash,
+                    isMultiplicative: false,
+                },
+                autoFilled: true,
+            });
+        }
+        return abilities;
     },
     // Chrono Reaver: periodic self-charge. Epic = every 3rd own turn, Legendary = every 2nd.
     // Rides end-of-turn (turn-ended) + the every-n-turns gate on the live turnsTaken counter

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -433,6 +433,24 @@ const RESONATING_FURY_PROC: Record<string, number> = {
     legendary: 0.16,
 };
 
+// Task 1.5: Voidfire Catalyst — detonation + splash pct per rarity.
+// rare/legendary have no detonation half → undefined. Splash is wired in a later phase
+// (table defined here for reference; NOT emitted yet).
+const VOIDFIRE_DETONATION_PCT: Record<string, number | undefined> = {
+    common: 2,
+    uncommon: 4,
+    rare: undefined,
+    epic: 8,
+    legendary: undefined,
+};
+const _VOIDFIRE_SPLASH_PCT: Record<string, number> = {
+    common: 4,
+    uncommon: 8,
+    rare: 24,
+    epic: 16,
+    legendary: 40,
+};
+
 // D-PR6: incoming-heal-amplification implant value tables
 // No common rarity for Exuberance
 const EXUBERANCE_PROC: Record<string, number> = {
@@ -1045,6 +1063,25 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
         return mkNamedBuffGrant('Crit Power Up III', 'all-allies', 'on-shield-applied', 1, {
             procChance,
         });
+    },
+    // Voidfire Catalyst: +X% detonation damage (detonation half). Splash half added in a later phase
+    // (will expand this to return an array). rare/legendary have no detonation half → undefined here.
+    VOIDFIRE_CATALYST: (rarity) => {
+        const det = VOIDFIRE_DETONATION_PCT[rarity];
+        if (det === undefined) return undefined;
+        return {
+            type: 'modifier',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [],
+            config: {
+                type: 'modifier',
+                channel: 'detonationDamage',
+                value: det,
+                isMultiplicative: false,
+            },
+            autoFilled: true,
+        };
     },
     // Chrono Reaver: periodic self-charge. Epic = every 3rd own turn, Legendary = every 2nd.
     // Rides end-of-turn (turn-ended) + the every-n-turns gate on the live turnsTaken counter

--- a/src/utils/calculators/dpsSimulator.ts
+++ b/src/utils/calculators/dpsSimulator.ts
@@ -140,6 +140,11 @@ export interface RoundData {
      *  reflected amount also surfaces automatically as the attacker's incoming damage (via the
      *  intake sink); this map is the dedicated attribution for surfacing. */
     perActorReflected?: Record<string, number>;
+    /** Bomb-splash-on-death: adjacent-ally actor id → total splash damage dealt to it THIS round
+     *  by dying bombed allies (positional only). Set ONLY when at least one ally took splash —
+     *  absent otherwise (non-positional / no-splash rounds keep the legacy RoundData shape,
+     *  goldens byte-identical). The splash is ALSO folded into perTargetDamage for that ally. */
+    perActorSplash?: Record<string, number>;
     activeCorrosionStacks: number;
     activeInfernoStacks: number;
     activeBombCount: number;

--- a/src/utils/combat/__tests__/bombSplash.test.ts
+++ b/src/utils/combat/__tests__/bombSplash.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { splashPctForTier, splashDamageForBomb } from '../bombSplash';
+import type { PendingBomb } from '../state';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeBomb(overrides: Partial<PendingBomb> = {}): PendingBomb {
+    return {
+        countdown: 3,
+        damagePerStack: 1000,
+        stacks: 2,
+        tier: 200,
+        sourceId: 'src-1',
+        affinityMult: 1.3, // intentionally ≠ 1 — must NOT affect splash math
+        detonationDamageModifier: 0,
+        ...overrides,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// splashPctForTier
+// ---------------------------------------------------------------------------
+
+describe('splashPctForTier', () => {
+    it('tier 100 → 25%', () => {
+        expect(splashPctForTier(100)).toBe(25);
+    });
+
+    it('tier 200 → 50%', () => {
+        expect(splashPctForTier(200)).toBe(50);
+    });
+
+    it('tier 300 → 75%', () => {
+        expect(splashPctForTier(300)).toBe(75);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// splashDamageForBomb
+// ---------------------------------------------------------------------------
+
+describe('splashDamageForBomb', () => {
+    it('tier-200 bomb, default splashModifierPct (0): 2 × 1000 × 0.50 = 1000', () => {
+        const bomb = makeBomb({ stacks: 2, damagePerStack: 1000, tier: 200 });
+        expect(splashDamageForBomb(bomb)).toBe(1000);
+    });
+
+    it('tier-200 bomb, splashModifierPct=50: 1000 × 1.5 = 1500', () => {
+        const bomb = makeBomb({ stacks: 2, damagePerStack: 1000, tier: 200 });
+        expect(splashDamageForBomb(bomb, 50)).toBe(1500);
+    });
+
+    it('tier-100 bomb: 3 × 500 × 0.25 = 375', () => {
+        const bomb = makeBomb({ stacks: 3, damagePerStack: 500, tier: 100 });
+        expect(splashDamageForBomb(bomb)).toBe(375);
+    });
+
+    it('tier-300 bomb: 1 × 2000 × 0.75 = 1500', () => {
+        const bomb = makeBomb({ stacks: 1, damagePerStack: 2000, tier: 300 });
+        expect(splashDamageForBomb(bomb)).toBe(1500);
+    });
+
+    it('affinityMult (1.3) does NOT affect result — bombs are not affinity-scaled', () => {
+        // bomb has affinityMult: 1.3 baked in via makeBomb defaults.
+        // The result must be identical to a bomb with affinityMult: 1.
+        const bombHighAffinity = makeBomb({
+            stacks: 2,
+            damagePerStack: 1000,
+            tier: 200,
+            affinityMult: 1.3,
+        });
+        const bombNeutralAffinity = makeBomb({
+            stacks: 2,
+            damagePerStack: 1000,
+            tier: 200,
+            affinityMult: 1.0,
+        });
+        expect(splashDamageForBomb(bombHighAffinity)).toBe(
+            splashDamageForBomb(bombNeutralAffinity)
+        );
+        // Absolute value check as well
+        expect(splashDamageForBomb(bombHighAffinity)).toBe(1000);
+    });
+});

--- a/src/utils/combat/__tests__/bombSplash.test.ts
+++ b/src/utils/combat/__tests__/bombSplash.test.ts
@@ -15,6 +15,7 @@ function makeBomb(overrides: Partial<PendingBomb> = {}): PendingBomb {
         sourceId: 'src-1',
         affinityMult: 1.3, // intentionally ≠ 1 — must NOT affect splash math
         detonationDamageModifier: 0,
+        splashModifier: 0,
         ...overrides,
     };
 }

--- a/src/utils/combat/__tests__/bombSplashOnDeath.integration.test.ts
+++ b/src/utils/combat/__tests__/bombSplashOnDeath.integration.test.ts
@@ -125,6 +125,7 @@ const expectedBomb: PendingBomb = {
     sourceId: 'attacker',
     affinityMult: 1,
     detonationDamageModifier: 0,
+    splashModifier: 0,
 };
 const EXPECTED_SPLASH = splashDamageForBomb(expectedBomb); // 10000
 
@@ -200,6 +201,7 @@ describe('bomb-splash-on-death (positional core mechanic)', () => {
             sourceId: 'enemy-b',
             affinityMult: 1,
             detonationDamageModifier: 0,
+            splashModifier: 0,
         };
         const expectedBSplash = splashDamageForBomb(bBomb); // 125
 
@@ -290,6 +292,7 @@ describe('bomb-splash-on-death (positional core mechanic)', () => {
             sourceId: 'attacker',
             affinityMult: 1.5, // non-neutral — must not change splash
             detonationDamageModifier: 0,
+            splashModifier: 0,
         };
         const bomb2: PendingBomb = {
             countdown: 3,
@@ -299,6 +302,7 @@ describe('bomb-splash-on-death (positional core mechanic)', () => {
             sourceId: 'attacker',
             affinityMult: 1,
             detonationDamageModifier: 0,
+            splashModifier: 0,
         };
         const expectedPerAlly = splashDamageForBomb(bomb1) + splashDamageForBomb(bomb2); // 250 + 1500 = 1750
 
@@ -354,6 +358,7 @@ describe('bomb-splash-on-death (positional core mechanic)', () => {
             sourceId: 'enemy-dead-applier',
             affinityMult: 1,
             detonationDamageModifier: 0,
+            splashModifier: 0,
         };
         const expectedDeadApplierSplash = splashDamageForBomb(deadApplierBomb); // 10000
 
@@ -446,5 +451,56 @@ describe('bomb-splash-on-death (positional core mechanic)', () => {
         expect(round.perActorSplash).toBeUndefined();
         // enemy-mid took no damage at all (outside the base footprint, no splash fired).
         expect(round.perTargetDamage?.['enemy-mid']).toBeUndefined();
+    });
+
+    // ─── (g) splashModifier: 50 gives 1.5× splash ────────────────────────────
+    // A pre-seeded bomb with splashModifier=50 must produce 1.5× the baseline splash.
+    // Uses __testTapActors to inject the bomb directly onto the carrier, isolating the
+    // splashModifier field. Mirrors case (e) structurally.
+    it('(g) splashModifier: 50 on a pre-seeded bomb gives 1.5× the baseline splash', () => {
+        idc = 0;
+        const baselineBomb: PendingBomb = {
+            countdown: 3,
+            damagePerStack: 5000 * (BOMB_TIER / 100), // 10000
+            stacks: BOMB_STACKS,
+            tier: BOMB_TIER,
+            sourceId: 'enemy-carrier',
+            affinityMult: 1,
+            detonationDamageModifier: 0,
+            splashModifier: 50,
+        };
+        const expectedSplash = splashDamageForBomb(baselineBomb, 50); // 10000 × 1.5 = 15000
+
+        const input = BASE({
+            // Damage-only skill: the direct hit kills the carrier; no bomb from the skill.
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active',
+                        abilities: [
+                            ab({
+                                type: 'damage',
+                                target: 'enemy',
+                                config: { type: 'damage', multiplier: 100 },
+                            }),
+                        ],
+                    },
+                ],
+            },
+            enemyAttackers: [
+                enemyAt('enemy-carrier', 'M4', 5000),
+                enemyAt('enemy-mid', 'M3', 1_000_000_000),
+            ],
+            __testTapActors: (actors) => {
+                const carrier = actors.find((a) => a.id === 'enemy-carrier');
+                if (carrier) carrier.pendingBombs.push(baselineBomb);
+            },
+        });
+
+        const result = runCombat(input);
+        const round = result.rounds[0];
+
+        // The splash must be 1.5× the default (splashModifier flows through to the helper).
+        expect(round.perActorSplash?.['enemy-mid']).toBe(expectedSplash);
     });
 });

--- a/src/utils/combat/__tests__/bombSplashOnDeath.integration.test.ts
+++ b/src/utils/combat/__tests__/bombSplashOnDeath.integration.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Bomb-splash-on-death (NEW core combat mechanic, positional-only).
+ *
+ * When a ship dies while carrying un-detonated bombs (`pendingBombs`), each LIVING same-side
+ * adjacent ally takes a tier-scaled fraction (`splashDamageForBomb`, tier/4% — no affinity) of
+ * each bomb's damage. The death seam is `recordDestroyed` (engine.ts), so every kill path
+ * (positional, aggregate, DoT, reflected) routes through it; adjacency is positional-only
+ * (`adjacentAllyIdsFor` returns [] without board positions → non-positional sims byte-identical).
+ *
+ * FIXTURE STRATEGY (mirrors positionalDamage.integration.test.ts):
+ * A positional player attacker at M4 fires a basic attack at the FRONT enemy with a BASE
+ * (origin-only) pattern, AND its active also applies a Blast bomb to that same anchor enemy.
+ * The firing hit kills the bombed front enemy (HP sized at/below the direct damage) WHILE the
+ * bomb is still pending (countdown ≥ 1 — never decremented before death). On death the front
+ * enemy splashes to its LIVING adjacent same-side ally (a high-HP enemy at M3, which is OUTSIDE
+ * the origin-only footprint so it takes NO direct damage — isolating the splash). The splash to
+ * M3 is observed via `round.perTargetDamage['enemy-mid']`, which the engine writes for the splash
+ * exactly as the firing path writes per-victim damage. Healing mode is required for the positioned
+ * enemy roster to be built (see positionalDamage.integration.test.ts).
+ *
+ * Bomb math: damagePerStack = attacker effectiveAttack × (tier/100); splash =
+ * stacks × damagePerStack × (tier/4)/100, no affinity (defence 0, affinity neutral here anyway).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import { splashDamageForBomb } from '../bombSplash';
+import type { PendingBomb } from '../state';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `bs${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+// Bomb knobs used by both the skill and the expected-splash math.
+const BOMB_TIER = 200; // splashPct = tier/4 = 50%
+const BOMB_STACKS = 2;
+const BOMB_DURATION = 3; // countdown ≥ 1 → still pending at the round-1 kill
+
+// A single-hit basic attack that ALSO applies a Blast bomb to the target on cast.
+const bombAndStrike = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } }),
+        ab({
+            type: 'dot',
+            target: 'enemy',
+            config: {
+                type: 'dot',
+                dotType: 'bomb',
+                tier: BOMB_TIER,
+                stacks: BOMB_STACKS,
+                duration: BOMB_DURATION,
+            },
+        }),
+    ],
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+// Origin-only footprint: the direct hit touches ONLY the anchor enemy (front), not the ally.
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+const enemyAt = (id: string, position: Position, hp: number): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        shipSkills: { slots: [] } as ShipSkills,
+    }) as EnemyAttacker;
+
+// Focus attacker at M4: attack 5000 vs defence 0, multiplier 100% (1x), 1 hit, no crit →
+// firing-hit damage = 5000 (kills the front enemy when its HP ≤ 5000). Its active also applies
+// the Blast bomb to the front enemy.
+const BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 5000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [bombAndStrike()] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    ...overrides,
+});
+
+// The expected splash one tier-200 bomb deals to one adjacent ally, given the attacker's
+// effectiveAttack (5000) → damagePerStack = 5000 × (200/100) = 10000, stacks 2, splashPct 50%:
+//   2 × 10000 × 0.50 = 10000.
+const expectedBomb: PendingBomb = {
+    countdown: BOMB_DURATION,
+    damagePerStack: 5000 * (BOMB_TIER / 100),
+    stacks: BOMB_STACKS,
+    tier: BOMB_TIER,
+    sourceId: 'attacker',
+    affinityMult: 1,
+    detonationDamageModifier: 0,
+};
+const EXPECTED_SPLASH = splashDamageForBomb(expectedBomb); // 10000
+
+describe('bomb-splash-on-death (positional core mechanic)', () => {
+    it('a bombed enemy killed by a direct hit splashes splashDamageForBomb to its LIVING adjacent ally', () => {
+        idc = 0;
+        // Front enemy (M4) HP 5000 → dies to the 5000 firing hit while bombed. Adjacent ally at M3
+        // (a hex-neighbour of M4) is huge-HP and OUTSIDE the origin-only footprint → takes ONLY
+        // the splash. The splash to M3 surfaces in perTargetDamage['enemy-mid'].
+        const input = BASE({
+            enemyAttackers: [
+                enemyAt('enemy-front', 'M4', 5000),
+                enemyAt('enemy-mid', 'M3', 1_000_000_000),
+            ],
+        });
+        const result = runCombat(input);
+        const round = result.rounds[0];
+
+        expect(round.perTargetDamage).toBeDefined();
+        // The adjacent ally took EXACTLY the splash (no direct damage — outside the footprint).
+        expect(round.perTargetDamage?.['enemy-mid']).toBe(EXPECTED_SPLASH);
+        // The splash is surfaced on the dedicated per-actor map too.
+        expect(round.perActorSplash).toBeDefined();
+        expect(round.perActorSplash?.['enemy-mid']).toBe(EXPECTED_SPLASH);
+    });
+
+    it('no adjacent ally → no splash (lone bombed enemy dies cleanly)', () => {
+        idc = 0;
+        // Front enemy at M4 with a NON-adjacent ally at M1 (not a hex-neighbour of M4). The ally
+        // takes no splash; perActorSplash stays absent.
+        const input = BASE({
+            enemyAttackers: [
+                enemyAt('enemy-front', 'M4', 5000),
+                enemyAt('enemy-far', 'M1', 1_000_000_000),
+            ],
+        });
+        const result = runCombat(input);
+        const round = result.rounds[0];
+        expect(round.perActorSplash).toBeUndefined();
+        expect(round.perTargetDamage?.['enemy-far']).toBeUndefined();
+    });
+
+    it('a bombed enemy that SURVIVES the hit does not splash (no death = no splash)', () => {
+        idc = 0;
+        // Front enemy HP 5001 > 5000 firing hit → survives → no death → no splash, even though it
+        // carries the bomb and has an adjacent ally.
+        const input = BASE({
+            enemyAttackers: [
+                enemyAt('enemy-front', 'M4', 5001),
+                enemyAt('enemy-mid', 'M3', 1_000_000_000),
+            ],
+        });
+        const result = runCombat(input);
+        const round = result.rounds[0];
+        expect(round.perActorSplash).toBeUndefined();
+        // enemy-mid took no damage (outside the footprint, and the front survived → no splash).
+        expect(round.perTargetDamage?.['enemy-mid']).toBeUndefined();
+    });
+});

--- a/src/utils/combat/__tests__/bombSplashOnDeath.integration.test.ts
+++ b/src/utils/combat/__tests__/bombSplashOnDeath.integration.test.ts
@@ -183,4 +183,268 @@ describe('bomb-splash-on-death (positional core mechanic)', () => {
         // enemy-mid took no damage (outside the footprint, and the front survived → no splash).
         expect(round.perTargetDamage?.['enemy-mid']).toBeUndefined();
     });
+
+    // ─── (b) Chain reaction ───────────────────────────────────────────────────
+    // A (M4) dies to direct hit → splashes B (M3, pre-seeded bombs, low HP) → B dies
+    // from splash → B's bombs splash C (M2, high HP, adjacent to B but NOT to A).
+    // The chain terminates naturally: each ship's bombs are consumed up-front.
+    it('(b) chain reaction: A dies → splashes B → B dies → splashes C', () => {
+        idc = 0;
+        // A's bomb splash: 2 × (5000 × (200/100)) × 0.50 = 10000 (same as EXPECTED_SPLASH).
+        // B's pre-seeded bomb: tier=100, stacks=1, damagePerStack=500 → splash = 1×500×0.25=125.
+        const bBomb: PendingBomb = {
+            countdown: 3,
+            damagePerStack: 500,
+            stacks: 1,
+            tier: 100,
+            sourceId: 'enemy-b',
+            affinityMult: 1,
+            detonationDamageModifier: 0,
+        };
+        const expectedBSplash = splashDamageForBomb(bBomb); // 125
+
+        // C has huge HP → survives B's splash.
+        const input = BASE({
+            enemyAttackers: [
+                enemyAt('enemy-a', 'M4', 5000), // dies to 5000 direct hit
+                enemyAt('enemy-b', 'M3', 50), // dies to A's 10000 splash (HP 50 < 10000)
+                enemyAt('enemy-c', 'M2', 1_000_000_000), // adjacent to B, survives B's splash
+            ],
+            __testTapActors: (actors) => {
+                // Pre-seed B's pending bomb so it splashes when B dies.
+                const b = actors.find((a) => a.id === 'enemy-b');
+                if (b) b.pendingBombs.push(bBomb);
+            },
+        });
+
+        const result = runCombat(input);
+        const round = result.rounds[0];
+
+        // A → B splash fired (A's bomb).
+        expect(round.perActorSplash?.['enemy-b']).toBe(EXPECTED_SPLASH);
+        // B → C splash fired (B's bomb; chain worked).
+        expect(round.perActorSplash?.['enemy-c']).toBe(expectedBSplash);
+        // C is alive (didn't die from B's small splash).
+        expect(round.perActorSplash?.['enemy-a']).toBeUndefined(); // A was the first to die
+    });
+
+    // ─── (c) Non-positional no-op ─────────────────────────────────────────────
+    // No ships have board positions. A ship has pendingBombs and dies.
+    // The victim.position gate (Task 1) must prevent any splash.
+    it('(c) non-positional: dying bombed ship with no position produces no splash', () => {
+        idc = 0;
+        // Override BASE to remove all positions. The focus attacker fires and kills the dummy
+        // enemy (via the skill), which has no position. The bomb is applied to it. On death,
+        // victim.position === undefined → splash gate blocks.
+        const noPositionInput: CombatEngineInput = {
+            attack: 5000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [bombAndStrike()] },
+            enemyDefense: 0,
+            enemyHp: 5000, // dies to first hit → bomb is pending at death
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            healTargetId: 'attacker',
+            // NO position on the attacker, and NO enemyAttackers (no positions at all).
+        };
+
+        const result = runCombat(noPositionInput);
+        const round = result.rounds[0];
+
+        // No splash: victim.position was undefined → gate blocked.
+        expect(round.perActorSplash).toBeUndefined();
+    });
+
+    // ─── (d) Multi-bomb / multi-ally ─────────────────────────────────────────
+    // A dying ship has TWO pending bombs (tiers 100 and 300) and TWO living adjacent allies.
+    // Each ally takes the SUM of both bombs' splash. One bomb carries a non-neutral affinityMult
+    // (1.5) — the splash formula must ignore it (no-affinity proof, end-to-end).
+    it('(d) multi-bomb + multi-ally: each ally takes sum of all bombs; affinityMult is ignored', () => {
+        idc = 0;
+        // Carrier at M4 (dies to direct hit). Adjacent allies at M3 and B4.
+        // M4 (q=2,r=1); M3 (q=1,r=1) Δ=(-1,0) ✓ adjacent.
+        // B4 (q=2,r=2); M4 Δ=(0,1) ✓ adjacent.
+        // Bomb 1: tier=100, stacks=1, damagePerStack=1000, affinityMult=1.5 (must NOT affect splash).
+        //   splash = 1×1000×0.25 = 250.
+        // Bomb 2: tier=300, stacks=1, damagePerStack=2000, affinityMult=1 (neutral).
+        //   splash = 1×2000×0.75 = 1500.
+        // Expected per-ally: 250 + 1500 = 1750.
+        const bomb1: PendingBomb = {
+            countdown: 3,
+            damagePerStack: 1000,
+            stacks: 1,
+            tier: 100,
+            sourceId: 'attacker',
+            affinityMult: 1.5, // non-neutral — must not change splash
+            detonationDamageModifier: 0,
+        };
+        const bomb2: PendingBomb = {
+            countdown: 3,
+            damagePerStack: 2000,
+            stacks: 1,
+            tier: 300,
+            sourceId: 'attacker',
+            affinityMult: 1,
+            detonationDamageModifier: 0,
+        };
+        const expectedPerAlly = splashDamageForBomb(bomb1) + splashDamageForBomb(bomb2); // 250 + 1500 = 1750
+
+        // Use a skill-free carrier to isolate the pre-seeded bombs (no bomb from the skill).
+        const isolatedInput = BASE({
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active',
+                        abilities: [
+                            ab({
+                                type: 'damage',
+                                target: 'enemy',
+                                config: { type: 'damage', multiplier: 100 },
+                            }),
+                        ],
+                    },
+                ],
+            },
+            enemyAttackers: [
+                enemyAt('enemy-carrier', 'M4', 5000),
+                enemyAt('enemy-ally1', 'M3', 1_000_000_000),
+                enemyAt('enemy-ally2', 'B4', 1_000_000_000),
+            ],
+            __testTapActors: (actors) => {
+                const carrier = actors.find((a) => a.id === 'enemy-carrier');
+                if (carrier) {
+                    carrier.pendingBombs.push(bomb1, bomb2);
+                }
+            },
+        });
+
+        const result = runCombat(isolatedInput);
+        const round = result.rounds[0];
+
+        expect(round.perActorSplash?.['enemy-ally1']).toBe(expectedPerAlly);
+        expect(round.perActorSplash?.['enemy-ally2']).toBe(expectedPerAlly);
+    });
+
+    // ─── (e) Dead applier still splashes ─────────────────────────────────────
+    // The bomb's sourceId refers to an actor that is already destroyed (destroyedRound set)
+    // when the carrier dies. The splash must still fire (no applier-liveness check).
+    it('(e) dead applier: splash fires even when the bomb sourceId actor is already destroyed', () => {
+        idc = 0;
+        // Carrier at M4, ally at M3. Carrier has a pre-seeded bomb whose sourceId is
+        // 'enemy-dead-applier', a separate enemy actor that is already marked destroyed
+        // (destroyedRound set before rounds start via __testTapActors).
+        const deadApplierBomb: PendingBomb = {
+            countdown: 3,
+            damagePerStack: 5000 * (BOMB_TIER / 100), // same math as EXPECTED_SPLASH
+            stacks: BOMB_STACKS,
+            tier: BOMB_TIER,
+            sourceId: 'enemy-dead-applier',
+            affinityMult: 1,
+            detonationDamageModifier: 0,
+        };
+        const expectedDeadApplierSplash = splashDamageForBomb(deadApplierBomb); // 10000
+
+        const input = BASE({
+            // Use a damage-only skill (no bomb from skill) so only the pre-seeded bomb fires.
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active',
+                        abilities: [
+                            ab({
+                                type: 'damage',
+                                target: 'enemy',
+                                config: { type: 'damage', multiplier: 100 },
+                            }),
+                        ],
+                    },
+                ],
+            },
+            enemyAttackers: [
+                enemyAt('enemy-carrier', 'M4', 5000),
+                enemyAt('enemy-mid', 'M3', 1_000_000_000),
+                // The applier is part of the roster but at a non-adjacent position and pre-marked dead.
+                enemyAt('enemy-dead-applier', 'M1', 1_000_000_000),
+            ],
+            __testTapActors: (actors) => {
+                const carrier = actors.find((a) => a.id === 'enemy-carrier');
+                if (carrier) carrier.pendingBombs.push(deadApplierBomb);
+                // Mark the applier as already destroyed before rounds start.
+                const applier = actors.find((a) => a.id === 'enemy-dead-applier');
+                if (applier) applier.destroyedRound = 0;
+            },
+        });
+
+        const result = runCombat(input);
+        const round = result.rounds[0];
+
+        // Splash fired despite the applier being dead.
+        expect(round.perActorSplash?.['enemy-mid']).toBe(expectedDeadApplierSplash);
+    });
+
+    // ─── (f) Cheat-death survivor does NOT splash ─────────────────────────────
+    // An enemy with pendingBombs takes a lethal hit but has a recurring Cheat-Death aura
+    // (registered via a passive self-buff ability). The engine intercepts the death, sets
+    // HP to 1 — the ship never enters the splash branch → no splash fires.
+    it('(f) cheat-death save: fatal hit intercepted → ship survives → no splash', () => {
+        idc = 0;
+        // Front enemy (M4) HP 5000 → lethal 5000 hit. Has Cheat Death aura via passive ability.
+        // Mid ally at M3 (adjacent). If splash fired, ally would take EXPECTED_SPLASH; it must not.
+        const cheatDeathAuraAbility = ab({
+            type: 'buff',
+            target: 'self',
+            trigger: 'on-cast', // trigger unused for aura; aura is always-active
+            config: {
+                type: 'buff',
+                buffName: 'Cheat Death',
+                parsedEffects: {},
+                stacks: 1,
+                isStackable: false,
+                duration: 'recurring', // recurring → registered as aura, always active
+            },
+        });
+        const cheatDeathEnemy: NonNullable<CombatEngineInput['enemyAttackers']>[number] = {
+            id: 'enemy-cheat-death',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 5000, speed: 1 },
+            chargeCount: 0,
+            startCharged: false,
+            position: 'M4',
+            // Passive slot → castPathCheatDeath = false → registered as aura
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'passive',
+                        abilities: [cheatDeathAuraAbility],
+                    },
+                ],
+            },
+        };
+        const input = BASE({
+            enemyAttackers: [
+                cheatDeathEnemy,
+                enemyAt('enemy-mid', 'M3', 1_000_000_000), // adjacent ally — MUST take no splash
+            ],
+        });
+
+        const result = runCombat(input);
+        const round = result.rounds[0];
+
+        // Cheat Death intercepted → no splash → enemy-mid is unharmed by splash.
+        expect(round.perActorSplash).toBeUndefined();
+        // enemy-mid took no damage at all (outside the base footprint, no splash fired).
+        expect(round.perTargetDamage?.['enemy-mid']).toBeUndefined();
+    });
 });

--- a/src/utils/combat/__tests__/engine.events.test.ts
+++ b/src/utils/combat/__tests__/engine.events.test.ts
@@ -741,6 +741,107 @@ describe('Phase 3 Task 3 — event shape and timing', () => {
         }
     });
 
+    // Case 5b: bomb with detonationDamageModifier=100 timed-detonates for 2× the baseline.
+    // Validates that processBombs scales the burst by (1 + detonationDamageModifier/100).
+    it('timed bomb detonation scales by detonationDamageModifier: modifier 100 doubles the burst', () => {
+        // A ship skill that applies a Bomb DoT with countdown 2 on the active slot.
+        // The passive slot carries a modifier ability with channel 'detonationDamage', value 100
+        // (a +100% detonation damage multiplier → burst should be 2× the baseline).
+        // Baseline run: same skills but no passive modifier → burst at 1×.
+        // Modified run: passive modifier 100 → burst at 2×.
+        // At default speeds: attacker acts round 1 (bomb applied), enemy acts round 1 (countdown
+        // decrements to 1), attacker acts round 2 (charged slot, no new bomb), enemy acts round 2
+        // (countdown → 0 → detonates). We compare the bomb-detonated damage between the two runs.
+        const bombSkillsBase = (): ShipSkills => ({
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        ab({ type: 'damage', config: { type: 'damage', multiplier: 120 } }),
+                        ab({
+                            type: 'dot',
+                            config: {
+                                type: 'dot',
+                                dotType: 'bomb',
+                                tier: 10,
+                                stacks: 2,
+                                duration: 2,
+                            },
+                        }),
+                    ],
+                },
+                {
+                    slot: 'charged',
+                    abilities: [
+                        ab({ type: 'damage', config: { type: 'damage', multiplier: 280 } }),
+                    ],
+                },
+            ],
+        });
+
+        const bombSkillsWithModifier = (): ShipSkills => ({
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        ab({ type: 'damage', config: { type: 'damage', multiplier: 120 } }),
+                        ab({
+                            type: 'dot',
+                            config: {
+                                type: 'dot',
+                                dotType: 'bomb',
+                                tier: 10,
+                                stacks: 2,
+                                duration: 2,
+                            },
+                        }),
+                    ],
+                },
+                {
+                    slot: 'charged',
+                    abilities: [
+                        ab({ type: 'damage', config: { type: 'damage', multiplier: 280 } }),
+                    ],
+                },
+                {
+                    slot: 'passive',
+                    abilities: [
+                        ab({
+                            type: 'modifier',
+                            target: 'self',
+                            trigger: 'on-cast',
+                            config: {
+                                type: 'modifier',
+                                channel: 'detonationDamage',
+                                value: 100,
+                                isMultiplicative: false,
+                            },
+                        }),
+                    ],
+                },
+            ],
+        });
+
+        const { events: baseEvents } = collect(
+            baseInput({ shipSkills: bombSkillsBase(), numRounds: 4 })
+        );
+        const { events: modEvents } = collect(
+            baseInput({ shipSkills: bombSkillsWithModifier(), numRounds: 4 })
+        );
+
+        const baseBurst = baseEvents
+            .filter((e) => e.type === 'bomb-detonated')
+            .reduce((sum, e) => sum + (e.type === 'bomb-detonated' ? e.damage : 0), 0);
+        const modBurst = modEvents
+            .filter((e) => e.type === 'bomb-detonated')
+            .reduce((sum, e) => sum + (e.type === 'bomb-detonated' ? e.damage : 0), 0);
+
+        // With modifier 0: burst = stacks × damagePerStack × affinityMult × (1 + 0/100) = baseBurst
+        // With modifier 100: burst = stacks × damagePerStack × affinityMult × (1 + 100/100) = 2 × baseBurst
+        expect(baseBurst).toBeGreaterThan(0);
+        expect(modBurst).toBe(baseBurst * 2);
+    });
+
     // Case 6: a team actor's landed timed debuff emits debuff-applied with sourceId = team
     // actor id, on every application round (not just the first).
     it("team actor's landed timed debuff emits debuff-applied with that actor's sourceId on every application round", () => {

--- a/src/utils/combat/__tests__/engine.events.test.ts
+++ b/src/utils/combat/__tests__/engine.events.test.ts
@@ -842,6 +842,116 @@ describe('Phase 3 Task 3 — event shape and timing', () => {
         expect(modBurst).toBe(baseBurst * 2);
     });
 
+    // Case 5c: skill-triggered bomb detonation scales by detonator's detonationDamageModifier.
+    // The DETONATING actor carries a passive modifier +50% detonation damage (value 50 → mult 1.5).
+    // Validates that the skill-triggered detonate() path scales by (1 + detonationDamageModifier/100).
+    it('skill-triggered bomb detonation scales by detonationDamageModifier: modifier 50 gives 1.5× burst', () => {
+        // Active slot: apply bomb (tier 10, 2 stacks, duration 3 — survives until charged fires).
+        // Charged slot: detonate bomb (powerPct 100).
+        // Passive slot (modifier run only): detonationDamage modifier +50 → mult 1.5.
+        // chargeCount 3, startCharged false → round 4 fires charged (detonate).
+        // Baseline: same layout without the passive modifier.
+        // Compare sum of bomb-detonated damage across both runs.
+        const skillsBase = (): ShipSkills => ({
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        ab({ type: 'damage', config: { type: 'damage', multiplier: 120 } }),
+                        ab({
+                            type: 'dot',
+                            config: {
+                                type: 'dot',
+                                dotType: 'bomb',
+                                tier: 10,
+                                stacks: 2,
+                                duration: 3,
+                            },
+                        }),
+                    ],
+                },
+                {
+                    slot: 'charged',
+                    abilities: [
+                        ab({
+                            type: 'detonate-dot',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            config: { type: 'detonate-dot', dotType: 'bomb', powerPct: 100 },
+                        }),
+                    ],
+                },
+            ],
+        });
+
+        const skillsWithModifier = (): ShipSkills => ({
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        ab({ type: 'damage', config: { type: 'damage', multiplier: 120 } }),
+                        ab({
+                            type: 'dot',
+                            config: {
+                                type: 'dot',
+                                dotType: 'bomb',
+                                tier: 10,
+                                stacks: 2,
+                                duration: 3,
+                            },
+                        }),
+                    ],
+                },
+                {
+                    slot: 'charged',
+                    abilities: [
+                        ab({
+                            type: 'detonate-dot',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            config: { type: 'detonate-dot', dotType: 'bomb', powerPct: 100 },
+                        }),
+                    ],
+                },
+                {
+                    slot: 'passive',
+                    abilities: [
+                        ab({
+                            type: 'modifier',
+                            target: 'self',
+                            trigger: 'on-cast',
+                            config: {
+                                type: 'modifier',
+                                channel: 'detonationDamage',
+                                value: 50,
+                                isMultiplicative: false,
+                            },
+                        }),
+                    ],
+                },
+            ],
+        });
+
+        const { events: baseEvents } = collect(
+            baseInput({ shipSkills: skillsBase(), numRounds: 4 })
+        );
+        const { events: modEvents } = collect(
+            baseInput({ shipSkills: skillsWithModifier(), numRounds: 4 })
+        );
+
+        const baseBurstSkill = baseEvents
+            .filter((e) => e.type === 'bomb-detonated')
+            .reduce((sum, e) => sum + (e.type === 'bomb-detonated' ? e.damage : 0), 0);
+        const modBurstSkill = modEvents
+            .filter((e) => e.type === 'bomb-detonated')
+            .reduce((sum, e) => sum + (e.type === 'bomb-detonated' ? e.damage : 0), 0);
+
+        // With modifier 0: burst = baseline
+        // With modifier 50: burst = baseline × 1.5
+        expect(baseBurstSkill).toBeGreaterThan(0);
+        expect(modBurstSkill).toBeCloseTo(baseBurstSkill * 1.5, 5);
+    });
+
     // Case 6: a team actor's landed timed debuff emits debuff-applied with sourceId = team
     // actor id, on every application round (not just the first).
     it("team actor's landed timed debuff emits debuff-applied with that actor's sourceId on every application round", () => {

--- a/src/utils/combat/__tests__/engine.events.test.ts
+++ b/src/utils/combat/__tests__/engine.events.test.ts
@@ -952,6 +952,226 @@ describe('Phase 3 Task 3 — event shape and timing', () => {
         expect(modBurstSkill).toBeCloseTo(baseBurstSkill * 1.5, 5);
     });
 
+    // Case 5d: skill-triggered Inferno detonation scales by detonator's detonationDamageModifier.
+    // The DETONATING actor carries a passive modifier +50% detonation damage (value 50 → mult 1.5).
+    // Validates that the detonate() inferno branch scales by (1 + detonationDamageModifier/100).
+    it('skill-triggered inferno detonation scales by detonationDamageModifier: modifier 50 gives 1.5× burst', () => {
+        // Active slot: apply inferno DoT (tier 8, stacks 3, duration 3 — survives until charged fires).
+        // Charged slot: detonate inferno (powerPct 100).
+        // Passive slot (modifier run only): detonationDamage modifier +50 → mult 1.5.
+        // chargeCount 3, startCharged false → round 4 fires charged (detonate).
+        // Baseline: same layout without the passive modifier.
+        // Compare sum of dot-detonated damage across both runs.
+        const infernoSkillsBase = (): ShipSkills => ({
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        ab({ type: 'damage', config: { type: 'damage', multiplier: 120 } }),
+                        ab({
+                            type: 'dot',
+                            config: {
+                                type: 'dot',
+                                dotType: 'inferno',
+                                tier: 8,
+                                stacks: 3,
+                                duration: 3,
+                            },
+                        }),
+                    ],
+                },
+                {
+                    slot: 'charged',
+                    abilities: [
+                        ab({
+                            type: 'detonate-dot',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            config: { type: 'detonate-dot', dotType: 'inferno', powerPct: 100 },
+                        }),
+                    ],
+                },
+            ],
+        });
+
+        const infernoSkillsWithModifier = (): ShipSkills => ({
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        ab({ type: 'damage', config: { type: 'damage', multiplier: 120 } }),
+                        ab({
+                            type: 'dot',
+                            config: {
+                                type: 'dot',
+                                dotType: 'inferno',
+                                tier: 8,
+                                stacks: 3,
+                                duration: 3,
+                            },
+                        }),
+                    ],
+                },
+                {
+                    slot: 'charged',
+                    abilities: [
+                        ab({
+                            type: 'detonate-dot',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            config: { type: 'detonate-dot', dotType: 'inferno', powerPct: 100 },
+                        }),
+                    ],
+                },
+                {
+                    slot: 'passive',
+                    abilities: [
+                        ab({
+                            type: 'modifier',
+                            target: 'self',
+                            trigger: 'on-cast',
+                            config: {
+                                type: 'modifier',
+                                channel: 'detonationDamage',
+                                value: 50,
+                                isMultiplicative: false,
+                            },
+                        }),
+                    ],
+                },
+            ],
+        });
+
+        const { events: baseEvents } = collect(
+            baseInput({ shipSkills: infernoSkillsBase(), numRounds: 4 })
+        );
+        const { events: modEvents } = collect(
+            baseInput({ shipSkills: infernoSkillsWithModifier(), numRounds: 4 })
+        );
+
+        const baseBurst = baseEvents
+            .filter((e) => e.type === 'dot-detonated')
+            .reduce((sum, e) => sum + (e.type === 'dot-detonated' ? e.damage : 0), 0);
+        const modBurst = modEvents
+            .filter((e) => e.type === 'dot-detonated')
+            .reduce((sum, e) => sum + (e.type === 'dot-detonated' ? e.damage : 0), 0);
+
+        // With modifier 0: burst = baseline
+        // With modifier 50: burst = baseline × 1.5
+        expect(baseBurst).toBeGreaterThan(0);
+        expect(modBurst).toBeCloseTo(baseBurst * 1.5, 5);
+    });
+
+    // Case 5e: skill-triggered Corrosion detonation scales by detonator's detonationDamageModifier.
+    // The DETONATING actor carries a passive modifier +50% detonation damage (value 50 → mult 1.5).
+    // Validates that the detonate() corrosion branch scales by (1 + detonationDamageModifier/100).
+    it('skill-triggered corrosion detonation scales by detonationDamageModifier: modifier 50 gives 1.5× burst', () => {
+        // Active slot: apply corrosion DoT (tier 5, stacks 2, duration 3 — survives until charged fires).
+        // Charged slot: detonate corrosion (powerPct 100).
+        // Passive slot (modifier run only): detonationDamage modifier +50 → mult 1.5.
+        // chargeCount 3, startCharged false → round 4 fires charged (detonate).
+        // Baseline: same layout without the passive modifier.
+        // Compare sum of dot-detonated damage across both runs.
+        const corrosionSkillsBase = (): ShipSkills => ({
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        ab({ type: 'damage', config: { type: 'damage', multiplier: 120 } }),
+                        ab({
+                            type: 'dot',
+                            config: {
+                                type: 'dot',
+                                dotType: 'corrosion',
+                                tier: 5,
+                                stacks: 2,
+                                duration: 3,
+                            },
+                        }),
+                    ],
+                },
+                {
+                    slot: 'charged',
+                    abilities: [
+                        ab({
+                            type: 'detonate-dot',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            config: { type: 'detonate-dot', dotType: 'corrosion', powerPct: 100 },
+                        }),
+                    ],
+                },
+            ],
+        });
+
+        const corrosionSkillsWithModifier = (): ShipSkills => ({
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        ab({ type: 'damage', config: { type: 'damage', multiplier: 120 } }),
+                        ab({
+                            type: 'dot',
+                            config: {
+                                type: 'dot',
+                                dotType: 'corrosion',
+                                tier: 5,
+                                stacks: 2,
+                                duration: 3,
+                            },
+                        }),
+                    ],
+                },
+                {
+                    slot: 'charged',
+                    abilities: [
+                        ab({
+                            type: 'detonate-dot',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            config: { type: 'detonate-dot', dotType: 'corrosion', powerPct: 100 },
+                        }),
+                    ],
+                },
+                {
+                    slot: 'passive',
+                    abilities: [
+                        ab({
+                            type: 'modifier',
+                            target: 'self',
+                            trigger: 'on-cast',
+                            config: {
+                                type: 'modifier',
+                                channel: 'detonationDamage',
+                                value: 50,
+                                isMultiplicative: false,
+                            },
+                        }),
+                    ],
+                },
+            ],
+        });
+
+        const { events: baseEvents } = collect(
+            baseInput({ shipSkills: corrosionSkillsBase(), numRounds: 4 })
+        );
+        const { events: modEvents } = collect(
+            baseInput({ shipSkills: corrosionSkillsWithModifier(), numRounds: 4 })
+        );
+
+        const baseBurst = baseEvents
+            .filter((e) => e.type === 'dot-detonated')
+            .reduce((sum, e) => sum + (e.type === 'dot-detonated' ? e.damage : 0), 0);
+        const modBurst = modEvents
+            .filter((e) => e.type === 'dot-detonated')
+            .reduce((sum, e) => sum + (e.type === 'dot-detonated' ? e.damage : 0), 0);
+
+        // With modifier 0: burst = baseline
+        // With modifier 50: burst = baseline × 1.5
+        expect(baseBurst).toBeGreaterThan(0);
+        expect(modBurst).toBeCloseTo(baseBurst * 1.5, 5);
+    });
+
     // Case 6: a team actor's landed timed debuff emits debuff-applied with sourceId = team
     // actor id, on every application round (not just the first).
     it("team actor's landed timed debuff emits debuff-applied with that actor's sourceId on every application round", () => {

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -5780,30 +5780,22 @@ describe('Lifeline (incoming-shield-grant)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Task 1.5: Voidfire Catalyst implant — detonationDamage modifier (registry fold)
+// Tasks 1.5 + 3.3: Voidfire Catalyst implant — detonationDamage + bombSplashDamage modifiers
 // ---------------------------------------------------------------------------
 //
-// Voidfire Catalyst is an ultimate implant whose description states:
-//   common:    2% more detonation damage (+ 4% splash — later phase)
-//   uncommon:  4% more detonation damage (+ 8% splash — later phase)
-//   rare:      splash-only (24%) — no detonation half → builder returns undefined
-//   epic:      8% more detonation damage (+ 16% splash — later phase)
-//   legendary: splash-only (40%) — no detonation half → builder returns undefined
-//
-// This phase wires ONLY the detonationDamage modifier half (rare/legendary → no ability).
-// The test exercises the REAL registry through buildEquipmentAbilities and asserts:
-//   (a) common  → 1 modifier ability with channel 'detonationDamage', value 2
-//   (b) uncommon→ 1 modifier ability with channel 'detonationDamage', value 4
-//   (c) epic    → 1 modifier ability with channel 'detonationDamage', value 8
-//   (d) rare    → NO detonationDamage ability in the output (builder returns undefined)
-//   (e) legendary → NO detonationDamage ability in the output (builder returns undefined)
+// Voidfire Catalyst is an ultimate implant. Both halves are now wired:
+//   common:    detonationDamage 2 + bombSplashDamage 4    → 2 abilities
+//   uncommon:  detonationDamage 4 + bombSplashDamage 8    → 2 abilities
+//   rare:      bombSplashDamage 24 only (no detonation)   → 1 ability
+//   epic:      detonationDamage 8 + bombSplashDamage 16   → 2 abilities
+//   legendary: bombSplashDamage 40 only (no detonation)   → 1 ability
 
-describe('Task 1.5 — Voidfire Catalyst: detonationDamage modifier (registry fold)', () => {
+describe('Tasks 1.5 + 3.3 — Voidfire Catalyst: detonationDamage + bombSplashDamage modifiers', () => {
     /**
      * Build an implant piece with setBonus 'VOIDFIRE_CATALYST' at the given rarity
      * and return the abilities produced by buildEquipmentAbilities.
      */
-    function voidirefireAbilities(rarity: GearPiece['rarity']) {
+    function voidfireAbilities(rarity: GearPiece['rarity']) {
         const id = `voidfire-${rarity}`;
         const piece = makePiece({
             id,
@@ -5826,21 +5818,40 @@ describe('Task 1.5 — Voidfire Catalyst: detonationDamage modifier (registry fo
         );
     }
 
-    it('common → 1 ability; modifier channel detonationDamage, value 2', () => {
-        const abilities = voidirefireAbilities('common');
+    /** Extract the first modifier ability with channel 'bombSplashDamage', if any. */
+    function findSplashAbility(abilities: ReturnType<typeof buildEquipmentAbilities>) {
+        return abilities.find(
+            (a) =>
+                a.type === 'modifier' &&
+                'channel' in a.config &&
+                (a.config as { channel: string }).channel === 'bombSplashDamage'
+        );
+    }
+
+    it('common → 2 abilities: detonationDamage value 2 AND bombSplashDamage value 4', () => {
+        const abilities = voidfireAbilities('common');
+        expect(abilities).toHaveLength(2);
         const det = findDetAbility(abilities);
         expect(det).toBeDefined();
-        expect(det!.type).toBe('modifier');
         expect(det!.config).toMatchObject({
             type: 'modifier',
             channel: 'detonationDamage',
             value: 2,
             isMultiplicative: false,
         });
+        const splash = findSplashAbility(abilities);
+        expect(splash).toBeDefined();
+        expect(splash!.config).toMatchObject({
+            type: 'modifier',
+            channel: 'bombSplashDamage',
+            value: 4,
+            isMultiplicative: false,
+        });
     });
 
-    it('uncommon → 1 ability; modifier channel detonationDamage, value 4', () => {
-        const abilities = voidirefireAbilities('uncommon');
+    it('uncommon → 2 abilities: detonationDamage value 4 AND bombSplashDamage value 8', () => {
+        const abilities = voidfireAbilities('uncommon');
+        expect(abilities).toHaveLength(2);
         const det = findDetAbility(abilities);
         expect(det).toBeDefined();
         expect(det!.config).toMatchObject({
@@ -5849,10 +5860,19 @@ describe('Task 1.5 — Voidfire Catalyst: detonationDamage modifier (registry fo
             value: 4,
             isMultiplicative: false,
         });
+        const splash = findSplashAbility(abilities);
+        expect(splash).toBeDefined();
+        expect(splash!.config).toMatchObject({
+            type: 'modifier',
+            channel: 'bombSplashDamage',
+            value: 8,
+            isMultiplicative: false,
+        });
     });
 
-    it('epic → 1 ability; modifier channel detonationDamage, value 8', () => {
-        const abilities = voidirefireAbilities('epic');
+    it('epic → 2 abilities: detonationDamage value 8 AND bombSplashDamage value 16', () => {
+        const abilities = voidfireAbilities('epic');
+        expect(abilities).toHaveLength(2);
         const det = findDetAbility(abilities);
         expect(det).toBeDefined();
         expect(det!.config).toMatchObject({
@@ -5861,17 +5881,43 @@ describe('Task 1.5 — Voidfire Catalyst: detonationDamage modifier (registry fo
             value: 8,
             isMultiplicative: false,
         });
+        const splash = findSplashAbility(abilities);
+        expect(splash).toBeDefined();
+        expect(splash!.config).toMatchObject({
+            type: 'modifier',
+            channel: 'bombSplashDamage',
+            value: 16,
+            isMultiplicative: false,
+        });
     });
 
-    it('rare → NO detonationDamage ability (splash-only rarity, builder returns undefined)', () => {
-        const abilities = voidirefireAbilities('rare');
+    it('rare → 1 ability: bombSplashDamage value 24, NO detonationDamage', () => {
+        const abilities = voidfireAbilities('rare');
+        expect(abilities).toHaveLength(1);
         const det = findDetAbility(abilities);
         expect(det).toBeUndefined();
+        const splash = findSplashAbility(abilities);
+        expect(splash).toBeDefined();
+        expect(splash!.config).toMatchObject({
+            type: 'modifier',
+            channel: 'bombSplashDamage',
+            value: 24,
+            isMultiplicative: false,
+        });
     });
 
-    it('legendary → NO detonationDamage ability (splash-only rarity, builder returns undefined)', () => {
-        const abilities = voidirefireAbilities('legendary');
+    it('legendary → 1 ability: bombSplashDamage value 40, NO detonationDamage', () => {
+        const abilities = voidfireAbilities('legendary');
+        expect(abilities).toHaveLength(1);
         const det = findDetAbility(abilities);
         expect(det).toBeUndefined();
+        const splash = findSplashAbility(abilities);
+        expect(splash).toBeDefined();
+        expect(splash!.config).toMatchObject({
+            type: 'modifier',
+            channel: 'bombSplashDamage',
+            value: 40,
+            isMultiplicative: false,
+        });
     });
 });

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -5743,6 +5743,7 @@ describe('Lifeline (incoming-shield-grant)', () => {
     );
 
     // ── Case 3: once per battle ───────────────────────────────────────────────────
+
     //
     // Per-hit 4000 over 5 rounds. maxHp 10000, attack 2000, T = 3000.
     //   R1: HP 10000 → 6000 (pool 0).
@@ -5776,4 +5777,101 @@ describe('Lifeline (incoming-shield-grant)', () => {
             expect(carrierDied(result)).toBe(true);
         }
     );
+});
+
+// ---------------------------------------------------------------------------
+// Task 1.5: Voidfire Catalyst implant — detonationDamage modifier (registry fold)
+// ---------------------------------------------------------------------------
+//
+// Voidfire Catalyst is an ultimate implant whose description states:
+//   common:    2% more detonation damage (+ 4% splash — later phase)
+//   uncommon:  4% more detonation damage (+ 8% splash — later phase)
+//   rare:      splash-only (24%) — no detonation half → builder returns undefined
+//   epic:      8% more detonation damage (+ 16% splash — later phase)
+//   legendary: splash-only (40%) — no detonation half → builder returns undefined
+//
+// This phase wires ONLY the detonationDamage modifier half (rare/legendary → no ability).
+// The test exercises the REAL registry through buildEquipmentAbilities and asserts:
+//   (a) common  → 1 modifier ability with channel 'detonationDamage', value 2
+//   (b) uncommon→ 1 modifier ability with channel 'detonationDamage', value 4
+//   (c) epic    → 1 modifier ability with channel 'detonationDamage', value 8
+//   (d) rare    → NO detonationDamage ability in the output (builder returns undefined)
+//   (e) legendary → NO detonationDamage ability in the output (builder returns undefined)
+
+describe('Task 1.5 — Voidfire Catalyst: detonationDamage modifier (registry fold)', () => {
+    /**
+     * Build an implant piece with setBonus 'VOIDFIRE_CATALYST' at the given rarity
+     * and return the abilities produced by buildEquipmentAbilities.
+     */
+    function voidirefireAbilities(rarity: GearPiece['rarity']) {
+        const id = `voidfire-${rarity}`;
+        const piece = makePiece({
+            id,
+            slot: 'implant_major',
+            rarity,
+            setBonus: 'VOIDFIRE_CATALYST',
+        });
+        const ship = makeShip({ implants: { implant_major: id } });
+        const getGearPiece = makeGetGearPiece({ [id]: piece });
+        return buildEquipmentAbilities(ship, getGearPiece);
+    }
+
+    /** Extract the first modifier ability with channel 'detonationDamage', if any. */
+    function findDetAbility(abilities: ReturnType<typeof buildEquipmentAbilities>) {
+        return abilities.find(
+            (a) =>
+                a.type === 'modifier' &&
+                'channel' in a.config &&
+                (a.config as { channel: string }).channel === 'detonationDamage'
+        );
+    }
+
+    it('common → 1 ability; modifier channel detonationDamage, value 2', () => {
+        const abilities = voidirefireAbilities('common');
+        const det = findDetAbility(abilities);
+        expect(det).toBeDefined();
+        expect(det!.type).toBe('modifier');
+        expect(det!.config).toMatchObject({
+            type: 'modifier',
+            channel: 'detonationDamage',
+            value: 2,
+            isMultiplicative: false,
+        });
+    });
+
+    it('uncommon → 1 ability; modifier channel detonationDamage, value 4', () => {
+        const abilities = voidirefireAbilities('uncommon');
+        const det = findDetAbility(abilities);
+        expect(det).toBeDefined();
+        expect(det!.config).toMatchObject({
+            type: 'modifier',
+            channel: 'detonationDamage',
+            value: 4,
+            isMultiplicative: false,
+        });
+    });
+
+    it('epic → 1 ability; modifier channel detonationDamage, value 8', () => {
+        const abilities = voidirefireAbilities('epic');
+        const det = findDetAbility(abilities);
+        expect(det).toBeDefined();
+        expect(det!.config).toMatchObject({
+            type: 'modifier',
+            channel: 'detonationDamage',
+            value: 8,
+            isMultiplicative: false,
+        });
+    });
+
+    it('rare → NO detonationDamage ability (splash-only rarity, builder returns undefined)', () => {
+        const abilities = voidirefireAbilities('rare');
+        const det = findDetAbility(abilities);
+        expect(det).toBeUndefined();
+    });
+
+    it('legendary → NO detonationDamage ability (splash-only rarity, builder returns undefined)', () => {
+        const abilities = voidirefireAbilities('legendary');
+        const det = findDetAbility(abilities);
+        expect(det).toBeUndefined();
+    });
 });

--- a/src/utils/combat/bombSplash.ts
+++ b/src/utils/combat/bombSplash.ts
@@ -9,8 +9,12 @@ export function splashPctForTier(tier: number): number {
 /** Splash damage one pending bomb deals to ONE adjacent ally when the carrier dies.
  *  = stacks × damagePerStack × splashPct/100 × (1 + splashModifierPct/100). No affinity
  *  (bombs/DoTs are not affinity-scaled). `splashModifierPct` is the applier's Voidfire
- *  bonus (wired in a later phase); defaults to 0. */
-export function splashDamageForBomb(bomb: PendingBomb, splashModifierPct = 0): number {
+ *  bonus, snapshotted on the bomb at application; defaults to the bomb's own
+ *  `splashModifier` so callers can't silently undercount by omitting it. */
+export function splashDamageForBomb(
+    bomb: PendingBomb,
+    splashModifierPct = bomb.splashModifier
+): number {
     return (
         bomb.stacks *
         bomb.damagePerStack *

--- a/src/utils/combat/bombSplash.ts
+++ b/src/utils/combat/bombSplash.ts
@@ -1,0 +1,20 @@
+import type { PendingBomb } from './state';
+
+/** Splash fraction (percent) of a bomb's damage dealt to each adjacent ally when the
+ *  carrier dies before detonation. Scales by bomb tier: 100→25, 200→50, 300→75 (tier/4). */
+export function splashPctForTier(tier: number): number {
+    return tier / 4;
+}
+
+/** Splash damage one pending bomb deals to ONE adjacent ally when the carrier dies.
+ *  = stacks × damagePerStack × splashPct/100 × (1 + splashModifierPct/100). No affinity
+ *  (bombs/DoTs are not affinity-scaled). `splashModifierPct` is the applier's Voidfire
+ *  bonus (wired in a later phase); defaults to 0. */
+export function splashDamageForBomb(bomb: PendingBomb, splashModifierPct = 0): number {
+    return (
+        bomb.stacks *
+        bomb.damagePerStack *
+        (splashPctForTier(bomb.tier) / 100) *
+        (1 + splashModifierPct / 100)
+    );
+}

--- a/src/utils/combat/effectiveStats.ts
+++ b/src/utils/combat/effectiveStats.ts
@@ -152,6 +152,8 @@ export interface EffectiveDamageStats {
     effectivePen: number;
     /** toDotAndPenModifiers(abilitySelfEffects, []).dotDamageModifier — self Out. DoT, for dotMult. */
     selfDotDamageModifier: number;
+    /** mod.detonationDamage — outgoing detonation-burst multiplier delta (percentage points). */
+    detonationDamageModifier: number;
     /** Full summed buff totals (layers 1+2+3+4) — exposes outgoingDamage/heal channels for the turn loop. */
     totals: ReturnType<typeof calculateBuffTotals>;
 }
@@ -212,6 +214,7 @@ export function effectiveDamageStatsOf(args: {
             mod.defensePenetration +
             dotPen.defensePenetrationBuff,
         selfDotDamageModifier: dotPen.dotDamageModifier + mod.dotDamage,
+        detonationDamageModifier: mod.detonationDamage,
         totals,
     };
 }

--- a/src/utils/combat/effectiveStats.ts
+++ b/src/utils/combat/effectiveStats.ts
@@ -154,6 +154,8 @@ export interface EffectiveDamageStats {
     selfDotDamageModifier: number;
     /** mod.detonationDamage — outgoing detonation-burst multiplier delta (percentage points). */
     detonationDamageModifier: number;
+    /** mod.bombSplashDamage — outgoing bomb-splash multiplier delta (percentage points). */
+    bombSplashModifier: number;
     /** Full summed buff totals (layers 1+2+3+4) — exposes outgoingDamage/heal channels for the turn loop. */
     totals: ReturnType<typeof calculateBuffTotals>;
 }
@@ -215,6 +217,7 @@ export function effectiveDamageStatsOf(args: {
             dotPen.defensePenetrationBuff,
         selfDotDamageModifier: dotPen.dotDamageModifier + mod.dotDamage,
         detonationDamageModifier: mod.detonationDamage,
+        bombSplashModifier: mod.bombSplashDamage,
         totals,
     };
 }

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2916,8 +2916,9 @@ export function runCombat(input: CombatEngineInput): {
                     recordDestroyed(victim, r, bus, cause?.killerId, cause?.byDirectDamage);
                     // Bomb-splash-on-death: a ship that dies with un-detonated bombs splashes a
                     // tier-scaled fraction (tier/4%: 100→25,200→50,300→75) of each bomb's damage to
-                    // its LIVING same-side adjacent allies (positional only — adjacentAllyIdsFor
-                    // returns [] without board positions, so non-positional sims are byte-identical).
+                    // its LIVING same-side adjacent allies (positional only — victim.position gate
+                    // enforces this; adjacentAllyIds has an all-allies fallback and does NOT
+                    // self-gate, so the position check here is the sole non-positional guard).
                     // NO affinity (bombs aren't affinity-scaled). Bomb-like: full shield drain, no
                     // penetration (bombPortion = full). Credited to the bomb applier (sourceId).
                     // Chains: a splash that kills an adjacent bombed ally re-enters this same
@@ -2925,7 +2926,11 @@ export function runCombat(input: CombatEngineInput): {
                     // (each ship dies once; bombs consumed up-front). Guarded against double-fire on a
                     // second hit to a corpse by (a) the wasAliveBeforeThisCall check and (b) consuming
                     // the bombs before splashing.
-                    if (wasAliveBeforeThisCall && victim.pendingBombs.length > 0) {
+                    if (
+                        wasAliveBeforeThisCall &&
+                        victim.position !== undefined &&
+                        victim.pendingBombs.length > 0
+                    ) {
                         const bombs = victim.pendingBombs;
                         victim.pendingBombs = []; // consume up-front so a chain re-entry / corpse re-hit won't re-splash
                         const allyIds = bySide(

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -701,7 +701,11 @@ function processBombs(args: {
         args.pendingBombs[i].countdown -= 1;
         if (args.pendingBombs[i].countdown <= 0) {
             const bomb = args.pendingBombs[i];
-            const burstDamage = bomb.stacks * bomb.damagePerStack * bomb.affinityMult;
+            const burstDamage =
+                bomb.stacks *
+                bomb.damagePerStack *
+                bomb.affinityMult *
+                (1 + bomb.detonationDamageModifier / 100);
             args.emitBombDetonated?.(bomb.sourceId, bomb.stacks, burstDamage);
             args.creditDetonation(bomb.sourceId, burstDamage);
             args.pendingBombs.splice(i, 1);

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -53,6 +53,7 @@ import {
 import type { AttackerDamageScalars } from './victimDamage';
 import { incomingReductionForHit, incomingBlockForIntake } from './incomingEffects';
 import { reflectedDamageForHit } from './damageReflection';
+import { splashDamageForBomb } from './bombSplash';
 import { outgoingAmplificationForHit } from './outgoingEffects';
 import { incomingHealAmpForRecipient } from './healAmplification';
 import { CHEAT_DEATH_BUFFS } from './cheatDeathBuffs';
@@ -1912,6 +1913,12 @@ export function runCombat(input: CombatEngineInput): {
     // rebound fresh each round so it never accumulates across rounds. Surfaced both as the
     // attacker's incoming (automatic via the sink) AND on RoundData.perActorReflected.
     let perActorReflected = new Map<string, number>();
+    // Bomb-splash-on-death: per-round accumulator (adjacent-ally actor id → total splash damage
+    // dealt to it THIS round by dying bombed allies). Mirrors perActorShieldGranted's lifecycle
+    // (declared once, rebound fresh each round at ~3352, captured by the splash block in the death
+    // seam). Surfaced as RoundData.perActorSplash at the post-round push (absent when empty →
+    // non-positional / no-splash rounds stay byte-identical).
+    let perActorSplash = new Map<string, number>();
 
     // Recipient's CURRENT effective max HP: prefer the actor's last-turn ctx (live buffs),
     // else its base HP (pre-first-turn). Same pattern for incoming-heal % (ctx value ?? 0).
@@ -2874,6 +2881,10 @@ export function runCombat(input: CombatEngineInput): {
             // own id, covering every Cheat Death source.
             if (victim.currentHp <= 0) {
                 const targetId = victim.id;
+                // Captured BEFORE recordDestroyed (which sets destroyedRound): the death `else`
+                // can RE-ENTER on a corpse hit again (currentHp ≤ 0 → recordDestroyed idempotent),
+                // so this gate + the up-front bomb-consume below make the splash fire exactly once.
+                const wasAliveBeforeThisCall = victim.destroyedRound === undefined;
                 const carriesCheatDeath = selfBuffNamesForOwners(statusEngine, [targetId]).some(
                     (n) => CHEAT_DEATH_BUFFS.has(n)
                 );
@@ -2903,6 +2914,47 @@ export function runCombat(input: CombatEngineInput): {
                     // off the heal target's runtime `destroyedRound` field at the result site —
                     // no side-specific scalar write is needed here.
                     recordDestroyed(victim, r, bus, cause?.killerId, cause?.byDirectDamage);
+                    // Bomb-splash-on-death: a ship that dies with un-detonated bombs splashes a
+                    // tier-scaled fraction (tier/4%: 100→25,200→50,300→75) of each bomb's damage to
+                    // its LIVING same-side adjacent allies (positional only — adjacentAllyIdsFor
+                    // returns [] without board positions, so non-positional sims are byte-identical).
+                    // NO affinity (bombs aren't affinity-scaled). Bomb-like: full shield drain, no
+                    // penetration (bombPortion = full). Credited to the bomb applier (sourceId).
+                    // Chains: a splash that kills an adjacent bombed ally re-enters this same
+                    // recordDestroyed else-branch for that ally, firing its splash — naturally finite
+                    // (each ship dies once; bombs consumed up-front). Guarded against double-fire on a
+                    // second hit to a corpse by (a) the wasAliveBeforeThisCall check and (b) consuming
+                    // the bombs before splashing.
+                    if (wasAliveBeforeThisCall && victim.pendingBombs.length > 0) {
+                        const bombs = victim.pendingBombs;
+                        victim.pendingBombs = []; // consume up-front so a chain re-entry / corpse re-hit won't re-splash
+                        const allyIds = bySide(
+                            isEnemySide(victim.id) ? 'enemy' : 'player'
+                        ).adjacentAllyIdsFor(victim.id);
+                        for (const allyId of allyIds) {
+                            const ally = allActorsById.get(allyId);
+                            if (!ally || ally.destroyedRound !== undefined) continue;
+                            const splashSink = ally.side === 'player' ? playerSink : enemySink;
+                            for (const bomb of bombs) {
+                                const splash = splashDamageForBomb(bomb);
+                                if (splash <= 0) continue;
+                                applyVictimDamage(splash, ally, splashSink, {
+                                    killerId: bomb.sourceId,
+                                    byDirectDamage: true,
+                                    bombPortion: splash, // full bomb → full shield drain, no penetration
+                                    shieldPenetrationPct: 0,
+                                });
+                                perActorSplash.set(
+                                    ally.id,
+                                    (perActorSplash.get(ally.id) ?? 0) + splash
+                                );
+                                roundPerTargetDamage.set(
+                                    ally.id,
+                                    (roundPerTargetDamage.get(ally.id) ?? 0) + splash
+                                );
+                            }
+                        }
+                    }
                 }
             }
             // Tank-side hp-changed (Phase 4c PR 3): ONCE per HP-intake event — this closure
@@ -3492,6 +3544,9 @@ export function runCombat(input: CombatEngineInput): {
         // Reflect gear set (Task 5): rebind the per-round reflected-thorns accumulator EVERY round
         // (mirrors perActorShieldGranted), so a stale carry-over never over-reports reflected damage.
         perActorReflected = new Map<string, number>();
+        // Bomb-splash-on-death: rebind every round (like perActorShieldGranted) so a stale
+        // carry-over never over-reports splash. Written only by the death-seam splash block.
+        perActorSplash = new Map<string, number>();
         if (healTarget) {
             currentRoundHealing = new Map<string, ActorHealing>();
             const targetMaxHp = recipientMaxHp(healTarget.id);
@@ -5123,6 +5178,11 @@ export function runCombat(input: CombatEngineInput): {
             // round (map non-empty). Non-positional rounds leave it absent → goldens byte-identical.
             ...(roundPerTargetDamage.size > 0
                 ? { perTargetDamage: Object.fromEntries(roundPerTargetDamage) }
+                : {}),
+            // perActorSplash (bomb-splash-on-death): set ONLY when a dying bombed ally splashed
+            // adjacent allies this round (map non-empty). Absent otherwise → byte-identical.
+            ...(perActorSplash.size > 0
+                ? { perActorSplash: Object.fromEntries(perActorSplash) }
                 : {}),
             // perActorShield (H1 Task 6): per-actor shield accounting for THIS round, set only
             // when at least one actor has a nonzero {granted, absorbed, pool}. Mirrors

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2941,7 +2941,7 @@ export function runCombat(input: CombatEngineInput): {
                             if (!ally || ally.destroyedRound !== undefined) continue;
                             const splashSink = ally.side === 'player' ? playerSink : enemySink;
                             for (const bomb of bombs) {
-                                const splash = splashDamageForBomb(bomb);
+                                const splash = splashDamageForBomb(bomb, bomb.splashModifier);
                                 if (splash <= 0) continue;
                                 applyVictimDamage(splash, ally, splashSink, {
                                     killerId: bomb.sourceId,

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -594,6 +594,7 @@ function applyNewDoTs(args: {
     effectiveAttack: number;
     affinityMult: number;
     detonationDamageModifier: number;
+    splashModifier: number;
     sourceId: string;
     corrosionEntries: ActiveDoTStack[];
     infernoEntries: ActiveDoTStack[];
@@ -627,6 +628,7 @@ function applyNewDoTs(args: {
                 sourceId: args.sourceId,
                 affinityMult: args.affinityMult,
                 detonationDamageModifier: args.detonationDamageModifier,
+                splashModifier: args.splashModifier,
             });
             args.emitDotApplied('bomb', dot.stacks);
         }
@@ -1535,6 +1537,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 effectiveAttack,
                 affinityMult,
                 detonationDamageModifier: dmgStats.detonationDamageModifier,
+                splashModifier: dmgStats.bombSplashModifier,
                 sourceId: actor.id,
                 corrosionEntries,
                 infernoEntries,

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -529,6 +529,7 @@ function detonate(args: {
     enemyHp: number;
     dotMult: number;
     affinityMult: number;
+    detonationMult: number;
     corrosionEntries: ActiveDoTStack[];
     infernoEntries: ActiveDoTStack[];
     pendingBombs: PendingBomb[];
@@ -546,7 +547,8 @@ function detonate(args: {
                 ) *
                 args.dotMult *
                 args.affinityMult *
-                pct;
+                pct *
+                args.detonationMult;
             args.infernoEntries.length = 0;
         } else if (det.dotType === 'corrosion') {
             const baseHp = Math.min(args.enemyHp, 500_000);
@@ -557,7 +559,8 @@ function detonate(args: {
                 ) *
                 args.dotMult *
                 args.affinityMult *
-                pct;
+                pct *
+                args.detonationMult;
             args.corrosionEntries.length = 0;
         } else if (det.dotType === 'bomb') {
             const totalStacks = args.pendingBombs.reduce((sum, b) => sum + b.stacks, 0);
@@ -570,7 +573,9 @@ function detonate(args: {
                 args.pendingBombs.reduce(
                     (sum, b) => sum + b.stacks * b.damagePerStack * b.affinityMult,
                     0
-                ) * pct;
+                ) *
+                pct *
+                args.detonationMult;
             if (payout > 0) {
                 args.emitBombDetonated?.(totalStacks, payout);
             }
@@ -1491,6 +1496,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         enemyHp,
         dotMult,
         affinityMult,
+        detonationMult: 1 + dmgStats.detonationDamageModifier / 100,
         corrosionEntries,
         infernoEntries,
         pendingBombs,

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -588,6 +588,7 @@ function applyNewDoTs(args: {
     dotsConfig: DoTApplicationConfig;
     effectiveAttack: number;
     affinityMult: number;
+    detonationDamageModifier: number;
     sourceId: string;
     corrosionEntries: ActiveDoTStack[];
     infernoEntries: ActiveDoTStack[];
@@ -620,6 +621,7 @@ function applyNewDoTs(args: {
                 tier: dot.tier,
                 sourceId: args.sourceId,
                 affinityMult: args.affinityMult,
+                detonationDamageModifier: args.detonationDamageModifier,
             });
             args.emitDotApplied('bomb', dot.stacks);
         }
@@ -1526,6 +1528,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 dotsConfig,
                 effectiveAttack,
                 affinityMult,
+                detonationDamageModifier: dmgStats.detonationDamageModifier,
                 sourceId: actor.id,
                 corrosionEntries,
                 infernoEntries,

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -564,18 +564,23 @@ function detonate(args: {
             args.corrosionEntries.length = 0;
         } else if (det.dotType === 'bomb') {
             const totalStacks = args.pendingBombs.reduce((sum, b) => sum + b.stacks, 0);
-            // Each bomb bursts with the APPLIER's affinity matchup, snapshotted at
-            // application (PendingBomb.affinityMult) — NOT the detonating actor's. A
-            // team-applied bomb detonated by the attacker's skill keeps the team's
-            // modifier, mirroring processBombs' per-entry handling on the enemy turn.
-            // Identical for attacker-only runs (every entry carries the attacker's mult).
+            // Each bomb bursts with the APPLIER's affinity matchup AND the applier's
+            // detonation-damage modifier (Voidfire), both snapshotted at application
+            // (PendingBomb.affinityMult / .detonationDamageModifier) — NOT the detonating
+            // actor's. A team-applied bomb detonated by the attacker's skill keeps the
+            // team's modifiers, mirroring the per-entry burst on the enemy turn (engine.ts
+            // detonatePendingBombs). Identical for attacker-only runs (every entry carries
+            // the attacker's mult, equal to args.detonationMult).
             const payout =
                 args.pendingBombs.reduce(
-                    (sum, b) => sum + b.stacks * b.damagePerStack * b.affinityMult,
+                    (sum, b) =>
+                        sum +
+                        b.stacks *
+                            b.damagePerStack *
+                            b.affinityMult *
+                            (1 + b.detonationDamageModifier / 100),
                     0
-                ) *
-                pct *
-                args.detonationMult;
+                ) * pct;
             if (payout > 0) {
                 args.emitBombDetonated?.(totalStacks, payout);
             }

--- a/src/utils/combat/state.ts
+++ b/src/utils/combat/state.ts
@@ -66,6 +66,9 @@ export interface PendingBomb {
     /** The applier's detonation-damage modifier (%), snapshotted at application like affinityMult.
      *  Scales the timed-expiry burst in processBombs and (later) skill detonation. Default 0. */
     detonationDamageModifier: number;
+    /** The applier's bomb-splash-damage modifier (%), snapshotted at application like
+     *  affinityMult/detonationDamageModifier. Scales splash-on-death. Default 0. */
+    splashModifier: number;
 }
 
 // Echoing Burst-style debuff: gathers the direct damage dealt to the enemy each round it

--- a/src/utils/combat/state.ts
+++ b/src/utils/combat/state.ts
@@ -63,6 +63,9 @@ export interface PendingBomb {
     /** Affinity multiplier snapshotted at application from the applier's affinity matchup,
      *  so the burst on detonation uses the APPLIER's affinity, not the focus actor's. */
     affinityMult: number;
+    /** The applier's detonation-damage modifier (%), snapshotted at application like affinityMult.
+     *  Scales the timed-expiry burst in processBombs and (later) skill detonation. Default 0. */
+    detonationDamageModifier: number;
 }
 
 // Echoing Burst-style debuff: gathers the direct damage dealt to the enemy each round it

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1565,6 +1565,8 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
                 // does not carry the owner's live detonation modifier; documented approximation —
                 // no shipped reactive bomb applier also wears Voidfire.
                 detonationDamageModifier: 0,
+                // Same approximation: reactive ctx does not carry the live splash modifier.
+                splashModifier: 0,
             });
         }
         // Discrete infliction event — sourceId = the owner so the application is chainable

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1561,6 +1561,10 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
                 tier: cfg.tier,
                 sourceId: intent.ownerId,
                 affinityMult: ownerCtx.affinityMult,
+                // Reactive-applied bombs default the detonation modifier to 0: the reactive ctx
+                // does not carry the owner's live detonation modifier; documented approximation —
+                // no shipped reactive bomb applier also wears Voidfire.
+                detonationDamageModifier: 0,
             });
         }
         // Discrete infliction event — sourceId = the owner so the application is chainable


### PR DESCRIPTION
## Summary

Models the **Voidfire Catalyst** implant (the last un-modelled D-bucket implant) and the base **bomb-splash-on-death** combat mechanic its splash half rides on. Built as three phases on one branch (the planned 3-way split was to isolate the golden-moving phase — but it turned out byte-identical, so it ships as one PR).

- **Detonation half** — new `detonationDamage` modifier channel (mirrors `dotDamage`/Decimation). Scales all three detonation branches in `detonate()` (skill-triggered, detonator's live modifier) and the timed `processBombs` path (applier's snapshot on `PendingBomb`). Voidfire common/uncommon/epic light up the detonation bonus.
- **Bomb-splash-on-death** — NEW core mechanic (not implant-gated): when a ship dies with un-detonated bombs, each living **same-side adjacent** ally takes `tier/4`% (25/50/75 by bomb tier) of each bomb's raw burst, applied bomb-like (full shield drain, no penetration, **no affinity** — bombs aren't affinity-scaled), credited to the applier. Chains recursively (finite); idempotent (gated on newly-destroyed + bombs consumed up-front); **positional-only** (explicitly gated on `victim.position`). Surfaced via `roundPerTargetDamage` (HP curve) + a reserved `perActorSplash` round field.
- **Splash half** — new `bombSplashDamage` modifier channel snapshotted onto each bomb (applier-owned); amplifies the splash for all rarities (incl. rare/legendary, which are splash-only).

Per-rarity: common 2det/4splash, uncommon 4/8, rare splash-24-only, epic 8/16, legendary splash-40-only.

## Notes

- **Byte-identical**: no fixture equips Voidfire and all new `PendingBomb` fields default 0; splash is positional-only and no existing positional fixture has a bombed death adjacent to a living same-side ally. All goldens unchanged.
- DPS calculator needs no wiring (it has no detonation computation).
- Spec & plan: `docs/superpowers/specs/2026-06-26-voidfire-catalyst-bomb-splash-design.md`, `docs/superpowers/plans/2026-06-26-voidfire-catalyst-bomb-splash.md`.
- Known minor follow-up (non-blocking): no test exercises the cast-site snapshot-write seam (`dmgStats.bombSplashModifier`/`detonationDamageModifier` → `PendingBomb`) — a trivial passthrough; the channel fold, registry output, and engine read are all tested. `perActorSplash` has no StatCard yet (reserved).

## Test Plan

- [x] Full suite green (3343 passing), tsc + lint clean, `audit:skills` 141/0
- [x] All goldens byte-identical
- [x] Splash unit + integration tests: single, chain, multi-bomb/multi-ally (affinity-isolation), dead-applier, cheat-death-no-splash, non-positional no-op, survivor-no-splash, splashModifier 1.5×
- [x] Detonation scaling tests: timed + skill-triggered, bomb/Inferno/Corrosion branches
- [x] Voidfire registry per-rarity assertions through the real registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)