### PR TITLE
feat(combat): counterattack refinements — sub-project G PR2 (Nyxen + Centurion)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -45,6 +45,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Voidfire Catalyst implant now also amplifies bomb splash damage — when a bomb-carrier is destroyed, the splash damage dealt to adjacent ships is increased by Voidfire Catalyst, including its rare and legendary splash-only variants.',
     'Combat & DPS simulators now model the Boost gear set: while a ship wears 4 or more Boost pieces, each timed buff it applies — to itself or its allies — lasts one extra turn.',
     "Combat simulator now models counterattacks: one of your ships with a 'when directly damaged' passive (e.g. Stalwart) strikes back at the attacker for a share of its own attack — full damage that can crit and kill. Enemy-side counters are coming in a later update.",
+    'Combat simulator now models more counterattackers: Nyxen strikes back when its shield is directly hit, and Centurion retaliates when it or an adjacent ally is directly damaged.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3153,8 +3153,12 @@ const DocumentationPage: React.FC = () => {
                                     damaged&quot; passive (such as <strong>Stalwart</strong>)
                                     retaliates against the attacker for a share of its own attack —
                                     a full hit that can crit and kill (enemy-side counters are
-                                    coming in a later update). More implant and gear-set effects
-                                    will be added in future updates.
+                                    coming in a later update). Different counterattackers have their
+                                    own triggers: <strong>Nyxen</strong> strikes back only when its
+                                    shield is the part that takes the hit, and{' '}
+                                    <strong>Centurion</strong> retaliates when it or an adjacent
+                                    ally is directly damaged. More implant and gear-set effects will
+                                    be added in future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -3889,6 +3889,33 @@ describe('parseCounterAbilities', () => {
         ).toMatchObject({ multiplier: 30, requirePrimaryTarget: true });
     });
 
+    it('Centurion second passive (50%): self/adjacent-ally retaliate → allySubject, no primary-target/shield', () => {
+        expect(
+            parseCounterAbilities(
+                'At the start of combat, this Unit gains 750 attack per adjacent ally.<br /><br />When this Unit or an adjacent ally is directly damaged, this Unit retaliates dealing <unit-damage>50%</unit-damage>.'
+            )
+        ).toEqual({ multiplier: 50, requirePrimaryTarget: false, allySubject: true });
+    });
+
+    it('Centurion third passive (100%): allySubject retaliate', () => {
+        expect(
+            parseCounterAbilities(
+                'At the start of combat, this Unit gains 1000 attack per adjacent ally.<br /><br />When this Unit or an adjacent ally is directly damaged, this Unit retaliates dealing <unit-damage>100%</unit-damage>.'
+            )
+        ).toEqual({ multiplier: 100, requirePrimaryTarget: false, allySubject: true });
+    });
+
+    it('Stalwart/Nyxen do NOT set allySubject', () => {
+        const stalwart = parseCounterAbilities(
+            'When this Unit is directly damaged as a primary target, it deals <unit-damage>30% damage</unit-damage> to that enemy.'
+        );
+        expect(stalwart?.allySubject).toBeUndefined();
+        const nyxen = parseCounterAbilities(
+            'This Unit deals <unit-damage>100% damage</unit-damage> when its Shield is directly damaged.'
+        );
+        expect(nyxen?.allySubject).toBeUndefined();
+    });
+
     it('returns null for empty/unmatched text', () => {
         expect(parseCounterAbilities(null)).toBeNull();
         expect(parseCounterAbilities('This Unit gains a Shield when attacked.')).toBeNull();

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -41,6 +41,7 @@ import {
     parseDoesntBreakStasis,
     parseChargeRemoval,
     parseEnemyChargedCastReaction,
+    parseCounterAbilities,
 } from '../skillTextParser';
 import type { Ship } from '../../types/ship';
 
@@ -3858,5 +3859,38 @@ describe('parseEnemyChargedCastReaction (Curator enemy-charged-cast reaction)', 
         // NOT the 25%-of-Max-HP start-of-combat preamble (which the parser correctly excludes here).
         expect(shield.target).toBe('self');
         expect(shield.config).toMatchObject({ type: 'shield', basis: 'attack', pct: 24 });
+    });
+});
+
+describe('parseCounterAbilities', () => {
+    // Combat G PR1: Stalwart shape ("When this Unit is directly damaged as a primary target,
+    // it deals X% damage to that enemy"). PR2: Nyxen shield-hit shape.
+    it('Nyxen first passive (100%): shield-hit counter, no primary-target requirement', () => {
+        expect(
+            parseCounterAbilities(
+                'This Unit deals <unit-damage>100% damage</unit-damage> when its Shield is directly damaged.'
+            )
+        ).toEqual({ multiplier: 100, requirePrimaryTarget: false, requireShieldHit: true });
+    });
+
+    it('Nyxen second passive (200%): shield-hit counter', () => {
+        expect(
+            parseCounterAbilities(
+                'This Unit deals <unit-damage>200% damage</unit-damage> when its Shield is directly damaged.'
+            )
+        ).toMatchObject({ multiplier: 200, requireShieldHit: true });
+    });
+
+    it('Stalwart regression: still primary-target, no shield flag', () => {
+        expect(
+            parseCounterAbilities(
+                'When this Unit is directly damaged as a primary target, it deals <unit-damage>30% damage</unit-damage> to that enemy and gains <unit-skill>Legion Discipline II</unit-skill> for 3 turns.'
+            )
+        ).toMatchObject({ multiplier: 30, requirePrimaryTarget: true });
+    });
+
+    it('returns null for empty/unmatched text', () => {
+        expect(parseCounterAbilities(null)).toBeNull();
+        expect(parseCounterAbilities('This Unit gains a Shield when attacked.')).toBeNull();
     });
 });

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -1606,6 +1606,50 @@ describe('buildShipAbilities', () => {
             });
         });
 
