### PR TITLE
feat(combat): per-victim skill-triggered detonation on the positional path (PR1)

### DIFF
--- a/docs/superpowers/plans/2026-06-27-positional-per-victim-detonation.md
+++ b/docs/superpowers/plans/2026-06-27-positional-per-victim-detonation.md
@@ -1,0 +1,221 @@
+# Positional Per-Victim Detonation Attribution — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make skill-triggered and timed bomb/DoT detonation land per footprint victim on the positional path — each victim detonates its own stored containers against its own `currentHp` (so detonation can kill positioned victims and fire per-victim death/reactives) — symmetric across sides.
+
+**Architecture:** Route each victim's detonation payout through the existing per-victim sink `applyVictimDamage` (the same sink the per-victim direct hit and bomb-splash-on-death #161 use). Extract `detonate()`'s per-type payout math into a pure per-victim helper, expose the detonation "recipe" from `runPlayerTurn`, and invoke it per footprint victim at the positional apply site — suppressing the legacy aggregate detonation credit in positional mode. Timed bursts lift the focus-enemy-only gate so each positioned enemy bursts its own containers.
+
+**Tech Stack:** TypeScript, Vitest. Combat engine in `src/utils/combat/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-27-positional-per-victim-detonation-design.md`
+
+**Branch:** stacks on `feat/combat-enemy-cleanse-lift` (confirmed by user 2026-06-27).
+
+---
+
+## Critical conventions (read before any task)
+
+- **Golden discipline (LOAD-BEARING):** NEVER run `vitest -u` to update goldens/snapshots. Hand-validate every positional golden delta. Run the **whole** `npm test` suite for the golden audit — detonation fixtures live outside `src/utils/combat/` too (e.g. `healingGoldenParity`). A non-positional fixture moving = a bug, not a refresh.
+- **Byte-identical guard:** No existing production caller threads `position + target + pattern`, so the positional branch is inert for all current goldens. Every PR here must keep non-positional fixtures byte-identical.
+- **`gh auth switch --user TheSusort`** before any `gh pr` operation.
+- **Worktree setup** (if used): copy main repo's `.env` + `docs/*.csv`, symlink `node_modules` (else `.tsx` collection + `audit:skills`/bio tests fail).
+- **Commit message footer:** `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`
+- **Team symmetry ([[feedback_engine_team_symmetry]]):** a ship behaves identically on either side. PR3 makes this explicit; PR1/PR2 must not bake in a player-centric assumption that PR3 would have to unwind.
+
+---
+
+## Scope across PRs (stacked)
+
+| PR | Scope |
+|----|-------|
+| **PR1** | Player→enemy **skill-triggered** detonation per-victim. Includes the Task-0 spike + the line-5326 seam resolution. |
+| **PR2** | **Timed** bombs + accumulators per positioned enemy (lift the `actor.id === enemy.id` gate). |
+| **PR3** | **Enemy→player** symmetric (same helper via `playerSink`). |
+
+This plan details **PR1** in full. PR2/PR3 are outlined at the end — their concrete tasks are written **after PR1 lands**, because the per-victim helper shape and the 5326 resolution from PR1 Task 0 are their inputs.
+
+---
+
+## PR1 — Player→enemy skill-triggered detonation per-victim
+
+### Task 0: Wiring spike (BLOCKING — resolve before writing implementation code)
+
+**Goal:** Resolve four genuinely-open wiring questions the spec flagged. Output a short "Decisions" subsection appended to THIS plan file, then proceed. No production code in this task except a throwaway spike test if needed (deleted before Task 1).
+
+**Files:**
+- Read: `src/utils/combat/playerTurn.ts:526-591` (`detonate`), `:1500` (call site), `:2081-2093` (`positionalScalars`)
+- Read: `src/utils/combat/engine.ts:4387-4474` (positional gate + credit suppression), `:5289-5326` (focus detonation row + 5326 reconciliation), `:2717-2739` (`applyVictimDamage` opts), `:2956-2989` (bomb-splash precedent)
+- Read: `docs/ship-skills.csv` + `src/utils/skillTextParser.ts` / `detonationsFromSkill` (does detonate co-occur with a damage ability?)
+- Modify: this plan (append "## PR1 Task 0 — Decisions")
+
+- [ ] **Step 1: Resolve detonate-only positional entry.** `positionalScalars` is set ONLY when `hasDamageAbility` (`playerTurn.ts:2081`); the engine's `positional` gate requires `turn.positionalScalars != null` (`engine.ts:4391`). Determine via `docs/ship-skills.csv` + `detonationsFromSkill` whether any real ship has a **detonate-only** skill (detonate with no damage ability). Decision: (a) if detonate always co-occurs with damage → positional gate is sufficient as-is; (b) if detonate-only skills exist → the positional branch entry must ALSO trigger when a detonation recipe is present (widen the gate to `turn.positionalScalars != null || turn.positionalDetonation != null`). Record which. **NOTE for Task 3:** the engine's `positional` local at `:4387` currently ANDs in `positionalScalars != null`; the `args.positional` HINT passed into `runPlayerTurn` (Task 2) is computed independently of `positionalScalars`, so a detonate-only skill CAN get `args.positional: true` (recipe present) while the line-4387 `positional` is false. If detonate-only skills exist, Task 3 must gate the per-victim detonation block on the WIDENED condition, not the unchanged `:4387` local. Record the exact gate expression Task 3 should use.
+
+- [ ] **Step 2: Resolve anchor double-consume.** `detonate()` runs inside `runPlayerTurn` and CONSUMES the anchor's containers (`.length = 0`) + emits `bomb-detonated` + returns the aggregate number. The anchor IS a footprint victim, so per-victim re-detonation would find empty containers. Decision: `runPlayerTurn` must NOT consume/credit/emit detonation in positional mode. Mechanism: pass a `positional` hint into `runPlayerTurn` (the engine knows `isPositional(actor.position, enemyAttackerActors) && target != null && pattern != null` BEFORE the call — only the `hasDamageAbility` sub-condition is post-hoc, and that does not affect whether to SKIP anchor consumption). When the hint is set, `runPlayerTurn` skips the `detonate()` call entirely and instead returns a `positionalDetonation` recipe `{ dets, effectiveAttack, dotMult, affinityMult, detonationMult }` (the inputs `detonate()` would have used, MINUS the per-victim containers/HP which the engine supplies per victim). Confirm this hint is safe (no other in-`runPlayerTurn` consumer depends on detonation having run). Record the exact arg name + recipe shape.
+
+- [ ] **Step 3: Resolve inferno/corrosion shield-bypass flags.** Bomb detonation is precedented: `applyVictimDamage(dmg, victim, sink, { killerId, byDirectDamage: true, bombPortion: dmg, shieldPenetrationPct: 0 })` (full drain, no pen — `engine.ts:2973`). Inferno/corrosion must BYPASS shield (locked H rule). Determine the correct `cause` flags so they skip the shield pool to HP — candidate `{ byDirectDamage: true, shieldPenetrationPct: 100, bombPortion: 0 }` (100% of the direct portion bypasses), vs. whether a dedicated bypass flag is cleaner. Verify against the shield-absorb path (`shieldAbsorb.ts` / the drain inside `applyVictimDamage`). Record the exact flags for each of bomb / inferno / corrosion.
+
+- [ ] **Step 4: Resolve the line-5326 display-vs-HP arithmetic.** Per-victim detonation decrements each victim's `currentHp` via `applyVictimDamage` (it must NOT also feed `cumulativeDamage` → line 5326, else focus enemy is hit twice). But the `detonationDamage` RoundData row (`engine.ts:5386`) + `totalDetonationRaw` summary (`:5309`) must STILL reflect detonation for the focus actor. Determine how `direct` solves the analogous problem (it sources the displayed row from the per-victim path / `roundPerTargetDamage`) and mirror it: decide whether to accumulate per-victim detonation into a per-actor detonation tally for the row, or reuse `focus.detonation` fed from a per-victim credit that does NOT reach `cumulativeDamage`. Record the exact accumulation + which line changes.
+
+- [ ] **Step 5: Append decisions to this plan.** Write "## PR1 Task 0 — Decisions" with the four answers above (entry gate, recipe shape + arg name, per-type cause flags, display accumulation). Subsequent tasks reference these. Commit the plan update:
+
+```bash
+git add -f docs/superpowers/plans/2026-06-27-positional-per-victim-detonation.md
+git commit -m "docs(combat): PR1 Task 0 wiring decisions for per-victim detonation"
+```
+
+---
+
+### Task 1: Pure per-victim detonation helper
+
+**Goal:** Extract `detonate()`'s per-type payout math into a pure, per-victim, testable helper that takes one victim's containers + the attacker recipe and returns the per-type payouts (does NOT apply HP, does NOT mutate the engine — the engine applies + emits). Refactor the existing `detonate()` to call it (byte-identical for non-positional).
+
+**Files:**
+- Create: `src/utils/combat/detonation.ts`
+- Modify: `src/utils/combat/playerTurn.ts:526-591` (`detonate` delegates to the helper)
+- Test: `src/utils/combat/__tests__/detonation.test.ts`
+
+- [ ] **Step 1: Write failing unit tests** for a `detonateContainers(recipe, containers)` helper returning `{ bomb, inferno, corrosion, totalBombStacks }` payouts, consuming (clearing) the containers it detonates. Cover: bomb payout uses per-bomb `affinityMult × (1 + detonationDamageModifier/100)`; inferno uses attacker `effectiveAttack × dotMult × affinityMult × detonationMult`; corrosion uses `min(victimHp, 500_000)` (PER-VICTIM hp passed in); each `det.powerPct/100` factor; empty containers → 0. Mirror the exact arithmetic in `playerTurn.ts:540-588`.
+
+- [ ] **Step 2: Run tests, verify they fail** (helper not defined).
+Run: `npx vitest --run src/utils/combat/__tests__/detonation.test.ts`
+Expected: FAIL (module/function not found).
+
+- [ ] **Step 3: Implement `detonateContainers`** by lifting the three branches verbatim from `detonate()` (`playerTurn.ts:539-589`), parameterized by `victimHp` (for corrosion `baseHp`) and the recipe scalars. Keep the per-type return separate so the engine can emit `dot-detonated` (inferno+corrosion) vs `bomb-detonated` (bomb) distinctly.
+
+- [ ] **Step 4: Refactor `detonate()` to delegate** to `detonateContainers`, passing `args.enemyHp` as `victimHp`, summing the payouts into the returned number, and emitting `bomb-detonated` as before. Verify byte-identical: the non-positional detonation path must be unchanged.
+
+- [ ] **Step 5: Run helper tests + full suite.**
+Run: `npx vitest --run src/utils/combat/__tests__/detonation.test.ts` → PASS
+Run: `npm test` → all green, ZERO goldens moved.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add src/utils/combat/detonation.ts src/utils/combat/__tests__/detonation.test.ts src/utils/combat/playerTurn.ts
+git commit -m "refactor(combat): extract pure per-victim detonateContainers helper"
+```
+
+---
+
+### Task 2: Expose the detonation recipe + skip anchor consumption in positional mode
+
+**Goal:** Per Task-0 Step 2 decision: add the `positional` hint to `PlayerTurnArgs`; when set, `runPlayerTurn` skips `detonate()` (no consume/credit/emit) and returns `positionalDetonation` recipe on the turn result.
+
+**Files:**
+- Modify: `src/utils/combat/playerTurn.ts:223-321` (`PlayerTurnArgs` — add hint), `:130-160` (return type — add `positionalDetonation?`), `:1500-1512` (gate the `detonate()` call), `:2095-2113` (return the recipe)
+- Test: `src/utils/combat/__tests__/detonation.test.ts` (add `runPlayerTurn`-level cases) or a new positional integration test in Task 3
+
+- [ ] **Step 1: Write failing test** — `runPlayerTurn` with the `positional` hint set + a detonate skill + an anchor carrying bombs returns `positionalDetonation` recipe (dets + scalars) AND leaves the anchor's containers UNCONSUMED (the engine will consume per-victim) AND `detonationDamage === 0` (not aggregate-credited). Without the hint → unchanged (recipe absent, containers consumed, `detonationDamage` populated).
+
+- [ ] **Step 2: Run test, verify fail.**
+
+- [ ] **Step 3: Implement.** Add `positional?: boolean` to `PlayerTurnArgs` (name per Task-0). Gate `playerTurn.ts:1500` `detonate()` on `!args.positional`. When `args.positional`, build `positionalDetonation = { dets: detonationsFromSkill(gatedSkill), effectiveAttack, dotMult, affinityMult, detonationMult }` and add to the return; leave `detonationDamage = 0`. Confirm containers untouched (no `.length = 0`).
+
+- [ ] **Step 4: Run test + full suite.** All green, byte-identical (no caller passes `positional: true` yet).
+
+- [ ] **Step 5: Commit.**
+```bash
+git add src/utils/combat/playerTurn.ts src/utils/combat/__tests__/detonation.test.ts
+git commit -m "feat(combat): expose positional detonation recipe; skip anchor consume when positional"
+```
+
+---
+
+### Task 3: Per-victim detonation at the positional apply site + suppress aggregate credit
+
+**Goal:** Wire the engine: pass `positional: true` into `runPlayerTurn` for the focus turn when positional; after `drivePositionalApply`, iterate footprint victims and detonate each victim's own containers via `detonateContainers` → `applyVictimDamage` (per Task-0 cause flags); emit per-victim events; accumulate display total (Task-0 Step 4); suppress the aggregate detonation credit (`engine.ts:4474` joins the `!positional` block).
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts:4336-4343` (pass `positional` into `runPlayerTurn`), `:4392-4474` (per-victim detonation loop + credit suppression), `:5289-5326` (display row sourcing per Task-0 Step 4)
+- Test: `src/utils/combat/__tests__/perVictimDetonation.integration.test.ts` (NEW — harness mirrors `perVictimLeech.test.ts`)
+
+- [ ] **Step 1: Write failing integration tests** (harness = `perVictimLeech.test.ts`: positioned actors, seeded containers, crit 0 → exact integers). Seed bombs on BOTH the origin footprint victim AND a covered footprint victim; fire a positional detonate skill. Assert:
+  - origin victim's bombs detonate full against ITS hp; covered victim's bombs detonate full against ITS hp (covered no longer ignored);
+  - corrosion uses per-victim `min(hp,500k)`;
+  - a victim whose detonation exceeds its HP DIES (assert `ship-destroyed` for that victim + bomb-splash-on-death chain → `perActorSplash`). **Test-seeding note:** detonation CONSUMES the victim's bombs before death, so the splash chain needs the dying victim to carry *leftover* bombs the detonate skill did NOT consume (e.g. detonate inferno/corrosion to kill, leaving a bomb stack for the on-death splash), OR kill it via a non-bomb detonation type. Otherwise the consumed bombs won't be present at `recordDestroyed` and no splash fires.
+  - `bomb-detonated` / `dot-detonated` emit per victim with that victim's `targetId`;
+  - per-victim detonation recorded in `perTargetDamage`;
+  - credit attributed to the applier (bombs per-entry `sourceId`, inferno/corrosion → detonating attacker).
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement.**
+  - Pass `positional` into `buildTurnArgs`/`runPlayerTurn` for the focus attacker (compute the hint from `isPositional && target != null && pattern != null` — available pre-call).
+  - In the `if (positional)` block (after `drivePositionalApply`), if `turn.positionalDetonation` present: for each footprint victim (reuse `footprintVictims(pattern, anchor, opposingRoster)` — NO role-scale), call `detonateContainers(recipe, { victim's containers, victimHp })`, then `applyVictimDamage(payout, victim, enemySink, <Task-0 flags per type>)`, emit `bomb-detonated`/`dot-detonated` per victim, record `roundPerTargetDamage`, and accumulate the focus actor's display detonation tally.
+  - Add `creditDamage(actor.id, 'detonation', turn.detonationDamage)` to the `if (!positional)` block (`engine.ts:4469`) — in positional it is 0 anyway, but the explicit move documents intent and guards a future non-zero.
+  - Adjust the display row sourcing per Task-0 Step 4 so `detonationDamage`/`totalDetonationRaw` reflect the per-victim total WITHOUT feeding `cumulativeDamage`→5326.
+
+- [ ] **Step 4: Run integration tests + FULL suite.**
+Run: `npx vitest --run src/utils/combat/__tests__/perVictimDetonation.integration.test.ts` → PASS
+Run: `npm test` → all green. **Hand-audit any moved golden** (expect zero for non-positional). NEVER `vitest -u`.
+
+- [ ] **Step 5: tsc + lint.**
+Run: `npx tsc --noEmit && npm run lint` → clean (max-warnings 0).
+
+- [ ] **Step 6: Commit.**
+```bash
+git add src/utils/combat/engine.ts src/utils/combat/__tests__/perVictimDetonation.integration.test.ts
+git commit -m "feat(combat): per-victim skill-triggered detonation on the positional path"
+```
+
+---
+
+### Task 4: Changelog + docs + memory
+
+**Files:**
+- Modify: `src/constants/changelog.ts` (`UNRELEASED_CHANGES`)
+- Modify: `src/pages/DocumentationPage.tsx` (if positional detonation is user-surfaced in combat docs)
+- Modify: memory `project_positional_per_victim_detonation.md` + `MEMORY.md` (PR1 status)
+
+- [ ] **Step 1: Add a plain-English changelog entry** — positioned battle sim: bomb/DoT detonation now damages each targeted ship individually (can kill covered targets, triggers their death effects).
+- [ ] **Step 2: Update DocumentationPage** if combat-sim behavior is documented there; else skip (note skip in commit).
+- [ ] **Step 3: Update memory** (PR1 status + any Task-0 decisions worth persisting).
+- [ ] **Step 4: Commit + run full suite once more.**
+```bash
+git add src/constants/changelog.ts src/pages/DocumentationPage.tsx
+git commit -m "docs(combat): changelog + docs for per-victim skill detonation"
+```
+
+---
+
+### Task 5: Requesting code review + open PR1
+
+- [ ] **Step 1:** Use superpowers:requesting-code-review on the PR1 diff.
+- [ ] **Step 2:** Address findings (prefer doc-only / targeted fixes; re-run full suite after each).
+- [ ] **Step 3:** `gh auth switch --user TheSusort`; open PR1 stacked on `feat/combat-enemy-cleanse-lift`. PR body documents the byte-identical guarantee + the line-5326 resolution.
+
+---
+
+## PR2 — Timed bombs + accumulators per positioned enemy (OUTLINE — detail after PR1)
+
+**Goal:** `processBombs` / `processAccumulators` (`engine.ts:4725` / `:4746`) run today only on the focus enemy's turn (`actor.id === enemy.id` gate, `:4695`). Make each positioned enemy burst its own timed bombs/accumulators against its own HP on its own turn, routing through `applyVictimDamage` (reusing Task-1 `detonateContainers` for bombs / the accumulator burst math) instead of the aggregate `creditDetonation`.
+
+**Key questions for PR2's Task 0:**
+- How does the round loop iterate non-focus positioned enemies, and where is their per-turn hook (the `actor.kind === 'enemy'` branches at `:4695` and `:4752`)?
+- Do non-focus enemies even carry `pendingBombs`/`pendingAccumulators` today (application is anchor-only — so timed bursts on non-focus enemies only matter once those containers can be populated; confirm via PR1's seeding tests whether this is reachable)?
+- Reconcile with the 5326 focus-enemy reconciliation (same seam as PR1).
+
+PR2 is detailed once PR1's `detonateContainers` + apply-site pattern are concrete.
+
+---
+
+## PR3 — Enemy→player symmetric (OUTLINE — detail after PR1)
+
+**Goal:** Enemy detonate skills land per-player. The enemy-dispatch branch (`engine.ts:4752+`) already runs `runPlayerTurn` with the player target bound as `enemy`; the positional enemy→player apply uses `playerSink`/`applyIncomingToTarget`. Wire the same per-victim detonation through `playerSink`, mirroring PR1.
+
+**Key questions for PR3's Task 0:**
+- The enemy-dispatch branch's positional apply site (the symmetric analogue of `drivePositionalApply` for enemy→player) and its victim wrapper.
+- The E5-symmetry invariant test: a ship with a detonate skill behaves identically detonating player bombs as enemy bombs.
+
+PR3 is detailed once PR1 lands.
+
+---
+
+## Done criteria (PR1)
+
+- [ ] Per-victim skill-triggered detonation lands on each footprint victim's own HP (origin + covered), full (no role-scale).
+- [ ] Detonation can kill a positioned victim → death + bomb-splash chain + per-victim reactives fire.
+- [ ] `bomb-detonated` / `dot-detonated` emit per victim; `perTargetDamage` reflects detonation; credit per applier.
+- [ ] Aggregate detonation credit suppressed in positional (no double-count vs line 5326); display `detonationDamage` row still correct.
+- [ ] Non-positional fixtures **byte-identical**; full `npm test` green; tsc + lint clean.
+- [ ] Changelog updated; PR1 opened stacked on `feat/combat-enemy-cleanse-lift`.

--- a/docs/superpowers/plans/2026-06-27-positional-per-victim-detonation.md
+++ b/docs/superpowers/plans/2026-06-27-positional-per-victim-detonation.md
@@ -66,6 +66,62 @@ git commit -m "docs(combat): PR1 Task 0 wiring decisions for per-victim detonati
 
 ---
 
+## PR1 Task 0 — Decisions (resolved 2026-06-27 via wiring spike)
+
+**Q1 — Detonate-only positional entry: NOT NEEDED.** No ship has a detonate-only skill. The
+only abilities `detonationsFromSkill` returns are `detonate-dot` (parsed solely by
+`DETONATE_DOT_RE`, `skillTextParser.ts:1470`), produced by exactly three ships — Crocus,
+Demolisher, Incinerator — and all three "deal X% damage AND detonate" in the same skill →
+`hasDamageAbility` true → `positionalScalars` always set whenever detonation is present.
+Lingshe/Chimei "detonate" text parses as reactive triggers / buffs, never `detonate-dot`.
+**→ Task 3 gates the per-victim detonation block on the EXISTING `positional` local
+(`engine.ts:4387`); NO gate widening.** (Belt-and-suspenders: also guard on the recipe's
+`dets.length > 0` so a non-damage skill that somehow set `positional` is a no-op.)
+
+**Q2 — Per-type `applyVictimDamage` cause flags** (shield math in `shieldAbsorb.ts:12-30`;
+`isDot = cause.byDirectDamage === false` at `engine.ts:2885`):
+- **Bomb** (full shield drain, no pen): `{ killerId: bomb.sourceId, byDirectDamage: true,
+  bombPortion: <bomb payout>, shieldPenetrationPct: 0 }` — `bomb === damage` → `shieldEligible =
+  full` regardless of pen. Matches bomb-splash precedent (`engine.ts:2973`).
+- **Inferno** (BYPASS shield): `{ byDirectDamage: false }` → `isDot` → `shieldAbsorb` returns
+  `{ absorbed: 0, hpDamage: damage }` (`shieldAbsorb.ts:20`). The canonical DoT bypass.
+- **Corrosion** (BYPASS shield): `{ byDirectDamage: false }` — same as inferno.
+- Rationale: bombs FULL-DRAIN the shield (locked H rule) → must pass through it (byDirectDamage
+  true + bombPortion); inferno/corrosion BYPASS (locked H rule) → DoT semantics (byDirectDamage
+  false). A victim still dies if a bypass hit zeroes its HP (`recordDestroyed` fires inside
+  `applyVictimDamage` regardless of `byDirectDamage`); the `killerId`/`byDirectDamage` fields only
+  stamp the (currently unconsumed) ship-destroyed attribution, so omitting them on inferno/
+  corrosion is acceptable. Credit/attribution rides Q4's tally + `roundPerTargetDamage`, NOT
+  `killerId`.
+
+**Q3 — Skip `detonate()` in positional mode: SAFE.** Add `positional?: boolean` to
+`PlayerTurnArgs`. Nothing after `detonate()` (`playerTurn.ts:1500`) reads `detonationDamage`
+except the return field (`:2109`); `applyNewDoTs`/`extendDoTs` do not depend on the anchor
+containers having been consumed (extendDoTs runs BEFORE detonate; applyNewDoTs only appends).
+When `positional` set: skip the `detonate()` call entirely (no consume, no credit, no emit), set
+`detonationDamage: 0`, and add a `positionalDetonation` recipe to the return:
+`{ dets: detonationsFromSkill(gatedSkill), effectiveAttack, dotMult, affinityMult, detonationMult }`.
+The engine computes the hint as `isPositional(actor.position, enemyAttackerActors) && target !=
+null && pattern != null` (known pre-call). Since detonation ⟹ damage ability (Q1), the hint and
+the engine's full `positional` gate agree for any turn carrying detonation.
+
+**Q4 — Display vs HP, mirror `perActorSplash`.** Positional DIRECT damage shows via
+`roundPerTargetDamage` (`engine.ts:3445`, surfaced as `perTargetDamage` at `:5396`), NOT
+`cumulativeDamage` (its credit is suppressed at `:4469`), and HP loss happens inside
+`applyVictimDamage` (`:2891`). Bomb-splash-on-death already routes detonation-class damage through
+`applyVictimDamage` + `roundPerTargetDamage` WITHOUT touching `cumulativeDamage` (`:2973-2986`).
+**→ For per-victim detonation:** (1) apply each victim's payout via `applyVictimDamage` (Q2
+flags) + record into `roundPerTargetDamage`; (2) accumulate a NEW per-round tally
+`perActorDetonation` (mirror `perActorSplash`, declared near `:2617`, assembled into RoundData
+near `:5399`) to source the `detonationDamage` display row in positional mode; (3) move the
+aggregate `creditDamage(actor.id,'detonation', turn.detonationDamage)` (`:4474`) INTO the
+`if (!positional)` block — in positional `turn.detonationDamage` is 0 anyway, but the move
+documents intent and prevents feeding `cumulativeDamage`→line-5326. The display row sourcing
+(`focus.detonation` at `:5289`→`:5386`) must read the new tally when positional so the row
+reflects per-victim totals without the cumulative coupling.
+
+---
+
 ### Task 1: Pure per-victim detonation helper
 
 **Goal:** Extract `detonate()`'s per-type payout math into a pure, per-victim, testable helper that takes one victim's containers + the attacker recipe and returns the per-type payouts (does NOT apply HP, does NOT mutate the engine — the engine applies + emits). Refactor the existing `detonate()` to call it (byte-identical for non-positional).

