### PR TITLE
feat(combat): counterattack refinements — sub-project G PR1 (Stalwart)

### DIFF
--- a/docs/superpowers/plans/2026-06-27-counterattack-refinements-G-pr1.md
+++ b/docs/superpowers/plans/2026-06-27-counterattack-refinements-G-pr1.md
@@ -1,0 +1,446 @@
+# Sub-project G — PR1 (foundation + Stalwart) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Model the player-side reactive counterattack as a full mitigated/crit damage walk against the attacker, auto-parsed from skill text, gated on "primary target" — lighting up **Stalwart** (P1 30%, P2 70%).
+
+**Architecture:** A new reactive `counter` AbilityConfig + a `counter` branch in the reactive executor (`triggers.ts`) that calls a new engine helper `applyCounterAttack`. The helper rolls the owner's crit, computes raw damage via the pure `victimHitDamage`, and applies it through the EXISTING Reflect no-event apply path (`applyVictimDamage`, which drains shield→HP, runs death handling, emits no `attacked` event → no ping-pong). A new `isPrimaryTarget` flag on the `attacked` event + a new per-turn once-per-attack guard complete the contract.
+
+**Tech Stack:** React 18, TypeScript, Vitest. Combat engine in `src/utils/combat/`, parser in `src/utils/skillTextParser.ts` + `src/utils/abilities/buildShipAbilities.ts`.
+
+**Spec:** `docs/superpowers/specs/2026-06-27-counterattack-refinements-G-design.md`
+
+**Branch:** `feat/combat-g-counterattack-refinements` (already created; spec committed).
+
+**Invariant for EVERY task:** production must stay **byte-identical** (no combat fixture equips Stalwart — verified: the name appears only in `constants/ships.ts`, parser unit tests, and `recruitmentCalculator.ts`). After each task run `npx tsc --noEmit` AND `npm run lint` (max-warnings 0) — vitest/esbuild does NOT typecheck, so never trust a "tsc clean" claim without running it. Goldens (`.snap`) must not move; never run `vitest -u`.
+
+---
+
+## Key code landmarks (verified 2026-06-27)
+
+- `AbilityConfig` union: `src/types/abilities.ts:328` (the `damage` variant is line 329).
+- `Ability` interface: `src/types/abilities.ts:519` — already has top-level `procChance?` (555), `oncePerRound?` (541), `triggerCritFilter?`, `requireIncomingDamageFracOfMaxHp?`.
+- `victimHitDamage(s, v, didCrit, roleScale, equipReductionPct=0)`: pure — `src/utils/combat/victimDamage.ts:74`. `AttackerDamageScalars` (line 33) / `VictimDefenseProfile` (line 54).
+- `applyVictimDamage(amount, victim, sink, cause)`: per-round closure, `src/utils/combat/engine.ts:~2782–3112`. Returns `{shieldBefore, hpDamage, barriered}`. The reflect re-entry guard is at `engine.ts:3020` (`!cause?.isReflected`). The reflect call site (the template) is `engine.ts:3087`.
+- Reflect's affinity/defence/incoming-reduction resolution: `engine.ts:3051–3082` (uses `effectiveStatsOf(statusEngine, selfBuffLookup, actor).defence`, `computeAffinityModifiers`, `incomingReductionForHit`).
+- The SOLE `attacked` emit: `src/utils/combat/engine.ts:4970–4981` (enemy-turn body; `targetId: tgt.id`, `attackerId: actor.id`).
+- `on-attacked` listener: `src/utils/combat/triggers.ts:464–490` (routes `counterTargetId`, `didCrit`, `triggerDamage` into `eventCtx`).
+- Reactive `damage` executor branch (bomb-like, Grif): `src/utils/combat/triggers.ts:1763–1783`.
+- `IntentExecContext` per-round build (where `creditReactiveDamage` is set): `src/utils/combat/engine.ts:~3791`.
+- Parse template: `parseHealAbilities` (`src/utils/skillTextParser.ts:2166`) consumed at `src/utils/abilities/buildShipAbilities.ts:946`; the `damageReaction` annotation → `on-attacked`/`on-ally-attacked` mapping is at `buildShipAbilities.ts:968`. `detectDamageReactionTrigger` already recognizes "when directly damaged".
+- `eventCtx` type (reactive intent): `src/utils/combat/triggers.ts:~96–116`.
+
+---
+
+## File structure
+
+- **Modify** `src/types/abilities.ts` — new `counter` AbilityConfig variant; `eventCtx`/event type fields if declared here.
+- **Modify** `src/utils/combat/events.ts` — `isPrimaryTarget?: boolean` on the `attacked` event.
+- **Modify** `src/utils/combat/engine.ts` — `applyCounterAttack` helper + `IntentExecContext` wiring + set `isPrimaryTarget` at the emit + `counterFiredThisTurn` Set + per-turn clear + `isCounter` cause flag on the reflect guard.
+- **Modify** `src/utils/combat/triggers.ts` — `counter` executor branch + `applyCounterAttack`/`counterFiredThisTurn` on `IntentExecContext` interface + `isPrimaryTarget` passthrough in the `on-attacked` listener + `eventCtx.isPrimaryTarget`.
+- **Modify** `src/utils/skillTextParser.ts` — `parseCounterAbilities` (new) modeled on `parseHealAbilities`.
+- **Modify** `src/utils/abilities/buildShipAbilities.ts` — consume `parseCounterAbilities`, build `counter` abilities on `on-attacked`.
+- **Modify** editor exhaustiveness sites IF tsc forces: `src/components/skills/AbilityCard.tsx`, `AbilityTypePicker.tsx`, `src/utils/abilities/abilityDefaults.ts` (add stubs only).
+- **Modify** `src/constants/changelog.ts`, `src/pages/DocumentationPage.tsx` — final task.
+- **Tests:** `src/utils/combat/__tests__/counterAttack.test.ts` (new, executor/helper unit), `src/utils/combat/__tests__/counterAttack.integration.test.ts` (new, runCombat), parser test in `src/utils/abilities/__tests__/` or `src/utils/__tests__/skillTextParser` area.
+
+---
+
+## Task 0: Baseline
+
+- [ ] **Step 1: Confirm branch + clean baseline**
+
+Run:
+```bash
+cd /Users/kennethsusort/PersonalProjects/starborne-frontiers-calculator
+git branch --show-current   # expect feat/combat-g-counterattack-refinements
+git status --short          # expect clean
+npx vitest run src/utils/combat/__tests__/reflect 2>&1 | tail -5
+```
+Expected: branch correct, working tree clean, reflect tests pass (sanity that the apply path we reuse is healthy).
+
+---
+
+## Task 1: `counter` AbilityConfig variant + editor stubs
+
+**Files:**
+- Modify: `src/types/abilities.ts:328` (union)
+- Modify (only if tsc errors): `src/components/skills/AbilityCard.tsx`, `src/components/skills/AbilityTypePicker.tsx`, `src/utils/abilities/abilityDefaults.ts`
+
+- [ ] **Step 1: Add the union variant**
+
+In `src/types/abilities.ts`, add `'counter'` to the `AbilityType` union (after `'damage'`, line 7 area) AND a config variant immediately after the `damage` config (line 329):
+
+```ts
+    | {
+          type: 'counter';
+          /** raw percentage of the OWNER's effective attack, e.g. 30/70/100/200. */
+          multiplier: number;
+          hits?: number;
+          /** Stalwart: fire only when this unit was the directly-targeted (primary) victim,
+           *  not a splash/covered AoE victim. Gated on `attacked.isPrimaryTarget`. */
+          requirePrimaryTarget?: boolean;
+          /** Nyxen (PR2): fire only when the hit reduced the shield pool. Plumbed in PR2. */
+          requireShieldHit?: boolean;
+      }
+```
+
+- [ ] **Step 2: Build to find exhaustiveness sites**
+
+Run: `npx tsc --noEmit 2>&1 | head -30`
+Expected: errors at any `switch (ability.type)` / `Record<AbilityType, …>` that must enumerate `'counter'` (likely `AbilityCard.tsx`, `AbilityTypePicker.tsx`, `abilityDefaults.ts`, possibly `simCoverage.ts`). Note each.
+
+- [ ] **Step 3: Add minimal stubs**
+
+For each tsc error, add a minimal entry mirroring the `'damage'` case (e.g. in `abilityDefaults.ts` a `counter` default `{ type: 'counter', multiplier: 0 }`; in pickers a label like "Counterattack"; in `AbilityCard.tsx` reuse the damage rendering or a one-line summary). Do NOT add `'counter'` to `NOT_SIMULATED_TYPES` (it IS simulated). Keep stubs minimal — the editor is not the focus.
+
+- [ ] **Step 4: Verify clean**
+
+Run: `npx tsc --noEmit && npm run lint`
+Expected: both clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat(combat): counter AbilityConfig variant + editor stubs (G PR1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `isPrimaryTarget` signal + `on-attacked` passthrough + `isCounter` cause flag
+
+This task adds the signals only (no executor yet) — all byte-identical.
+
+**Files:**
+- Modify: `src/utils/combat/events.ts` (~line 199, `attacked` event)
+- Modify: `src/utils/combat/engine.ts` (emit ~4970; cause type + reflect guard ~3020)
+- Modify: `src/utils/combat/triggers.ts` (eventCtx type ~96; `on-attacked` listener ~482)
+
+- [ ] **Step 1: Add `isPrimaryTarget?` to the `attacked` event**
+
+`src/utils/combat/events.ts`, in the `attacked` event object (after `damage?`, line ~209):
+```ts
+          /** G PR1: true when the victim was the directly-targeted (primary) target of the
+           *  attack, false/absent for splash/covered AoE victims. Today the sole emit is the
+           *  focus victim (`tgt`) → always true; positional per-victim emission (future) sets
+           *  false for covered cells. Stalwart's counter gates on this. */
+          isPrimaryTarget?: boolean;
+```
+
+- [ ] **Step 2: Set it at the emit**
+
+`src/utils/combat/engine.ts:4970–4981`, add to the emitted object:
+```ts
+                                    isPrimaryTarget: true,
+```
+(The sole emit is for `tgt`, the focus/primary victim — see spec "Enemy-side scope" / I5. A comment should note this is the primary victim today; covered-cell emission, when added, passes the real role.)
+
+- [ ] **Step 3: Pass it through the `on-attacked` listener into eventCtx**
+
+`src/utils/combat/triggers.ts:482–489`, add `isPrimaryTarget: e.isPrimaryTarget` to the enqueued `eventCtx`. Add `isPrimaryTarget?: boolean` to the `eventCtx` type (~line 96–116, near `counterTargetId`).
+
+- [ ] **Step 4: Add `isCounter?` cause flag (for no-re-reflect / no-re-counter intent)**
+
+Find the `cause` type used by `applyVictimDamage` (search `isReflected?:` in `engine.ts`). Add `isCounter?: boolean` beside `isReflected?`. Update the reflect re-entry guard at `engine.ts:3020` from `if (!cause?.isReflected && …)` to `if (!cause?.isReflected && !cause?.isCounter && …)` so a counter application is NOT itself reflected (loop-safe; documented in spec rule 2). Add a one-line comment.
+
+- [ ] **Step 5: Verify byte-identical**
+
+Run: `npx tsc --noEmit && npm run lint && npx vitest run 2>&1 | tail -8`
+Expected: tsc/lint clean; full suite green; ZERO `.snap` changes (`git status --short` shows no `.snap`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat(combat): attacked.isPrimaryTarget signal + isCounter cause flag (G PR1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `applyCounterAttack` engine helper + IntentExecContext wiring
+
+The helper rolls the owner's crit, computes raw via `victimHitDamage`, applies via `applyVictimDamage` with `isCounter:true`. Modeled on the reflect block (`engine.ts:3051–3093`).
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts` (helper near the reflect block / where `applyVictimDamage` is in scope; ctx wiring ~3791)
+- Modify: `src/utils/combat/triggers.ts` (`IntentExecContext` interface: add `applyCounterAttack`)
+- Test: `src/utils/combat/__tests__/counterAttack.test.ts` (engine testtap)
+
+- [ ] **Step 1: Declare the ctx method on the interface**
+
+`src/utils/combat/triggers.ts`, in `IntentExecContext` (near `creditReactiveDamage?`, ~782):
+```ts
+    /** G PR1: apply a full mitigated/crit counter walk from `ownerId` to `attackerId`.
+     *  Reuses the engine's no-event apply path (no attacked event → no re-counter). */
+    applyCounterAttack?: (ownerId: string, attackerId: string, multiplier: number, hits: number) => void;
+```
+
+- [ ] **Step 2: Write the failing engine test (testtap)**
+
+Add `src/utils/combat/__tests__/counterAttack.test.ts`. Drive a minimal `runCombat` where a player ship carries a `counter` ability (built inline or via a test ability) and is hit by an enemy; assert via the result/perTargetDamage that the attacker took mitigated counter damage matching `victimHitDamage` (owner attack × mult/100, vs attacker defence/affinity), and that owner crit can apply. Mirror the harness in `reflect`/`reactiveExtraAction` tests. Start with the magnitude assertion.
+
+Run: `npx vitest run src/utils/combat/__tests__/counterAttack.test.ts -v`
+Expected: FAIL (no counter executor/helper yet).
+
+- [ ] **Step 3: Implement `applyCounterAttack`**
+
+Inside the per-round scope where `applyVictimDamage`, `statusEngine`, `selfBuffLookup`, `allActorsById`, `effectiveStatsOf`, `playerSink`/`enemySink`, and the crit rate-gate are available (same scope as the reflect block), add:
+
+```ts
+const applyCounterAttack = (
+    ownerId: string,
+    attackerId: string,
+    multiplier: number,
+    hits: number
+): void => {
+    const owner = allActorsById.get(ownerId);
+    const attacker = allActorsById.get(attackerId);
+    // Guards (spec rule 6): owner alive, attacker alive, not self.
+    if (!owner || !attacker) return;
+    if (owner.destroyedRound !== undefined) return;
+    if (attacker.destroyedRound !== undefined || attacker.id === owner.id) return;
+
+    const ownerStats = effectiveStatsOf(statusEngine, selfBuffLookup, owner);
+    const attackerStats = effectiveStatsOf(statusEngine, selfBuffLookup, attacker);
+
+    // Roll the OWNER's crit (spec rule 4). Use the SAME crit rate-gate machinery the
+    // normal attack path uses (locate it next to the existing crit gate; key per
+    // owner+ability or per the established reactive crit pattern). Dormant in every
+    // fixture (no Stalwart equipped) → byte-identical.
+    const didCrit = /* rollOwnerCrit(ownerId, ownerStats.crit) */ false; // see Step 3a
+
+    const raw = victimHitDamage(
+        {
+            effectiveAttack: ownerStats.attack,
+            multiplierPct: multiplier * hits,
+            secondaryStatValue: 0,
+            hits,
+            effectiveCritDamage: ownerStats.critDamage,
+            outgoingDamageBuffPct: 0,
+            incomingDamageModifierPct: 0,
+            defensePenetrationPct: ownerStats.defensePenetration ?? 0,
+            attackerAffinity: owner.affinity,
+        },
+        {
+            defence: attackerStats.defence,
+            defenceModifierPct: 0,
+            affinity: attacker.affinity,
+        },
+        didCrit,
+        1 // roleScale: a counter is a single full hit
+    );
+    if (raw <= 0) return;
+
+    const sink = attacker.side === 'player' ? playerSink : enemySink;
+    applyVictimDamage(raw, attacker, sink, {
+        killerId: owner.id,
+        byDirectDamage: true,
+        isCounter: true,
+        shieldPenetrationPct: ownerStats.shieldPenetration ?? 0,
+        bombPortion: 0,
+    });
+    // Surface on the attacker's incoming so it appears on the HP curve (mirror reflect
+    // engine.ts:3094–3106): perActor + roundPerTargetDamage.
+    roundPerTargetDamage.set(
+        attacker.id,
+        (roundPerTargetDamage.get(attacker.id) ?? 0) + raw
+    );
+};
+```
+
+- [ ] **Step 3a: Wire the owner crit roll**
+
+Locate the crit rate-gate used for normal/reactive crits (search `critGate`, `makeRateGate`, `rollRateGate` in `engine.ts`/`rateAccumulator.ts`). Replace the `didCrit` placeholder with a roll of the owner's effective crit chance through that gate (own stream — must NOT perturb existing gate draws for fixtures without Stalwart). If the simplest faithful option is to mirror the reflect path (which uses `didCrit:false`, i.e. no crit), STOP and reconsider — spec rule 4 requires crit. Prefer drawing the owner's crit gate. Document the chosen stream in a comment.
+
+- [ ] **Step 4: Expose on the per-round ctx**
+
+`src/utils/combat/engine.ts:~3791`, in the IntentExecContext object literal next to `creditReactiveDamage`, add `applyCounterAttack,`.
+
+- [ ] **Step 5: Run the test (still fails until executor — Task 4)**
+
+The helper exists but nothing calls it yet. Keep the magnitude test focused on the helper if you exposed a testtap; otherwise this test green-lights in Task 4. Run tsc/lint:
+
+Run: `npx tsc --noEmit && npm run lint`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat(combat): applyCounterAttack engine helper (full walk via reflect apply path) (G PR1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `counter` executor branch + per-turn once-per-attack guard
+
+**Files:**
+- Modify: `src/utils/combat/triggers.ts` (executor, near the `damage` branch ~1763)
+- Modify: `src/utils/combat/engine.ts` (`counterFiredThisTurn` Set + per-turn clear + ctx field)
+- Test: `src/utils/combat/__tests__/counterAttack.test.ts` (once-per-attack + primary gate)
+
+- [ ] **Step 1: Add the per-turn guard infra (engine)**
+
+In `engine.ts` at combat scope (near `hitThisRound`), declare:
+```ts
+// G PR1: once-per-attack guard. Cleared at every actor turn-start so all per-hit
+// `attacked` events of ONE attack collapse to a single counter, while a separate
+// later attack (a different turn) counters again. NOT per-round (a per-round set
+// would wrongly suppress a second attack in the same round).
+const counterFiredThisTurn = new Set<string>();
+```
+Clear it (`counterFiredThisTurn.clear();`) at the TOP of each per-actor turn iteration — locate the per-actor turn-order loop body / the `turn-started` emit (~engine.ts:3562) and clear once per actor turn, before the action branches and before the drain that follows the turn. Expose on the per-round ctx (next to `applyCounterAttack`):
+```ts
+counterFiredThisTurn,
+```
+and declare `counterFiredThisTurn?: Set<string>;` on `IntentExecContext` (triggers.ts).
+
+- [ ] **Step 2: Write the failing executor tests**
+
+In `counterAttack.test.ts` add: (a) a 3-hit attack on a counter-carrier → exactly ONE counter (assert attacker incoming == one counter's worth); (b) `requirePrimaryTarget:true` + an `attacked` with `isPrimaryTarget:false` → NO counter; with `true` → counter; (c) no-re-counter: attacker also carries a counter → only the first fires.
+
+Run: `npx vitest run src/utils/combat/__tests__/counterAttack.test.ts -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the `counter` executor branch**
+
+In `triggers.ts`, BEFORE or beside the `if (cfg.type === 'damage')` branch (1763), add:
+```ts
+if (cfg.type === 'counter') {
+    if (!passesProcChanceGate(intent, ctx)) return;
+    if (!passesOncePerRoundGate(intent, ctx)) return;
+    // Primary-target gate (Stalwart).
+    if (cfg.requirePrimaryTarget && intent.eventCtx?.isPrimaryTarget !== true) return;
+    // Shield-hit gate (Nyxen) — PR2 plumbs eventCtx.shieldWasHit; default-skip when required.
+    if (cfg.requireShieldHit && intent.eventCtx?.shieldWasHit !== true) return;
+    const attackerId = intent.eventCtx?.counterTargetId;
+    if (!attackerId) return;
+    // Once-per-attack guard (cleared per turn in the engine).
+    const key = `${intent.ownerId}:${intent.ability.id}`;
+    if (ctx.counterFiredThisTurn?.has(key)) return;
+    ctx.counterFiredThisTurn?.add(key);
+    ctx.applyCounterAttack?.(intent.ownerId, attackerId, cfg.multiplier, cfg.hits ?? 1);
+    return;
+}
+```
+(Confirm `passesOncePerRoundGate` consumes only when it returns true — mirror the `damage` branch ordering so the guard interplay is clean.)
+
+- [ ] **Step 4: Run tests green**
+
+Run: `npx vitest run src/utils/combat/__tests__/counterAttack.test.ts -v`
+Expected: PASS (magnitude from Task 3 + once-per-attack + primary gate + no-re-counter).
+
+- [ ] **Step 5: Full suite byte-identical**
+
+Run: `npx tsc --noEmit && npm run lint && npx vitest run 2>&1 | tail -8`
+Expected: clean, green, ZERO `.snap` movement.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat(combat): counter executor branch + per-turn once-per-attack guard (G PR1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Parser — `parseCounterAbilities` → Stalwart parses a counter
+
+**Files:**
+- Modify: `src/utils/skillTextParser.ts` (new `parseCounterAbilities`, modeled on `parseHealAbilities:2166`)
+- Modify: `src/utils/abilities/buildShipAbilities.ts` (consume it, ~near the heal loop 946)
+- Test: parser test (mirror an existing `skillTextParser`/`buildShipAbilities` test file)
+
+- [ ] **Step 1: Write the failing parser test**
+
+Assert `buildShipAbilities` for Stalwart yields a passive `counter` ability with `multiplier: 30` (P1) / `70` (P2), `trigger: 'on-attacked'`, `requirePrimaryTarget: true`, AND that Stalwart's co-located `Legion Discipline II` buff still parses (M1 non-regression). Use the real CSV-derived skill text (copy the verbatim string from `docs/ship-skills.csv`).
+
+Run it → FAIL.
+
+- [ ] **Step 2: Implement `parseCounterAbilities`**
+
+In `skillTextParser.ts`, add a function that scans a passive clause for the counter shapes (anchor on the consequence, NOT requiring the literal word "damage" — Centurion ends "retaliates dealing 50%."):
+- `it deals <X>% damage to that enemy` (Stalwart) → `{ multiplier: X, primaryTarget: <"as a primary target" present>, ... }`
+- `This Unit deals <X>% damage when its Shield is directly damaged` (Nyxen) → `{ multiplier: X, shieldHit: true }` (parsed now; gate wired in PR2)
+- `this Unit retaliates dealing <X>%` (Centurion) → `{ multiplier: X, allySubject: <"or an adjacent ally" present> }` (parsed now; ally routing in PR2)
+
+Guard against heal/shield/reflect false positives (the consequence must be a counter, not "repairs"/"gains Shield"/"reflects"). Return a typed list (mirror `ParsedHealAbility`'s `damageReaction` annotation shape).
+
+- [ ] **Step 3: Consume in `buildShipAbilities`**
+
+Near the heal loop (`buildShipAbilities.ts:946`), add a loop over `parseCounterAbilities(text)` that pushes a `counter` ability on `on-attacked` (PR1) with `requirePrimaryTarget` from the annotation. Use the same anchor-position convention for editor order. Leave `requireShieldHit`/`on-ally-attacked` routing for PR2 (parse the data now, but for PR1 only Stalwart's on-attacked primary-target counter must go live; Nyxen/Centurion counter abilities may be built but remain effectively dormant until PR2 wires their gates/triggers — OR scope `buildShipAbilities` to emit only the Stalwart shape in PR1 and add Nyxen/Centurion emission in PR2. Choose the latter if it keeps PR1 's blast radius smaller).
+
+- [ ] **Step 4: Tests green + audit**
+
+Run:
+```bash
+npx vitest run <parser test> -v
+npm run audit:skills 2>&1 | tail -3   # expect 141 ships, 0 findings
+```
+Expected: parser test passes; audit still 141/0.
+
+- [ ] **Step 5: Full suite byte-identical**
+
+Run: `npx tsc --noEmit && npm run lint && npx vitest run 2>&1 | tail -8`
+Expected: clean, green, ZERO `.snap` (Stalwart not in any fixture).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat(combat): parse counterattack passives → Stalwart on-attacked counter (G PR1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Integration test + changelog + docs
+
+**Files:**
+- Test: `src/utils/combat/__tests__/counterAttack.integration.test.ts`
+- Modify: `src/constants/changelog.ts` (`UNRELEASED_CHANGES`)
+- Modify: `src/pages/DocumentationPage.tsx` (combat-sim coverage prose)
+
+- [ ] **Step 1: Write the integration test**
+
+Via real `buildShipAbilities` (Stalwart) → `runCombat` / `simulateBattle`, player-side Stalwart hit by an enemy as the primary target retaliates for a mitigated amount (and can contribute to a kill); assert the attacker's `perTargetDamage`/HP reflects the counter. Confirm the co-located Legion Discipline II still applies. (No enemy-side mirror — spec I4.)
+
+Run: `npx vitest run src/utils/combat/__tests__/counterAttack.integration.test.ts -v`
+Expected: PASS.
+
+- [ ] **Step 2: Changelog**
+
+Add to `UNRELEASED_CHANGES` in `src/constants/changelog.ts`:
+> "Combat simulator now models counterattacks: a ship with a 'when directly damaged' passive (e.g. Stalwart) strikes back at the attacker for a share of its own attack — full damage that can crit and kill."
+
+- [ ] **Step 3: Docs**
+
+Update the combat-sim coverage prose in `src/pages/DocumentationPage.tsx` to mention counterattacks (player-side).
+
+- [ ] **Step 4: Final verification**
+
+Run: `npx tsc --noEmit && npm run lint && npx vitest run 2>&1 | tail -8 && npm run audit:skills 2>&1 | tail -3`
+Expected: all clean/green, audit 141/0, ZERO `.snap` movement.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat(combat): counterattack integration test + changelog + docs (G PR1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Done criteria (PR1)
+
+- Stalwart (P1/P2) parses a `counter` ability on `on-attacked` with `requirePrimaryTarget`.
+- A player-side counter is a full mitigated/crit walk against the attacker (can kill), fires once per attack, does not re-counter, and is gated on primary-target.
+- Co-located Stalwart buff (Legion Discipline II) unchanged.
+- `npx tsc --noEmit`, `npm run lint`, full `npx vitest run`, `npm run audit:skills` (141/0) all clean; ZERO `.snap` movement (production byte-identical).
+- PR2 will add Nyxen (`shieldWasHit`) + Centurion (`on-ally-attacked` + adjacency), reusing this foundation.

--- a/docs/superpowers/plans/2026-06-27-counterattack-refinements-G-pr1.md
+++ b/docs/superpowers/plans/2026-06-27-counterattack-refinements-G-pr1.md
@@ -40,7 +40,7 @@
 - **Modify** `src/utils/combat/triggers.ts` — `counter` executor branch + `applyCounterAttack`/`counterFiredThisTurn` on `IntentExecContext` interface + `isPrimaryTarget` passthrough in the `on-attacked` listener + `eventCtx.isPrimaryTarget`.
 - **Modify** `src/utils/skillTextParser.ts` — `parseCounterAbilities` (new) modeled on `parseHealAbilities`.
 - **Modify** `src/utils/abilities/buildShipAbilities.ts` — consume `parseCounterAbilities`, build `counter` abilities on `on-attacked`.
-- **Modify** editor exhaustiveness sites IF tsc forces: `src/components/skills/AbilityCard.tsx`, `AbilityTypePicker.tsx`, `src/utils/abilities/abilityDefaults.ts` (add stubs only).
+- **Modify** editor exhaustiveness sites IF tsc forces: `src/components/skills/AbilityCard.tsx`, `AbilityTypePicker.tsx`, `src/components/skills/abilityDefaults.ts` (add stubs only).
 - **Modify** `src/constants/changelog.ts`, `src/pages/DocumentationPage.tsx` — final task.
 - **Tests:** `src/utils/combat/__tests__/counterAttack.test.ts` (new, executor/helper unit), `src/utils/combat/__tests__/counterAttack.integration.test.ts` (new, runCombat), parser test in `src/utils/abilities/__tests__/` or `src/utils/__tests__/skillTextParser` area.
 
@@ -65,7 +65,7 @@ Expected: branch correct, working tree clean, reflect tests pass (sanity that th
 
 **Files:**
 - Modify: `src/types/abilities.ts:328` (union)
-- Modify (only if tsc errors): `src/components/skills/AbilityCard.tsx`, `src/components/skills/AbilityTypePicker.tsx`, `src/utils/abilities/abilityDefaults.ts`
+- Modify (only if tsc errors): `src/components/skills/AbilityCard.tsx`, `src/components/skills/AbilityTypePicker.tsx`, `src/components/skills/abilityDefaults.ts`
 
 - [ ] **Step 1: Add the union variant**
 
@@ -92,7 +92,7 @@ Expected: errors at any `switch (ability.type)` / `Record<AbilityType, …>` tha
 
 - [ ] **Step 3: Add minimal stubs**
 
-For each tsc error, add a minimal entry mirroring the `'damage'` case (e.g. in `abilityDefaults.ts` a `counter` default `{ type: 'counter', multiplier: 0 }`; in pickers a label like "Counterattack"; in `AbilityCard.tsx` reuse the damage rendering or a one-line summary). Do NOT add `'counter'` to `NOT_SIMULATED_TYPES` (it IS simulated). Keep stubs minimal — the editor is not the focus.
+For each tsc error, add a minimal entry mirroring the `'damage'` case. Expected sites (verified): `src/components/skills/abilityDefaults.ts` `makeDefaultConfig` switch (~line 7) + `DEFAULT_TARGETS: Record<AbilityType, AbilityTarget>` (~line 91, use `'enemy'`); `AbilityTypePicker.tsx` `TYPE_LABELS: Record<AbilityType, string>` (~line 10, label "Counterattack"); `AbilityCard.tsx` (~line 248) reuse the damage rendering or a one-line summary. **No `simCoverage.ts` edit is needed** — `NOT_SIMULATED_TYPES = {'control'}` (simCoverage.ts:17) and `PASSIVE_NOOP_TYPES` both correctly exclude `counter` (it IS simulated); do NOT add `counter` to either. Keep stubs minimal — the editor is not the focus.
 
 - [ ] **Step 4: Verify clean**
 
@@ -143,7 +143,13 @@ This task adds the signals only (no executor yet) — all byte-identical.
 
 - [ ] **Step 4: Add `isCounter?` cause flag (for no-re-reflect / no-re-counter intent)**
 
-Find the `cause` type used by `applyVictimDamage` (search `isReflected?:` in `engine.ts`). Add `isCounter?: boolean` beside `isReflected?`. Update the reflect re-entry guard at `engine.ts:3020` from `if (!cause?.isReflected && …)` to `if (!cause?.isReflected && !cause?.isCounter && …)` so a counter application is NOT itself reflected (loop-safe; documented in spec rule 2). Add a one-line comment.
+The `cause` param type is an INLINE object literal on `applyVictimDamage` at
+**engine.ts:~2701–2711** (a near-duplicate exists on `applyIncomingToTarget` ~3143–3148;
+only the `applyVictimDamage` one is load-bearing for the counter apply path). Add
+`isCounter?: boolean` to the `applyVictimDamage` cause literal (2701–2711). Update the
+reflect re-entry guard at **engine.ts:3020** from `if (!cause?.isReflected && …)` to
+`if (!cause?.isReflected && !cause?.isCounter && …)` so a counter application is NOT
+itself reflected (loop-safe; documented in spec rule 2). Add a one-line comment.
 
 - [ ] **Step 5: Verify byte-identical**
 
@@ -174,16 +180,25 @@ The helper rolls the owner's crit, computes raw via `victimHitDamage`, applies v
 `src/utils/combat/triggers.ts`, in `IntentExecContext` (near `creditReactiveDamage?`, ~782):
 ```ts
     /** G PR1: apply a full mitigated/crit counter walk from `ownerId` to `attackerId`.
-     *  Reuses the engine's no-event apply path (no attacked event → no re-counter). */
-    applyCounterAttack?: (ownerId: string, attackerId: string, multiplier: number, hits: number) => void;
+     *  `abilityId` keys the dedicated counter crit-gate. Reuses the engine's no-event
+     *  apply path (no attacked event → no re-counter). */
+    applyCounterAttack?: (
+        ownerId: string,
+        attackerId: string,
+        abilityId: string,
+        multiplier: number,
+        hits: number
+    ) => void;
 ```
 
-- [ ] **Step 2: Write the failing engine test (testtap)**
+- [ ] **Step 2: (No test committed in this task — see note)**
 
-Add `src/utils/combat/__tests__/counterAttack.test.ts`. Drive a minimal `runCombat` where a player ship carries a `counter` ability (built inline or via a test ability) and is hit by an enemy; assert via the result/perTargetDamage that the attacker took mitigated counter damage matching `victimHitDamage` (owner attack × mult/100, vs attacker defence/affinity), and that owner crit can apply. Mirror the harness in `reflect`/`reactiveExtraAction` tests. Start with the magnitude assertion.
-
-Run: `npx vitest run src/utils/combat/__tests__/counterAttack.test.ts -v`
-Expected: FAIL (no counter executor/helper yet).
+The helper's magnitude is only observable once the executor calls it (Task 4). To avoid
+committing a RED test, the end-to-end magnitude test (`counterAttack.test.ts`) is written
+in **Task 4** alongside the executor. This task adds the helper + ctx wiring only and
+verifies via tsc/lint. (If you prefer a Task-3 test, expose an engine `__testTap` that
+invokes `applyCounterAttack` directly and assert magnitude against `victimHitDamage` — but
+the default is to defer the test to Task 4.)
 
 - [ ] **Step 3: Implement `applyCounterAttack`**
 
@@ -193,6 +208,7 @@ Inside the per-round scope where `applyVictimDamage`, `statusEngine`, `selfBuffL
 const applyCounterAttack = (
     ownerId: string,
     attackerId: string,
+    abilityId: string,
     multiplier: number,
     hits: number
 ): void => {
@@ -206,11 +222,16 @@ const applyCounterAttack = (
     const ownerStats = effectiveStatsOf(statusEngine, selfBuffLookup, owner);
     const attackerStats = effectiveStatsOf(statusEngine, selfBuffLookup, attacker);
 
-    // Roll the OWNER's crit (spec rule 4). Use the SAME crit rate-gate machinery the
-    // normal attack path uses (locate it next to the existing crit gate; key per
-    // owner+ability or per the established reactive crit pattern). Dormant in every
-    // fixture (no Stalwart equipped) → byte-identical.
-    const didCrit = /* rollOwnerCrit(ownerId, ownerStats.crit) */ false; // see Step 3a
+    // Roll the OWNER's crit (spec rule 4) via a NEW dedicated combat-scoped gate map
+    // (Task 3a) — NOT any existing per-actor crit gate (reusing one would corrupt that
+    // actor's crit schedule and could move goldens even without Stalwart). A dedicated
+    // map only ever creates keys for counter-carriers → no key, no draw, no perturbation
+    // for every existing fixture → byte-identical.
+    const didCrit = rollRateGate(
+        counterCritGates,
+        `${ownerId}:${abilityId}`, // one crit stream per counter ability per owner
+        ownerStats.crit / 100
+    );
 
     const raw = victimHitDamage(
         {
@@ -221,7 +242,10 @@ const applyCounterAttack = (
             effectiveCritDamage: ownerStats.critDamage,
             outgoingDamageBuffPct: 0,
             incomingDamageModifierPct: 0,
-            defensePenetrationPct: ownerStats.defensePenetration ?? 0,
+            // effectiveStatsOf.defensePenetration is BASE-only (the buff folds via a
+            // separate channel) — acceptable: no Stalwart fixture, and counters ignoring
+            // pen-buffs is a documented approximation. Field exists on EffectiveStats.
+            defensePenetrationPct: ownerStats.defensePenetration,
             attackerAffinity: owner.affinity,
         },
         {
@@ -239,7 +263,10 @@ const applyCounterAttack = (
         killerId: owner.id,
         byDirectDamage: true,
         isCounter: true,
-        shieldPenetrationPct: ownerStats.shieldPenetration ?? 0,
+        // Mirror Reflect (engine.ts:3091): no shield penetration on the reactive hit.
+        // (EffectiveStats has NO shieldPenetration field; shield-pen lives on
+        // actor.stats.shieldPenetration via attackerShieldPenOf — deliberately not used.)
+        shieldPenetrationPct: 0,
         bombPortion: 0,
     });
     // Surface on the attacker's incoming so it appears on the HP curve (mirror reflect
@@ -251,20 +278,35 @@ const applyCounterAttack = (
 };
 ```
 
-- [ ] **Step 3a: Wire the owner crit roll**
+- [ ] **Step 3a: Wire the owner crit roll via a NEW dedicated gate map**
 
-Locate the crit rate-gate used for normal/reactive crits (search `critGate`, `makeRateGate`, `rollRateGate` in `engine.ts`/`rateAccumulator.ts`). Replace the `didCrit` placeholder with a roll of the owner's effective crit chance through that gate (own stream — must NOT perturb existing gate draws for fixtures without Stalwart). If the simplest faithful option is to mirror the reflect path (which uses `didCrit:false`, i.e. no crit), STOP and reconsider — spec rule 4 requires crit. Prefer drawing the owner's crit gate. Document the chosen stream in a comment.
+Do NOT reuse any existing per-actor crit gate — those are per-actor-runtime fields
+(`owner.activeCritGate(rate)` / `rt.activeHealCritGate(...)`, e.g. engine.ts:2352/2422/
+2497/4939) and reusing one corrupts that actor's crit schedule (golden movement risk
+even without Stalwart). Instead:
+1. Import `rollRateGate` from `./rateAccumulator` (it exists: `rateAccumulator.ts:31`,
+   signature `rollRateGate(gates, key, chance)` — the same deterministic accumulator the
+   D-PR proc gates use).
+2. Declare a NEW combat-scoped map next to the other gate maps (e.g. beside
+   `procChanceGates`): `const counterCritGates = new Map<string, ReturnType<typeof makeRateGate>>();`
+3. Key it `${ownerId}:${abilityId}` (NOT `${ownerId}:${attackerId}` — one crit stream per
+   counter ability per owner; update the helper's key accordingly, threading the ability id
+   into `applyCounterAttack` if needed, or roll the gate in the executor and pass `didCrit`
+   in). A dedicated map creates keys ONLY for counter-carriers → no draw for any existing
+   fixture → byte-identical.
+
+Document the chosen stream in a comment.
 
 - [ ] **Step 4: Expose on the per-round ctx**
 
 `src/utils/combat/engine.ts:~3791`, in the IntentExecContext object literal next to `creditReactiveDamage`, add `applyCounterAttack,`.
 
-- [ ] **Step 5: Run the test (still fails until executor — Task 4)**
+- [ ] **Step 5: Verify clean (no behavior change yet)**
 
-The helper exists but nothing calls it yet. Keep the magnitude test focused on the helper if you exposed a testtap; otherwise this test green-lights in Task 4. Run tsc/lint:
+The helper exists but nothing calls it yet → byte-identical. Run:
 
-Run: `npx tsc --noEmit && npm run lint`
-Expected: clean.
+Run: `npx tsc --noEmit && npm run lint && npx vitest run 2>&1 | tail -6`
+Expected: clean; full suite green; ZERO `.snap` movement (helper is unreferenced).
 
 - [ ] **Step 6: Commit**
 
@@ -293,7 +335,7 @@ In `engine.ts` at combat scope (near `hitThisRound`), declare:
 // would wrongly suppress a second attack in the same round).
 const counterFiredThisTurn = new Set<string>();
 ```
-Clear it (`counterFiredThisTurn.clear();`) at the TOP of each per-actor turn iteration — locate the per-actor turn-order loop body / the `turn-started` emit (~engine.ts:3562) and clear once per actor turn, before the action branches and before the drain that follows the turn. Expose on the per-round ctx (next to `applyCounterAttack`):
+Clear it (`counterFiredThisTurn.clear();`) once per actor turn at the TOP of the per-actor turn-order loop. The single boundary is the `turn-started` emit at **engine.ts:~4061** (loop `for (let actor = selectNext(); ...)` at ~4003; clear right after `actingActorId = actor.id` ~4059, before the action branches and before the post-turn drain). Two dead-actor `continue`s precede it (~4012, ~4044) — harmless, a skipped dead actor doesn't attack. (NOT line 3562 — that's unrelated `targetHpPctStart`.) Expose on the per-round ctx (next to `applyCounterAttack`):
 ```ts
 counterFiredThisTurn,
 ```
@@ -301,7 +343,7 @@ and declare `counterFiredThisTurn?: Set<string>;` on `IntentExecContext` (trigge
 
 - [ ] **Step 2: Write the failing executor tests**
 
-In `counterAttack.test.ts` add: (a) a 3-hit attack on a counter-carrier → exactly ONE counter (assert attacker incoming == one counter's worth); (b) `requirePrimaryTarget:true` + an `attacked` with `isPrimaryTarget:false` → NO counter; with `true` → counter; (c) no-re-counter: attacker also carries a counter → only the first fires.
+In `counterAttack.test.ts` add: (a) **magnitude** (moved from Task 3) — a player counter-carrier hit by an enemy → attacker takes mitigated counter damage matching `victimHitDamage` (owner attack × mult/100 vs attacker defence/affinity); (b) a 3-hit attack on a counter-carrier → exactly ONE counter (assert attacker incoming == one counter's worth); (c) `requirePrimaryTarget:true` + an `attacked` with `isPrimaryTarget:false` → NO counter; with `true` → counter; (d) no-re-counter: attacker also carries a counter → only the first fires.
 
 Run: `npx vitest run src/utils/combat/__tests__/counterAttack.test.ts -v`
 Expected: FAIL.
@@ -323,7 +365,7 @@ if (cfg.type === 'counter') {
     const key = `${intent.ownerId}:${intent.ability.id}`;
     if (ctx.counterFiredThisTurn?.has(key)) return;
     ctx.counterFiredThisTurn?.add(key);
-    ctx.applyCounterAttack?.(intent.ownerId, attackerId, cfg.multiplier, cfg.hits ?? 1);
+    ctx.applyCounterAttack?.(intent.ownerId, attackerId, intent.ability.id, cfg.multiplier, cfg.hits ?? 1);
     return;
 }
 ```

--- a/docs/superpowers/plans/2026-06-27-counterattack-refinements-G-pr1.md
+++ b/docs/superpowers/plans/2026-06-27-counterattack-refinements-G-pr1.md
@@ -284,11 +284,13 @@ Do NOT reuse any existing per-actor crit gate — those are per-actor-runtime fi
 (`owner.activeCritGate(rate)` / `rt.activeHealCritGate(...)`, e.g. engine.ts:2352/2422/
 2497/4939) and reusing one corrupts that actor's crit schedule (golden movement risk
 even without Stalwart). Instead:
-1. Import `rollRateGate` from `./rateAccumulator` (it exists: `rateAccumulator.ts:31`,
-   signature `rollRateGate(gates, key, chance)` — the same deterministic accumulator the
-   D-PR proc gates use).
+1. `rollRateGate` and `makeRateGate` are ALREADY imported in `engine.ts:12`
+   (`import { makeRateGate, rollRateGate } from '../calculators/rateAccumulator';`) — no new
+   import needed. Signature `rollRateGate(gates, key, chance)` (`calculators/rateAccumulator.ts:31`)
+   — the same deterministic accumulator the D-PR proc gates use.
 2. Declare a NEW combat-scoped map next to the other gate maps (e.g. beside
-   `procChanceGates`): `const counterCritGates = new Map<string, ReturnType<typeof makeRateGate>>();`
+   `procChanceGates`, engine.ts:~1997): `const counterCritGates = new Map<string, RateGate>();`
+   (use the `RateGate` alias to match `procChanceGates`' style).
 3. Key it `${ownerId}:${abilityId}` (NOT `${ownerId}:${attackerId}` — one crit stream per
    counter ability per owner; update the helper's key accordingly, threading the ability id
    into `applyCounterAttack` if needed, or roll the gate in the executor and pass `didCrit`

--- a/docs/superpowers/specs/2026-06-27-counterattack-refinements-G-design.md
+++ b/docs/superpowers/specs/2026-06-27-counterattack-refinements-G-design.md
@@ -28,11 +28,28 @@ Reflect (`Nosorog`, and the Reflect gear set) is already shipped — out of scop
 Malvex's "directly damaged as a primary target" is a *shield grant*, not damage —
 out of scope. The remaining unmodeled counterattacks are:
 
-| Ship | Passive text | Variant |
+Exact text (CSV-parsed 2026-06-27 — earlier explore quotes were inaccurate):
+
+| Ship | Passive text (verbatim, markup stripped) | Variant |
 | --- | --- | --- |
-| **Stalwart** (P1/P2) | "When this Unit is directly damaged **as a primary target**, it deals 30%/70% damage to that enemy" | plain + primary-target gate |
-| **Nyxen** (P1/P2) | "This Unit deals 100%/200% damage **when its Shield is directly damaged**" | shield-hit gate |
-| **Centurion** (P2/P3) | "When this Unit **or an adjacent ally** is directly damaged, this Unit retaliates dealing 50%/100% damage" | self-or-adjacent-ally trigger |
+| **Stalwart** (P1/P2) | "When this Unit is directly damaged **as a primary target**, it deals 30%/70% damage to that enemy and gains Legion Discipline II for 3 turns." | plain + primary-target gate |
+| **Nyxen** (P1/P2) | "This Unit deals 100%/200% damage **when its Shield is directly damaged**." | shield-hit gate |
+| **Centurion** (P2/P3) | "When this Unit **or an adjacent ally** is directly damaged, this Unit **retaliates dealing** 50%/100%." | self-or-adjacent-ally trigger |
+
+Notes on the verbatim text:
+- **Centurion's clause ends "retaliates dealing 50%." — there is no trailing word
+  "damage"** (the `<unit-damage>` tag wraps just "50%"). The parser must anchor on
+  *"retaliates dealing X%"* as well as *"deals X% damage"* and must NOT require the
+  literal word "damage". Centurion's counter is **flat** (50/100%), not scaled by
+  adjacent-ally count — the "per adjacent ally" scaling is a separate
+  start-of-combat attack buff in the same cells (see M1).
+- **Co-located abilities (M1):** these passive cells contain MORE than the counter
+  — Stalwart also "gains Legion Discipline II for 3 turns" (and P2 "+20% Attack
+  when adjacent to a Supporter"); Centurion's cells also carry "At the start of
+  combat, this Unit gains 500/750/1000 attack per adjacent ally". The `counter`
+  ability models **only the damage**; the co-located buffs parse as independent
+  abilities and **must not regress**. The parser change splits one cell into
+  multiple abilities (a `counter` plus the existing buff/start-of-combat parses).
 
 **Explicitly out of scope (YAGNI — no ship uses them):** HP-threshold-gated
 counters ("while below 40% HP"), attacker-debuff-gated counters ("by an enemy
@@ -57,6 +74,13 @@ affected by Taunt/Provoke").
    and crit-capable.
 5. **Retaliation target = the attacker** (the enemy who dealt the triggering
    direct hit), routed via the existing `counterTargetId`/`attackerId`.
+6. **Owner & attacker must be alive at resolution.** A counter does not fire if
+   the owner is destroyed when it would resolve (`owner.destroyedRound ===
+   undefined`) — a destroyed unit can't retaliate (this differs from Reflect's
+   thorns, which fire on the wearer's lethal hit). It also no-ops if the attacker
+   is already destroyed (mirrors Reflect's `attacker.destroyedRound === undefined`
+   guard, engine.ts:3047). A **stasised** owner is already suppressed by the
+   existing reactive-drain filter (`isStasised(intent.ownerId)` continue).
 
 ## Architecture (Approach A — new counter path + reuse damage pipeline)
 
@@ -88,52 +112,120 @@ A new branch (sibling of the `cfg.type === 'damage'` branch at ~1763) for
 - call the new `ctx.applyCounterAttack(ownerId, attackerId, multiplier, hits)`
   delegate instead of `creditReactiveDamage`.
 
-### Engine helper `applyCounterAttack` (`engine.ts`)
+### Engine helper `applyCounterAttack` (`engine.ts`) — anchored on the Reflect path
 
-Exposed on `IntentExecContext` like `creditReactiveDamage` (engine.ts ~3791).
-It performs a **single full damage walk** owner→attacker by reusing the existing
-per-victim pipeline (`victimHitDamage` in `victimDamage.ts:74` + the shared
-apply-to-victim path that drains shield then HP, records to the sink, and marks
-death). Inputs: owner's effective stats (attack/crit/critDamage/penetration),
-affinity(owner→attacker), attacker's defense/shield. It records damage to the
-normal sink and applies HP/shield mutation so the attacker can die.
+**The existing Reflect implementation is the direct precedent and validates
+Approach A.** Reflect already performs nearly exactly the proposed counter:
+`applyVictimDamage(..., { isReflected: true })` (the per-round closure spanning
+engine.ts:2782–2989, with the reflect branch ~2990–3078) drains the target's
+shield→HP per the H1 shield rules, runs full death handling/`recordDestroyed`,
+resolves affinity wearer→attacker (3051), reads attacker defence via
+`effectiveStatsOf` (3055) and attacker incoming-reduction (3065), guards
+`attacker.destroyedRound === undefined` (3047), and **emits no `attacked`/reaction
+events** (comment 2997–2998) — i.e. no ping-pong already. `applyCounterAttack`
+**reuses this same no-event apply path**.
 
-**No-re-counter enforcement:** the counter applies damage **without emitting an
-`attacked` event** (the event is what drives `on-attacked`/counter reactives), so
-it cannot re-trigger a counter. Shield absorption is part of `applyToVictim`
-itself (not a reactive), so it still happens. This is the cleanest seam for rule
-2 — analogous to Reflect's "direct slice" but going through full mitigation.
+Two things the spec must be explicit about (raised in review):
+- **It is a per-round closure, not a trivial credit.** Unlike `creditReactiveDamage`
+  (engine.ts:3791, a one-liner), `applyVictimDamage` is rebuilt each round and
+  captures `r`, `actingActorId`, the sinks, and `allActorsById`. Exposing
+  `applyCounterAttack` on `IntentExecContext` means **capturing this per-round
+  closure into the per-round ctx** (the ctx is already rebuilt per round next to
+  `creditReactiveDamage`). Feasible, but more than "add a field".
+- **Damage computation:** the raw counter amount = owner's effective stats run
+  through `victimHitDamage` (`victimDamage.ts:74`, pure — takes
+  `AttackerDamageScalars` + `VictimDefenseProfile` + a **pre-decided `didCrit`** +
+  roleScale) against the attacker's defense profile, with `multiplierPct =
+  rawMultiplier` (e.g. 30/70/100/200) and the owner's penetration/affinity.
+  Reflect instead uses its own `reflectedDamageForHit` (% of incoming); the plan
+  picks one — default is `victimHitDamage` (it is the general mitigation+crit
+  formula the counter wants), feeding its output into the reflect-style no-event
+  apply path.
 
-### Once-per-attack guard
+**Crit (rule 4):** `victimHitDamage` does NOT roll crit — it takes a `didCrit`
+boolean. To make the counter crit-capable, `applyCounterAttack` first **rolls the
+owner's crit** (the owner's effective crit chance via the same rate-gate
+machinery the normal attack path uses) to produce `didCrit`, then computes/applies.
+The plan pins which RNG/rate-gate stream this draws from. Because counters are new
+and **dormant in every existing fixture** (the parser produced none before), no
+golden draws this gate → production stays byte-identical.
 
-`attacked` fires per-hit; the guard collapses a multi-hit/AoE attack to one
-counter. Use a per-turn (or per-triggering-attack) set keyed on
-`${ownerId}:${abilityId}` populated when the counter fires and cleared at
-turn/round boundary — mirrors the `oncePerRound` / `hitThisRound` patterns
-already in the engine. (Exact keying — per attacker-turn vs per round — pinned in
-the plan; "per triggering attack" is the intent.)
+**No-re-counter enforcement (rule 2):** inherited for free from the reflect apply
+path — it emits no `attacked` event, so it cannot re-trigger `on-attacked`/counter
+reactives. Shield absorption is internal to `applyVictimDamage` (engine.ts
+~2855–2863), not a reactive, so the attacker's shields still soak the counter.
+
+### Once-per-attack guard — NEW per-turn guard (NOT per-round)
+
+`attacked` fires per-hit, so a multi-hit attack or an AoE hitting self + multiple
+adjacent allies produces several `attacked` events **within the attacker's single
+turn**. The guard must collapse those to **one** counter, while still allowing a
+*separate later attack* (a different turn) to counter again.
+
+**The existing `oncePerRound` / `hitThisRound` patterns are the WRONG model** —
+both are keyed per round and cleared at round start (`oncePerRoundConsumed`
+engine.ts ~3844; `hitThisRound` cleared ~2532). A per-round guard would wrongly
+suppress a *second, separate* attack's counter in the same round. So this is a
+**new** guard:
+
+- A combat-scoped Set keyed `${counterOwnerId}:${abilityId}`, populated when a
+  counter fires, **cleared at every actor-turn boundary** (start of each turn) —
+  not at round start.
+- Because all `attacked` events of one attack fall within one attacker turn,
+  clearing per-turn yields exactly "once per triggering attack": multi-hit/AoE in
+  one turn → one counter; a different attacker's turn (or a later extra action) →
+  the guard is clear → counters again.
+
+The plan pins the precise clear site (the per-turn reset already present in the
+turn loop) and the key shape.
 
 ## New signals
 
+**Plumbing caveat (review I5):** both new signals are *known* at seams that are
+**detached from the single `attacked` emit site** (engine.ts:4971, which emits
+per-crit from `hitOutcomes`, not per-victim-with-role and not per-apply-call).
+Threading them is more than "add a field" — the plan must carry role and absorb
+data forward to the emit. This is plan-level plumbing; the data sources are pinned
+below.
+
 ### `isPrimaryTarget` on the `attacked` event (Stalwart)
 
-The `attacked` event (`events.ts:199`) carries no primary-vs-splash flag, but the
-positional path already distinguishes a **primary cell (full damage, 1.0)** from
-**covered/splash cells (0.5)** (`positionalApply.ts:15`). Add
-`isPrimaryTarget?: boolean` to the event, set true for the directly-targeted
-victim and false/absent for splash/covered victims. Stalwart's gate
-(`requirePrimaryTarget`) fires only when true. In the non-positional/aggregate
-path (single focus target) the lone target is primary → true.
+The `attacked` event (`events.ts:199`) carries no primary-vs-splash flag. The
+positional path already distinguishes a **primary/origin cell (roleScale 1.0)**
+from **covered/splash cells (0.5)** via `roleScaleFor` (`positionalApply.ts` ~19/37,
+`role === 'origin'`). Add `isPrimaryTarget?: boolean` to the event, sourced from
+`role === 'origin'`, set true for the directly-targeted victim and false/absent
+for splash/covered victims. Stalwart's gate (`requirePrimaryTarget`) fires only
+when true. In the non-positional/aggregate path (single focus target / legacy
+`tgt`) the lone target is primary → true.
 
 ### `shieldWasHit` signal (Nyxen)
 
 Nyxen counters only when the direct hit **actually reduced the shield pool**
 (absorbed > 0). The shield-absorb amount is known at the apply seam
-(`victim.shieldPool -= absorbed; addShieldAbsorbed(absorbed, victim.id)` per the
-shield system). Thread an `shieldWasHit?: boolean` (absorbed > 0) onto the
-`attacked` event (or the eventCtx the listener stamps). Nyxen's gate
-(`requireShieldHit`) fires only when true. A hit that fully penetrates to HP
-without touching shield, or a victim with no shield, → false → no counter.
+(`victim.shieldPool -= absorbed; addShieldAbsorbed(...)`, engine.ts ~2862). Thread
+a `shieldWasHit?: boolean` (absorbed > 0) forward to the `attacked` emit. Nyxen's
+gate (`requireShieldHit`) fires only when true. A hit that fully penetrates to HP
+without touching shield, or a victim with no shield, → false → no counter. (Note:
+this requires shield sources to be active — H is merged, so Nyxen's own
+shield-grant skill and the Shield gear set make this live.)
+
+### Enemy-side counters are OUT OF SCOPE for G (review I4)
+
+The **only** `attacked` emit site (engine.ts:4971) fires when an **enemy attacks a
+player-side victim** (`attackerId = enemy actor`, `targetId = tgt` = player ship).
+**Enemy ships hit by the player never emit `attacked`.** Therefore enemy-side
+counters cannot fire without adding enemy-victim `attacked` emission — and doing
+so would light up **every enemy `on-attacked` reactive** (Second Wind, Tenacity,
+Reactive Ward, …), not just counters, with broad two-team golden churn. That is a
+separate piece of the enemy-team-support work, not G.
+
+**G models PLAYER-side counters** — the primary use case: the player equips
+Stalwart / Nyxen / Centurion and they retaliate against enemy attacks. This fully
+delivers the corpus for the player. Enemy-side parity (those ships countering on
+the enemy team) is **explicitly deferred** to the enemy-victim-`attacked`-emission
+work. The integration tests therefore assert **player-side** counters; no
+"enemy-side mirror" test is claimed for G.
 
 ### Centurion — `on-ally-attacked` + adjacency
 
@@ -151,20 +243,35 @@ Centurion fires when **self or an adjacent living ally** is directly damaged.
 
 ## Parser auto-detection (`skillTextParser.ts`)
 
-`detectReactiveTrigger` gains a **damage path**. Recognize:
-- *"When [this Unit is] directly damaged … [this Unit] deals/retaliates **X%**
-  damage"* → `counter` ability on `on-attacked`, `multiplier = X`.
-- *"… **as a primary target** …"* → `requirePrimaryTarget: true`.
-- *"… when its **Shield** is directly damaged …"* → `requireShieldHit: true`.
-- *"… this Unit **or an adjacent ally** is directly damaged … retaliates …"* →
-  trigger `on-ally-attacked` (+ self) with adjacency gate.
+`detectReactiveTrigger` gains a **damage path**. The consequence anchor must match
+**both** corpus phrasings and must NOT require the literal word "damage" after the
+percent (Centurion ends "retaliates dealing 50%."):
+- *"it deals **X%** damage to that enemy"* (Stalwart) and
+- *"this Unit **retaliates dealing X%**"* (Centurion) and
+- *"This Unit deals **X%** damage when its Shield is directly damaged"* (Nyxen)
+  → `counter` ability with `multiplier = X`.
 
-Guard against false positives: "directly damaged" also appears in heal
-(Guardian), shield-grant (Malvex), and reflect (Nosorog) clauses — the damage
-path must only match when the *consequence* is "deals/retaliates X% damage" (not
-heal/shield/reflect), and must not collide with the existing reflect parse.
-`npm run audit:skills` must stay green and the three target ships must newly parse
-a `counter` ability (verified in the audit/coverage).
+Condition/trigger flags:
+- *"… **as a primary target** …"* → `requirePrimaryTarget: true` (Stalwart).
+- *"… when its **Shield** is directly damaged …"* → `requireShieldHit: true`
+  (Nyxen).
+- *"… this Unit **or an adjacent ally** is directly damaged … retaliates …"* →
+  trigger `on-ally-attacked` (+ self) with adjacency gate (Centurion).
+- otherwise → trigger `on-attacked` (Stalwart, Nyxen).
+
+**False-positive & regression guards:**
+- "directly damaged" also appears in heal (Guardian/Makoli), shield-grant
+  (Malvex "gains Shield"), and **reflect** (Nosorog "reflects 40% of the Damage
+  taken") clauses. The damage path must match **only** when the consequence is a
+  counter ("deals X% damage to that enemy" / "retaliates dealing X%"), and must
+  not collide with the existing reflect parse.
+- **Co-located ability preservation (M1):** Stalwart's cell also grants Legion
+  Discipline II (and P2 a Supporter-adjacency attack buff); Centurion's cells also
+  carry start-of-combat "+N attack per adjacent ally". The parser splits the cell
+  into the new `counter` PLUS the existing buff/start-of-combat abilities — the
+  pre-existing parses for those must remain unchanged (asserted in tests).
+- `npm run audit:skills` must stay green (141/0) and Stalwart, Nyxen, Centurion
+  must newly parse a `counter` ability (verified via coverage/audit).
 
 ## PR split
 
@@ -187,19 +294,31 @@ a `counter` ability (verified in the audit/coverage).
   affinity + shield absorb), no-re-counter (a counter against an attacker that
   *also* has a counter fires only the first), once-per-attack (3-hit attack → 1
   counter; AoE self+2 allies → 1 Centurion counter).
-- Integration (`runCombat` via real `buildShipAbilities`): Stalwart kills/dents a
-  primary attacker but not when hit as splash; Nyxen counters only when shield
-  absorbed > 0; Centurion retaliates when an adjacent ally is hit, positional
-  adjacency drives recipient selection, enemy-side mirror.
+- Integration (`runCombat` via real `buildShipAbilities`, **player-side** ships):
+  Stalwart dents/kills a primary attacker but does NOT counter when hit as splash;
+  Nyxen counters only when shield absorbed > 0 (and not when fully penetrated / no
+  shield); Centurion retaliates when self OR an adjacent ally is hit, with
+  positional adjacency driving the trigger. No enemy-side mirror is asserted
+  (enemy victims don't emit `attacked` — see review I4 / Enemy-side scope above).
+  Confirm the co-located buffs (Stalwart Legion Discipline II; Centurion
+  start-of-combat attack) still parse and apply (M1 non-regression).
 - `npm run audit:skills` green (141/0); the three ships newly carry a parsed
   `counter` ability; `npx tsc --noEmit` + `npm run lint` clean.
 
 ## Open items for plan phase
 
-- Exact `counter` config field names and whether `hits` is needed (Centurion/
-  Stalwart are single-hit).
-- Once-per-attack guard keying (per attacker-turn vs per round) — pin against the
-  multi-hit event cadence.
-- Whether the counter damage should record under a distinct event kind for sim
-  surfacing (vs. folding into the normal direct-damage sink). Default: normal
-  direct sink, no new event (preserves no-re-counter).
+- Exact `counter` config field names and whether `hits` is needed (all three
+  ships are single-hit → likely default 1).
+- The precise per-turn clear site + key shape for the once-per-attack guard
+  (resolved to per-turn, not per-round — see guard section).
+- Crit roll: which rate-gate/RNG stream `applyCounterAttack` draws the owner's
+  crit from, and confirming no existing fixture draws it (byte-identical).
+- Whether to compute the raw via `victimHitDamage` (default) or reuse Reflect's
+  `reflectedDamageForHit` — both precedents exist; the apply path is the shared
+  reflect no-event walk either way.
+- The exact plumbing of `isPrimaryTarget` (role) and `shieldWasHit` (absorbed>0)
+  forward to the `attacked` emit (engine.ts:4971), which is detached from those
+  seams (review I5).
+- Whether the counter damage records under a distinct event kind for sim
+  surfacing vs. folding into the normal direct-damage sink. Default: normal direct
+  sink, no `attacked` event (preserves no-re-counter).

--- a/docs/superpowers/specs/2026-06-27-counterattack-refinements-G-design.md
+++ b/docs/superpowers/specs/2026-06-27-counterattack-refinements-G-design.md
@@ -1,0 +1,205 @@
+# Sub-project G — Reactive Counterattack Refinements (design)
+
+**Date:** 2026-06-27
+**Epic:** combat-realism (sub-project G — damage-reaction mechanics)
+**Status:** design, pending spec review
+**Prereqs shipped:** Reflect gear set (#160), reactive-damage executor + proc/once-per-round gates, adjacency helper, per-victim damage pipeline.
+
+## Goal
+
+Model the game's **counterattack** passives in the combat sim. The reactive
+`on-attacked` machinery exists, but it has two gaps:
+
+1. The reactive **damage** executor is a *bomb-like approximation* (owner-attack
+   × multiplier, **no** defense mitigation, **no** crit, emits **no** event, and
+   only `creditDamage`s output — it does not actually reduce the attacker's HP).
+   Counterattacks must be a **full damage walk** against the attacker.
+2. The parser auto-detects **no** reactive-damage triggers
+   (`detectReactiveTrigger` has no damage path), so every counterattack passive
+   is silently inert in the sim today.
+
+This sub-project adds a faithful counterattack: a full mitigated/crit damage walk
+against the attacker, auto-parsed from skill text, with the per-ship condition
+gates the corpus actually uses.
+
+## Corpus (the real, verified set)
+
+Reflect (`Nosorog`, and the Reflect gear set) is already shipped — out of scope.
+Malvex's "directly damaged as a primary target" is a *shield grant*, not damage —
+out of scope. The remaining unmodeled counterattacks are:
+
+| Ship | Passive text | Variant |
+| --- | --- | --- |
+| **Stalwart** (P1/P2) | "When this Unit is directly damaged **as a primary target**, it deals 30%/70% damage to that enemy" | plain + primary-target gate |
+| **Nyxen** (P1/P2) | "This Unit deals 100%/200% damage **when its Shield is directly damaged**" | shield-hit gate |
+| **Centurion** (P2/P3) | "When this Unit **or an adjacent ally** is directly damaged, this Unit retaliates dealing 50%/100% damage" | self-or-adjacent-ally trigger |
+
+**Explicitly out of scope (YAGNI — no ship uses them):** HP-threshold-gated
+counters ("while below 40% HP"), attacker-debuff-gated counters ("by an enemy
+affected by Taunt/Provoke").
+
+## Locked rules (user-ratified during brainstorm)
+
+1. **Full damage walk, not bomb-like.** A counter runs the **owner's** live
+   effective stats through the real damage pipeline against the attacker: target
+   **defense mitigation**, the owner's **penetration**, **affinity** (owner vs
+   attacker), **crit** (owner's own crit chance/damage), **shield absorption** on
+   the attacker, reduces HP, **can kill**.
+2. **No re-counter (no ping-pong).** The counter-hit is real damage but does
+   **not** itself trigger the attacker's counterattack or `on-attacked`
+   reactives. It still resolves through normal damage application (the attacker's
+   shields absorb it). This prevents counter→counter→counter loops.
+3. **Once per triggering attack.** A multi-hit attack (3 `attacked` events) or an
+   AoE that hits self + multiple adjacent allies triggers **one** counter that
+   turn (one retaliation), via a once-per-turn guard — not one per hit/victim.
+4. **Damage basis = owner's effective attack × multiplier.** (e.g. 30/70/100/200
+   → ÷100.) Consistent with the existing reactive-damage basis, but now mitigated
+   and crit-capable.
+5. **Retaliation target = the attacker** (the enemy who dealt the triggering
+   direct hit), routed via the existing `counterTargetId`/`attackerId`.
+
+## Architecture (Approach A — new counter path + reuse damage pipeline)
+
+### New reactive `counter` ability config
+
+A distinct ability config variant (NOT a flag on the bomb-like `damage` type —
+keeps the two semantics cleanly separated). Shape (final names settled in plan):
+
+```ts
+{ type: 'counter'; multiplier: number; hits?: number;
+  // condition gates (all optional, default off):
+  requirePrimaryTarget?: boolean;   // Stalwart
+  requireShieldHit?: boolean;       // Nyxen
+  // procChance?/oncePerRound? inherited from the shared Ability fields
+}
+```
+
+Triggers: `on-attacked` (Stalwart, Nyxen) or `on-ally-attacked` (Centurion);
+both already route `counterTargetId = e.attackerId`.
+
+### Executor (`triggers.ts`)
+
+A new branch (sibling of the `cfg.type === 'damage'` branch at ~1763) for
+`cfg.type === 'counter'`:
+- honor `passesProcChanceGate` / `passesOncePerRoundGate` (existing);
+- enforce the **once-per-attack** guard (see below);
+- evaluate the condition gates from `intent.eventCtx`
+  (`isPrimaryTarget`, `shieldWasHit`);
+- call the new `ctx.applyCounterAttack(ownerId, attackerId, multiplier, hits)`
+  delegate instead of `creditReactiveDamage`.
+
+### Engine helper `applyCounterAttack` (`engine.ts`)
+
+Exposed on `IntentExecContext` like `creditReactiveDamage` (engine.ts ~3791).
+It performs a **single full damage walk** owner→attacker by reusing the existing
+per-victim pipeline (`victimHitDamage` in `victimDamage.ts:74` + the shared
+apply-to-victim path that drains shield then HP, records to the sink, and marks
+death). Inputs: owner's effective stats (attack/crit/critDamage/penetration),
+affinity(owner→attacker), attacker's defense/shield. It records damage to the
+normal sink and applies HP/shield mutation so the attacker can die.
+
+**No-re-counter enforcement:** the counter applies damage **without emitting an
+`attacked` event** (the event is what drives `on-attacked`/counter reactives), so
+it cannot re-trigger a counter. Shield absorption is part of `applyToVictim`
+itself (not a reactive), so it still happens. This is the cleanest seam for rule
+2 — analogous to Reflect's "direct slice" but going through full mitigation.
+
+### Once-per-attack guard
+
+`attacked` fires per-hit; the guard collapses a multi-hit/AoE attack to one
+counter. Use a per-turn (or per-triggering-attack) set keyed on
+`${ownerId}:${abilityId}` populated when the counter fires and cleared at
+turn/round boundary — mirrors the `oncePerRound` / `hitThisRound` patterns
+already in the engine. (Exact keying — per attacker-turn vs per round — pinned in
+the plan; "per triggering attack" is the intent.)
+
+## New signals
+
+### `isPrimaryTarget` on the `attacked` event (Stalwart)
+
+The `attacked` event (`events.ts:199`) carries no primary-vs-splash flag, but the
+positional path already distinguishes a **primary cell (full damage, 1.0)** from
+**covered/splash cells (0.5)** (`positionalApply.ts:15`). Add
+`isPrimaryTarget?: boolean` to the event, set true for the directly-targeted
+victim and false/absent for splash/covered victims. Stalwart's gate
+(`requirePrimaryTarget`) fires only when true. In the non-positional/aggregate
+path (single focus target) the lone target is primary → true.
+
+### `shieldWasHit` signal (Nyxen)
+
+Nyxen counters only when the direct hit **actually reduced the shield pool**
+(absorbed > 0). The shield-absorb amount is known at the apply seam
+(`victim.shieldPool -= absorbed; addShieldAbsorbed(absorbed, victim.id)` per the
+shield system). Thread an `shieldWasHit?: boolean` (absorbed > 0) onto the
+`attacked` event (or the eventCtx the listener stamps). Nyxen's gate
+(`requireShieldHit`) fires only when true. A hit that fully penetrates to HP
+without touching shield, or a victim with no shield, → false → no counter.
+
+### Centurion — `on-ally-attacked` + adjacency
+
+Centurion fires when **self or an adjacent living ally** is directly damaged.
+- Rides the existing `on-ally-attacked` listener (`triggers.ts:509`) **plus** the
+  self path, and gates the ally branch on **adjacency** via the existing
+  `adjacentAllyIdsFor` delegate (`triggers.ts:262`, `adjacency.ts`).
+- Retaliation still comes from **Centurion** against the **attacker**
+  (`counterTargetId = e.attackerId`), not from the damaged ally.
+- Positional adjacency uses board positions; falls back to all-allies when
+  positions aren't wired (same contract as Fortifying Shroud — production callers
+  don't wire positions yet, so the integration tests drive the positional path).
+- The once-per-attack guard ensures one retaliation even if an AoE hits Centurion
+  + multiple adjacent allies in one attack.
+
+## Parser auto-detection (`skillTextParser.ts`)
+
+`detectReactiveTrigger` gains a **damage path**. Recognize:
+- *"When [this Unit is] directly damaged … [this Unit] deals/retaliates **X%**
+  damage"* → `counter` ability on `on-attacked`, `multiplier = X`.
+- *"… **as a primary target** …"* → `requirePrimaryTarget: true`.
+- *"… when its **Shield** is directly damaged …"* → `requireShieldHit: true`.
+- *"… this Unit **or an adjacent ally** is directly damaged … retaliates …"* →
+  trigger `on-ally-attacked` (+ self) with adjacency gate.
+
+Guard against false positives: "directly damaged" also appears in heal
+(Guardian), shield-grant (Malvex), and reflect (Nosorog) clauses — the damage
+path must only match when the *consequence* is "deals/retaliates X% damage" (not
+heal/shield/reflect), and must not collide with the existing reflect parse.
+`npm run audit:skills` must stay green and the three target ships must newly parse
+a `counter` ability (verified in the audit/coverage).
+
+## PR split
+
+- **PR1 — foundation + Stalwart.** `counter` ability config + executor branch +
+  `applyCounterAttack` engine helper (full walk via `victimHitDamage`) +
+  once-per-attack guard + `isPrimaryTarget` signal/gate + parser auto-detect for
+  the plain "directly damaged [as a primary target] → deals X% damage" form.
+  Lights up **Stalwart**.
+- **PR2 — Nyxen + Centurion.** `shieldWasHit` signal + `requireShieldHit` gate
+  (Nyxen) + `on-ally-attacked`/self routing with adjacency gate (Centurion) +
+  parser detection for the shield-hit and adjacent-ally phrasings.
+
+## Testing & goldens
+
+- **Production byte-identical** expected: no current fixture plays these as live
+  counters (the parser was inert), so DPS/healing/single-enemy goldens shouldn't
+  move. Two-team-sim fixtures that newly fire a counter = **audited** churn only,
+  never `vitest -u`.
+- Unit tests: `victimHitDamage`-based counter magnitude (mitigation + crit +
+  affinity + shield absorb), no-re-counter (a counter against an attacker that
+  *also* has a counter fires only the first), once-per-attack (3-hit attack → 1
+  counter; AoE self+2 allies → 1 Centurion counter).
+- Integration (`runCombat` via real `buildShipAbilities`): Stalwart kills/dents a
+  primary attacker but not when hit as splash; Nyxen counters only when shield
+  absorbed > 0; Centurion retaliates when an adjacent ally is hit, positional
+  adjacency drives recipient selection, enemy-side mirror.
+- `npm run audit:skills` green (141/0); the three ships newly carry a parsed
+  `counter` ability; `npx tsc --noEmit` + `npm run lint` clean.
+
+## Open items for plan phase
+
+- Exact `counter` config field names and whether `hits` is needed (Centurion/
+  Stalwart are single-hit).
+- Once-per-attack guard keying (per attacker-turn vs per round) — pin against the
+  multi-hit event cadence.
+- Whether the counter damage should record under a distinct event kind for sim
+  surfacing (vs. folding into the normal direct-damage sink). Default: normal
+  direct sink, no new event (preserves no-re-counter).

--- a/src/components/skills/AbilityCard.tsx
+++ b/src/components/skills/AbilityCard.tsx
@@ -39,6 +39,7 @@ interface Props {
 
 const ABILITY_TYPE_LABELS: Record<Ability['type'], string> = {
     damage: 'Damage',
+    counter: 'Counterattack',
     'additional-damage': 'Additional Damage',
     modifier: 'Modifier',
     buff: 'Buff',

--- a/src/components/skills/AbilityTypePicker.tsx
+++ b/src/components/skills/AbilityTypePicker.tsx
@@ -9,6 +9,7 @@ interface Props {
 
 const TYPE_LABELS: Record<AbilityType, string> = {
     damage: 'Damage',
+    counter: 'Counterattack',
     'additional-damage': 'Additional Damage',
     modifier: 'Modifier',
     buff: 'Buff',

--- a/src/components/skills/__tests__/abilityDefaults.test.ts
+++ b/src/components/skills/__tests__/abilityDefaults.test.ts
@@ -70,6 +70,10 @@ describe('makeDefaultAbility', () => {
         expect(ability.conditions).toEqual([]);
     });
 
+    it('defaults a counter to the on-attacked trigger (its only valid firing path)', () => {
+        expect(makeDefaultAbility('counter').trigger).toBe('on-attacked');
+    });
+
     it('honours a passed-in id and generates unique ids otherwise', () => {
         expect(makeDefaultAbility('damage', 'fixed-id').id).toBe('fixed-id');
         const a = makeDefaultAbility('damage');

--- a/src/components/skills/abilityDefaults.ts
+++ b/src/components/skills/abilityDefaults.ts
@@ -9,7 +9,7 @@ const makeDefaultConfig = (type: AbilityType): AbilityConfig => {
         case 'damage':
             return { type: 'damage', multiplier: 100 };
         case 'counter':
-            return { type: 'counter', multiplier: 0 };
+            return { type: 'counter', multiplier: 100 };
         case 'additional-damage':
             return { type: 'additional-damage', stat: 'hp', pct: 10 };
         case 'modifier':

--- a/src/components/skills/abilityDefaults.ts
+++ b/src/components/skills/abilityDefaults.ts
@@ -125,7 +125,11 @@ export const makeDefaultAbility = (type: AbilityType, id: string = nextId()): Ab
     id,
     type,
     target: DEFAULT_TARGETS[type],
-    trigger: 'on-cast',
+    // A counter only ever fires on the victim-side `on-attacked` path (the parser builds it
+    // that way and the combat executor reads that trigger), so default it correctly — the
+    // helper should always yield a semantically valid ability, even though counters are
+    // currently parser-generated rather than authored via the picker.
+    trigger: type === 'counter' ? 'on-attacked' : 'on-cast',
     conditions: [],
     config: makeDefaultConfig(type),
 });

--- a/src/components/skills/abilityDefaults.ts
+++ b/src/components/skills/abilityDefaults.ts
@@ -8,6 +8,8 @@ const makeDefaultConfig = (type: AbilityType): AbilityConfig => {
     switch (type) {
         case 'damage':
             return { type: 'damage', multiplier: 100 };
+        case 'counter':
+            return { type: 'counter', multiplier: 0 };
         case 'additional-damage':
             return { type: 'additional-damage', stat: 'hp', pct: 10 };
         case 'modifier':
@@ -90,6 +92,7 @@ const makeDefaultConfig = (type: AbilityType): AbilityConfig => {
 
 const DEFAULT_TARGETS: Record<AbilityType, AbilityTarget> = {
     damage: 'enemy',
+    counter: 'enemy',
     'additional-damage': 'enemy',
     modifier: 'self',
     buff: 'self',

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -44,6 +44,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat simulator now models bomb splash-on-death: when a ship is destroyed while still carrying un-detonated bombs, each adjacent ally takes a share of every bomb's damage (25% at tier 1, 50% at tier 2, 75% at tier 3). This is positional, so it only applies in battles with board positions.",
     'Voidfire Catalyst implant now also amplifies bomb splash damage — when a bomb-carrier is destroyed, the splash damage dealt to adjacent ships is increased by Voidfire Catalyst, including its rare and legendary splash-only variants.',
     'Combat & DPS simulators now model the Boost gear set: while a ship wears 4 or more Boost pieces, each timed buff it applies — to itself or its allies — lasts one extra turn.',
+    "Combat simulator now models counterattacks: a ship with a 'when directly damaged' passive (e.g. Stalwart) strikes back at the attacker for a share of its own attack — full damage that can crit and kill.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -44,7 +44,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat simulator now models bomb splash-on-death: when a ship is destroyed while still carrying un-detonated bombs, each adjacent ally takes a share of every bomb's damage (25% at tier 1, 50% at tier 2, 75% at tier 3). This is positional, so it only applies in battles with board positions.",
     'Voidfire Catalyst implant now also amplifies bomb splash damage — when a bomb-carrier is destroyed, the splash damage dealt to adjacent ships is increased by Voidfire Catalyst, including its rare and legendary splash-only variants.',
     'Combat & DPS simulators now model the Boost gear set: while a ship wears 4 or more Boost pieces, each timed buff it applies — to itself or its allies — lasts one extra turn.',
-    "Combat simulator now models counterattacks: a ship with a 'when directly damaged' passive (e.g. Stalwart) strikes back at the attacker for a share of its own attack — full damage that can crit and kill.",
+    "Combat simulator now models counterattacks: one of your ships with a 'when directly damaged' passive (e.g. Stalwart) strikes back at the attacker for a share of its own attack — full damage that can crit and kill. Enemy-side counters are coming in a later update.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3149,11 +3149,12 @@ const DocumentationPage: React.FC = () => {
                                     Inferno detonations, and Corrosion detonations) and bomb splash
                                     damage by a percentage based on rarity — its rare and legendary
                                     variants amplify bomb splash damage only. Counterattacks are now
-                                    modeled too: a ship with a &quot;when directly damaged&quot;
-                                    passive (such as <strong>Stalwart</strong>) retaliates against
-                                    the attacker for a share of its own attack — a full hit that can
-                                    crit and kill. More implant and gear-set effects will be added in
-                                    future updates.
+                                    modeled too: one of your ships with a &quot;when directly
+                                    damaged&quot; passive (such as <strong>Stalwart</strong>)
+                                    retaliates against the attacker for a share of its own attack —
+                                    a full hit that can crit and kill (enemy-side counters are
+                                    coming in a later update). More implant and gear-set effects
+                                    will be added in future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3148,8 +3148,12 @@ const DocumentationPage: React.FC = () => {
                                     also modeled: it increases detonation damage (bomb bursts,
                                     Inferno detonations, and Corrosion detonations) and bomb splash
                                     damage by a percentage based on rarity — its rare and legendary
-                                    variants amplify bomb splash damage only. More implant and
-                                    gear-set effects will be added in future updates.
+                                    variants amplify bomb splash damage only. Counterattacks are now
+                                    modeled too: a ship with a &quot;when directly damaged&quot;
+                                    passive (such as <strong>Stalwart</strong>) retaliates against
+                                    the attacker for a share of its own attack — a full hit that can
+                                    crit and kill. More implant and gear-set effects will be added in
+                                    future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -5,6 +5,7 @@ export type SkillSlot = 'active' | 'charged' | 'passive';
 
 export type AbilityType =
     | 'damage'
+    | 'counter'
     | 'additional-damage'
     | 'modifier'
     | 'buff'
@@ -327,6 +328,17 @@ export type ModifierChannel =
 
 export type AbilityConfig =
     | { type: 'damage'; multiplier: number; hits?: number; noCrit?: boolean }
+    | {
+          type: 'counter';
+          /** raw percentage of the OWNER's effective attack, e.g. 30/70/100/200. */
+          multiplier: number;
+          hits?: number;
+          /** Stalwart: fire only when this unit was the directly-targeted (primary) victim,
+           *  not a splash/covered AoE victim. Gated on `attacked.isPrimaryTarget`. */
+          requirePrimaryTarget?: boolean;
+          /** Nyxen (PR2): fire only when the hit reduced the shield pool. Plumbed in PR2. */
+          requireShieldHit?: boolean;
+      }
     | { type: 'additional-damage'; stat: 'hp' | 'defense'; pct: number }
     | { type: 'modifier'; channel: ModifierChannel; value: number; isMultiplicative: boolean }
     | {

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -1549,6 +1549,82 @@ describe('buildShipAbilities', () => {
         });
     });
 
+    // Combat G PR1 (Task 5): Stalwart's counterattack passive — "When directly damaged as a
+    // primary target, it deals X% damage to that enemy" — auto-produces a reactive `counter`
+    // ability (on-attacked, requirePrimaryTarget) instead of a plain on-cast `damage`, while the
+    // co-located buff grant ("gains Legion Discipline II for 3 turns") still parses.
+    describe('counterattack passives → on-attacked counter (Combat G PR1)', () => {
+        const passiveOf = (s: Ship): Skill | undefined =>
+            buildShipAbilities(s).slots.find((x) => x.slot === 'passive');
+
+        it('Stalwart first passive (30%): emits an on-attacked counter with requirePrimaryTarget and keeps the Legion Discipline II buff', () => {
+            const s = ship({
+                firstPassiveSkillText:
+                    'When this Unit is directly damaged as a primary target, it deals <unit-damage>30% damage</unit-damage> to that enemy and gains <unit-skill>Legion Discipline II</unit-skill> for 3 turns.',
+            });
+            const passive = passiveOf(s);
+            const counterAb = passive?.abilities.find((a) => a.type === 'counter');
+            expect(counterAb).toMatchObject({
+                type: 'counter',
+                target: 'enemy',
+                trigger: 'on-attacked',
+                config: { type: 'counter', multiplier: 30, requirePrimaryTarget: true },
+            });
+            // Non-regression: no phantom on-cast plain damage left behind.
+            const all = buildShipAbilities(s).slots.flatMap((x) => x.abilities);
+            expect(all.filter((a) => a.type === 'damage')).toHaveLength(0);
+            // Co-located buff still parses.
+            const buff = passive?.abilities.find((a) => a.type === 'buff');
+            expect(buff).toMatchObject({
+                type: 'buff',
+                config: { type: 'buff', buffName: 'Legion Discipline II', duration: 3 },
+            });
+        });
+
+        it('Stalwart second passive (70%): emits an on-attacked counter with requirePrimaryTarget and keeps the Legion Discipline II buff', () => {
+            const s = ship({
+                secondPassiveSkillText:
+                    'When this Unit is directly damaged as a primary target, it deals <unit-damage>70% damage</unit-damage> to that enemy and gains <unit-skill>Legion Discipline II</unit-skill> for 3 turns.<br /><br />Additionally, when this Unit is adjacent to a Supporter, this Unit gains <unit-skill>20% Attack</unit-skill>.',
+            });
+            const passive = passiveOf(s);
+            const counterAb = passive?.abilities.find((a) => a.type === 'counter');
+            expect(counterAb).toMatchObject({
+                type: 'counter',
+                target: 'enemy',
+                trigger: 'on-attacked',
+                config: { type: 'counter', multiplier: 70, requirePrimaryTarget: true },
+            });
+            const all = buildShipAbilities(s).slots.flatMap((x) => x.abilities);
+            expect(all.filter((a) => a.type === 'damage')).toHaveLength(0);
+            const buff = passive?.abilities.find(
+                (a) =>
+                    a.type === 'buff' &&
+                    (a.config as { buffName?: string }).buffName === 'Legion Discipline II'
+            );
+            expect(buff).toMatchObject({
+                config: { type: 'buff', buffName: 'Legion Discipline II', duration: 3 },
+            });
+        });
+
+        it('false-positive guard: a "directly damaged" passive that HEALS does not produce a counter', () => {
+            const s = ship({
+                firstPassiveSkillText:
+                    'When directly damaged while below 40% HP, this Unit <unit-damage>repairs 20%</unit-damage> of its Max HP.',
+            });
+            const all = buildShipAbilities(s).slots.flatMap((x) => x.abilities);
+            expect(all.filter((a) => a.type === 'counter')).toHaveLength(0);
+        });
+
+        it('false-positive guard: a reflect ("reflects X% of the Damage taken") passive does not produce a counter', () => {
+            const s = ship({
+                firstPassiveSkillText:
+                    'When directly damaged, this Unit reflects <unit-damage>40%</unit-damage> of the Damage taken to the attacker.',
+            });
+            const all = buildShipAbilities(s).slots.flatMap((x) => x.abilities);
+            expect(all.filter((a) => a.type === 'counter')).toHaveLength(0);
+        });
+    });
+
     // Phase 4c PR 1 (Task 8): non-heal damage reactions. Self-subject reaction sentences
     // route their buff grants / debuff inflictions through the LIVE on-attacked trigger
     // (+ triggerCritFilter for "is critically hit") instead of registering as unconditional

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -20,6 +20,7 @@ import {
 import { getShipSkillRows, getSkillRowForSlot } from '../ship/skillRows';
 import {
     parseSkillDamage,
+    parseCounterAbilities,
     parseSecondaryDamage,
     parseConditionalDamage,
     parseChargeGain,
@@ -683,7 +684,33 @@ function abilitiesFromText(
         new RegExp(`<unit-damage>\\s*${escNum(mult)}%\\s*damage`, 'i')
     );
     const damagePos = damageTagPos >= 0 ? damageTagPos : text.search(/<unit-damage>/i);
-    if (mult > 0) {
+    // Combat G PR1: on a PASSIVE, the "When this Unit is directly damaged as a primary target,
+    // it deals X% damage to that enemy" shape (Stalwart) is a reactive COUNTERATTACK, not an
+    // on-cast base damage. Re-type that component to a `counter` ability (on-attacked,
+    // requirePrimaryTarget) when the parsed counter multiplier matches the base damage the tag
+    // carries. Heal/shield/reflect "directly damaged" consequences are not matched by
+    // parseCounterAbilities, so they keep their existing parse. PR2 (Nyxen/Centurion) is unhandled.
+    const counter = slot === 'passive' ? parseCounterAbilities(text) : null;
+    if (mult > 0 && counter && counter.multiplier === mult) {
+        const hits = parseHitCount(text);
+        out.push({
+            ability: {
+                id: nextId(),
+                type: 'counter',
+                target: 'enemy',
+                trigger: 'on-attacked',
+                conditions: [],
+                config: {
+                    type: 'counter',
+                    multiplier: mult,
+                    ...(hits !== undefined ? { hits } : {}),
+                    ...(counter.requirePrimaryTarget ? { requirePrimaryTarget: true } : {}),
+                },
+                autoFilled: true,
+            },
+            pos: damagePos >= 0 ? damagePos : MAX_POS,
+        });
+    } else if (mult > 0) {
         const hits = parseHitCount(text);
         const noCrit = parseNoCrit(text);
         out.push({

--- a/src/utils/combat/__tests__/counterAttack.integration.test.ts
+++ b/src/utils/combat/__tests__/counterAttack.integration.test.ts
@@ -1,0 +1,171 @@
+/**
+ * counterAttack.integration.test.ts — G PR1: END-TO-END counter via the REAL registry.
+ *
+ * Unlike counterAttack.test.ts (which builds the `counter` ability INLINE), this test drives the
+ * counter through the REAL parse path: a player ship constructed with Stalwart's verbatim skill text
+ * is run through `buildShipAbilities` (the same registry every production ship uses), and the
+ * resulting `ShipSkills` is fed straight into `runCombat`. This makes the test mutation-resistant:
+ * removing the parser branch (Task 5) OR the executor branch (Task 4) breaks it.
+ *
+ * Harness mirrors counterAttack.test.ts EXACTLY: healing mode, the FOCUS ('attacker') is the heal
+ * target and carries the parsed Stalwart skills; one `enemyAttackers` actor ('foe') lands a real
+ * primary-target basic hit on it each round. The counter surfaces as the foe's incoming damage via
+ * the round `perTargetDamage` map (the same channel the unit tests + REFLECT thorns use). The
+ * co-located `Legion Discipline II` self-buff surfaces via `buff-applied` events on the bus.
+ *
+ * Determinism: the focus has crit 0 → the counter never crits → fixed magnitude. The co-located
+ * Legion Discipline II self-buff (+15% Attack, non-stackable) is live when the counter resolves, so
+ * the magnitude is owner.attack × 1.15 × multiplier/100 vs defence 0 / neutral affinity. Stalwart's
+ * counter carries no procChance, so no proc override is needed.
+ *
+ * Scope: NO enemy-side mirror (enemy victims don't emit `attacked` — out of scope per the spec).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { ShipSkills } from '../../../types/abilities';
+
+/** A Ship carrying Stalwart's first-passive (30%) counterattack skill text, verbatim from
+ *  constants/ships.ts. Parsed through the real registry → an on-attacked `counter` ability
+ *  (requirePrimaryTarget) plus the co-located `Legion Discipline II` self-buff. */
+function stalwartShip(passiveText: string): Ship {
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        firstPassiveSkillText: passiveText,
+    } as Ship;
+}
+
+// Verbatim CSV-derived skill text (docs/ship-skills.csv, Stalwart row). The real registry parses
+// the `<unit-damage>`/`<unit-skill>`-tagged source — using the exact in-game strings keeps the
+// test grounded in the canonical data the parser actually consumes.
+const STALWART_P1 =
+    'When this Unit is directly damaged as a primary target, it deals <unit-damage>30% damage</unit-damage> to that enemy and gains <unit-skill>Legion Discipline II</unit-skill> for 3 turns.';
+const STALWART_P2 =
+    'When this Unit is directly damaged as a primary target, it deals <unit-damage>70% damage</unit-damage> to that enemy and gains <unit-skill>Legion Discipline II</unit-skill> for 3 turns.<br /><br />Additionally, when this Unit is adjacent to a Supporter, this Unit gains 20% Attack.';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+/** An enemy attacker that lands a single-hit basic attack (synthesized 100% active) on the focus. */
+const basicEnemy = (id: string, attack: number): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000, speed: 50 },
+        chargeCount: 0,
+        startCharged: false,
+    }) as EnemyAttacker;
+
+/** Healing-mode base: the FOCUS ('attacker') is the heal target and carries `skills` (parsed from
+ *  the real registry); one enemy attacker hits it each round. owner crit 0 → deterministic counter. */
+const counterBase = (
+    skills: ShipSkills,
+    overrides: Partial<CombatEngineInput> = {}
+): CombatEngineInput => ({
+    attack: 10_000, // OWNER (counter source) attack
+    crit: 0, // no crit → didCrit false → predictable counter
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: skills,
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 3,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000,
+    healTargetId: 'attacker',
+    enemyAttackers: [basicEnemy('foe', 3_000)],
+    ...overrides,
+});
+
+/** Cumulative damage credited to `actorId` across the run via the round perTargetDamage maps. */
+const totalPerTargetDamage = (result: ReturnType<typeof runCombat>, actorId: string): number => {
+    let sum = 0;
+    for (const rd of result.rounds) sum += rd.perTargetDamage?.[actorId] ?? 0;
+    return sum;
+};
+
+describe('G PR1 — Stalwart counterattack END-TO-END via the real registry', () => {
+    it('parsing produces a real on-attacked counter (sanity: registry wiring)', () => {
+        const skills = buildShipAbilities(stalwartShip(STALWART_P1));
+        const passive = skills.slots.find((s) => s.slot === 'passive');
+        const counter = passive?.abilities.find((a) => a.type === 'counter');
+        // Mutation guard: if the parser stops emitting a counter, this fails before the run.
+        expect(counter).toMatchObject({
+            type: 'counter',
+            trigger: 'on-attacked',
+            config: { type: 'counter', multiplier: 30, requirePrimaryTarget: true },
+        });
+    });
+
+    it('(P1 30%) the attacker takes mitigated counter damage; Legion Discipline II is granted', () => {
+        const skills = buildShipAbilities(stalwartShip(STALWART_P1));
+
+        const bus = createEventBus();
+        const buffEvents: CombatEvent[] = [];
+        bus.on('buff-applied', (e) => buffEvents.push(e as CombatEvent));
+
+        const result = runCombat(counterBase(skills, { bus }));
+
+        // The enemy ('foe') took counter damage; a non-countering control credits nothing.
+        const withCounter = totalPerTargetDamage(result, 'foe');
+        const control = runCombat(counterBase({ slots: [] }));
+        expect(totalPerTargetDamage(control, 'foe')).toBe(0);
+
+        // Per round: exactly one counter, of a bounded magnitude. Base = owner.attack × 30% =
+        // 10000 × 0.30 = 3000 (vs defence 0 / neutral affinity / no crit). The co-located Legion
+        // Discipline II self-buff (+15% Attack, non-stackable) is granted by the SAME on-attacked
+        // reaction, so the round-1 counter resolves at base (3000) and subsequent rounds resolve
+        // with the buff live (3000 × 1.15 = 3450). Every non-zero round is one of those two values.
+        const BASE = 10_000 * 0.3; // 3000
+        const BUFFED = BASE * 1.15; // 3450
+        const counterRounds = result.rounds
+            .map((rd) => rd.perTargetDamage?.['foe'] ?? 0)
+            .filter((d) => d > 0);
+        expect(counterRounds.length).toBeGreaterThan(0);
+        for (const dealt of counterRounds) {
+            const isBase = Math.abs(dealt - BASE) < 1e-6;
+            const isBuffed = Math.abs(dealt - BUFFED) < 1e-6;
+            expect(isBase || isBuffed).toBe(true);
+        }
+        // The first counter resolves at base (the LD2 buff lands with it, not before it).
+        expect(counterRounds[0]).toBeCloseTo(BASE, 6);
+        expect(withCounter).toBeGreaterThanOrEqual(BASE - 1e-6);
+
+        // M1 non-regression: the co-located Legion Discipline II self-buff fires on the focus.
+        const ld2 = buffEvents.filter(
+            (e) => e.type === 'buff-applied' && e.buffName === 'Legion Discipline II'
+        );
+        expect(ld2.length).toBeGreaterThan(0);
+        expect(ld2.every((e) => e.type === 'buff-applied' && e.actorId === 'attacker')).toBe(true);
+    });
+
+    it('(P2 70%) the counter scales with the parsed multiplier (base 7000, buffed 8050)', () => {
+        const skills = buildShipAbilities(stalwartShip(STALWART_P2));
+        const result = runCombat(counterBase(skills));
+        // Base = 10000 × 0.70 = 7000; with LD2 (+15% Attack) live = 7000 × 1.15 = 8050.
+        const BASE = 10_000 * 0.7; // 7000
+        const BUFFED = BASE * 1.15; // 8050
+        const counterRounds = result.rounds
+            .map((rd) => rd.perTargetDamage?.['foe'] ?? 0)
+            .filter((d) => d > 0);
+        expect(counterRounds.length).toBeGreaterThan(0);
+        for (const dealt of counterRounds) {
+            const isBase = Math.abs(dealt - BASE) < 1e-6;
+            const isBuffed = Math.abs(dealt - BUFFED) < 1e-6;
+            expect(isBase || isBuffed).toBe(true);
+        }
+        expect(counterRounds[0]).toBeCloseTo(BASE, 6);
+    });
+});

--- a/src/utils/combat/__tests__/counterAttack.test.ts
+++ b/src/utils/combat/__tests__/counterAttack.test.ts
@@ -1,0 +1,317 @@
+/**
+ * counterAttack.test.ts — G PR1: the LIVE counter executor branch.
+ *
+ * A ship carrying a `counter` reactive ability (trigger `on-attacked`) hits its attacker back for
+ * `owner.attack × multiplier/100`, mitigated by the attacker's defence/affinity. The counter:
+ *   - is mitigated/crit-walked through the engine's `applyCounterAttack` (no `attacked` event → no
+ *     re-counter — a counter-of-a-counter never fires);
+ *   - collapses ALL per-hit `attacked` events of ONE attack to a SINGLE counter (per-turn guard);
+ *   - obeys the `requirePrimaryTarget` gate (the live emit always sets isPrimaryTarget:true, so the
+ *     false-case is asserted at the executor gate level; the true-case is asserted end-to-end).
+ *
+ * END-TO-END harness: driven through `runCombat` in healing mode (mirrors
+ * reactiveExtraAction.test.ts) — the player FOCUS is the heal target ('attacker') and carries the
+ * counter reactive in its shipSkills; an `enemyAttackers` actor lands a real basic hit on it each
+ * turn. The counter surfaces as the enemy attacker's incoming damage via the round's
+ * `perTargetDamage` map (the same channel REFLECT thorns use).
+ *
+ * GATE-LEVEL harness for the primary-target FALSE case: the executor (`executeIntent`) is driven
+ * directly with a hand-built ctx + a spy `applyCounterAttack` (mirrors reactiveDamageTakenShield.test.ts).
+ *
+ * The counter abilities are constructed INLINE (no parser — that is Task 5).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { executeIntent, Intent, IntentExecContext } from '../triggers';
+import { createStatusEngine } from '../statusEngine';
+import { Ability, ShipSkills } from '../../../types/abilities';
+
+let idCounter = 0;
+const ab = (partial: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `cnt${++idCounter}`,
+    target: 'self',
+    trigger: 'on-attacked',
+    conditions: [],
+    ...partial,
+});
+
+/** ShipSkills with a single passive `counter` reactive (owner counters the enemy that hits it). */
+const counterSkills = (
+    multiplier: number,
+    extra: Partial<import('../../../types/abilities').AbilityConfig> = {}
+): ShipSkills => {
+    idCounter = 0;
+    return {
+        slots: [
+            {
+                slot: 'passive',
+                abilities: [
+                    ab({
+                        type: 'counter',
+                        target: 'self',
+                        trigger: 'on-attacked',
+                        config: { type: 'counter', multiplier, ...extra } as Extract<
+                            import('../../../types/abilities').AbilityConfig,
+                            { type: 'counter' }
+                        >,
+                    }),
+                ],
+            },
+        ],
+    };
+};
+
+/** A non-counter ShipSkills (no reactive) for the control / non-countering ships. */
+const noSkills = (): ShipSkills => ({ slots: [] });
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+/** An enemy attacker that lands a single-hit basic attack (synthesized 100% active) on the focus. */
+const basicEnemy = (id: string, attack: number, opts: Partial<EnemyAttacker> = {}): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000, speed: 50 },
+        chargeCount: 0,
+        startCharged: false,
+        ...opts,
+    }) as EnemyAttacker;
+
+/** Healing-mode base: the FOCUS ('attacker') is the heal target and carries `skills`; one enemy
+ *  attacker hits it each round. owner crit 0 → no crit → deterministic counter magnitude. */
+const counterBase = (
+    skills: ShipSkills,
+    overrides: Partial<CombatEngineInput> = {}
+): CombatEngineInput => ({
+    attack: 10_000, // OWNER (counter source) attack
+    crit: 0, // no crit → didCrit false → predictable counter
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: skills,
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 3,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000,
+    healTargetId: 'attacker',
+    enemyAttackers: [basicEnemy('foe', 3_000)],
+    ...overrides,
+});
+
+/** Cumulative damage credited to `actorId` across the run via the round perTargetDamage maps. */
+const totalPerTargetDamage = (result: ReturnType<typeof runCombat>, actorId: string): number => {
+    let sum = 0;
+    for (const rd of result.rounds) sum += rd.perTargetDamage?.[actorId] ?? 0;
+    return sum;
+};
+
+describe('G PR1 — counter executor branch (end-to-end via runCombat)', () => {
+    // (a) MAGNITUDE: owner attack 10000 × 50% vs defence 0 / neutral affinity / no crit = 5000
+    // per counter. The enemy attacks once per round → one counter per round.
+    it('(a) the attacker takes mitigated counter damage = owner.attack × multiplier/100', () => {
+        const result = runCombat(counterBase(counterSkills(50)));
+
+        // The enemy ('foe') took counter damage; a non-countering control credits nothing.
+        const withCounter = totalPerTargetDamage(result, 'foe');
+        const control = runCombat(counterBase(noSkills()));
+        expect(totalPerTargetDamage(control, 'foe')).toBe(0);
+
+        // Per round: exactly one counter of 10000 × 0.50 = 5000. The enemy attacks every round
+        // (3 rounds) → 3 counters total. Assert the PER-ROUND magnitude is exactly 5000.
+        for (const rd of result.rounds) {
+            const dealt = rd.perTargetDamage?.['foe'] ?? 0;
+            // Some round(s) the enemy may not have acted (it acts last at speed 50) — but with a
+            // living focus it attacks each round. Assert any non-zero round is exactly one counter.
+            if (dealt > 0) expect(dealt).toBeCloseTo(5000, 6);
+        }
+        // And the total is a positive multiple of one counter (≥ one round's worth).
+        expect(withCounter).toBeGreaterThanOrEqual(5000 - 1e-6);
+        expect(withCounter % 5000).toBeCloseTo(0, 6);
+    });
+
+    // (b) ONCE PER ATTACK: a 3-hit enemy attack produces exactly ONE counter (5000), not 3×.
+    it('(b) a multi-hit attack triggers exactly ONE counter (once-per-attack guard)', () => {
+        idCounter = 0;
+        // Enemy with a 3-hit active: each hit emits its own `attacked` event, but the per-turn
+        // guard collapses them to a single counter.
+        const multiHitEnemy: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'foe-active',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 90, hits: 3 },
+                        },
+                    ],
+                },
+            ],
+        };
+        const result = runCombat(
+            counterBase(counterSkills(50), {
+                enemyAttackers: [basicEnemy('foe', 3_000, { shipSkills: multiHitEnemy })],
+            })
+        );
+        // Each round the 3-hit attack lands → exactly ONE counter (5000), never 3 × 5000 = 15000.
+        for (const rd of result.rounds) {
+            const dealt = rd.perTargetDamage?.['foe'] ?? 0;
+            if (dealt > 0) expect(dealt).toBeCloseTo(5000, 6);
+        }
+        expect(totalPerTargetDamage(result, 'foe')).toBeGreaterThan(0);
+    });
+
+    // (c-true) PRIMARY-TARGET gate fires on a normal primary hit (the live emit sets
+    // isPrimaryTarget:true). The counter still lands.
+    it('(c) requirePrimaryTarget:true → the counter DOES fire on a normal primary hit', () => {
+        const result = runCombat(counterBase(counterSkills(50, { requirePrimaryTarget: true })));
+        expect(totalPerTargetDamage(result, 'foe')).toBeGreaterThan(0);
+    });
+
+    // (d) NO RE-COUNTER: the enemy also carries a counter ability. The player's counter hits the
+    // enemy WITHOUT emitting an `attacked` event, so the enemy's own counter never fires → the
+    // player owner ('attacker') takes ZERO counter-of-counter damage.
+    it("(d) the counter hit does not itself trigger the attacked ship's counter (no re-counter)", () => {
+        idCounter = 0;
+        // Enemy carries BOTH a basic 100% active (to attack the focus) AND a counter passive.
+        const enemyWithCounter: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'foe-active',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 100 },
+                        },
+                    ],
+                },
+                {
+                    slot: 'passive',
+                    abilities: [
+                        {
+                            id: 'foe-counter',
+                            type: 'counter',
+                            target: 'self',
+                            trigger: 'on-attacked',
+                            conditions: [],
+                            config: { type: 'counter', multiplier: 100 },
+                        },
+                    ],
+                },
+            ],
+        };
+        const result = runCombat(
+            counterBase(counterSkills(50), {
+                enemyAttackers: [basicEnemy('foe', 3_000, { shipSkills: enemyWithCounter })],
+            })
+        );
+        // The player's counter DID fire (the enemy took counter damage)...
+        expect(totalPerTargetDamage(result, 'foe')).toBeGreaterThan(0);
+        // ...but the enemy's counter NEVER fired in response — the player owner takes ZERO counter
+        // damage (the counter walk emits no `attacked` event → no re-counter).
+        expect(totalPerTargetDamage(result, 'attacker')).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// (c-false) PRIMARY-TARGET gate at the executor level: with requirePrimaryTarget:true and an
+// eventCtx whose isPrimaryTarget !== true, the executor must NOT call applyCounterAttack.
+// ---------------------------------------------------------------------------
+
+const OWNER = 'owner';
+
+function makeCounterCtx(spy: IntentExecContext['applyCounterAttack']): IntentExecContext {
+    return {
+        round: 1,
+        runtimes: new Map([[OWNER, { actor: { id: OWNER } } as never]]),
+        statusEngine: createStatusEngine({ selfBuffs: [], enemyDebuffs: [] }),
+        corrosionEntries: [],
+        infernoEntries: [],
+        pendingBombs: [],
+        applyCounterAttack: spy,
+        counterFiredThisTurn: new Set<string>(),
+    } as unknown as IntentExecContext;
+}
+
+function counterIntent(
+    cfg: Extract<import('../../../types/abilities').AbilityConfig, { type: 'counter' }>,
+    eventCtx: Intent['eventCtx']
+): Intent {
+    return {
+        ability: {
+            id: 'cnt-gate',
+            type: 'counter',
+            target: 'self',
+            trigger: 'on-attacked',
+            conditions: [],
+            config: cfg,
+        },
+        sourceSlot: 'passive',
+        ownerId: OWNER,
+        eventCtx,
+    };
+}
+
+describe('G PR1 — counter primary-target gate (executor level)', () => {
+    it('requirePrimaryTarget:true + isPrimaryTarget:true → fires', () => {
+        const spy = vi.fn();
+        executeIntent(
+            counterIntent(
+                { type: 'counter', multiplier: 50, requirePrimaryTarget: true },
+                { counterTargetId: 'foe', isPrimaryTarget: true }
+            ),
+            makeCounterCtx(spy)
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(OWNER, 'foe', 'cnt-gate', 50, 1);
+    });
+
+    it('requirePrimaryTarget:true + isPrimaryTarget NOT true → does NOT fire', () => {
+        const spy = vi.fn();
+        executeIntent(
+            counterIntent(
+                { type: 'counter', multiplier: 50, requirePrimaryTarget: true },
+                { counterTargetId: 'foe', isPrimaryTarget: false }
+            ),
+            makeCounterCtx(spy)
+        );
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('no requirePrimaryTarget → fires regardless of isPrimaryTarget', () => {
+        const spy = vi.fn();
+        executeIntent(
+            counterIntent({ type: 'counter', multiplier: 50 }, { counterTargetId: 'foe' }),
+            makeCounterCtx(spy)
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('once-per-attack: a second intent with the same owner:ability key in the same turn is suppressed', () => {
+        const spy = vi.fn();
+        const ctx = makeCounterCtx(spy);
+        const intent = counterIntent(
+            { type: 'counter', multiplier: 50 },
+            { counterTargetId: 'foe' }
+        );
+        executeIntent(intent, ctx);
+        executeIntent(intent, ctx); // same turn, same key → guarded
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2721,6 +2721,9 @@ export function runCombat(input: CombatEngineInput): {
                 /** True when THIS application is itself reflected thorns (Reflect gear set). The
                  *  reflection block skips when set → no ping-pong (a reflected hit never reflects). */
                 isReflected?: boolean;
+                /** G PR1: true when THIS application is a counterattack (Stalwart). The reflect
+                 *  re-entry guard skips when set → a counter is never itself reflected (loop-safe). */
+                isCounter?: boolean;
             }
         ): VictimDamageOutcome => {
             // D-PR3: a hit may be reduced by proc block BEFORE it is recorded/absorbed. `damage`
@@ -3030,7 +3033,13 @@ export function runCombat(input: CombatEngineInput): {
             // The attacker.destroyedRound guard below prevents posthumous reflection TO an
             // already-dead attacker, but the WEARER dying on the same hit is intentional and
             // covered by test case (e).
-            if (!cause?.isReflected && hpDamage > 0 && cause?.byDirectDamage !== false) {
+            // !cause?.isCounter is loop-safe: a counter application must not itself be reflected.
+            if (
+                !cause?.isReflected &&
+                !cause?.isCounter &&
+                hpDamage > 0 &&
+                cause?.byDirectDamage !== false
+            ) {
                 // Direct slice of the net HP damage: exclude the bomb portion by the raw direct
                 // fraction of the post-block total. bombPortion 0 → directFraction 1 (full reflect);
                 // bombPortion === total → directFraction 0 → basis 0 → skipped below.
@@ -4988,6 +4997,9 @@ export function runCombat(input: CombatEngineInput): {
                                     targetId: tgt.id,
                                     attackerId: actor.id,
                                     round: r,
+                                    // `tgt` is the focus/primary victim today; covered-cell
+                                    // emission (future) would pass the real per-victim role.
+                                    isPrimaryTarget: true,
                                     ...(hitCrit ? { didCrit: true } : {}),
                                     ...(damage > 0 ? { damage } : {}),
                                 });

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -51,6 +51,7 @@ import {
     type VictimDamageOutcome,
 } from './positionalApply';
 import type { AttackerDamageScalars } from './victimDamage';
+import { victimHitDamage } from './victimDamage';
 import { incomingReductionForHit, incomingBlockForIntake } from './incomingEffects';
 import { reflectedDamageForHit } from './damageReflection';
 import { splashDamageForBomb } from './bombSplash';
@@ -2008,6 +2009,10 @@ export function runCombat(input: CombatEngineInput): {
     // `${ownerId}:${abilityId}`; each gate is a RateGate accumulator that fires at the
     // ability's procChance rate across all rounds, deterministically (like crit/landing gates).
     const procChanceGates = new Map<string, RateGate>();
+    // G PR1: dedicated crit-gate for counterattacks. A NEW map (NOT any existing per-actor
+    // crit gate) so it only ever creates keys for counter-carriers → no draw, no perturbation
+    // for every existing fixture → byte-identical.
+    const counterCritGates = new Map<string, RateGate>();
 
     // ═══════════════════════════════════════════════════════════════════════════════════════
     // Reactive extra-action timing analysis (Phase 4b Task 10). Two death paths land an
@@ -3219,6 +3224,74 @@ export function runCombat(input: CombatEngineInput): {
         // first round it is built is sufficient. Inert in production (the field is never set).
         input.__testTapApplyOutgoingToEnemy?.(applyOutgoingToEnemy);
 
+        // G PR1: full mitigated/crit counter walk from the counter owner to the attacker.
+        // Unreferenced dead code until the executor (Task 4) wires it via ctx.applyCounterAttack
+        // → byte-identical now. Reuses applyVictimDamage (no attacked event → no re-counter).
+        const applyCounterAttack = (
+            ownerId: string,
+            attackerId: string,
+            abilityId: string,
+            multiplier: number,
+            hits: number
+        ): void => {
+            const owner = allActorsById.get(ownerId);
+            const attacker = allActorsById.get(attackerId);
+            // Guards: owner alive, attacker alive, not self (spec rule 6).
+            if (!owner || !attacker) return;
+            if (owner.destroyedRound !== undefined) return;
+            if (attacker.destroyedRound !== undefined || attacker.id === owner.id) return;
+
+            const ownerStats = effectiveStatsOf(statusEngine, selfBuffLookup, owner);
+            const attackerStats = effectiveStatsOf(statusEngine, selfBuffLookup, attacker);
+
+            // Roll the OWNER's crit via the dedicated gate (one stream per counter ability per owner).
+            const didCrit = rollRateGate(
+                counterCritGates,
+                `${ownerId}:${abilityId}`,
+                ownerStats.crit / 100
+            );
+
+            const raw = victimHitDamage(
+                {
+                    effectiveAttack: ownerStats.attack,
+                    multiplierPct: multiplier * hits,
+                    secondaryStatValue: 0,
+                    hits,
+                    effectiveCritDamage: ownerStats.critDamage,
+                    outgoingDamageBuffPct: 0,
+                    incomingDamageModifierPct: 0,
+                    // effectiveStatsOf.defensePenetration is BASE-only (buff folds separately) —
+                    // acceptable approximation (no Stalwart fixture; counters ignore pen-buffs).
+                    defensePenetrationPct: ownerStats.defensePenetration,
+                    attackerAffinity: owner.affinity ?? 'antimatter',
+                },
+                {
+                    defence: attackerStats.defence,
+                    defenceModifierPct: 0,
+                    affinity: attacker.affinity ?? 'antimatter',
+                },
+                didCrit,
+                1 // roleScale: a counter is a single full hit
+            );
+            if (raw <= 0) return;
+
+            const sink = attacker.side === 'player' ? playerSink : enemySink;
+            applyVictimDamage(raw, attacker, sink, {
+                killerId: owner.id,
+                byDirectDamage: true,
+                isCounter: true,
+                // Mirror Reflect (no shield penetration on the reactive hit). EffectiveStats has NO
+                // shieldPenetration field; we deliberately pass 0.
+                shieldPenetrationPct: 0,
+                bombPortion: 0,
+            });
+            // Surface on the attacker's incoming so it appears on the HP curve (mirror Reflect).
+            roundPerTargetDamage.set(
+                attacker.id,
+                (roundPerTargetDamage.get(attacker.id) ?? 0) + raw
+            );
+        };
+
         // §4.5 STASIS direct-damage break (B3 Task 2). Fires via the `onHitBreakStasis` hook
         // injected into `runPlayerTurn` (playerTurn.ts), which calls it AFTER the scheduled
         // debuffs (sourceFired) but BEFORE the ability timed-debuff loop. This ordering ensures:
@@ -3813,6 +3886,7 @@ export function runCombat(input: CombatEngineInput): {
                         creditReactiveDamage: (ownerId: string, amount: number): void => {
                             creditDamage(ownerId, 'direct', amount);
                         },
+                        applyCounterAttack,
                         // Healing mode only — the SAME shared ctx the player turns use, so a
                         // reactive heal/shield/cleanse credits the same per-round buckets and
                         // mutates the same live target. Undefined in DPS mode → the executor's

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2066,6 +2066,11 @@ export function runCombat(input: CombatEngineInput): {
     // round alongside repairedThisRound.
     const hitThisRound = new Set<string>();
 
+    // G PR1: once-per-attack guard. Cleared at every actor turn-start so all per-hit `attacked`
+    // events of ONE attack collapse to a single counter, while a separate later attack (a different
+    // turn) counters again. NOT per-round.
+    const counterFiredThisTurn = new Set<string>();
+
     // The SHARED healing ctx (built once; closures capture the live target + currentRoundHealing
     // through the `let`/the target reference). Only constructed in healing mode.
     const healingCtx: HealingRuntimeCtx | undefined = healTarget
@@ -3887,6 +3892,7 @@ export function runCombat(input: CombatEngineInput): {
                             creditDamage(ownerId, 'direct', amount);
                         },
                         applyCounterAttack,
+                        counterFiredThisTurn,
                         // Healing mode only — the SAME shared ctx the player turns use, so a
                         // reactive heal/shield/cleanse credits the same per-round buckets and
                         // mutates the same live target. Undefined in DPS mode → the executor's
@@ -4153,6 +4159,11 @@ export function runCombat(input: CombatEngineInput): {
                 // is the one intake that runs in this same turn yet passes byDirectDamage:false,
                 // so it never uses this value as a killer.
                 actingActorId = actor.id;
+
+                // G PR1: reset the once-per-attack counter guard at each actor turn-start so a
+                // later attack (a different turn) can counter again while all per-hit `attacked`
+                // events of ONE attack collapse to a single counter.
+                counterFiredThisTurn.clear();
 
                 bus.emit({ type: 'turn-started', actorId: actor.id, round: r });
                 // Phase 0 Task 5: bump the actor's own-turn counter so every-n-turns conditions

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3259,9 +3259,15 @@ export function runCombat(input: CombatEngineInput): {
             const raw = victimHitDamage(
                 {
                     effectiveAttack: ownerStats.attack,
+                    // `multiplier` is the PER-HIT value, so the full counter total is
+                    // multiplier × hits. The counter is modeled as ONE consolidated applied
+                    // hit, so fold the count into the multiplier and pass hits:1 — passing the
+                    // real `hits` here would make victimHitDamage re-split (preCritDamage / hits)
+                    // and silently collapse a multi-hit counter back to a single hit's damage.
+                    // Byte-identical for single-hit counters (hits === 1).
                     multiplierPct: multiplier * hits,
                     secondaryStatValue: 0,
-                    hits,
+                    hits: 1,
                     effectiveCritDamage: ownerStats.critDamage,
                     outgoingDamageBuffPct: 0,
                     // APPROXIMATION (asymmetry vs Reflect, which threads the attacker's

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3264,6 +3264,11 @@ export function runCombat(input: CombatEngineInput): {
                     hits,
                     effectiveCritDamage: ownerStats.critDamage,
                     outgoingDamageBuffPct: 0,
+                    // APPROXIMATION (asymmetry vs Reflect, which threads the attacker's
+                    // incomingReductionForHit): the counter does NOT apply the attacker's
+                    // incoming-damage-reduction abilities. Harmless today (no Stalwart fixture);
+                    // PR2 may thread incomingReductionForHit(incomingAbilitiesOf(attacker.id))
+                    // here to match the Reflect path exactly.
                     incomingDamageModifierPct: 0,
                     // effectiveStatsOf.defensePenetration is BASE-only (buff folds separately) —
                     // acceptable approximation (no Stalwart fixture; counters ignore pen-buffs).

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -207,6 +207,11 @@ export type CombatEvent =
            *  Bloodthirst's triggerDamage). Present only when a damage aggregate is in scope.
            *  Tenacity's >25%-max-HP filter reads this. */
           damage?: number;
+          /** G PR1: true when the victim was the directly-targeted (primary) target of the
+           *  attack, false/absent for splash/covered AoE victims. Today the sole emit is the
+           *  focus victim (`tgt`) → always true; positional per-victim emission (future) sets
+           *  false for covered cells. Stalwart's counter gates on this. */
+          isPrimaryTarget?: boolean;
       };
 
 export type CombatEventType = CombatEvent['type'];

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -116,6 +116,10 @@ export interface Intent {
         /** The triggering hit's crit outcome (on-attacked -> attacked.didCrit), read by the
          *  reactive cleanse executor to pick `critCount` over `count` (Reactive Ward). */
         didCrit?: boolean;
+        /** G PR1: true when the owner was the primary (directly-targeted) victim of the
+         *  triggering attack (on-attacked -> attacked.isPrimaryTarget). Stalwart's counter
+         *  gates on this so splash/covered victims do not counter. */
+        isPrimaryTarget?: boolean;
         /** The actor ids of the allies repaired by an on-own-repair-to-ally event
          *  (excludes the caster). The buff branch fans an 'ally'-target grant out to
          *  exactly these recipients (Font of Power -> repaired allies). */
@@ -485,6 +489,7 @@ export function registerReactiveListeners(args: {
                                 counterTargetId: e.attackerId,
                                 didCrit: e.didCrit,
                                 triggerDamage: e.damage,
+                                isPrimaryTarget: e.isPrimaryTarget,
                             },
                         });
                     });

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -60,6 +60,7 @@ export type ReactiveAbilityType =
     | 'cleanse'
     | 'extra-action'
     | 'damage'
+    | 'counter' // G PR1: counter-attack reactive (on-attacked) — no parser produces it until Task 5
     | 'purge'; // C2b-1: purge can be reactive — Sefuba on-enemy-purged chain
 
 /** Runtime mirror of ReactiveAbilityType for the partition check. */
@@ -73,6 +74,7 @@ const REACTIVE_ABILITY_TYPES: readonly ReactiveAbilityType[] = [
     'cleanse',
     'extra-action',
     'damage',
+    'counter', // G PR1: counter reactive — byte-identical (no fixture carries a counter ability)
     'purge', // C2b-1: purge can be reactive — Sefuba on-enemy-purged chain
 ];
 
@@ -120,6 +122,10 @@ export interface Intent {
          *  triggering attack (on-attacked -> attacked.isPrimaryTarget). Stalwart's counter
          *  gates on this so splash/covered victims do not counter. */
         isPrimaryTarget?: boolean;
+        /** G PR1 (plumbed in PR2): true when the triggering hit reduced the owner's SHIELD pool.
+         *  Nyxen's counter gates on this (`requireShieldHit`). No listener sets it yet → always
+         *  undefined here → the shield-hit gate is currently inert (byte-identical). */
+        shieldWasHit?: boolean;
         /** The actor ids of the allies repaired by an on-own-repair-to-ally event
          *  (excludes the caster). The buff branch fans an 'ally'-target grant out to
          *  exactly these recipients (Font of Power -> repaired allies). */
@@ -795,6 +801,11 @@ export interface IntentExecContext {
         multiplier: number,
         hits: number
     ) => void;
+    /** G PR1: per-actor-turn once-per-attack guard. Keyed `ownerId:abilityId`. Cleared at each
+     *  actor turn-start (engine) so the per-hit `attacked` events of ONE attack collapse to a
+     *  single counter; a later attack (different turn) counters again. Absent → no guard (the
+     *  counter branch is inert without the engine ctx). */
+    counterFiredThisTurn?: Set<string>;
     /** Resolve the opposing actor carrying the most buffs (Rhodium's enemy-most-buffs purge).
      *  Per-side: a player owner scans the enemy roster, an enemy owner scans the player roster.
      *  Returns undefined when no opposing actor exists (DPS dummy) → executor falls back to
@@ -1772,6 +1783,40 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
         for (const rid of recipients) removed += ctx.statusEngine.cleanse(rid, count);
         // Credit the ACTUAL removed count (was the nominal cfg.count pre-T4).
         ctx.healing.credit(intent.ownerId, 'cleanseCount', removed);
+        return;
+    }
+
+    if (cfg.type === 'counter') {
+        // G PR1: a live counter-attack — the owner hits its attacker back via the engine's full
+        // mitigated/crit walk (applyCounterAttack), which emits NO `attacked` event → no re-counter.
+        //
+        // GATE ORDERING (intentional DEVIATION from the `damage` branch's proc→once-per-round
+        // first): the CHEAP, NON-CONSUMING boolean gates run FIRST (primary-target, shield-hit,
+        // attacker presence, once-per-attack), and the CONSUMING gates (proc-chance, once-per-round)
+        // run LAST. `passesOncePerRoundGate` CONSUMES its slot only when it returns true; running it
+        // before the cheap gates would let a counter that is then suppressed (wrong-target hit /
+        // already-fired-this-attack) burn a once-per-round slot it never used. Putting it last means
+        // it is only ever consulted for a counter that WILL fire on this event.
+        if (cfg.requirePrimaryTarget && intent.eventCtx?.isPrimaryTarget !== true) return;
+        if (cfg.requireShieldHit && intent.eventCtx?.shieldWasHit !== true) return; // PR2 plumbs shieldWasHit
+        const attackerId = intent.eventCtx?.counterTargetId;
+        if (!attackerId) return;
+        // Once-per-ATTACK: all per-hit `attacked` events of ONE attack collapse to a single counter.
+        // The guard set is cleared at every actor turn-start (engine), so a separate later attack
+        // counters again. Absent (unit ctxs without the engine) → no guard.
+        const key = `${intent.ownerId}:${intent.ability.id}`;
+        if (ctx.counterFiredThisTurn?.has(key)) return;
+        // Consuming gates LAST (see ordering note above).
+        if (!passesProcChanceGate(intent, ctx)) return;
+        if (!passesOncePerRoundGate(intent, ctx)) return;
+        ctx.counterFiredThisTurn?.add(key);
+        ctx.applyCounterAttack?.(
+            intent.ownerId,
+            attackerId,
+            intent.ability.id,
+            cfg.multiplier,
+            cfg.hits ?? 1
+        );
         return;
     }
 

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -785,6 +785,16 @@ export interface IntentExecContext {
      *  engine's `creditDamage(ownerId, 'direct', amount)` so the standing-leech hook still
      *  sees it. Absent → the damage branch is inert (unit fixtures / DPS mode w/o delegate). */
     creditReactiveDamage?: (ownerId: string, amount: number) => void;
+    /** G PR1: apply a full mitigated/crit counter walk from `ownerId` to `attackerId`.
+     *  `abilityId` keys the dedicated counter crit-gate. Reuses the engine's no-event
+     *  apply path (no attacked event → no re-counter). */
+    applyCounterAttack?: (
+        ownerId: string,
+        attackerId: string,
+        abilityId: string,
+        multiplier: number,
+        hits: number
+    ) => void;
     /** Resolve the opposing actor carrying the most buffs (Rhodium's enemy-most-buffs purge).
      *  Per-side: a player owner scans the enemy roster, an enemy owner scans the player roster.
      *  Returns undefined when no opposing actor exists (DPS dummy) → executor falls back to

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1804,6 +1804,12 @@ export function executeIntent(intent: Intent, ctx: IntentExecContext): void {
         // Once-per-ATTACK: all per-hit `attacked` events of ONE attack collapse to a single counter.
         // The guard set is cleared at every actor turn-start (engine), so a separate later attack
         // counters again. Absent (unit ctxs without the engine) → no guard.
+        // SCOPE NOTE: today this turn-granularity IS per-attack — the `attacked` event is emitted
+        // once per turn for the focus victim only (events.ts), and extra actions re-enter the turn
+        // loop (re-clearing the guard), so one actor can't land two DISTINCT attacks on the same
+        // victim inside one guard window. When positional per-victim emission or multi-attack-per-turn
+        // lands (the same future work that makes isPrimaryTarget meaningful), this key must gain an
+        // attack-instance token from the triggering `attacked` event to stay once-per-attack.
         const key = `${intent.ownerId}:${intent.ability.id}`;
         if (ctx.counterFiredThisTurn?.has(key)) return;
         // Consuming gates LAST (see ordering note above).

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -188,6 +188,42 @@ export function parseSkillDamage(text: string): number {
     return 0;
 }
 
+/** A parsed counterattack consequence (Combat G PR1: Stalwart shape only). */
+export interface ParsedCounterAbility {
+    /** raw percentage of the OWNER's effective attack, e.g. 30/70. */
+    multiplier: number;
+    /** true when the trigger clause says "as a primary target" (Stalwart). */
+    requirePrimaryTarget: boolean;
+}
+
+/**
+ * Parses a counterattack consequence from PASSIVE skill text (Combat G PR1: Stalwart ONLY).
+ *
+ * Recognizes the shape: "When this Unit is directly damaged [as a primary target], it deals
+ * <unit-damage>X% damage</unit-damage> to that enemy …". The discriminator is the consequence
+ * verb — "it deals X% damage to that enemy" inside a "directly damaged" trigger clause. Heal
+ * ("repairs"), shield ("gains a Shield"), and reflect ("reflects X% of the Damage taken")
+ * consequences are NOT counters and produce nothing here.
+ *
+ * PR2 (Nyxen shield-hit, Centurion retaliate/adjacent-ally) is intentionally NOT handled.
+ */
+export function parseCounterAbilities(
+    text: string | null | undefined
+): ParsedCounterAbility | null {
+    if (!text) return null;
+    const plain = stripUnitTags(text).replace(/<br\s*\/?>/gi, '. ');
+    // Trigger clause + counter consequence must co-occur in the same sentence.
+    // Stalwart: "When this Unit is directly damaged as a primary target, it deals 30% damage
+    // to that enemy …". Anchor the % on the "deals X% damage to that enemy" consequence.
+    const re =
+        /when\s+this\s+unit\s+is\s+directly\s+damaged(?<primary>\s+as\s+a\s+primary\s+target)?[^.;]*?\bit\s+deals\s+(\d+(?:\.\d+)?)%\s+damage\s+to\s+that\s+enemy/i;
+    const m = re.exec(plain);
+    if (!m) return null;
+    const multiplier = parseFloat(m[2]);
+    if (isNaN(multiplier)) return null;
+    return { multiplier, requirePrimaryTarget: Boolean(m.groups?.primary) };
+}
+
 /**
  * Returns the secondary stat-based damage from a skill, e.g.
  * "additional damage equal to <unit-damage>80%</unit-damage> of its Defense".


### PR DESCRIPTION
## Summary

Sub-project **G** (damage-reaction mechanics) of the combat-realism epic — PR1 of 2. Models the game's **reactive counterattack** as a faithful **full damage walk** against the attacker, auto-parsed from skill text. Lights up **Stalwart** (P1 30%, P2 70%), player-side.

Before this, the reactive-damage executor was a bomb-like approximation (owner-attack × mult, no mitigation, no crit, credit-only) and the parser auto-detected **no** counterattack triggers — so every counterattack passive was silently inert.

### What a counter now does
- A new reactive `counter` ability runs the **owner's** live stats through the **real damage pipeline** against the attacker: defence mitigation, owner's **crit**, affinity, **shield absorption**, reduces HP, **can kill** — reusing the existing Reflect `applyVictimDamage` no-event apply path.
- **No re-counter / no ping-pong**: the counter-hit emits no `attacked` event and is excluded from the reflect re-entry guard.
- **Once per triggering attack**: a multi-hit/AoE attack collapses to one counter (per-turn-cleared guard, not per-round).
- **Primary-target gate** (Stalwart): only fires when hit as the directly-targeted victim, via a new `attacked.isPrimaryTarget` signal.
- Crit rolled from a **dedicated** `counterCritGates` map (no perturbation of existing gate streams).

### Scope
- **PR1 = Stalwart only** (the "directly damaged as a primary target → it deals X% damage to that enemy" shape).
- **PR2 (follow-up)** = Nyxen (shield-hit gate) + Centurion (self-or-adjacent-ally trigger). The `requireShieldHit` gate + `shieldWasHit` field are stubbed inert with PR2 notes.
- **Enemy-side counters deferred**: the sole `attacked` emit is enemy→player only; enemy-victim emission would wake all enemy on-attacked reactives (separate enemy-team-support work).

### Notable
- **Production byte-identical**: no combat fixture equips Stalwart → zero `.snap` movement.
- Stalwart's counter scales with its own co-located Legion Discipline II buff from round 2 (emergent, verified in the integration test).

Spec: `docs/superpowers/specs/2026-06-27-counterattack-refinements-G-design.md`
Plan: `docs/superpowers/plans/2026-06-27-counterattack-refinements-G-pr1.md`

## Test Plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (max-warnings 0)
- [x] `npm run audit:skills` — 141 ships, 0 findings
- [x] Full suite: 3385 passed
- [x] Zero `.snap` movement vs main (production byte-identical)
- [x] Unit + parser + integration tests (magnitude, once-per-attack, primary-target gate, no-re-counter, M1 co-located-buff non-regression) — mutation-resistant via the real registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)