### PR TITLE
feat(combat): lift enemy on-cast cleanse removal (symmetric to E5/shield lifts)

### DIFF
--- a/docs/superpowers/plans/2026-06-27-enemy-cleanse-lift.md
+++ b/docs/superpowers/plans/2026-06-27-enemy-cleanse-lift.md
@@ -481,24 +481,92 @@ describe('enemy on-cast cleanse: drives a focus on-enemy-cleansed (Grif) proc on
 
 > If `damageThenDebuff`/`playerVsEnemy`/`selfCleanseSkills` are defined inside another describe's scope, hoist the helpers to module scope (or duplicate minimally) so this new describe can use them. Keep it compiling and DRY.
 
-- [ ] **Step 3: Verify the whole combat suite is green with ZERO `.snap` movement**
+- [ ] **Step 3: Verify the combat suite is green (commit happens after Task 3c)**
 
 Run: `npx vitest --run src/utils/combat`
-Expected: 0 failed. Confirm `git status --porcelain | grep '\.snap'` is empty. Then `npx tsc --noEmit` clean.
+Expected: 0 failed in `src/utils/combat`. Confirm `git status --porcelain | grep '\.snap'` is empty (no combat-suite golden moved). Then `npx tsc --noEmit` clean. **Do NOT commit yet** — the full-suite golden-parity scenario (scenario 28) is handled in Task 3c, and everything lands in ONE combined commit at the end of Task 3c.
 
-- [ ] **Step 4: Single combined commit (lift + all test changes)**
+---
 
-The working tree now holds: the lift (`playerTurn.ts`), the `enemyActions.test.ts` changes (E5 seeding + partial + negative + the retargeted Task 5b), and the integration-test Grif addition. Husky runs the full suite on commit — it should pass now, so do NOT use `--no-verify`.
+## Task 3c: Retarget the golden-parity scenario 28 + deliberate snapshot refresh
+
+**Why this exists:** The full husky suite (`npm test`) runs beyond `src/utils/combat`. A SECOND pre-existing enemy-cleanser fixture lives in `src/utils/calculators/__tests__/healingGoldenParity.test.ts` — **scenario 28** (`scenario28Input` ~line 2355; `snap('enemy cleanse reaction (player damage proc + self-buff on enemy cleanse)', …)` ~line 2416; `it('scenario 28: enemy cleanse → Grif damage proc credited + Vigor Up self-buff from round 2')` ~line 2426). Identical structure to Task 5b: an enemy whose active is `cleanse self count:1` with **no debuff ever applied**, relying on the old always-fire cadence to drive a focus player's on-enemy-cleansed Grif damage proc AND a Yarrow "Vigor Up" self-buff. Under the lift, the no-op cleanse removes nothing → no `cleanse-performed` → neither reactive fires → the assertions AND the snapshot move.
+
+**Decisions (user-approved):** Retarget scenario 28 to assert the NEW symmetric cadence (no-op enemy cleanse → no event → no proc, no buff). Deliberately refresh the scenario-28 snapshot via this file's sanctioned delete-and-rerun discipline (the file forbids `vitest -u`), reviewing the diff to confirm ONLY scenario 28 moved. The positive on-enemy-cleansed chain remains covered by the Grif case added in Task 3b Step 2.
+
+**Files:**
+- Modify: `src/utils/calculators/__tests__/healingGoldenParity.test.ts` (scenario 28 + its comments)
+- Refresh: `src/utils/calculators/__tests__/__snapshots__/healingGoldenParity.test.ts.snap` (scenario-28 entry only)
+
+- [ ] **Step 1: Retarget the scenario 28 assertions**
+
+In the `it('scenario 28: …')` body (~lines 2426–2456), replace the cleanse/Vigor-Up assertions to reflect the no-removal cadence. Keep the no-healing assertions (still true). Replace:
+
+```ts
+        // The enemy cleanse-performed fired with the ENEMY's id each round it cast.
+        expect(cleanses.length).toBeGreaterThan(0);
+        expect(cleanses.every((e) => e.casterId === 'e1' && e.count === 1)).toBe(true);
+```
+with
+```ts
+        // SYMMETRIC CADENCE: the enemy's cleanse has nothing to remove (no debuff was applied
+        // to e1), so real removal is 0 → NO cleanse-performed fires (matches the player path,
+        // and the lift's full-symmetry rule). The on-enemy-cleansed reactives therefore never wake.
+        expect(cleanses).toHaveLength(0);
+```
+
+And replace the Vigor-Up block:
+```ts
+        const buffNamesByRound = result.rounds.map((r) => r.activeSelfBuffs.map((b) => b.buffName));
+        expect(buffNamesByRound[0]).not.toContain('Vigor Up');
+        expect(buffNamesByRound[1]).toContain('Vigor Up');
+        expect(buffNamesByRound[3]).toContain('Vigor Up');
+```
+with
+```ts
+        // No cleanse-performed → the on-enemy-cleansed Vigor Up self-buff is NEVER granted.
+        const buffNamesByRound = result.rounds.map((r) => r.activeSelfBuffs.map((b) => b.buffName));
+        expect(buffNamesByRound.every((names) => !names.includes('Vigor Up'))).toBe(true);
+```
+
+Keep the `directHeal/hotHeal/shield/cleanseCount/incomingDamage` zero assertions and `expect(result.summary.totalHealing).toBe(0)` (all still hold). Rename the `it(...)` title to e.g. `'scenario 28: enemy cleanse with nothing to remove emits no cleanse-performed → no Grif proc, no Vigor Up (symmetric cadence)'`. Update the scenario's narrative comment block (~lines 2330–2354 and 2421–2425, 2450–2454) to describe the no-reaction behavior (the per-round trace now: focus turn does nothing; enemy cleanse removes nothing → no event → no proc/buff; all buckets 0).
+
+- [ ] **Step 2: Deliberately refresh the scenario-28 snapshot (sanctioned delete-and-rerun)**
+
+This file's discipline (header lines 11–18) is: regenerate via DELETE-AND-RERUN, never `vitest -u`. Do exactly:
 
 ```bash
-git add src/utils/combat/playerTurn.ts src/utils/combat/__tests__/enemyActions.test.ts src/utils/combat/__tests__/enemyCleanse.integration.test.ts
+rm src/utils/calculators/__tests__/__snapshots__/healingGoldenParity.test.ts.snap
+npx vitest --run src/utils/calculators/__tests__/healingGoldenParity.test.ts
+git diff -- src/utils/calculators/__tests__/__snapshots__/healingGoldenParity.test.ts.snap
+```
+
+The regenerated file is byte-identical for every scenario whose behavior is unchanged (same input → same output), so the `git diff` MUST show changes confined to the `enemy cleanse reaction (player damage proc + self-buff on enemy cleanse)` snapshot entry only (losing the Vigor Up buff display from round 2 on). **If the diff touches ANY other scenario's entry, STOP and report BLOCKED** — that indicates unexpected drift to investigate, not a clean refresh.
+
+- [ ] **Step 3: Full-suite verification**
+
+Run (the full suite, husky parity): `npm test`
+Expected: 0 failed tests. If any OTHER test fails from the cadence change (a third enemy-cleanser fixture the audit missed), STOP and report BLOCKED with specifics — do not paper over. Then `npx tsc --noEmit` clean, `npm run lint` 0 warnings.
+
+- [ ] **Step 4: Single combined commit (lift + all test changes + refreshed golden)**
+
+The working tree now holds: the lift (`playerTurn.ts`), the `enemyActions.test.ts` changes (E5 seeding + partial + negative + retargeted Task 5b), the integration-test Grif addition (`enemyCleanse.integration.test.ts`), the retargeted scenario 28 (`healingGoldenParity.test.ts`), and the refreshed snapshot. Husky runs the full suite on commit — it should pass now, so do NOT use `--no-verify`.
+
+```bash
+git add src/utils/combat/playerTurn.ts \
+        src/utils/combat/__tests__/enemyActions.test.ts \
+        src/utils/combat/__tests__/enemyCleanse.integration.test.ts \
+        src/utils/calculators/__tests__/healingGoldenParity.test.ts \
+        src/utils/calculators/__tests__/__snapshots__/healingGoldenParity.test.ts.snap
 git commit -m "feat(combat): lift enemy on-cast cleanse removal (symmetric to E5/shield lifts)
 
 Enemy cleanse abilities now remove player-applied debuffs via the side-agnostic
 statusEngine.cleanse over side-aware recipients; cleanse-performed reflects the REAL
 removed count on both sides. Player cleanseCount metric suppressed on the enemy path.
 A no-op enemy cleanse no longer fires cleanse-performed (symmetric cadence) — the
-on-enemy-cleansed Grif chain now requires a real removal.
+on-enemy-cleansed reactor chain (Grif/Yarrow) now requires a real removal. Retargets the
+two pre-existing no-op-cleanse reactor fixtures (enemyActions Task 5b + healingGoldenParity
+scenario 28) to the new cadence; scenario-28 golden deliberately refreshed.
 
 Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ```
@@ -528,8 +596,10 @@ Open `src/pages/DocumentationPage.tsx` and search for any combat/cleanse descrip
 npx tsc --noEmit            # clean
 npm run lint                # 0 warnings
 npm run audit:skills        # 141/0
-npx vitest --run src/utils/combat   # 0 failed, ZERO .snap movement
+npx vitest --run src/utils/combat   # 0 failed, ZERO combat .snap movement
 ```
+
+NOTE: the ONLY intended golden movement in this PR is the deliberate scenario-28 refresh in `healingGoldenParity.test.ts.snap` (Task 3c) — already committed. No combat `.snap` moves. The spec's original "byte-identical / ZERO .snap" claim was scoped too narrowly (it missed the two enemy-cleanser reactor fixtures); update the spec's Testing/golden-audit section to record this in Step 6 below.
 
 Expected: all clean. If `audit:skills` is not 141/0, STOP — the parser corpus is unrelated to this change and a delta means something else moved.
 
@@ -538,11 +608,16 @@ Expected: all clean. If `audit:skills` is not 141/0, STOP — the parser corpus 
 Run: `npm test`
 Expected: 0 failed tests. (If a fresh worktree: copy the main repo's `.env` first or ~14 `.tsx` files fail to *collect* — that's 0 failed tests, a collection error, not a regression.)
 
-- [ ] **Step 5: Commit changelog/docs**
+- [ ] **Step 5: Update the spec's golden-audit section**
+
+In `docs/superpowers/specs/2026-06-27-enemy-cleanse-lift-design.md`, update the Testing/golden-audit and any "byte-identical / ZERO `.snap`" language to record reality: two pre-existing enemy-cleanser reactor fixtures (`enemyActions.test.ts` Task 5b, `healingGoldenParity.test.ts` scenario 28) asserted the old always-fire cadence; both were retargeted to the symmetric no-removal cadence, and the scenario-28 golden was deliberately refreshed (one intended `.snap` move). `git add -f` the spec (gitignored).
+
+- [ ] **Step 6: Commit changelog/docs + spec**
 
 ```bash
 git add src/constants/changelog.ts src/pages/DocumentationPage.tsx
-git commit -m "docs(combat): changelog + docs for enemy cleanse lift
+git add -f docs/superpowers/specs/2026-06-27-enemy-cleanse-lift-design.md
+git commit -m "docs(combat): changelog + docs + spec golden-audit for enemy cleanse lift
 
 Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ```
@@ -553,8 +628,9 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 ## Done criteria
 
-- `enemyCleanse.integration.test.ts` positive (real count 1) + negative (no event) pass; reverting the lift fails exactly those.
-- `enemyActions.test.ts` E5 test passes via 2 seeded debuffs; partial-removal (count 1) and negative-control cases pass.
-- `cleanseCastPath.test.ts` and all other combat tests stay byte-identical / green; ZERO `.snap` movement.
-- `tsc` clean, lint 0 warnings, `audit:skills` 141/0, full suite 0 failed.
-- Changelog line added.
+- `enemyCleanse.integration.test.ts` positive (real count 1) + negative (no event) + Grif positive pass; reverting the lift fails exactly those.
+- `enemyActions.test.ts` E5 test passes via 2 seeded debuffs; partial-removal (count 1), negative-control, and retargeted Task 5b cases pass.
+- `healingGoldenParity.test.ts` scenario 28 retargeted to the no-removal cadence; its golden deliberately refreshed (the ONLY snapshot that moves), diff confined to that one entry.
+- `cleanseCastPath.test.ts` and all other combat tests stay byte-identical / green; ZERO COMBAT `.snap` movement.
+- `tsc` clean, lint 0 warnings, `audit:skills` 141/0, full `npm test` suite 0 failed.
+- Changelog line added; spec golden-audit section updated.

--- a/docs/superpowers/plans/2026-06-27-enemy-cleanse-lift.md
+++ b/docs/superpowers/plans/2026-06-27-enemy-cleanse-lift.md
@@ -402,20 +402,103 @@ Add another `it(...)`:
     });
 ```
 
-- [ ] **Step 5: Run `enemyActions.test.ts` + the integration test — verify all pass**
+- [ ] **Step 5: Run `enemyActions.test.ts` + the integration test — verify the lift cases pass**
 
 Run: `npx vitest --run src/utils/combat/__tests__/enemyActions.test.ts src/utils/combat/__tests__/enemyCleanse.integration.test.ts`
-Expected: ALL PASS.
+Expected: the E5-seeded, partial, and negative cases PASS. The pre-existing "Task 5b" Grif test in `enemyActions.test.ts` will still FAIL here — it is handled in Task 3b below. Do NOT commit yet.
 
-> If you deferred the Task 2 commit (recommended): the working tree now contains the lift (Task 2) + these test updates. Run `npx vitest --run src/utils/combat` to confirm the WHOLE combat suite is green with ZERO `.snap` movement, then make a single combined commit:
+---
+
+## Task 3b: Reconcile the pre-existing "Task 5b" Grif test with the symmetric cadence
+
+**Why this exists:** `enemyActions.test.ts` has a pre-existing test (the `Phase 4c PR 4 Task 5b` describe, ~line 705, `it('enemy cleanse cast emits cleanse-performed (enemy id), no player credit, Grif procs')`) that asserts the OLD always-fire cadence: an enemy whose active is `cleanse self count:1` — **with no debuff ever applied to it** — fires `cleanse-performed` every round and drives a focus-player Grif `on-enemy-cleansed` damage proc (`grifDamage === perRoundProc * 3`). Under the lift, a no-op enemy cleanse removes nothing → no `cleanse-performed` → no Grif proc. This is the exact open-Q2 Arum/Grif reactor behavior change the spec approved (full symmetry). The fix splits cleanly: (a) the old test's harness already models "enemy cleanse with nothing to remove", so it becomes the NEGATIVE/cadence assertion; (b) the positive Grif chain (proc fires on a REAL removal) moves to the positional integration test, where landing a debuff on the enemy already works (Task 1's harness).
+
+Key facts (verified): `creditReactiveDamage(ownerId, amount)` → `creditDamage(ownerId, 'direct', amount)` (engine.ts:3904), so a Grif `on-enemy-cleansed` proc credits the `direct` bucket → surfaces in `result.rounds[r].directDamage` on BOTH paths. A positional player's own ATTACK damage credits the per-target bucket (`perTargetDamage`), NOT `directDamage` — so reading `directDamage` isolates the Grif reactive even when the focus also attacks.
+
+**Files:**
+- Modify: `src/utils/combat/__tests__/enemyActions.test.ts` (the Task 5b test)
+- Modify: `src/utils/combat/__tests__/enemyCleanse.integration.test.ts` (add a Grif positive case)
+
+- [ ] **Step 1: Retarget the Task 5b test to assert the new symmetric cadence**
+
+Update the existing `it('enemy cleanse cast emits cleanse-performed (enemy id), no player credit, Grif procs')` (~line 755) to reflect that a no-op enemy cleanse now removes nothing → no event → no Grif proc. Keep the no-player-credit assertion (still true). Rename the `it(...)` title to describe the new behavior, e.g. `'enemy cleanse with nothing to remove emits NO cleanse-performed and does not proc Grif (symmetric cadence)'`. Replace the three assertion blocks (the `cleanseEvents`, the `enemyRows` credit check, and the `grifDamage` block at ~lines 792–819) with:
+
+```ts
+        // SYMMETRIC CADENCE: the enemy cleanse has nothing to remove (no debuff was applied to
+        // enemy1), so real removal is 0 → NO cleanse-performed fires (matches the player path).
+        const cleanseEvents = events.filter((e) => e.type === 'cleanse-performed');
+        expect(cleanseEvents).toHaveLength(0);
+
+        // The enemy credited NO player healing buckets under its own id (unchanged by the lift).
+        const enemyRows = (result.healing?.rounds ?? []).map((rd) => rd.perActor.get('enemy1'));
+        for (const row of enemyRows) {
+            if (!row) continue;
+            expect(row.cleanseCount ?? 0).toBe(0);
+            expect(row.directHeal ?? 0).toBe(0);
+            expect(row.effectiveHeal ?? 0).toBe(0);
+        }
+
+        // No cleanse-performed → the focus's on-enemy-cleansed Grif proc never fires → no damage.
+        const grifDamage = result.rounds.reduce((sum, rd) => sum + rd.directDamage, 0);
+        expect(grifDamage).toBe(0);
+```
+
+Update the describe-block header comment (~lines 700–704) to note the test now asserts the no-removal cadence; the positive Grif chain lives in `enemyCleanse.integration.test.ts`.
+
+- [ ] **Step 2: Add a Grif positive case to the positional integration test**
+
+In `src/utils/combat/__tests__/enemyCleanse.integration.test.ts`, add a focus-side Grif `on-enemy-cleansed` damage passive to a player who ALSO applies a removable debuff to the enemy, so the enemy's real cleanse drives the proc. Add a new `it(...)` in a new describe block. Build a player slot list = the existing `damageThenDebuff()` active PLUS a Grif passive:
+
+```ts
+const grifPassive = (): ShipSkills['slots'][number] => ({
+    slot: 'passive',
+    abilities: [
+        {
+            id: 'ec-grif',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-enemy-cleansed',
+            conditions: [],
+            config: { type: 'damage', multiplier: 200, noCrit: true },
+        } as unknown as Ability,
+    ],
+});
+
+describe('enemy on-cast cleanse: drives a focus on-enemy-cleansed (Grif) proc on REAL removal', () => {
+    it('enemy removes a player-applied debuff → focus Grif on-enemy-cleansed proc fires', () => {
+        const input = playerVsEnemy(damageThenDebuff(), [enemyAt('foe', 'M4', selfCleanseSkills(2))]);
+        // Inject the Grif passive alongside the player's debuff active.
+        input.shipSkills = { slots: [damageThenDebuff(), grifPassive()] };
+        const result = runCombat(input);
+        // The Grif on-enemy-cleansed reactive credits the 'direct' bucket (creditReactiveDamage →
+        // creditDamage(_, 'direct', _)). The player's OWN attack credits perTargetDamage, so
+        // directDamage isolates the proc. Real removal happened → proc fired → directDamage > 0.
+        const grifDamage = result.rounds.reduce((sum, rd) => sum + rd.directDamage, 0);
+        expect(grifDamage).toBeGreaterThan(0);
+    });
+});
+```
+
+> If `damageThenDebuff`/`playerVsEnemy`/`selfCleanseSkills` are defined inside another describe's scope, hoist the helpers to module scope (or duplicate minimally) so this new describe can use them. Keep it compiling and DRY.
+
+- [ ] **Step 3: Verify the whole combat suite is green with ZERO `.snap` movement**
+
+Run: `npx vitest --run src/utils/combat`
+Expected: 0 failed. Confirm `git status --porcelain | grep '\.snap'` is empty. Then `npx tsc --noEmit` clean.
+
+- [ ] **Step 4: Single combined commit (lift + all test changes)**
+
+The working tree now holds: the lift (`playerTurn.ts`), the `enemyActions.test.ts` changes (E5 seeding + partial + negative + the retargeted Task 5b), and the integration-test Grif addition. Husky runs the full suite on commit — it should pass now, so do NOT use `--no-verify`.
 
 ```bash
-git add src/utils/combat/playerTurn.ts src/utils/combat/__tests__/enemyActions.test.ts
+git add src/utils/combat/playerTurn.ts src/utils/combat/__tests__/enemyActions.test.ts src/utils/combat/__tests__/enemyCleanse.integration.test.ts
 git commit -m "feat(combat): lift enemy on-cast cleanse removal (symmetric to E5/shield lifts)
 
 Enemy cleanse abilities now remove player-applied debuffs via the side-agnostic
 statusEngine.cleanse over side-aware recipients; cleanse-performed reflects the REAL
 removed count on both sides. Player cleanseCount metric suppressed on the enemy path.
+A no-op enemy cleanse no longer fires cleanse-performed (symmetric cadence) — the
+on-enemy-cleansed Grif chain now requires a real removal.
 
 Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ```

