### PR TITLE
feat(combat): enemy-side attacked emission — enemy ships react when hit (counters + reactives)

### DIFF
--- a/docs/superpowers/plans/2026-06-27-enemy-side-attacked-emission.md
+++ b/docs/superpowers/plans/2026-06-27-enemy-side-attacked-emission.md
@@ -1,0 +1,415 @@
+# Enemy-side `attacked` Emission Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make enemy ships react when the player hits them — add the symmetric **player→enemy `attacked` emit** on the positional two-team-sim path, lighting up all enemy `on-attacked` reactives (counters + Second Wind, Tenacity, Reactive Ward, …), and make the `shieldWasHit` signal work on the **positional** path in **both** directions (so player Nyxen and enemy Nyxen both fire in the positioned sim).
+
+**Architecture:** Extract the per-hit `attacked` emit (currently inline in the enemy-turn body, `engine.ts:5093-5109`) into a shared, direction-agnostic `emitAttacked` helper. Capture each direction's **focus victim** outcome from the existing `drivePositionalApply` `onVictimResolved` callback (matched by `victim.id === tgt.id`, first-hit-focus semantics — `onVictimResolved` does not expose role), and feed `shieldWasHit` from it. Call `emitAttacked` from the enemy-turn branch (unchanged behavior) AND from the two player-attack positional branches (the new behavior). Routing is already team-agnostic (`registerReactiveListeners` per side; locked by `enemyReactiveRouting.test.ts`), so the single new emit wakes every enemy `on-attacked` reactive with no executor changes.
+
+**Tech Stack:** React 18, TypeScript, Vitest. Combat engine in `src/utils/combat/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-27-enemy-side-attacked-emission-design.md`
+
+**Branch:** `feat/combat-enemy-side-attacked-emission` (already created, stacked on the G PR2 branch `feat/combat-g-counterattack-pr2`, off the post-#163 main; the spec is committed here). **It must stack on PR2** — the enemy-side counter integration tests need PR2's parsed Stalwart/Nyxen/Centurion counter abilities. When PR2 (#164) merges, rebase this branch onto `main` (`git rebase --onto origin/main <pr2-tip> feat/combat-enemy-side-attacked-emission`) and retarget the PR base to `main`.
+
+---
+
+## Critical context (verified 2026-06-27)
+
+- **Two-team sim uses the positional path by default.** `simulateBattle` (`battleSimulator.ts:594`) → `runCombat` threads `position`+`target`+`pattern` for every actor, so player→enemy attacks run through the positional branch (`engine.ts:4386-4390` gate). Enemies are real `CombatActor`s in `enemyAttackerActors` (`engine.ts:1737`), registered as reactive owners via `registerReactiveListeners({ perOwner: enemyReactivePerOwner, … })` (`engine.ts:2196`).
+- **The sole `attacked` emit today** is the enemy→player one at `engine.ts:5093-5109` (per-hit over `hitOutcomes = enemyHitCrits.length ? enemyHitCrits : [enemyTurnDidCrit]`; sets `targetId: tgt.id`, `attackerId: actor.id`, `isPrimaryTarget: true`, conditional `shieldWasHit`/`didCrit`/`damage`).
+- **`shieldWasHit` (5091-5092)** = `!barriered && shieldBefore > 0 && hpDamage < damage`, where `barriered/shieldBefore/hpDamage` are bound ONLY on the non-positional `else` branch (`engine.ts:~4989`). On the enemy POSITIONAL branch they stay `0` → `shieldWasHit` always false there today (comment 5089-5090). **This is why player Nyxen is inert in the positioned sim — Step 3 fixes it.**
+- **`onVictimResolved` signature:** `onVictimResolved?.(victim, dmg, outcome, didCrit)` (`positionalApply.ts:189`); `outcome` is `VictimDamageOutcome { shieldBefore, hpDamage, barriered }` (`positionalApply.ts:30-34`). It does NOT expose the victim's role.
+- **`drivePositionalApply` sites:**
+  - Player FOCUS: call `engine.ts:4395`, `onVictimResolved` `engine.ts:4409` (`(_victim, damage) => procStandingLeechesPerVictim(actor.id, damage)`); `tgt` from `selectTurnTarget(actor)` at `engine.ts:4323`; turn = `turn` (has `.hitCrits` 4397, `.roundCrit`).
+  - Player TEAM: call `engine.ts:4552`, `onVictimResolved` `engine.ts:4565`; `tgt` at `engine.ts:4507`; turn = `teamTurn` (`.hitCrits` 4554, `.roundCrit`).
+  - Enemy: call `engine.ts:~4970`, `onVictimResolved` `engine.ts:4985` (`(victim, dmg, outcome) => procTakenLeechesPerVictim(victim, dmg, outcome)`); enemy `tgt` from `selectTurnTarget(actor)` at `engine.ts:4727`.
+- **`tgt` is the real positional enemy/player focus victim** on the positional path (`selectTurnTarget` resolves the parsed target to a living opposing actor, `engine.ts:3562-3593`); on the non-positional path it's the dummy sink. So `victim.id === tgt.id` correctly identifies the focus victim on the positional path.
+- **Per-side bindings:** `playerTurnBindings` (`engine.ts:3528`, `applyToVictim = applyOutgoingToEnemy`), `enemyTurnBindings` (`engine.ts:3538`, `applyToVictim = applyIncomingToTarget`); `turnBindings(side)` 3556. `VictimDamageOutcome` type is already imported in engine.ts (used at 3395/3526).
+- **`runPlayerTurn` returns `hitCrits` + `roundCrit`** (`playerTurn.ts:2071`).
+- **Counter-back works already:** `applyCounterAttack` picks `sink = attacker.side === 'player' ? playerSink : enemySink` (`engine.ts:~3294`) and applies via the no-event path → an enemy counter hits the player attacker, emits no `attacked` (no ping-pong).
+- **`CombatEventBus` type:** `src/utils/combat/events.ts:221`.
+- **Test harnesses:** positional two-team battles are set up in `src/utils/combat/__tests__/twoTeamBattle.test.ts` and `src/utils/combat/__tests__/positionalDamage.integration.test.ts` (player fires positionally at real enemy actors with `position`+`target`+`pattern`+a damage skill). The G `counterAttack.integration.test.ts` `counterBase` healing harness drives enemy→player only — DO NOT use it for enemy-side counters.
+
+---
+
+## File structure
+
+- **Create** `src/utils/combat/emitAttacked.ts` — the shared per-hit emit helper (one responsibility; keeps the giant `engine.ts` from growing another inline block).
+- **Modify** `src/utils/combat/engine.ts` — call `emitAttacked` from the enemy-turn branch (refactor); capture focus outcome on the enemy positional branch and source `shieldWasHit` from it (Step 3); capture focus outcome on the two player positional branches and call `emitAttacked` (the new player→enemy emit).
+- **Tests:**
+  - `src/utils/combat/__tests__/emitAttacked.test.ts` (new) — unit test the helper.
+  - `src/utils/combat/__tests__/enemySideAttacked.integration.test.ts` (new) — positional two-team integration: enemy Stalwart/Nyxen/Centurion counter the player attacker; player Nyxen counters a positional enemy attacker (Step 3); enemy Second Wind heals when hit.
+- **Modify** `src/constants/changelog.ts`, `src/pages/DocumentationPage.tsx` — final task.
+
+**Invariant for Tasks 1–2:** production stays **byte-identical** (no `.snap` golden moves). After every task run `npx tsc --noEmit` AND `npm run lint` (max-warnings 0). **Never `vitest -u`.** Task 3 is the deliberate behavior change (audited goldens).
+
+---
+
+## Task 0: Branch + baseline
+
+- [ ] **Step 1: Confirm branch + clean baseline**
+
+```bash
+cd /Users/kennethsusort/PersonalProjects/starborne-frontiers-calculator
+git branch --show-current   # expect feat/combat-enemy-side-attacked-emission
+git status --short          # expect clean
+npx vitest run src/utils/combat/__tests__/counterAttack src/utils/combat/__tests__/twoTeamBattle 2>&1 | tail -6
+```
+Expected: branch correct, clean tree, those suites pass (sanity: PR2 counters + the positional two-team harness are healthy on this branch).
+
+- [ ] **Step 2: Enumerate the expected golden churn up front (discovery)**
+
+Before changing behavior, find which test fixtures build an **enemy** team that (a) contains a ship with an `on-attacked`/`on-ally-attacked` reactive AND (b) runs **positionally** (threads enemy `position`+`target`+`pattern`). These are the only goldens Task 3 can move. Approaches:
+```bash
+# Tests that drive a positional two-team battle (enemy positions threaded):
+grep -rln "position" src/utils/combat/__tests__ | xargs grep -ln "enemyAttacker\|enemyTeam\|simulateBattle\|twoTeam" 2>/dev/null
+# Of those, which build enemies with on-attacked reactive ships (counters/Second Wind/Tenacity/Reactive Ward/etc.)?
+# Inspect each candidate's enemy roster + look for ships whose passives parse on-attacked reactions.
+```
+Record the candidate fixture list (it may be empty — most combat goldens are DPS/single-target or player-only-reactive). This is the baseline expectation Task 3 Step 6 audits against: a move OUTSIDE this set is a red flag. If the set is empty, Task 3 should be byte-identical too (and any movement is suspect).
+
+---
+
+## Task 1: Extract `emitAttacked` helper (byte-identical refactor)
+
+**Files:**
+- Create: `src/utils/combat/emitAttacked.ts`
+- Modify: `src/utils/combat/engine.ts:5085-5109` (replace the inline loop with a helper call)
+- Test: `src/utils/combat/__tests__/emitAttacked.test.ts`
+
+- [ ] **Step 1: Write the helper unit test**
+
+`src/utils/combat/__tests__/emitAttacked.test.ts`: a fake `bus` that records emitted events; assert `emitAttacked` emits one event per `hitOutcomes` entry with the right fields, `didCrit` only when the entry is true, `shieldWasHit`/`damage` only when truthy/positive, `isPrimaryTarget` always present when passed true. Example:
+```ts
+import { describe, it, expect } from 'vitest';
+import { emitAttacked } from '../emitAttacked';
+import type { CombatEvent } from '../events';
+
+const fakeBus = () => {
+    const events: CombatEvent[] = [];
+    return { events, bus: { on() {}, emit: (e: CombatEvent) => void events.push(e) } };
+};
+
+describe('emitAttacked', () => {
+    it('emits one attacked event per hit outcome with correct flags', () => {
+        const { events, bus } = fakeBus();
+        emitAttacked({ bus, round: 2, targetId: 't1', attackerId: 'a1',
+            hitOutcomes: [true, false], isPrimaryTarget: true, shieldWasHit: true, damage: 500 });
+        expect(events).toHaveLength(2);
+        expect(events[0]).toEqual({ type: 'attacked', targetId: 't1', attackerId: 'a1', round: 2,
+            isPrimaryTarget: true, shieldWasHit: true, didCrit: true, damage: 500 });
+        expect(events[1]).toEqual({ type: 'attacked', targetId: 't1', attackerId: 'a1', round: 2,
+            isPrimaryTarget: true, shieldWasHit: true, damage: 500 }); // no didCrit
+    });
+
+    it('omits shieldWasHit/damage when falsy and isPrimaryTarget when false', () => {
+        const { events, bus } = fakeBus();
+        emitAttacked({ bus, round: 1, targetId: 't', attackerId: 'a',
+            hitOutcomes: [false], isPrimaryTarget: false, shieldWasHit: false, damage: 0 });
+        expect(events[0]).toEqual({ type: 'attacked', targetId: 't', attackerId: 'a', round: 1 });
+    });
+});
+```
+
+- [ ] **Step 2: Run it (fails — module missing)**
+
+Run: `npx vitest run src/utils/combat/__tests__/emitAttacked.test.ts`
+Expected: FAIL (cannot find `../emitAttacked`).
+
+- [ ] **Step 3: Implement the helper**
+
+`src/utils/combat/emitAttacked.ts`:
+```ts
+import type { CombatEventBus } from './events';
+
+/**
+ * Emits one `attacked` event per hit (Combat: symmetric reactive emission). Direction-agnostic —
+ * the caller supplies the victim/attacker ids, the per-hit crit list, and the pre-decided
+ * focus-victim signals. Conditional spreads keep the emitted shape minimal (and identical to the
+ * historical inline enemy-turn emit it replaces). DoT/bomb/detonation hits never call this — only
+ * direct weapon hits emit `attacked`.
+ */
+export function emitAttacked(args: {
+    bus: CombatEventBus;
+    round: number;
+    targetId: string;
+    attackerId: string;
+    /** one entry per hit; `true` = that hit critted. */
+    hitOutcomes: boolean[];
+    isPrimaryTarget: boolean;
+    shieldWasHit: boolean;
+    /** per-attack aggregate dealt to the focus victim (Tenacity's >25%-maxHP gate reads this). */
+    damage: number;
+}): void {
+    const { bus, round, targetId, attackerId, hitOutcomes, isPrimaryTarget, shieldWasHit, damage } =
+        args;
+    for (const hitCrit of hitOutcomes) {
+        bus.emit({
+            type: 'attacked',
+            targetId,
+            attackerId,
+            round,
+            ...(isPrimaryTarget ? { isPrimaryTarget: true } : {}),
+            ...(shieldWasHit ? { shieldWasHit: true } : {}),
+            ...(hitCrit ? { didCrit: true } : {}),
+            ...(damage > 0 ? { damage } : {}),
+        });
+    }
+}
+```
+
+- [ ] **Step 4: Run helper test (passes)**
+
+Run: `npx vitest run src/utils/combat/__tests__/emitAttacked.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Call the helper from the enemy-turn branch**
+
+In `engine.ts`, replace the inline loop at `5085-5109` (keep computing `hitOutcomes` and `shieldWasHit` exactly as now) with a single call:
+```ts
+                            const hitOutcomes =
+                                enemyHitCrits.length > 0 ? enemyHitCrits : [enemyTurnDidCrit];
+                            const shieldWasHit =
+                                !barriered && shieldBefore > 0 && hpDamage < damage;
+                            emitAttacked({
+                                bus,
+                                round: r,
+                                targetId: tgt.id,
+                                attackerId: actor.id,
+                                hitOutcomes,
+                                isPrimaryTarget: true,
+                                shieldWasHit,
+                                damage,
+                            });
+```
+Add `import { emitAttacked } from './emitAttacked';` at the top of engine.ts. (Leave the explanatory comments above `hitOutcomes`/`shieldWasHit` intact.)
+
+- [ ] **Step 6: Verify byte-identical**
+
+Run: `npx tsc --noEmit && npm run lint && npx vitest run 2>&1 | tail -8`
+Then: `git status --short` — expect NO `.snap` files changed.
+Expected: tsc/lint clean, full suite green, ZERO `.snap` movement.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A && git commit -m "refactor(combat): extract emitAttacked helper (byte-identical)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Enemy→player positional `shieldWasHit` (Step 3 — player Nyxen in the positioned sim)
+
+Source `shieldWasHit` from the enemy positional branch's per-victim outcome so player Nyxen counters a positional enemy attacker. Byte-identical for existing goldens (no fixture equips Nyxen); adds one NEW behavior test.
+
+**Files:**
+- Modify: `engine.ts` enemy positional branch (`onVictimResolved` ~4985) + the `shieldWasHit` source (~5091)
+- Test: `src/utils/combat/__tests__/enemySideAttacked.integration.test.ts` (new — player-Nyxen case)
+
+- [ ] **Step 1: Write the failing integration test (player Nyxen, positional enemy attack)**
+
+In a new `enemySideAttacked.integration.test.ts`, mirror the `twoTeamBattle` / `positionalDamage.integration.test.ts` setup: a positional two-team battle where an **enemy** attacker (with a damage skill, position, target, pattern) hits a **player Nyxen** that has a live shield. Build Nyxen via the real registry (its active grants itself a shield; ensure the shield exists when the enemy hits). Assert the enemy attacker takes counter damage (Nyxen's shield-hit counter fired) — which is impossible today because positional `shieldWasHit` is false. Read the two harness files first to copy the exact battle-construction pattern (positions, target ids, pattern, `simulateBattle`/`runCombat` entry, how to read an actor's HP / per-target damage).
+
+Run it → FAIL (no counter; enemy attacker undamaged by a counter).
+
+- [ ] **Step 2: Capture the focus player victim's shield outcome on the enemy positional branch**
+
+In `engine.ts`, declare the capture vars in the **same scope as the existing** `let shieldBefore = 0; let hpDamage = 0; let barriered = false;` declarations (the enemy-turn body, **before** the `if (enemyPositional) { … } else { … }` split — NOT inside the `if (enemyPositional)` block, or they'll be out of scope at the emit ~5091):
+```ts
+                            // Symmetric shieldWasHit: capture the FOCUS player victim's shield
+                            // outcome on the positional path (the non-positional `else` branch binds
+                            // shieldBefore/hpDamage/barriered directly; positional leaves them 0).
+                            // First-hit-focus victim matched by victim.id === tgt.id; OR'd across the
+                            // attack's hits so an early shield-denting hit still counts.
+                            let positionalShieldWasHit = false;
+                            let positionalShieldCaptured = false;
+```
+Extend the existing enemy positional `onVictimResolved` (4985) to also capture (keep the leech call). `onVictimResolved` fires **once per hit** for the focus victim, so OR the shield flag across hits:
+```ts
+                                    onVictimResolved: (victim, dmg, outcome) => {
+                                        procTakenLeechesPerVictim(victim, dmg, outcome);
+                                        if (victim.id === tgt.id) {
+                                            positionalShieldCaptured = true;
+                                            positionalShieldWasHit ||=
+                                                !outcome.barriered &&
+                                                outcome.shieldBefore > 0 &&
+                                                outcome.hpDamage < dmg;
+                                        }
+                                    },
+```
+(Confirm `tgt` and `procTakenLeechesPerVictim` are in scope at this site — they are, per the landmarks. Match the exact existing indentation. If `||=` trips the linter, use `positionalShieldWasHit = positionalShieldWasHit || (…)`.)
+
+- [ ] **Step 3: Source `shieldWasHit` from the capture when positional**
+
+At the emit site (~5091), change the `shieldWasHit` computation to prefer the positional capture:
+```ts
+                            const shieldWasHit = positionalShieldCaptured
+                                ? positionalShieldWasHit
+                                : !barriered && shieldBefore > 0 && hpDamage < damage;
+```
+Update the comment to note the positional source. (The two `let`s declared in Step 2 alongside `shieldBefore`/`hpDamage`/`barriered` are guaranteed in scope here — both the `if (enemyPositional)` capture and this emit live in the same enemy-turn body.)
+
+- [ ] **Step 4: Run the player-Nyxen test (passes)**
+
+Run: `npx vitest run src/utils/combat/__tests__/enemySideAttacked.integration.test.ts -v`
+Expected: PASS (player Nyxen now counters the positional enemy attacker).
+
+- [ ] **Step 5: Verify byte-identical for existing goldens**
+
+Run: `npx tsc --noEmit && npm run lint && npx vitest run 2>&1 | tail -8`
+Then `git status --short` — expect NO `.snap` movement (no existing fixture equips a player Nyxen; positional `shieldWasHit` only gates `requireShieldHit`).
+Expected: clean, green, ZERO `.snap` movement.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat(combat): positional shieldWasHit on enemy->player path (player Nyxen in positioned sim)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Player→enemy `attacked` emit (the behavior change)
+
+Emit `attacked` for the focus enemy victim on the two player positional branches → enemy `on-attacked` reactives (counters + the rest) fire. NOT byte-identical: audited golden churn.
+
+**Files:**
+- Modify: `engine.ts` player FOCUS branch (`drivePositionalApply` 4395 + after) and player TEAM branch (4552 + after)
+- Test: `enemySideAttacked.integration.test.ts` (enemy Stalwart/Nyxen/Centurion + Second Wind)
+
+- [ ] **Step 1: Write the failing enemy-counter integration tests**
+
+In `enemySideAttacked.integration.test.ts`, add positional two-team cases where the **player** attacks an enemy that carries a counter (built via the real registry):
+- enemy **Stalwart** (primary-target counter) → the player attacker takes counter damage;
+- enemy **Nyxen** (shield-hit) with a live shield → counters only when the player hit reduced its shield;
+- enemy **Centurion** → retaliates when it OR an adjacent enemy ally is the player's focus victim;
+- enemy **Second Wind** (representative non-counter) → repairs itself when it takes a crit hit from the player.
+Assert via the player attacker's HP / per-target damage (counter landed on the player) and the enemy's HP (Second Wind heal). Use the positional harness (player has `position`+`target`+`pattern`+a damage skill; enemies are real positioned actors).
+
+Run → FAIL (no enemy reaction; player→enemy emits nothing yet).
+
+- [ ] **Step 2: Capture the focus enemy victim outcome on the player FOCUS branch**
+
+Before the focus `drivePositionalApply` (4395) declare:
+```ts
+                            let focusEnemyDamage = 0;
+                            let focusEnemyShieldWasHit = false;
+                            let focusEnemyHit = false;
+```
+Extend its `onVictimResolved` (4409, keep the leech call). It fires **once per hit** for the focus victim, so **accumulate** the damage (to match the enemy side's per-attack aggregate, which Tenacity's >25%-maxHP gate reads) and **OR** the shield flag across hits:
+```ts
+                                onVictimResolved: (victim, damage, outcome) => {
+                                    procStandingLeechesPerVictim(actor.id, damage);
+                                    if (victim.id === tgt.id) {
+                                        focusEnemyHit = true;
+                                        focusEnemyDamage += damage;
+                                        focusEnemyShieldWasHit ||=
+                                            !outcome.barriered &&
+                                            outcome.shieldBefore > 0 &&
+                                            outcome.hpDamage < damage;
+                                    }
+                                },
+```
+(If `||=` trips the linter, use `focusEnemyShieldWasHit = focusEnemyShieldWasHit || (…)`. `focusEnemyDamage` is the sum of direct hits to the focus victim — the per-victim analogue of the enemy side's aggregate `damage`; positional detonation is not per-victim-attributed today, same E5 deferral noted elsewhere.)
+
+- [ ] **Step 3: Emit after the focus `drivePositionalApply`**
+
+Immediately after the focus `drivePositionalApply(...)` call closes (still inside `if (positional) { … }`), add:
+```ts
+                            if (focusEnemyHit) {
+                                const hitOutcomes =
+                                    turn.hitCrits.length > 0 ? turn.hitCrits : [turn.roundCrit];
+                                emitAttacked({
+                                    bus,
+                                    round: r,
+                                    targetId: tgt.id,
+                                    attackerId: actor.id,
+                                    hitOutcomes,
+                                    isPrimaryTarget: true,
+                                    shieldWasHit: focusEnemyShieldWasHit,
+                                    damage: focusEnemyDamage,
+                                });
+                            }
+```
+(Confirm `turn.roundCrit` exists on the `runPlayerTurn` return — `playerTurn.ts:2071` area. Mirror the enemy side's empty-`hitCrits` fallback.)
+
+- [ ] **Step 4: Mirror on the player TEAM branch**
+
+Repeat Steps 2–3 for the team branch: declare the three `let`s before the team `drivePositionalApply` (4552), extend its `onVictimResolved` (4565) capturing on `victim.id === tgt.id`, and emit after the call using `teamTurn.hitCrits`/`teamTurn.roundCrit`, `targetId: tgt.id`, `attackerId: actor.id`. (Each walked team actor runs one apply per its own turn → one emit per team actor; no extra loop.)
+
+- [ ] **Step 5: Run the enemy-counter tests (pass)**
+
+Run: `npx vitest run src/utils/combat/__tests__/enemySideAttacked.integration.test.ts -v`
+Expected: PASS (enemy Stalwart/Nyxen/Centurion counter the player; Second Wind heals).
+
+- [ ] **Step 6: Audit the golden churn (NOT byte-identical)**
+
+Run: `npx vitest run 2>&1 | tail -20` and `git status --short`.
+Expected: only `.snap` files in the **candidate set enumerated in Task 0 Step 2** should move (fixtures whose enemy team has an `on-attacked` ship AND runs positionally). **A move OUTSIDE that set is a red flag — STOP and investigate.** If Task 0 Step 2's set was empty, expect ZERO movement (and treat any move as suspect). For EACH moved golden:
+- Open the diff; confirm the move is **directionally sane** (enemy HP higher where Second Wind / Reactive Ward / repair reactions fire; the player attacker dented/killed where an enemy counter fires; enemy buffs/charge/stealth where the relevant reactive applies).
+- **Do NOT `vitest -u` blindly.** Only accept snapshots after confirming each change is explained by a now-active enemy `on-attacked` reactive. If a move is NOT explained by such a reactive, STOP and investigate (it may be a real bug).
+- Record the audited fixtures + which enemy reactive caused each move in the commit message.
+
+If a moved golden is confirmed correct, update it deliberately (re-run the specific failing test file with `-u` ONLY after auditing that file's diff, or hand-edit). List every touched `.snap` in the commit.
+
+- [ ] **Step 7: Full verification**
+
+Run: `npx tsc --noEmit && npm run lint && npx vitest run 2>&1 | tail -8 && npm run audit:skills 2>&1 | grep -iE "audited|finding"`
+Expected: tsc/lint clean, full suite green (with audited goldens), audit 141/0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A && git commit -m "feat(combat): player->enemy attacked emit — enemy ships now react when hit (counters + reactives)
+
+Audited golden churn: <list fixtures + the enemy reactive that moved each>.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Changelog + docs + final verification
+
+**Files:**
+- Modify: `src/constants/changelog.ts` (`UNRELEASED_CHANGES`)
+- Modify: `src/pages/DocumentationPage.tsx` (combat-sim coverage prose)
+
+- [ ] **Step 1: Changelog**
+
+Append to `UNRELEASED_CHANGES` in `src/constants/changelog.ts`:
+> "Combat simulator: enemy ships now react when the player hits them — enemy counterattackers (Stalwart, Nyxen, Centurion) strike back, and enemy on-hit reactions (self-repairs, defensive buffs, cleanses) now fire, making enemy teams play more like real opponents. Shield-hit counters (Nyxen) now also work for your own ships in positioned battles."
+
+- [ ] **Step 2: Docs**
+
+Update the combat-sim reactive/counterattack prose in `src/pages/DocumentationPage.tsx` (the Reactive Triggers / counterattack section, ~line 3149) to note that reactions now fire for **both** teams (enemy ships react to your hits too), consistent with the existing player-side counterattack mention.
+
+- [ ] **Step 3: Final verification**
+
+Run: `npx tsc --noEmit && npm run lint && npx vitest run 2>&1 | tail -8 && npm run audit:skills 2>&1 | grep -iE "audited|finding"`
+Then `git status --short`.
+Expected: all clean/green, audit 141/0, only the changelog/docs files modified.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A && git commit -m "feat(combat): enemy-side reactive emission changelog + docs
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Done criteria
+
+- A shared `emitAttacked` helper is the single emit path for both directions (enemy-turn refactor byte-identical).
+- `shieldWasHit` is computed from the focus victim's per-victim outcome on the **positional** path in **both** directions → player Nyxen AND enemy Nyxen fire in the positioned two-team sim.
+- The player→enemy emit lights up enemy `on-attacked` reactives: enemy Stalwart/Nyxen/Centurion counter the player attacker; enemy on-hit reactives (Second Wind, etc.) fire — verified by positional two-team integration tests.
+- No ping-pong (counters use the no-event apply path; guard unchanged); focus-victim-only, direct-hits-only, symmetric.
+- Tasks 1–2 byte-identical; Task 3's golden churn is **audited** (each move explained by a now-active enemy reactive), never blind-`-u`'d.
+- `npx tsc --noEmit`, `npm run lint`, full `npx vitest run`, `npm run audit:skills` (141/0) all clean.
+- Non-positional/DPS paths emit nothing (synthetic indestructible sink — not a reactive owner), as designed.

--- a/docs/superpowers/specs/2026-06-27-enemy-side-attacked-emission-design.md
+++ b/docs/superpowers/specs/2026-06-27-enemy-side-attacked-emission-design.md
@@ -1,0 +1,117 @@
+# Enemy-side `attacked` emission — design
+
+**Date:** 2026-06-27
+**Epic:** combat-realism (extends sub-project G — reactive counterattacks)
+**Status:** design, pending spec review
+**Prereqs shipped:** sub-project G PR1+PR2 (player-side counterattacks, #163/#164); team-agnostic reactive routing (`registerReactiveListeners` per-side `isOpposing`, `grantExtraAction` over combined `allActorsById`, locked by `enemyReactiveRouting.test.ts`); the `attacked` event with `didCrit`/`damage`/`isPrimaryTarget`/`shieldWasHit`; the positional two-team battle sim (`simulateBattle` → `runCombat`, positional player→enemy apply via `drivePositionalApply`).
+
+## Goal
+
+Make **enemy ships react when they are directly hit by the player**, mirroring how player ships already react to enemy hits. Today the combat sim emits the `attacked` event in exactly **one** direction — enemy→player (`engine.ts:5093–5108`, the enemy-turn body). When the **player attacks an enemy**, damage is applied but **no `attacked` event is emitted**, so every enemy `on-attacked` / `on-ally-attacked` reactive is silently inert.
+
+This sub-project adds the symmetric **player→enemy** emit. Because routing and every reactive executor are already team-agnostic, that single emit lights up **all** enemy `on-attacked` reactives at once — the three counterattackers (Stalwart / Nyxen / Centurion) **and** the broader family (Second Wind, Tenacity, Reactive Ward, Smokescreen, Firewall, Lockdown, Last Stand, …). The headline user-facing win is **enemy-side counterattacks**, delivered as part of making enemy teams react realistically to being hit.
+
+## Scope decision (user-ratified)
+
+**Broad, not counter-only.** The emit is a shared signal; it cannot selectively wake only counters without a bespoke divergence from the symmetric player-side path. We embrace the full behavior: enemy teams now react to being hit, exactly as player teams do.
+
+**Symmetric — and this PR makes the `shieldWasHit` signal symmetric too.** The two directions must behave the same way. The existing enemy→player emit is **focus-victim-only, per-hit**; the new player→enemy emit matches that exactly, and per-covered-victim (splash) emission stays deferred on **both** sides.
+
+**Pre-existing asymmetry this PR closes (user-ratified):** today `shieldWasHit` on the enemy→player emit is computed **only on the non-positional path** (`engine.ts:4989` binds `{shieldBefore,hpDamage,barriered}`; the positional enemy-attack branch leaves them `0` → `shieldWasHit` always `false`, per the comment at `engine.ts:5089-5090`). Because the two-team sim runs enemy attacks **positionally**, **player-side Nyxen's shield-hit counter is effectively inert in the positioned sim today.** The new player→enemy emit computes `shieldWasHit` from the positional per-victim outcome, so enemy Nyxen would work — creating a real asymmetry. To avoid that, this PR **also populates `shieldWasHit` on the enemy→player positional path** (from its existing per-victim `onVictimResolved` capture), so **both** Nyxens work in the positioned sim. This stays byte-identical (no golden fixture equips Nyxen).
+
+## Where this lives: the positional two-team sim
+
+Critical context discovered during design (corrects an earlier assumption of a generic "player-turn branch"):
+
+- `simulateBattle` (`src/utils/calculators/battleSimulator.ts:594`) → `runCombat` (`engine.ts:1160`) builds the enemy team as **real `CombatActor`s** (`engine.ts:1737` `enemyAttackerActors`), each with its own `currentHp`/`shieldPool`/`position`, included in `allActorsById` and **registered as a reactive owner** via `registerReactiveListeners({ perOwner: enemyReactivePerOwner, … })` (`engine.ts:2196`).
+- `simulateBattle` threads `position` + `target` + `pattern` for every actor (`battleSimulator.ts:652-654/689-691/739-741`), so the per-turn **positional** branch fires (`engine.ts:4386-4390`) whenever a ship has parseable targeting. **The two-team sim runs player→enemy attacks through the positional path by default.**
+- The positional player→enemy apply is `drivePositionalApply(…)` → `applyToVictim = applyOutgoingToEnemy` (`engine.ts:3536` binding, `~3215` impl, wrapping `applyVictimDamage`). It mutates each real enemy victim's HP/shield/Barrier and surfaces a per-victim `{ shieldBefore, hpDamage, barriered }` outcome through the existing `onVictimResolved(victim, dmg, outcome, didCrit)` callback (`positionalApply.ts:187-189`, outcome shape `positionalApply.ts:30-34`).
+- The focus attacker calls `drivePositionalApply` at `engine.ts:~4395`; the walked-team attacker at `engine.ts:~4552`. **Both** already pass an `onVictimResolved` (today only for per-victim leech).
+
+**Out-of-scope paths (correct, not a gap):** the **non-positional/legacy** path folds player damage into a scalar accumulator applied to a single **indestructible synthetic `enemy` sink** (`engine.ts:1268`, `5241-5242`) with no per-victim shield outcome, and the **DPS/single-enemy page** always uses that sink. The synthetic sink is **not** a real reactive owner, so emitting there would be meaningless. Enemy-side counters are therefore a **positioned-two-team-sim feature** — which is exactly where they matter.
+
+## Locked rules (user-ratified)
+
+1. **Symmetric, focus-victim-only, per-hit emit.** Emit `attacked` for the **origin/focus** enemy victim of the attack, one event per hit (driven by the attacker's `hitCrits`), exactly as the enemy→player emit does. Covered/splash victims do not emit (deferred both sides).
+2. **Positional two-team sim only.** The emit fires on the positional player→enemy apply path. The legacy-accumulator and DPS paths do not emit (synthetic sink, not a reactive owner) — documented, expected.
+3. **Direct weapon hits only.** DoT ticks, bomb detonations, and accumulator damage never emit `attacked` — preserved.
+4. **No new reactive logic.** Only the emit is added; routing/executors are already team-agnostic. No listener/executor/helper changes.
+5. **No ping-pong, both directions.** Counters/reflect apply via the no-event `applyVictimDamage` path (`isCounter`/`isReflected` cause; `applyVictimDamage` emits only `hp-changed`/`cheat-death-activated`, never `attacked`). So an enemy counter hitting a player can't re-trigger the player's counters, and vice-versa. Recursion bounded at depth 1, symmetric.
+6. **Once-per-attack guard unchanged.** Keyed `${ownerId}:${ability.id}`, combat-scoped, cleared at each actor turn-start. Owner-keyed ⇒ isolates enemy owners. Focus-victim-only ⇒ no `${ownerId}` switch.
+7. **Not byte-identical — deliberate two-team behavior change.** Goldens whose **enemy** team contains an `on-attacked` ship (and that run positionally) will move. Moves are **audited for directional sanity**, never `vitest -u`'d blindly.
+
+## Architecture (Approach B — shared `emitAttacked` helper, symmetric both directions)
+
+### Step 1 — Extract `emitAttacked(...)` (byte-identical refactor)
+
+Pull the per-hit emit logic out of the enemy-turn branch (`engine.ts:5085-5108`: `hitOutcomes = enemyHitCrits.length ? enemyHitCrits : [enemyTurnDidCrit]`, looped into `bus.emit({ type: 'attacked', … })`) into one helper:
+
+```
+emitAttacked({ bus, round, targetId, attackerId, hitOutcomes, isPrimaryTarget, shieldWasHit, damage })
+```
+
+It emits one `attacked` per entry in `hitOutcomes` (with `didCrit` set per entry; `damage`/`isPrimaryTarget`/`shieldWasHit` folded in conditionally exactly as today). Call it from the (unchanged) enemy-turn branch. **Zero golden movement** — verified by the full suite before any new emit is wired.
+
+### Step 2 — Wire the player→enemy emit (the behavior change)
+
+At the two positional player-attack sites (`engine.ts:~4395` focus, `~4552` team):
+- In the existing `onVictimResolved(victim, dmg, outcome, didCrit)` callback, **capture the focus victim's outcome.** `onVictimResolved` does **not** expose the victim's role, so the focus victim is identified by `victim.id === tgt.id`, where `tgt` is the pre-resolved focus target from `selectTurnTarget(actor)` (`engine.ts:~4323` focus / `~4507` team). Covered victims are ignored for emission (symmetric focus-only). **Multi-hit semantics:** `drivePositionalApply` re-anchors per hit (`positionalApply.ts:158-168`), so if the focus victim dies on hit 1 it captures nothing for later hits — i.e. **first-hit-focus** semantics, which matches the enemy side's single-`tgt` behavior (`engine.ts:5099`). Capture `shieldWasHit`/`damage` from the focus victim's hit; if it was never the live victim (already dead / fully evaded), emit nothing.
+- **After `drivePositionalApply` returns**, call `emitAttacked(...)` with:
+  - `targetId` = the focus enemy victim's id (a real enemy `CombatActor`, registered in `enemyReactivePerOwner` → the event is heard);
+  - `attackerId` = the acting player actor;
+  - `hitOutcomes` from the player turn's `hitCrits` (`turn.hitCrits` / `teamTurn.hitCrits`, same empty → `[roundCrit]` fallback as the enemy side);
+  - `isPrimaryTarget: true`;
+  - `shieldWasHit` from the captured outcome — **identical formula** to the player-victim side: `!outcome.barriered && outcome.shieldBefore > 0 && outcome.hpDamage < damage`;
+  - `damage` = the per-attack aggregate dealt to the focus enemy victim.
+
+If no enemy victim was hit (no damage ability / fully evaded / target already dead), emit nothing (mirror the enemy side's `damage > 0`/empty-`hitCrits` handling).
+
+### Step 3 — Make the enemy→player positional `shieldWasHit` real (close the asymmetry)
+
+Today the enemy→player emit reads `shieldWasHit` from `{shieldBefore,hpDamage,barriered}` bound only on the **non-positional** branch (`engine.ts:4989`); the **positional** enemy-attack branch (which the two-team sim actually uses) leaves them `0`, so player Nyxen never counters there. The positional enemy branch already has the per-victim outcome in hand — its `onVictimResolved` runs `procTakenLeechesPerVictim(victim, dmg, outcome)` (`engine.ts:~4985`). Capture the **focus player victim's** outcome there (same `victim.id === tgt.id` rule as Step 2) and feed `shieldWasHit` into the enemy→player `emitAttacked(...)` call — instead of the current non-positional-only computation. The non-positional branch keeps its existing aggregate `{shieldBefore,hpDamage,barriered}` computation as the fallback. Net effect: **both directions compute `shieldWasHit` from the focus victim's per-hit outcome on the positional path** (same formula, now a symmetric source), and player Nyxen works in the positioned sim. Byte-identical (no fixture equips Nyxen).
+
+### Why it works without routing changes
+
+`registerReactiveListeners` is invoked for both sides; executors/helpers are team-agnostic (locked by `enemyReactiveRouting.test.ts`). An enemy `on-attacked` reactive uses the **same tested code path** as its player-side counterpart — it was only missing the event. The counter-back direction already works: `applyCounterAttack` picks `sink = attacker.side === 'player' ? playerSink : enemySink` (`engine.ts:~3294`), so an enemy counter damages the **player** attacker via `playerSink` — already surfaced on player HP curves (no new surfacing).
+
+## New signals
+
+**None.** The `attacked` event already carries `didCrit`, `damage`, `isPrimaryTarget`, and `shieldWasHit` (G PR1/PR2). This sub-project only *produces* the event in the second direction.
+
+## Out of scope (YAGNI / deferred)
+
+- **Per-covered-victim (splash) emission** — deferred on **both** sides (preserves symmetry). When it lands, the once-per-attack guard switches to `${ownerId}` (the in-code comment from G PR2 in `buildShipAbilities.ts`).
+- **Non-positional / DPS-page emit** — the synthetic indestructible `enemy` sink is not a real reactive owner; emitting there is meaningless and omitted.
+- **New reactive logic / fixing half-wired enemy reactives.** Only the emit is added. If the audit reveals an enemy reactive behaving oddly, it's a **follow-up**, not fixed here — unless it crashes on the enemy path.
+- **DoT/bomb/detonation-triggered reactions** — `attacked` stays direct-weapon-hit-only.
+
+## Testing & golden strategy
+
+- **Commit 1 (refactor) is byte-identical.** Extracting `emitAttacked` and calling it from the unchanged enemy-turn branch must move **zero** goldens — full suite green is the gate.
+- **Commit 2 (new emit) is NOT byte-identical** — a deliberate two-team change. Every moved golden is **audited** for directional sanity (enemy HP higher where Second Wind / Reactive Ward fire; the player attacker dented or killed where an enemy counter fires; enemy buffs/charge where the relevant reactive applies). **Never `vitest -u` blindly.** The plan enumerates up front which fixtures have enemy-side `on-attacked` ships that run positionally, so the moved set is known before running.
+- **Harness (important):** enemy-side reactions must be tested with the **positional two-team harness** (`twoTeamBattle.test.ts` / `positionalDamage.integration.test.ts` style — player fires positionally at a real enemy actor with a `position` + `target` + `pattern` + a damage skill), **not** G's existing `counterAttack.integration.test.ts` `counterBase` healing harness (that drives the enemy→player direction only and routes the player's own counter directly into `enemySink` without an `attacked` emit).
+- **New tests — mirror the counters + one representative reactive (user-ratified):**
+  - Enemy **Stalwart** counters the player attacker when hit as its primary target.
+  - Enemy **Nyxen** counters only when the player hit reduced its shield (give the enemy Nyxen a live shield); not when fully penetrated / no shield. (Feasible — `shieldWasHit` is computed per-victim on the positional path.)
+  - **Player Nyxen** (the Step 3 fix): in the positional two-team sim, a player Nyxen with a live shield counters a **positional** enemy attacker when its shield is hit — proving the enemy→player positional `shieldWasHit` now fires (this is the direction that was inert before).
+  - Enemy **Centurion** retaliates when itself or an adjacent **enemy** ally is directly damaged (positional adjacency), once per attack.
+  - One representative non-counter case: an enemy **Second Wind** repairs itself when it takes a critical hit — proving the general enemy `on-attacked` path is live.
+  - All assert the cross-team direction: a **player** positional attack drives the enemy reactive, and an enemy counter's damage lands on the **player** attacker.
+- **Everything else** relies on the shared, already-tested team-agnostic executors (player-side coverage + `enemyReactiveRouting.test.ts`) plus the golden audit — no per-reactive mirror test.
+- **Gates:** `npx tsc --noEmit`, `npm run lint`, `npm run audit:skills` (141/0) all clean; full suite green with the moved goldens explicitly audited.
+
+## PR shape
+
+**Single PR, two commits** — the new-emit half is inherently all-or-nothing (the emit can't be staged per-reactive):
+1. **Byte-identical foundation:** extract `emitAttacked` helper + call from the enemy-turn branch, AND switch the enemy→player `shieldWasHit` to the positional per-victim capture (Step 3). Both byte-identical (no Nyxen fixture) — full suite green is the gate.
+2. **Behavior change:** wire the player→enemy positional emit + enemy-side mirror tests (+ the player-Nyxen positional test) + audited goldens + changelog + docs.
+
+## Open items for the plan phase
+
+- **Confirm `emitAttacked` placement** for the team-walk site (`engine.ts:~4552`): each walked-team actor runs one `drivePositionalApply` per its own turn with its own `selectTurnTarget` → one emit per turn, focus-only; the plan confirms no wrapping loop causes a double-emit.
+- **Confirm the player turn's `hitCrits`** is the right per-hit list (empty → `[roundCrit]` fallback) at both sites (`turn.hitCrits` `engine.ts:4397`, `teamTurn.hitCrits` `engine.ts:4554`; `runPlayerTurn` returns it, `playerTurn.ts:2071`).
+- **`emitAttacked` signature** — pass a precomputed `shieldWasHit: boolean` (both directions now compute it from their captured focus-victim outcome on the positional path; the enemy side keeps its non-positional aggregate as the fallback), keeping the helper direction-agnostic.
+- **Enumerate the golden churn:** list fixtures whose enemy team contains an `on-attacked` ship AND runs positionally, and which enemy reactives newly fire, so the audited moved set is known up front.
+- **Verify no enemy-path crash** for any reactive firing for the first time (extra-action, cleanse, buff-protection grants) — routing is resolved, but the audit should confirm no enemy reactive assumes player-only context.
+
+(Resolved during design: `onVictimResolved` does NOT expose role → focus victim matched by `victim.id === tgt.id` with first-hit-focus semantics — see Architecture Steps 2–3.)

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -44,8 +44,9 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat simulator now models bomb splash-on-death: when a ship is destroyed while still carrying un-detonated bombs, each adjacent ally takes a share of every bomb's damage (25% at tier 1, 50% at tier 2, 75% at tier 3). This is positional, so it only applies in battles with board positions.",
     'Voidfire Catalyst implant now also amplifies bomb splash damage — when a bomb-carrier is destroyed, the splash damage dealt to adjacent ships is increased by Voidfire Catalyst, including its rare and legendary splash-only variants.',
     'Combat & DPS simulators now model the Boost gear set: while a ship wears 4 or more Boost pieces, each timed buff it applies — to itself or its allies — lasts one extra turn.',
-    "Combat simulator now models counterattacks: one of your ships with a 'when directly damaged' passive (e.g. Stalwart) strikes back at the attacker for a share of its own attack — full damage that can crit and kill. Enemy-side counters are coming in a later update.",
+    "Combat simulator now models counterattacks: one of your ships with a 'when directly damaged' passive (e.g. Stalwart) strikes back at the attacker for a share of its own attack — full damage that can crit and kill.",
     'Combat simulator now models more counterattackers: Nyxen strikes back when its shield is directly hit, and Centurion retaliates when it or an adjacent ally is directly damaged.',
+    'Combat simulator: enemy ships now react when you hit them — enemy counterattackers (Stalwart, Nyxen, Centurion) strike back, and enemy on-hit reactions (self-repairs, defensive buffs, cleanses) now fire, so enemy teams play more like real opponents. Shield-hit counters (Nyxen) now also work for your own ships in positioned battles.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3152,13 +3152,17 @@ const DocumentationPage: React.FC = () => {
                                     modeled too: one of your ships with a &quot;when directly
                                     damaged&quot; passive (such as <strong>Stalwart</strong>)
                                     retaliates against the attacker for a share of its own attack —
-                                    a full hit that can crit and kill (enemy-side counters are
-                                    coming in a later update). Different counterattackers have their
-                                    own triggers: <strong>Nyxen</strong> strikes back only when its
-                                    shield is the part that takes the hit, and{' '}
+                                    a full hit that can crit and kill. Different counterattackers
+                                    have their own triggers: <strong>Nyxen</strong> strikes back
+                                    only when its shield is the part that takes the hit, and{' '}
                                     <strong>Centurion</strong> retaliates when it or an adjacent
-                                    ally is directly damaged. More implant and gear-set effects will
-                                    be added in future updates.
+                                    ally is directly damaged. These reactions now fire for{' '}
+                                    <strong>both teams</strong>: enemy ships react when you hit them
+                                    too — enemy counterattackers strike back, and enemy on-hit
+                                    reactions (self-repairs, defensive buffs, cleanses) fire — so
+                                    enemy teams play more like real opponents in positioned battles.
+                                    More implant and gear-set effects will be added in future
+                                    updates.
                                 </p>
                             </div>
                         </div>

--- a/src/utils/combat/__tests__/emitAttacked.test.ts
+++ b/src/utils/combat/__tests__/emitAttacked.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { emitAttacked } from '../emitAttacked';
+import type { CombatEvent } from '../events';
+
+const fakeBus = () => {
+    const events: CombatEvent[] = [];
+    return { events, bus: { on() {}, emit: (e: CombatEvent) => void events.push(e) } };
+};
+
+describe('emitAttacked', () => {
+    it('emits one attacked event per hit outcome with correct flags', () => {
+        const { events, bus } = fakeBus();
+        emitAttacked({
+            bus,
+            round: 2,
+            targetId: 't1',
+            attackerId: 'a1',
+            hitOutcomes: [true, false],
+            isPrimaryTarget: true,
+            shieldWasHit: true,
+            damage: 500,
+        });
+        expect(events).toHaveLength(2);
+        expect(events[0]).toEqual({
+            type: 'attacked',
+            targetId: 't1',
+            attackerId: 'a1',
+            round: 2,
+            isPrimaryTarget: true,
+            shieldWasHit: true,
+            didCrit: true,
+            damage: 500,
+        });
+        expect(events[1]).toEqual({
+            type: 'attacked',
+            targetId: 't1',
+            attackerId: 'a1',
+            round: 2,
+            isPrimaryTarget: true,
+            shieldWasHit: true,
+            damage: 500,
+        });
+    });
+
+    it('omits shieldWasHit/damage when falsy and isPrimaryTarget when false', () => {
+        const { events, bus } = fakeBus();
+        emitAttacked({
+            bus,
+            round: 1,
+            targetId: 't',
+            attackerId: 'a',
+            hitOutcomes: [false],
+            isPrimaryTarget: false,
+            shieldWasHit: false,
+            damage: 0,
+        });
+        expect(events[0]).toEqual({ type: 'attacked', targetId: 't', attackerId: 'a', round: 1 });
+    });
+});

--- a/src/utils/combat/__tests__/enemySideAttacked.integration.test.ts
+++ b/src/utils/combat/__tests__/enemySideAttacked.integration.test.ts
@@ -1,6 +1,10 @@
 /**
- * enemySideAttacked.integration.test.ts — Task 2 (Step 3): POSITIONAL `shieldWasHit` on the
- * enemy→player path so a PLAYER Nyxen counters a POSITIONAL enemy attacker.
+ * enemySideAttacked.integration.test.ts — enemy-side reactive emission (positional two-team sim).
+ *
+ * Task 2 (Step 3): POSITIONAL `shieldWasHit` on the enemy→player path so a PLAYER Nyxen counters
+ * a POSITIONAL enemy attacker (below). Task 3: the symmetric player→enemy `attacked` emit so
+ * ENEMY ships react when the player hits them — enemy Stalwart/Nyxen/Centurion counters + a
+ * representative non-counter on-attacked reactive (see the "Task 3" section further down).
  *
  * The existing Nyxen end-to-end test (counterAttack.integration.test.ts) drives the
  * NON-positional path (`counterBase`, no enemy position/target/pattern), where the enemy's

--- a/src/utils/combat/__tests__/enemySideAttacked.integration.test.ts
+++ b/src/utils/combat/__tests__/enemySideAttacked.integration.test.ts
@@ -1,0 +1,167 @@
+/**
+ * enemySideAttacked.integration.test.ts — Task 2 (Step 3): POSITIONAL `shieldWasHit` on the
+ * enemy→player path so a PLAYER Nyxen counters a POSITIONAL enemy attacker.
+ *
+ * The existing Nyxen end-to-end test (counterAttack.integration.test.ts) drives the
+ * NON-positional path (`counterBase`, no enemy position/target/pattern), where the enemy's
+ * incoming `applyIncomingToTarget` binds shieldBefore/hpDamage/barriered directly so
+ * `shieldWasHit` is computed. The two-team battle sim runs enemy attacks POSITIONALLY
+ * (`drivePositionalApply`), where those locals stayed at 0 → `shieldWasHit` was always false →
+ * a player Nyxen never countered in the positioned sim.
+ *
+ * This test builds a positional two-team battle (mirroring twoTeamBattle.test.ts /
+ * positionalDamage.integration.test.ts): a player FOCUS Nyxen — built via the REAL registry
+ * (`buildShipAbilities`) so its self-shield active + shield-hit counter parse — that acts FIRST
+ * (higher speed) and casts its 15%-Max-HP shield, then a POSITIONAL enemy attacker drains that
+ * shield. The enemy must take counter damage (Nyxen's shield-hit counter fired). This is
+ * impossible today because positional `shieldWasHit` is false → the counter never gates true.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+// Verbatim CSV-derived skill text (docs/ship-skills.csv, Nyxen row). The active grants a
+// self-shield equal to 15% of Max HP; the first passive parses to an on-attacked counter with
+// requireShieldHit:true.
+const NYXEN_ACTIVE =
+    'This Unit <unit-aid>Cleanses 2 bombs</unit-aid>, Grants a <unit-damage>Shield equal to 15%</unit-damage> of its Max HP, and Grants <unit-skill>Atlas Readiness II</unit-skill> for 1 turn.';
+const NYXEN_P1 =
+    'This Unit deals <unit-damage>100% damage</unit-damage> when its Shield is directly damaged.';
+
+/** A Ship carrying Nyxen's active (self-shield) + first passive (shield-hit counter), parsed
+ *  through the real registry → a self-shield ability + an on-attacked counter (requireShieldHit). */
+function nyxenShip(withActiveShield = true): Ship {
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        ...(withActiveShield ? { activeSkillText: NYXEN_ACTIVE } : {}),
+        firstPassiveSkillText: NYXEN_P1,
+    } as Ship;
+}
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+// Origin-only (single-target) footprint.
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+// A no-passive single-hit basic-attack active slot (multiplier 100% = 1x, 1 hit).
+const basicAttack = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: 'esa-basic',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 100 },
+        },
+    ],
+});
+
+// A POSITIONED enemy attacker that fires on the player roster: position + target + pattern + a
+// damage skill so its firing hit produces positionalScalars (the enemy positional branch).
+const offensiveEnemyAt = (
+    id: string,
+    position: Position,
+    selection: ParsedTarget['selection'],
+    attack: number,
+    hp: number,
+    speed: number
+): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack, crit: 0, critDamage: 0, defence: 0, hp, speed },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget(selection),
+        pattern: basePattern(),
+        shipSkills: { slots: [basicAttack()] },
+    }) as EnemyAttacker;
+
+/** Cumulative damage credited to `actorId` across the run via the round perTargetDamage maps. */
+const totalPerTargetDamage = (result: ReturnType<typeof runCombat>, actorId: string): number => {
+    let sum = 0;
+    for (const rd of result.rounds) sum += rd.perTargetDamage?.[actorId] ?? 0;
+    return sum;
+};
+
+/**
+ * A positional two-team battle: the player FOCUS ('attacker', the heal target) is a Nyxen built
+ * from the real registry, placed at M4 with a base pattern, acting FIRST (speed 200) so it casts
+ * its self-shield active before the enemy hits. One positioned enemy ('foe', speed 50) fires
+ * `front` → anchors the front-most player (the focus) → drains its live shield.
+ *
+ * SHIELD HP: focus HP 40_000 → 15% shield = 6_000. Enemy attack 3_000 < 6_000 so the hit dents
+ * (does not fully drain) the shield → shieldWasHit true on a working positional path.
+ */
+const nyxenFocusBattle = (
+    skills: ShipSkills,
+    overrides: Partial<CombatEngineInput> = {}
+): CombatEngineInput => ({
+    attack: 10_000, // Nyxen (counter source) attack → counter = 10000 × 100% = 10000
+    crit: 0, // no crit → deterministic counter
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: skills,
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 3,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 40_000,
+    speed: 200, // acts BEFORE the enemy (speed 50) so the shield is live when the hit arrives
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    enemyAttackers: [offensiveEnemyAt('foe', 'M4', 'front', 3_000, 1_000_000_000, 50)],
+    ...overrides,
+});
+
+describe('Task 2 — POSITIONAL shieldWasHit: player Nyxen counters a positional enemy attacker', () => {
+    it('player Nyxen (live shield) counters the POSITIONAL enemy attacker that dents its shield', () => {
+        // Focus speed 200 casts its 15%-Max-HP self-shield FIRST; the speed-50 positional enemy
+        // then drains a LIVE shield → positional shieldWasHit must be true → the shield-hit counter
+        // fires against the enemy. The enemy's incoming counter damage surfaces via perTargetDamage.
+        const shielded = buildShipAbilities(nyxenShip(/* withActiveShield */ true));
+        const result = runCombat(nyxenFocusBattle(shielded));
+
+        const fired = totalPerTargetDamage(result, 'foe');
+        // Owner attack 10000 × 100% vs defence 0 / neutral affinity / no crit = 10000 per counter.
+        expect(fired).toBeGreaterThan(0);
+        for (const rd of result.rounds) {
+            const dealt = rd.perTargetDamage?.['foe'] ?? 0;
+            if (dealt > 0) expect(dealt).toBeCloseTo(10_000, 6);
+        }
+    });
+
+    it('NEGATIVE control: no self-shield → no shield ever exists → NO counter on the positional path', () => {
+        // Same positional setup but Nyxen has ONLY the passive (no active shield) → the shield never
+        // exists → shieldWasHit never true → the foe takes zero counter damage.
+        const noShield = buildShipAbilities(nyxenShip(/* withActiveShield */ false));
+        const result = runCombat(nyxenFocusBattle(noShield));
+        expect(totalPerTargetDamage(result, 'foe')).toBe(0);
+    });
+});

--- a/src/utils/combat/__tests__/enemySideAttacked.integration.test.ts
+++ b/src/utils/combat/__tests__/enemySideAttacked.integration.test.ts
@@ -18,9 +18,10 @@
  */
 import { describe, it, expect } from 'vitest';
 import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
 import { buildShipAbilities } from '../../abilities/buildShipAbilities';
 import { Ship } from '../../../types/ship';
-import { ShipSkills } from '../../../types/abilities';
+import { Ability, ShipSkills } from '../../../types/abilities';
 import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
 import type { Position } from '../../../types/encounters';
 
@@ -163,5 +164,319 @@ describe('Task 2 — POSITIONAL shieldWasHit: player Nyxen counters a positional
         const noShield = buildShipAbilities(nyxenShip(/* withActiveShield */ false));
         const result = runCombat(nyxenFocusBattle(noShield));
         expect(totalPerTargetDamage(result, 'foe')).toBe(0);
+    });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Task 3 — PLAYER→ENEMY `attacked` emit: ENEMY ships react when the PLAYER hits them.
+//
+// The reverse direction of Task 2: the player FOCUS ('attacker') is a positional attacker
+// (position + target + pattern + a damage active); the ENEMY is the real reactive ship built
+// via the registry (Stalwart/Nyxen/Centurion) OR carrying an injected non-counter on-attacked
+// reaction (Second Wind). The player→enemy positional firing hit must now emit `attacked` for
+// the focus enemy victim so the enemy's `on-attacked`/`on-ally-attacked` reactives wake.
+//
+// READ MECHANISMS:
+//   - ENEMY COUNTER landed on the player attacker → the player attacker ('attacker') takes
+//     incoming damage, surfaced via the round perTargetDamage map keyed by 'attacker'.
+//   - SECOND WIND self-repair → a `heal-performed` event keyed by the enemy casterId.
+// ───────────────────────────────────────────────────────────────────────────
+
+// Verbatim CSV-derived skill text (docs/ship-skills.csv).
+const STALWART_P1 =
+    'When this Unit is directly damaged as a primary target, it deals <unit-damage>30% damage</unit-damage> to that enemy and gains <unit-skill>Legion Discipline II</unit-skill> for 3 turns.';
+const CENTURION_P2 =
+    'At the start of combat, this Unit gains 750 attack per adjacent ally.<br /><br />When this Unit or an adjacent ally is directly damaged, this Unit retaliates dealing <unit-damage>50%</unit-damage>.';
+
+/** A reactive enemy ship built from verbatim skill text via the real registry. The parsed
+ *  ShipSkills (the on-attacked counter passive) is fed straight into the enemy actor — no active
+ *  needed, the reactive partition picks up the passive. */
+function reactiveEnemyShip(opts: {
+    firstPassiveSkillText?: string;
+    secondPassiveSkillText?: string;
+}): Ship {
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        ...opts,
+    } as Ship;
+}
+
+/** A POSITIONED enemy carrying parsed reactive `shipSkills` (+ an optional extra active so it's a
+ *  fully-real positioned actor). attack/hp/speed control the geometry; counters source from the
+ *  enemy's OWN attack. */
+const reactiveEnemyAt = (
+    id: string,
+    position: Position,
+    shipSkills: ShipSkills,
+    attack: number,
+    hp: number,
+    speed: number
+): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack, crit: 0, critDamage: 0, defence: 0, hp, speed },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        shipSkills,
+    }) as EnemyAttacker;
+
+/**
+ * A positional two-team battle where the PLAYER FOCUS ('attacker') fires at the enemy roster.
+ * Focus at M4, fires `front` with a base pattern + a 100% damage active. The player attacker's HP
+ * is huge so an enemy counter never kills it (we read its incoming counter via perTargetDamage).
+ */
+const playerAttacksEnemy = (
+    enemies: EnemyAttacker[],
+    overrides: Partial<CombatEngineInput> = {}
+): CombatEngineInput => ({
+    attack: 10_000, // player focus attack → the hit that wakes the enemy reactive
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [basicAttack()] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 3,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000, // immortal player attacker so enemy counters never kill it
+    speed: 200, // player acts first → its hit wakes the enemy reactive each round
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    enemyAttackers: enemies,
+    ...overrides,
+});
+
+describe('Task 3 — player→enemy attacked emit: enemy COUNTERS fire when the player hits them', () => {
+    it('enemy STALWART (primary-target counter) strikes the player attacker back', () => {
+        // The player focus fires `front` → anchors the enemy Stalwart (its primary target) → the
+        // new player→enemy attacked emit (isPrimaryTarget:true) wakes Stalwart's on-attacked
+        // counter → it deals 30% of ITS attack (5000 × 30% = 1500) back to the player attacker.
+        const stalwart = buildShipAbilities(
+            reactiveEnemyShip({ firstPassiveSkillText: STALWART_P1 })
+        );
+        const result = runCombat(
+            playerAttacksEnemy([reactiveEnemyAt('foe', 'M4', stalwart, 5_000, 1_000_000_000, 50)])
+        );
+        // Counter landed on the player attacker ('attacker'): 5000 × 30% = 1500 (round 1 base; later
+        // rounds carry the +15% Legion Discipline II self-buff → 1725). Any non-zero round is one.
+        const counterRounds = result.rounds
+            .map((rd) => rd.perTargetDamage?.['attacker'] ?? 0)
+            .filter((d) => d > 0);
+        expect(counterRounds.length).toBeGreaterThan(0);
+        const BASE = 5_000 * 0.3; // 1500
+        const BUFFED = BASE * 1.15; // 1725
+        for (const dealt of counterRounds) {
+            const isBase = Math.abs(dealt - BASE) < 1e-6;
+            const isBuffed = Math.abs(dealt - BUFFED) < 1e-6;
+            expect(isBase || isBuffed).toBe(true);
+        }
+        expect(counterRounds[0]).toBeCloseTo(BASE, 6);
+    });
+
+    it('enemy NYXEN (shield-hit counter) counters ONLY when the player dents its live shield', () => {
+        // ENGINE NOTE: the engine does NOT model enemy self-shields from on-CAST shield abilities
+        // (playerTurn.ts:1962-1964: enemy event-only shields `continue` before granting a pool), so
+        // Nyxen's own active 15%-Max-HP shield never goes live on an enemy. A REACTIVE on-attacked
+        // shield grant DOES create a live enemy pool (it routes through grantShieldToTarget directly,
+        // bypassing the event-only gate). So we pair Nyxen's REAL parsed shield-hit counter
+        // (requireShieldHit) with an injected reactive on-attacked self-shield: round 1 the player
+        // hits an UNSHIELDED enemy (no counter — shieldWasHit false), the reactive grants a shield,
+        // and from round 2 the player dents the LIVE shield → the player→enemy emit carries
+        // shieldWasHit:true → Nyxen's counter fires. This exercises the emit's shieldWasHit gating.
+        const nyxenCounter = buildShipAbilities(nyxenShip(/* withActiveShield */ false));
+        const counterAbility = nyxenCounter.slots
+            .find((s) => s.slot === 'passive')
+            ?.abilities.find((a) => a.type === 'counter');
+        expect(counterAbility).toBeDefined(); // mutation guard: the real shield-hit counter exists
+        const reactiveSelfShield: Ability = {
+            id: 'enemy-reactive-shield',
+            type: 'shield',
+            target: 'self',
+            trigger: 'on-attacked',
+            conditions: [],
+            config: { type: 'shield', pct: 50, basis: 'hp' },
+        };
+        const nyxenShieldHitSkills: ShipSkills = {
+            slots: [{ slot: 'passive', abilities: [reactiveSelfShield, counterAbility!] }],
+        };
+        // Enemy attack 9000 < shield pool (50% of 40_000 = 20_000) so the player's 10_000 dents but
+        // does not drain it from round 2 on. Counter = enemy attack 9000 × 100% = 9000.
+        const result = runCombat(
+            playerAttacksEnemy([
+                reactiveEnemyAt('foe', 'M4', nyxenShieldHitSkills, 9_000, 40_000, 50),
+            ])
+        );
+        const counterRounds = result.rounds
+            .map((rd) => rd.perTargetDamage?.['attacker'] ?? 0)
+            .filter((d) => d > 0);
+        expect(counterRounds.length).toBeGreaterThan(0); // counters DO fire (shielded rounds)
+        for (const dealt of counterRounds) expect(dealt).toBeCloseTo(9_000, 6);
+        // Round 1 (unshielded): the player hit does NOT dent a shield → NO counter that round.
+        expect(result.rounds[0].perTargetDamage?.['attacker'] ?? 0).toBe(0);
+
+        // NEGATIVE control: Nyxen's counter WITHOUT any shield source → the shield never exists →
+        // shieldWasHit never true → no counter ever lands on the player attacker.
+        const noShieldSkills: ShipSkills = {
+            slots: [{ slot: 'passive', abilities: [counterAbility!] }],
+        };
+        const noShieldResult = runCombat(
+            playerAttacksEnemy([reactiveEnemyAt('foe', 'M4', noShieldSkills, 9_000, 40_000, 50)])
+        );
+        expect(totalPerTargetDamage(noShieldResult, 'attacker')).toBe(0);
+    });
+
+    it('enemy CENTURION retaliates when IT is the player focus victim (self counter)', () => {
+        // The player fires `front` → anchors the Centurion enemy directly → its self on-attacked
+        // counter (50% of its attack) strikes the player attacker. Centurion at M2 with no adjacent
+        // ally → start-of-combat attack bonus is 0, so the counter is exactly 5000 × 50% = 2500.
+        const centurion = buildShipAbilities(
+            reactiveEnemyShip({ secondPassiveSkillText: CENTURION_P2 })
+        );
+        const result = runCombat(
+            playerAttacksEnemy([reactiveEnemyAt('foe', 'M4', centurion, 5_000, 1_000_000_000, 50)])
+        );
+        const counterRounds = result.rounds
+            .map((rd) => rd.perTargetDamage?.['attacker'] ?? 0)
+            .filter((d) => d > 0);
+        expect(counterRounds.length).toBeGreaterThan(0);
+        for (const dealt of counterRounds) expect(dealt).toBeCloseTo(2_500, 6);
+    });
+
+    it('enemy CENTURION retaliates when an ADJACENT enemy ally is the focus victim; a NON-adjacent ally does NOT', () => {
+        // Centurion at M2 has the adjacent-ally on-ally-attacked counter. Geometry (board.ts): M2
+        // adjacent = T1,T2,M1,M3,B1,B2; NON-adjacent = M4. The player fires `front`, anchoring the
+        // FRONT-most enemy. We place a victim enemy at M4 (front) so the player hits IT; Centurion
+        // sits behind. ADJACENT case: a Centurion at M3 (adjacent to the M4 victim) retaliates.
+        // NON-adjacent case: Centurion at M1 is NOT adjacent to M4 → no retaliation.
+        const adjCenturion = buildShipAbilities(
+            reactiveEnemyShip({ secondPassiveSkillText: CENTURION_P2 })
+        );
+        // An inert front victim enemy the player anchors (no reactive, big HP).
+        const victimEnemy = (): EnemyAttacker =>
+            ({
+                id: 'victim',
+                stats: {
+                    attack: 0,
+                    crit: 0,
+                    critDamage: 0,
+                    defence: 0,
+                    hp: 1_000_000_000,
+                    speed: 1,
+                },
+                chargeCount: 0,
+                startCharged: false,
+                position: 'M4',
+                target: parsedTarget('front'),
+                pattern: basePattern(),
+                shipSkills: { slots: [] },
+            }) as EnemyAttacker;
+
+        // ADJACENT: Centurion at M3 (adjacent to M4 victim) → its on-ally-attacked counter fires.
+        const adjResult = runCombat(
+            playerAttacksEnemy([
+                victimEnemy(),
+                reactiveEnemyAt('centurion', 'M3', adjCenturion, 5_000, 1_000_000_000, 50),
+            ])
+        );
+        const adjCounter = totalPerTargetDamage(adjResult, 'attacker');
+        expect(adjCounter).toBeGreaterThan(0);
+
+        // NON-ADJACENT: Centurion at M1 (NOT adjacent to M4 victim) → adjacency gate rejects → no
+        // counter ever lands on the player attacker.
+        const farCenturion = buildShipAbilities(
+            reactiveEnemyShip({ secondPassiveSkillText: CENTURION_P2 })
+        );
+        const farResult = runCombat(
+            playerAttacksEnemy([
+                victimEnemy(),
+                reactiveEnemyAt('centurion', 'M1', farCenturion, 5_000, 1_000_000_000, 50),
+            ])
+        );
+        expect(totalPerTargetDamage(farResult, 'attacker')).toBe(0);
+    });
+});
+
+describe('Task 3 — player→enemy attacked emit: a NON-counter enemy reactive (on-attacked self-buff) fires too', () => {
+    // The representative NON-counter on-attacked reactive: a crit-filtered self-BUFF grant injected
+    // directly into the enemy's passive slot (the reactive executor emits `buff-applied` for it —
+    // unlike reactive heals, which are deliberately silent; triggers.ts:1731). Modeled like Second
+    // Wind (on-attacked + crit filter) but as a defensive buff so the fire is event-observable.
+    // Proves the player→enemy emit lights up the GENERAL on-attacked path, not only counters.
+    const SELF_BUFF = 'Reactive Resolve';
+    const selfBuffAbility: Ability = {
+        id: 'enemy-reactive-selfbuff',
+        type: 'buff',
+        target: 'self',
+        trigger: 'on-attacked',
+        triggerCritFilter: 'crit',
+        conditions: [],
+        config: {
+            type: 'buff',
+            buffName: SELF_BUFF,
+            parsedEffects: { defense: 20 },
+            stacks: 1,
+            isStackable: false,
+            duration: 2,
+        },
+    };
+
+    /** An enemy carrying the reactive self-buff in its passive slot. */
+    const reactiveBuffEnemy = (id: string, hp: number): EnemyAttacker =>
+        ({
+            id,
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp, speed: 1 },
+            chargeCount: 0,
+            startCharged: false,
+            position: 'M4',
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            shipSkills: { slots: [{ slot: 'passive', abilities: [selfBuffAbility] }] },
+        }) as EnemyAttacker;
+
+    /** Run a battle capturing buff-applied events. */
+    const runWithBuffs = (input: CombatEngineInput) => {
+        const bus = createEventBus();
+        const buffs: Extract<CombatEvent, { type: 'buff-applied' }>[] = [];
+        bus.on('buff-applied', (e) => buffs.push(e));
+        const result = runCombat({ ...input, bus });
+        return { result, buffs };
+    };
+
+    it('an enemy with an on-attacked self-buff applies it when the player CRITS it', () => {
+        // Player crits every hit (crit 100) → the player→enemy attacked emit carries didCrit:true →
+        // the crit-filtered on-attacked self-buff fires on the enemy each round.
+        const { buffs } = runWithBuffs(
+            playerAttacksEnemy([reactiveBuffEnemy('foe', 100_000)], { crit: 100, critDamage: 0 })
+        );
+        const enemyBuffs = buffs.filter((e) => e.actorId === 'foe' && e.buffName === SELF_BUFF);
+        expect(enemyBuffs.length).toBeGreaterThan(0);
+    });
+
+    it('NEGATIVE control: a NON-crit player hit never fires the crit-filtered enemy reactive', () => {
+        // Player crit 0 → no didCrit on the emitted attacked events → the crit-filtered reactive
+        // never fires → the enemy applies no self-buff.
+        const { buffs } = runWithBuffs(
+            playerAttacksEnemy([reactiveBuffEnemy('foe', 100_000)], { crit: 0 })
+        );
+        expect(buffs.filter((e) => e.actorId === 'foe' && e.buffName === SELF_BUFF)).toHaveLength(
+            0
+        );
     });
 });

--- a/src/utils/combat/__tests__/twoTeamBattle.test.ts
+++ b/src/utils/combat/__tests__/twoTeamBattle.test.ts
@@ -317,13 +317,24 @@ describe('Two-team positional battle — characterization spike (Phase 5 PR 1, T
             (e): e is Extract<CombatEvent, { type: 'attacked' }> => e.type === 'attacked'
         );
         expect(attacked.length).toBeGreaterThan(0);
-        // Anchor victims only: enemy attackers struck players (the anchor `tgt`).
-        expect(attacked.every((e) => ENEMY_IDS.has(e.attackerId))).toBe(true);
-        expect(attacked.every((e) => PLAYER_IDS.has(e.targetId))).toBe(true);
-        // CONTRACT (D-PR16): `attacked` now carries the per-ATTACK aggregate damage (5000 here,
-        // enemyAttack with the victim's defence 0) so Tenacity's >25%-max-HP filter can read it.
-        // Added via conditional spread → present only when damage > 0 (healing-mode 0-damage
-        // events stay byte-identical).
+        // SYMMETRIC EMIT (player→enemy attacked emit): `attacked` now fires for BOTH directions —
+        // enemy attackers struck players (anchor `tgt`) AND player attackers struck enemies — so
+        // enemy on-attacked reactives wake when the player hits them. Every event still pairs an
+        // attacker with the single anchor victim it fired at on the OPPOSING side.
+        const enemyToPlayer = attacked.filter(
+            (e) => ENEMY_IDS.has(e.attackerId) && PLAYER_IDS.has(e.targetId)
+        );
+        const playerToEnemy = attacked.filter(
+            (e) => PLAYER_IDS.has(e.attackerId) && ENEMY_IDS.has(e.targetId)
+        );
+        expect(enemyToPlayer.length).toBeGreaterThan(0); // enemy→player (pre-existing)
+        expect(playerToEnemy.length).toBeGreaterThan(0); // player→enemy (the new symmetric emit)
+        // Every attacked event is one of those two cross-team directions (no same-side / stray ids).
+        expect(attacked.length).toBe(enemyToPlayer.length + playerToEnemy.length);
+        // CONTRACT (D-PR16): `attacked` carries the per-ATTACK aggregate damage (5000 here — both
+        // sides have attack 5000 vs the victim's defence 0) so Tenacity's >25%-max-HP filter can
+        // read it. Added via conditional spread → present only when damage > 0 (healing-mode
+        // 0-damage events stay byte-identical).
         expect(attacked.every((e) => e.damage === 5000)).toBe(true);
     });
 

--- a/src/utils/combat/emitAttacked.ts
+++ b/src/utils/combat/emitAttacked.ts
@@ -1,0 +1,36 @@
+import type { CombatEventBus } from './events';
+
+/**
+ * Emits one `attacked` event per hit (Combat: symmetric reactive emission). Direction-agnostic —
+ * the caller supplies the victim/attacker ids, the per-hit crit list, and the pre-decided
+ * focus-victim signals. Conditional spreads keep the emitted shape minimal (and identical to the
+ * historical inline enemy-turn emit it replaces). DoT/bomb/detonation hits never call this — only
+ * direct weapon hits emit `attacked`.
+ */
+export function emitAttacked(args: {
+    bus: CombatEventBus;
+    round: number;
+    targetId: string;
+    attackerId: string;
+    /** one entry per hit; `true` = that hit critted. */
+    hitOutcomes: boolean[];
+    isPrimaryTarget: boolean;
+    shieldWasHit: boolean;
+    /** per-attack aggregate dealt to the focus victim (Tenacity's >25%-maxHP gate reads this). */
+    damage: number;
+}): void {
+    const { bus, round, targetId, attackerId, hitOutcomes, isPrimaryTarget, shieldWasHit, damage } =
+        args;
+    for (const hitCrit of hitOutcomes) {
+        bus.emit({
+            type: 'attacked',
+            targetId,
+            attackerId,
+            round,
+            ...(isPrimaryTarget ? { isPrimaryTarget: true } : {}),
+            ...(shieldWasHit ? { shieldWasHit: true } : {}),
+            ...(hitCrit ? { didCrit: true } : {}),
+            ...(damage > 0 ? { damage } : {}),
+        });
+    }
+}

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -4393,6 +4393,15 @@ export function runCombat(input: CombatEngineInput): {
                             // Opposing roster + victim wrapper come from the per-side bindings
                             // (player→enemy here). pattern/target are non-null via the `positional` gate.
                             const tb = turnBindings(actor.side);
+                            // Player→enemy `attacked` capture: aggregate the FOCUS enemy victim's
+                            // per-attack damage + OR its shield-hit flag across the attack's hits so
+                            // the post-apply emit wakes the enemy's on-attacked reactives (counters +
+                            // self-repairs/defensive buffs). focusEnemyDamage is the per-victim
+                            // analogue of the enemy side's aggregate `damage` (Tenacity's >25%-maxHP
+                            // gate reads it). Matched by victim.id === tgt.id (first-hit-focus victim).
+                            let focusEnemyDamage = 0;
+                            let focusEnemyShieldWasHit = false;
+                            let focusEnemyHit = false;
                             drivePositionalApply({
                                 scalars: turn.positionalScalars!,
                                 hitCrits: turn.hitCrits,
@@ -4407,9 +4416,37 @@ export function runCombat(input: CombatEngineInput): {
                                 // attacker's standing leeches proc off EACH footprint victim's
                                 // role-scaled dealt damage (origin full, covered half) → restoring
                                 // the leech the positional credit-suppression had silenced.
-                                onVictimResolved: (_victim, damage) =>
-                                    procStandingLeechesPerVictim(actor.id, damage),
+                                onVictimResolved: (victim, damage, outcome) => {
+                                    procStandingLeechesPerVictim(actor.id, damage);
+                                    if (victim.id === tgt.id) {
+                                        focusEnemyHit = true;
+                                        focusEnemyDamage += damage;
+                                        focusEnemyShieldWasHit =
+                                            focusEnemyShieldWasHit ||
+                                            (!outcome.barriered &&
+                                                outcome.shieldBefore > 0 &&
+                                                outcome.hpDamage < damage);
+                                    }
+                                },
                             });
+                            // Player→enemy `attacked` emit (Task 3 — the symmetric reaction). Fires
+                            // once per hit (mirrors the enemy-turn empty-hitCrits fallback) for the
+                            // focus enemy victim → enemy Stalwart/Nyxen/Centurion counter the player
+                            // attacker, and enemy on-hit reactions (Second Wind, etc.) fire.
+                            if (focusEnemyHit) {
+                                const hitOutcomes =
+                                    turn.hitCrits.length > 0 ? turn.hitCrits : [turn.roundCrit];
+                                emitAttacked({
+                                    bus,
+                                    round: r,
+                                    targetId: tgt.id,
+                                    attackerId: actor.id,
+                                    hitOutcomes,
+                                    isPrimaryTarget: true,
+                                    shieldWasHit: focusEnemyShieldWasHit,
+                                    damage: focusEnemyDamage,
+                                });
+                            }
                         }
 
                         // Fold the focus turn's numeric damage into the round accumulator.
@@ -4550,6 +4587,11 @@ export function runCombat(input: CombatEngineInput): {
                             // Same direction as the focus site (player→enemy); keyed to THIS team
                             // actor's position / parsed target / parsed pattern. Non-null via the gate.
                             const tb = turnBindings(actor.side);
+                            // Player→enemy `attacked` capture (Task 3) — mirror of the focus site,
+                            // keyed to THIS walked team actor's focus enemy victim (teamTarget tgt).
+                            let teamFocusEnemyDamage = 0;
+                            let teamFocusEnemyShieldWasHit = false;
+                            let teamFocusEnemyHit = false;
                             drivePositionalApply({
                                 scalars: teamTurn.positionalScalars!,
                                 hitCrits: teamTurn.hitCrits,
@@ -4563,9 +4605,38 @@ export function runCombat(input: CombatEngineInput): {
                                 // E2 Task 3: per-victim standing leech (player→enemy), keyed to
                                 // THIS walked team actor as the acting attacker. Same per-victim
                                 // proc as the focus site.
-                                onVictimResolved: (_victim, damage) =>
-                                    procStandingLeechesPerVictim(actor.id, damage),
+                                onVictimResolved: (victim, damage, outcome) => {
+                                    procStandingLeechesPerVictim(actor.id, damage);
+                                    if (victim.id === tgt.id) {
+                                        teamFocusEnemyHit = true;
+                                        teamFocusEnemyDamage += damage;
+                                        teamFocusEnemyShieldWasHit =
+                                            teamFocusEnemyShieldWasHit ||
+                                            (!outcome.barriered &&
+                                                outcome.shieldBefore > 0 &&
+                                                outcome.hpDamage < damage);
+                                    }
+                                },
                             });
+                            // Player→enemy `attacked` emit (Task 3) — one per walked team actor's
+                            // firing turn for its focus enemy victim. Wakes the enemy's on-attacked
+                            // reactives just like the focus site.
+                            if (teamFocusEnemyHit) {
+                                const hitOutcomes =
+                                    teamTurn.hitCrits.length > 0
+                                        ? teamTurn.hitCrits
+                                        : [teamTurn.roundCrit];
+                                emitAttacked({
+                                    bus,
+                                    round: r,
+                                    targetId: tgt.id,
+                                    attackerId: actor.id,
+                                    hitOutcomes,
+                                    isPrimaryTarget: true,
+                                    shieldWasHit: teamFocusEnemyShieldWasHit,
+                                    damage: teamFocusEnemyDamage,
+                                });
+                            }
                         }
 
                         // Fold the team turn's damage into ITS OWN map entry (post-round assembly

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -64,6 +64,7 @@ import { thresholdShieldForHit } from './thresholdShield';
 import { isStasis, STASIS_BUFFS } from './stasisBuffs';
 import { isDisable } from './disableBuffs';
 import { highestAttackAmong } from './highestAttack';
+import { emitAttacked } from './emitAttacked';
 import { CombatEventBus, createEventBus } from './events';
 import { normalizeTeamActorsToWalked } from './teamActorWalk';
 import { buildBuffDurationExtensionByOwner } from './buffDurationExtension';
@@ -5090,23 +5091,16 @@ export function runCombat(input: CombatEngineInput): {
                             // shieldBefore/hpDamage at 0 → false; no fixture threads enemy positions).
                             const shieldWasHit =
                                 !barriered && shieldBefore > 0 && hpDamage < damage;
-                            for (const hitCrit of hitOutcomes) {
-                                bus.emit({
-                                    type: 'attacked',
-                                    // The actor actually hit this turn (`tgt`). Legacy path:
-                                    // tgt === healTarget! → byte-identical. Positional path: the
-                                    // selected player actor.
-                                    targetId: tgt.id,
-                                    attackerId: actor.id,
-                                    round: r,
-                                    // `tgt` is the focus/primary victim today; covered-cell
-                                    // emission (future) would pass the real per-victim role.
-                                    isPrimaryTarget: true,
-                                    ...(shieldWasHit ? { shieldWasHit: true } : {}),
-                                    ...(hitCrit ? { didCrit: true } : {}),
-                                    ...(damage > 0 ? { damage } : {}),
-                                });
-                            }
+                            emitAttacked({
+                                bus,
+                                round: r,
+                                targetId: tgt.id,
+                                attackerId: actor.id,
+                                hitOutcomes,
+                                isPrimaryTarget: true,
+                                shieldWasHit,
+                                damage,
+                            });
                         }
                     } else {
                         // §4.5 Deferred break: consume any pending Stasis break (real-enemy skip).

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -4941,6 +4941,13 @@ export function runCombat(input: CombatEngineInput): {
                             let shieldBefore = 0;
                             let hpDamage = 0;
                             let barriered = false;
+                            // Symmetric shieldWasHit: capture the FOCUS player victim's shield
+                            // outcome on the positional path (the non-positional `else` branch binds
+                            // shieldBefore/hpDamage/barriered directly; positional leaves them 0).
+                            // First-hit-focus victim matched by victim.id === tgt.id; OR'd across the
+                            // attack's hits so an early shield-denting hit still counts.
+                            let positionalShieldWasHit = false;
+                            let positionalShieldCaptured = false;
                             if (enemyPositional) {
                                 // Opposing roster + victim wrapper from the per-side bindings
                                 // (enemy→player here). PLAYER-side wrapper: each player victim takes
@@ -4983,8 +4990,17 @@ export function runCombat(input: CombatEngineInput): {
                                     // off the damage IT took, with the per-victim Barrier /
                                     // requiresHpDamage gates — mirroring the non-positional block
                                     // below, per victim.
-                                    onVictimResolved: (victim, dmg, outcome) =>
-                                        procTakenLeechesPerVictim(victim, dmg, outcome),
+                                    onVictimResolved: (victim, dmg, outcome) => {
+                                        procTakenLeechesPerVictim(victim, dmg, outcome);
+                                        if (victim.id === tgt.id) {
+                                            positionalShieldCaptured = true;
+                                            positionalShieldWasHit =
+                                                positionalShieldWasHit ||
+                                                (!outcome.barriered &&
+                                                    outcome.shieldBefore > 0 &&
+                                                    outcome.hpDamage < dmg);
+                                        }
+                                    },
                                 });
                             } else {
                                 ({ shieldBefore, hpDamage, barriered } = applyIncomingToTarget(
@@ -5089,8 +5105,11 @@ export function runCombat(input: CombatEngineInput): {
                             // absorbed = damage - hpDamage when not barriered; shieldBefore>0 guards a
                             // "had a shield" precondition. Non-positional path only (positional leaves
                             // shieldBefore/hpDamage at 0 → false; no fixture threads enemy positions).
-                            const shieldWasHit =
-                                !barriered && shieldBefore > 0 && hpDamage < damage;
+                            // Positional path captures the focus victim's per-hit shield outcome
+                            // (Step 3); the non-positional else-branch keeps the aggregate fallback.
+                            const shieldWasHit = positionalShieldCaptured
+                                ? positionalShieldWasHit
+                                : !barriered && shieldBefore > 0 && hpDamage < damage;
                             emitAttacked({
                                 bus,
                                 round: r,


### PR DESCRIPTION
## Summary

Adds the symmetric **player→enemy `attacked` emit** on the positional two-team-sim path, so **enemy ships react when the player hits them** — lighting up all enemy `on-attacked`/`on-ally-attacked` reactives: the counterattackers (Stalwart / Nyxen / Centurion) **and** the broader family (Second Wind-style self-buffs, etc.). Also makes the `shieldWasHit` signal work on the **positional** path in **both** directions, so **player Nyxen and enemy Nyxen both** fire their shield-hit counters in the positioned sim.

**Stacked on #164** (base = `feat/combat-g-counterattack-pr2`) — the enemy-counter tests need PR2's parsed Stalwart/Nyxen/Centurion counters. Retarget to `main` after #164 merges.

This is the deferred "enemy-side" half of sub-project G. Routing was already team-agnostic (`registerReactiveListeners` per side; `enemyReactiveRouting.test.ts`), so no executor/listener/guard changes were needed — only the emit.

## How it works
- The single per-hit `attacked` emit is extracted into a shared, direction-agnostic `emitAttacked` helper, called from the enemy-turn branch (unchanged) and the two player positional branches (new).
- Each direction captures its **focus victim** (`victim.id === tgt.id`, first-hit-focus) outcome from the existing `drivePositionalApply` `onVictimResolved` callback → `shieldWasHit` from the per-victim outcome; `damage` accumulated; per-hit `didCrit` from the turn's `hitCrits`.
- Focus-victim-only, per-hit, **no ping-pong** (counters apply via the no-event path; the once-per-attack guard is untouched). Enemy counters route back onto the player attacker via `applyCounterAttack`'s `attacker.side` sink.

## Commits
1. `refactor: extract emitAttacked helper` (byte-identical)
2. `feat: positional shieldWasHit on enemy→player path` (player Nyxen in positioned sim; byte-identical)
3. `feat: player→enemy attacked emit` (the behavior change)
4. `feat: changelog + docs`
(+ spec, plan, and a test-docstring commit)

## Scope / deferrals
- Non-positional & DPS paths emit nothing (synthetic indestructible enemy sink — not a reactive owner), as designed.
- Per-covered-victim (splash) emission stays deferred on **both** sides (focus-only — symmetric).
- Known pre-existing gaps this PR works around honestly (follow-ups, not regressions): enemy **on-cast** self-shields are engine-inert (enemy Nyxen relies on a reactive shield source); positional detonation isn't per-victim-attributed (E5 deferral), so the emit's `damage` excludes detonation.

## Test Plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (max-warnings 0)
- [x] `npm run audit:skills` → 141 ships / 0 findings
- [x] Full suite `npx vitest run` → 3439 passing
- [x] **Zero `.snap` golden movement** across the whole PR; only existing-test change is the `twoTeamBattle` spike assertion (tightened to assert both directions + no stray events)
- [x] New integration tests (real registry + positional harness, with negative controls): enemy Stalwart / Nyxen / Centurion (self + adjacent + non-adjacent) counters; player Nyxen positional shield-hit counter; a non-counter on-attacked enemy reactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)