### PR TITLE
feat(combat): enemy→player per-victim skill-triggered detonation (PR3)

### DIFF
--- a/docs/superpowers/plans/2026-06-27-positional-per-victim-detonation.md
+++ b/docs/superpowers/plans/2026-06-27-positional-per-victim-detonation.md
@@ -379,15 +379,103 @@ git commit -m "docs(combat): changelog for per-positioned-enemy timed detonation
 
 ---
 
-## PR3 — Enemy→player symmetric (OUTLINE — detail after PR1)
+## PR3 — Enemy→player symmetric skill-triggered detonation (DETAILED 2026-06-27, post-PR1/PR2)
 
-**Goal:** Enemy detonate skills land per-player. The enemy-dispatch branch (`engine.ts:4752+`) already runs `runPlayerTurn` with the player target bound as `enemy`; the positional enemy→player apply uses `playerSink`/`applyIncomingToTarget`. Wire the same per-victim detonation through `playerSink`, mirroring PR1.
+**Goal:** An enemy ship's detonate skill lands per **player** footprint victim — each player victim detonates its OWN stored containers against its OWN HP (so an enemy detonate can kill a covered player and fire its death/reactive chain), exactly mirroring PR1's player→enemy block but routed through `playerSink`. The canonical team-symmetry close ([[feedback_engine_team_symmetry]]): the same detonate ship behaves identically on either side.
 
-**Key questions for PR3's Task 0:**
-- The enemy-dispatch branch's positional apply site (the symmetric analogue of `drivePositionalApply` for enemy→player) and its victim wrapper.
-- The E5-symmetry invariant test: a ship with a detonate skill behaves identically detonating player bombs as enemy bombs.
+**Direction:** enemy→player. The enemy-attacker branch (`engine.ts:4851`+) already runs `runPlayerTurn(buildTurnArgs(actor, tgt))` with the player victim bound as `enemy`, and its positional firing hit lands per-victim via `drivePositionalApply` + the enemy-side `applyToVictim` (= `applyIncomingToTarget` → `playerSink`). PR3 routes the per-victim DETONATION through `applyVictimDamage(..., victim, playerSink, flags)`.
 