--- a/docs/superpowers/plans/2026-06-27-enemy-cleanse-lift.md
+++ b/docs/superpowers/plans/2026-06-27-enemy-cleanse-lift.md
@@ -1,0 +1,477 @@
+# Enemy-side Cleanse Lift Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lift the enemy-side event-only cleanse stub so an enemy ship's on-cast cleanse actually removes player-applied debuffs from itself/its allies, symmetric to the already-shipped E5 enemy-heal lift and #166 enemy-shield lift.
+
+**Architecture:** Unify the two arms of the cleanse branch in `runPlayerTurn`'s heal/shield/cleanse loop. Both player and enemy paths call the already-side-agnostic `statusEngine.cleanse(rid)` over the already-side-aware `recipientsFor(ability.target)` recipients; the ONLY remaining side-difference is suppressing the player-facing `cleanseCount` metric credit on the enemy path. The `cleanse-performed` emit guard (`> 0`) is unchanged, so the event now reflects real removal on both sides.
+
+**Tech Stack:** TypeScript, Vitest, the combat engine under `src/utils/combat/`.
+
+---
+
+## Background (read before starting)
+
+- Spec: `docs/superpowers/specs/2026-06-27-enemy-cleanse-lift-design.md`
+- Handoff: `docs/superpowers/handoffs/2026-06-27-enemy-cleanse-lift-handoff.md`
+- The locked principle is **team-symmetry**: an enemy `else`-stub that removes nothing while the player path removes is a bug. Memory `feedback_engine_team_symmetry`.
+- **Branch:** stack on the current `feat/combat-enemy-oncast-self-shields` (#166) tip. Create the work branch off it. Rebase onto `main` once #165/#166 merge.
+- **Workflow gotchas:** `gh auth switch --user TheSusort` if `gh` is the wrong account. Husky pre-commit runs the full vitest suite. **Never `vitest -u`** (don't auto-update goldens). `docs/` is gitignored → `git add -f` to track spec/plan.
+
+### Verified facts (don't re-investigate)
+
+- `statusEngine.cleanse(actorId, count)` → `removeNewestFirst(actorId, 'debuffs', count)` reads `enemyMaps.get(actorId)` + `accumEnemyMaps.get(actorId)` — side-agnostic, keyed by actor id (`statusEngine.ts:1002-1003`, `968-997`). No new primitive needed.
+- In the positional sim, player-applied debuffs on an enemy land in `enemyMaps` keyed by that enemy's **real actor id** (`playerTurn.ts:987` passes `targetId`; `engine.ts:3618` sets `targetId: tgt.id`).
+- An enemy self-cleanse resolves recipients via `recipientsFor` (`playerTurn.ts:1709-1718`): `self → [actor.id]`, `all-allies → enemyIds`, single `ally → lowestHpEnemyAllyId()`. The same id keys `enemyMaps` → cleanse finds the player-applied debuff.
+
+---
+
+## File Structure
+
+- **Modify:** `src/utils/combat/playerTurn.ts` (~lines 2002–2017) — the cleanse branch. The one production change.
+- **Create:** `src/utils/combat/__tests__/enemyCleanse.integration.test.ts` — positional two-team end-to-end test (mirrors `enemyOnCastShield.integration.test.ts`).
+- **Modify:** `src/utils/combat/__tests__/enemyActions.test.ts` — the existing event-only emission test that moves under the lift, plus a new partial-removal case and an explicit negative control.
+- **Modify:** `src/constants/changelog.ts` — one `UNRELEASED_CHANGES` line.
+
+---
+
+## Task 1: Failing integration test for the enemy cleanse lift
+
+Mirror `enemyOnCastShield.integration.test.ts`. The player (focus, speed 200) applies a removable debuff to the enemy each round, then the enemy (speed 50) casts a `cleanse count: 2` on its turn. The distinguishing observable is the `cleanse-performed` **count**: the old stub emits the nominal `2`; the lift emits the **real removed `1`**. The negative control (no debuff applied → no event) doubles as the cadence-change assertion.
+
+**Files:**
+- Create: `src/utils/combat/__tests__/enemyCleanse.integration.test.ts`
+
+- [ ] **Step 1: Write the failing test file**
+
+```ts
+/**
+ * enemyCleanse.integration.test.ts — enemy on-cast cleanse removal (positional two-team sim).
+ *
+ * Symmetric counterpart to E5's enemy HEAL lift and #166's enemy SHIELD lift: an enemy ship's
+ * on-cast CLEANSE ability now REMOVES debuffs the player applied to it (and emits a
+ * cleanse-performed reflecting the REAL removed count) — previously the enemy arm of the cleanse
+ * branch removed nothing and bumped the count by the nominal cfg.count.
+ *
+ * Distinguishing observable: the player applies ONE removable debuff and the enemy cleanses
+ * count: 2. PRE-FIX the stub emits cleanse-performed { count: 2 } (nominal) and removes nothing;
+ * POST-FIX it emits { count: 1 } (real removal). The negative control (no debuff applied → no
+ * cleanse-performed) is the explicit cadence-change guard (old stub always fired).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import type { ShipSkills, Ability } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+type CleansePerformed = Extract<CombatEvent, { type: 'cleanse-performed' }>;
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+// Player active: a damage hit PLUS a removable debuff ('Attack Down', application 'apply' → lands
+// with no affinity disadvantage) onto the positionally-anchored front enemy.
+const damageThenDebuff = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: 'ec-basic',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 100 },
+        },
+        {
+            id: 'ec-debuff',
+            type: 'debuff',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: {
+                type: 'debuff',
+                buffName: 'Attack Down',
+                parsedEffects: { attack: -30 },
+                stacks: 1,
+                isStackable: false,
+                application: 'apply',
+                duration: 5,
+            },
+        } as unknown as Ability,
+    ],
+});
+
+const damageOnly = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: 'ec-basic',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 100 },
+        },
+    ],
+});
+
+// Enemy whose ACTIVE cleanses up to `count` debuffs off itself (no damage).
+const selfCleanseSkills = (count: number): ShipSkills => ({
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                {
+                    id: 'enemy-oncast-cleanse',
+                    type: 'cleanse',
+                    target: 'self',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config: { type: 'cleanse', count },
+                },
+            ],
+        },
+    ],
+});
+
+const enemyAt = (id: string, position: Position, shipSkills: ShipSkills): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 1_000, crit: 0, critDamage: 0, defence: 0, hp: 40_000, speed: 50 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        shipSkills,
+    }) as EnemyAttacker;
+
+// Player FOCUS at M4 fires `front` (anchors the enemy at M4) and acts FIRST (speed 200), immortal.
+const playerVsEnemy = (
+    playerSlot: ShipSkills['slots'][number],
+    enemies: EnemyAttacker[],
+    overrides: Partial<CombatEngineInput> = {}
+): CombatEngineInput => ({
+    attack: 10_000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [playerSlot] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    speed: 200,
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    enemyAttackers: enemies,
+    ...overrides,
+});
+
+describe('enemy on-cast cleanse: removes a player-applied debuff (real removed count)', () => {
+    it('POSITIVE: player applies 1 debuff, enemy cleanses count 2 → cleanse-performed { count: 1 }', () => {
+        const bus = createEventBus();
+        const events: CleansePerformed[] = [];
+        bus.on('cleanse-performed', (e) => {
+            if (e.type === 'cleanse-performed') events.push(e);
+        });
+        runCombat(
+            playerVsEnemy(damageThenDebuff(), [enemyAt('foe', 'M4', selfCleanseSkills(2))], { bus })
+        );
+        // The enemy's own cleanse-performed, keyed on the enemy id.
+        const enemyCleanse = events.filter((e) => e.casterId === 'foe');
+        expect(enemyCleanse.length).toBe(1);
+        // REAL removal (1) — NOT the nominal cfg.count (2). PRE-FIX this is 2 and the test fails.
+        expect(enemyCleanse[0].count).toBe(1);
+    });
+
+    it('NEGATIVE control: enemy cleanses with NO debuff applied → no cleanse-performed (cadence)', () => {
+        const bus = createEventBus();
+        const events: CleansePerformed[] = [];
+        bus.on('cleanse-performed', (e) => {
+            if (e.type === 'cleanse-performed') events.push(e);
+        });
+        runCombat(
+            playerVsEnemy(damageOnly(), [enemyAt('foe', 'M4', selfCleanseSkills(2))], { bus })
+        );
+        // Nothing to remove → real count 0 → NO event. PRE-FIX the stub fires { count: 2 } and fails.
+        expect(events.filter((e) => e.casterId === 'foe')).toHaveLength(0);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails against current code**
+
+Run: `npx vitest --run src/utils/combat/__tests__/enemyCleanse.integration.test.ts`
+Expected: BOTH cases FAIL — positive expects `count` 1 but gets 2 (nominal stub); negative expects 0 events but the stub fired one with `count: 2`.
+
+> If instead the positive case fails because `enemyCleanse.length` is 0 (no event at all), STOP — that means the enemy cleanse isn't running through the event-only stub in this harness; re-verify the player→enemy debuff actually landed (the `damageThenDebuff` ability) and that the enemy acts. Do not proceed to Task 2 until the failure is the EXPECTED nominal-vs-real-count failure.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add src/utils/combat/__tests__/enemyCleanse.integration.test.ts
+git commit -m "test(combat): failing enemy on-cast cleanse-lift integration test
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+> Note: the husky pre-commit runs the full suite and this test fails by design. Use `--no-verify` for THIS commit only (the failing-test commit), matching the epic's cadence (`19dbbd24 test(combat): failing enemy on-cast self-shield integration test`). Re-enable the hook for all later commits.
+
+```bash
+git commit --no-verify -m "test(combat): failing enemy on-cast cleanse-lift integration test
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Implement the lift
+
+**Files:**
+- Modify: `src/utils/combat/playerTurn.ts` (~lines 2002–2017)
+
+- [ ] **Step 1: Replace the cleanse branch with the unified version**
+
+Find this block (the `else if (cfg.type === 'cleanse')` arm of the heal/shield/cleanse loop):
+
+```ts
+            } else if (cfg.type === 'cleanse') {
+                // Real removal is player-side only (recipientsFor returns player ids; enemy-side
+                // actors run event-only and side-correct enemy routing is deferred). The metric
+                // and the cleanse-performed event reflect the ACTUAL number removed.
+                if (!healEventOnly) {
+                    let removed = 0;
+                    for (const rid of recipientsFor(ability.target)) {
+                        removed += statusEngine.cleanse(rid, cfg.count);
+                    }
+                    cleansePerformedCount += removed;
+                    healing.credit(actor.id, 'cleanseCount', removed);
+                } else {
+                    // Enemy-side event-only: no removal yet — preserve the cleanse-performed
+                    // cadence so on-enemy-cleansed reactors (Arum/Grif) stay unaffected.
+                    cleansePerformedCount += typeof cfg.count === 'number' ? cfg.count : 1;
+                }
+            }
+```
+
+Replace it with:
+
+```ts
+            } else if (cfg.type === 'cleanse') {
+                // Team-symmetric removal: BOTH the player path and the enemy (event-only) path
+                // remove real debuffs via the side-agnostic statusEngine.cleanse over the
+                // side-aware recipientsFor recipients (self/ally/all-allies). cleansePerformedCount
+                // reflects the ACTUAL removed count on both sides, so the cleanse-performed emit
+                // (guarded `> 0`) now fires only on real removal — symmetric to the E5 heal lift and
+                // the #166 shield lift. The ONLY side-difference is the player-facing cleanseCount
+                // metric: the enemy event-only path suppresses it (mirrors E5/#166 credit suppression).
+                let removed = 0;
+                for (const rid of recipientsFor(ability.target)) {
+                    removed += statusEngine.cleanse(rid, cfg.count);
+                }
+                cleansePerformedCount += removed;
+                if (!healEventOnly) healing.credit(actor.id, 'cleanseCount', removed);
+            }
+```
+
+- [ ] **Step 2: Run the Task 1 integration test — verify it passes**
+
+Run: `npx vitest --run src/utils/combat/__tests__/enemyCleanse.integration.test.ts`
+Expected: BOTH cases PASS (positive `count` 1; negative 0 events).
+
+- [ ] **Step 3: Run the broader combat suite — verify no golden movement + spot the moving assertion test**
+
+Run: `npx vitest --run src/utils/combat`
+Expected: the ONLY failures are in `enemyActions.test.ts` (the event-only emission test that asserts the old nominal cadence — fixed in Task 3). **ZERO `.snap` movement.** If any OTHER assertion test fails, STOP and investigate (it indicates an unanticipated fixture with an enemy cleanser).
+
+- [ ] **Step 4: Commit the lift**
+
+```bash
+git add src/utils/combat/playerTurn.ts
+git commit -m "feat(combat): lift enemy on-cast cleanse removal (symmetric to E5/shield lifts)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+> The husky hook will run the full suite; the known `enemyActions.test.ts` failures from this lift mean the hook blocks. Commit with `--no-verify` here (the suite is green except for the deliberately-stale assertions fixed in the very next task), OR reorder to land Task 3 first. RECOMMENDED: do Task 3 before committing Task 2, then make ONE combined commit. See Task 3 Step 5.
+
+---
+
+## Task 3: Update + extend `enemyActions.test.ts`
+
+The "E5: enemy heal RESTORES HP…" test (~line 405) asserts `cleanse.count === 2` but seeds no debuffs on the cleanse recipient. Under the lift, real removal = 0 → no `cleanse-performed` → assertions at ~420–422 fail. Seed 2 removable debuffs on the recipient so real removal = 2 and the assertion holds. Then add a partial-removal case and an explicit negative control.
+
+The cleanse ability in `healCleanseSkills()` targets `'ally'`; for this enemy runtime `recipientsFor('ally')` → `lowestHpEnemyAllyId()` → `'enemy1'` (the sole `enemyIds` entry). So seed the debuffs on `'enemy1'`.
+
+**Files:**
+- Modify: `src/utils/combat/__tests__/enemyActions.test.ts`
+
+- [ ] **Step 1: Add a timed-debuff seeding helper near the top of the `Phase 4c PR 4 Task 5a` describe block**
+
+Add this helper (mirrors `cleanseRemoval.test.ts`'s `mkTimed`) inside the describe, before the `it(...)` blocks. Extend the existing statusEngine import to bring in the type — use the inline `type` modifier to stay clean under `verbatimModuleSyntax`: `import { createStatusEngine, type RegisteredAbilityStatus } from '../statusEngine';` (adapt to whatever the file's current statusEngine import line is):
+
+```ts
+    // Minimal enemy-side timed debuff to seed onto a recipient's per-actor debuff store, so an
+    // enemy cleanse has something REAL to remove. Shape mirrors cleanseRemoval.test.ts's mkTimed.
+    const mkTimedDebuff = (
+        buffName: string
+    ): Extract<RegisteredAbilityStatus, { kind: 'timed' }> => ({
+        kind: 'timed',
+        side: 'enemy',
+        sourceSlot: 'active',
+        conditions: [],
+        duration: 5,
+        payload: { buffName, stacks: 1, parsedEffects: {} },
+    });
+```
+
+- [ ] **Step 2: In the "E5: enemy heal RESTORES HP…" test, seed 2 debuffs on `'enemy1'` before `runPlayerTurn`**
+
+After `const args = makeArgs(makeRuntime(healCleanseSkills(), 'enemy'), spy.healing, true);` and before `runPlayerTurn(args);`, insert:
+
+```ts
+        // Seed two removable debuffs on the cleanse recipient (enemy1 — the lowest-HP enemy ally
+        // the 'ally'-targeted cleanse routes to) so the lift removes a REAL count of 2.
+        args.statusEngine.applyTimedAbilityStatus(1, mkTimedDebuff('Attack Down'), 'attacker', 'enemy1');
+        args.statusEngine.applyTimedAbilityStatus(1, mkTimedDebuff('Defense Down'), 'attacker', 'enemy1');
+```
+
+The existing assertions (`cleanse!.count === 2`, etc.) now hold because real removal = 2. Update the inline comment on the count assertion if present to read "REAL removal of the 2 seeded debuffs (not the nominal cfg.count)".
+
+- [ ] **Step 3: Add a partial-removal test (count 2, only 1 debuff → event count 1)**
+
+Add a new `it(...)` in the same describe block:
+
+```ts
+    it('lift: enemy cleanse count 2 against ONE seeded debuff emits cleanse-performed { count: 1 }', () => {
+        const events: CombatEvent[] = [];
+        const spy = makeHealingSpy();
+        const args = makeArgs(makeRuntime(healCleanseSkills(), 'enemy'), spy.healing, true);
+        // Only ONE removable debuff exists → real removal clamps to 1, NOT the nominal cfg.count 2.
+        args.statusEngine.applyTimedAbilityStatus(1, mkTimedDebuff('Attack Down'), 'attacker', 'enemy1');
+        args.bus.on('cleanse-performed', (e) => events.push(e));
+
+        runPlayerTurn(args);
+
+        const cleanse = events.find((e) => e.type === 'cleanse-performed');
+        expect(cleanse).toBeDefined();
+        expect(cleanse!.casterId).toBe('enemy1');
+        expect(cleanse!.count).toBe(1);
+        // Still no player metric credit on the enemy path.
+        expect(spy.credits).toHaveLength(0);
+    });
+```
+
+- [ ] **Step 4: Add an explicit negative control (no debuff → no cleanse-performed)**
+
+Add another `it(...)`:
+
+```ts
+    it('lift: enemy cleanse with NO seeded debuff removes nothing and emits no cleanse-performed', () => {
+        const events: CombatEvent[] = [];
+        const spy = makeHealingSpy();
+        const args = makeArgs(makeRuntime(healCleanseSkills(), 'enemy'), spy.healing, true);
+        // No debuffs seeded on enemy1 → real removal 0 → cleanse-performed must NOT fire (cadence
+        // change from the old stub, which always fired by nominal count).
+        args.bus.on('cleanse-performed', (e) => events.push(e));
+
+        runPlayerTurn(args);
+
+        expect(events.find((e) => e.type === 'cleanse-performed')).toBeUndefined();
+        expect(spy.credits).toHaveLength(0);
+    });
+```
+
+- [ ] **Step 5: Run `enemyActions.test.ts` + the integration test — verify all pass**
+
+Run: `npx vitest --run src/utils/combat/__tests__/enemyActions.test.ts src/utils/combat/__tests__/enemyCleanse.integration.test.ts`
+Expected: ALL PASS.
+
+> If you deferred the Task 2 commit (recommended): the working tree now contains the lift (Task 2) + these test updates. Run `npx vitest --run src/utils/combat` to confirm the WHOLE combat suite is green with ZERO `.snap` movement, then make a single combined commit:
+
+```bash
+git add src/utils/combat/playerTurn.ts src/utils/combat/__tests__/enemyActions.test.ts
+git commit -m "feat(combat): lift enemy on-cast cleanse removal (symmetric to E5/shield lifts)
+
+Enemy cleanse abilities now remove player-applied debuffs via the side-agnostic
+statusEngine.cleanse over side-aware recipients; cleanse-performed reflects the REAL
+removed count on both sides. Player cleanseCount metric suppressed on the enemy path.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Changelog, docs, and final verification gates
+
+**Files:**
+- Modify: `src/constants/changelog.ts`
+
+- [ ] **Step 1: Add a changelog line**
+
+Insert a new entry into the `UNRELEASED_CHANGES` array in `src/constants/changelog.ts` (append after the last existing string, before the closing `];`):
+
+```ts
+    'Combat simulator: enemy ships that cast a cleanse skill now actually remove the debuffs you applied to them, instead of the cleanse having no effect. Skills that trigger off an enemy being cleansed (such as Arum and Grif) now fire only when a debuff is really removed.',
+```
+
+- [ ] **Step 2: Check in-app docs**
+
+Open `src/pages/DocumentationPage.tsx` and search for any combat/cleanse description that claims enemy cleanses are inert or unsupported. If present, update it to reflect that enemy cleanses now remove debuffs. If there's no such mention, no change is needed (note this in the task summary).
+
+- [ ] **Step 3: Run the full verification gates**
+
+```bash
+npx tsc --noEmit            # clean
+npm run lint                # 0 warnings
+npm run audit:skills        # 141/0
+npx vitest --run src/utils/combat   # 0 failed, ZERO .snap movement
+```
+
+Expected: all clean. If `audit:skills` is not 141/0, STOP — the parser corpus is unrelated to this change and a delta means something else moved.
+
+- [ ] **Step 4: Run the complete test suite once (husky parity)**
+
+Run: `npm test`
+Expected: 0 failed tests. (If a fresh worktree: copy the main repo's `.env` first or ~14 `.tsx` files fail to *collect* — that's 0 failed tests, a collection error, not a regression.)
+
+- [ ] **Step 5: Commit changelog/docs**
+
+```bash
+git add src/constants/changelog.ts src/pages/DocumentationPage.tsx
+git commit -m "docs(combat): changelog + docs for enemy cleanse lift
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+(Drop `DocumentationPage.tsx` from the `git add` if Step 2 made no change.)
+
+---
+
+## Done criteria
+
+- `enemyCleanse.integration.test.ts` positive (real count 1) + negative (no event) pass; reverting the lift fails exactly those.
+- `enemyActions.test.ts` E5 test passes via 2 seeded debuffs; partial-removal (count 1) and negative-control cases pass.
+- `cleanseCastPath.test.ts` and all other combat tests stay byte-identical / green; ZERO `.snap` movement.
+- `tsc` clean, lint 0 warnings, `audit:skills` 141/0, full suite 0 failed.
+- Changelog line added.

--- a/docs/superpowers/specs/2026-06-27-enemy-cleanse-lift-design.md
+++ b/docs/superpowers/specs/2026-06-27-enemy-cleanse-lift-design.md
@@ -135,20 +135,34 @@ removal = 2 and `cleanse.count === 2` holds — turning the assertion into a gen
 Add a negative-control assertion in the same suite: with no debuffs seeded, no `cleanse-performed`
 fires (makes the symmetry behavior change explicit).
 
+### Update: partial-removal case in `enemyActions.test.ts`
+
+Add a partial-removal assertion to the same suite — this is the crux of the symmetry fix and the
+case where the old stub diverged most. `statusEngine.cleanse(rid, count)` clamps to available
+candidates (`Math.min(count, candidates.length)`, statusEngine.ts:994), so an enemy cleanse with
+`count: 2` against **only 1** removable debuff fires `cleanse-performed` with `count === 1` — not
+the nominal 2 the old stub always bumped. Assert this explicitly.
+
 ### New: `enemyCleanse.integration.test.ts`
 
 Mirror `enemyOnCastShield.integration.test.ts` — real skill registry + positional two-team
-harness:
+harness. Real cleanse actives (e.g. Cultivator, Hayyan) bundle cleanse with shields/buffs/heals,
+so all assertions must scope to the **`cleanse-performed`** event specifically (not "no events"),
+and isolate the cleanse observable from co-bundled effects:
 - **Positive:** an enemy with a cleanse active + the player has landed a removable debuff on that
   enemy → after the enemy's cast, the debuff is gone (assert via status snapshot / debuff-derived
   observable, or a `cleanse-performed` count reflecting REAL removal).
-- **Negative control:** enemy with no removable debuff → nothing removed, no event.
+- **Negative control:** enemy with no removable debuff → nothing removed, **no `cleanse-performed`
+  fires** (assert on that event's absence specifically).
 - **Revert check:** reverting the lift makes exactly the positive case fail.
 
 ### Player-side regression guard
 
-An existing player cleanse test stays **byte-identical** (the `if (!healEventOnly)` credit path
-is unchanged for the player; player removal already happened pre-lift).
+The dedicated player cleanse cast-path test `cleanseCastPath.test.ts` stays **byte-identical**
+(player-only path, untouched by the `else`-branch change; player removal already happened
+pre-lift). Note: the `enemyActions.test.ts` "normal mode (healEventOnly false)" test (~lines
+437–470) already seeds debuffs and asserts real removal on the player branch — it is already
+correct and must NOT move.
 
 ### Golden audit
 

--- a/docs/superpowers/specs/2026-06-27-enemy-cleanse-lift-design.md
+++ b/docs/superpowers/specs/2026-06-27-enemy-cleanse-lift-design.md
@@ -1,0 +1,186 @@
+# Design: Enemy-side cleanse lift
+
+**Date:** 2026-06-27
+**Status:** Approved (brainstorm complete)
+**Epic:** combat-realism — enemy-side event-only consumption trio (heal / shield / cleanse)
+**Siblings:** E5 enemy-heal lift; #166 enemy on-cast self-shields
+**Handoff:** `docs/superpowers/handoffs/2026-06-27-enemy-cleanse-lift-handoff.md`
+
+---
+
+## Summary
+
+Lift the **event-only cleanse stub** in `src/utils/combat/playerTurn.ts` so enemy cleanse
+abilities actually **remove debuffs**, instead of only bumping a count and emitting the event.
+This completes the enemy event-only consumption trio: enemy heals restore HP (E5), enemy
+on-cast shields grant pools (#166), and now enemy cleanses remove debuffs.
+
+**Guiding principle (locked):** combat-engine work is **team-symmetric** — a ship behaves
+identically whatever side it's on. The enemy-side `else` stub that removes nothing while the
+player path removes is a bug, not a simplification. See memory `feedback_engine_team_symmetry`.
+
+## Background / the gap
+
+`src/utils/combat/playerTurn.ts`, the heal/shield/cleanse consumption loop runs enemy casts in
+event-only mode (`healEventOnly === true`). The cleanse branch (~lines 2002–2017) today:
+
+```ts
+} else if (cfg.type === 'cleanse') {
+    if (!healEventOnly) {
+        let removed = 0;
+        for (const rid of recipientsFor(ability.target)) {
+            removed += statusEngine.cleanse(rid, cfg.count);
+        }
+        cleansePerformedCount += removed;
+        healing.credit(actor.id, 'cleanseCount', removed);
+    } else {
+        // Enemy-side event-only: no removal yet — preserve the cleanse-performed
+        // cadence so on-enemy-cleansed reactors (Arum/Grif) stay unaffected.
+        cleansePerformedCount += typeof cfg.count === 'number' ? cfg.count : 1;
+    }
+}
+```
+
+The `else` (enemy) branch removes **nothing** — it bumps the count by the nominal `count` (or 1)
+so `cleanse-performed` still fires, driving on-enemy-cleansed reactors (Arum/Grif).
+
+## Verification of the key unknown (resolved)
+
+The handoff's open-question #1 — *do player-applied debuffs on an enemy land keyed by that
+enemy's real id in the positional sim, so an enemy cleanse finds them?* — is **resolved: YES**.
+
+Evidence chain (positional two-team sim):
+- Player applies a timed debuff to a specific enemy via
+  `playerTurn.ts:987` → `statusEngine.applyTimedAbilityStatus(r, status, actor.id, targetId)`,
+  where the 4th arg `targetId` is the **real enemy victim id** (sourced from `engine.ts:3618`,
+  `targetId: tgt.id`, `tgt` being a real enemy `CombatActor` from `enemyAttackerActors`).
+- `statusEngine.ts:1136-1137` routes the enemy-side status to
+  `getEnemyMap(enemyTargetId ?? DEFAULT_ENEMY_TARGET)` → keyed by that real enemy id.
+- The enemy self-cleanse calls `cleanse(rid)` where `rid` comes from `recipientsFor('self')`
+  → `[actor.id]` (`playerTurn.ts:1710`) → the enemy's **own real id**.
+- `cleanse(actorId)` → `removeNewestFirst(actorId, 'debuffs', count)` reads
+  `enemyMaps.get(actorId)` + `accumEnemyMaps.get(actorId)` (`statusEngine.ts:1002-1003`, `968-997`)
+  — side-agnostic, keyed by actor id.
+
+So the player applies and the enemy cleanses under the **same real enemy actor id**; the lift
+is observable end-to-end. (The legacy single-attacker DPS path also works, via the shared
+`DEFAULT_ENEMY_TARGET` sentinel on both sides.) No new status-engine primitive is required
+(unlike the reactive-cleanse PR, which added `reduceNewestDebuffDuration`).
+
+## Design
+
+### 1. The lift (playerTurn.ts ~2002–2017)
+
+Unify the cleanse branch so both modes perform real removal over the routed recipients; the
+**only** side-difference is suppressing the player-facing metric credit on the enemy path:
+
+```ts
+} else if (cfg.type === 'cleanse') {
+    let removed = 0;
+    for (const rid of recipientsFor(ability.target)) {
+        removed += statusEngine.cleanse(rid, cfg.count);
+    }
+    cleansePerformedCount += removed;
+    // Player path ONLY: credit the player-facing cleanseCount metric bucket.
+    // Enemy (event-only) path suppresses it — mirrors E5/#166 credit suppression.
+    if (!healEventOnly) healing.credit(actor.id, 'cleanseCount', removed);
+}
+```
+
+- `statusEngine.cleanse(rid)` is already side-agnostic (removes from `enemyMaps.get(rid)`).
+- `recipientsFor(ability.target)` already routes enemy recipients
+  (`self → [actor.id]`, `all-allies → enemyIds`, single `ally → lowestHpEnemyAllyId()`).
+  Cleanse abilities target self/ally/all-allies — all covered. Same routing E5/#166 use.
+- Credit suppression: the enemy path must NOT credit `healing.credit(actor.id, 'cleanseCount', …)`
+  — it's a player-facing metric bucket (mirrors E5/#166).
+
+### 2. Event cadence — full symmetry (locked decision)
+
+The unified code makes `cleansePerformedCount` reflect the **real removed count** on both sides.
+The existing emit guard already does the right thing:
+
+```ts
+if (cleansePerformedCount > 0) {
+    bus.emit({ type: 'cleanse-performed', casterId: actor.id, count: cleansePerformedCount, round: r });
+}
+```
+
+So `cleanse-performed` fires **only when ≥1 debuff was actually removed**. An enemy cleanse with
+nothing to remove no longer fires the event — on-enemy-cleansed reactors (Arum/Grif) react only
+to real removals, exactly like the player side. **No code change to the emit block;** the cadence
+shift falls out of the unified count.
+
+This is a deliberate, by-symmetry behavior change from the old stub (which always fired ≥1).
+
+### 3. Scope
+
+- All recipients: self / ally / all-allies (mirrors #166's all-recipients decision).
+- Out of scope: positional per-victim **detonation** attribution (the remaining epic deferral,
+  `engine.ts` ~4000 caveat).
+
+## Testing
+
+### Update: `enemyActions.test.ts` "E5: enemy heal RESTORES HP…" (~line 405)
+
+This test asserts `cleanse.count === 2` for an enemy cleanser (`enemy1`) but seeds **no debuffs**
+(`createStatusEngine({ selfBuffs: [], enemyDebuffs: [] })`). Under the lift, real removal = 0 →
+no `cleanse-performed` → the assertions at ~420–422 fail. This is the single moving assertion
+test the handoff flagged (NOT a `.snap` golden).
+
+Fix: seed **2 removable debuffs on the cleanse recipient** before `runPlayerTurn` — the cleanse
+ability targets `'ally'`, which for this enemy runtime routes to `lowestHpEnemyAllyId()` =
+`enemy1` (the sole enemy ally). Apply via
+`statusEngine.applyTimedAbilityStatus(1, <timed debuff status>, undefined, 'enemy1')` so real
+removal = 2 and `cleanse.count === 2` holds — turning the assertion into a genuine positive.
+Add a negative-control assertion in the same suite: with no debuffs seeded, no `cleanse-performed`
+fires (makes the symmetry behavior change explicit).
+
+### New: `enemyCleanse.integration.test.ts`
+
+Mirror `enemyOnCastShield.integration.test.ts` — real skill registry + positional two-team
+harness:
+- **Positive:** an enemy with a cleanse active + the player has landed a removable debuff on that
+  enemy → after the enemy's cast, the debuff is gone (assert via status snapshot / debuff-derived
+  observable, or a `cleanse-performed` count reflecting REAL removal).
+- **Negative control:** enemy with no removable debuff → nothing removed, no event.
+- **Revert check:** reverting the lift makes exactly the positive case fail.
+
+### Player-side regression guard
+
+An existing player cleanse test stays **byte-identical** (the `if (!healEventOnly)` credit path
+is unchanged for the player; player removal already happened pre-lift).
+
+### Golden audit
+
+`npx vitest --run src/utils/combat` → expect **ZERO `.snap` movement** (no fixture equips an enemy
+cleanser, same as #166). Investigate any assertion test that moves beyond the deliberately-updated
+`enemyActions.test.ts` case.
+
+## Verification gates (every epic PR)
+
+`npx tsc --noEmit` clean · `npm run lint` 0 warnings · `npm run audit:skills` 141/0 ·
+`npm test` 0 failed tests · ZERO `.snap` golden movement.
+
+## Branch / stack hygiene
+
+- Branch off the **#166 tip** (current branch `feat/combat-enemy-oncast-self-shields`), matching
+  how #166 stacked on #165. Rebase onto `main` once #165 and #166 land
+  (`git rebase --onto origin/main <166-tip> <cleanse-branch>`).
+- `docs/` is gitignored → `git add -f` to track spec/plan.
+- Workflow gotchas: `gh auth switch --user TheSusort` if `gh` acts as the wrong account; fresh
+  worktrees lack `.env` (~14 `.tsx` test files fail to *collect*, 0 failed tests — copy `.env`
+  in); Husky pre-commit runs the full vitest suite; **never `vitest -u`**.
+
+## Changelog
+
+User-facing combat behaviour change → add a plain-English line to `UNRELEASED_CHANGES` in
+`src/constants/changelog.ts` before committing the implementation (enemy ships that cast cleanse
+now actually remove debuffs you applied to them).
+
+## Pointers
+
+- Memory: `feedback_engine_team_symmetry`, `project_enemy_oncast_self_shields` (#166 — closest
+  template), `project_enemy_side_attacked_emission` (#165), `project_combat_realism_epic`
+  (sub-project C cleanse/purge history), `project_combat_engine_current_state` (workflow gotchas).
+- Sub-project C (cleanse/purge) is marked CLOSED in epic memory, but that closure was player-side
+  + reactive; this enemy-side on-cast cleanse removal is the remaining symmetry gap.

--- a/docs/superpowers/specs/2026-06-27-enemy-cleanse-lift-design.md
+++ b/docs/superpowers/specs/2026-06-27-enemy-cleanse-lift-design.md
@@ -164,16 +164,36 @@ pre-lift). Note: the `enemyActions.test.ts` "normal mode (healEventOnly false)" 
 437–470) already seeds debuffs and asserts real removal on the player branch — it is already
 correct and must NOT move.
 
-### Golden audit
+### Golden audit (as-built)
 
-`npx vitest --run src/utils/combat` → expect **ZERO `.snap` movement** (no fixture equips an enemy
-cleanser, same as #166). Investigate any assertion test that moves beyond the deliberately-updated
-`enemyActions.test.ts` case.
+`npx vitest --run src/utils/combat` → **ZERO combat `.snap` movement** (confirmed: no combat
+fixture equips an enemy cleanser, same as #166).
+
+**Correction to the original "byte-identical / ZERO `.snap`" claim (scoped too narrowly):** the
+implementation surfaced **two** pre-existing enemy-cleanser **reactor** fixtures that asserted the
+OLD always-fire cadence (an enemy `cleanse self count:1` with **no debuff ever applied**, relying
+on a nominal `cleanse-performed` to drive a focus on-enemy-cleansed proc):
+
+1. `enemyActions.test.ts` **Task 5b** Grif test — an assertion-only fixture (no `.snap`). Retargeted
+   to the symmetric **no-removal** cadence: a no-op enemy cleanse removes nothing → no
+   `cleanse-performed` → no Grif proc. The positive Grif chain (proc on a REAL removal) moved to
+   `enemyCleanse.integration.test.ts`.
+2. `healingGoldenParity.test.ts` **scenario 28** — a golden-backed fixture (Grif damage proc +
+   Yarrow "Vigor Up" self-buff off the no-op cleanse). Retargeted to the same no-removal cadence and
+   its golden **deliberately refreshed** via the file's sanctioned delete-and-rerun discipline (NOT
+   `vitest -u`) — **one intended `.snap` move**, diff confined to scenario 28's
+   `enemy cleanse reaction (player damage proc + self-buff on enemy cleanse)` entry only (losing the
+   Vigor Up display from round 2 on).
+
+So the as-built audit is: **zero combat `.snap` movement; exactly one deliberate
+`healingGoldenParity.test.ts.snap` scenario-28 refresh.** This is the full-symmetry cadence the spec
+approved (open-Q2): the on-enemy-cleansed reactor chain now requires a real removal on both sides.
 
 ## Verification gates (every epic PR)
 
 `npx tsc --noEmit` clean · `npm run lint` 0 warnings · `npm run audit:skills` 141/0 ·
-`npm test` 0 failed tests · ZERO `.snap` golden movement.
+`npm test` 0 failed tests · ZERO **combat** `.snap` movement (the single deliberate scenario-28
+golden refresh in `healingGoldenParity.test.ts.snap` is the only intended snapshot change).
 
 ## Branch / stack hygiene
 

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -48,6 +48,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator now models more counterattackers: Nyxen strikes back when its shield is directly hit, and Centurion retaliates when it or an adjacent ally is directly damaged.',
     'Combat simulator: enemy ships now react when you hit them — enemy counterattackers (Stalwart, Nyxen, Centurion) strike back, and enemy on-hit reactions (self-repairs, defensive buffs, cleanses) now fire, so enemy teams play more like real opponents. Shield-hit counters (Nyxen) now also work for your own ships in positioned battles.',
     'Combat simulator: enemy ships now benefit from their on-cast shield skills — they gain shields, absorb your damage, and trigger shield-reactive abilities (e.g. shield-hit counters). Previously these effects only worked on your own ships.',
+    'Combat simulator: enemy ships that cast a cleanse skill now actually remove the debuffs you applied to them, instead of the cleanse having no effect. Skills that trigger off an enemy being cleansed (such as Arum and Grif) now fire only when a debuff is really removed.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/calculators/__tests__/__snapshots__/healingGoldenParity.test.ts.snap
+++ b/src/utils/calculators/__tests__/__snapshots__/healingGoldenParity.test.ts.snap
@@ -2616,12 +2616,7 @@ exports[`healingGoldenParity > enemy cleanse reaction (player damage proc + self
     },
     {
       "action": "active",
-      "activeSelfBuffs": [
-        {
-          "buffName": "Vigor Up",
-          "turnsRemaining": 2,
-        },
-      ],
+      "activeSelfBuffs": [],
       "barrierAbsorbed": 0,
       "chargeCount": 0,
       "charges": 0,
@@ -2631,12 +2626,7 @@ exports[`healingGoldenParity > enemy cleanse reaction (player damage proc + self
       "directHeal": 0,
       "effectiveHealing": 0,
       "enemyEffects": [],
-      "healTargetBuffs": [
-        {
-          "buffName": "Vigor Up",
-          "turnsRemaining": 2,
-        },
-      ],
+      "healTargetBuffs": [],
       "hotHeal": 0,
       "incomingDamage": 0,
       "overheal": 0,
@@ -2649,12 +2639,7 @@ exports[`healingGoldenParity > enemy cleanse reaction (player damage proc + self
     },
     {
       "action": "active",
-      "activeSelfBuffs": [
-        {
-          "buffName": "Vigor Up",
-          "turnsRemaining": 2,
-        },
-      ],
+      "activeSelfBuffs": [],
       "barrierAbsorbed": 0,
       "chargeCount": 0,
       "charges": 0,
@@ -2664,12 +2649,7 @@ exports[`healingGoldenParity > enemy cleanse reaction (player damage proc + self
       "directHeal": 0,
       "effectiveHealing": 0,
       "enemyEffects": [],
-      "healTargetBuffs": [
-        {
-          "buffName": "Vigor Up",
-          "turnsRemaining": 2,
-        },
-      ],
+      "healTargetBuffs": [],
       "hotHeal": 0,
       "incomingDamage": 0,
       "overheal": 0,
@@ -2682,12 +2662,7 @@ exports[`healingGoldenParity > enemy cleanse reaction (player damage proc + self
     },
     {
       "action": "active",
-      "activeSelfBuffs": [
-        {
-          "buffName": "Vigor Up",
-          "turnsRemaining": 2,
-        },
-      ],
+      "activeSelfBuffs": [],
       "barrierAbsorbed": 0,
       "chargeCount": 0,
       "charges": 0,
@@ -2697,12 +2672,7 @@ exports[`healingGoldenParity > enemy cleanse reaction (player damage proc + self
       "directHeal": 0,
       "effectiveHealing": 0,
       "enemyEffects": [],
-      "healTargetBuffs": [
-        {
-          "buffName": "Vigor Up",
-          "turnsRemaining": 2,
-        },
-      ],
+      "healTargetBuffs": [],
       "hotHeal": 0,
       "incomingDamage": 0,
       "overheal": 0,

--- a/src/utils/calculators/__tests__/healingGoldenParity.test.ts
+++ b/src/utils/calculators/__tests__/healingGoldenParity.test.ts
@@ -2340,18 +2340,20 @@ describe('healingGoldenParity', () => {
     // — it emits `cleanse-performed` (casterId = enemy id) each cast, event-only (no enemy
     // numeric, no player-map credit), speed 50 → acts AFTER the focus.
     //
+    // SYMMETRIC CADENCE (post enemy-cleanse lift): the enemy's cleanse has NOTHING to remove —
+    // no debuff is ever applied to e1 — so real removal is 0 → NO `cleanse-performed` fires
+    // (matching the player path and the lift's full-symmetry rule). The on-enemy-cleansed
+    // reactives therefore NEVER wake, so neither the Grif damage proc nor the Yarrow Vigor Up
+    // self-buff ever fire.
+    //
     // Per round (focus speed 100 acts first; nothing to do — its only abilities are reactive;
-    // then the enemy cleanses → both reactives fire):
-    //   R1 focus turn: ctx populated. enemy cleanse → Grif proc credits damage; Vigor Up
-    //       GRANTED to self (lands AFTER the focus's R1 turn → shows from R2).
-    //   R2 enter: activeSelfBuffs/healTargetBuffs = ['Vigor Up'] (the R1 grant). enemy cleanse
-    //       again → proc + re-grant.
-    //   R3, R4: steady — Vigor Up held, reaction fires every round.
+    // then the enemy cleanses → removes nothing → no event → no reactive fires):
+    //   R1–R4: focus turn does nothing (reactive-only); enemy cleanse removes nothing → no
+    //       cleanse-performed → no Grif proc, no Vigor Up grant.
     //   ⇒ No healing of any kind (directHeal/hotHeal/shield/cleanseCount/effective/overheal 0
-    //     every round — the player NEVER heals; the enemy's heal/cleanse are event-only).
-    //     incomingDamage 0 (the enemy has no damage ability). The Vigor Up self-buff appears in
-    //     the round buff display from round 2 (turnsRemaining 2). The Grif damage proc is
-    //     credited to the player damage pool (asserted via the bus, not the healing snapshot).
+    //     every round — the player NEVER heals; the enemy's cleanse removes nothing).
+    //     incomingDamage 0 (the enemy has no damage ability). Vigor Up NEVER appears in the
+    //     round buff display, and the Grif damage proc NEVER credits the player damage pool.
     const scenario28Input = () =>
         BASE({
             rounds: 4,
@@ -2418,21 +2420,22 @@ describe('healingGoldenParity', () => {
         scenario28Input
     );
 
-    // Supplementary: the enemy cleanse fires the player's on-enemy-cleansed reactives every round.
-    // The Grif damage proc credits the player damage pool (not a healing bucket → invisible to the
-    // healing snapshot, asserted off the result), and the Yarrow self-buff surfaces in the round
-    // buff display from round 2 (granted on the round-1 enemy cleanse, which lands after the focus's
-    // round-1 turn). No healing of any kind, and incomingDamage stays 0 (cleanse-only enemy).
-    it('scenario 28: enemy cleanse → Grif damage proc credited + Vigor Up self-buff from round 2', () => {
+    // Supplementary: under the lift the enemy cleanse has nothing to remove → no cleanse-performed
+    // → the player's on-enemy-cleansed reactives never wake. No Grif damage proc, no Yarrow Vigor
+    // Up self-buff, no healing of any kind, and incomingDamage stays 0 (cleanse-only enemy). The
+    // positive on-enemy-cleansed chain (real removal → proc fires) is covered by the Grif case in
+    // enemyCleanse.integration.test.ts.
+    it('scenario 28: enemy cleanse with nothing to remove emits no cleanse-performed → no Grif proc, no Vigor Up (symmetric cadence)', () => {
         idCounter = 0;
         const bus = createEventBus();
         const cleanses: Extract<CombatEvent, { type: 'cleanse-performed' }>[] = [];
         bus.on('cleanse-performed', (e) => cleanses.push(e));
         const result = simulateHealing({ ...scenario28Input(), bus });
 
-        // The enemy cleanse-performed fired with the ENEMY's id each round it cast.
-        expect(cleanses.length).toBeGreaterThan(0);
-        expect(cleanses.every((e) => e.casterId === 'e1' && e.count === 1)).toBe(true);
+        // SYMMETRIC CADENCE: the enemy's cleanse has nothing to remove (no debuff was applied
+        // to e1), so real removal is 0 → NO cleanse-performed fires (matches the player path,
+        // and the lift's full-symmetry rule). The on-enemy-cleansed reactives therefore never wake.
+        expect(cleanses).toHaveLength(0);
 
         // No healing of any kind, and the cleanse-only enemy deals no damage.
         expect(result.rounds.every((r) => r.directHeal === 0)).toBe(true);
@@ -2440,18 +2443,12 @@ describe('healingGoldenParity', () => {
         expect(result.rounds.every((r) => r.cleanseCount === 0)).toBe(true);
         expect(result.rounds.every((r) => r.incomingDamage === 0)).toBe(true);
 
-        // The Vigor Up self-buff surfaces from round 2 (the round-1 grant lands after the focus's
-        // round-1 turn) and persists thereafter.
+        // No cleanse-performed → the on-enemy-cleansed Vigor Up self-buff is NEVER granted.
         const buffNamesByRound = result.rounds.map((r) => r.activeSelfBuffs.map((b) => b.buffName));
-        expect(buffNamesByRound[0]).not.toContain('Vigor Up');
-        expect(buffNamesByRound[1]).toContain('Vigor Up');
-        expect(buffNamesByRound[3]).toContain('Vigor Up');
+        expect(buffNamesByRound.every((names) => !names.includes('Vigor Up'))).toBe(true);
 
-        // The Vigor Up grant fires off the SAME on-enemy-cleansed trigger + firing slot as the
-        // Grif damage proc, so its appearance proves that reactive path resolves. The damage proc
-        // itself credits the player DAMAGE pool (NOT a healing bucket), which the healing result
-        // does not expose — the sister buff is the observable proof the reaction fired, and no
-        // healing leaked from the enemy's event-only cleanse (totalHealing 0).
+        // No reactive ever fired (neither the Grif damage proc nor the Vigor Up self-buff), and no
+        // healing leaked from the enemy's no-op cleanse.
         expect(result.summary.totalHealing).toBe(0);
     });
 });

--- a/src/utils/combat/__tests__/enemyActions.test.ts
+++ b/src/utils/combat/__tests__/enemyActions.test.ts
@@ -9,7 +9,7 @@ import {
     IntentExecContext,
 } from '../triggers';
 import { createEventBus, CombatEvent } from '../events';
-import { createStatusEngine } from '../statusEngine';
+import { createStatusEngine, type RegisteredAbilityStatus } from '../statusEngine';
 import {
     runPlayerTurn,
     PlayerActorRuntime,
@@ -402,12 +402,39 @@ describe('Phase 4c PR 4 Task 5a: event-only enemy heal/cleanse emission', () => 
         ],
     });
 
+    // Minimal enemy-side timed debuff to seed onto a recipient's per-actor debuff store, so an
+    // enemy cleanse has something REAL to remove. Shape mirrors cleanseRemoval.test.ts's mkTimed.
+    const mkTimedDebuff = (
+        buffName: string
+    ): Extract<RegisteredAbilityStatus, { kind: 'timed' }> => ({
+        kind: 'timed',
+        side: 'enemy',
+        sourceSlot: 'active',
+        conditions: [],
+        duration: 5,
+        payload: { buffName, stacks: 1, parsedEffects: {} },
+    });
+
     it('E5: enemy heal RESTORES HP + emits a real heal-performed amount, still NO player credit', () => {
         const events: CombatEvent[] = [];
         const spy = makeHealingSpy();
         // side:'enemy' → E5 side-aware routing: the 'ally' heal targets the lowest-HP enemy ally
         // (the caster itself here), and applyHealToTarget runs on the enemy path.
         const args = makeArgs(makeRuntime(healCleanseSkills(), 'enemy'), spy.healing, true);
+        // Seed two removable debuffs on the cleanse recipient (enemy1 — the lowest-HP enemy ally
+        // the 'ally'-targeted cleanse routes to) so the lift removes a REAL count of 2.
+        args.statusEngine.applyTimedAbilityStatus(
+            1,
+            mkTimedDebuff('Attack Down'),
+            'attacker',
+            'enemy1'
+        );
+        args.statusEngine.applyTimedAbilityStatus(
+            1,
+            mkTimedDebuff('Defense Down'),
+            'attacker',
+            'enemy1'
+        );
         args.bus.on('heal-performed', (e) => events.push(e));
         args.bus.on('cleanse-performed', (e) => events.push(e));
 
@@ -419,6 +446,7 @@ describe('Phase 4c PR 4 Task 5a: event-only enemy heal/cleanse emission', () => 
         // Both events fired with the enemy actor's id.
         expect(cleanse).toBeDefined();
         expect(cleanse!.casterId).toBe('enemy1');
+        // REAL removal of the 2 seeded debuffs (not the nominal cfg.count).
         expect(cleanse!.count).toBe(2);
         expect(heal).toBeDefined();
         expect(heal!.casterId).toBe('enemy1');
@@ -432,6 +460,43 @@ describe('Phase 4c PR 4 Task 5a: event-only enemy heal/cleanse emission', () => 
         // ...but NOTHING is credited to the player healing buckets, and no shield was granted.
         expect(spy.credits).toHaveLength(0);
         expect(spy.shields).toHaveLength(0);
+    });
+
+    it('lift: enemy cleanse count 2 against ONE seeded debuff emits cleanse-performed { count: 1 }', () => {
+        const events: CombatEvent[] = [];
+        const spy = makeHealingSpy();
+        const args = makeArgs(makeRuntime(healCleanseSkills(), 'enemy'), spy.healing, true);
+        // Only ONE removable debuff exists → real removal clamps to 1, NOT the nominal cfg.count 2.
+        args.statusEngine.applyTimedAbilityStatus(
+            1,
+            mkTimedDebuff('Attack Down'),
+            'attacker',
+            'enemy1'
+        );
+        args.bus.on('cleanse-performed', (e) => events.push(e));
+
+        runPlayerTurn(args);
+
+        const cleanse = events.find((e) => e.type === 'cleanse-performed');
+        expect(cleanse).toBeDefined();
+        expect(cleanse!.casterId).toBe('enemy1');
+        expect(cleanse!.count).toBe(1);
+        // Still no player metric credit on the enemy path.
+        expect(spy.credits).toHaveLength(0);
+    });
+
+    it('lift: enemy cleanse with NO seeded debuff removes nothing and emits no cleanse-performed', () => {
+        const events: CombatEvent[] = [];
+        const spy = makeHealingSpy();
+        const args = makeArgs(makeRuntime(healCleanseSkills(), 'enemy'), spy.healing, true);
+        // No debuffs seeded on enemy1 → real removal 0 → cleanse-performed must NOT fire (cadence
+        // change from the old stub, which always fired by nominal count).
+        args.bus.on('cleanse-performed', (e) => events.push(e));
+
+        runPlayerTurn(args);
+
+        expect(events.find((e) => e.type === 'cleanse-performed')).toBeUndefined();
+        expect(spy.credits).toHaveLength(0);
     });
 
     it('normal mode (healEventOnly false) DOES credit and emit cleanse-performed', () => {
@@ -648,9 +713,11 @@ describe('Phase 4c PR 4 Task 5 fix: HoT ticking is gated behind healEventOnly', 
 
 // ----------------------------------------------------------------------
 // Phase 4c PR 4 Task 5b: integration — a ship-backed enemy attacker whose
-// cast cleanses emits cleanse-performed (casterId = enemy id), credits NO
-// player healing buckets under the enemy id, and a Grif-like player's
-// on-enemy-cleansed damage proc credits the enemy pool.
+// cast cleanses with NOTHING to remove now emits NO cleanse-performed and
+// credits NO player healing buckets under the enemy id (symmetric cadence
+// after the enemy cleanse lift). A no-op enemy cleanse no longer drives a
+// Grif on-enemy-cleansed proc. The POSITIVE Grif chain (proc fires on a
+// REAL removal) lives in enemyCleanse.integration.test.ts.
 // ----------------------------------------------------------------------
 describe('Phase 4c PR 4 Task 5b: enemy cleanse cast → cleanse-performed + Grif proc', () => {
     const ab = (partial: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
@@ -702,7 +769,7 @@ describe('Phase 4c PR 4 Task 5b: enemy cleanse cast → cleanse-performed + Grif
         ...overrides,
     });
 
-    it('enemy cleanse cast emits cleanse-performed (enemy id), no player credit, Grif procs', () => {
+    it('enemy cleanse with nothing to remove emits NO cleanse-performed and does not proc Grif (symmetric cadence)', () => {
         const events: CombatEvent[] = [];
         const bus = createEventBus();
         bus.on('cleanse-performed', (e) => events.push(e));
@@ -739,15 +806,12 @@ describe('Phase 4c PR 4 Task 5b: enemy cleanse cast → cleanse-performed + Grif
             })
         );
 
-        // cleanse-performed fired with the ENEMY's id (every round it cast).
+        // SYMMETRIC CADENCE: the enemy cleanse has nothing to remove (no debuff was applied to
+        // enemy1), so real removal is 0 → NO cleanse-performed fires (matches the player path).
         const cleanseEvents = events.filter((e) => e.type === 'cleanse-performed');
-        expect(cleanseEvents.length).toBeGreaterThan(0);
-        for (const e of cleanseEvents) {
-            expect(e.casterId).toBe('enemy1');
-            expect(e.count).toBe(1);
-        }
+        expect(cleanseEvents).toHaveLength(0);
 
-        // The enemy credited NO player healing buckets under its own id.
+        // The enemy credited NO player healing buckets under its own id (unchanged by the lift).
         const enemyRows = (result.healing?.rounds ?? []).map((rd) => rd.perActor.get('enemy1'));
         for (const row of enemyRows) {
             if (!row) continue;
@@ -756,16 +820,8 @@ describe('Phase 4c PR 4 Task 5b: enemy cleanse cast → cleanse-performed + Grif
             expect(row.effectiveHeal ?? 0).toBe(0);
         }
 
-        // Grif's on-enemy-cleansed damage proc credited the focus player's damage pool
-        // (creditReactiveDamage → direct). The focus has NO cast damage of its own, so any
-        // directDamage in the result comes solely from the on-enemy-cleansed proc. The proc
-        // folds the owner's last-turn ctx bomb-style: focusAttack × multiplier × affinityMult,
-        // with NO defense and NO crit (noCrit). The focus acts before the enemy each round, so
-        // its ctx is already populated when the enemy cleanses — the proc lands every round.
-        // Deterministic value: multiplier is a raw percentage (200 → 2.0), so the fold divides
-        // by 100: 5000 attack × (200/100) × 1.0 affinityMult (no affinity set) × 3 rounds = 30000.
+        // No cleanse-performed → the focus's on-enemy-cleansed Grif proc never fires → no damage.
         const grifDamage = result.rounds.reduce((sum, rd) => sum + rd.directDamage, 0);
-        const perRoundProc = 5000 * (200 / 100) * 1.0;
-        expect(grifDamage).toBe(perRoundProc * 3);
+        expect(grifDamage).toBe(0);
     });
 });

--- a/src/utils/combat/__tests__/enemyCleanse.integration.test.ts
+++ b/src/utils/combat/__tests__/enemyCleanse.integration.test.ts
@@ -170,3 +170,33 @@ describe('enemy on-cast cleanse: removes a player-applied debuff (real removed c
         expect(events.filter((e) => e.casterId === 'foe')).toHaveLength(0);
     });
 });
+
+const grifPassive = (): ShipSkills['slots'][number] => ({
+    slot: 'passive',
+    abilities: [
+        {
+            id: 'ec-grif',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-enemy-cleansed',
+            conditions: [],
+            config: { type: 'damage', multiplier: 200, noCrit: true },
+        } as unknown as Ability,
+    ],
+});
+
+describe('enemy on-cast cleanse: drives a focus on-enemy-cleansed (Grif) proc on REAL removal', () => {
+    it('enemy removes a player-applied debuff → focus Grif on-enemy-cleansed proc fires', () => {
+        const input = playerVsEnemy(damageThenDebuff(), [
+            enemyAt('foe', 'M4', selfCleanseSkills(2)),
+        ]);
+        // Inject the Grif passive alongside the player's debuff active.
+        input.shipSkills = { slots: [damageThenDebuff(), grifPassive()] };
+        const result = runCombat(input);
+        // The Grif on-enemy-cleansed reactive credits the 'direct' bucket (creditReactiveDamage →
+        // creditDamage(_, 'direct', _)). The player's OWN attack credits perTargetDamage, so
+        // directDamage isolates the proc. Real removal happened → proc fired → directDamage > 0.
+        const grifDamage = result.rounds.reduce((sum, rd) => sum + rd.directDamage, 0);
+        expect(grifDamage).toBeGreaterThan(0);
+    });
+});

--- a/src/utils/combat/__tests__/enemyCleanse.integration.test.ts
+++ b/src/utils/combat/__tests__/enemyCleanse.integration.test.ts
@@ -1,0 +1,172 @@
+/**
+ * enemyCleanse.integration.test.ts — enemy on-cast cleanse removal (positional two-team sim).
+ *
+ * Symmetric counterpart to E5's enemy HEAL lift and #166's enemy SHIELD lift: an enemy ship's
+ * on-cast CLEANSE ability now REMOVES debuffs the player applied to it (and emits a
+ * cleanse-performed reflecting the REAL removed count) — previously the enemy arm of the cleanse
+ * branch removed nothing and bumped the count by the nominal cfg.count.
+ *
+ * Distinguishing observable: the player applies ONE removable debuff and the enemy cleanses
+ * count: 2. PRE-FIX the stub emits cleanse-performed { count: 2 } (nominal) and removes nothing;
+ * POST-FIX it emits { count: 1 } (real removal). The negative control (no debuff applied → no
+ * cleanse-performed) is the explicit cadence-change guard (old stub always fired).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import type { ShipSkills, Ability } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+type CleansePerformed = Extract<CombatEvent, { type: 'cleanse-performed' }>;
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+// Player active: a damage hit PLUS a removable debuff ('Attack Down', application 'apply' → lands
+// with no affinity disadvantage) onto the positionally-anchored front enemy.
+const damageThenDebuff = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: 'ec-basic',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 100 },
+        },
+        {
+            id: 'ec-debuff',
+            type: 'debuff',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: {
+                type: 'debuff',
+                buffName: 'Attack Down',
+                parsedEffects: { attack: -30 },
+                stacks: 1,
+                isStackable: false,
+                application: 'apply',
+                duration: 5,
+            },
+        } as unknown as Ability,
+    ],
+});
+
+const damageOnly = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: 'ec-basic',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 100 },
+        },
+    ],
+});
+
+// Enemy whose ACTIVE cleanses up to `count` debuffs off itself (no damage).
+const selfCleanseSkills = (count: number): ShipSkills => ({
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                {
+                    id: 'enemy-oncast-cleanse',
+                    type: 'cleanse',
+                    target: 'self',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config: { type: 'cleanse', count },
+                },
+            ],
+        },
+    ],
+});
+
+const enemyAt = (id: string, position: Position, shipSkills: ShipSkills): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 1_000, crit: 0, critDamage: 0, defence: 0, hp: 40_000, speed: 50 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        shipSkills,
+    }) as EnemyAttacker;
+
+// Player FOCUS at M4 fires `front` (anchors the enemy at M4) and acts FIRST (speed 200), immortal.
+const playerVsEnemy = (
+    playerSlot: ShipSkills['slots'][number],
+    enemies: EnemyAttacker[],
+    overrides: Partial<CombatEngineInput> = {}
+): CombatEngineInput => ({
+    attack: 10_000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [playerSlot] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    speed: 200,
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    enemyAttackers: enemies,
+    ...overrides,
+});
+
+describe('enemy on-cast cleanse: removes a player-applied debuff (real removed count)', () => {
+    it('POSITIVE: player applies 1 debuff, enemy cleanses count 2 → cleanse-performed { count: 1 }', () => {
+        const bus = createEventBus();
+        const events: CleansePerformed[] = [];
+        bus.on('cleanse-performed', (e) => {
+            if (e.type === 'cleanse-performed') events.push(e);
+        });
+        runCombat(
+            playerVsEnemy(damageThenDebuff(), [enemyAt('foe', 'M4', selfCleanseSkills(2))], { bus })
+        );
+        // The enemy's own cleanse-performed, keyed on the enemy id.
+        const enemyCleanse = events.filter((e) => e.casterId === 'foe');
+        expect(enemyCleanse.length).toBe(1);
+        // REAL removal (1) — NOT the nominal cfg.count (2). PRE-FIX this is 2 and the test fails.
+        expect(enemyCleanse[0].count).toBe(1);
+    });
+
+    it('NEGATIVE control: enemy cleanses with NO debuff applied → no cleanse-performed (cadence)', () => {
+        const bus = createEventBus();
+        const events: CleansePerformed[] = [];
+        bus.on('cleanse-performed', (e) => {
+            if (e.type === 'cleanse-performed') events.push(e);
+        });
+        runCombat(
+            playerVsEnemy(damageOnly(), [enemyAt('foe', 'M4', selfCleanseSkills(2))], { bus })
+        );
+        // Nothing to remove → real count 0 → NO event. PRE-FIX the stub fires { count: 2 } and fails.
+        expect(events.filter((e) => e.casterId === 'foe')).toHaveLength(0);
+    });
+});

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -2000,21 +2000,19 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                     });
                 }
             } else if (cfg.type === 'cleanse') {
-                // Real removal is player-side only (recipientsFor returns player ids; enemy-side
-                // actors run event-only and side-correct enemy routing is deferred). The metric
-                // and the cleanse-performed event reflect the ACTUAL number removed.
-                if (!healEventOnly) {
-                    let removed = 0;
-                    for (const rid of recipientsFor(ability.target)) {
-                        removed += statusEngine.cleanse(rid, cfg.count);
-                    }
-                    cleansePerformedCount += removed;
-                    healing.credit(actor.id, 'cleanseCount', removed);
-                } else {
-                    // Enemy-side event-only: no removal yet — preserve the cleanse-performed
-                    // cadence so on-enemy-cleansed reactors (Arum/Grif) stay unaffected.
-                    cleansePerformedCount += typeof cfg.count === 'number' ? cfg.count : 1;
+                // Team-symmetric removal: BOTH the player path and the enemy (event-only) path
+                // remove real debuffs via the side-agnostic statusEngine.cleanse over the
+                // side-aware recipientsFor recipients (self/ally/all-allies). cleansePerformedCount
+                // reflects the ACTUAL removed count on both sides, so the cleanse-performed emit
+                // (guarded `> 0`) now fires only on real removal — symmetric to the E5 heal lift and
+                // the #166 shield lift. The ONLY side-difference is the player-facing cleanseCount
+                // metric: the enemy event-only path suppresses it (mirrors E5/#166 credit suppression).
+                let removed = 0;
+                for (const rid of recipientsFor(ability.target)) {
+                    removed += statusEngine.cleanse(rid, cfg.count);
                 }
+                cleansePerformedCount += removed;
+                if (!healEventOnly) healing.credit(actor.id, 'cleanseCount', removed);
             }
         }
 

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1846,12 +1846,13 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
             if (c.basis === 'damage-taken') return true;
             return c.basis === 'damage-dealt' && fromPassive;
         };
-        // Event-only mode (enemy walk, Task 5; HP-restore lifted in E5 §4.1): EMIT heal/cleanse
-        // events and (E5) restore each heal recipient's OWN currentHp via the per-victim pool,
-        // but credit NO player healing bucket and never mutate the player heal-target. Shields
-        // and cleanse still mutate NOTHING on the enemy path (deferred to sub-projects H / enemy
-        // cleanse). Scope to the CAST skill only (the spec: "the cast skill carries"), never the
-        // passive. Normal (player/team) mode keeps both slots and credits/mutates as before.
+        // Event-only mode (enemy walk, Task 5): the enemy path now performs the SAME real effects
+        // as the player path — heals restore each recipient's OWN currentHp (E5 §4.1), shields
+        // grant real pools (#166), and cleanse removes real debuffs (this lift) — via the
+        // side-agnostic helpers over recipientsFor; it only credits NO player healing/metric bucket
+        // and never mutates the player heal-target. Scope to the CAST skill only (the spec: "the
+        // cast skill carries"), never the passive. Normal (player/team) mode keeps both slots and
+        // credits/mutates as before.
         const healAbilities = healEventOnly
             ? (gatedSkill?.abilities ?? []).filter((a) => !isHookOwned(a, false))
             : [


### PR DESCRIPTION
## Summary

Completes the enemy event-only consumption trio (heal / shield / **cleanse**). An enemy ship's on-cast **cleanse** ability now actually **removes the debuffs you applied to it**, instead of the old event-only stub that bumped a nominal count and removed nothing. Symmetric to the shipped **E5 enemy-heal lift** and **#166 enemy-shield lift** (team-symmetry: a ship behaves identically on either side).

**The lift** (`src/utils/combat/playerTurn.ts`): unify the cleanse branch so **both** player and enemy paths perform real removal via the side-agnostic `statusEngine.cleanse(rid)` over the side-aware `recipientsFor(ability.target)` recipients (self/ally/all-allies). The **only** side-difference is suppressing the player-facing `cleanseCount` metric credit on the enemy path (`if (!healEventOnly)`). No new status-engine primitive — `cleanse` already reads the side-agnostic per-actor debuff store, keyed by the enemy's real id in the positional sim (verified end-to-end).

**Cadence — full symmetry (deliberate behavior change):** `cleansePerformedCount` now reflects the **real** removed count on both sides, so the unchanged `> 0` emit guard means a **no-op enemy cleanse no longer fires `cleanse-performed`**. On-enemy-cleansed reactors (Arum / Grif / Yarrow) now wake only on a real removal — exactly like the player side.

## Scope note (discovered during impl)

The spec's original "byte-identical / ZERO `.snap`" claim was scoped too narrowly. **Two** pre-existing fixtures asserted the old always-fire cadence and were retargeted to the symmetric no-removal cadence:
- `enemyActions.test.ts` "Task 5b" (assertion-only)
- `healingGoldenParity.test.ts` scenario 28 (golden-backed) — its snapshot was **deliberately refreshed** (sanctioned delete-and-rerun; diff confined to that single entry, dropping the on-cleanse Vigor Up buff). This is the only golden that moves.

The positive on-enemy-cleansed chain is preserved by a new Grif positive case in the integration test.

## Test Plan
- [x] New `enemyCleanse.integration.test.ts` (positional two-team): positive (real count 1 vs nominal 2), negative control (no event), Grif on-enemy-cleansed positive. Reverting the lift fails exactly these.
- [x] `enemyActions.test.ts`: E5 test seeded with 2 real debuffs (count 2), new partial-removal case (count 1), new negative control, retargeted Task 5b.
- [x] `healingGoldenParity.test.ts` scenario 28 retargeted; golden refresh confined to the one entry.
- [x] Player path unchanged; `cleanseCastPath.test.ts` byte-identical.
- [x] `npx tsc --noEmit` clean · `npm run lint` 0 warnings · `npm run audit:skills` 141/0 · `npm test` **3449/0**.

> Stacked on #166 (`feat/combat-enemy-oncast-self-shields`). Retarget base → `main` and rebase once #165/#166 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)