--- a/docs/superpowers/specs/2026-06-27-positional-per-victim-detonation-design.md
+++ b/docs/superpowers/specs/2026-06-27-positional-per-victim-detonation-design.md
@@ -1,0 +1,226 @@
+# Positional Per-Victim Detonation Attribution — Design
+
+**Date:** 2026-06-27
+**Status:** Approved (design); spec under review
+**Epic:** Combat realism — positional battle sim (follows E2 per-victim leech, bomb-splash-on-death #161)
+
+## Problem
+
+In the positioned battle sim, the **firing hit** already lands **per-victim**: it routes through
+`applyVictimDamage`, which decrements each footprint victim's own `currentHp`, records
+`roundPerTargetDamage`, and fires that victim's death / per-victim reactives. Per-victim leech
+(E2) and bomb-splash-on-death (#161) ride this same per-victim sink.
+
+**Bomb/DoT detonation never made that jump.** It was explicitly left out of scope when the
+per-victim direct path shipped — see `engine.ts:4462-4474`:
+
+> "KEEP detonation (bombs are a separate mechanic, out of scope)."
+
+So today, in positional mode, detonation flows **only** through the legacy aggregate path:
+
+```
+detonate()  (reads the ANCHOR enemy's containers only)
+  → creditDamage(actor.id, 'detonation', turn.detonationDamage)        // engine.ts:4474
+  → cumulativeDamage                                                    // engine.ts:5301
+  → enemy.currentHp = enemyHp − (cumulativeDamage + cumulativeTeamDamage)   // engine.ts:5326
+```
+
+That reconciliation is **focus-enemy-only** and **anchor-container-only**. The consequences:
+
+1. Only the **anchor's** stored bombs/DoTs detonate; bombs/DoTs accumulated on **covered /
+   non-focus** victims (from other attackers or prior rounds) are silently ignored.
+2. Detonation **cannot kill** a positioned victim, fire its per-victim death, on-death
+   reactives, or the bomb-splash-on-death chain.
+3. It routes through the focus-enemy `cumulativeDamage` overwrite (line 5326), which is itself
+   suspect once direct damage is per-victim — a **must-verify seam** (see §4).
+
+The same shape afflicts **timed** `processBombs` and `processAccumulators`: they run only on the
+**focus enemy's** turn (`actor.id === enemy.id` gate at `engine.ts:4695`) against the focus
+enemy's containers, crediting aggregate, never per positioned enemy.
+
+This is distinct from bomb-splash-on-death (#161), which fires when a bomb **carrier dies before
+detonation**. This design is about the **detonation event itself** landing per-victim.
+
+## Goal
+
+Make skill-triggered and timed bomb/DoT detonation land **per-victim** on the positional path —
+each footprint victim (player→enemy) or footprint player (enemy→player) detonates its **own**
+stored containers against its **own** `currentHp`, so detonation can kill positioned victims and
+fire per-victim death/reactives — mirroring the per-victim firing-hit + per-victim leech model
+already shipped, and honoring the engine team-symmetry rule (a ship behaves identically on
+either side).
+
+## Locked decisions (user-ratified 2026-06-27)
+
+- **No role-scale.** Origin and covered footprint victims both detonate the **full** stored
+  stacks. Bombs/DoTs are not affinity- or AoE-role-scaled in-game; only direct hits are.
+- **Scope = skill-triggered detonate() + timed processBombs + processAccumulators.** DoT *ticks*
+  (`tickDoTs`) are continuous damage, not detonation, and are flagged as a sibling follow-up
+  (see §5), not included here.
+- **Both directions (symmetric).** Player→enemy AND enemy→player per-victim detonation, in the
+  same epic (stacked PRs), per [[feedback_engine_team_symmetry]].
+- **Approach A** (per-victim detonation on the `applyVictimDamage` sink), decomposed into stacked
+  PRs.
+
+## Approach (chosen: A)
+
+Extract detonation from the aggregate-credit path and route each victim's payout through the
+existing per-victim sink `applyVictimDamage` — the single function that already handles
+HP/shield/Barrier/Cheat-Death/death/per-victim reactives and feeds `roundPerTargetDamage`. This
+is the exact sink bomb-splash-on-death (#161) and the per-victim direct hit already use, so the
+HP/shield/death plumbing and team-symmetry come for free.
+
+Rejected alternatives:
+
+- **B — thread footprint victims + apply callback into `runPlayerTurn`.** Inflates an
+  already-huge function's signature, does not naturally cover the engine-loop timed/accumulator
+  bursts (which live outside `runPlayerTurn`), and raises byte-identical risk. Rejected.
+- **C — unify all stored-damage resolution (skill + timed + ticks + accumulators, both sides)
+  into one per-victim module in a single change.** Cleanest end state but largest blast radius /
+  highest golden-move risk in one PR. The stacked-PR decomposition of A reaches the same place
+  incrementally with per-PR byte-identical guarantees. Rejected as a single step.
+
+## Design
+
+### 1. Per-victim detonation mechanics
+
+When a positional skill with a detonate ability fires, **each footprint victim** (the same
+victim list `applyPositionalDamage` already resolves) detonates its **own** stored containers —
+`pendingBombs`, `corrosionEntries`, `infernoEntries` — against its **own** `currentHp`. Victims
+with empty containers contribute 0 (no event).
+
+The three detonation types keep their existing formulas (`playerTurn.ts:526-591`,
+`detonate()`), now evaluated against per-victim containers, and map onto the existing
+`applyVictimDamage` flags (locked rules from shield-system H + bomb-splash precedent):
+
+| Type | Damage formula (unchanged) | Shield interaction | Affinity |
+|---|---|---|---|
+| **Bomb** | `Σ stacks × dmgPerStack × affinityMult × (1 + detMod/100) × pct` | full-drain, **no penetration** (bomb-portion = full) | stored per-bomb `affinityMult` |
+| **Inferno** | `Σ stacks × (tier/100) × attackerAtk × rounds × dotMult × affMult × pct × detMult` | **bypass** shield | detonating attacker's |
+| **Corrosion** | `Σ stacks × (tier/100) × min(victimHp,500k) × rounds × dotMult × affMult × pct × detMult` | **bypass** shield | detonating attacker's |
+
+Two behaviors fall out of "per-victim":
+
+- **(a)** Corrosion's `baseHp` becomes `min(victimHp, 500_000)` — *that victim's* HP, not the
+  anchor's (`detonate()` currently reads `args.enemyHp` = anchor).
+- **(b)** The attacker-scalar terms (`effectiveAttack`, `dotMult`, `affinityMult` for
+  inferno/corrosion; `detonationMult`) stay the **detonating attacker's** — matmul against
+  per-victim containers, exactly as `detonate()` does today. Bomb entries keep their snapshotted
+  per-entry `affinityMult` / `detonationDamageModifier` (the applier's), unchanged.
+
+Detonation can now **kill** a positioned victim, firing its per-victim death →
+`recordDestroyed` → on-death reactives + bomb-splash-on-death chain (all already wired through
+`applyVictimDamage`).
+
+### 2. Event shapes (per-victim)
+
+- `dot-detonated` (`engine.ts:5291`) and `bomb-detonated` currently carry the **anchor**
+  `targetId` / aggregate `damage`. Per-victim, they emit **once per victim** with that victim's
+  `targetId` and that victim's payout — same pattern per-victim `dot-applied` / hit events
+  already use on the positional path.
+- Per-victim detonation damage records into `roundPerTargetDamage` (so the `perTargetDamage`
+  RoundData row reflects it) and credits the **applier**: bombs keep per-entry applier
+  attribution; inferno/corrosion credit the detonating attacker. These attribution rules are
+  unchanged — now keyed per victim.
+
+### 3. Timed bombs + accumulators
+
+`processBombs` / `processAccumulators` (`engine.ts:4725` / `:4746`) run today only on the focus
+enemy's turn (`actor.id === enemy.id`, `engine.ts:4695`) against the focus enemy's containers.
+Per-victim means each **positioned enemy** bursts its own timed bombs / accumulators against its
+own HP on its own turn. The round loop already iterates all `actor.kind === 'enemy'` actors; the
+`actor.id === enemy.id` gate is what restricts the bursts to the focus enemy. Enemy→player
+symmetry routes player-carried timed bombs through `playerSink` on the player victims' turns.
+
+### 4. The line-5326 seam (crux risk)
+
+Once detonation lands per-victim through `applyVictimDamage` (which decrements each victim's own
+`currentHp` directly, like direct damage), it **must stop** feeding the focus-enemy
+`cumulativeDamage` overwrite at `engine.ts:5326` — otherwise the focus enemy is hit twice (once
+per-victim, once via the 5326 reconciliation). The change mirrors the existing direct-damage
+credit suppression at `engine.ts:4469`:
+
+```
+if (!positional) {
+    d.secondary += turn.secondaryDamage;
+    d.conditional += turn.conditionalDamage;
+    creditDamage(actor.id, 'direct', turn.directDamage);
+    creditDamage(actor.id, 'detonation', turn.detonationDamage);   // ← detonation joins suppression
+}
+```
+
+(non-positional keeps crediting detonation through the aggregate path → byte-identical).
+
+**Display vs HP application are separate concerns.** The `detonationDamage` RoundData row /
+`totalDetonationRaw` summary must still reflect detonation for the focus actor even when HP
+application is per-victim — `direct` already solves this by sourcing the displayed row from the
+per-victim path. **Planning Task 0 will verify** the exact arithmetic: whether `focus.detonation`
+must source from `roundPerTargetDamage` (per-victim) for display, and confirm no double-count
+against line 5326. This is the single highest-risk seam.
+
+### 5. Out of scope (flagged follow-ups)
+
+- **DoT ticks** (`tickDoTs`, `engine.ts:4705`): continuous per-round DoT damage shares the same
+  focus-enemy-only restriction (`actor.id === enemy.id`) and is likely a sibling per-victim gap,
+  but it is **not detonation** and is out of scope here. Flagged for a follow-up audit.
+- **Per-victim NEW bomb/DoT application:** application stays anchor-only today
+  (`runPlayerTurn` applies to `tgt.pendingBombs`/`corrosionEntries`). Per-victim detonation is
+  meaningful regardless (bombs/DoTs accumulate on different victims across attackers/rounds), so
+  per-victim *application* is a separate concern, not required by this design.
+
+## PR decomposition
+
+Stacked, each aiming **byte-identical** for non-positional goldens (hand-validate every
+positional delta — never `vitest -u`):
+
+- **PR1 — player→enemy skill-triggered detonation per-victim.** Extract `detonate()`'s per-type
+  payout into a per-victim helper; invoke it for each footprint victim at the positional site;
+  route through `applyVictimDamage`; suppress the aggregate detonation credit in positional
+  (§4); per-victim events (§2). Resolves the line-5326 seam.
+- **PR2 — timed bombs + accumulators per positioned enemy.** Lift the `actor.id === enemy.id`
+  restriction so each positioned enemy bursts its own timed bombs/accumulators against its own
+  HP (§3).
+- **PR3 — enemy→player symmetric.** Same helper via `playerSink`; enemy detonate skills land
+  per-player; the E5-symmetry invariant test.
+
+## Testing
+
+Harness mirrors `perVictimLeech.test.ts` — positioned actors, seeded containers, crit 0 for
+exact integers.
+
+- **PR1:** seed bombs/inferno/corrosion on *covered* and *origin* footprint victims; assert
+  each detonates full against its own HP; covered victim's bombs no longer ignored; corrosion
+  uses per-victim HP (`min(victimHp,500k)`); detonation kills a covered victim → death event +
+  bomb-splash chain; credit attributed per applier; `dot-detonated`/`bomb-detonated` emit per
+  victim. Byte-identical guard: non-positional detonation fixtures unchanged.
+- **PR2:** seed timed bombs on a non-focus positioned enemy; assert they burst against its own
+  HP on its own turn (not folded into the focus enemy).
+- **PR3:** seed bombs on positioned players; enemy detonate skill lands per-player via
+  `playerSink`; E5-symmetry invariant — a ship behaves identically on either side.
+
+## Golden discipline (from project memory)
+
+- Hand-validate **every** positional golden delta; **never** `vitest -u` goldens.
+- Run the **whole** `npm test` suite for the golden audit — detonation fixtures live outside
+  `src/utils/combat` too (enemy-cleanser lesson: `healingGoldenParity` scenarios).
+- Worktrees need `.env` + `docs/*.csv` copied (else `.tsx` test collection + audit tests fail)
+  and `node_modules` symlinked.
+
+## Key file references
+
+- `src/utils/combat/playerTurn.ts:526-591` — `detonate()`, the 3-branch per-type payout (the
+  logic to extract into a per-victim helper).
+- `src/utils/combat/playerTurn.ts:1500` — `detonate()` call site (anchor `enemy`).
+- `src/utils/combat/engine.ts:4462-4474` — positional credit suppression block (where detonation
+  credit joins suppression).
+- `src/utils/combat/engine.ts:3216-3231` — `applyOutgoingToEnemy` / `applyVictimDamage` wrapper
+  (the per-victim sink to route detonation through).
+- `src/utils/combat/engine.ts:3306,3446` — `roundPerTargetDamage` writes (per-victim damage
+  recording).
+- `src/utils/combat/engine.ts:4695-4751` — focus-enemy-turn `processBombs`/`processAccumulators`
+  (PR2).
+- `src/utils/combat/engine.ts:5289-5326` — focus `detonationDamage` row + `cumulativeDamage` →
+  `enemy.currentHp` reconciliation (the crux seam).
+- `src/utils/combat/applyPositionalDamage` (`positionalApply.ts`) + `drivePositionalApply` /
+  `onVictimResolved` — the per-victim apply loop and hook (E2 precedent for per-victim work).
+- `src/utils/combat/__tests__/perVictimLeech.test.ts` — test-harness template.

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -49,6 +49,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator: enemy ships now react when you hit them — enemy counterattackers (Stalwart, Nyxen, Centurion) strike back, and enemy on-hit reactions (self-repairs, defensive buffs, cleanses) now fire, so enemy teams play more like real opponents. Shield-hit counters (Nyxen) now also work for your own ships in positioned battles.',
     'Combat simulator: enemy ships now benefit from their on-cast shield skills — they gain shields, absorb your damage, and trigger shield-reactive abilities (e.g. shield-hit counters). Previously these effects only worked on your own ships.',
     'Combat simulator: enemy ships that cast a cleanse skill now actually remove the debuffs you applied to them, instead of the cleanse having no effect. Skills that trigger off an enemy being cleansed (such as Arum and Grif) now fire only when a debuff is really removed.',
+    'Combat simulator: in positioned battles, bomb/Inferno/Corrosion detonation now damages each ship the skill hits individually — every target detonates its own stored bombs and damage-over-time effects against its own HP, so a detonation can now kill secondary (splash) targets and trigger their on-death effects, instead of only counting against the primary target.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3163,8 +3163,14 @@ const DocumentationPage: React.FC = () => {
                                     ships also benefit from their own on-cast shield skills — they
                                     gain shields, absorb your damage, and trigger shield-reactive
                                     abilities — so enemy teams play more like real opponents in
-                                    positioned battles. More implant and gear-set effects will be
-                                    added in future updates.
+                                    positioned battles. In positioned battles, bomb, Inferno, and
+                                    Corrosion <strong>detonation</strong> now lands on each ship the
+                                    skill hits individually — every target detonates its own stored
+                                    bombs and damage-over-time effects against its own HP, so a
+                                    detonation can kill secondary (splash) targets and trigger their
+                                    on-death effects, rather than only counting against the primary
+                                    target. More implant and gear-set effects will be added in
+                                    future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/utils/calculators/dpsSimulator.ts
+++ b/src/utils/calculators/dpsSimulator.ts
@@ -145,6 +145,12 @@ export interface RoundData {
      *  absent otherwise (non-positional / no-splash rounds keep the legacy RoundData shape,
      *  goldens byte-identical). The splash is ALSO folded into perTargetDamage for that ally. */
     perActorSplash?: Record<string, number>;
+    /** Per-victim skill-triggered detonation (positional only): detonating actor id → total
+     *  detonation damage it dealt across footprint victims THIS round. Set ONLY when the positional
+     *  detonation loop dealt damage (map non-empty) — absent otherwise (non-positional rounds keep
+     *  the legacy RoundData shape, goldens byte-identical). The detonation also lands per-victim via
+     *  applyVictimDamage (surfaced in perTargetDamage); this map is the dedicated attribution. */
+    perActorDetonation?: Record<string, number>;
     activeCorrosionStacks: number;
     activeInfernoStacks: number;
     activeBombCount: number;

--- a/src/utils/combat/__tests__/detonation.test.ts
+++ b/src/utils/combat/__tests__/detonation.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import {
+    detonateContainers,
+    type DetonationRecipe,
+    type DetonationContainers,
+} from '../detonation';
+import type { ActiveDoTStack, PendingBomb } from '../state';
+
+// Crit-free, exact-integer assertions. These pin the EXACT detonation math lifted from
+// playerTurn.ts detonate(): bomb uses per-bomb snapshots only (NO dotMult/affinityMult/
+// detonationMult); inferno scales on effectiveAttack; corrosion clamps baseHp at 500k.
+
+const bomb = (over: Partial<PendingBomb> = {}): PendingBomb => ({
+    countdown: 1,
+    damagePerStack: 100,
+    stacks: 1,
+    tier: 100,
+    sourceId: 's',
+    affinityMult: 1,
+    detonationDamageModifier: 0,
+    splashModifier: 0,
+    ...over,
+});
+
+const dot = (over: Partial<ActiveDoTStack> = {}): ActiveDoTStack => ({
+    stacks: 1,
+    tier: 100,
+    remainingRounds: 1,
+    sourceId: 's',
+    ...over,
+});
+
+const emptyContainers = (over: Partial<DetonationContainers> = {}): DetonationContainers => ({
+    corrosionEntries: [],
+    infernoEntries: [],
+    pendingBombs: [],
+    victimHp: 1000,
+    ...over,
+});
+
+const baseRecipe = (over: Partial<DetonationRecipe> = {}): DetonationRecipe => ({
+    dets: [],
+    effectiveAttack: 1000,
+    dotMult: 1,
+    affinityMult: 1,
+    detonationMult: 1,
+    ...over,
+});
+
+describe('detonateContainers', () => {
+    it('returns all-zero when no dets', () => {
+        const c = emptyContainers({ pendingBombs: [bomb()] });
+        const res = detonateContainers(baseRecipe(), c);
+        expect(res).toEqual({ bomb: 0, inferno: 0, corrosion: 0, bombStacks: 0, total: 0 });
+        // Containers untouched when no dets requested.
+        expect(c.pendingBombs.length).toBe(1);
+    });
+
+    it('returns zero for empty containers (bomb det, no bombs)', () => {
+        const c = emptyContainers();
+        const res = detonateContainers(
+            baseRecipe({ dets: [{ dotType: 'bomb', powerPct: 100 }] }),
+            c
+        );
+        expect(res).toEqual({ bomb: 0, inferno: 0, corrosion: 0, bombStacks: 0, total: 0 });
+    });
+
+    it('computes bomb payout from per-bomb snapshots only (no dotMult/affinity/detonationMult)', () => {
+        // Two bombs: (2 stacks * 50 dps * 2 affinity * (1+50/100)) + (3 * 100 * 1 * 1) = 300 + 300 = 600
+        // powerPct 100 → *1. Recipe dotMult/affinityMult/detonationMult are 5/7/9 — MUST be ignored.
+        const c = emptyContainers({
+            pendingBombs: [
+                bomb({
+                    stacks: 2,
+                    damagePerStack: 50,
+                    affinityMult: 2,
+                    detonationDamageModifier: 50,
+                }),
+                bomb({
+                    stacks: 3,
+                    damagePerStack: 100,
+                    affinityMult: 1,
+                    detonationDamageModifier: 0,
+                }),
+            ],
+        });
+        const res = detonateContainers(
+            baseRecipe({
+                dets: [{ dotType: 'bomb', powerPct: 100 }],
+                dotMult: 5,
+                affinityMult: 7,
+                detonationMult: 9,
+            }),
+            c
+        );
+        expect(res.bomb).toBe(600);
+        expect(res.bombStacks).toBe(5);
+        expect(res.total).toBe(600);
+        expect(c.pendingBombs.length).toBe(0);
+    });
+
+    it('applies powerPct to bomb payout', () => {
+        const c = emptyContainers({ pendingBombs: [bomb({ stacks: 4, damagePerStack: 100 })] });
+        const res = detonateContainers(
+            baseRecipe({ dets: [{ dotType: 'bomb', powerPct: 50 }] }),
+            c
+        );
+        // 4 * 100 * 1 * 1 = 400, *0.5 = 200
+        expect(res.bomb).toBe(200);
+        expect(res.bombStacks).toBe(4);
+    });
+
+    it('computes inferno payout scaling on effectiveAttack (with dotMult/affinity/detonationMult)', () => {
+        // sum: 2 stacks * (50/100) * 1000 attack * 3 rounds = 3000; *dotMult2 *affinity3 *pct1 *det2 = 36000
+        const c = emptyContainers({
+            infernoEntries: [dot({ stacks: 2, tier: 50, remainingRounds: 3 })],
+        });
+        const res = detonateContainers(
+            baseRecipe({
+                dets: [{ dotType: 'inferno', powerPct: 100 }],
+                effectiveAttack: 1000,
+                dotMult: 2,
+                affinityMult: 3,
+                detonationMult: 2,
+            }),
+            c
+        );
+        expect(res.inferno).toBe(36000);
+        expect(res.total).toBe(36000);
+        expect(c.infernoEntries.length).toBe(0);
+    });
+
+    it('computes corrosion payout clamped at 500k when victimHp below clamp', () => {
+        // baseHp = min(400000, 500000) = 400000. 1 stack * (100/100) * 400000 * 1 round = 400000; mults 1 → 400000
+        const c = emptyContainers({
+            corrosionEntries: [dot({ stacks: 1, tier: 100, remainingRounds: 1 })],
+            victimHp: 400_000,
+        });
+        const res = detonateContainers(
+            baseRecipe({ dets: [{ dotType: 'corrosion', powerPct: 100 }] }),
+            c
+        );
+        expect(res.corrosion).toBe(400_000);
+        expect(c.corrosionEntries.length).toBe(0);
+    });
+
+    it('clamps corrosion baseHp at 500k when victimHp above clamp', () => {
+        // baseHp = min(900000, 500000) = 500000.
+        const c = emptyContainers({
+            corrosionEntries: [dot({ stacks: 1, tier: 100, remainingRounds: 1 })],
+            victimHp: 900_000,
+        });
+        const res = detonateContainers(
+            baseRecipe({ dets: [{ dotType: 'corrosion', powerPct: 100 }] }),
+            c
+        );
+        expect(res.corrosion).toBe(500_000);
+    });
+
+    it('processes dets in order, consuming containers (2nd bomb det sees empty)', () => {
+        const c = emptyContainers({ pendingBombs: [bomb({ stacks: 3, damagePerStack: 100 })] });
+        const res = detonateContainers(
+            baseRecipe({
+                dets: [
+                    { dotType: 'bomb', powerPct: 100 },
+                    { dotType: 'bomb', powerPct: 100 },
+                ],
+            }),
+            c
+        );
+        // first det pays 300, second sees emptied bombs → 0
+        expect(res.bomb).toBe(300);
+        expect(res.bombStacks).toBe(3);
+        expect(c.pendingBombs.length).toBe(0);
+    });
+
+    it('sums total across all three types (bomb + inferno + corrosion)', () => {
+        const c = emptyContainers({
+            pendingBombs: [bomb({ stacks: 1, damagePerStack: 100 })], // 100
+            infernoEntries: [dot({ stacks: 1, tier: 100, remainingRounds: 1 })], // 1*1*1000*1 = 1000
+            corrosionEntries: [dot({ stacks: 1, tier: 100, remainingRounds: 1 })], // 1*1*1000*1 = 1000
+            victimHp: 1000,
+        });
+        const res = detonateContainers(
+            baseRecipe({
+                dets: [
+                    { dotType: 'bomb', powerPct: 100 },
+                    { dotType: 'inferno', powerPct: 100 },
+                    { dotType: 'corrosion', powerPct: 100 },
+                ],
+                effectiveAttack: 1000,
+            }),
+            c
+        );
+        expect(res.bomb).toBe(100);
+        expect(res.inferno).toBe(1000);
+        expect(res.corrosion).toBe(1000);
+        expect(res.total).toBe(2100);
+    });
+});

--- a/src/utils/combat/__tests__/detonationRecipe.test.ts
+++ b/src/utils/combat/__tests__/detonationRecipe.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Positional per-victim detonation recipe.
+ *
+ * When `runPlayerTurn` runs in POSITIONAL mode it must NOT detonate the anchor enemy's
+ * containers (no consume / no credit / no `bomb-detonated` emit) — instead it returns a
+ * `positionalDetonation` recipe so the engine can detonate each footprint victim later.
+ * Non-positional behavior stays byte-identical (legacy anchor detonation).
+ *
+ * Harness mirrors positionalScalars.test.ts: it constructs PlayerTurnArgs and calls
+ * runPlayerTurn directly, with the anchor seeded with pendingBombs and a detonate-dot skill.
+ */
+import { describe, expect, it } from 'vitest';
+import { runPlayerTurn, PlayerActorRuntime, PlayerTurnArgs } from '../playerTurn';
+import { createActor, PendingBomb } from '../state';
+import { createStatusEngine } from '../statusEngine';
+import { createEventBus } from '../events';
+import { makeRateGate } from '../../calculators/rateAccumulator';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import { AffinityName } from '../../../types/ship';
+
+const ATTACKER_AFFINITY: AffinityName = 'thermal';
+const AFFINITY_DAMAGE_MODIFIER = 25;
+const ENEMY_DEFENCE = 850;
+
+function makeRuntime(skills: ShipSkills): PlayerActorRuntime {
+    const actor = createActor({
+        id: 'attacker',
+        side: 'player',
+        kind: 'attacker',
+        stats: {
+            attack: 12000,
+            crit: 50,
+            critDamage: 65,
+            defensePenetration: 20,
+            shieldPenetration: 0,
+            defence: 0,
+            hp: 20000,
+            speed: 100,
+        },
+        chargeCount: 0,
+        startCharged: false,
+    });
+
+    return {
+        actor,
+        focus: true,
+        castSkills: skills,
+        reactiveAbilities: [],
+        timedSelfBySlot: [],
+        timedEnemyBySlot: [],
+        hasChargedSkill: false,
+        attack: 12000,
+        crit: 50,
+        critDamage: 65,
+        defensePenetration: 20,
+        defence: 0,
+        hp: 20000,
+        healModifier: 0,
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        affinityDamageModifier: AFFINITY_DAMAGE_MODIFIER,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        affinityDisadvantage: false,
+        attackerAffinity: ATTACKER_AFFINITY,
+        activeCritGate: () => false,
+        chargedCritGate: () => false,
+        activeHealCritGate: () => false,
+        chargedHealCritGate: () => false,
+        debuffLandingGate: makeRateGate(),
+        extendChanceGate: makeRateGate(),
+        landsTimedEnemyApplication: () => true,
+        selfBuffLookup: new Map(),
+        enemyDebuffLookup: new Map(),
+    };
+}
+
+function makeBomb(): PendingBomb {
+    return {
+        countdown: 3,
+        damagePerStack: 5000,
+        stacks: 2,
+        tier: 100,
+        sourceId: 'attacker',
+        affinityMult: 1,
+        detonationDamageModifier: 0,
+        splashModifier: 0,
+    };
+}
+
+function makeArgs(runtime: PlayerActorRuntime, pendingBombs: PendingBomb[]): PlayerTurnArgs {
+    const enemy = createActor({
+        id: 'enemy',
+        side: 'enemy',
+        kind: 'enemy',
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            shieldPenetration: 0,
+            defence: ENEMY_DEFENCE,
+            hp: 10_000_000,
+            speed: 50,
+        },
+    });
+
+    const statusEngine = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+    statusEngine.beginRound(1);
+
+    return {
+        runtime,
+        enemy,
+        statusEngine,
+        corrosionEntries: [],
+        infernoEntries: [],
+        pendingBombs,
+        pendingAccumulators: [],
+        enemyDefense: ENEMY_DEFENCE,
+        enemyHp: 10_000_000,
+        enemyType: undefined,
+        bus: createEventBus(),
+        round: 1,
+    } as PlayerTurnArgs;
+}
+
+// A skill that BOTH deals damage (realistic firing hit) and detonates bombs.
+const SKILLS: ShipSkills = {
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                {
+                    id: 'hit',
+                    type: 'damage',
+                    target: 'enemy',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config: { type: 'damage', multiplier: 80, hits: 1 },
+                } as Ability,
+                {
+                    id: 'detonate',
+                    type: 'damage',
+                    target: 'enemy',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config: { type: 'detonate-dot', dotType: 'bomb', powerPct: 100 },
+                } as Ability,
+            ],
+        },
+    ],
+};
+
+describe('positionalDetonation recipe', () => {
+    it('positional: does NOT detonate the anchor; exposes the recipe instead', () => {
+        const runtime = makeRuntime(SKILLS);
+        const pendingBombs = [makeBomb()];
+        const args = makeArgs(runtime, pendingBombs);
+
+        const emitted: unknown[] = [];
+        args.bus.on('bomb-detonated', (e) => emitted.push(e));
+
+        const result = runPlayerTurn({ ...args, positional: true });
+
+        expect(result.positionalDetonation).toBeDefined();
+        const recipe = result.positionalDetonation!;
+        expect(recipe.dets).toEqual([{ dotType: 'bomb', powerPct: 100 }]);
+        expect(recipe.effectiveAttack).toBeGreaterThan(0);
+        expect(recipe.dotMult).toBeGreaterThan(0);
+        expect(recipe.affinityMult).toBeGreaterThan(0);
+        expect(recipe.detonationMult).toBe(1);
+
+        // Anchor's bombs UNCONSUMED.
+        expect(pendingBombs).toHaveLength(1);
+        expect(pendingBombs[0].stacks).toBe(2);
+
+        // No anchor credit, no event.
+        expect(result.detonationDamage).toBe(0);
+        expect(emitted).toHaveLength(0);
+    });
+
+    it('legacy (no positional): detonates the anchor; no recipe exposed', () => {
+        const runtime = makeRuntime(SKILLS);
+        const pendingBombs = [makeBomb()];
+        const args = makeArgs(runtime, pendingBombs);
+
+        const emitted: unknown[] = [];
+        args.bus.on('bomb-detonated', (e) => emitted.push(e));
+
+        const result = runPlayerTurn(args);
+
+        expect(result.positionalDetonation).toBeUndefined();
+
+        // Anchor's bombs CONSUMED.
+        expect(pendingBombs).toHaveLength(0);
+
+        // Anchor credited + event emitted.
+        expect(result.detonationDamage).toBeGreaterThan(0);
+        expect(emitted).toHaveLength(1);
+    });
+});

--- a/src/utils/combat/__tests__/perVictimDetonation.integration.test.ts
+++ b/src/utils/combat/__tests__/perVictimDetonation.integration.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Per-victim skill-triggered detonation on the POSITIONAL apply path (player → enemy).
+ *
+ * Prior tasks shipped the pure math (`detonateContainers`) and made `runPlayerTurn` SKIP the
+ * anchor detonation when `positional` is set (returning a `positionalDetonation` recipe instead,
+ * with `detonationDamage === 0`). THIS suite pins the engine wiring: when the focus attacker fires
+ * a positional AoE detonate skill, EACH footprint victim HIT by the firing damage (and still alive)
+ * detonates its OWN stored containers — bombs (full shield drain, no pen) and inferno+corrosion
+ * (BYPASS shield, DoT semantics) — landing on that victim's own HP via `applyVictimDamage`, emitting
+ * per-victim `bomb-detonated` / `dot-detonated`, and surfacing on a per-round `perActorDetonation`
+ * tally (the focus `detonationDamage` row sources from it in positional mode).
+ *
+ * SEEDING: containers cannot be applied per-footprint-victim via abilities (DoT-apply hits only the
+ * anchor), so we pre-seed each enemy victim's `pendingBombs` / `corrosionEntries` / `infernoEntries`
+ * directly through the `__testTapActors` construction hook (the same approach
+ * bombSplashOnDeath.integration.test.ts uses for pre-seeded bombs). The focus then fires a
+ * Line-Range-1 AoE detonate skill at `front`, anchored at the front enemy (M4) covering M3.
+ *
+ * Crit 0 keeps every credited value an exact integer.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { CombatActor, PendingBomb, ActiveDoTStack } from '../state';
+import type { CombatEvent } from '../events';
+import { createEventBus } from '../events';
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `pvd${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+// A small single-hit basic attack (multiplier 100%, 1 hit). attack is kept tiny so the FIRING hit
+// touches every footprint victim (marking them "hit") WITHOUT killing the high-HP ones.
+const basicAttack = (): Ability =>
+    ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } });
+
+const detonate = (dotType: 'bomb' | 'inferno' | 'corrosion', powerPct = 100): Ability =>
+    ab({
+        type: 'detonate-dot',
+        target: 'enemy',
+        config: { type: 'detonate-dot', dotType, powerPct },
+    });
+
+// An active slot: a basic attack (so the firing hit lands per-victim) plus the requested detonate
+// abilities (which the engine turns into the per-victim detonation recipe in positional mode).
+const detonateSlot = (...dets: Ability[]): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [basicAttack(), ...dets],
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+// AoE pattern: origin + one covered cell one step toward back (Pattern-Line-Range-1). Anchored at
+// the FRONT enemy (M4) it covers M3 — both are HIT by the firing damage.
+const lineRange1Pattern = (): ParsedPattern => ({
+    raw: 'line-range-1',
+    shape: 'line',
+    range: 1,
+    modifiers: {},
+});
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+// A positioned, zero-offense, finite-HP enemy victim (a stationary, damageable target).
+const enemyAt = (id: string, position: Position, hp: number): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        shipSkills: { slots: [] } as ShipSkills,
+    }) as EnemyAttacker;
+
+// A pre-seeded bomb with all multipliers neutral (bomb payout = stacks × damagePerStack × powerPct).
+const bomb = (damagePerStack: number, stacks: number, sourceId = 'attacker'): PendingBomb => ({
+    countdown: 5, // never decremented to 0 before detonation
+    damagePerStack,
+    stacks,
+    tier: 100,
+    sourceId,
+    affinityMult: 1,
+    detonationDamageModifier: 0,
+    splashModifier: 0,
+});
+
+// A pre-seeded corrosion entry. Detonation corrosion payout (powerPct 100, neutral mults) =
+// stacks × (tier/100) × min(victimHp, 500_000) × remainingRounds.
+const corrosion = (tier: number, stacks: number, remainingRounds: number): ActiveDoTStack => ({
+    stacks,
+    tier,
+    remainingRounds,
+    sourceId: 'attacker',
+});
+
+const FOCUS_ATTACK = 100; // tiny firing hit — marks victims hit without killing high-HP ones.
+
+const BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: FOCUS_ATTACK,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [detonateSlot(detonate('bomb'))] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healModifier: 0,
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedTarget('front'),
+    pattern: lineRange1Pattern(),
+    enemyAttackers: [
+        enemyAt('enemy-front', 'M4', 1_000_000_000),
+        enemyAt('enemy-mid', 'M3', 1_000_000_000),
+    ],
+    ...overrides,
+});
+
+// Tap an ordered event log (mirrors engine.events.test.ts).
+const collect = (input: CombatEngineInput) => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    const types: CombatEvent['type'][] = ['bomb-detonated', 'dot-detonated', 'ship-destroyed'];
+    for (const t of types) bus.on(t, (e) => events.push(e as CombatEvent));
+    const result = runCombat({ ...input, bus });
+    return { events, result };
+};
+
+describe('per-victim skill-triggered detonation (positional player → enemy)', () => {
+    it('BOTH the origin and the covered victim detonate their OWN bombs (covered no longer ignored)', () => {
+        idc = 0;
+        // Each victim carries a 2 × 1000 bomb → detonates for 2000 (powerPct 100, neutral mults).
+        const { events, result } = collect(
+            BASE({
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors.find((a) => a.id === 'enemy-front')?.pendingBombs.push(bomb(1000, 2));
+                    actors.find((a) => a.id === 'enemy-mid')?.pendingBombs.push(bomb(1000, 2));
+                },
+            })
+        );
+        const round = result.rounds[0];
+        // Per-target damage = firing hit (origin full 100 / covered half 50) + detonation 2000 each.
+        expect(round.perTargetDamage?.['enemy-front']).toBe(100 + 2000);
+        expect(round.perTargetDamage?.['enemy-mid']).toBe(50 + 2000);
+        // The per-round detonation tally credits the focus attacker the SUM across both victims.
+        expect(round.perActorDetonation?.['attacker']).toBe(4000);
+        // bomb-detonated emitted per victim (one per bomb-carrying victim hit).
+        const bombDet = events.filter((e) => e.type === 'bomb-detonated');
+        expect(bombDet.length).toBe(2);
+        for (const e of bombDet) {
+            expect(e.actorId).toBe('attacker');
+            expect(e.damage).toBe(2000);
+        }
+    });
+
+    it("corrosion detonation uses the VICTIM's own HP for min(hp, 500k)", () => {
+        idc = 0;
+        // Only the covered victim (enemy-mid, HP 300_000) carries corrosion: tier 100, 1 stack,
+        // remainingRounds 1 → payout = 1 × (100/100) × min(300_000, 500_000) × 1 = 300_000.
+        const { result } = collect(
+            BASE({
+                shipSkills: { slots: [detonateSlot(detonate('corrosion'))] },
+                enemyAttackers: [
+                    enemyAt('enemy-front', 'M4', 1_000_000_000),
+                    enemyAt('enemy-mid', 'M3', 300_000),
+                ],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'enemy-mid')
+                        ?.corrosionEntries.push(corrosion(100, 1, 1));
+                },
+            })
+        );
+        const round = result.rounds[0];
+        // covered victim: firing hit 50 (half of 100) + corrosion detonation 300_000 (bypass).
+        expect(round.perTargetDamage?.['enemy-mid']).toBe(50 + 300_000);
+        expect(round.perActorDetonation?.['attacker']).toBe(300_000);
+    });
+
+    it('a victim whose detonation exceeds its HP DIES; a leftover bomb then splashes its ally', () => {
+        idc = 0;
+        // Covered victim enemy-mid (HP 1000) carries BOTH a corrosion entry (detonated this cast —
+        // tier 100, 1 stack, 1 round, hp-capped 1000 → 1000 damage, lethal) AND a leftover bomb the
+        // CORROSION-typed detonate does NOT consume. The detonate skill detonates ONLY corrosion, so
+        // the bomb survives → enemy-mid dies from the corrosion detonation while still carrying the
+        // bomb → bomb-splash-on-death fires to its adjacent ally (enemy-back at M2, a hex-neighbour
+        // of M3 but OUTSIDE the M4-anchored Line-Range-1 footprint → it took no firing/detonation
+        // damage, isolating the splash). enemy-front (origin, huge HP) just detonates nothing extra.
+        const leftover = bomb(800, 1, 'enemy-mid'); // splash = 1 × 800 × (100/4)/100 = 200
+        const { events, result } = collect(
+            BASE({
+                shipSkills: { slots: [detonateSlot(detonate('corrosion'))] },
+                enemyAttackers: [
+                    enemyAt('enemy-front', 'M4', 1_000_000_000),
+                    enemyAt('enemy-mid', 'M3', 1000),
+                    enemyAt('enemy-back', 'M2', 1_000_000_000), // adjacent to M3, outside footprint, survives splash
+                ],
+                __testTapActors: (actors: CombatActor[]) => {
+                    const mid = actors.find((a) => a.id === 'enemy-mid');
+                    mid?.corrosionEntries.push(corrosion(100, 1, 1)); // 1000 → lethal
+                    mid?.pendingBombs.push(leftover); // NOT consumed by the corrosion detonate
+                },
+            })
+        );
+        const round = result.rounds[0];
+        // enemy-mid died this round.
+        const destroyed = events.filter((e) => e.type === 'ship-destroyed');
+        expect(destroyed.some((e) => e.actorId === 'enemy-mid')).toBe(true);
+        // Its leftover bomb splashed the adjacent ally (bomb-splash-on-death chain).
+        expect(round.perActorSplash?.['enemy-back']).toBe(200);
+    });
+
+    it("dot-detonated emits per victim carrying that victim's id (inferno + corrosion bypass)", () => {
+        idc = 0;
+        // enemy-mid carries an inferno entry; the detonate skill detonates inferno. Inferno payout =
+        // stacks × (tier/100) × effectiveAttack × remainingRounds × dotMult × affinityMult × pct ×
+        // detonationMult. With dotMult/affinityMult/detonationMult = 1, effectiveAttack = 100:
+        // 1 × (100/100) × 100 × 1 = 100.
+        const { events, result } = collect(
+            BASE({
+                shipSkills: { slots: [detonateSlot(detonate('inferno'))] },
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'enemy-mid')
+                        ?.infernoEntries.push({
+                            stacks: 1,
+                            tier: 100,
+                            remainingRounds: 1,
+                            sourceId: 'attacker',
+                        });
+                },
+            })
+        );
+        const round = result.rounds[0];
+        const dotDet = events.filter((e) => e.type === 'dot-detonated');
+        // Exactly one dot-detonated, carrying the covered victim's id.
+        expect(dotDet.length).toBe(1);
+        expect(dotDet[0].targetId).toBe('enemy-mid');
+        expect(dotDet[0].damage).toBe(100);
+        // Covered victim took firing 50 + inferno bypass 100.
+        expect(round.perTargetDamage?.['enemy-mid']).toBe(50 + 100);
+        expect(round.perActorDetonation?.['attacker']).toBe(100);
+    });
+
+    it('a NON-detonating positional cast does not populate perActorDetonation (no-op guard)', () => {
+        idc = 0;
+        // A bomb-bearing roster but the focus fires a plain AoE (no detonate ability) → the recipe
+        // has no dets → the per-victim detonation loop never runs → perActorDetonation absent.
+        const { events, result } = collect(
+            BASE({
+                shipSkills: { slots: [detonateSlot()] }, // basic attack only, no detonate
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors.find((a) => a.id === 'enemy-front')?.pendingBombs.push(bomb(1000, 2));
+                    actors.find((a) => a.id === 'enemy-mid')?.pendingBombs.push(bomb(1000, 2));
+                },
+            })
+        );
+        const round = result.rounds[0];
+        expect(round.perActorDetonation).toBeUndefined();
+        expect(events.filter((e) => e.type === 'bomb-detonated').length).toBe(0);
+        // Firing hit still lands per-victim.
+        expect(round.perTargetDamage?.['enemy-front']).toBe(100);
+        expect(round.perTargetDamage?.['enemy-mid']).toBe(50);
+    });
+});

--- a/src/utils/combat/detonation.ts
+++ b/src/utils/combat/detonation.ts
@@ -1,0 +1,91 @@
+import type { ActiveDoTStack, PendingBomb } from './state';
+
+// Pure per-victim detonation math, lifted verbatim from playerTurn.ts detonate().
+// Computes the DETONATION-category payout for each requested det type and CONSUMES the
+// matching container (`.length = 0`) as it resolves, in `dets` order — so a 2nd bomb det
+// sees emptied bombs, mirroring the original loop. No events, no HP application.
+//
+// Precedence is preserved EXACTLY:
+//  - inferno: Σ(stacks · tier/100 · effectiveAttack · remainingRounds) · dotMult · affinityMult · pct · detonationMult
+//  - corrosion: Σ(stacks · tier/100 · baseHp · remainingRounds) · dotMult · affinityMult · pct · detonationMult,
+//               baseHp = min(victimHp, 500_000)
+//  - bomb: Σ(stacks · damagePerStack · b.affinityMult · (1 + b.detonationDamageModifier/100)) · pct
+//          — per-bomb snapshots ONLY (NO dotMult/affinityMult/detonationMult).
+
+export interface DetonationRecipe {
+    dets: { dotType: 'corrosion' | 'inferno' | 'bomb'; powerPct: number }[];
+    effectiveAttack: number;
+    dotMult: number;
+    affinityMult: number;
+    detonationMult: number;
+}
+
+export interface DetonationContainers {
+    corrosionEntries: ActiveDoTStack[];
+    infernoEntries: ActiveDoTStack[];
+    pendingBombs: PendingBomb[];
+    victimHp: number;
+}
+
+export interface DetonationResult {
+    bomb: number;
+    inferno: number;
+    corrosion: number;
+    bombStacks: number;
+    total: number;
+}
+
+export function detonateContainers(
+    recipe: DetonationRecipe,
+    c: DetonationContainers
+): DetonationResult {
+    let bomb = 0;
+    let inferno = 0;
+    let corrosion = 0;
+    let bombStacks = 0;
+
+    for (const det of recipe.dets) {
+        const pct = det.powerPct / 100;
+        if (det.dotType === 'inferno') {
+            inferno +=
+                c.infernoEntries.reduce(
+                    (sum, e) =>
+                        sum +
+                        e.stacks * (e.tier / 100) * recipe.effectiveAttack * e.remainingRounds,
+                    0
+                ) *
+                recipe.dotMult *
+                recipe.affinityMult *
+                pct *
+                recipe.detonationMult;
+            c.infernoEntries.length = 0;
+        } else if (det.dotType === 'corrosion') {
+            const baseHp = Math.min(c.victimHp, 500_000);
+            corrosion +=
+                c.corrosionEntries.reduce(
+                    (sum, e) => sum + e.stacks * (e.tier / 100) * baseHp * e.remainingRounds,
+                    0
+                ) *
+                recipe.dotMult *
+                recipe.affinityMult *
+                pct *
+                recipe.detonationMult;
+            c.corrosionEntries.length = 0;
+        } else if (det.dotType === 'bomb') {
+            bombStacks += c.pendingBombs.reduce((sum, b) => sum + b.stacks, 0);
+            bomb +=
+                c.pendingBombs.reduce(
+                    (sum, b) =>
+                        sum +
+                        b.stacks *
+                            b.damagePerStack *
+                            b.affinityMult *
+                            (1 + b.detonationDamageModifier / 100),
+                    0
+                ) * pct;
+            c.pendingBombs.length = 0;
+        }
+    }
+
+    return { bomb, inferno, corrosion, bombStacks, total: bomb + inferno + corrosion };
+}

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3657,7 +3657,17 @@ export function runCombat(input: CombatEngineInput): {
                 // runPlayerTurn SKIPS the anchor detonation (no consume/credit/emit) and instead
                 // returns a `positionalDetonation` recipe for the per-victim detonation loop below
                 // to apply. Conditional spread → non-positional turns omit the key → byte-identical.
-                ...(aoePattern != null && aoeTarget != null && tgt.position != null
+                //
+                // SCOPED TO THE FOCUS ATTACKER (PR1): only the focus-turn site consumes the recipe
+                // (the per-victim detonation loop). The walked-team and enemy-attacker sites have no
+                // such loop yet, so setting `positional` for them would skip their anchor detonation
+                // and silently DROP it (recipe ignored). Gating on focusActorId keeps team/enemy on
+                // their prior anchor-detonation path (byte-identical) until PR2/PR3 wire the loop to
+                // those sites symmetrically.
+                ...(a.id === focusActorId &&
+                aoePattern != null &&
+                aoeTarget != null &&
+                tgt.position != null
                     ? { positional: true }
                     : {}),
                 // D-PR4: target's effective attack (for 'amplify-vs-higher-attack' eligibility) and

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -55,6 +55,7 @@ import { victimHitDamage } from './victimDamage';
 import { incomingReductionForHit, incomingBlockForIntake } from './incomingEffects';
 import { reflectedDamageForHit } from './damageReflection';
 import { splashDamageForBomb } from './bombSplash';
+import { detonateContainers } from './detonation';
 import { outgoingAmplificationForHit } from './outgoingEffects';
 import { incomingHealAmpForRecipient } from './healAmplification';
 import { CHEAT_DEATH_BUFFS } from './cheatDeathBuffs';
@@ -1934,6 +1935,13 @@ export function runCombat(input: CombatEngineInput): {
     // seam). Surfaced as RoundData.perActorSplash at the post-round push (absent when empty →
     // non-positional / no-splash rounds stay byte-identical).
     let perActorSplash = new Map<string, number>();
+    // Per-victim skill-triggered detonation (positional): per-round accumulator (detonating
+    // actor id → total detonation damage it dealt across footprint victims THIS round). Mirrors
+    // perActorSplash's lifecycle (declared once, rebound fresh each round, captured by the
+    // positional detonation loop). Sources the focus detonationDamage display row in positional
+    // mode (focus.detonation is 0 there — the aggregate credit is suppressed). Absent when empty
+    // → non-positional rounds byte-identical.
+    let perActorDetonation = new Map<string, number>();
 
     // Recipient's CURRENT effective max HP: prefer the actor's last-turn ctx (live buffs),
     // else its base HP (pre-first-turn). Same pattern for incoming-heal % (ctx value ?? 0).
@@ -3644,6 +3652,14 @@ export function runCombat(input: CombatEngineInput): {
                 enemyBuffNames: tb.enemyBuffNamesUnion(),
                 selfDebuffNames: ownerDebuffNames(a.id),
                 ...(aoeVictimIds ? { aoeVictimIds } : {}),
+                // Positional detonation hint: when the engine will take the positional apply path
+                // (same predicate that computes aoeVictimIds — pattern + target + position all set),
+                // runPlayerTurn SKIPS the anchor detonation (no consume/credit/emit) and instead
+                // returns a `positionalDetonation` recipe for the per-victim detonation loop below
+                // to apply. Conditional spread → non-positional turns omit the key → byte-identical.
+                ...(aoePattern != null && aoeTarget != null && tgt.position != null
+                    ? { positional: true }
+                    : {}),
                 // D-PR4: target's effective attack (for 'amplify-vs-higher-attack' eligibility) and
                 // a per-(owner,ability) deterministic proc closure. Both are READ only when the
                 // actor's passive slot carries an outgoing-amplification ability → byte-identical
@@ -3664,6 +3680,7 @@ export function runCombat(input: CombatEngineInput): {
         // Bomb-splash-on-death: rebind every round (like perActorShieldGranted) so a stale
         // carry-over never over-reports splash. Written only by the death-seam splash block.
         perActorSplash = new Map<string, number>();
+        perActorDetonation = new Map<string, number>();
         if (healTarget) {
             currentRoundHealing = new Map<string, ActorHealing>();
             const targetMaxHp = recipientMaxHp(healTarget.id);
@@ -4402,6 +4419,11 @@ export function runCombat(input: CombatEngineInput): {
                             let focusEnemyDamage = 0;
                             let focusEnemyShieldWasHit = false;
                             let focusEnemyHit = false;
+                            // Per-victim detonation (positional): collect EVERY footprint victim
+                            // hit by this cast's firing damage (unique by id), so each can detonate
+                            // its OWN containers after the firing hits land. Populated in the
+                            // onVictimResolved hook below alongside the standing-leech proc.
+                            const detonationTargets = new Map<string, CombatActor>();
                             drivePositionalApply({
                                 scalars: turn.positionalScalars!,
                                 hitCrits: turn.hitCrits,
@@ -4418,6 +4440,7 @@ export function runCombat(input: CombatEngineInput): {
                                 // the leech the positional credit-suppression had silenced.
                                 onVictimResolved: (victim, damage, outcome) => {
                                     procStandingLeechesPerVictim(actor.id, damage);
+                                    detonationTargets.set(victim.id, victim);
                                     if (victim.id === tgt.id) {
                                         focusEnemyHit = true;
                                         focusEnemyDamage += damage;
@@ -4447,6 +4470,68 @@ export function runCombat(input: CombatEngineInput): {
                                     damage: focusEnemyDamage,
                                 });
                             }
+
+                            // Per-victim skill-triggered detonation (positional). Each victim HIT
+                            // by this cast that is STILL ALIVE detonates its OWN containers (no
+                            // role-scale — full stored stacks). Bombs = full shield drain/no pen;
+                            // inferno+corrosion BYPASS the shield (DoT semantics). Credited to the
+                            // detonating actor's per-round detonation tally + roundPerTargetDamage;
+                            // NOT into cumulativeDamage (HP lands per-victim via applyVictimDamage).
+                            // recipe present only when a detonate-dot ability fired (else dets empty).
+                            const detonationRecipe = turn.positionalDetonation;
+                            if (detonationRecipe && detonationRecipe.dets.length > 0) {
+                                for (const victim of detonationTargets.values()) {
+                                    if (victim.currentHp <= 0) continue; // died to the firing hit (already splashed)
+                                    const result = detonateContainers(detonationRecipe, {
+                                        corrosionEntries: victim.corrosionEntries,
+                                        infernoEntries: victim.infernoEntries,
+                                        pendingBombs: victim.pendingBombs,
+                                        victimHp: tb.victimMaxHpFor(victim),
+                                    });
+                                    if (result.bomb > 0) {
+                                        applyVictimDamage(result.bomb, victim, enemySink, {
+                                            killerId: actor.id,
+                                            byDirectDamage: true,
+                                            bombPortion: result.bomb, // full shield drain, no pen
+                                            shieldPenetrationPct: 0,
+                                        });
+                                        bus.emit({
+                                            type: 'bomb-detonated',
+                                            actorId: actor.id,
+                                            round: r,
+                                            stacks: result.bombStacks,
+                                            damage: result.bomb,
+                                        });
+                                        roundPerTargetDamage.set(
+                                            victim.id,
+                                            (roundPerTargetDamage.get(victim.id) ?? 0) + result.bomb
+                                        );
+                                    }
+                                    const bypass = result.inferno + result.corrosion;
+                                    if (bypass > 0) {
+                                        applyVictimDamage(bypass, victim, enemySink, {
+                                            byDirectDamage: false, // DoT → bypass shield
+                                        });
+                                        bus.emit({
+                                            type: 'dot-detonated',
+                                            targetId: victim.id,
+                                            round: r,
+                                            damage: bypass,
+                                        });
+                                        roundPerTargetDamage.set(
+                                            victim.id,
+                                            (roundPerTargetDamage.get(victim.id) ?? 0) + bypass
+                                        );
+                                    }
+                                    const dealt = result.bomb + bypass;
+                                    if (dealt > 0) {
+                                        perActorDetonation.set(
+                                            actor.id,
+                                            (perActorDetonation.get(actor.id) ?? 0) + dealt
+                                        );
+                                    }
+                                }
+                            }
                         }
 
                         // Fold the focus turn's numeric damage into the round accumulator.
@@ -4470,8 +4555,12 @@ export function runCombat(input: CombatEngineInput): {
                             d.secondary += turn.secondaryDamage;
                             d.conditional += turn.conditionalDamage;
                             creditDamage(actor.id, 'direct', turn.directDamage);
+                            // Detonation credit is suppressed in positional mode (turn.detonationDamage
+                            // is 0 there anyway — runPlayerTurn returns the recipe instead). Keeping it
+                            // inside this guard documents intent and keeps per-victim detonation out of
+                            // cumulativeDamage (it lands per-victim via applyVictimDamage above).
+                            creditDamage(actor.id, 'detonation', turn.detonationDamage);
                         }
-                        creditDamage(actor.id, 'detonation', turn.detonationDamage);
                         focusTurns.push(turn);
 
                         // Heal-target buffs: if this focus actor IS the heal target (self-heal case),
@@ -5286,14 +5375,17 @@ export function runCombat(input: CombatEngineInput): {
         const directDamage = focus.direct;
         const corrosionDamage = focus.corrosion;
         const infernoDamage = focus.inferno;
-        const detonationDamage = focus.detonation;
+        const focusPositionalDetonation = perActorDetonation.get(focusActorId) ?? 0;
+        const detonationDamage = focus.detonation + focusPositionalDetonation;
 
-        if (detonationDamage > 0) {
+        // Aggregate dot-detonated fires ONLY for the non-positional aggregate path; positional
+        // detonation already emitted per-victim bomb-detonated/dot-detonated in the apply loop.
+        if (focus.detonation > 0) {
             bus.emit({
                 type: 'dot-detonated',
                 targetId: enemy.id,
                 round: r,
-                damage: detonationDamage,
+                damage: focus.detonation,
             });
         }
 
@@ -5306,7 +5398,11 @@ export function runCombat(input: CombatEngineInput): {
         totalConditionalRaw += focus.conditional;
         totalCorrosionRaw += focus.corrosion;
         totalInfernoRaw += focus.inferno;
-        totalDetonationRaw += focus.detonation;
+        // Summary detonation reflects per-victim positional detonation too (focusPositionalDetonation
+        // is 0 non-positionally → byte-identical). NOTE: cumulativeDamage/totalRoundDamage above
+        // deliberately use focus.detonation ONLY — per-victim detonation lands via applyVictimDamage,
+        // so folding it into cumulativeDamage would double-count the enemy-HP decline.
+        totalDetonationRaw += detonationDamage;
 
         // Team damage = Σ over all NON-focus actor entries of every channel (direct already
         // includes its secondary/conditional sub-buckets, so they are NOT added separately).
@@ -5400,6 +5496,12 @@ export function runCombat(input: CombatEngineInput): {
             // adjacent allies this round (map non-empty). Absent otherwise → byte-identical.
             ...(perActorSplash.size > 0
                 ? { perActorSplash: Object.fromEntries(perActorSplash) }
+                : {}),
+            // perActorDetonation (per-victim skill-triggered detonation, positional): set ONLY when
+            // the positional detonation loop dealt damage this round (map non-empty). Absent
+            // otherwise → non-positional rounds keep the legacy RoundData shape, goldens byte-identical.
+            ...(perActorDetonation.size > 0
+                ? { perActorDetonation: Object.fromEntries(perActorDetonation) }
                 : {}),
             // perActorShield (H1 Task 6): per-actor shield accounting for THIS round, set only
             // when at least one actor has a nonzero {granted, absorbed, pool}. Mirrors

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -34,7 +34,7 @@ import {
     createStatusEngine,
 } from './statusEngine';
 import { CombatEventBus } from './events';
-import { detonateContainers } from './detonation';
+import { detonateContainers, type DetonationRecipe } from './detonation';
 import { synthesizeResisted } from './shared';
 import { buildActorConditionContext, type ReactiveAbility } from './triggers';
 import { recipientCarriesBlockBuff } from './blockBuffBuffs';
@@ -157,6 +157,10 @@ export interface PlayerTurnResult {
      *  engine branch (Task 8); non-positional callers ignore it → goldens byte-identical.
      *  Present whenever a damage ability fired this cast (else undefined). */
     positionalScalars?: AttackerDamageScalars;
+    /** Per-cast detonation recipe for the positional per-victim path. Present ONLY when the
+     *  `positional` arg was set (the engine then detonates each footprint victim's own containers
+     *  via detonateContainers). Absent for non-positional callers → byte-identical. */
+    positionalDetonation?: DetonationRecipe;
     turnCtx: PlayerRoundCtx; // round-scoped context for the enemy's DoT tick (this actor)
 }
 
@@ -308,6 +312,11 @@ export interface PlayerTurnArgs {
      * single `targetId`. Absent for non-positional callers → single-anchor (byte-identical).
      */
     aoeVictimIds?: string[];
+    /** Positional mode (per-victim detonation): when true, runPlayerTurn does NOT detonate the
+     *  anchor enemy's containers (no consume, no credit, no bomb-detonated emit) and instead
+     *  returns a `positionalDetonation` recipe for the engine to apply per footprint victim.
+     *  detonationDamage is 0 in this mode. Absent/false → legacy anchor detonation (byte-identical). */
+    positional?: boolean;
     /** D-PR3: victim-side incoming %-reduction against the bound target.
      *  nonCrit = applies to ALL hits (Voidshade/Nebula); critFamily = take-max crit-family reduction
      *  applied to the crit fraction only (Iridium/Hardened/Hyperion). Both default 0 → byte-identical. */
@@ -665,6 +674,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         healEventOnly = false,
         onHitBreakStasis,
         aoeVictimIds,
+        positional,
     } = args;
 
     const {
@@ -1469,19 +1479,33 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     // This is the player-turn portion; the caller folds it into the round
     // accumulator's detonationDamage with += (the enemy turn may have already
     // added bursts this round at a faster speed).
-    const detonationDamage = detonate({
-        gatedSkill,
-        effectiveAttack,
-        enemyHp,
-        dotMult,
-        affinityMult,
-        detonationMult: 1 + dmgStats.detonationDamageModifier / 100,
-        corrosionEntries,
-        infernoEntries,
-        pendingBombs,
-        emitBombDetonated: (stacks, damage) =>
-            bus.emit({ type: 'bomb-detonated', actorId: actor.id, round: r, stacks, damage }),
-    });
+    let detonationDamage = 0;
+    let positionalDetonation: DetonationRecipe | undefined;
+    if (positional) {
+        // Positional: DO NOT detonate the anchor (no consume/credit/emit). Expose the recipe so the
+        // engine detonates each footprint victim's own containers. detonationDamage stays 0.
+        positionalDetonation = {
+            dets: detonationsFromSkill(gatedSkill),
+            effectiveAttack,
+            dotMult,
+            affinityMult,
+            detonationMult: 1 + dmgStats.detonationDamageModifier / 100,
+        };
+    } else {
+        detonationDamage = detonate({
+            gatedSkill,
+            effectiveAttack,
+            enemyHp,
+            dotMult,
+            affinityMult,
+            detonationMult: 1 + dmgStats.detonationDamageModifier / 100,
+            corrosionEntries,
+            infernoEntries,
+            pendingBombs,
+            emitBombDetonated: (stacks, damage) =>
+                bus.emit({ type: 'bomb-detonated', actorId: actor.id, round: r, stacks, damage }),
+        });
+    }
 
     // Step 3: Apply new DoT stacks from this round's skill (subject to landing roll).
     // Block Debuff (Task 6): when the turn target is immune, every cast-side DoT is
@@ -2081,6 +2105,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         detonationDamage,
         extraActionGrants,
         positionalScalars,
+        ...(positionalDetonation ? { positionalDetonation } : {}),
         turnCtx,
     };
 }

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -34,6 +34,7 @@ import {
     createStatusEngine,
 } from './statusEngine';
 import { CombatEventBus } from './events';
+import { detonateContainers } from './detonation';
 import { synthesizeResisted } from './shared';
 import { buildActorConditionContext, type ReactiveAbility } from './triggers';
 import { recipientCarriesBlockBuff } from './blockBuffBuffs';
@@ -535,60 +536,31 @@ function detonate(args: {
     pendingBombs: PendingBomb[];
     emitBombDetonated?: (stacks: number, damage: number) => void;
 }): number {
-    let detonationDamage = 0;
-    for (const det of detonationsFromSkill(args.gatedSkill)) {
-        const pct = det.powerPct / 100;
-        if (det.dotType === 'inferno') {
-            detonationDamage +=
-                args.infernoEntries.reduce(
-                    (sum, e) =>
-                        sum + e.stacks * (e.tier / 100) * args.effectiveAttack * e.remainingRounds,
-                    0
-                ) *
-                args.dotMult *
-                args.affinityMult *
-                pct *
-                args.detonationMult;
-            args.infernoEntries.length = 0;
-        } else if (det.dotType === 'corrosion') {
-            const baseHp = Math.min(args.enemyHp, 500_000);
-            detonationDamage +=
-                args.corrosionEntries.reduce(
-                    (sum, e) => sum + e.stacks * (e.tier / 100) * baseHp * e.remainingRounds,
-                    0
-                ) *
-                args.dotMult *
-                args.affinityMult *
-                pct *
-                args.detonationMult;
-            args.corrosionEntries.length = 0;
-        } else if (det.dotType === 'bomb') {
-            const totalStacks = args.pendingBombs.reduce((sum, b) => sum + b.stacks, 0);
-            // Each bomb bursts with the APPLIER's affinity matchup AND the applier's
-            // detonation-damage modifier (Voidfire), both snapshotted at application
-            // (PendingBomb.affinityMult / .detonationDamageModifier) — NOT the detonating
-            // actor's. A team-applied bomb detonated by the attacker's skill keeps the
-            // team's modifiers, mirroring the per-entry burst on the enemy turn (engine.ts
-            // detonatePendingBombs). Identical for attacker-only runs (every entry carries
-            // the attacker's mult, equal to args.detonationMult).
-            const payout =
-                args.pendingBombs.reduce(
-                    (sum, b) =>
-                        sum +
-                        b.stacks *
-                            b.damagePerStack *
-                            b.affinityMult *
-                            (1 + b.detonationDamageModifier / 100),
-                    0
-                ) * pct;
-            if (payout > 0) {
-                args.emitBombDetonated?.(totalStacks, payout);
-            }
-            detonationDamage += payout;
-            args.pendingBombs.length = 0;
+    // Delegate the per-type detonation MATH to the pure helper. Bombs burst with the
+    // APPLIER's affinity matchup AND detonation-damage modifier (Voidfire), both snapshotted
+    // at application (PendingBomb.affinityMult / .detonationDamageModifier) — NOT the
+    // detonating actor's — mirroring the per-entry burst on the enemy turn (engine.ts
+    // detonatePendingBombs). The helper consumes each container (`.length = 0`) in `dets`
+    // order, so a 2nd bomb det sees emptied bombs. We keep the side-effect (event emit) here.
+    const result = detonateContainers(
+        {
+            dets: detonationsFromSkill(args.gatedSkill),
+            effectiveAttack: args.effectiveAttack,
+            dotMult: args.dotMult,
+            affinityMult: args.affinityMult,
+            detonationMult: args.detonationMult,
+        },
+        {
+            corrosionEntries: args.corrosionEntries,
+            infernoEntries: args.infernoEntries,
+            pendingBombs: args.pendingBombs,
+            victimHp: args.enemyHp,
         }
+    );
+    if (result.bomb > 0) {
+        args.emitBombDetonated?.(result.bombStacks, result.bomb);
     }
-    return detonationDamage;
+    return result.total;
 }
 
 // Step 3: Apply new DoT stacks from this round's skill (subject to landing roll).


### PR DESCRIPTION
## Summary

Makes bomb/Inferno/Corrosion **detonation** land **per-victim** on the positional battle sim (player→enemy, focus attacker). Previously positional detonation was an aggregate *phantom*: credited to the attacker's damage total but never decrementing any positioned victim's HP, reading only the anchor's containers — so covered victims' stored bombs were ignored and detonation could never kill a positioned target.

Now each footprint victim the cast hits detonates its **own** stored bombs/DoTs against its **own** HP, routed through the existing per-victim `applyVictimDamage` sink (the same one the firing hit, per-victim leech, and bomb-splash-on-death use):

- **Bomb** → full shield drain, no penetration (`bombPortion`).
- **Inferno + Corrosion** → bypass shield (DoT semantics); corrosion uses the victim's own HP for its `min(hp, 500k)` basis.
- **No role-scale** — origin and covered victims both detonate full.
- Detonation can now **kill** a positioned victim → fires its per-victim death, on-death reactives, and the bomb-splash-on-death chain.
- Per-victim `bomb-detonated` / `dot-detonated` events; per-victim `perTargetDamage`; a new `perActorDetonation` display tally.

The aggregate detonation credit is **suppressed** in positional mode, so per-victim detonation never feeds `cumulativeDamage` / the focus-enemy HP reconciliation (no double-count — the crux correctness seam).

### How it's built (stacked tasks)
1. `detonateContainers` — pure, per-victim detonation-math helper (`detonation.ts`); `detonate()` delegates (byte-identical).
2. `runPlayerTurn` gains a `positional` flag → skips anchor detonation, returns a `positionalDetonation` recipe.
3. Engine: per-victim detonation loop over the victims actually hit (still-alive), credit suppression, display tally, RoundData field.
4. Changelog + docs.
5. Final-review fix: the `positional` hint is **scoped to the focus attacker** — walked-team and enemy-attacker sites have no per-victim loop yet, so they keep their prior anchor-detonation path (byte-identical) until PR2/PR3.

### Scope
Player→enemy **focus attacker, skill-triggered** detonation only. Timed `processBombs`/`processAccumulators` (PR2) and enemy→player symmetry (PR3) are stacked follow-ups.

## Test Plan
- [x] 16 new tests (pure helper, recipe exposure, full per-victim integration incl. covered-victim detonation, per-victim corrosion HP basis, detonation-kill + splash chain, per-victim events, no-op guard).
- [x] Full suite **3465 passing**, **zero existing goldens/snapshots moved** (byte-identical for all non-positional fixtures).
- [x] `tsc --noEmit` + `lint` (max-warnings 0) clean.
- [x] Two-stage review (spec + quality) per task + final holistic review — all approved.

> Stacked on `feat/combat-enemy-cleanse-lift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)