### PR TITLE
feat(combat): Boost gear set — +1 turn on buffs the wearer applies

### DIFF
--- a/docs/superpowers/plans/2026-06-26-boost-gear-set.md
+++ b/docs/superpowers/plans/2026-06-26-boost-gear-set.md
@@ -63,13 +63,12 @@
 
 - [ ] **Step 1: Write the failing test**
 
-Add to `buildEquipmentAbilities.test.ts` (follow the existing REFLECT test block ~ near other gear-set tests; reuse the file's existing `makePiece` / ship-builder helpers — match how REFLECT/SHIELD tests construct a ship with N set pieces):
+Add to `buildEquipmentAbilities.test.ts`. The file already has a `buildForGearSet(setKey)` helper (~197) that builds a ship equipping exactly `GEAR_SETS[setKey].minPieces` pieces + the matching `getGearPiece` — use it directly for the **pass** case (it gives 4 BOOST pieces). It has NO count parameter, so for the **fail** case hand-roll a 3-piece map using the same `makePiece` + inline `(g) => pieceMap[g]` lookup that `buildForGearSet`'s body uses (read it to copy the exact shape).
 
 ```typescript
 describe('buildEquipmentAbilities — Boost set', () => {
-    it('emits a buff-duration-extension ability (turns 1) when ≥4 BOOST pieces are equipped', () => {
-        // Build a ship with 4 BOOST gear pieces (copy the REFLECT test's piece-construction).
-        const { ship, getGearPiece } = buildShipWithSet('BOOST', 4); // use the file's existing helper pattern
+    it('emits a buff-duration-extension ability (turns 1) at ≥4 BOOST pieces', () => {
+        const { ship, getGearPiece } = buildForGearSet('BOOST'); // minPieces = 4
         const abilities = buildEquipmentAbilities(ship, getGearPiece);
         const boost = abilities.find((a) => a.id === 'equip-set-BOOST');
         expect(boost).toBeDefined();
@@ -77,15 +76,25 @@ describe('buildEquipmentAbilities — Boost set', () => {
         expect(boost!.type).toBe('modifier'); // placeholder, like REFLECT
     });
 
-    it('emits nothing when only 3 BOOST pieces are equipped (minPieces 4)', () => {
-        const { ship, getGearPiece } = buildShipWithSet('BOOST', 3);
-        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+    it('emits nothing with only 3 BOOST pieces (minPieces 4)', () => {
+        // Hand-roll 3 pieces (buildForGearSet has no count param). Copy makePiece + the
+        // inline getGearPiece lookup from buildForGearSet's body.
+        const pieceMap: Record<string, GearPiece> = {};
+        const slots = ['weapon', 'hull', 'generator'] as const; // any 3 distinct slots
+        const equipment: Record<string, string> = {};
+        slots.forEach((slot, i) => {
+            const id = `BOOST-piece-${i}`;
+            pieceMap[id] = makePiece({ id, slot, setBonus: 'BOOST' });
+            equipment[slot] = id;
+        });
+        const ship = { /* minimal Ship with `equipment` — copy from buildForGearSet */ } as Ship;
+        const abilities = buildEquipmentAbilities(ship, (g: string) => pieceMap[g]);
         expect(abilities.find((a) => a.id === 'equip-set-BOOST')).toBeUndefined();
     });
 });
 ```
 
-> NOTE: there is no `buildShipWithSet` helper in the file — replicate exactly how the REFLECT/SHIELD `it(...)` blocks build a ship (they loop `minPieces` slots calling `makePiece({ id, slot, setBonus })` into an `equipment` map + a `getGearPiece` lookup). Use 4 pieces for the pass case, 3 for the fail case.
+> Read `buildForGearSet` and `makePiece` in the file first and mirror their exact `Ship`/`equipment`/slot construction — the snippet above is a sketch, not literal.
 
 - [ ] **Step 2: Run the test, verify it fails**
 
@@ -428,7 +437,7 @@ Immediately before `const statusEngine = createStatusEngine({` (~1422), insert:
     // team-agnostically: attacker + walked team allies + enemy attackers.
     const buffDurationExtensionByOwner = buildBuffDurationExtensionByOwner([
         { id: 'attacker', shipSkills: input.shipSkills },
-        ...teamActors.map((t) => ({ id: t.id, shipSkills: t.shipSkills })),
+        ...teamActors.map((t) => ({ id: t.id, shipSkills: t.walk?.shipSkills })),
         ...(input.enemyAttackers ?? []).map((e) => ({ id: e.id, shipSkills: e.shipSkills })),
     ]);
 ```
@@ -439,7 +448,11 @@ Add the import at the top of `engine.ts` (near the other `src/utils/combat` impo
 import { buildBuffDurationExtensionByOwner } from './buffDurationExtension';
 ```
 
-> VERIFY while implementing: `input.shipSkills` is the RAW attacker skills (the local `shipSkills` binding is rebound to the partitioned cast-only subset at ~1227, but `input.shipSkills` still holds the full skills with the passive slot). `teamActors` (normalized ~1204) and `input.enemyAttackers` each expose `{ id, shipSkills }`. Confirm the `shipSkills` field names on the team/enemy actor types (`t.shipSkills`, `e.shipSkills`); adjust if the walked-actor type names it differently.
+> **FIELD NAMES (verified — get these exactly right):**
+> - **Attacker:** `input.shipSkills` is the RAW attacker skills with the passive slot intact. The local `shipSkills` binding is rebound to the partitioned cast-only subset at ~1227, but `input.shipSkills` is untouched, and gear-set abilities are merged into the *passive* slot (which `partitionReactiveAbilities` does not strip). Correct as written.
+> - **Team allies:** team-actor ship skills live at **`t.walk?.shipSkills`**, NOT `t.shipSkills`. `teamActors = normalizeTeamActorsToWalked(input.teamActors)` (`engine.ts:1204`) returns `TeamActorEngineInput[]` whose merged skills are on the `walk` bundle (`teamActorWalk.ts:28` synthesizes `walk.shipSkills` for every normalized actor — buff-only actors get `buildEmptyShipSkills()`). A top-level `t.shipSkills` is `undefined` in the combat-sim production path (`battleSimulator.ts` sets only `walk.shipSkills`) → using it would silently kill the ally-buff feature in the simulator. **Use `t.walk?.shipSkills`.**
+> - **Enemies:** `e.shipSkills` is correct — `enemyAttackers[].shipSkills?` is a top-level field on that input type (`engine.ts:923`).
+> The `buildBuffDurationExtensionByOwner` helper already accepts `ShipSkills | undefined`, so undefined entries are harmless (map omits them).
 
 - [ ] **Step 2: Pass the lookup into `createStatusEngine`**
 
@@ -529,7 +542,10 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 - [ ] **Step 1: Update the coverage tracker test**
 
-In `equipmentCoverage.test.ts`: add `'BOOST'` to the `implementedSets` `.toEqual([...])` array (~130, keep alphabetical/decl order consistent with the file) and to the `IMPLEMENTED_SETS` `new Set([...])` (~195). Update the long `it('exactly { ... } are currently implemented')` title string to include BOOST.
+In `equipmentCoverage.test.ts`, three edits:
+- The `implementedSets` `.toEqual([...])` array (~130) is built from `Object.keys(GEAR_SETS).filter(...)` and the assertion is **order-sensitive (declaration order, not alphabetical)**. `BOOST` is the FIRST key in `GEAR_SETS` (`gearSets.ts:56`, before `BURNER`), so insert `'BOOST'` as the **first** element of the array — do NOT append or alphabetize. The existing order is BURNER, DECIMATION, LEECH, REFLECT, REVENGE, SHIELD, CLOAKING, HARDENED.
+- The `IMPLEMENTED_SETS` `new Set([...])` (~195) is order-insensitive — add `'BOOST'` anywhere.
+- Update the long `it('exactly { ... } are currently implemented')` title string (~125) to include BOOST.
 
 - [ ] **Step 2: Run the coverage test**
 

--- a/docs/superpowers/plans/2026-06-26-boost-gear-set.md
+++ b/docs/superpowers/plans/2026-06-26-boost-gear-set.md
@@ -68,8 +68,9 @@ Add to `buildEquipmentAbilities.test.ts`. The file already has a `buildForGearSe
 ```typescript
 describe('buildEquipmentAbilities — Boost set', () => {
     it('emits a buff-duration-extension ability (turns 1) at ≥4 BOOST pieces', () => {
-        const { ship, getGearPiece } = buildForGearSet('BOOST'); // minPieces = 4
-        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        // buildForGearSet returns Ability[] directly (it calls buildEquipmentAbilities internally
+        // on a ship equipping minPieces of the set) — confirm its exact return shape in the file.
+        const abilities = buildForGearSet('BOOST'); // minPieces = 4
         const boost = abilities.find((a) => a.id === 'equip-set-BOOST');
         expect(boost).toBeDefined();
         expect(boost!.config).toEqual({ type: 'buff-duration-extension', turns: 1 });

--- a/docs/superpowers/plans/2026-06-26-boost-gear-set.md
+++ b/docs/superpowers/plans/2026-06-26-boost-gear-set.md
@@ -557,8 +557,8 @@ Expected: PASS.
 
 Add to `UNRELEASED_CHANGES` in `src/constants/changelog.ts` (plain English, match the existing entry voice):
 
-```
-'The combat and DPS simulators now model the Boost gear set: while a ship wears 4+ Boost pieces, every buff it applies — to itself or its allies — lasts one extra turn.'
+```typescript
+'The combat and DPS simulators now model the Boost gear set: while a ship wears 4+ Boost pieces, each timed buff it applies — to itself or its allies — lasts one extra turn.'
 ```
 
 - [ ] **Step 4: Docs**

--- a/docs/superpowers/plans/2026-06-26-boost-gear-set.md
+++ b/docs/superpowers/plans/2026-06-26-boost-gear-set.md
@@ -1,0 +1,592 @@
+# Boost Gear Set Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Model the Boost gear set (4-piece) so that every buff the wearer applies — its own self-buffs and buffs it grants allies — lasts +1 turn, in both the combat simulator and the DPS calculator.
+
+**Architecture:** Boost is caster-side and lives at the buff-duration write seams in `statusEngine.ts`, NOT in the ability damage/heal fold. A new no-op `AbilityConfig` variant `buff-duration-extension` (mirrors REFLECT's `damage-reflection`) is emitted by the gear-set registry; the engine scans every actor's passive slots into a per-owner extension map BEFORE constructing the status engine, and threads a `buffDurationExtensionFor(casterId)` lookup into `StatusEngineInput`. The status engine adds the extension at the two `turnsRemaining` writes, gated to finite-duration self-side buffs.
+
+**Tech Stack:** React 18, TypeScript, Vite, Vitest. All combat code is pure TypeScript under `src/utils/combat/` and `src/utils/abilities/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-26-boost-gear-set-design.md`
+
+**Branch / worktree:** `feat/combat-d-pr-boost-set` in `.worktrees/boost-set` (off main `bd2b6aa8`).
+
+---
+
+## Background an implementer needs
+
+- **The effect:** `GEAR_SETS.BOOST` (`src/constants/gearSets.ts`) is `{ name:'Boost', stats:[], minPieces:4, description:'All buffs last an extra turn' }`. Wearing **≥4 Boost pieces** → every buff the wearer **applies** lasts **+1 turn**, wherever it lands (its own self-buffs + buffs it grants allies). Caster-side: the determinant is the *applying* ship's set, not whose buff it sits on. Binary bonus (+1 at ≥4 pieces; 6 pieces is still +1).
+- **Excluded (by design):** debuffs the wearer inflicts on enemies (those land enemy-side); permanent / recurring / persistent-stacking buffs (no finite duration). These fall out for free — see the two seams below.
+- **The two buff-duration write seams** in `src/utils/combat/statusEngine.ts`:
+  1. `upsertBuff(buff, side)` (~633) — scheduled ship-skill buffs. The self-side write is `turnsRemaining: buff.skillDuration` (~649), guarded by `familyApplicationWins(existing, tier, buff.skillDuration)` (~646). Called ONLY from `sourceFired(sourceId, slot, round)`: self at ~711 (`upsertBuff(buff, 'self')`), enemy at ~735. `sourceId` is the caster and is in scope at both calls. Scheduled self-buffs are stored under the `'attacker'` carrier owner regardless of `sourceId` — the +1 must gate on the firing `sourceId`, not the carrier.
+  2. `applyTimedAbilityStatus(round, status, recipientId?, enemyTargetId?)` (~1083) — ability-granted buffs (self + ally targets + reactive grants). The write is `turnsRemaining: status.duration` (~1138), guarded by `familyApplicationWins(existing, tier, status.duration)` (~1135). `status.casterId` is the applying ship (stamped at registration); may be undefined only in unit-test fixtures → default to `'attacker'`.
+  - Both writes sit AFTER the `PERSISTENT_STACKING_BUFFS.has(...)` early-returns (~639 / ~1114) and the numeric-duration guards, so persistent/permanent/recurring buffs never reach them — no extra guard needed.
+  - **Dual-write footgun:** each seam references the duration TWICE (the family-rule check AND the store). Compute the extended duration once and use it in BOTH, or a Boost re-cast of an N-turn buff fails the `> N` family win-check and silently drops the +1.
+- **REFLECT precedent (copy this shape):** `GEAR_SET_ABILITIES.REFLECT` (`src/utils/abilities/buildEquipmentAbilities.ts` ~116) emits `{ type:'modifier' (placeholder), target:'self', trigger:'on-cast', conditions:[], config:{ type:'damage-reflection', pct:10 }, autoFilled:true }`. The engine keys on `config.type`, never the placeholder top-level `type`. The modifier fold ignores it (`applyAbilities.ts:38` skips any ability whose `config.type !== 'modifier'`), so it is inert in damage math. BOOST mirrors this exactly.
+- **Engine collection ordering:** `createStatusEngine(...)` is constructed at `engine.ts:1422`, but the existing per-owner ability maps (`incomingAbilitiesById` etc.) are built ~2257+ from runtimes that don't exist at 1422. So the Boost map MUST be built from the raw `ShipSkills` (which already contain the BOOST passive — merged at the page level by `buildShipAbilitiesWithEquipment`) BEFORE line 1422. Available at that point: `input.shipSkills` (attacker, id `'attacker'`), `teamActors` (normalized at 1204, each `{ id, shipSkills }`), `input.enemyAttackers` (each `{ id, shipSkills? }`).
+- **DPS path:** `simulateDPS` (`dpsSimulator.ts` ~274) calls `runCombat`; it does NOT build its own `StatusEngineInput`. Threading the lookup once into the single `createStatusEngine` covers DPS automatically.
+- **Golden safety:** no combat/DPS fixture equips a 4-piece BOOST set, so `buffDurationExtensionFor` returns 0 everywhere in the existing suite → byte-identical goldens/`.snap`. (The only BOOST test references are autogear fast-scoring equivalence fixtures, which don't run the engine.)
+
+### Commands
+
+- Single test file: `npm test -- src/path/to/file.test.ts`
+- Single test by name: `npm test -- src/path/to/file.test.ts -t "name fragment"`
+- Full suite: `npm test`  ·  Types: `npx tsc --noEmit`  ·  Lint: `npm run lint`  ·  Skill audit: `npm run audit:skills`
+- **Commit:** the husky pre-commit hook runs the full vitest suite. For code commits let it run. The worktree already has `.env` copied in (needed or ~14 `.tsx` test files fail to collect).
+
+---
+
+## File Structure
+
+- **Create** `src/utils/combat/buffDurationExtension.ts` — pure helper: scan a `ShipSkills`' passive slots for `buff-duration-extension` configs → max turns; build a per-owner `Map`.
+- **Create** `src/utils/combat/__tests__/buffDurationExtension.test.ts` — unit tests for the helper.
+- **Create** `src/utils/combat/__tests__/boostGearSet.integration.test.ts` — engine + DPS integration via the real registry.
+- **Modify** `src/types/abilities.ts` — add the `buff-duration-extension` `AbilityConfig` variant.
+- **Modify** `src/utils/abilities/buildEquipmentAbilities.ts` — `GEAR_SET_ABILITIES.BOOST` entry.
+- **Modify** `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts` — BOOST registry test.
+- **Modify** `src/utils/combat/statusEngine.ts` — `StatusEngineInput.buffDurationExtensionFor?`; apply +1 at the two seams (`upsertBuff` gains a caster param).
+- **Modify** `src/utils/combat/__tests__/statusEngine.test.ts` — pure-seam unit tests.
+- **Modify** `src/utils/combat/engine.ts` — build the per-owner map before 1422; pass the lookup into `createStatusEngine`.
+- **Modify** `src/utils/abilities/__tests__/equipmentCoverage.test.ts` — add BOOST to the implemented gear-set sets (2 spots).
+- **Modify** `src/constants/changelog.ts` — `UNRELEASED_CHANGES` entry.
+- **Modify** `src/pages/DocumentationPage.tsx` — note Boost is modeled.
+
+---
+
+## Task 1: AbilityConfig variant + BOOST registry entry
+
+**Files:**
+- Modify: `src/types/abilities.ts:326-510` (the `AbilityConfig` union — add a variant at the end, next to `damage-reflection`)
+- Modify: `src/utils/abilities/buildEquipmentAbilities.ts` (add `BOOST` to `GEAR_SET_ABILITIES`, ~after the SHIELD entry ~146)
+- Test: `src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `buildEquipmentAbilities.test.ts` (follow the existing REFLECT test block ~ near other gear-set tests; reuse the file's existing `makePiece` / ship-builder helpers — match how REFLECT/SHIELD tests construct a ship with N set pieces):
+
+```typescript
+describe('buildEquipmentAbilities — Boost set', () => {
+    it('emits a buff-duration-extension ability (turns 1) when ≥4 BOOST pieces are equipped', () => {
+        // Build a ship with 4 BOOST gear pieces (copy the REFLECT test's piece-construction).
+        const { ship, getGearPiece } = buildShipWithSet('BOOST', 4); // use the file's existing helper pattern
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        const boost = abilities.find((a) => a.id === 'equip-set-BOOST');
+        expect(boost).toBeDefined();
+        expect(boost!.config).toEqual({ type: 'buff-duration-extension', turns: 1 });
+        expect(boost!.type).toBe('modifier'); // placeholder, like REFLECT
+    });
+
+    it('emits nothing when only 3 BOOST pieces are equipped (minPieces 4)', () => {
+        const { ship, getGearPiece } = buildShipWithSet('BOOST', 3);
+        const abilities = buildEquipmentAbilities(ship, getGearPiece);
+        expect(abilities.find((a) => a.id === 'equip-set-BOOST')).toBeUndefined();
+    });
+});
+```
+
+> NOTE: there is no `buildShipWithSet` helper in the file — replicate exactly how the REFLECT/SHIELD `it(...)` blocks build a ship (they loop `minPieces` slots calling `makePiece({ id, slot, setBonus })` into an `equipment` map + a `getGearPiece` lookup). Use 4 pieces for the pass case, 3 for the fail case.
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `npm test -- src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts -t "Boost set"`
+Expected: FAIL — `equip-set-BOOST` not found / config type does not exist.
+
+- [ ] **Step 3: Add the AbilityConfig variant**
+
+In `src/types/abilities.ts`, append to the `AbilityConfig` union (after the `damage-reflection` variant ~510, before the closing `;`):
+
+```typescript
+    // Boost gear set: caster-side +1-turn extension on every buff the wearer applies.
+    // No-op marker config (mirrors damage-reflection) — read by the engine when building
+    // the per-owner extension map, NEVER executed by the ability fold.
+    | {
+          type: 'buff-duration-extension';
+          /** Extra turns added to buffs this wearer applies (Boost = 1). */
+          turns: number;
+      };
+```
+
+- [ ] **Step 4: Add the registry entry**
+
+In `src/utils/abilities/buildEquipmentAbilities.ts`, add to `GEAR_SET_ABILITIES` (after the `SHIELD` entry ~146):
+
+```typescript
+    // Boost (4pc set): every buff the wearer APPLIES lasts +1 turn (caster-side). Modeled NOT
+    // as a damage/heal fold but as a marker the engine collects into a per-owner extension map,
+    // applied at the status-engine buff-duration write seams. Top-level type:'modifier' is a
+    // placeholder (engine keys on config.type:'buff-duration-extension', like REFLECT). The
+    // modifier fold ignores it (applyAbilities.ts skips config.type !== 'modifier').
+    BOOST: () => ({
+        type: 'modifier',
+        target: 'self',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'buff-duration-extension', turns: 1 },
+        autoFilled: true,
+    }),
+```
+
+- [ ] **Step 5: Run the test, verify it passes**
+
+Run: `npm test -- src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts -t "Boost set"`
+Expected: PASS (both cases). Also `npx tsc --noEmit` clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types/abilities.ts src/utils/abilities/buildEquipmentAbilities.ts src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+git commit -m "feat(combat): Boost gear set — buff-duration-extension config + registry entry
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Pure per-owner extension helper
+
+**Files:**
+- Create: `src/utils/combat/buffDurationExtension.ts`
+- Test: `src/utils/combat/__tests__/buffDurationExtension.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import {
+    buffDurationExtensionTurns,
+    buildBuffDurationExtensionByOwner,
+} from '../buffDurationExtension';
+import type { ShipSkills } from '../../../types/abilities';
+
+// Minimal ShipSkills with one passive slot carrying the given ability configs.
+const skillsWithPassiveConfigs = (configs: Array<{ type: string; turns?: number }>): ShipSkills =>
+    ({
+        slots: [
+            {
+                slot: 'passive',
+                abilities: configs.map((config, i) => ({
+                    id: `a${i}`,
+                    type: 'modifier',
+                    target: 'self',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config,
+                })),
+            },
+        ],
+    }) as unknown as ShipSkills;
+
+describe('buffDurationExtensionTurns', () => {
+    it('returns the turns of a passive buff-duration-extension config', () => {
+        expect(
+            buffDurationExtensionTurns(
+                skillsWithPassiveConfigs([{ type: 'buff-duration-extension', turns: 1 }])
+            )
+        ).toBe(1);
+    });
+
+    it('returns 0 when no buff-duration-extension config is present', () => {
+        expect(
+            buffDurationExtensionTurns(
+                skillsWithPassiveConfigs([{ type: 'damage-reflection' } as never])
+            )
+        ).toBe(0);
+    });
+
+    it('returns 0 for undefined skills', () => {
+        expect(buffDurationExtensionTurns(undefined)).toBe(0);
+    });
+
+    it('takes the max when multiple extension configs are present', () => {
+        expect(
+            buffDurationExtensionTurns(
+                skillsWithPassiveConfigs([
+                    { type: 'buff-duration-extension', turns: 1 },
+                    { type: 'buff-duration-extension', turns: 2 },
+                ])
+            )
+        ).toBe(2);
+    });
+});
+
+describe('buildBuffDurationExtensionByOwner', () => {
+    it('maps only owners that carry an extension; lookup of others returns 0', () => {
+        const map = buildBuffDurationExtensionByOwner([
+            { id: 'attacker', shipSkills: skillsWithPassiveConfigs([{ type: 'buff-duration-extension', turns: 1 }]) },
+            { id: 'ally-1', shipSkills: skillsWithPassiveConfigs([{ type: 'damage-reflection' } as never]) },
+        ]);
+        expect(map.get('attacker')).toBe(1);
+        expect(map.has('ally-1')).toBe(false);
+    });
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `npm test -- src/utils/combat/__tests__/buffDurationExtension.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the helper**
+
+```typescript
+import type { ShipSkills } from '../../types/abilities';
+
+/**
+ * Boost gear set support. Scans a ship's PASSIVE abilities for `buff-duration-extension`
+ * configs (emitted by GEAR_SET_ABILITIES.BOOST) and returns the max extra turns (0 if none).
+ * Pure; never throws.
+ */
+export function buffDurationExtensionTurns(skills: ShipSkills | undefined): number {
+    if (!skills?.slots) return 0;
+    let max = 0;
+    for (const slot of skills.slots) {
+        if (slot.slot !== 'passive') continue;
+        for (const ability of slot.abilities) {
+            if (ability.config.type === 'buff-duration-extension') {
+                max = Math.max(max, ability.config.turns);
+            }
+        }
+    }
+    return max;
+}
+
+/**
+ * Build a per-owner extension map from a list of actors. Owners with no extension are
+ * ABSENT (callers default a miss to 0). Used by the engine to back the
+ * StatusEngineInput.buffDurationExtensionFor lookup.
+ */
+export function buildBuffDurationExtensionByOwner(
+    actors: Array<{ id: string; shipSkills: ShipSkills | undefined }>
+): Map<string, number> {
+    const map = new Map<string, number>();
+    for (const { id, shipSkills } of actors) {
+        const turns = buffDurationExtensionTurns(shipSkills);
+        if (turns > 0) map.set(id, turns);
+    }
+    return map;
+}
+```
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `npm test -- src/utils/combat/__tests__/buffDurationExtension.test.ts`
+Expected: PASS (all cases). `npx tsc --noEmit` clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/combat/buffDurationExtension.ts src/utils/combat/__tests__/buffDurationExtension.test.ts
+git commit -m "feat(combat): pure per-owner buff-duration-extension helper (Boost)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Status-engine seam — apply +1 to caster-in-set buffs
+
+**Files:**
+- Modify: `src/utils/combat/statusEngine.ts` — `StatusEngineInput` (~17-37), `createStatusEngine` destructure (~339), `upsertBuff` (~633), `sourceFired` self call (~711), `applyTimedAbilityStatus` (~1135-1143)
+- Test: `src/utils/combat/__tests__/statusEngine.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a `describe('buffDurationExtensionFor (Boost)')` block to `statusEngine.test.ts`. Match the file's existing setup style for constructing an engine + applying a timed ability status (find an existing `applyTimedAbilityStatus` test and copy its scaffolding: `beginRound`, a `timed` `RegisteredAbilityStatus`, then read state via the engine's snapshot/active-status accessors). Cases:
+
+```typescript
+// 1. A self-side timed ability buff applied by a caster in the Boost set gets +1 turn.
+//    With buffDurationExtensionFor = (id) => id === 'booster' ? 1 : 0, a status with
+//    casterId 'booster', side 'self', duration 2 → turnsRemaining 3.
+// 2. The same buff applied by casterId 'plain' (not in set) → turnsRemaining 2 (unchanged).
+// 3. An enemy-side (side 'enemy') status applied by 'booster' → turnsRemaining unchanged
+//    (debuffs the wearer inflicts are NOT extended).
+// 4. Family rule: re-applying the SAME family at base duration 2 from 'booster' against an
+//    existing turnsRemaining 2 still wins (because the extended 3 > 2) and lands at 3.
+// 5. A scheduled self-buff via sourceFired('booster', slot, round) with skillDuration 2 →
+//    stored turnsRemaining 3; via sourceFired('plain', ...) → 2.
+```
+
+For case 5, seed `teamSources: [{ sourceId: 'booster', selfBuffs: [<a timed buff, skillDuration 2, skillSource matching the fired slot>], enemyDebuffs: [] }]` (and a `'plain'` source), then call `sourceFired(sourceId, slot, round)` and read the `'attacker'` carrier's self map (scheduled self-buffs store under `'attacker'`). Confirm the helper text in the spec: the gate keys on the firing `sourceId`, not the carrier.
+
+Construct the engine with the new input field:
+```typescript
+const engine = createStatusEngine({
+    selfBuffs: [],
+    enemyDebuffs: [],
+    teamSources: [...],
+    buffDurationExtensionFor: (id) => (id === 'booster' ? 1 : 0),
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `npm test -- src/utils/combat/__tests__/statusEngine.test.ts -t "Boost"`
+Expected: FAIL — `buffDurationExtensionFor` not honored (durations not extended) / type error on the new field.
+
+- [ ] **Step 3: Add the input field + default**
+
+In `StatusEngineInput` (~37, after `landsTimedEnemyApplication?`):
+
+```typescript
+    /** Boost gear set: extra turns to add to a TIMED SELF-SIDE buff applied by `casterId`
+     *  (the firing source for scheduled buffs, `status.casterId` for ability buffs). Returns 0
+     *  for non-wearers. Default → always 0 (byte-identical: no wearer, no change). */
+    buffDurationExtensionFor?: (casterId: string) => number;
+```
+
+In `createStatusEngine` destructure (~339-340) add:
+
+```typescript
+    const buffDurationExtensionFor = input.buffDurationExtensionFor ?? (() => 0);
+```
+
+- [ ] **Step 4: Extend `upsertBuff` (seam 1)**
+
+Change the `upsertBuff` signature (~633) to accept the firing caster id, and apply the extension to the self-side numeric write — computed ONCE, used in BOTH the family-rule check and the store:
+
+```typescript
+    const upsertBuff = (buff: SelectedGameBuff, side: 'self' | 'enemy', casterId?: string) => {
+        // ... PERSISTENT_STACKING_BUFFS early-return unchanged ...
+        if (typeof buff.skillDuration !== 'number') return;
+        const { familyKey, tier } = deriveFamilyKey(buff.buffName);
+        // Boost: +N turns on a buff the caster APPLIES, self-side only (debuffs land enemy-side).
+        const extension = side === 'self' && casterId ? buffDurationExtensionFor(casterId) : 0;
+        const duration = buff.skillDuration + extension;
+        const existing = map.get(familyKey);
+        if (!familyApplicationWins(existing, tier, duration)) return;
+        map.set(familyKey, {
+            buffName: buff.buffName,
+            turnsRemaining: duration,
+            tier,
+            appliedSeq: nextAppliedSeq(),
+        });
+    };
+```
+
+Update the two `sourceFired` call sites: self (~711) → `upsertBuff(buff, 'self', sourceId)`; enemy (~735) → leave as `upsertBuff(buff, 'enemy')` (or pass `sourceId` — it is ignored for the enemy side).
+
+- [ ] **Step 5: Extend `applyTimedAbilityStatus` (seam 2)**
+
+At the write region (~1135-1143), compute the extended duration once (self-side only, caster fail-safe to `'attacker'`) and use it in BOTH the family check and the store:
+
+```typescript
+        const extension =
+            status.side === 'self' ? buffDurationExtensionFor(status.casterId ?? 'attacker') : 0;
+        const duration = status.duration + extension;
+        const { familyKey, tier } = deriveFamilyKey(status.payload.buffName);
+        const existing = map.get(familyKey);
+        if (!familyApplicationWins(existing, tier, duration)) return;
+        map.set(familyKey, {
+            buffName: status.payload.buffName,
+            turnsRemaining: duration,
+            tier,
+            payload: status.payload,
+            casterId: status.casterId,
+            appliedSeq: nextAppliedSeq(),
+        });
+```
+
+(Persistent-stacking is already handled by the early-return above this block — no change there.)
+
+- [ ] **Step 6: Run, verify pass**
+
+Run: `npm test -- src/utils/combat/__tests__/statusEngine.test.ts`
+Expected: PASS (new Boost cases + all existing statusEngine tests unchanged).
+
+- [ ] **Step 7: Confirm no other `upsertBuff` callers**
+
+Run: `grep -n "upsertBuff" src/utils/combat/statusEngine.ts`
+Expected: definition (~633) + the two `sourceFired` calls only. If any other caller exists, verify the caster id passed there is correct (or pass nothing → ext 0).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/utils/combat/statusEngine.ts src/utils/combat/__tests__/statusEngine.test.ts
+git commit -m "feat(combat): Boost — +1 turn on caster-in-set buffs at status-engine seams
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Engine wiring — build the per-owner map, thread the lookup
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts` — build the map before `createStatusEngine` (~1422); pass `buffDurationExtensionFor`
+- Test: `src/utils/combat/__tests__/boostGearSet.integration.test.ts` (created in Task 5; this task is verified by the full suite staying byte-identical)
+
+- [ ] **Step 1: Build the map before construction**
+
+Immediately before `const statusEngine = createStatusEngine({` (~1422), insert:
+
+```typescript
+    // Boost gear set: per-owner buff-duration extension. Built from the RAW ShipSkills (which
+    // already carry the BOOST passive merged by buildShipAbilitiesWithEquipment at the page
+    // level) BEFORE the status engine is constructed — the runtime-derived ability maps
+    // (incomingAbilitiesById etc.) aren't built until much later (~2257). Covers all actors
+    // team-agnostically: attacker + walked team allies + enemy attackers.
+    const buffDurationExtensionByOwner = buildBuffDurationExtensionByOwner([
+        { id: 'attacker', shipSkills: input.shipSkills },
+        ...teamActors.map((t) => ({ id: t.id, shipSkills: t.shipSkills })),
+        ...(input.enemyAttackers ?? []).map((e) => ({ id: e.id, shipSkills: e.shipSkills })),
+    ]);
+```
+
+Add the import at the top of `engine.ts` (near the other `src/utils/combat` imports):
+
+```typescript
+import { buildBuffDurationExtensionByOwner } from './buffDurationExtension';
+```
+
+> VERIFY while implementing: `input.shipSkills` is the RAW attacker skills (the local `shipSkills` binding is rebound to the partitioned cast-only subset at ~1227, but `input.shipSkills` still holds the full skills with the passive slot). `teamActors` (normalized ~1204) and `input.enemyAttackers` each expose `{ id, shipSkills }`. Confirm the `shipSkills` field names on the team/enemy actor types (`t.shipSkills`, `e.shipSkills`); adjust if the walked-actor type names it differently.
+
+- [ ] **Step 2: Pass the lookup into `createStatusEngine`**
+
+In the `createStatusEngine({ ... })` literal (~1422-1432), add a field:
+
+```typescript
+        buffDurationExtensionFor: (casterId) => buffDurationExtensionByOwner.get(casterId) ?? 0,
+```
+
+- [ ] **Step 3: Verify the full suite is byte-identical**
+
+Run: `npm test`
+Expected: ALL existing tests pass with ZERO golden/`.snap` movement (no fixture equips Boost → lookup returns 0 everywhere). If any golden moves, STOP — a fixture unexpectedly equips Boost or the gate leaked; do not update goldens.
+
+Run: `npx tsc --noEmit` and `npm run lint` — both clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/combat/engine.ts
+git commit -m "feat(combat): Boost — collect per-owner extension, thread into status engine
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Integration tests — combat sim + DPS via the real registry
+
+**Files:**
+- Create: `src/utils/combat/__tests__/boostGearSet.integration.test.ts`
+
+Use the **real** registry path (`buildShipAbilitiesWithEquipment(ship, getGearPiece)` with `setBonus:'BOOST'` on 4 pieces), NOT a hand-rolled ability — this is the D-PR16 mutation-resistance lesson (a hand-rolled ability lets a broken wiring still pass). Find a sibling integration test (`reflectGearSet.integration.test.ts` / `revengeGearSet.integration.test.ts`) and copy its harness: how it builds a ship with a gear set, supplies `getGearPiece`, runs `simulateBattle`/`runCombat`, and asserts on `RoundData`/status state.
+
+- [ ] **Step 1: Write the integration tests**
+
+```typescript
+// Harness mirrors revengeGearSet.integration.test.ts. Build a ship whose skill grants itself a
+// timed self-buff (e.g. Attack Up for 2 turns) and equip it with 4 BOOST pieces via getGearPiece.
+
+// Test A — self-buff extended: run the sim with BOOST equipped vs without; the wearer's
+//   self-buff is active for one more round with BOOST (assert via the status snapshot / a
+//   round where the buffed stat is still elevated that is bare without BOOST).
+// Test B — ally-buff extended: a buffer ship granting an ally a timed buff, with the buffer
+//   wearing BOOST → the ally's buff lasts +1 turn. (If no convenient ally-buff fixture exists,
+//   cover this at the engine level by asserting buildBuffDurationExtensionByOwner maps the
+//   buffer id AND that an applyTimedAbilityStatus with that casterId extends — i.e. lean on the
+//   Task 3 unit test for the seam and keep this integration case to the self-buff path.)
+// Test C — enemy debuff NOT extended: the BOOST wearer inflicts a timed debuff on an enemy;
+//   the debuff duration is unchanged vs. without BOOST.
+// Test D — registry shape: buildShipAbilitiesWithEquipment(ship, getGearPiece) yields a passive
+//   ability with config { type:'buff-duration-extension', turns:1 } (proves the wiring routes
+//   through the real registry, not a stub).
+```
+
+- [ ] **Step 2: Write a DPS integration assertion**
+
+```typescript
+// Test E (DPS) — simulateDPS for a self-buffing attacker yields >= DPS with BOOST equipped vs
+//   without (extended self-buff uptime). Copy the simulateDPS setup from an existing dps test
+//   (e.g. decimationDps.test.ts). Assert dpsWithBoost > dpsWithoutBoost (strictly greater if the
+//   buff is damage-relevant and its base duration is shorter than the modeled horizon).
+```
+
+- [ ] **Step 3: Run, verify pass**
+
+Run: `npm test -- src/utils/combat/__tests__/boostGearSet.integration.test.ts`
+Expected: PASS. If Test E is not strictly greater, inspect the buff/horizon and adjust the fixture so the extra turn falls within the modeled rounds (document the choice in a comment).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/combat/__tests__/boostGearSet.integration.test.ts
+git commit -m "test(combat): Boost integration — self-buff/DPS extended, enemy debuff unchanged
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Coverage tracker + changelog + docs
+
+**Files:**
+- Modify: `src/utils/abilities/__tests__/equipmentCoverage.test.ts` (2 spots: the `it('exactly {...}')` title + `.toEqual([...])` array ~130, and `IMPLEMENTED_SETS` ~195)
+- Modify: `src/constants/changelog.ts` (`UNRELEASED_CHANGES`)
+- Modify: `src/pages/DocumentationPage.tsx`
+
+- [ ] **Step 1: Update the coverage tracker test**
+
+In `equipmentCoverage.test.ts`: add `'BOOST'` to the `implementedSets` `.toEqual([...])` array (~130, keep alphabetical/decl order consistent with the file) and to the `IMPLEMENTED_SETS` `new Set([...])` (~195). Update the long `it('exactly { ... } are currently implemented')` title string to include BOOST.
+
+- [ ] **Step 2: Run the coverage test**
+
+Run: `npm test -- src/utils/abilities/__tests__/equipmentCoverage.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Changelog**
+
+Add to `UNRELEASED_CHANGES` in `src/constants/changelog.ts` (plain English, match the existing entry voice):
+
+```
+'The combat and DPS simulators now model the Boost gear set: while a ship wears 4+ Boost pieces, every buff it applies — to itself or its allies — lasts one extra turn.'
+```
+
+- [ ] **Step 4: Docs**
+
+In `src/pages/DocumentationPage.tsx`, find where the other special-effect gear sets (Reflect/Revenge/Burner/Decimation) are described and add a Boost line: "Boost (4-piece): buffs the wearer applies last +1 turn (modeled in the combat + DPS simulators)." Match the surrounding markup/components.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/abilities/__tests__/equipmentCoverage.test.ts src/constants/changelog.ts src/pages/DocumentationPage.tsx
+git commit -m "docs(combat): Boost gear set — coverage tracker, changelog, in-app docs
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Full suite**
+
+Run: `npm test`
+Expected: ALL pass; ZERO golden/`.snap` movement vs main. (Pre-existing env-failing `.tsx` files needing Supabase URL or gitignored `docs/*.csv` are NOT ours — confirm the count matches main's baseline, not new failures.)
+
+- [ ] **Step 2: Types, lint, skill audit**
+
+Run: `npx tsc --noEmit` → clean.
+Run: `npm run lint` → clean (max-warnings 0).
+Run: `npm run audit:skills` → unchanged (e.g. 141/0).
+
+- [ ] **Step 3: Confirm byte-identical goldens explicitly**
+
+Run: `git status --porcelain` and `git diff --stat` — ensure NO `__snapshots__/*.snap` or golden fixture files are modified. If any are, investigate (do NOT `vitest -u`).
+
+- [ ] **Step 4: Requesting code review**
+
+Use superpowers:requesting-code-review for a holistic review against this plan + the spec before opening the PR.
+
+---
+
+## Notes / pitfalls
+
+- **Never run `vitest -u`** — golden movement here means a real regression, not a stale snapshot.
+- **Caster vs carrier:** scheduled self-buffs are stored under the `'attacker'` carrier but the +1 gates on the firing `sourceId`. Keep these distinct.
+- **Compute-once:** at both seams the extended duration must feed the `familyApplicationWins` check AND the `turnsRemaining` store.
+- **`'attacker'` fail-safe:** only unit-test fixtures omit `status.casterId`; `?? 'attacker'` returns 0 in every byte-identical suite.
+- **DPS needs no separate file** — it routes through the single `createStatusEngine`.
+- **Pre-existing `BoostSetStatus.tsx`** is a cosmetic presence indicator (reads `activeSets`); unrelated, no change, no double-count.

--- a/docs/superpowers/specs/2026-06-26-boost-gear-set-design.md
+++ b/docs/superpowers/specs/2026-06-26-boost-gear-set-design.md
@@ -38,7 +38,7 @@ Timed self-side buffs get their `turnsRemaining` written in exactly two places i
 
 **`upsertBuff` needs a signature change.** Its closure is `(buff, side)` today and scheduled self-buffs are deliberately routed to the `'attacker'` *carrier* owner regardless of `sourceId`. The caster (the ship whose Boost membership matters) is the firing `sourceId`, available in `sourceFired` at the call site but not inside `upsertBuff`. Thread `sourceId` (or the resolved extension turns) into `upsertBuff` as a new parameter, and gate on the **firing source**, not the `'attacker'` carrier the buff is stored under — these differ for team-actor casts. Confirm there are no other `upsertBuff(..., 'self')` callers where the caster would be wrong/unavailable.
 
-At each seam, before writing `turnsRemaining = <duration>`, add `extensionFor(casterId)` (0 or 1 turn). Gated so the +1 only applies to:
+At each seam, before writing `turnsRemaining = <duration>`, add `buffDurationExtensionFor(casterId)` (0 or 1 turn). Gated so the +1 only applies to:
 
 - **self-side** statuses (`side === 'self'`) — excludes enemy debuffs;
 - **finite-duration** entries — the persistent-stacking early-return (`PERSISTENT_STACKING_BUFFS.has(...)`, statusEngine.ts ~639 / ~1114) and permanent/recurring kinds (seeded via separate sentinel paths that never reach the numeric writes) already return before the numeric duration write, so they are untouched without extra guards. *(Verified: the only two numeric `turnsRemaining` writes are `upsertBuff` ~649 and `applyTimedAbilityStatus` ~1138, both after these early-returns.)*

--- a/docs/superpowers/specs/2026-06-26-boost-gear-set-design.md
+++ b/docs/superpowers/specs/2026-06-26-boost-gear-set-design.md
@@ -33,15 +33,19 @@ Timed self-side buffs get their `turnsRemaining` written in exactly two places i
 
 | Seam | Buff kind | Caster identity available |
 |---|---|---|
-| `upsertBuff(buff, 'self')`, called inside `sourceFired(sourceId, slot, round)` | scheduled ship-skill self-buffs | `sourceId` (the firing source = caster) |
+| `upsertBuff(buff, 'self')`, called inside `sourceFired(sourceId, slot, round)` (~711) | scheduled ship-skill self-buffs | `sourceId` (the firing source = caster) — **at the call site, NOT in the closure** (see below) |
 | `applyTimedAbilityStatus(round, status, recipientId)` | ability-granted buffs (self + ally targets, including reactive grants) | `status.casterId` (the registering owner = caster) |
+
+**`upsertBuff` needs a signature change.** Its closure is `(buff, side)` today and scheduled self-buffs are deliberately routed to the `'attacker'` *carrier* owner regardless of `sourceId`. The caster (the ship whose Boost membership matters) is the firing `sourceId`, available in `sourceFired` at the call site but not inside `upsertBuff`. Thread `sourceId` (or the resolved extension turns) into `upsertBuff` as a new parameter, and gate on the **firing source**, not the `'attacker'` carrier the buff is stored under — these differ for team-actor casts. Confirm there are no other `upsertBuff(..., 'self')` callers where the caster would be wrong/unavailable.
 
 At each seam, before writing `turnsRemaining = <duration>`, add `extensionFor(casterId)` (0 or 1 turn). Gated so the +1 only applies to:
 
 - **self-side** statuses (`side === 'self'`) — excludes enemy debuffs;
-- **finite-duration** entries — the persistent-stacking early-return (`PERSISTENT_STACKING_BUFFS.has(...)`) and permanent/recurring kinds already return before the numeric duration write, so they are untouched without extra guards.
+- **finite-duration** entries — the persistent-stacking early-return (`PERSISTENT_STACKING_BUFFS.has(...)`, statusEngine.ts ~639 / ~1114) and permanent/recurring kinds (seeded via separate sentinel paths that never reach the numeric writes) already return before the numeric duration write, so they are untouched without extra guards. *(Verified: the only two numeric `turnsRemaining` writes are `upsertBuff` ~649 and `applyTimedAbilityStatus` ~1138, both after these early-returns.)*
 
-The family-rule comparison (`familyApplicationWins(existing, tier, duration)`) operates on the *extended* duration, which is correct: a Boost-extended buff legitimately wins over a shorter same-family application.
+**Compute the extended duration ONCE and use it in BOTH the family-rule check and the store.** Each seam references the duration twice — `familyApplicationWins(existing, tier, <dur>)` AND `turnsRemaining: <dur>` (upsertBuff ~646/~649; applyTimedAbilityStatus ~1135/~1138). The +1 MUST feed the comparison too, not only the stored value: otherwise a Boost re-cast of an N-turn buff against an existing `turnsRemaining === N` fails the `> N` win-check and silently drops the extension. Compute `const dur = baseDuration + extension;` before the win-check and use `dur` in both spots.
+
+**`casterId` fail-safe.** Read sites already default a missing `casterId` to `'attacker'`. In production `casterId` is reliably stamped (`engine.ts` registration `casterId: ownerId`; reactive grants `casterId: intent.ownerId`), so real ally-targeted/reactive self-buffs carry the wearer id. Use `buffDurationExtensionFor(status.casterId ?? 'attacker')` so an undefined caster (unit-test fixtures only) fails safe to the attacker's membership rather than throwing — `'attacker'` is not a Boost wearer in any byte-identical fixture, so this returns 0.
 
 ### 3.2 How the wearer-set reaches the status engine (Approach A — registry + collected map)
 
@@ -49,17 +53,22 @@ Consistent with the REFLECT precedent (a config type the ability fold ignores, r
 
 1. **Registry entry** — `GEAR_SET_ABILITIES.BOOST` in `buildEquipmentAbilities.ts` emits an `Ability` with a new no-op config `{ type: 'buff-duration-extension', turns: 1 }`. Top-level `type: 'modifier'` is a placeholder (the engine keys on `config.type`, exactly as REFLECT does with `damage-reflection`). Gated by the existing `minPieces` check (4) in `buildEquipmentAbilities`.
 2. **New `AbilityConfig` variant** — `buff-duration-extension` added to the `AbilityConfig` union in `types/abilities.ts` (`{ type: 'buff-duration-extension'; turns: number }`).
-3. **Engine collection** — where the engine already builds per-owner ability maps (`incomingAbilitiesById`, `outgoingAbilitiesById`), also collect a `buffDurationExtensionByOwner: Map<string, number>` (owner id → max extension turns). Owners with no Boost ability are absent (lookup → 0).
-4. **Thread into the status engine** — add `buffDurationExtensionFor?: (casterId: string) => number` to `StatusEngineInput` (returns extra turns, default 0). The engine passes a lookup backed by the map; the DPS path passes the same lookup built from its team actors.
-5. The config type is **inert in the ability fold** — it is purely a marker the engine reads at collection time, never executed by the ability executor.
+3. **Engine collection** — build a `buffDurationExtensionByOwner: Map<string, number>` (owner id → max extension turns; absent → 0). Owners with no Boost ability are absent (lookup → 0).
+4. **Thread into the status engine** — add `buffDurationExtensionFor?: (casterId: string) => number` to `StatusEngineInput` (returns extra turns, default 0). The engine passes a lookup backed by the map.
+
+   **ORDERING (blocker — must be handled explicitly):** `createStatusEngine(...)` is constructed **early** in `engine.ts` (~1422), but the existing per-owner ability maps (`incomingAbilitiesById` / `outgoingAbilitiesById`) are built **much later** (~2257–2315) from the assembled runtimes. So a lookup passed into `createStatusEngine` **cannot** close over a map that doesn't exist yet at line ~1422. The seams (`sourceFired` / `applyTimedAbilityStatus`) only fire at turn time (after ~2539), so two resolutions are viable — the plan must pick one and test it:
+   - **(a) Hoist a minimal BOOST scan before ~1422.** Boost membership needs only the equipped-set counts per actor (not the full runtime), so a small `buildBoostWearerSet(actors, getGearPiece)` can run before construction and back the lookup directly. *(Preferred — simplest, no mutable-ref aliasing.)*
+   - **(b) Closure over a mutable ref** populated before the first turn (alongside the existing `ByOwner` collection at ~2300). Requires a test asserting the lookup is live by the first `sourceFired`.
+5. The config type is **inert in the ability fold** — it is purely a marker read at collection time, never executed by the ability executor. *(If resolution (a) is chosen, the registry ability is optional — the BOOST scan could read set counts directly. Keeping the registry entry is still preferred for coverage-tracker consistency and a single source of the "+1 turns" value; the plan decides.)*
 
 ### 3.3 DPS calculator
 
-No separate effect wiring needed. `simulateDPS` → `runCombat` uses the same status engine and already builds equipment abilities via `buildShipAbilitiesWithEquipment`. A self-buffing attacker wearing Boost gets longer self-buff uptime → higher DPS, which is correct. The only requirement is that the DPS construction path threads the same `buffDurationExtensionFor` lookup into its status-engine input (built from the same team-actor gear it already reads). This must be verified during implementation, not assumed.
+No separate DPS wiring needed. `simulateDPS` (`dpsSimulator.ts` ~274) calls `runCombat`, and the DPS path does **not** construct its own `StatusEngineInput` — it routes through the single `createStatusEngine` in `engine.ts`. So threading the lookup once into the engine's status-engine input covers the DPS path automatically (confirmed: one `createStatusEngine` call site). A self-buffing attacker wearing Boost gets longer self-buff uptime → higher DPS, which is correct. **No separate DPS construction file is touched** (§7 corrected accordingly).
 
 ## 4. Surfacing & editor
 
 - **Ability editor** — no stub needed. The editor's exhaustiveness switches key on `AbilityType` (top-level `type`), not `config.type`, with a permissive default — same as REFLECT's `damage-reflection`. Confirm during implementation.
+- **Pre-existing presence indicator** — `src/components/simulation/statLines/BoostSetStatus.tsx` already renders "Boost Set: Active/Inactive" from `simulation.activeSets?.includes('BOOST')`. It is purely cosmetic and does NOT model the duration effect. The new combat modeling is independent of it — no change needed there, and there is no double-count (the component reads set presence, not buff durations).
 - **Coverage tracker** — add `BOOST` to the implemented gear-set set in `equipmentCoverage.test.ts`.
 - **Changelog** — add a plain-English `UNRELEASED_CHANGES` entry (`src/constants/changelog.ts`).
 - **DocumentationPage** — note Boost is now modeled in the combat + DPS simulators.
@@ -85,10 +94,9 @@ Note: this is unrelated to the separate "universal decrement-timing" bug (a glob
 ## 7. Files touched (anticipated)
 
 - `src/types/abilities.ts` — new `buff-duration-extension` `AbilityConfig` variant.
-- `src/utils/abilities/buildEquipmentAbilities.ts` — `GEAR_SET_ABILITIES.BOOST` entry.
-- `src/utils/combat/statusEngine.ts` — `StatusEngineInput.buffDurationExtensionFor?`; +1 at the two seams.
-- `src/utils/combat/engine.ts` — collect `buffDurationExtensionByOwner`; thread the lookup into the status-engine input.
-- DPS construction path (`engine.ts` / `dpsSimulator.ts` as needed) — thread the same lookup.
+- `src/utils/abilities/buildEquipmentAbilities.ts` — `GEAR_SET_ABILITIES.BOOST` entry (registry; kept for coverage-tracker consistency even if resolution (a) reads set counts directly).
+- `src/utils/combat/statusEngine.ts` — `StatusEngineInput.buffDurationExtensionFor?`; `upsertBuff` signature gains the firing-source/extension param; +1 (computed once, used in both the family-check and the store) at the two seams.
+- `src/utils/combat/engine.ts` — build `buffDurationExtensionByOwner` (hoisted before `createStatusEngine` ~1422 per §3.2 resolution (a), or mutable-ref per (b)); thread the lookup into the status-engine input. **No DPS file is touched — DPS routes through this same construction.**
 - `src/utils/abilities/__tests__/equipmentCoverage.test.ts` — add BOOST.
 - New test files for the unit + integration + DPS cases above.
 - `src/constants/changelog.ts`, `src/pages/DocumentationPage.tsx`.

--- a/docs/superpowers/specs/2026-06-26-boost-gear-set-design.md
+++ b/docs/superpowers/specs/2026-06-26-boost-gear-set-design.md
@@ -1,0 +1,94 @@
+# Boost gear set — design
+
+**Status:** Approved (scope + Approach A ratified by user 2026-06-26)
+**Sub-project:** Combat-realism epic, sub-project D (implants + gear-set abilities) — the final special-effect gear set leftover.
+**Branch:** `feat/combat-d-pr-boost-set` (worktree `.worktrees/boost-set`), off main `bd2b6aa8` (Reflect/Revenge/Smokescreen #160).
+
+## 1. Effect
+
+The **Boost** gear set (4-piece bonus, `GEAR_SETS.BOOST`, `minPieces: 4`, description *"All buffs last an extra turn"*) makes every **buff the wearer applies** last **+1 turn**, wherever that buff lands:
+
+- the wearer's own self-buffs (e.g. Attack Up it grants itself from a skill), and
+- buffs the wearer grants to allies (e.g. a buffer casting Attack Up on all allies).
+
+This is **caster-side**: the determinant is whether the *applying* (casting) ship wears 4-piece Boost, not whose buff it ultimately sits on. This matches Boost being the recommended set for the buffer role in `shipTypes.ts` ("big bonus if boost set") — a buffer's value is the buffs it puts on allies, and Boost extends those.
+
+It is a **binary set bonus**: +1 turn flat at ≥4 pieces. 6 pieces is still +1 (not per-2-pieces like Decimation).
+
+### Out of scope (ratified design decisions)
+
+- **Debuffs the wearer inflicts on enemies are NOT extended.** "All *buffs*" = positive statuses only. The engine separates these by side (buffs land self-side, debuffs enemy-side), so gating the +1 to the self side excludes enemy debuffs for free.
+- **Permanent / recurring / persistent-stacking buffs get no +1.** They carry no finite duration; the existing early-returns at the application seams skip them before the duration is ever written.
+- **No stacking with itself.** One Boost set on the caster = +1. (Two Boost wearers do not compound on the same buff — each buff has exactly one caster.)
+
+## 2. Why Boost is structurally different from prior D effects
+
+Every prior D gear-set / implant effect folds into a damage / heal / shield / targeting channel via an `Ability` consumed by the ability executor or an in-flight seam. Boost changes **buff durations**, which live in `src/utils/combat/statusEngine.ts`. The +1 is applied at the moment a timed buff's `turnsRemaining` is written, conditioned on the caster wearing Boost — not in the ability fold.
+
+## 3. Mechanism
+
+### 3.1 The two application seams
+
+Timed self-side buffs get their `turnsRemaining` written in exactly two places in `statusEngine.ts`:
+
+| Seam | Buff kind | Caster identity available |
+|---|---|---|
+| `upsertBuff(buff, 'self')`, called inside `sourceFired(sourceId, slot, round)` | scheduled ship-skill self-buffs | `sourceId` (the firing source = caster) |
+| `applyTimedAbilityStatus(round, status, recipientId)` | ability-granted buffs (self + ally targets, including reactive grants) | `status.casterId` (the registering owner = caster) |
+
+At each seam, before writing `turnsRemaining = <duration>`, add `extensionFor(casterId)` (0 or 1 turn). Gated so the +1 only applies to:
+
+- **self-side** statuses (`side === 'self'`) — excludes enemy debuffs;
+- **finite-duration** entries — the persistent-stacking early-return (`PERSISTENT_STACKING_BUFFS.has(...)`) and permanent/recurring kinds already return before the numeric duration write, so they are untouched without extra guards.
+
+The family-rule comparison (`familyApplicationWins(existing, tier, duration)`) operates on the *extended* duration, which is correct: a Boost-extended buff legitimately wins over a shorter same-family application.
+
+### 3.2 How the wearer-set reaches the status engine (Approach A — registry + collected map)
+
+Consistent with the REFLECT precedent (a config type the ability fold ignores, read by the engine at a dedicated seam):
+
+1. **Registry entry** — `GEAR_SET_ABILITIES.BOOST` in `buildEquipmentAbilities.ts` emits an `Ability` with a new no-op config `{ type: 'buff-duration-extension', turns: 1 }`. Top-level `type: 'modifier'` is a placeholder (the engine keys on `config.type`, exactly as REFLECT does with `damage-reflection`). Gated by the existing `minPieces` check (4) in `buildEquipmentAbilities`.
+2. **New `AbilityConfig` variant** — `buff-duration-extension` added to the `AbilityConfig` union in `types/abilities.ts` (`{ type: 'buff-duration-extension'; turns: number }`).
+3. **Engine collection** — where the engine already builds per-owner ability maps (`incomingAbilitiesById`, `outgoingAbilitiesById`), also collect a `buffDurationExtensionByOwner: Map<string, number>` (owner id → max extension turns). Owners with no Boost ability are absent (lookup → 0).
+4. **Thread into the status engine** — add `buffDurationExtensionFor?: (casterId: string) => number` to `StatusEngineInput` (returns extra turns, default 0). The engine passes a lookup backed by the map; the DPS path passes the same lookup built from its team actors.
+5. The config type is **inert in the ability fold** — it is purely a marker the engine reads at collection time, never executed by the ability executor.
+
+### 3.3 DPS calculator
+
+No separate effect wiring needed. `simulateDPS` → `runCombat` uses the same status engine and already builds equipment abilities via `buildShipAbilitiesWithEquipment`. A self-buffing attacker wearing Boost gets longer self-buff uptime → higher DPS, which is correct. The only requirement is that the DPS construction path threads the same `buffDurationExtensionFor` lookup into its status-engine input (built from the same team-actor gear it already reads). This must be verified during implementation, not assumed.
+
+## 4. Surfacing & editor
+
+- **Ability editor** — no stub needed. The editor's exhaustiveness switches key on `AbilityType` (top-level `type`), not `config.type`, with a permissive default — same as REFLECT's `damage-reflection`. Confirm during implementation.
+- **Coverage tracker** — add `BOOST` to the implemented gear-set set in `equipmentCoverage.test.ts`.
+- **Changelog** — add a plain-English `UNRELEASED_CHANGES` entry (`src/constants/changelog.ts`).
+- **DocumentationPage** — note Boost is now modeled in the combat + DPS simulators.
+
+## 5. Golden / byte-identical guarantee
+
+Like every prior D PR: the +1 only fires when `buffDurationExtensionFor(casterId) > 0`, i.e. when the caster actually wears 4-piece Boost. No combat or DPS golden fixture equips a 4-piece Boost set (verified: no `simulateBattle`/`runCombat` fixture sets `setBonus: 'BOOST'` on 4+ pieces). Therefore the lookup returns 0 everywhere in the existing suites → `turnsRemaining` is written exactly as today → **goldens and `.snap` files are byte-identical**. This must be re-confirmed by running the full suite during implementation.
+
+Note: this is unrelated to the separate "universal decrement-timing" bug (a global rule change that *would* move every golden). Boost is a caster-gated, application-time additive — it changes nothing for non-wearers.
+
+## 6. Testing strategy
+
+1. **Pure status-engine unit tests** — construct a `StatusEngine` with a `buffDurationExtensionFor` that returns 1 for a designated caster id:
+   - a self-side timed buff applied by that caster gets `turnsRemaining + 1`;
+   - a buff applied by a non-wearer caster is untouched;
+   - an enemy-side debuff by the wearer is untouched;
+   - a persistent-stacking / permanent / recurring buff is untouched;
+   - the family rule still picks the longer (extended) duration.
+2. **Engine integration (real registry)** — a ship with `setBonus: 'BOOST'` on 4 pieces (override `getGearPiece`): its self-buff and an ally-targeted buff each persist one turn longer than without Boost; a debuff it inflicts on an enemy is unchanged. Route through the real `buildShipAbilitiesWithEquipment` + a registry-shape assertion (mutation-resistant, per the D-PR16 Last Stand lesson).
+3. **DPS integration** — a self-buffing attacker wearing Boost yields measurably higher DPS than the same ship without Boost (buff uptime extended).
+4. **Full suite + goldens** — byte-identical; `audit:skills` unchanged; `tsc`/`lint` clean.
+
+## 7. Files touched (anticipated)
+
+- `src/types/abilities.ts` — new `buff-duration-extension` `AbilityConfig` variant.
+- `src/utils/abilities/buildEquipmentAbilities.ts` — `GEAR_SET_ABILITIES.BOOST` entry.
+- `src/utils/combat/statusEngine.ts` — `StatusEngineInput.buffDurationExtensionFor?`; +1 at the two seams.
+- `src/utils/combat/engine.ts` — collect `buffDurationExtensionByOwner`; thread the lookup into the status-engine input.
+- DPS construction path (`engine.ts` / `dpsSimulator.ts` as needed) — thread the same lookup.
+- `src/utils/abilities/__tests__/equipmentCoverage.test.ts` — add BOOST.
+- New test files for the unit + integration + DPS cases above.
+- `src/constants/changelog.ts`, `src/pages/DocumentationPage.tsx`.

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -43,7 +43,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Voidfire Catalyst implant now increases detonation damage (bomb, Inferno, and Corrosion bursts).',
     "Combat simulator now models bomb splash-on-death: when a ship is destroyed while still carrying un-detonated bombs, each adjacent ally takes a share of every bomb's damage (25% at tier 1, 50% at tier 2, 75% at tier 3). This is positional, so it only applies in battles with board positions.",
     'Voidfire Catalyst implant now also amplifies bomb splash damage — when a bomb-carrier is destroyed, the splash damage dealt to adjacent ships is increased by Voidfire Catalyst, including its rare and legendary splash-only variants.',
-    'Combat & DPS simulators now model the Boost gear set: while a ship wears 4 or more Boost pieces, every buff it applies — to itself or its allies — lasts one extra turn.',
+    'Combat & DPS simulators now model the Boost gear set: while a ship wears 4 or more Boost pieces, each timed buff it applies — to itself or its allies — lasts one extra turn.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -43,6 +43,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Voidfire Catalyst implant now increases detonation damage (bomb, Inferno, and Corrosion bursts).',
     "Combat simulator now models bomb splash-on-death: when a ship is destroyed while still carrying un-detonated bombs, each adjacent ally takes a share of every bomb's damage (25% at tier 1, 50% at tier 2, 75% at tier 3). This is positional, so it only applies in battles with board positions.",
     'Voidfire Catalyst implant now also amplifies bomb splash damage — when a bomb-carrier is destroyed, the splash damage dealt to adjacent ships is increased by Voidfire Catalyst, including its rare and legendary splash-only variants.',
+    'Combat & DPS simulators now model the Boost gear set: while a ship wears 4 or more Boost pieces, every buff it applies — to itself or its allies — lasts one extra turn.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3142,14 +3142,14 @@ const DocumentationPage: React.FC = () => {
                                     increasing damage as its HP drops, up to +25% near death), and
                                     the <strong>Smokescreen</strong> implant (a chance to gain
                                     Stealth when directly hit), and the <strong>Boost</strong> gear
-                                    set (every buff the wearer applies — to itself or allies — lasts
-                                    one extra turn, modeled in both the combat and DPS simulators).
-                                    The <strong>Voidfire Catalyst</strong> implant is also modeled:
-                                    it increases detonation damage (bomb bursts, Inferno detonations,
-                                    and Corrosion detonations) and bomb splash damage by a percentage
-                                    based on rarity — its rare and legendary variants amplify bomb
-                                    splash damage only. More implant and gear-set effects will be
-                                    added in future updates.
+                                    set (each timed buff the wearer applies — to itself or allies —
+                                    lasts one extra turn, modeled in both the combat and DPS
+                                    simulators). The <strong>Voidfire Catalyst</strong> implant is
+                                    also modeled: it increases detonation damage (bomb bursts,
+                                    Inferno detonations, and Corrosion detonations) and bomb splash
+                                    damage by a percentage based on rarity — its rare and legendary
+                                    variants amplify bomb splash damage only. More implant and
+                                    gear-set effects will be added in future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3141,13 +3141,15 @@ const DocumentationPage: React.FC = () => {
                                     the <strong>Revenge</strong> gear set (the wearer deals
                                     increasing damage as its HP drops, up to +25% near death), and
                                     the <strong>Smokescreen</strong> implant (a chance to gain
-                                    Stealth when directly hit). The{' '}
-                                    <strong>Voidfire Catalyst</strong> implant is also modeled: it
-                                    increases detonation damage (bomb bursts, Inferno detonations,
-                                    and Corrosion detonations) and bomb splash damage by a
-                                    percentage based on rarity — its rare and legendary variants
-                                    amplify bomb splash damage only. More implant and gear-set
-                                    effects will be added in future updates.
+                                    Stealth when directly hit), and the <strong>Boost</strong> gear
+                                    set (every buff the wearer applies — to itself or allies — lasts
+                                    one extra turn, modeled in both the combat and DPS simulators).
+                                    The <strong>Voidfire Catalyst</strong> implant is also modeled:
+                                    it increases detonation damage (bomb bursts, Inferno detonations,
+                                    and Corrosion detonations) and bomb splash damage by a percentage
+                                    based on rarity — its rare and legendary variants amplify bomb
+                                    splash damage only. More implant and gear-set effects will be
+                                    added in future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -509,6 +509,14 @@ export type AbilityConfig =
           type: 'damage-reflection';
           /** Percentage of incoming direct damage reflected back to the attacker (e.g. 10). */
           pct: number;
+      }
+    // Boost gear set: caster-side +1-turn extension on every buff the wearer applies.
+    // No-op marker config (mirrors damage-reflection) — read by the engine when building
+    // the per-owner extension map, NEVER executed by the ability fold.
+    | {
+          type: 'buff-duration-extension';
+          /** Extra turns added to buffs this wearer applies (Boost = 1). */
+          turns: number;
       };
 
 /** Crowd-control effects a `control` ability can apply. The engine does not simulate

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -797,7 +797,11 @@ describe('Decimation gear set', () => {
         return { ship: makeShip({ equipment }), getGearPiece: (id: string) => map[id] };
     }
     it('emits a dotDamage modifier scaling 10% per complete 2pc set', () => {
-        for (const [pieces, expected] of [[2, 10], [4, 20], [6, 30]] as const) {
+        for (const [pieces, expected] of [
+            [2, 10],
+            [4, 20],
+            [6, 30],
+        ] as const) {
             const { ship, getGearPiece } = shipWithDecimation(pieces);
             const abilities = buildEquipmentAbilities(ship, getGearPiece);
             const dec = abilities.find((a) => a.id === 'equip-set-DECIMATION');
@@ -870,6 +874,32 @@ describe('Power Infused Nanobots buff (D-PR9 + D-PR10 — Font of Power, flat at
         expect(effects.attackFlatPctOfCaster).toBe(100);
         expect(effects.attack).toBeUndefined();
         expect(effects.attackFlat).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Boost gear set (4pc): every buff the wearer applies lasts +1 turn
+// ---------------------------------------------------------------------------
+describe('buildEquipmentAbilities — Boost set', () => {
+    it('emits an equip-set-BOOST ability with buff-duration-extension config at 4 pieces', () => {
+        const abilities = buildForGearSet('BOOST');
+        const ab = abilities.find((a) => a.id === 'equip-set-BOOST');
+        expect(ab).toBeDefined();
+        expect(ab!.type).toBe('modifier');
+        expect(ab!.config).toEqual({ type: 'buff-duration-extension', turns: 1 });
+    });
+
+    it('emits nothing when only 3 BOOST pieces are equipped (minPieces is 4)', () => {
+        const slots = ['weapon', 'hull', 'sensor'] as const;
+        const equipment: Record<string, string> = {};
+        const pieceMap: Record<string, GearPiece> = {};
+        for (let i = 0; i < 3; i++) {
+            const id = `BOOST-${i}`;
+            equipment[slots[i]] = id;
+            pieceMap[id] = makePiece({ id, slot: slots[i], setBonus: 'BOOST' });
+        }
+        const abilities = buildEquipmentAbilities(makeShip({ equipment }), (g) => pieceMap[g]);
+        expect(abilities.find((a) => a.id === 'equip-set-BOOST')).toBeUndefined();
     });
 });
 

--- a/src/utils/abilities/__tests__/equipmentCoverage.test.ts
+++ b/src/utils/abilities/__tests__/equipmentCoverage.test.ts
@@ -122,12 +122,13 @@ function implantAbilities(implantKey: string, rarity: string) {
 // ---------------------------------------------------------------------------
 
 describe('equipmentCoverage — implemented effects registry', () => {
-    it('exactly { BURNER + DECIMATION + LEECH + REFLECT + CLOAKING + HARDENED + REVENGE + SHIELD (gear sets), MARTYRDOM + ARCANE_SIEGE + CHRONO_REAVER + HYPERION_GAZE + INTRUSION + LIFELINE + NEBULA_NULLIFIER + NOURISHMENT + SMOKESCREEN + SYNAPTIC_RESONANCE + VOIDFIRE_CATALYST + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_STAND + LAST_WISH + LOCKDOWN + MENACE + REACTIVE_WARD + SECOND_WIND + SHADOWGUARD + SPEARHEAD + TENACITY + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
+    it('exactly { BOOST + BURNER + DECIMATION + LEECH + REFLECT + CLOAKING + HARDENED + REVENGE + SHIELD (gear sets), MARTYRDOM + ARCANE_SIEGE + CHRONO_REAVER + HYPERION_GAZE + INTRUSION + LIFELINE + NEBULA_NULLIFIER + NOURISHMENT + SMOKESCREEN + SYNAPTIC_RESONANCE + VOIDFIRE_CATALYST + VOIDSHADE + VORTEX_VEIL + WARPSTRIKE + ALACRITY + AMBUSH + BATTLECRY + BLOODTHIRST + BULWARK + DOOMSAYER + EXUBERANCE + FIREWALL + FONT_OF_POWER + FORTIFYING_SHROUD + GIANT_SLAYER + INSIDIOUSNESS + IRONCLAD + LAST_STAND + LAST_WISH + LOCKDOWN + MENACE + REACTIVE_WARD + SECOND_WIND + SHADOWGUARD + SPEARHEAD + TENACITY + VIVACIOUS_REPAIR (implants) } are currently implemented', () => {
         // Gear sets with an ability builder
         const implementedSets = Object.keys(GEAR_SETS).filter(
             (key) => gearSetAbilityCount(key) > 0
         );
         expect(implementedSets).toEqual([
+            'BOOST',
             'BURNER',
             'DECIMATION',
             'LEECH',
@@ -194,6 +195,7 @@ describe('equipmentCoverage — implemented effects registry', () => {
 // ---------------------------------------------------------------------------
 
 const IMPLEMENTED_SETS = new Set([
+    'BOOST',
     'BURNER',
     'DECIMATION',
     'LEECH',
@@ -205,6 +207,10 @@ const IMPLEMENTED_SETS = new Set([
 ]);
 
 describe('equipmentCoverage — gear sets', () => {
+    it('BOOST produces exactly 1 ability (the buff-duration-extension marker)', () => {
+        expect(gearSetAbilityCount('BOOST')).toBe(1);
+    });
+
     it('BURNER produces exactly 1 ability (the on-cast inferno)', () => {
         expect(gearSetAbilityCount('BURNER')).toBe(1);
     });

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -144,6 +144,19 @@ const GEAR_SET_ABILITIES: Partial<
         config: { type: 'shield', pct: 4, basis: 'hp' },
         autoFilled: true,
     }),
+    // Boost (4pc set): every buff the wearer APPLIES lasts +1 turn (caster-side). Modeled NOT
+    // as a damage/heal fold but as a marker the engine collects into a per-owner extension map,
+    // applied at the status-engine buff-duration write seams. Top-level type:'modifier' is a
+    // placeholder (engine keys on config.type:'buff-duration-extension', like REFLECT). The
+    // modifier fold ignores it (applyAbilities.ts skips config.type !== 'modifier').
+    BOOST: () => ({
+        type: 'modifier',
+        target: 'self',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'buff-duration-extension', turns: 1 },
+        autoFilled: true,
+    }),
 };
 
 // ---------------------------------------------------------------------------

--- a/src/utils/combat/__tests__/boostGearSet.integration.test.ts
+++ b/src/utils/combat/__tests__/boostGearSet.integration.test.ts
@@ -1,0 +1,357 @@
+/**
+ * boostGearSet.integration.test.ts
+ *
+ * End-to-end integration tests for the BOOST gear set (4-piece): every TIMED, SELF-SIDE buff
+ * the wearer APPLIES lasts +1 turn (caster-side). Enemy debuffs and non-finite buffs are excluded.
+ *
+ * These tests route through the REAL registry path — NOT a hand-rolled BOOST ability:
+ *   - ships are built with 4 real BOOST gear pieces (`setBonus:'BOOST'`) + a `getGearPiece` lookup,
+ *   - `buildShipAbilitiesWithEquipment(ship, getGearPiece)` merges GEAR_SET_ABILITIES.BOOST into the
+ *     passive slot (`config:{ type:'buff-duration-extension', turns:1 }`),
+ *   - the engine (`buildBuffDurationExtensionByOwner` → `buffDurationExtensionFor`) feeds the
+ *     status engine, which adds +1 to the wearer's self-side timed buffs.
+ * A broken wiring anywhere on that chain (registry → engine → status-engine seam) fails these tests.
+ *
+ * For every with-vs-without comparison the SAME ship/scenario is built twice, differing ONLY by
+ * whether 4 BOOST pieces are equipped, so the delta is unambiguously Boost.
+ *
+ * Test A (sim) and Test C/D (DPS) both run the SAME combat loop (`runCombat`): the battle simulator
+ * and the DPS simulator are two adapters over it. `simulateBattle` is used where a board-positioned
+ * self-buff window is the cleanest read; `simulateDPS` is used where the engine's per-round
+ * `activeEnemyDebuffs` expiry window or a damage total is the cleanest read.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateBattle, BattlePlacement } from '../../calculators/battleSimulator';
+import { simulateDPS } from '../../calculators/dpsSimulator';
+import { buildShipAbilitiesWithEquipment } from '../../abilities/buildShipAbilitiesWithEquipment';
+import { Ship, AffinityName } from '../../../types/ship';
+import { GearPiece } from '../../../types/gear';
+import { GEAR_SETS } from '../../../constants/gearSets';
+import type { Position } from '../../../types/encounters';
+
+// ---------------------------------------------------------------------------
+// Harness helpers (mirrored from reflectGearSet.integration.test.ts)
+// ---------------------------------------------------------------------------
+
+function makePiece(over: Partial<GearPiece>): GearPiece {
+    return {
+        id: 'piece-1',
+        slot: 'weapon',
+        level: 16,
+        stars: 6,
+        rarity: 'legendary',
+        mainStat: null,
+        subStats: [],
+        setBonus: null,
+        ...over,
+    } as GearPiece;
+}
+
+/** BOOST pieces equipping the wearer with `minPieces` (4) of the set across distinct slots. */
+const BOOST_SLOTS = ['weapon', 'hull', 'sensor', 'engine', 'shield', 'computer'] as const;
+function boostPieces(): GearPiece[] {
+    const minPieces = GEAR_SETS['BOOST']?.minPieces ?? 4;
+    const out: GearPiece[] = [];
+    for (let i = 0; i < minPieces; i++) {
+        out.push(
+            makePiece({
+                id: `BOOST-${i}`,
+                slot: BOOST_SLOTS[i % BOOST_SLOTS.length],
+                setBonus: 'BOOST',
+            })
+        );
+    }
+    return out;
+}
+
+/** id→GearPiece lookup for every piece used across the placements. */
+function getGearPieceFor(pieces: GearPiece[]): (id: string) => GearPiece | undefined {
+    const map: Record<string, GearPiece> = {};
+    for (const p of pieces) map[p.id] = p;
+    return (id) => map[id];
+}
+
+/**
+ * A ship whose ACTIVE skill is a plain 100% direct hit and whose CHARGED skill ALSO grants a
+ * self-buff. With a low chargeCount the charged skill fires periodically (not every turn), so the
+ * granted buff has DOWNTIME between applications — the window where Boost's +1 turn is observable.
+ */
+function makeShip(
+    id: string,
+    affinity: AffinityName,
+    pieces: GearPiece[],
+    opts: { activeText: string; chargedText: string; chargeCount: number }
+): Ship {
+    const equipment: Record<string, string> = {};
+    for (const p of pieces) equipment[p.slot] = p.id;
+    return {
+        id,
+        name: id,
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'ATTACKER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: equipment as Ship['equipment'],
+        implants: {},
+        refits: [],
+        affinity,
+        activeSkillText: opts.activeText,
+        chargeSkillText: opts.chargedText,
+        chargeSkillCharge: opts.chargeCount,
+        activeTarget: 'front',
+        activePattern: 'Pattern-Base',
+    } as Partial<Ship> as Ship;
+}
+
+const place = (
+    ship: Ship,
+    position: Position,
+    overrides: Partial<BattlePlacement['statOverrides']> = {}
+): BattlePlacement => ({
+    ship,
+    position,
+    statOverrides: {
+        attack: 5000,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        hacking: 200,
+        defence: 0,
+        hp: 1_000_000,
+        ...overrides,
+    } as BattlePlacement['statOverrides'],
+});
+
+const PLAIN_HIT = 'This Unit deals <unit-damage>100% damage</unit-damage>.';
+
+/** Whether the focus player wearer (reserved id 'attacker') has `buffName` active in a round. */
+function wearerHasBuff(
+    result: ReturnType<typeof simulateBattle>,
+    round: number,
+    buffName: string
+): boolean {
+    const r = result.rounds.find((x) => x.round === round);
+    if (!r) return false;
+    const s = r.ships.find((sh) => sh.actorId === 'attacker');
+    return !!s && s.activeBuffs.includes(buffName);
+}
+
+/**
+ * Build the wearer's full ShipSkills through the REAL registry: equip `pieces`, route through
+ * buildShipAbilitiesWithEquipment so the BOOST passive (when ≥4 pieces) lands in the passive slot.
+ */
+function registrySkills(
+    pieces: GearPiece[],
+    opts: { activeText: string; chargedText: string; chargeCount: number }
+) {
+    const ship = makeShip('attacker', 'thermal', pieces, opts);
+    return buildShipAbilitiesWithEquipment(ship, getGearPieceFor(pieces));
+}
+
+// ---------------------------------------------------------------------------
+// Test A — self-buff extended (combat sim)
+// ---------------------------------------------------------------------------
+
+describe('BOOST gear set — self-buff extended (combat sim)', () => {
+    it('(A) the wearer self-buff stays active one round LONGER with 4 BOOST pieces', () => {
+        // Wearer's CHARGED skill grants itself Attack Up III for 2 turns. chargeCount 2 → the
+        // charged skill fires on round 3 (banks charge on rounds 1-2). The granted buff is applied
+        // ONCE there and then left to decay — no re-application on the in-between active rounds, so
+        // the +1 turn is directly observable.
+        //
+        // Base duration 2 → present round 3 only (decremented at the wearer's own Post-Turn).
+        // With Boost: duration 2 + 1 = 3 → present rounds 3 AND 4. Round 4 is the unambiguous
+        // delta (an active round — the buff is NOT re-applied there, so its presence is purely the
+        // extended tail). The same delta repeats on the next charged cycle (round 6 fire → round 7).
+        const chargedText =
+            'This Unit deals <unit-damage>100% damage</unit-damage> and gains <unit-skill>Attack Up III</unit-skill> for 2 turns.';
+        const opts = { activeText: PLAIN_HIT, chargedText, chargeCount: 2 };
+
+        const pieces = boostPieces();
+        const withBoost = simulateBattle(
+            {
+                playerTeam: [place(makeShip('wearer', 'thermal', pieces, opts), 'M4')],
+                enemyTeam: [
+                    place(
+                        makeShip('foe', 'antimatter', [], {
+                            activeText: PLAIN_HIT,
+                            chargedText: PLAIN_HIT,
+                            chargeCount: 99,
+                        }),
+                        'M4'
+                    ),
+                ],
+                rounds: 8,
+            },
+            getGearPieceFor(pieces)
+        );
+
+        // Control: identical scenario, NO BOOST pieces (empty lookup → no set ability built).
+        const noBoost = simulateBattle(
+            {
+                playerTeam: [place(makeShip('wearer', 'thermal', [], opts), 'M4')],
+                enemyTeam: [
+                    place(
+                        makeShip('foe', 'antimatter', [], {
+                            activeText: PLAIN_HIT,
+                            chargedText: PLAIN_HIT,
+                            chargeCount: 99,
+                        }),
+                        'M4'
+                    ),
+                ],
+                rounds: 8,
+            },
+            getGearPieceFor([])
+        );
+
+        // Round 3 (the application round): the buff lands in BOTH runs — proves the buff exists.
+        expect(wearerHasBuff(withBoost, 3, 'Attack Up III')).toBe(true);
+        expect(wearerHasBuff(noBoost, 3, 'Attack Up III')).toBe(true);
+
+        // Round 4 (the extended tail): present ONLY with Boost. This is the unambiguous +1 turn.
+        // Non-vacuous: the without-Boost branch is FALSE here, so the assertion would fail if Boost
+        // did nothing.
+        expect(wearerHasBuff(withBoost, 4, 'Attack Up III')).toBe(true);
+        expect(wearerHasBuff(noBoost, 4, 'Attack Up III')).toBe(false);
+
+        // Sanity: the buff has truly expired in BOTH runs by round 5 (no application that round).
+        expect(wearerHasBuff(withBoost, 5, 'Attack Up III')).toBe(false);
+        expect(wearerHasBuff(noBoost, 5, 'Attack Up III')).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test B — registry shape (mutation guard)
+// ---------------------------------------------------------------------------
+
+describe('BOOST gear set — registry shape (mutation guard)', () => {
+    it('(B) a 4-BOOST ship yields a passive buff-duration-extension ability via the real registry', () => {
+        // Proves the test's gear actually routes through the real registry → engine wiring. If the
+        // registry entry is removed/altered, this fails and every comparison below loses its basis.
+        const pieces = boostPieces();
+        const skills = registrySkills(pieces, {
+            activeText: PLAIN_HIT,
+            chargedText: PLAIN_HIT,
+            chargeCount: 2,
+        });
+        const passive = skills.slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        const boostAbility = passive!.abilities.find((a) => a.id === 'equip-set-BOOST');
+        expect(boostAbility).toBeDefined();
+        expect(boostAbility!.config).toEqual({ type: 'buff-duration-extension', turns: 1 });
+
+        // Control: a ship with NO BOOST pieces yields no such ability (the +1 has no source).
+        const noBoostSkills = registrySkills([], {
+            activeText: PLAIN_HIT,
+            chargedText: PLAIN_HIT,
+            chargeCount: 2,
+        });
+        const noBoostPassive = noBoostSkills.slots.find((s) => s.slot === 'passive');
+        const noBoostAbility = noBoostPassive?.abilities.find((a) => a.id === 'equip-set-BOOST');
+        expect(noBoostAbility).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test C — enemy debuff NOT extended (DPS path)
+// ---------------------------------------------------------------------------
+
+describe('BOOST gear set — enemy debuff NOT extended', () => {
+    it('(C) a timed debuff the BOOST wearer inflicts on an enemy keeps the SAME duration', () => {
+        // Enemy debuffs land enemy-side and are explicitly excluded from Boost. The wearer's CHARGED
+        // skill inflicts Attack Down II for 2 turns on the enemy; startCharged + a huge chargeCount
+        // fires it ONCE (round 1) and never again, so the debuff window is observable as it decays.
+        //
+        // simulateDPS surfaces a proper enemy-debuff expiry window via `activeEnemyDebuffs` (the
+        // battle simulator's activeDebuffs is infliction-only and never clears, so it cannot show a
+        // duration). Routed through the REAL registry shipSkills.
+        const chargedText =
+            'This Unit deals <unit-damage>100% damage</unit-damage> and inflicts <unit-skill>Attack Down II</unit-skill> for 2 turns.';
+        const opts = { activeText: PLAIN_HIT, chargedText, chargeCount: 99 };
+
+        const base = {
+            attack: 5000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 99,
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000_000,
+            rounds: 6,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            startCharged: true,
+        };
+
+        const withBoost = simulateDPS({ ...base, shipSkills: registrySkills(boostPieces(), opts) });
+        const noBoost = simulateDPS({ ...base, shipSkills: registrySkills([], opts) });
+
+        const debuffActive = (
+            res: ReturnType<typeof simulateDPS>,
+            round: number,
+            name: string
+        ): boolean => {
+            const r = res.rounds.find((x) => x.round === round);
+            return !!r && r.activeEnemyDebuffs.some((b) => b.buffName === name);
+        };
+
+        // Pre-condition: the debuff actually landed (round 1) in BOTH runs — non-trivial scenario.
+        expect(debuffActive(withBoost, 1, 'Attack Down II')).toBe(true);
+        expect(debuffActive(noBoost, 1, 'Attack Down II')).toBe(true);
+
+        // The debuff window is IDENTICAL with and without Boost: present rounds 1-2, gone round 3.
+        // Boost does NOT add the +1 it would add to a self-side buff (enemy debuffs are excluded).
+        for (const round of [1, 2, 3, 4]) {
+            expect(debuffActive(withBoost, round, 'Attack Down II')).toBe(
+                debuffActive(noBoost, round, 'Attack Down II')
+            );
+        }
+        // Explicit boundary: gone by round 3 in BOTH runs (no second-turn extension from Boost).
+        expect(debuffActive(withBoost, 3, 'Attack Down II')).toBe(false);
+        expect(debuffActive(noBoost, 3, 'Attack Down II')).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test D — DPS higher with Boost (DPS path)
+// ---------------------------------------------------------------------------
+
+describe('BOOST gear set — DPS higher with extended self-buff', () => {
+    it('(D) a self-buffing attacker deals strictly MORE direct damage with 4 BOOST pieces', () => {
+        // Fixture: the CHARGED skill grants Attack Up III (a damage-relevant attack buff) for 2
+        // turns; startCharged + a huge chargeCount fires it ONCE (round 1) so the buff DECAYS rather
+        // than being refreshed every turn — without decay, uptime would be 100% with or without
+        // Boost and the +1 turn would be invisible. With 8 rounds the extra (3rd) turn of the buff
+        // lands well inside the horizon, so the extended uptime translates into more direct damage.
+        // (Affinity is neutral-to-self in the DPS path; the only difference between runs is Boost.)
+        const chargedText =
+            'This Unit deals <unit-damage>100% damage</unit-damage> and gains <unit-skill>Attack Up III</unit-skill> for 2 turns.';
+        const opts = { activeText: PLAIN_HIT, chargedText, chargeCount: 99 };
+
+        const base = {
+            attack: 5000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 99,
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000_000,
+            rounds: 8,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            startCharged: true,
+        };
+
+        const withBoost = simulateDPS({ ...base, shipSkills: registrySkills(boostPieces(), opts) });
+        const noBoost = simulateDPS({ ...base, shipSkills: registrySkills([], opts) });
+
+        // Both runs deal real direct damage (non-trivial fixture).
+        expect(noBoost.summary.totalDirectDamage).toBeGreaterThan(0);
+        // Strictly greater WITH Boost: the extended Attack Up III adds one more buffed turn of
+        // direct damage. Non-vacuous: with == without would fail this assertion.
+        expect(withBoost.summary.totalDirectDamage).toBeGreaterThan(
+            noBoost.summary.totalDirectDamage
+        );
+    });
+});

--- a/src/utils/combat/__tests__/buffDurationExtension.test.ts
+++ b/src/utils/combat/__tests__/buffDurationExtension.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+    buffDurationExtensionTurns,
+    buildBuffDurationExtensionByOwner,
+} from '../buffDurationExtension';
+import type { ShipSkills } from '../../../types/abilities';
+
+// Minimal ShipSkills with one passive slot carrying the given ability configs.
+const skillsWithPassiveConfigs = (configs: Array<{ type: string; turns?: number }>): ShipSkills =>
+    ({
+        slots: [
+            {
+                slot: 'passive',
+                abilities: configs.map((config, i) => ({
+                    id: `a${i}`,
+                    type: 'modifier',
+                    target: 'self',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config,
+                })),
+            },
+        ],
+    }) as unknown as ShipSkills;
+
+describe('buffDurationExtensionTurns', () => {
+    it('returns the turns of a passive buff-duration-extension config', () => {
+        expect(
+            buffDurationExtensionTurns(
+                skillsWithPassiveConfigs([{ type: 'buff-duration-extension', turns: 1 }])
+            )
+        ).toBe(1);
+    });
+
+    it('returns 0 when no buff-duration-extension config is present', () => {
+        expect(
+            buffDurationExtensionTurns(
+                skillsWithPassiveConfigs([{ type: 'damage-reflection' } as never])
+            )
+        ).toBe(0);
+    });
+
+    it('returns 0 for undefined skills', () => {
+        expect(buffDurationExtensionTurns(undefined)).toBe(0);
+    });
+
+    it('takes the max when multiple extension configs are present', () => {
+        expect(
+            buffDurationExtensionTurns(
+                skillsWithPassiveConfigs([
+                    { type: 'buff-duration-extension', turns: 1 },
+                    { type: 'buff-duration-extension', turns: 2 },
+                ])
+            )
+        ).toBe(2);
+    });
+});
+
+describe('buildBuffDurationExtensionByOwner', () => {
+    it('maps only owners that carry an extension; lookup of others returns 0', () => {
+        const map = buildBuffDurationExtensionByOwner([
+            {
+                id: 'attacker',
+                shipSkills: skillsWithPassiveConfigs([
+                    { type: 'buff-duration-extension', turns: 1 },
+                ]),
+            },
+            {
+                id: 'ally-1',
+                shipSkills: skillsWithPassiveConfigs([{ type: 'damage-reflection' } as never]),
+            },
+        ]);
+        expect(map.get('attacker')).toBe(1);
+        expect(map.has('ally-1')).toBe(false);
+    });
+});

--- a/src/utils/combat/__tests__/statusEngine.test.ts
+++ b/src/utils/combat/__tests__/statusEngine.test.ts
@@ -1723,6 +1723,35 @@ describe('buffDurationExtensionFor (Boost)', () => {
         expect(active[0].active.turnsRemaining).toBe(3);
     });
 
+    it('scheduled family rule: extended duration is used in the win check (3 > existing 2 → lands at 3)', () => {
+        // Scheduled-path mirror of the ability-path family-rule test above. Both buffs store
+        // under the 'attacker' carrier (scheduled self-buffs always route there); the family
+        // win-check must use the EXTENDED 3, not the un-extended base 2.
+        const plainBuff = makeBuff('Attack Up II', { skillSource: 'active', skillDuration: 2 });
+        const boosterBuff = makeBuff('Attack Up II', { skillSource: 'active', skillDuration: 2 });
+        const eng = createStatusEngine({
+            selfBuffs: [],
+            enemyDebuffs: [],
+            buffDurationExtensionFor: boostExt,
+            teamSources: [
+                { sourceId: 'plain', selfBuffs: [plainBuff], enemyDebuffs: [] },
+                { sourceId: 'booster', selfBuffs: [boosterBuff], enemyDebuffs: [] },
+            ],
+        });
+        eng.beginRound(1);
+        // Pre-existing same-family entry at base duration 2, applied by a non-wearer → 2.
+        eng.sourceFired('plain', 'active', 1);
+        expect(eng.snapshot('attacker').activeSelfBuffs).toEqual([
+            { buffName: 'Attack Up II', turnsRemaining: 2 },
+        ]);
+        // Wearer re-fires the SAME family at base duration 2 → extended to 3, 3 > 2 → wins.
+        // (An un-extended 2 > 2 would NOT win — this guards the scheduled dual-write.)
+        eng.sourceFired('booster', 'active', 1);
+        expect(eng.snapshot('attacker').activeSelfBuffs).toEqual([
+            { buffName: 'Attack Up II', turnsRemaining: 3 },
+        ]);
+    });
+
     it('scheduled self-buff: gated on the FIRING sourceId, not the attacker carrier', () => {
         const boosterBuff = makeBuff('Attack Up', { skillSource: 'active', skillDuration: 2 });
         const eng = createStatusEngine({

--- a/src/utils/combat/__tests__/statusEngine.test.ts
+++ b/src/utils/combat/__tests__/statusEngine.test.ts
@@ -1649,3 +1649,125 @@ describe('clearRemovable', () => {
         expect(eng.timedAbilityStatuses('self', 'tank')).toHaveLength(1);
     });
 });
+
+describe('buffDurationExtensionFor (Boost)', () => {
+    // Boost gear set: +1 turn on every TIMED SELF-SIDE buff its wearer APPLIES (caster-side).
+    // Enemy debuffs and non-finite-duration buffs are excluded. The lookup is keyed by the
+    // APPLYING caster id: status.casterId for ability buffs, the firing sourceId for scheduled
+    // buffs. Default (no field) → always 0, byte-identical.
+
+    const boostExt = (id: string): number => (id === 'booster' ? 1 : 0);
+
+    const timedAbility = (
+        buffName: string,
+        duration: number,
+        side: 'self' | 'enemy',
+        casterId?: string
+    ): Extract<RegisteredAbilityStatus, { kind: 'timed' }> => ({
+        payload: { buffName, stacks: 1, parsedEffects: { attack: 10 } },
+        side,
+        sourceSlot: 'active',
+        duration,
+        conditions: [],
+        kind: 'timed',
+        casterId,
+    });
+
+    it('self-side timed ability from a wearer extends +1', () => {
+        const eng = createStatusEngine({
+            selfBuffs: [],
+            enemyDebuffs: [],
+            buffDurationExtensionFor: boostExt,
+        });
+        eng.beginRound(1);
+        eng.applyTimedAbilityStatus(1, timedAbility('Attack Up', 2, 'self', 'booster'));
+        expect(eng.timedAbilityStatuses('self')[0].active.turnsRemaining).toBe(3);
+    });
+
+    it('self-side timed ability from a non-wearer is unchanged', () => {
+        const eng = createStatusEngine({
+            selfBuffs: [],
+            enemyDebuffs: [],
+            buffDurationExtensionFor: boostExt,
+        });
+        eng.beginRound(1);
+        eng.applyTimedAbilityStatus(1, timedAbility('Attack Up', 2, 'self', 'plain'));
+        expect(eng.timedAbilityStatuses('self')[0].active.turnsRemaining).toBe(2);
+    });
+
+    it('enemy-side timed ability from a wearer is NOT extended (debuffs excluded)', () => {
+        const eng = createStatusEngine({
+            selfBuffs: [],
+            enemyDebuffs: [],
+            buffDurationExtensionFor: boostExt,
+        });
+        eng.beginRound(1);
+        eng.applyTimedAbilityStatus(1, timedAbility('Def Down', 2, 'enemy', 'booster'));
+        expect(eng.timedAbilityStatuses('enemy')[0].active.turnsRemaining).toBe(2);
+    });
+
+    it('family rule: extended duration is used in the win check (3 > existing 2 → lands at 3)', () => {
+        const eng = createStatusEngine({
+            selfBuffs: [],
+            enemyDebuffs: [],
+            buffDurationExtensionFor: boostExt,
+        });
+        eng.beginRound(1);
+        // Pre-existing same-family entry at base duration 2, applied by a non-wearer.
+        eng.applyTimedAbilityStatus(1, timedAbility('Attack Up II', 2, 'self', 'plain'));
+        expect(eng.timedAbilityStatuses('self')[0].active.turnsRemaining).toBe(2);
+        // Wearer re-applies the SAME family at base duration 2 → extended to 3, 3 > 2 → wins.
+        eng.applyTimedAbilityStatus(1, timedAbility('Attack Up II', 2, 'self', 'booster'));
+        const active = eng.timedAbilityStatuses('self');
+        expect(active).toHaveLength(1);
+        expect(active[0].active.turnsRemaining).toBe(3);
+    });
+
+    it('scheduled self-buff: gated on the FIRING sourceId, not the attacker carrier', () => {
+        const boosterBuff = makeBuff('Attack Up', { skillSource: 'active', skillDuration: 2 });
+        const eng = createStatusEngine({
+            selfBuffs: [],
+            enemyDebuffs: [],
+            buffDurationExtensionFor: boostExt,
+            teamSources: [{ sourceId: 'booster', selfBuffs: [boosterBuff], enemyDebuffs: [] }],
+        });
+        eng.beginRound(1);
+        eng.sourceFired('booster', 'active', 1);
+        // Scheduled self-buffs store under the 'attacker' carrier, but the +1 is gated on the
+        // firing source ('booster') — so this lands at 3 even though the carrier is 'attacker'.
+        expect(eng.snapshot('attacker').activeSelfBuffs).toEqual([
+            { buffName: 'Attack Up', turnsRemaining: 3 },
+        ]);
+    });
+
+    it('scheduled self-buff from a non-wearer source is unchanged', () => {
+        const plainBuff = makeBuff('Attack Up', { skillSource: 'active', skillDuration: 2 });
+        const eng = createStatusEngine({
+            selfBuffs: [],
+            enemyDebuffs: [],
+            buffDurationExtensionFor: boostExt,
+            teamSources: [{ sourceId: 'plain', selfBuffs: [plainBuff], enemyDebuffs: [] }],
+        });
+        eng.beginRound(1);
+        eng.sourceFired('plain', 'active', 1);
+        expect(eng.snapshot('attacker').activeSelfBuffs).toEqual([
+            { buffName: 'Attack Up', turnsRemaining: 2 },
+        ]);
+    });
+
+    it('no buffDurationExtensionFor field → default extends nothing', () => {
+        const buff = makeBuff('Attack Up', { skillSource: 'active', skillDuration: 2 });
+        const eng = createStatusEngine({
+            selfBuffs: [buff],
+            enemyDebuffs: [],
+            teamSources: [{ sourceId: 'booster', selfBuffs: [buff], enemyDebuffs: [] }],
+        });
+        eng.beginRound(1);
+        eng.sourceFired('booster', 'active', 1);
+        eng.applyTimedAbilityStatus(1, timedAbility('Shield Up', 2, 'self', 'booster'));
+        expect(eng.snapshot('attacker').activeSelfBuffs).toEqual([
+            { buffName: 'Attack Up', turnsRemaining: 2 },
+        ]);
+        expect(eng.timedAbilityStatuses('self')[0].active.turnsRemaining).toBe(2);
+    });
+});

--- a/src/utils/combat/buffDurationExtension.ts
+++ b/src/utils/combat/buffDurationExtension.ts
@@ -1,0 +1,36 @@
+import type { ShipSkills } from '../../types/abilities';
+
+/**
+ * Boost gear set support. Scans a ship's PASSIVE abilities for `buff-duration-extension`
+ * configs (emitted by GEAR_SET_ABILITIES.BOOST) and returns the max extra turns (0 if none).
+ * Pure; never throws.
+ */
+export function buffDurationExtensionTurns(skills: ShipSkills | undefined): number {
+    if (!skills?.slots) return 0;
+    let max = 0;
+    for (const slot of skills.slots) {
+        if (slot.slot !== 'passive') continue;
+        for (const ability of slot.abilities) {
+            if (ability.config.type === 'buff-duration-extension') {
+                max = Math.max(max, ability.config.turns);
+            }
+        }
+    }
+    return max;
+}
+
+/**
+ * Build a per-owner extension map from a list of actors. Owners with no extension are
+ * ABSENT (callers default a miss to 0). Used by the engine to back the
+ * StatusEngineInput.buffDurationExtensionFor lookup.
+ */
+export function buildBuffDurationExtensionByOwner(
+    actors: Array<{ id: string; shipSkills: ShipSkills | undefined }>
+): Map<string, number> {
+    const map = new Map<string, number>();
+    for (const { id, shipSkills } of actors) {
+        const turns = buffDurationExtensionTurns(shipSkills);
+        if (turns > 0) map.set(id, turns);
+    }
+    return map;
+}

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -65,6 +65,7 @@ import { isDisable } from './disableBuffs';
 import { highestAttackAmong } from './highestAttack';
 import { CombatEventBus, createEventBus } from './events';
 import { normalizeTeamActorsToWalked } from './teamActorWalk';
+import { buildBuffDurationExtensionByOwner } from './buffDurationExtension';
 import {
     HealingRuntimeCtx,
     PlayerActorRuntime,
@@ -1423,6 +1424,17 @@ export function runCombat(input: CombatEngineInput): {
             ? !affinityDisadvantage
             : debuffLandingGate(attackerRuntime.liveDebuffLandingChance ?? 1);
 
+    // Boost gear set: per-owner buff-duration extension. Built from the RAW ShipSkills (which
+    // already carry the BOOST passive merged by buildShipAbilitiesWithEquipment at the page
+    // level) BEFORE the status engine is constructed — the runtime-derived ability maps
+    // (incomingAbilitiesById etc.) aren't built until much later (~2257). Covers all actors
+    // team-agnostically: attacker + walked team allies + enemy attackers.
+    const buffDurationExtensionByOwner = buildBuffDurationExtensionByOwner([
+        { id: 'attacker', shipSkills: input.shipSkills },
+        ...teamActors.map((t) => ({ id: t.id, shipSkills: t.walk?.shipSkills })),
+        ...(input.enemyAttackers ?? []).map((e) => ({ id: e.id, shipSkills: e.shipSkills })),
+    ]);
+
     // Incremental status machine — replaces the precomputed computeBuffTimeline array.
     const statusEngine = createStatusEngine({
         selfBuffs,
@@ -1434,6 +1446,7 @@ export function runCombat(input: CombatEngineInput): {
             enemyDebuffs: t.enemyDebuffs,
         })),
         landsTimedEnemyApplication: (buff) => landsTimedEnemyApplication(buff.application),
+        buffDurationExtensionFor: (casterId) => buffDurationExtensionByOwner.get(casterId) ?? 0,
     });
 
     // TEST-ONLY: expose the live status engine so a test can read settled self/enemy state after

--- a/src/utils/combat/statusEngine.ts
+++ b/src/utils/combat/statusEngine.ts
@@ -648,6 +648,7 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
         if (typeof buff.skillDuration !== 'number') return;
         const { familyKey, tier } = deriveFamilyKey(buff.buffName);
         // Boost: +N turns on a buff the caster APPLIES, self-side only (debuffs land enemy-side).
+        // The `&& casterId` is defensive: scheduled buffs always carry a concrete firing sourceId.
         const extension = side === 'self' && casterId ? buffDurationExtensionFor(casterId) : 0;
         const duration = buff.skillDuration + extension;
         const existing = map.get(familyKey);

--- a/src/utils/combat/statusEngine.ts
+++ b/src/utils/combat/statusEngine.ts
@@ -33,6 +33,10 @@ export interface StatusEngineInput {
      *  not cleared) and the buffName is collected into sourceFired's `resistedEnemy`.
      *  Optional — defaulting to "always lands" keeps the unit tests gate-free. */
     landsTimedEnemyApplication?: (buff: SelectedGameBuff) => boolean;
+    /** Boost gear set: extra turns to add to a TIMED SELF-SIDE buff applied by `casterId`
+     *  (the firing source for scheduled buffs, `status.casterId` for ability buffs). Returns 0
+     *  for non-wearers. Default → always 0 (byte-identical: no wearer, no change). */
+    buffDurationExtensionFor?: (casterId: string) => number;
 }
 
 /** Effect payload of an ability-sourced status, folded into the round totals by the engine. */
@@ -346,6 +350,7 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
     const setLandsTimedEnemyApplication = (fn: (buff: SelectedGameBuff) => boolean): void => {
         landsTimedEnemyApplication = fn;
     };
+    const buffDurationExtensionFor = input.buffDurationExtensionFor ?? (() => 0);
 
     // Categorized collections — kept as named closure variables (not inlined) so
     // Task 6 can append ability-sourced statuses to them later.
@@ -630,7 +635,7 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
     // the DEFAULT_ENEMY_TARGET on the enemy side (legacy semantics: scheduled buffs/debuffs
     // ride the attacker's cadence and route to the singular default stores — byte-identical
     // to the pre-Task-1 enemyMap/persistentEnemy single-store path).
-    const upsertBuff = (buff: SelectedGameBuff, side: 'self' | 'enemy') => {
+    const upsertBuff = (buff: SelectedGameBuff, side: 'self' | 'enemy', casterId?: string) => {
         const map = side === 'self' ? getSelfMap('attacker') : getEnemyMap(DEFAULT_ENEMY_TARGET);
         // Persistent stacking statuses route by NAME before the family-rule timed path: this
         // application landed (the landing hook already ran at the call site), so add a stack
@@ -642,11 +647,14 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
         }
         if (typeof buff.skillDuration !== 'number') return;
         const { familyKey, tier } = deriveFamilyKey(buff.buffName);
+        // Boost: +N turns on a buff the caster APPLIES, self-side only (debuffs land enemy-side).
+        const extension = side === 'self' && casterId ? buffDurationExtensionFor(casterId) : 0;
+        const duration = buff.skillDuration + extension;
         const existing = map.get(familyKey);
-        if (!familyApplicationWins(existing, tier, buff.skillDuration)) return;
+        if (!familyApplicationWins(existing, tier, duration)) return;
         map.set(familyKey, {
             buffName: buff.buffName,
-            turnsRemaining: buff.skillDuration,
+            turnsRemaining: duration,
             tier,
             appliedSeq: nextAppliedSeq(),
         });
@@ -708,7 +716,7 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
 
         // Timed scheduled buffs (this source's) whose skillSource matches the fired slot.
         for (const buff of sets.timedSelf) {
-            if (buff.skillSource === slot) upsertBuff(buff, 'self');
+            if (buff.skillSource === slot) upsertBuff(buff, 'self', sourceId);
         }
         // Timed ENEMY upserts draw the landing decision ONCE here (Task 7). A rejected
         // application is NOT upserted (the existing in-window status is untouched) and
@@ -1127,15 +1135,20 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
         const map =
             status.side === 'self' ? getSelfMap(selfEffectiveId) : getEnemyMap(enemyEffectiveId);
         const { familyKey, tier } = deriveFamilyKey(status.payload.buffName);
+        // Boost: +N turns on a buff the caster APPLIES, self-side only (debuffs land enemy-side).
+        // Caster fail-safe: fixtures may omit casterId → default to 'attacker'.
+        const extension =
+            status.side === 'self' ? buffDurationExtensionFor(status.casterId ?? 'attacker') : 0;
+        const duration = status.duration + extension;
         const existing = map.get(familyKey);
         // A landed-but-family-blocked application is silently absorbed: the landing roll
         // was already consumed by the caller's gate (the family rule runs AFTER the landing
         // hook), so a blocked application is NOT recorded as resisted — the stronger/longer
         // buff simply persists and this entry never enters the timed-ability folding.
-        if (!familyApplicationWins(existing, tier, status.duration)) return;
+        if (!familyApplicationWins(existing, tier, duration)) return;
         map.set(familyKey, {
             buffName: status.payload.buffName,
-            turnsRemaining: status.duration,
+            turnsRemaining: duration,
             tier,
             payload: status.payload,
             casterId: status.casterId,


### PR DESCRIPTION
## Summary

Models the **Boost** gear set (4-piece) in both the combat simulator and the DPS calculator: while a ship wears 4+ Boost pieces, every **timed buff it applies** lasts **+1 turn** — its own self-buffs and buffs it grants allies (caster-side). The last unmodelled special-effect gear set in sub-project D.

- **Caster-side, self-side only.** The +1 keys on the *applying* ship's set, not the holder's. Enemy debuffs the wearer inflicts are NOT extended; permanent/recurring/persistent-stacking buffs are excluded (they never reach the finite-duration write).
- **New `buff-duration-extension` `AbilityConfig`** marker (mirrors REFLECT's `damage-reflection`): emitted by `GEAR_SET_ABILITIES.BOOST`, inert in the modifier fold, read by the engine.
- **Engine** builds a per-owner extension map from each actor's raw `ShipSkills` (attacker + `walk.shipSkills` allies + enemies) before `createStatusEngine`, threading a `buffDurationExtensionFor(casterId)` lookup into `StatusEngineInput`.
- **Status engine** adds the extension at its two buff-duration write seams — computed once, used in both the family-rule win-check and the store (guards against a re-cast silently dropping the +1).
- **DPS** flows automatically — `simulateDPS` routes through the same `createStatusEngine`.

## Byte-identical
No combat/DPS golden fixture equips a 4-piece Boost set, so the lookup returns 0 everywhere in the existing suite. Full suite **3361 passing**, zero golden/`.snap` movement, `tsc`/`lint` clean, `audit:skills` 141/0.

## Test Plan
- [x] Unit: pure helper (max-of-multiple, undefined, absent owner)
- [x] Unit: both status-engine seams (self-extend / non-wearer / enemy-excluded / family-rule dual-write / scheduled-firing-source / default no-op)
- [x] Integration (real registry, `setBonus:'BOOST'` ×4): self-buff active one round longer; registry-shape mutation guard; enemy debuff unchanged; DPS strictly higher with Boost — mutation-verified non-vacuous
- [x] Full suite byte-identical; tsc/lint/audit clean

Spec: `docs/superpowers/specs/2026-06-26-boost-gear-set-design.md`
Plan: `docs/superpowers/plans/2026-06-26-boost-gear-set.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)