-PR3 is detailed once PR1 lands.
+**Scope (locked):** skill-triggered detonation only (the PR1 analogue). Timed bombs/accumulators on positioned PLAYER victims are PR2's mirror — NOT in PR3 (PR2 lifted the focus-enemy timed gate for positioned ENEMIES; positioned-player timed bursts are a sibling follow-up, same as the player→enemy timed burst was its own PR). DoT TICKS still OUT.
+
+### PR3 Task 0 — Decisions (resolved 2026-06-27 via wiring spike against live source)
+
+**THE GAP is already named in-source.** `engine.ts:5249-5261` carries an explicit `DETONATION CAVEAT (E5 §4.3 — PEELED to a dedicated follow-up)`: on the enemy positional path, `drivePositionalApply` lands ONLY the direct firing hit (`enemyScalars`); the detonation slice (folded into the aggregate `damage` as `enemyTurn.detonationDamage`) is left **unrouted** (the non-positional `else` drains it per-victim via `applyIncomingToTarget(damage, tgt, { bombPortion: enemyDetonationDamage })`, but the positional branch drops it). **PR3 IS that peeled follow-up.**
+
+**Q1 — Widen the positional-hint gate (`engine.ts:3667`).** Today the `positional: true` hint passed into `runPlayerTurn` is gated `a.id === focusActorId` (PR1 CR-fix `d2632128` — team/enemy sites had no per-victim loop, so the hint would skip their anchor detonate() and silently DROP it). Widen to **`(a.id === focusActorId || a.side === 'enemy')`** so a positional ENEMY actor's `runPlayerTurn` also gets `positional: true` → skips `detonate()` (no consume/credit/emit), returns the `positionalDetonation` recipe, leaves `detonationDamage = 0`. **Walked-team PLAYER actors STAY on the legacy anchor path** (no per-victim detonation loop at the team site yet — out of scope). **VERIFIED safe (`playerTurn.ts:1484-1508`):** `positional: true` ONLY swaps the `detonate()` call for the recipe build; nothing else in `runPlayerTurn` branches on it. Byte-identical for every golden (no production caller threads enemy position+pattern → `enemyPositional` is false for all fixtures; the gate widening only affects newly-seeded PR3 tests).
+
+**Q2 — No `playerTurn.ts` change.** The `positionalDetonation` recipe (`DetonationRecipe` from `./detonation`, already imported into engine.ts:58) is side-agnostic — built from the gated skill's `detonationsFromSkill` + the attacker's own scalars. `runPlayerTurn` already returns it whenever `positional` is set, regardless of side. PR3 is an **engine.ts-only** change.
+
+**Q3 — Hoist the recipe + collect victims (mirror `enemyScalars`).** `enemyTurn` is scoped INSIDE the enemy turn's `else` block (`engine.ts:5060`+). Add a hoisted `let enemyPositionalDetonation: DetonationRecipe | undefined;` next to `enemyScalars`/`enemyHitCrits` (`:5037`), assigned `= enemyTurn.positionalDetonation;` inside the else (next to `enemyScalars = enemyTurn.positionalScalars;` at `:5130`). Declare `const detonationTargets = new Map<string, CombatActor>();` before the `drivePositionalApply` call (`:5263`) and add `detonationTargets.set(victim.id, victim);` to its `onVictimResolved` hook (`:5278`, alongside `procTakenLeechesPerVictim`) — mirror PR1's collection at `:4453`.
+
+**Q4 — Per-victim detonation block (mirror PR1 `:4484-4544`), routed through `playerSink`.** After the `emitAttacked` call (`engine.ts:5401-5410`), still inside `if (damage > 0)`, gated on `enemyPositional && enemyPositionalDetonation && enemyPositionalDetonation.dets.length > 0`:
+- for each `victim` of `detonationTargets.values()`: skip if `victim.currentHp <= 0` (died to the firing hit → already splashed);
+- `const result = detonateContainers(enemyPositionalDetonation, { corrosionEntries, infernoEntries, pendingBombs: victim.*, victimHp: tb.victimMaxHpFor(victim) })` — `tb = turnBindings(actor.side)` (= `enemyTurnBindings`), so `victimMaxHpFor` = `recipientMaxHp(victim.id)` (the player victim's max HP, used for corrosion `min(hp,500k)`);
+- bomb (`result.bomb > 0`): `applyVictimDamage(result.bomb, victim, playerSink, { killerId: actor.id, byDirectDamage: true, bombPortion: result.bomb, shieldPenetrationPct: 0 })` — full shield drain, no pen; emit `bomb-detonated { actorId: actor.id, round: r, stacks: result.bombStacks, damage: result.bomb }`; `roundPerTargetDamage[victim.id] += result.bomb`;
+- bypass (`result.inferno + result.corrosion > 0`): `applyVictimDamage(bypass, victim, playerSink, { byDirectDamage: false })` — DoT shield BYPASS; emit `dot-detonated { targetId: victim.id, round: r, damage: bypass }`; `roundPerTargetDamage[victim.id] += bypass`;
+- `perActorDetonation[actor.id] += (result.bomb + bypass)` (caster-keyed, mirrors PR1's `actor.id` keying). **The ONLY delta from PR1's block is `enemySink` → `playerSink`.**
+
+**Q5 — No line-5432 double-count.** When `positional: true`, `enemyTurn.detonationDamage === 0` → `damage = enemyTurn.directDamage` only → the dropped-detonation caveat is moot (nothing to drop). The per-victim payout lands via `applyVictimDamage` (decrements the player victim's own `currentHp`) + `roundPerTargetDamage` + the `perActorDetonation[actor.id]` display tally; it NEVER calls `creditDamage(actor.id, 'detonation', …)`, so it stays off `cumulativeDamage`→`:5432` (which overwrites the FOCUS DUMMY enemy's HP only — irrelevant to player victims, who carry their own HP). Identical discipline to PR1/PR2.
+
+**Q6 — E5-symmetry invariant.** The defining PR3 test: the SAME detonate ship, given the SAME seeded victim containers + HP, must produce the SAME per-victim detonation payout integers / death / events whether it acts as a PLAYER (PR1 path, focus or via positioned player attacker) or as an ENEMY (PR3 path). Crit 0 → exact integers. This is the team-symmetry pin ([[feedback_engine_team_symmetry]], E5 heal-lift template).
+
+---
+
+### Task 1: Failing integration test — enemy→player per-victim detonation + E5-symmetry
+
+**Goal:** Pin the enemy→player per-victim skill-triggered detonation. Harness = `perVictimDetonation.integration.test.ts` (PR1's player→enemy test) MIRRORED to the enemy direction: positioned enemy ATTACKER with a parsed target+pattern, positioned PLAYER victims carrying seeded containers, crit 0 → exact integers, `__testTapActors` seeding.
+
+**Files:** Create `src/utils/combat/__tests__/perVictimEnemyDetonation.integration.test.ts`.
+
+- [ ] **Step 1: Write failing tests.** Seed bombs/inferno/corrosion on BOTH an origin player footprint victim AND a covered player victim; fire a positional enemy detonate skill. Assert:
+  - origin player victim's bombs detonate full against ITS hp; covered player victim's bombs detonate full against ITS hp (covered no longer ignored);
+  - corrosion uses per-victim `min(playerHp, 500k)`;
+  - a player victim whose detonation exceeds its HP DIES (`ship-destroyed` + bomb-splash-on-death chain → `perActorSplash`), with the leftover-bomb seeding caveat from PR1 (detonation consumes the bombs before death — kill via inferno/corrosion leaving a bomb stack, or via a non-bomb type);
+  - `bomb-detonated` (`actorId: enemy attacker`) / `dot-detonated` (`targetId: player victim`) emit per victim;
+  - per-victim detonation recorded in `perTargetDamage`; `perActorDetonation[enemy attacker]` credited;
+  - NOT double-counted via line-5432 (focus dummy unaffected);
+  - **byte-identical guard / regression pin:** a NON-positional enemy detonate (focus-dummy victim, no enemy position+pattern) still drains exactly as today via `applyIncomingToTarget(damage, tgt, { bombPortion })` — prove the new positional branch is non-vacuous by checking the gate negative path.
+  - **E5-symmetry test (Q6):** assert the same ship + same seeded containers yields identical per-victim detonation whether player-cast (PR1) or enemy-cast (PR3).
+- [ ] **Step 2: Run, verify fail** (`npx vitest --run src/utils/combat/__tests__/perVictimEnemyDetonation.integration.test.ts`).
+
+---
+
+### Task 2: Implement enemy→player per-victim detonation
+
+**Files:** `src/utils/combat/engine.ts` (gate widening `:3667`; hoist `enemyPositionalDetonation` `:5037`; assign inside else `:5130`; `detonationTargets` declare + `onVictimResolved` collect `:5263-5288`; the detonation loop after `emitAttacked` `:5411`). No `dpsSimulator.ts` change (reuse PR1's `perActorDetonation`/`perTargetDamage`).
+
+- [ ] **Step 1: Implement** per Q1-Q5. The detonation loop is PR1's block with `enemySink` → `playerSink` and `turn.positionalDetonation` → the hoisted `enemyPositionalDetonation`.
+- [ ] **Step 2: New integration test → PASS.**
+- [ ] **Step 3: FULL suite** (`npm test`). All green. **Hand-audit any moved golden — expect ZERO** for non-positional. NEVER `vitest -u`.
+- [ ] **Step 4: tsc + lint** (`npx tsc --noEmit && npm run lint`) → clean (max-warnings 0).
+- [ ] **Step 5: Commit.**
+```bash
+git add src/utils/combat/engine.ts src/utils/combat/__tests__/perVictimEnemyDetonation.integration.test.ts
+git commit -m "feat(combat): enemy->player per-victim skill-triggered detonation"
+```
+
+---
+
+### Task 3: Changelog + docs + memory
+
+**Files:** `src/constants/changelog.ts` (`UNRELEASED_CHANGES`); `src/pages/DocumentationPage.tsx` (only if combat-sim detonation is user-surfaced — else note skip); memory `project_positional_per_victim_detonation.md` + `MEMORY.md` (PR3 status).
+
+- [ ] **Step 1: Changelog** — positioned battle sim: enemy bomb/DoT detonation now damages each targeted player ship individually (can kill covered ships, triggers their death effects), matching how player detonation already works.
+- [ ] **Step 2: Update memory** with PR3 status + the gate-widening fact.
+- [ ] **Step 3: Commit.**
+```bash
+git add src/constants/changelog.ts
+git commit -m "docs(combat): changelog for enemy->player per-victim detonation"
+```
+
+---
+
+### Task 4: Code review + open PR3
+
+- [ ] **Step 1:** `superpowers:requesting-code-review` on the PR3 diff.
+- [ ] **Step 2:** Address findings (prefer doc-only / targeted; re-run full suite after each).
+- [ ] **Step 3:** `gh auth switch --user TheSusort`; open PR3 stacked on `feat/combat-positional-detonation-pr2-timed` (PR2 #169). PR body: the byte-identical guarantee + that this resolves the E5 §4.3 PEELED detonation caveat (`engine.ts:5249`) and completes the symmetry (player→enemy PR1 + enemy→player PR3).
+
+---
+
+## Done criteria (PR3)
+
+- [ ] An enemy detonate skill lands per player footprint victim's own HP (origin + covered), full (no role-scale).
+- [ ] Enemy detonation can kill a positioned player → death + bomb-splash chain + per-victim reactives.
+- [ ] `bomb-detonated`/`dot-detonated` emit per victim; `perTargetDamage`/`perActorDetonation` reflect it; credit to the enemy attacker.
+- [ ] No double-count vs line 5432; the E5 §4.3 detonation caveat (`engine.ts:5249`) is resolved/removed.
+- [ ] E5-symmetry invariant: the same ship detonates identically on either side.
+- [ ] Non-positional fixtures **byte-identical**; full `npm test` green; tsc + lint clean.
+- [ ] Changelog updated; PR3 opened stacked on PR2 (#169).
 
 ---
 

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -51,6 +51,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator: enemy ships that cast a cleanse skill now actually remove the debuffs you applied to them, instead of the cleanse having no effect. Skills that trigger off an enemy being cleansed (such as Arum and Grif) now fire only when a debuff is really removed.',
     'Combat simulator: in positioned battles, bomb/Inferno/Corrosion detonation now damages each ship the skill hits individually — every target detonates its own stored bombs and damage-over-time effects against its own HP, so a detonation can now kill secondary (splash) targets and trigger their on-death effects, instead of only counting against the primary target.',
     'Combat simulator: in positioned battles, timed bombs and Echoing Burst accumulators now burst on each enemy ship individually — every affected ship detonates its own timed bombs and accumulators against its own HP on its own turn, so a timed burst can now kill that ship and trigger its on-death effects, instead of only counting against the primary target.',
+    'Combat simulator: in positioned battles, enemy detonation skills now damage each of your ships they hit individually — every targeted ship detonates its own stored bombs and damage-over-time effects against its own HP, mirroring how your ships detonate enemies, so an enemy detonation can now kill secondary (splash) targets and trigger their on-death effects.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3172,8 +3172,12 @@ const DocumentationPage: React.FC = () => {
                                     target. Timed bombs and Echoing Burst accumulators likewise
                                     burst on each enemy individually — every affected ship detonates
                                     its own timed bombs and accumulators against its own HP on its
-                                    own turn. More implant and gear-set effects will be added in
-                                    future updates.
+                                    own turn. This per-ship detonation works for{' '}
+                                    <strong>both teams</strong>: enemy detonation skills now damage
+                                    each of your ships they hit individually too, so an enemy
+                                    detonation can kill secondary (splash) targets and trigger their
+                                    on-death effects. More implant and gear-set effects will be
+                                    added in future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/utils/combat/__tests__/perVictimEnemyDetonation.integration.test.ts
+++ b/src/utils/combat/__tests__/perVictimEnemyDetonation.integration.test.ts
@@ -1,0 +1,516 @@
+/**
+ * Per-victim skill-triggered detonation on the POSITIONAL apply path (ENEMY → player).
+ *
+ * The mirror of perVictimDetonation.integration.test.ts (player → enemy). PR1 (#168) made the
+ * PLAYER focus attacker's positional detonate skill land per footprint enemy victim. PR3 wires the
+ * SAME behaviour for an ENEMY attacker: when a positioned enemy fires a positional AoE detonate
+ * skill at the player team, EACH player footprint victim HIT by the firing damage (and still alive)
+ * detonates its OWN stored containers — bombs (full shield drain, no pen) and inferno+corrosion
+ * (BYPASS shield, DoT semantics) — landing on that victim's own HP via `applyVictimDamage`, routed
+ * through `playerSink`, emitting per-victim `bomb-detonated` / `dot-detonated`, and surfacing on the
+ * per-round `perActorDetonation` tally credited to the ENEMY attacker.
+ *
+ * Before PR3 the enemy positional path applied ONLY the firing hit per-victim and DROPPED the
+ * detonation slice (the "DETONATION CAVEAT" at engine.ts:5249-5261).
+ *
+ * SEEDING: containers cannot be applied per-footprint-victim via abilities, so each PLAYER victim's
+ * `pendingBombs` / `corrosionEntries` / `infernoEntries` is pre-seeded directly through the
+ * `__testTapActors` construction hook (the same approach the player→enemy test uses). The enemy
+ * fires a Line-Range-1 AoE detonate skill at `front`, anchored at the front player covering the one
+ * behind it — both are HIT by the firing damage.
+ *
+ * Crit 0 keeps every credited value an exact integer.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { CombatActor, PendingBomb, ActiveDoTStack } from '../state';
+import type { CombatStatBlock } from '../../../types/calculator';
+import type { CombatEvent } from '../events';
+import { createEventBus } from '../events';
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `pved${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+// A small single-hit basic attack (multiplier 100%, 1 hit). attack is kept tiny so the FIRING hit
+// touches every footprint victim (marking them "hit") WITHOUT killing the high-HP ones.
+const basicAttack = (): Ability =>
+    ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } });
+
+const detonate = (dotType: 'bomb' | 'inferno' | 'corrosion', powerPct = 100): Ability =>
+    ab({
+        type: 'detonate-dot',
+        target: 'enemy',
+        config: { type: 'detonate-dot', dotType, powerPct },
+    });
+
+// An active slot: a basic attack (so the firing hit lands per-victim) plus the requested detonate
+// abilities (which the engine turns into the per-victim detonation recipe in positional mode).
+const detonateSlot = (...dets: Ability[]): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [basicAttack(), ...dets],
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+// AoE pattern: origin + one covered cell one step toward back (Pattern-Line-Range-1). Anchored at
+// the FRONT player it covers the cell behind — both are HIT by the firing damage.
+const lineRange1Pattern = (): ParsedPattern => ({
+    raw: 'line-range-1',
+    shape: 'line',
+    range: 1,
+    modifiers: {},
+});
+
+const ENEMY_ATTACK = 100; // tiny firing hit — marks victims hit without killing high-HP ones.
+
+// A neutral combat stat block for a positioned, zero-offense PLAYER team victim. crit 0 keeps
+// every credited value an exact integer; finite hp makes the victim damageable/killable.
+const victimStats = (hp: number): CombatStatBlock => ({
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    shieldPenetration: 0,
+    defence: 0,
+    hp,
+    hacking: 0,
+});
+
+// A positioned, zero-offense PLAYER team victim (walked so it has real stats/position). Its active
+// slot is empty → its own turn deals nothing (it is purely a damageable target).
+const playerVictim = (id: string, position: Position, hp: number): TeamActorEngineInput =>
+    ({
+        id,
+        speed: 1,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        walk: {
+            shipSkills: { slots: [] } as ShipSkills,
+            stats: victimStats(hp),
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+            healModifier: 0,
+        },
+    }) as TeamActorEngineInput;
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+// A positioned ENEMY attacker that fires a positional AoE detonate skill at the player team.
+const enemyDetonator = (id: string, position: Position, dets: Ability[]): EnemyAttacker =>
+    ({
+        id,
+        stats: {
+            attack: ENEMY_ATTACK,
+            crit: 0,
+            critDamage: 0,
+            defence: 0,
+            hp: 1_000_000,
+            speed: 100,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget('front'),
+        pattern: lineRange1Pattern(),
+        shipSkills: { slots: [detonateSlot(...dets)] },
+    }) as EnemyAttacker;
+
+// A pre-seeded bomb with all multipliers neutral (bomb payout = stacks × damagePerStack × powerPct).
+const bomb = (damagePerStack: number, stacks: number, sourceId = 'enemy-det'): PendingBomb => ({
+    countdown: 5, // never decremented to 0 before detonation
+    damagePerStack,
+    stacks,
+    tier: 100,
+    sourceId,
+    affinityMult: 1,
+    detonationDamageModifier: 0,
+    splashModifier: 0,
+});
+
+// A pre-seeded corrosion entry. Detonation corrosion payout (powerPct 100, neutral mults) =
+// stacks × (tier/100) × min(victimHp, 500_000) × remainingRounds.
+const corrosion = (tier: number, stacks: number, remainingRounds: number): ActiveDoTStack => ({
+    stacks,
+    tier,
+    remainingRounds,
+    sourceId: 'enemy-det',
+});
+
+// The two player victims occupy the front column (M4) and the cell behind (M3): the M4-anchored
+// Line-Range-1 footprint covers BOTH. The focus attacker (id 'attacker') is the heal target and
+// sits OUT of the footprint (M1, an isolated cell) so it is never hit — keeping the focus dummy
+// enemy HP and the focus player both inert. front = id 'pl-front' at M4; covered = 'pl-mid' at M3.
+const BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    // Focus player attacker: zero-offense, parked OUT of the enemy footprint (M1). It is the heal
+    // target (enemyAttackers require one). It fires nothing meaningful (empty active slot below).
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healModifier: 0,
+    healTargetId: 'attacker',
+    position: 'M1',
+    teamActors: [
+        playerVictim('pl-front', 'M4', 1_000_000_000),
+        playerVictim('pl-mid', 'M3', 1_000_000_000),
+    ],
+    enemyAttackers: [enemyDetonator('enemy-det', 'M4', [detonate('bomb')])],
+    ...overrides,
+});
+
+// Tap an ordered event log (mirrors the player→enemy test).
+const collect = (input: CombatEngineInput) => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    const types: CombatEvent['type'][] = ['bomb-detonated', 'dot-detonated', 'ship-destroyed'];
+    for (const t of types) bus.on(t, (e) => events.push(e as CombatEvent));
+    const result = runCombat({ ...input, bus });
+    return { events, result };
+};
+
+describe('per-victim skill-triggered detonation (positional ENEMY → player)', () => {
+    it('BOTH the origin and the covered PLAYER victim detonate their OWN bombs (covered no longer ignored)', () => {
+        idc = 0;
+        // Each victim carries a 2 × 1000 bomb → detonates for 2000 (powerPct 100, neutral mults).
+        const { events, result } = collect(
+            BASE({
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors.find((a) => a.id === 'pl-front')?.pendingBombs.push(bomb(1000, 2));
+                    actors.find((a) => a.id === 'pl-mid')?.pendingBombs.push(bomb(1000, 2));
+                },
+            })
+        );
+        const round = result.rounds[0];
+        // Per-target damage = firing hit (origin full 100 / covered half 50) + detonation 2000 each.
+        expect(round.perTargetDamage?.['pl-front']).toBe(100 + 2000);
+        expect(round.perTargetDamage?.['pl-mid']).toBe(50 + 2000);
+        // The per-round detonation tally credits the ENEMY attacker the SUM across both victims.
+        expect(round.perActorDetonation?.['enemy-det']).toBe(4000);
+        // bomb-detonated emitted per victim (one per bomb-carrying victim hit), crediting the enemy.
+        const bombDet = events.filter((e) => e.type === 'bomb-detonated');
+        expect(bombDet.length).toBe(2);
+        for (const e of bombDet) {
+            expect(e.actorId).toBe('enemy-det');
+            expect(e.damage).toBe(2000);
+        }
+    });
+
+    it("corrosion detonation uses the VICTIM's own HP for min(hp, 500k)", () => {
+        idc = 0;
+        // Only the covered victim (pl-mid, HP 300_000) carries corrosion: tier 100, 1 stack,
+        // remainingRounds 1 → payout = 1 × (100/100) × min(300_000, 500_000) × 1 = 300_000.
+        const { result } = collect(
+            BASE({
+                enemyAttackers: [enemyDetonator('enemy-det', 'M4', [detonate('corrosion')])],
+                teamActors: [
+                    playerVictim('pl-front', 'M4', 1_000_000_000),
+                    playerVictim('pl-mid', 'M3', 300_000),
+                ],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'pl-mid')
+                        ?.corrosionEntries.push(corrosion(100, 1, 1));
+                },
+            })
+        );
+        const round = result.rounds[0];
+        // covered victim: firing hit 50 (half of 100) + corrosion detonation 300_000 (bypass).
+        expect(round.perTargetDamage?.['pl-mid']).toBe(50 + 300_000);
+        expect(round.perActorDetonation?.['enemy-det']).toBe(300_000);
+    });
+
+    it('a PLAYER victim whose detonation exceeds its HP DIES; a leftover bomb then splashes its ally', () => {
+        idc = 0;
+        // Covered victim pl-mid (HP 1000) carries BOTH a corrosion entry (detonated this cast —
+        // tier 100, 1 stack, 1 round, hp-capped 1000 → 1000 damage, lethal) AND a leftover bomb the
+        // CORROSION-typed detonate does NOT consume. The detonate skill detonates ONLY corrosion, so
+        // the bomb survives → pl-mid dies from the corrosion detonation while still carrying the
+        // bomb → bomb-splash-on-death fires to its adjacent ally (pl-back at M2, a hex-neighbour of
+        // M3 but OUTSIDE the M4-anchored Line-Range-1 footprint → it took no firing/detonation
+        // damage, isolating the splash). pl-front (origin, huge HP) just detonates nothing extra.
+        const leftover = bomb(800, 1, 'pl-mid'); // splash = 1 × 800 × (100/4)/100 = 200
+        const { events, result } = collect(
+            BASE({
+                enemyAttackers: [enemyDetonator('enemy-det', 'M4', [detonate('corrosion')])],
+                teamActors: [
+                    playerVictim('pl-front', 'M4', 1_000_000_000),
+                    playerVictim('pl-mid', 'M3', 1000),
+                    playerVictim('pl-back', 'M2', 1_000_000_000), // adjacent to M3, outside footprint
+                ],
+                __testTapActors: (actors: CombatActor[]) => {
+                    const mid = actors.find((a) => a.id === 'pl-mid');
+                    mid?.corrosionEntries.push(corrosion(100, 1, 1)); // 1000 → lethal
+                    mid?.pendingBombs.push(leftover); // NOT consumed by the corrosion detonate
+                },
+            })
+        );
+        const round = result.rounds[0];
+        // pl-mid died this round.
+        const destroyed = events.filter((e) => e.type === 'ship-destroyed');
+        expect(destroyed.some((e) => e.actorId === 'pl-mid')).toBe(true);
+        // Its leftover bomb splashed the adjacent ally (bomb-splash-on-death chain).
+        expect(round.perActorSplash?.['pl-back']).toBe(200);
+    });
+
+    it("dot-detonated emits per victim carrying that victim's id (inferno bypass)", () => {
+        idc = 0;
+        // pl-mid carries an inferno entry; the detonate skill detonates inferno. Inferno payout =
+        // stacks × (tier/100) × effectiveAttack × remainingRounds × dotMult × affinityMult × pct ×
+        // detonationMult. With dotMult/affinityMult/detonationMult = 1, effectiveAttack = enemy
+        // attack 100: 1 × (100/100) × 100 × 1 = 100.
+        const { events, result } = collect(
+            BASE({
+                enemyAttackers: [enemyDetonator('enemy-det', 'M4', [detonate('inferno')])],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'pl-mid')
+                        ?.infernoEntries.push({
+                            stacks: 1,
+                            tier: 100,
+                            remainingRounds: 1,
+                            sourceId: 'enemy-det',
+                        });
+                },
+            })
+        );
+        const round = result.rounds[0];
+        const dotDet = events.filter((e) => e.type === 'dot-detonated');
+        // Exactly one dot-detonated, carrying the covered victim's id.
+        expect(dotDet.length).toBe(1);
+        expect(dotDet[0].targetId).toBe('pl-mid');
+        expect(dotDet[0].damage).toBe(100);
+        // Covered victim took firing 50 + inferno bypass 100.
+        expect(round.perTargetDamage?.['pl-mid']).toBe(50 + 100);
+        expect(round.perActorDetonation?.['enemy-det']).toBe(100);
+    });
+
+    it('the per-victim detonation does NOT touch the focus dummy enemy HP (no line-5432 double-count)', () => {
+        idc = 0;
+        // The focus dummy `enemy` (the player's notional target) must be untouched by the enemy's
+        // per-victim detonation — the detonation lands on PLAYER victims via playerSink, never folded
+        // into the focus enemy's HP/cumulativeDamage. The focus player at M1 is zero-offense and out
+        // of the footprint, so it deals no damage to the dummy either → enemy HP stays at full.
+        const { result } = collect(
+            BASE({
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors.find((a) => a.id === 'pl-front')?.pendingBombs.push(bomb(1000, 2));
+                    actors.find((a) => a.id === 'pl-mid')?.pendingBombs.push(bomb(1000, 2));
+                },
+            })
+        );
+        const round = result.rounds[0];
+        // The focus dummy `enemy` HP row is untouched by the enemy→player detonation: enemyHpPct stays
+        // at 100 (entering-round value, the dummy never took damage — the focus player at M1 deals
+        // none, and the per-victim detonation lands on PLAYER victims via playerSink, never folded into
+        // the focus enemy HP / cumulativeDamage). The detonation is fully accounted on the player
+        // victims' perTargetDamage instead.
+        expect(round.enemyHpPct).toBe(100);
+        expect(
+            (round.perTargetDamage?.['pl-front'] ?? 0) + (round.perTargetDamage?.['pl-mid'] ?? 0)
+        ).toBe(100 + 2000 + 50 + 2000);
+    });
+
+    it('REGRESSION: a NON-positional enemy detonate still drains via the legacy single-apply path', () => {
+        idc = 0;
+        // A bomb-bearing heal target, but the enemy attacker has NO position/pattern → enemyPositional
+        // is false → the legacy applyIncomingToTarget(damage, tgt, {bombPortion}) path drains the heal
+        // target's seeded bomb exactly as before. The detonation folds into the aggregate `damage`
+        // (detonationDamage) and lands on the heal target's HP — surfacing on its perTargetDamage row.
+        // No enemyPositional → perActorDetonation absent (the positional tally is positional-only) and
+        // perTargetDamage stays absent (positional-only). The drain surfaces on the heal target's HP.
+        const HEAL_TARGET_HP = 1_000_000_000;
+        let healTargetActor: CombatActor | undefined;
+        const { result } = collect(
+            BASE({
+                // No team victims; the lone player is the heal target (focus attacker).
+                teamActors: [],
+                enemyAttackers: [
+                    {
+                        id: 'enemy-det',
+                        stats: {
+                            attack: ENEMY_ATTACK,
+                            crit: 0,
+                            critDamage: 0,
+                            defence: 0,
+                            hp: 1_000_000,
+                            speed: 100,
+                        },
+                        chargeCount: 0,
+                        startCharged: false,
+                        // NO position / target / pattern → non-positional legacy path.
+                        shipSkills: { slots: [detonateSlot(detonate('bomb'))] },
+                    } as EnemyAttacker,
+                ],
+                hp: HEAL_TARGET_HP, // focus attacker hp (heal target)
+                __testTapActors: (actors: CombatActor[]) => {
+                    healTargetActor = actors.find((a) => a.id === 'attacker');
+                    healTargetActor?.pendingBombs.push(bomb(1000, 2));
+                },
+            })
+        );
+        const round = result.rounds[0];
+        // Legacy path: the heal target took firing 100 + detonation 2000 = 2100 via the single
+        // applyIncomingToTarget(damage, tgt, {bombPortion}) drain → its live currentHp dropped by 2100.
+        // (healTargetActor is a LIVE reference mutated by the run; read after runCombat for the final HP.)
+        expect(HEAL_TARGET_HP - (healTargetActor?.currentHp ?? 0)).toBe(2100);
+        // Non-positional → both positional-only surfaces stay absent (proves the positional branch is
+        // non-vacuous: it is the ONLY path that populates perActorDetonation / perTargetDamage).
+        expect(round.perActorDetonation).toBeUndefined();
+        expect(round.perTargetDamage).toBeUndefined();
+    });
+
+    it('E5-SYMMETRY: the SAME detonate ship pays out IDENTICALLY whether it acts as a PLAYER or an ENEMY', () => {
+        idc = 0;
+        // The defining team-symmetry pin. A detonate ship firing a Line-Range-1 bomb detonate at two
+        // positioned victims (origin huge HP, covered HP 300_000) carrying identical seeded bombs must
+        // produce IDENTICAL per-victim detonation payout integers + events whether the detonator is on
+        // the PLAYER side (PR1 path) or the ENEMY side (PR3 path).
+        const SEED_BOMB = () => bomb(1500, 3); // 3 × 1500 = 4500 per victim
+        const ORIGIN_HP = 1_000_000_000;
+        const COVERED_HP = 300_000;
+
+        // --- PLAYER side (PR1 path): the FOCUS attacker detonates two ENEMY victims. ---
+        const playerBus = createEventBus();
+        const playerEvents: CombatEvent[] = [];
+        playerBus.on('bomb-detonated', (e) => playerEvents.push(e as CombatEvent));
+        const playerResult = runCombat({
+            bus: playerBus,
+            attack: ENEMY_ATTACK,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [detonateSlot(detonate('bomb'))] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            healModifier: 0,
+            healTargetId: 'attacker',
+            position: 'M4',
+            target: parsedTarget('front'),
+            pattern: lineRange1Pattern(),
+            enemyAttackers: [
+                {
+                    id: 'e-origin',
+                    stats: {
+                        attack: 0,
+                        crit: 0,
+                        critDamage: 0,
+                        defence: 0,
+                        hp: ORIGIN_HP,
+                        speed: 1,
+                    },
+                    chargeCount: 0,
+                    startCharged: false,
+                    position: 'M4',
+                    shipSkills: { slots: [] } as ShipSkills,
+                } as EnemyAttacker,
+                {
+                    id: 'e-cover',
+                    stats: {
+                        attack: 0,
+                        crit: 0,
+                        critDamage: 0,
+                        defence: 0,
+                        hp: COVERED_HP,
+                        speed: 1,
+                    },
+                    chargeCount: 0,
+                    startCharged: false,
+                    position: 'M3',
+                    shipSkills: { slots: [] } as ShipSkills,
+                } as EnemyAttacker,
+            ],
+            __testTapActors: (actors: CombatActor[]) => {
+                actors.find((a) => a.id === 'e-origin')?.pendingBombs.push(SEED_BOMB());
+                actors.find((a) => a.id === 'e-cover')?.pendingBombs.push(SEED_BOMB());
+            },
+        });
+        const playerRound = playerResult.rounds[0];
+
+        // --- ENEMY side (PR3 path): an ENEMY attacker detonates two PLAYER victims. ---
+        const enemyBus = createEventBus();
+        const enemyEvents: CombatEvent[] = [];
+        enemyBus.on('bomb-detonated', (e) => enemyEvents.push(e as CombatEvent));
+        const enemyResult = runCombat({
+            bus: enemyBus,
+            ...BASE({
+                teamActors: [
+                    playerVictim('pl-front', 'M4', ORIGIN_HP),
+                    playerVictim('pl-mid', 'M3', COVERED_HP),
+                ],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors.find((a) => a.id === 'pl-front')?.pendingBombs.push(SEED_BOMB());
+                    actors.find((a) => a.id === 'pl-mid')?.pendingBombs.push(SEED_BOMB());
+                },
+            }),
+        });
+        const enemyRound = enemyResult.rounds[0];
+
+        // IDENTICAL per-victim detonation payout (origin vs covered), regardless of side.
+        expect(playerRound.perTargetDamage?.['e-origin']).toBe(
+            enemyRound.perTargetDamage?.['pl-front']
+        );
+        expect(playerRound.perTargetDamage?.['e-cover']).toBe(
+            enemyRound.perTargetDamage?.['pl-mid']
+        );
+        // IDENTICAL total detonation payout credited to the SAME detonating ship.
+        expect(playerRound.perActorDetonation?.['attacker']).toBe(
+            enemyRound.perActorDetonation?.['enemy-det']
+        );
+        expect(playerRound.perActorDetonation?.['attacker']).toBe(9000); // 4500 × 2
+        // IDENTICAL bomb-detonated event payloads (count + per-event damage).
+        expect(playerEvents.length).toBe(enemyEvents.length);
+        expect(playerEvents.length).toBe(2);
+        for (const e of [...playerEvents, ...enemyEvents]) {
+            expect(e.type === 'bomb-detonated' && e.damage).toBe(4500);
+        }
+    });
+});

--- a/src/utils/combat/__tests__/perVictimEnemyDetonation.integration.test.ts
+++ b/src/utils/combat/__tests__/perVictimEnemyDetonation.integration.test.ts
@@ -11,7 +11,7 @@
  * per-round `perActorDetonation` tally credited to the ENEMY attacker.
  *
  * Before PR3 the enemy positional path applied ONLY the firing hit per-victim and DROPPED the
- * detonation slice (the "DETONATION CAVEAT" at engine.ts:5249-5261).
+ * detonation slice (the resolved E5 §4.3 "DETONATION CAVEAT" in the enemy positional apply path).
  *
  * SEEDING: containers cannot be applied per-footprint-victim via abilities, so each PLAYER victim's
  * `pendingBombs` / `corrosionEntries` / `infernoEntries` is pre-seeded directly through the
@@ -320,7 +320,7 @@ describe('per-victim skill-triggered detonation (positional ENEMY → player)', 
         expect(round.perActorDetonation?.['enemy-det']).toBe(100);
     });
 
-    it('the per-victim detonation does NOT touch the focus dummy enemy HP (no line-5432 double-count)', () => {
+    it('the per-victim detonation does NOT touch the focus dummy enemy HP (no cumulativeDamage double-count)', () => {
         idc = 0;
         // The focus dummy `enemy` (the player's notional target) must be untouched by the enemy's
         // per-victim detonation — the detonation lands on PLAYER victims via playerSink, never folded

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -55,7 +55,7 @@ import { victimHitDamage } from './victimDamage';
 import { incomingReductionForHit, incomingBlockForIntake } from './incomingEffects';
 import { reflectedDamageForHit } from './damageReflection';
 import { splashDamageForBomb } from './bombSplash';
-import { detonateContainers } from './detonation';
+import { detonateContainers, type DetonationRecipe } from './detonation';
 import { outgoingAmplificationForHit } from './outgoingEffects';
 import { incomingHealAmpForRecipient } from './healAmplification';
 import { CHEAT_DEATH_BUFFS } from './cheatDeathBuffs';
@@ -3658,13 +3658,16 @@ export function runCombat(input: CombatEngineInput): {
                 // returns a `positionalDetonation` recipe for the per-victim detonation loop below
                 // to apply. Conditional spread → non-positional turns omit the key → byte-identical.
                 //
-                // SCOPED TO THE FOCUS ATTACKER (PR1): only the focus-turn site consumes the recipe
-                // (the per-victim detonation loop). The walked-team and enemy-attacker sites have no
-                // such loop yet, so setting `positional` for them would skip their anchor detonation
-                // and silently DROP it (recipe ignored). Gating on focusActorId keeps team/enemy on
-                // their prior anchor-detonation path (byte-identical) until PR2/PR3 wire the loop to
-                // those sites symmetrically.
-                ...(a.id === focusActorId &&
+                // SCOPED TO THE FOCUS ATTACKER + ENEMY SIDE (PR1 + PR3): the focus-turn site (PR1)
+                // and now the enemy-attacker site (PR3) both consume the recipe via a per-victim
+                // detonation loop, so they get `positional: true` (runPlayerTurn SKIPS the anchor
+                // detonation and returns the recipe; detonationDamage stays 0 — the loop applies it
+                // per footprint victim). The WALKED-TEAM players (side 'player', id !== focusActorId)
+                // are the ONLY site without such a loop yet, so setting `positional` for them would
+                // skip their anchor detonation and silently DROP it (recipe ignored). They stay on
+                // the prior anchor-detonation path (byte-identical) until a future PR wires the loop
+                // to the walked-team site symmetrically.
+                ...((a.id === focusActorId || a.side === 'enemy') &&
                 aoePattern != null &&
                 aoeTarget != null &&
                 tgt.position != null
@@ -5035,6 +5038,13 @@ export function runCombat(input: CombatEngineInput): {
                             // dead-target path and whenever the enemy is non-positional → legacy single-apply.
                             let enemyPositional = false;
                             let enemyScalars: AttackerDamageScalars | undefined;
+                            // PR3: the per-victim detonation recipe for the enemy positional path,
+                            // hoisted out of the else block (enemyTurn is scoped inside it). When the
+                            // enemy fires a positional detonate skill, runPlayerTurn returns the recipe
+                            // (detonationDamage 0) and the per-victim loop at the enemy drivePositionalApply
+                            // site consumes it. Stays undefined on the dead-target path and for any bare
+                            // enemy with no detonate() → the loop never runs (byte-identical).
+                            let enemyPositionalDetonation: DetonationRecipe | undefined;
                             // §4.5: inject break hook into runPlayerTurn for the enemy turn (mirrors
                             // focus/team sites). Captured BEFORE runPlayerTurn so Stasis re-applied
                             // by the same attack's debuff ability is not inadvertently broken.
@@ -5128,6 +5138,10 @@ export function runCombat(input: CombatEngineInput): {
                                     enemyPattern != null &&
                                     enemyTurn.positionalScalars != null;
                                 enemyScalars = enemyTurn.positionalScalars;
+                                // PR3: capture the per-victim detonation recipe (returned whenever
+                                // `positional: true` was set for this enemy turn — see the positional
+                                // hint gate). Consumed by the enemy-site per-victim detonation loop below.
+                                enemyPositionalDetonation = enemyTurn.positionalDetonation;
                                 // Record the enemy actor's round-scoped ctx (parity with player/team branches;
                                 // its own future DoT entries would tick with this ctx).
                                 lastTurnCtxByActor.set(actor.id, enemyTurn.turnCtx);
@@ -5246,20 +5260,20 @@ export function runCombat(input: CombatEngineInput): {
                                     // Phase-5 symmetric-accounting surface (the result still exposes a single
                                     // heal-target row today). Inert here regardless (no production caller
                                     // threads enemy position+pattern).
-                                    // DETONATION CAVEAT (E5 §4.3 — PEELED to a dedicated follow-up): only the
-                                    // firing hit (enemyScalars, the DIRECT channel) lands per-victim here. The
-                                    // aggregate `damage` also folds enemyTurn.detonationDamage, which the
-                                    // NON-positional branch already drains per-victim via
-                                    // applyIncomingToTarget(damage, tgt) → perActorIncoming (so non-positional
-                                    // detonation intake is ALREADY recorded). Only the POSITIONAL path leaves it
-                                    // unrouted — and routing it per-victim needs per-victim bomb attribution the
-                                    // engine does not track yet (detonation is a single turn-scalar, not
-                                    // per-target). E5 PEELED this per the spec's §5 pressure valve: it requires
-                                    // NEW tracking and has zero observable cost to defer (perActorIncoming is
-                                    // internal/unread by the UI, and no fixture threads enemy position+pattern
-                                    // WITH detonation → byte-identical today). A positional enemy-detonation
-                                    // model lands in the follow-up.
+                                    // DETONATION (E5 §4.3 — RESOLVED in PR3): the firing hit
+                                    // (enemyScalars, the DIRECT channel) lands per-victim here, and the
+                                    // per-victim skill-triggered detonation slice is routed by the loop
+                                    // below — each player footprint victim detonates its OWN containers
+                                    // against its OWN HP via playerSink (the mirror of the player→enemy
+                                    // block). detonationDamage is 0 on the positional path because the
+                                    // recipe (enemyPositionalDetonation) is consumed per-victim, not as
+                                    // a single turn-scalar — so it is no longer dropped.
                                     const tb = turnBindings(actor.side);
+                                    // PR3: collect EVERY player footprint victim hit by this enemy
+                                    // cast's firing damage (unique by id), so each can detonate its OWN
+                                    // containers after the firing hits land. Populated in the
+                                    // onVictimResolved hook below alongside the per-victim taken leech.
+                                    const detonationTargets = new Map<string, CombatActor>();
                                     drivePositionalApply({
                                         scalars: enemyScalars!,
                                         hitCrits: enemyHitCrits,
@@ -5276,6 +5290,7 @@ export function runCombat(input: CombatEngineInput): {
                                         // requiresHpDamage gates — mirroring the non-positional block
                                         // below, per victim.
                                         onVictimResolved: (victim, dmg, outcome) => {
+                                            detonationTargets.set(victim.id, victim);
                                             procTakenLeechesPerVictim(victim, dmg, outcome);
                                             if (victim.id === tgt.id) {
                                                 positionalShieldCaptured = true;
@@ -5287,6 +5302,74 @@ export function runCombat(input: CombatEngineInput): {
                                             }
                                         },
                                     });
+                                    // PR3: enemy→player per-victim skill-triggered detonation
+                                    // (mirror of the player→enemy block, routed through playerSink).
+                                    // Each PLAYER victim hit by this enemy cast that is STILL ALIVE
+                                    // detonates its OWN containers (no role-scale). Bombs = full shield
+                                    // drain/no pen; inferno+corrosion BYPASS shield. Credited to the
+                                    // detonating enemy's per-round detonation tally + roundPerTargetDamage;
+                                    // NOT into cumulativeDamage (HP lands per-victim via applyVictimDamage).
+                                    if (
+                                        enemyPositionalDetonation &&
+                                        enemyPositionalDetonation.dets.length > 0
+                                    ) {
+                                        for (const victim of detonationTargets.values()) {
+                                            if (victim.currentHp <= 0) continue; // died to firing hit (already splashed)
+                                            const result = detonateContainers(
+                                                enemyPositionalDetonation,
+                                                {
+                                                    corrosionEntries: victim.corrosionEntries,
+                                                    infernoEntries: victim.infernoEntries,
+                                                    pendingBombs: victim.pendingBombs,
+                                                    victimHp: tb.victimMaxHpFor(victim),
+                                                }
+                                            );
+                                            if (result.bomb > 0) {
+                                                applyVictimDamage(result.bomb, victim, playerSink, {
+                                                    killerId: actor.id,
+                                                    byDirectDamage: true,
+                                                    bombPortion: result.bomb, // full shield drain, no pen
+                                                    shieldPenetrationPct: 0,
+                                                });
+                                                bus.emit({
+                                                    type: 'bomb-detonated',
+                                                    actorId: actor.id,
+                                                    round: r,
+                                                    stacks: result.bombStacks,
+                                                    damage: result.bomb,
+                                                });
+                                                roundPerTargetDamage.set(
+                                                    victim.id,
+                                                    (roundPerTargetDamage.get(victim.id) ?? 0) +
+                                                        result.bomb
+                                                );
+                                            }
+                                            const bypass = result.inferno + result.corrosion;
+                                            if (bypass > 0) {
+                                                applyVictimDamage(bypass, victim, playerSink, {
+                                                    byDirectDamage: false, // DoT → bypass shield
+                                                });
+                                                bus.emit({
+                                                    type: 'dot-detonated',
+                                                    targetId: victim.id,
+                                                    round: r,
+                                                    damage: bypass,
+                                                });
+                                                roundPerTargetDamage.set(
+                                                    victim.id,
+                                                    (roundPerTargetDamage.get(victim.id) ?? 0) +
+                                                        bypass
+                                                );
+                                            }
+                                            const dealt = result.bomb + bypass;
+                                            if (dealt > 0) {
+                                                perActorDetonation.set(
+                                                    actor.id,
+                                                    (perActorDetonation.get(actor.id) ?? 0) + dealt
+                                                );
+                                            }
+                                        }
+                                    }
                                 } else {
                                     ({ shieldBefore, hpDamage, barriered } = applyIncomingToTarget(
                                         damage,


### PR DESCRIPTION
## PR3 — Enemy→player symmetric per-victim skill-triggered detonation

Stacked on **PR2 #169** (review against `feat/combat-positional-detonation-pr2-timed`). The final member of the positional per-victim detonation stack: PR1 (#168) made **player→enemy** skill detonation land per footprint victim; PR2 (#169) lifted the focus-enemy timed-burst gate for positioned enemies; **PR3 mirrors PR1 in the enemy→player direction.**

### The gap (named in-source)
`engine.ts` carried an explicit `DETONATION CAVEAT (E5 §4.3 — PEELED to a dedicated follow-up)`: on the enemy positional apply path, `drivePositionalApply` landed **only the direct firing hit** per-victim; the detonation slice (folded into the aggregate `damage`) was **dropped**. So an enemy detonate skill in a positioned battle never detonated the player victims' stored bombs/DoTs. **PR3 is that follow-up.**

### What changed (engine.ts only)
A near-exact mirror of PR1's player→enemy focus block — **the only production delta is `enemySink` → `playerSink`** plus a hoisted recipe:
1. **Widened the positional-hint gate** from `a.id === focusActorId` to `(a.id === focusActorId || a.side === 'enemy')`, so a positioned enemy's `runPlayerTurn` skips the anchor `detonate()` and returns the `positionalDetonation` recipe. Walked-team **player** actors stay on the legacy anchor path (a future 4th loop site).
2. Hoisted `enemyPositionalDetonation` out of the enemy-turn `else` block.
3. Collect the hit player victims via the enemy `drivePositionalApply` `onVictimResolved` hook.
4. Per-victim detonation loop: each alive player victim detonates its OWN containers against its OWN HP via `applyVictimDamage(…, playerSink, …)` — bombs full-drain/no-pen, inferno+corrosion shield-bypass — emitting per-victim `bomb-detonated`/`dot-detonated`, tallying `perActorDetonation[enemy]` + `roundPerTargetDamage[victim]`, **never** feeding `creditDamage('detonation')` (no `cumulativeDamage` double-count).
5. Resolved the §4.3 caveat comment.

No `playerTurn.ts` change — the recipe is already side-agnostic.

### Tests
New `perVictimEnemyDetonation.integration.test.ts` (7 cases): origin+covered both detonate full against own HP; per-victim corrosion `min(hp,500k)`; lethal detonation → death + bomb-splash chain; per-victim event id correctness crediting the enemy attacker; focus-dummy HP untouched (no double-count); a **non-positional regression pin**; and the **E5-symmetry pin** — the same detonate ship pays out identically as player vs enemy (the project's team-symmetry invariant).

### Guarantees
- **Byte-identical** for every existing fixture (no production caller threads enemy position+pattern → the positional enemy branch is inert for all goldens). **ZERO snapshots/goldens moved.**
- Full `npm test` green (3477 passed, +7 new), `tsc --noEmit` + `lint` (max-warnings 0) clean.
- Two-stage reviewed: spec compliance ✅ + code quality ✅ (minors only — triplicated-loop helper extraction deferred to the future walked-team site, per prior PR1 review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)