+        // Combat G PR2: Nyxen's shield-hit counterattack passive — "This Unit deals X% damage
+        // when its Shield is directly damaged." — auto-produces a reactive `counter` ability
+        // (on-attacked, requireShieldHit) with NO requirePrimaryTarget.
+        it('Nyxen first passive (100%): emits an on-attacked counter with requireShieldHit and no primary-target requirement', () => {
+            const s = ship({
+                firstPassiveSkillText:
+                    'This Unit deals <unit-damage>100% damage</unit-damage> when its Shield is directly damaged.',
+            });
+            const passive = passiveOf(s);
+            const counterAb = passive?.abilities.find((a) => a.type === 'counter');
+            expect(counterAb).toMatchObject({
+                type: 'counter',
+                target: 'enemy',
+                trigger: 'on-attacked',
+                config: { type: 'counter', multiplier: 100, requireShieldHit: true },
+            });
+            expect(
+                (counterAb?.config as { requirePrimaryTarget?: boolean }).requirePrimaryTarget
+            ).toBeUndefined();
+            // Non-regression: no phantom on-cast plain damage left behind.
+            const all = buildShipAbilities(s).slots.flatMap((x) => x.abilities);
+            expect(all.filter((a) => a.type === 'damage')).toHaveLength(0);
+        });
+
+        it('Nyxen second passive (200%): emits an on-attacked counter with requireShieldHit', () => {
+            const s = ship({
+                secondPassiveSkillText:
+                    'This Unit deals <unit-damage>200% damage</unit-damage> when its Shield is directly damaged.',
+            });
+            const passive = passiveOf(s);
+            const counterAb = passive?.abilities.find((a) => a.type === 'counter');
+            expect(counterAb).toMatchObject({
+                type: 'counter',
+                target: 'enemy',
+                trigger: 'on-attacked',
+                config: { type: 'counter', multiplier: 200, requireShieldHit: true },
+            });
+            expect(
+                (counterAb?.config as { requirePrimaryTarget?: boolean }).requirePrimaryTarget
+            ).toBeUndefined();
+            const all = buildShipAbilities(s).slots.flatMap((x) => x.abilities);
+            expect(all.filter((a) => a.type === 'damage')).toHaveLength(0);
+        });
+
         it('false-positive guard: a "directly damaged" passive that HEALS does not produce a counter', () => {
             const s = ship({
                 firstPassiveSkillText:

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -1650,6 +1650,69 @@ describe('buildShipAbilities', () => {
             expect(all.filter((a) => a.type === 'damage')).toHaveLength(0);
         });
 
+        // Combat G PR2: Centurion's self/adjacent-ally retaliate passive — "When this Unit OR
+        // AN ADJACENT ALLY is directly damaged, this Unit retaliates dealing X%." Its retaliate
+        // <unit-damage> tag carries no "damage" word → parseSkillDamage returns 0 → it does NOT
+        // ride the re-type path; it is pushed as TWO counters (self on-attacked + adjacent-ally
+        // on-ally-attacked with requireDamagedAllyAdjacent).
+        it('Centurion second passive (50%): emits a self on-attacked counter and an adjacent-ally on-ally-attacked counter', () => {
+            const s = ship({
+                secondPassiveSkillText:
+                    'At the start of combat, this Unit gains 750 attack per adjacent ally.<br /><br />When this Unit or an adjacent ally is directly damaged, this Unit retaliates dealing <unit-damage>50%</unit-damage>.',
+            });
+            const all = buildShipAbilities(s).slots.flatMap((x) => x.abilities);
+            const counters = all.filter((a) => a.type === 'counter');
+            expect(counters).toHaveLength(2);
+
+            const self = counters.find((a) => a.trigger === 'on-attacked');
+            expect(self).toMatchObject({
+                type: 'counter',
+                target: 'enemy',
+                trigger: 'on-attacked',
+                config: { type: 'counter', multiplier: 50 },
+            });
+            expect(
+                (self?.config as { requirePrimaryTarget?: boolean }).requirePrimaryTarget
+            ).toBeUndefined();
+            expect(
+                (self?.config as { requireShieldHit?: boolean }).requireShieldHit
+            ).toBeUndefined();
+            expect(self?.requireDamagedAllyAdjacent).toBeUndefined();
+
+            const ally = counters.find((a) => a.trigger === 'on-ally-attacked');
+            expect(ally).toMatchObject({
+                type: 'counter',
+                target: 'enemy',
+                trigger: 'on-ally-attacked',
+                config: { type: 'counter', multiplier: 50 },
+                requireDamagedAllyAdjacent: true,
+            });
+
+            // M1 non-regression: the co-located "750 attack per adjacent ally" start-of-combat
+            // clause produces NO spurious damage/buff ability (it is unparsed today and stays so).
+            expect(all.filter((a) => a.type === 'damage')).toHaveLength(0);
+            expect(all.filter((a) => a.type === 'buff')).toHaveLength(0);
+        });
+
+        it('Centurion third passive (100%): self/adjacent-ally counters at multiplier 100', () => {
+            const s = ship({
+                thirdPassiveSkillText:
+                    'At the start of combat, this Unit gains 1000 attack per adjacent ally.<br /><br />When this Unit or an adjacent ally is directly damaged, this Unit retaliates dealing <unit-damage>100%</unit-damage>.',
+            });
+            const all = buildShipAbilities(s).slots.flatMap((x) => x.abilities);
+            const counters = all.filter((a) => a.type === 'counter');
+            expect(counters).toHaveLength(2);
+            expect(counters.find((a) => a.trigger === 'on-attacked')).toMatchObject({
+                config: { type: 'counter', multiplier: 100 },
+            });
+            expect(counters.find((a) => a.trigger === 'on-ally-attacked')).toMatchObject({
+                config: { type: 'counter', multiplier: 100 },
+                requireDamagedAllyAdjacent: true,
+            });
+            expect(all.filter((a) => a.type === 'damage')).toHaveLength(0);
+            expect(all.filter((a) => a.type === 'buff')).toHaveLength(0);
+        });
+
         it('false-positive guard: a "directly damaged" passive that HEALS does not produce a counter', () => {
             const s = ship({
                 firstPassiveSkillText:

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -689,7 +689,8 @@ function abilitiesFromText(
     // on-cast base damage. Re-type that component to a `counter` ability (on-attacked,
     // requirePrimaryTarget) when the parsed counter multiplier matches the base damage the tag
     // carries. Heal/shield/reflect "directly damaged" consequences are not matched by
-    // parseCounterAbilities, so they keep their existing parse. PR2 (Nyxen/Centurion) is unhandled.
+    // parseCounterAbilities, so they keep their existing parse. PR2: Nyxen's shield-hit shape
+    // also rides this path (requireShieldHit). Centurion (adjacent-ally) is still unhandled.
     const counter = slot === 'passive' ? parseCounterAbilities(text) : null;
     if (mult > 0 && counter && counter.multiplier === mult) {
         const hits = parseHitCount(text);
@@ -705,6 +706,7 @@ function abilitiesFromText(
                     multiplier: mult,
                     ...(hits !== undefined ? { hits } : {}),
                     ...(counter.requirePrimaryTarget ? { requirePrimaryTarget: true } : {}),
+                    ...(counter.requireShieldHit ? { requireShieldHit: true } : {}),
                 },
                 autoFilled: true,
             },

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -690,7 +690,8 @@ function abilitiesFromText(
     // requirePrimaryTarget) when the parsed counter multiplier matches the base damage the tag
     // carries. Heal/shield/reflect "directly damaged" consequences are not matched by
     // parseCounterAbilities, so they keep their existing parse. PR2: Nyxen's shield-hit shape
-    // also rides this path (requireShieldHit). Centurion (adjacent-ally) is still unhandled.
+    // also rides this path (requireShieldHit). Centurion (adjacent-ally) does NOT ride this path
+    // (its retaliate tag carries no "damage" word → mult is 0) — it is pushed separately below.
     const counter = slot === 'passive' ? parseCounterAbilities(text) : null;
     if (mult > 0 && counter && counter.multiplier === mult) {
         const hits = parseHitCount(text);
@@ -731,6 +732,51 @@ function abilitiesFromText(
                 autoFilled: true,
             },
             pos: damagePos >= 0 ? damagePos : MAX_POS,
+        });
+    }
+
+    // Combat G PR2 (Centurion): "When this Unit OR AN ADJACENT ALLY is directly damaged, this
+    // Unit retaliates dealing X%." The retaliate <unit-damage> tag omits "damage" → parseSkillDamage
+    // returns 0 → NOT an on-cast base-damage component, so it cannot ride the re-type path above.
+    // Push it directly as TWO counter abilities: a self counter (on-attacked, any direct hit) +
+    // an adjacent-ally counter (on-ally-attacked, reusing the existing requireDamagedAllyAdjacent
+    // gate). The per-ability once-per-attack guard collapses multi-hit; self/ally are mutually
+    // exclusive per attack (single-focus `attacked` emit), so exactly one retaliation fires. If
+    // multi-victim `attacked` emission is ever added, switch the executor guard to `${ownerId}` to
+    // dedupe across these two abilities. The co-located "start of combat … attack per adjacent
+    // ally" buff parses independently and is unaffected.
+    if (slot === 'passive' && counter && counter.allySubject) {
+        const hits = parseHitCount(text);
+        const counterConfig = {
+            type: 'counter' as const,
+            multiplier: counter.multiplier,
+            ...(hits !== undefined ? { hits } : {}),
+        };
+        const pos = damagePos >= 0 ? damagePos : MAX_POS;
+        out.push({
+            ability: {
+                id: nextId(),
+                type: 'counter',
+                target: 'enemy',
+                trigger: 'on-attacked',
+                conditions: [],
+                config: counterConfig,
+                autoFilled: true,
+            },
+            pos,
+        });
+        out.push({
+            ability: {
+                id: nextId(),
+                type: 'counter',
+                target: 'enemy',
+                trigger: 'on-ally-attacked',
+                conditions: [],
+                config: counterConfig,
+                requireDamagedAllyAdjacent: true,
+                autoFilled: true,
+            },
+            pos,
         });
     }
 

--- a/src/utils/combat/__tests__/counterAttack.integration.test.ts
+++ b/src/utils/combat/__tests__/counterAttack.integration.test.ts
@@ -21,11 +21,12 @@
  * Scope: NO enemy-side mirror (enemy victims don't emit `attacked` — out of scope per the spec).
  */
 import { describe, it, expect } from 'vitest';
-import { runCombat, CombatEngineInput } from '../engine';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
 import { createEventBus, CombatEvent } from '../events';
 import { buildShipAbilities } from '../../abilities/buildShipAbilities';
 import { Ship } from '../../../types/ship';
 import { ShipSkills } from '../../../types/abilities';
+import type { Position } from '../../../types/encounters';
 
 /** A Ship carrying Stalwart's first-passive (30%) counterattack skill text, verbatim from
  *  constants/ships.ts. Parsed through the real registry → an on-attacked `counter` ability
@@ -252,5 +253,138 @@ describe('G PR2 — Nyxen shield-hit counterattack END-TO-END via the real regis
             .filter((d) => d > 0);
         expect(counterRounds.length).toBeGreaterThan(0);
         for (const dealt of counterRounds) expect(dealt).toBeCloseTo(20_000, 6);
+    });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// G PR2 — Centurion self/adjacent-ally counterattack END-TO-END via the real registry.
+//
+// Centurion's passive ("At the start of combat, this Unit gains N attack per adjacent ally.<br/>
+// <br/>When this Unit OR AN ADJACENT ALLY is directly damaged, this Unit retaliates dealing X%.")
+// parses to TWO counters: a self on-attacked counter (no gate) + an adjacent-ally on-ally-attacked
+// counter (requireDamagedAllyAdjacent). Built through the real registry and fed to runCombat with
+// REAL board positions so the listener's adjacency gate is exercised end to end.
+//
+// Read mechanism: the counter surfaces as the attacking enemy's incoming damage via the round
+// perTargetDamage map (same channel as Stalwart/Nyxen above). Geometry (board.ts): owner at M2 →
+// adjacent = T1,T2,M1,M3,B1,B2; NON-adjacent = B4.
+// ───────────────────────────────────────────────────────────────────────────
+
+const CENTURION_P2 =
+    'At the start of combat, this Unit gains 750 attack per adjacent ally.<br /><br />When this Unit or an adjacent ally is directly damaged, this Unit retaliates dealing <unit-damage>50%</unit-damage>.';
+
+/** A Ship carrying Centurion's second passive (self/adjacent-ally retaliate), verbatim from
+ *  docs/ship-skills.csv, parsed through the real registry. */
+function centurionShip(passiveText: string): Ship {
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        secondPassiveSkillText: passiveText,
+    } as Ship;
+}
+
+/** A positioned, inert team ally (no skills, big HP, no real damage). Mirrors the cfProvoke harness. */
+function ally(id: string, position: Position): TeamActorEngineInput {
+    return {
+        id,
+        speed: 10, // slower than the focus / enemy so it never acts first
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        walk: {
+            shipSkills: { slots: [] },
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp: 1_000_000_000,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    };
+}
+
+describe('G PR2 — Centurion self/adjacent-ally counterattack END-TO-END via the real registry', () => {
+    it('parsing produces self (on-attacked) + adjacent-ally (on-ally-attacked) counters (sanity)', () => {
+        const skills = buildShipAbilities(centurionShip(CENTURION_P2));
+        const passive = skills.slots.find((s) => s.slot === 'passive');
+        const counters = passive?.abilities.filter((a) => a.type === 'counter') ?? [];
+        expect(counters).toHaveLength(2);
+        expect(counters.find((a) => a.trigger === 'on-attacked')).toMatchObject({
+            type: 'counter',
+            config: { type: 'counter', multiplier: 50 },
+        });
+        expect(counters.find((a) => a.trigger === 'on-ally-attacked')).toMatchObject({
+            type: 'counter',
+            config: { type: 'counter', multiplier: 50 },
+            requireDamagedAllyAdjacent: true,
+        });
+    });
+
+    it('SELF hit: Centurion retaliates against the attacker when it is directly hit', () => {
+        // Focus 'attacker' (Centurion owner) IS the heal target → the enemy hits IT each round →
+        // the self on-attacked counter fires. No adjacency needed.
+        const skills = buildShipAbilities(centurionShip(CENTURION_P2));
+        const result = runCombat(
+            counterBase(skills, {
+                position: 'M2',
+                healTargetId: 'attacker',
+                enemyAttackers: [basicEnemy('foe', 3_000)],
+            })
+        );
+        // Owner attack 10000 × 50% vs defence 0 / neutral affinity / no crit = 5000 per counter.
+        const counterRounds = result.rounds
+            .map((rd) => rd.perTargetDamage?.['foe'] ?? 0)
+            .filter((d) => d > 0);
+        expect(counterRounds.length).toBeGreaterThan(0);
+        for (const dealt of counterRounds) expect(dealt).toBeCloseTo(5_000, 6);
+    });
+
+    it('ADJACENT ally hit: Centurion retaliates when an adjacent ally is directly damaged', () => {
+        // Owner at M2; adjacent ally 'ally-T2' at T2 is the heal target → the enemy hits T2 →
+        // owner is adjacent → the on-ally-attacked counter fires against the attacker.
+        const skills = buildShipAbilities(centurionShip(CENTURION_P2));
+        const result = runCombat(
+            counterBase(skills, {
+                speed: 100, // owner acts first; its passive listens for the ally hit
+                position: 'M2',
+                teamActors: [ally('ally-T2', 'T2'), ally('ally-B4', 'B4')],
+                healTargetId: 'ally-T2',
+                enemyAttackers: [basicEnemy('foe', 3_000)],
+            })
+        );
+        const counterRounds = result.rounds
+            .map((rd) => rd.perTargetDamage?.['foe'] ?? 0)
+            .filter((d) => d > 0);
+        expect(counterRounds.length).toBeGreaterThan(0);
+        for (const dealt of counterRounds) expect(dealt).toBeCloseTo(5_000, 6);
+    });
+
+    it('NON-adjacent ally hit: Centurion does NOT retaliate (adjacency gate)', () => {
+        // Owner at M2; heal target is 'ally-B4' at B4 (NON-adjacent). The enemy hits B4; the
+        // on-ally-attacked listener runs but requireDamagedAllyAdjacent rejects it → no counter.
+        // Adjacent ally-T2 still present so the geometry is positional (not the all-allies fallback).
+        const skills = buildShipAbilities(centurionShip(CENTURION_P2));
+        const result = runCombat(
+            counterBase(skills, {
+                speed: 100,
+                position: 'M2',
+                teamActors: [ally('ally-T2', 'T2'), ally('ally-B4', 'B4')],
+                healTargetId: 'ally-B4',
+                enemyAttackers: [basicEnemy('foe', 3_000)],
+            })
+        );
+        expect(totalPerTargetDamage(result, 'foe')).toBe(0);
     });
 });

--- a/src/utils/combat/__tests__/counterAttack.integration.test.ts
+++ b/src/utils/combat/__tests__/counterAttack.integration.test.ts
@@ -169,3 +169,88 @@ describe('G PR1 — Stalwart counterattack END-TO-END via the real registry', ()
         expect(counterRounds[0]).toBeCloseTo(BASE, 6);
     });
 });
+
+// ───────────────────────────────────────────────────────────────────────────
+// G PR2 — Nyxen shield-hit counterattack END-TO-END via the real registry.
+//
+// Nyxen's passive ("This Unit deals X% damage when its Shield is directly damaged.") parses to
+// an on-attacked `counter` with requireShieldHit:true. Nyxen's ACTIVE grants a self-shield
+// ("Shield equal to 15% of its Max HP"). Built together through the real registry and fed to
+// runCombat: the focus (speed 100) casts its active FIRST each round → a live shield; the
+// speed-50 enemy then lands a primary hit that DRAINS the shield → attacked.shieldWasHit:true →
+// the counter fires. The NEGATIVE control builds Nyxen with ONLY the passive (no active shield) →
+// no shield ever exists → shieldWasHit never true → NO counter.
+// ───────────────────────────────────────────────────────────────────────────
+
+const NYXEN_ACTIVE =
+    'This Unit <unit-aid>Cleanses 2 bombs</unit-aid>, Grants a <unit-damage>Shield equal to 15%</unit-damage> of its Max HP, and Grants <unit-skill>Atlas Readiness II</unit-skill> for 1 turn.';
+const NYXEN_P1 =
+    'This Unit deals <unit-damage>100% damage</unit-damage> when its Shield is directly damaged.';
+const NYXEN_P2 =
+    'This Unit deals <unit-damage>200% damage</unit-damage> when its Shield is directly damaged.';
+
+/** A Ship carrying Nyxen's active (self-shield) and a chosen passive (shield-hit counter),
+ *  verbatim from docs/ship-skills.csv, parsed through the real registry. */
+function nyxenShip(passiveText: string, withActiveShield = true): Ship {
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        ...(withActiveShield ? { activeSkillText: NYXEN_ACTIVE } : {}),
+        firstPassiveSkillText: passiveText,
+    } as Ship;
+}
+
+describe('G PR2 — Nyxen shield-hit counterattack END-TO-END via the real registry', () => {
+    it('parsing produces a real on-attacked counter with requireShieldHit (sanity: registry wiring)', () => {
+        const skills = buildShipAbilities(nyxenShip(NYXEN_P1));
+        const passive = skills.slots.find((s) => s.slot === 'passive');
+        const counter = passive?.abilities.find((a) => a.type === 'counter');
+        // Mutation guard: if the parser stops emitting a shield-hit counter, this fails before the run.
+        expect(counter).toMatchObject({
+            type: 'counter',
+            trigger: 'on-attacked',
+            config: { type: 'counter', multiplier: 100, requireShieldHit: true },
+        });
+        expect(
+            (counter?.config as { requirePrimaryTarget?: boolean }).requirePrimaryTarget
+        ).toBeUndefined();
+    });
+
+    it('(P1 100%) the counter fires ONLY when the live shield is actually hit', () => {
+        // Focus speed 100 → casts its self-shield active BEFORE the speed-50 enemy hits, so the
+        // enemy's hit drains a LIVE shield → shieldWasHit:true → counter fires.
+        const shielded = buildShipAbilities(nyxenShip(NYXEN_P1, /* withActiveShield */ true));
+        const withShieldResult = runCombat(
+            counterBase(shielded, { speed: 100, enemyAttackers: [basicEnemy('foe', 3_000)] })
+        );
+        // Owner attack 10000 × 100% vs defence 0 / neutral affinity / no crit = 10000 per counter.
+        const fired = totalPerTargetDamage(withShieldResult, 'foe');
+        expect(fired).toBeGreaterThan(0);
+        for (const rd of withShieldResult.rounds) {
+            const dealt = rd.perTargetDamage?.['foe'] ?? 0;
+            if (dealt > 0) expect(dealt).toBeCloseTo(10_000, 6);
+        }
+
+        // NEGATIVE control: no active shield → the shield never exists → shieldWasHit never true →
+        // NO counter ever fires (the foe takes zero counter damage).
+        const noShield = buildShipAbilities(nyxenShip(NYXEN_P1, /* withActiveShield */ false));
+        const noShieldResult = runCombat(
+            counterBase(noShield, { speed: 100, enemyAttackers: [basicEnemy('foe', 3_000)] })
+        );
+        expect(totalPerTargetDamage(noShieldResult, 'foe')).toBe(0);
+    });
+
+    it('(P2 200%) the counter scales with the parsed multiplier (20000 per shield-hit counter)', () => {
+        const shielded = buildShipAbilities(nyxenShip(NYXEN_P2, /* withActiveShield */ true));
+        const result = runCombat(
+            counterBase(shielded, { speed: 100, enemyAttackers: [basicEnemy('foe', 3_000)] })
+        );
+        // Owner attack 10000 × 200% = 20000 per counter.
+        const counterRounds = result.rounds
+            .map((rd) => rd.perTargetDamage?.['foe'] ?? 0)
+            .filter((d) => d > 0);
+        expect(counterRounds.length).toBeGreaterThan(0);
+        for (const dealt of counterRounds) expect(dealt).toBeCloseTo(20_000, 6);
+    });
+});

--- a/src/utils/combat/__tests__/counterAttack.test.ts
+++ b/src/utils/combat/__tests__/counterAttack.test.ts
@@ -355,3 +355,44 @@ describe('G PR1 — counter primary-target gate (executor level)', () => {
         expect(spy).toHaveBeenCalledTimes(1);
     });
 });
+
+// ---------------------------------------------------------------------------
+// G PR2 — Centurion self/adjacent-ally counter (executor level).
+//
+// Centurion builds TWO counters (self on-attacked + adjacent-ally on-ally-attacked). Neither
+// carries requirePrimaryTarget/requireShieldHit. The adjacency gate (requireDamagedAllyAdjacent)
+// lives in the LISTENER (registerReactiveListeners), NOT the executor — by the time an intent
+// reaches executeIntent, counterTargetId is already routed. So at the executor level both fire
+// purely on a routed counterTargetId (no gates). The adjacency positive/negative is asserted at
+// the integration level (counterAttack.integration.test.ts).
+// ---------------------------------------------------------------------------
+describe('G PR2 — Centurion self/adjacent-ally counter (executor level)', () => {
+    it('self counter (no primary/shield gate): fires on a routed counterTargetId', () => {
+        const spy = vi.fn();
+        executeIntent(
+            counterIntent({ type: 'counter', multiplier: 50 }, { counterTargetId: 'foe' }),
+            makeCounterCtx(spy)
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(OWNER, 'foe', 'cnt-gate', 50, 1);
+    });
+
+    it('counter does NOT fire when no attacker is routed (counterTargetId absent)', () => {
+        const spy = vi.fn();
+        executeIntent(counterIntent({ type: 'counter', multiplier: 50 }, {}), makeCounterCtx(spy));
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('once-per-attack: 3 attacked events on the same focus victim collapse to ONE counter', () => {
+        const spy = vi.fn();
+        const ctx = makeCounterCtx(spy);
+        const intent = counterIntent(
+            { type: 'counter', multiplier: 100 },
+            { counterTargetId: 'foe' }
+        );
+        executeIntent(intent, ctx);
+        executeIntent(intent, ctx);
+        executeIntent(intent, ctx);
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/utils/combat/__tests__/counterAttack.test.ts
+++ b/src/utils/combat/__tests__/counterAttack.test.ts
@@ -303,6 +303,46 @@ describe('G PR1 — counter primary-target gate (executor level)', () => {
         expect(spy).toHaveBeenCalledTimes(1);
     });
 
+    // G PR2 — Nyxen shield-hit gate (executor level): requireShieldHit gates on
+    // eventCtx.shieldWasHit. The counter fires only when the triggering hit actually drained the
+    // owner's shield (> 0 absorbed).
+    it('requireShieldHit:true + shieldWasHit:true → fires', () => {
+        const spy = vi.fn();
+        executeIntent(
+            counterIntent(
+                { type: 'counter', multiplier: 100, requireShieldHit: true },
+                { counterTargetId: 'foe', shieldWasHit: true }
+            ),
+            makeCounterCtx(spy)
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(OWNER, 'foe', 'cnt-gate', 100, 1);
+    });
+
+    it('requireShieldHit:true + shieldWasHit false → does NOT fire', () => {
+        const spy = vi.fn();
+        executeIntent(
+            counterIntent(
+                { type: 'counter', multiplier: 100, requireShieldHit: true },
+                { counterTargetId: 'foe', shieldWasHit: false }
+            ),
+            makeCounterCtx(spy)
+        );
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('requireShieldHit:true + shieldWasHit absent → does NOT fire', () => {
+        const spy = vi.fn();
+        executeIntent(
+            counterIntent(
+                { type: 'counter', multiplier: 100, requireShieldHit: true },
+                { counterTargetId: 'foe' }
+            ),
+            makeCounterCtx(spy)
+        );
+        expect(spy).not.toHaveBeenCalled();
+    });
+
     it('once-per-attack: a second intent with the same owner:ability key in the same turn is suppressed', () => {
         const spy = vi.fn();
         const ctx = makeCounterCtx(spy);

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -5084,6 +5084,12 @@ export function runCombat(input: CombatEngineInput): {
                             // roundCrit binary — the pre-4c contract.
                             const hitOutcomes =
                                 enemyHitCrits.length > 0 ? enemyHitCrits : [enemyTurnDidCrit];
+                            // G PR2: did the attack actually dent the victim's shield this turn?
+                            // absorbed = damage - hpDamage when not barriered; shieldBefore>0 guards a
+                            // "had a shield" precondition. Non-positional path only (positional leaves
+                            // shieldBefore/hpDamage at 0 → false; no fixture threads enemy positions).
+                            const shieldWasHit =
+                                !barriered && shieldBefore > 0 && hpDamage < damage;
                             for (const hitCrit of hitOutcomes) {
                                 bus.emit({
                                     type: 'attacked',
@@ -5096,6 +5102,7 @@ export function runCombat(input: CombatEngineInput): {
                                     // `tgt` is the focus/primary victim today; covered-cell
                                     // emission (future) would pass the real per-victim role.
                                     isPrimaryTarget: true,
+                                    ...(shieldWasHit ? { shieldWasHit: true } : {}),
                                     ...(hitCrit ? { didCrit: true } : {}),
                                     ...(damage > 0 ? { damage } : {}),
                                 });

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -212,6 +212,12 @@ export type CombatEvent =
            *  focus victim (`tgt`) → always true; positional per-victim emission (future) sets
            *  false for covered cells. Stalwart's counter gates on this. */
           isPrimaryTarget?: boolean;
+          /** G PR2: true when this hit actually reduced the victim's shield pool
+           *  (absorbed > 0). Sourced from the shield-first drain at the emit
+           *  (shieldBefore > 0 && hpDamage < damage && !barriered). Nyxen's counter
+           *  gates on this. False/absent when no shield was present, the hit fully
+           *  penetrated to HP, or a Barrier blocked it (shield untouched). */
+          shieldWasHit?: boolean;
       };
 
 export type CombatEventType = CombatEvent['type'];

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -496,6 +496,7 @@ export function registerReactiveListeners(args: {
                                 didCrit: e.didCrit,
                                 triggerDamage: e.damage,
                                 isPrimaryTarget: e.isPrimaryTarget,
+                                shieldWasHit: e.shieldWasHit,
                             },
                         });
                     });

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -122,9 +122,9 @@ export interface Intent {
          *  triggering attack (on-attacked -> attacked.isPrimaryTarget). Stalwart's counter
          *  gates on this so splash/covered victims do not counter. */
         isPrimaryTarget?: boolean;
-        /** G PR1 (plumbed in PR2): true when the triggering hit reduced the owner's SHIELD pool.
-         *  Nyxen's counter gates on this (`requireShieldHit`). No listener sets it yet → always
-         *  undefined here → the shield-hit gate is currently inert (byte-identical). */
+        /** G PR2: true when the triggering hit reduced the owner's SHIELD pool (absorbed > 0).
+         *  Sourced at the `attacked` emit and copied here by the on-attacked listener. Nyxen's
+         *  counter gates on this (`requireShieldHit`). */
         shieldWasHit?: boolean;
         /** The actor ids of the allies repaired by an on-own-repair-to-ally event
          *  (excludes the caster). The buff branch fans an 'ally'-target grant out to

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -211,8 +211,9 @@ export interface ParsedCounterAbility {
  * consequences are NOT counters and produce nothing here.
  *
  * PR2: Nyxen's shield-hit shape ("This Unit deals X% damage when its Shield is directly
- * damaged.") IS handled and returns requireShieldHit: true. Centurion (adjacent-ally
- * retaliate / allySubject) is intentionally NOT handled here yet.
+ * damaged.") IS handled and returns requireShieldHit: true. Centurion's adjacent-ally
+ * retaliate shape ("When this Unit or an adjacent ally is directly damaged, this Unit
+ * retaliates dealing X%.") IS handled and returns allySubject: true.
  */
 export function parseCounterAbilities(
     text: string | null | undefined
@@ -242,6 +243,17 @@ export function parseCounterAbilities(
         const m = parseFloat(nyxen[1]);
         if (!isNaN(m))
             return { multiplier: m, requirePrimaryTarget: false, requireShieldHit: true };
+    }
+
+    // Centurion: "When this Unit or an adjacent ally is directly damaged, this Unit retaliates
+    // dealing X%." NOTE: the <unit-damage> tag wraps just "X%" — do NOT require the word "damage".
+    const centurion =
+        /when\s+this\s+unit\s+or\s+an\s+adjacent\s+ally\s+is\s+directly\s+damaged[^.;]*?\bretaliates\s+dealing\s+(\d+(?:\.\d+)?)%/i.exec(
+            plain
+        );
+    if (centurion) {
+        const m = parseFloat(centurion[1]);
+        if (!isNaN(m)) return { multiplier: m, requirePrimaryTarget: false, allySubject: true };
     }
 
     return null;

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -188,12 +188,17 @@ export function parseSkillDamage(text: string): number {
     return 0;
 }
 
-/** A parsed counterattack consequence (Combat G PR1: Stalwart shape only). */
+/** A parsed counterattack consequence (Combat G PR1: Stalwart; PR2: Nyxen). */
 export interface ParsedCounterAbility {
     /** raw percentage of the OWNER's effective attack, e.g. 30/70. */
     multiplier: number;
     /** true when the trigger clause says "as a primary target" (Stalwart). */
     requirePrimaryTarget: boolean;
+    /** G PR2: true for "deals X% damage when its Shield is directly damaged" (Nyxen). */
+    requireShieldHit?: boolean;
+    /** G PR2: true for "when this Unit or an adjacent ally is directly damaged …
+     *  retaliates dealing X%" (Centurion) — routes to self + adjacent-ally counters. */
+    allySubject?: boolean;
 }
 
 /**
@@ -205,7 +210,9 @@ export interface ParsedCounterAbility {
  * ("repairs"), shield ("gains a Shield"), and reflect ("reflects X% of the Damage taken")
  * consequences are NOT counters and produce nothing here.
  *
- * PR2 (Nyxen shield-hit, Centurion retaliate/adjacent-ally) is intentionally NOT handled.
+ * PR2: Nyxen's shield-hit shape ("This Unit deals X% damage when its Shield is directly
+ * damaged.") IS handled and returns requireShieldHit: true. Centurion (adjacent-ally
+ * retaliate / allySubject) is intentionally NOT handled here yet.
  */
 export function parseCounterAbilities(
     text: string | null | undefined
@@ -215,13 +222,29 @@ export function parseCounterAbilities(
     // Trigger clause + counter consequence must co-occur in the same sentence.
     // Stalwart: "When this Unit is directly damaged as a primary target, it deals 30% damage
     // to that enemy …". Anchor the % on the "deals X% damage to that enemy" consequence.
-    const re =
-        /when\s+this\s+unit\s+is\s+directly\s+damaged(?<primary>\s+as\s+a\s+primary\s+target)?[^.;]*?\bit\s+deals\s+(\d+(?:\.\d+)?)%\s+damage\s+to\s+that\s+enemy/i;
-    const m = re.exec(plain);
-    if (!m) return null;
-    const multiplier = parseFloat(m[2]);
-    if (isNaN(multiplier)) return null;
-    return { multiplier, requirePrimaryTarget: Boolean(m.groups?.primary) };
+    const stalwart =
+        /when\s+this\s+unit\s+is\s+directly\s+damaged(?<primary>\s+as\s+a\s+primary\s+target)?[^.;]*?\bit\s+deals\s+(\d+(?:\.\d+)?)%\s+damage\s+to\s+that\s+enemy/i.exec(
+            plain
+        );
+    if (stalwart) {
+        const m = parseFloat(stalwart[2]);
+        if (!isNaN(m))
+            return { multiplier: m, requirePrimaryTarget: Boolean(stalwart.groups?.primary) };
+    }
+
+    // Nyxen: "This Unit deals X% damage when its Shield is directly damaged." (consequence
+    // precedes the trigger; "its Shield … directly damaged" is the discriminator).
+    const nyxen =
+        /this\s+unit\s+deals\s+(\d+(?:\.\d+)?)%\s+damage\s+when\s+its\s+shield\s+is\s+directly\s+damaged/i.exec(
+            plain
+        );
+    if (nyxen) {
+        const m = parseFloat(nyxen[1]);
+        if (!isNaN(m))
+            return { multiplier: m, requirePrimaryTarget: false, requireShieldHit: true };
+    }
+
+    return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Sub-project G PR2 — lights up the remaining two **player-side** counterattackers on top of PR1's (#163, now merged) reactive `counter` pipeline.

- **Nyxen** (P1 100% / P2 200%) — counters the attacker only when its **shield** actually takes the hit (absorbed > 0). New `shieldWasHit` signal threaded from the `attacked` emit → `on-attacked` listener → `eventCtx` (the executor's `requireShieldHit` gate already shipped in PR1), plus parser `requireShieldHit` riding PR1's Approach-B re-type.
- **Centurion** (P2 50% / P3 100%) — retaliates when **itself or an adjacent ally** is directly damaged. Its retaliate tag lacks the word "damage" (so `parseSkillDamage` returns 0 and it can't re-type), so the builder pushes **two** counter abilities: a self counter on `on-attacked` and an adjacent-ally counter on `on-ally-attacked` reusing the existing `requireDamagedAllyAdjacent` adjacency gate. The two are mutually exclusive per attack (single-focus `attacked` emit), so exactly one retaliation fires.

Counters reuse PR1's full mitigated/crit damage walk (`applyCounterAttack`) — can crit and kill, fire once per attack, and don't re-counter. Enemy-side counters remain **out of scope** (the sole `attacked` emit is enemy→player).

## Commits
1. `attacked.shieldWasHit` signal plumbed to eventCtx (byte-identical)
2. parse + light up Nyxen shield-hit counterattack
3. parse + light up Centurion self/adjacent-ally counterattack
4. changelog + docs
5. fix stale shieldWasHit eventCtx comment

## Test Plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (max-warnings 0)
- [x] `npm run audit:skills` → 141 ships / 0 findings
- [x] Full suite `npx vitest run` → 3409 passing
- [x] **Production byte-identical** — zero `.snap` golden movement (no fixture equips these ships)
- [x] New tests: parser (Nyxen/Centurion shapes + Stalwart regression), build (re-type + two-counter push + M1 start-of-combat non-regression), executor (shield gate positive/negative/absent; Centurion self/adjacent/non-adjacent; once-per-attack collapse), integration (real registry + real board positions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)