### PR TITLE
feat(combat): walked-team per-victim skill detonation + shared-helper extraction (PR-A)

### DIFF
--- a/docs/superpowers/plans/2026-06-27-positional-per-victim-stored-damage-completion.md
+++ b/docs/superpowers/plans/2026-06-27-positional-per-victim-stored-damage-completion.md
@@ -1,0 +1,256 @@
+# Positional Per-Victim Stored-Damage Completion — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete per-victim resolution of all stored/continuous damage (skill detonation, timed bursts, DoT ticks) across all four combat turn-branch sites, both directions, so positioned victims resolve their own containers against their own HP.
+
+**Architecture:** Three stacked PRs (A→B→C) on top of PR3 (`feat/combat-positional-detonation-pr3-enemy`, #170). Each routes per-victim payout through the existing `applyVictimDamage` sink (Approach A, inherited from the parent detonation epic) and stays byte-identical for non-positional goldens. PR-A extracts the now-duplicated detonation loop into a shared closure then adds the walked-team site; PR-B mirrors PR2's timed bursts onto the player side; PR-C adds per-victim DoT ticks both sides and unifies the heal-target tick path.
+
+**Tech Stack:** TypeScript, Vitest. Combat engine in `src/utils/combat/engine.ts` (one large `runCombat` closure), pure detonation helper in `src/utils/combat/detonation.ts`.
+
+**Spec:** `docs/superpowers/specs/2026-06-27-positional-per-victim-stored-damage-completion-design.md`
+
+---
+
+## Conventions for this epic (read first)
+
+- **All `engine.ts:NNNN` references are grep-anchors, not literal offsets.** Line numbers drift, and each stacked PR shifts them further. Always grep for the named marker (the comment text or symbol) to locate a site.
+- **Golden discipline:** hand-validate **every** positional delta; **never** `vitest -u`. Run the **whole** `npm test` suite for each golden audit — detonation/DoT fixtures live outside `src/utils/combat` (e.g. `healingGoldenParity`).
+- **Auth/workflow:** `gh auth switch --user TheSusort` before any `gh` call. Dev server on :3000. In-place branches (no worktree) per the established epic pattern; if a worktree is used, copy `.env` + `docs/*.csv` and symlink `node_modules`.
+- **Byte-identical proof:** after each task, `npm test` must show ZERO `.snap` files moved and no pre-existing golden changes. tsc + lint clean (`npm run lint` is max-warnings 0).
+- **Stacking:** PR-A branches off #170. PR-B off PR-A. PR-C off PR-B. Detail PR-B/PR-C in-place once the prior PR lands (line numbers will have moved).
+
+---
+
+## PR-A — Walked-team skill detonation + shared-helper extraction
+
+**Branch:** `feat/combat-positional-detonation-pr4-walked-team` off `feat/combat-positional-detonation-pr3-enemy`.
+
+**Two commits:** (1) byte-identical refactor extracting `applyPerVictimDetonation`; (2) the walked-team site (new behavior).
+
+### Task A1: Extract the shared per-victim detonation closure (byte-identical refactor)
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts` (focus block — grep `for (const victim of detonationTargets.values())` near the focus attacker turn, currently ~`:4496`; enemy block — same marker near the enemy-attacker turn, currently ~`:5316`)
+- Test: the entire existing suite is the guard (no new test file — this is a provably-inert refactor)
+
+The two loops are identical except the sink (`enemySink`/`playerSink`) and recipe variable. Both close over `applyVictimDamage`, `bus`, `r`, `perActorDetonation`, `roundPerTargetDamage`, `tb`, and `detonateContainers`.
+
+- [ ] **Step 1: Establish the green baseline.**
+
+Run: `npm test 2>&1 | tail -20`
+Expected: full suite green (note the exact test count, e.g. `3477 passed`). Record it — A1 must not change it.
+
+- [ ] **Step 2: Define the shared closure.**
+
+Add this inner function in `runCombat`'s scope, AFTER `perActorDetonation` is declared and AFTER `tb`/`turnBindings` are available but BEFORE the turn loop (grep for `let perActorDetonation` ~`:1944` and `const drivePositionalApply` ~`:3393`; place it adjacent to `drivePositionalApply` so it shares the same closure neighborhood). The body is the existing focus loop verbatim, parameterized:
+
+```typescript
+// Shared per-victim skill-triggered detonation loop. Each victim hit by the cast
+// that is STILL ALIVE detonates its OWN containers (no role-scale). Bombs = full
+// shield drain/no pen; inferno+corrosion BYPASS shield. Credited to the detonating
+// actor's per-round detonation tally + roundPerTargetDamage; NOT into cumulativeDamage
+// (HP lands per-victim via applyVictimDamage). Used by the focus (player→enemy),
+// enemy (enemy→player), and walked-team (player→enemy) sites — the ONLY difference
+// between call sites is the sink + the recipe source.
+const applyPerVictimDetonation = (
+    recipe: DetonationRecipe,
+    victims: Map<string, CombatActor>,
+    sink: DamageAccountingSink,
+    actorId: string
+): void => {
+    for (const victim of victims.values()) {
+        if (victim.currentHp <= 0) continue; // died to the firing hit (already splashed)
+        const result = detonateContainers(recipe, {
+            corrosionEntries: victim.corrosionEntries,
+            infernoEntries: victim.infernoEntries,
+            pendingBombs: victim.pendingBombs,
+            victimHp: tb.victimMaxHpFor(victim),
+        });
+        if (result.bomb > 0) {
+            applyVictimDamage(result.bomb, victim, sink, {
+                killerId: actorId,
+                byDirectDamage: true,
+                bombPortion: result.bomb, // full shield drain, no pen
+                shieldPenetrationPct: 0,
+            });
+            bus.emit({
+                type: 'bomb-detonated',
+                actorId,
+                round: r,
+                stacks: result.bombStacks,
+                damage: result.bomb,
+            });
+            roundPerTargetDamage.set(
+                victim.id,
+                (roundPerTargetDamage.get(victim.id) ?? 0) + result.bomb
+            );
+        }
+        const bypass = result.inferno + result.corrosion;
+        if (bypass > 0) {
+            applyVictimDamage(bypass, victim, sink, { byDirectDamage: false }); // DoT → bypass shield
+            bus.emit({ type: 'dot-detonated', targetId: victim.id, round: r, damage: bypass });
+            roundPerTargetDamage.set(
+                victim.id,
+                (roundPerTargetDamage.get(victim.id) ?? 0) + bypass
+            );
+        }
+        const dealt = result.bomb + bypass;
+        if (dealt > 0) {
+            perActorDetonation.set(actorId, (perActorDetonation.get(actorId) ?? 0) + dealt);
+        }
+    }
+};
+```
+
+> **Caveat:** `tb` is per-side (`turnBindings(actor.side)`) at each call site. The focus/walked-team sites use the player→enemy `tb`; the enemy site uses the enemy→player `tb`. `victimMaxHpFor` must come from the **caller's** `tb`, not a captured one. Therefore pass `tb` in too — amend the signature to `(recipe, victims, sink, actorId, tb)` and have each call site pass its own `tb`. Verify which `tb` each existing loop used before extracting (grep `const tb = turnBindings` above each loop).
+>
+> **Capture guard:** the helper body must reference ONLY its parameters plus the legitimately-shared closures (`applyVictimDamage`, `bus`, `r`, `perActorDetonation`, `roundPerTargetDamage`, `detonateContainers`). It must NOT reference any outer `tb`, `actor`, `detonationRecipe`, or `enemyPositionalDetonation` — those differ per call site and are now passed in. After extracting, scan the body to confirm no accidental outer capture.
+
+- [ ] **Step 3: Replace the focus block with a call.**
+
+Grep the focus loop (`for (const victim of detonationTargets.values())` near the focus attacker turn). Replace the whole `if (detonationRecipe && detonationRecipe.dets.length > 0) { for (...) {...} }` body's inner loop with:
+```typescript
+if (detonationRecipe && detonationRecipe.dets.length > 0) {
+    applyPerVictimDetonation(detonationRecipe, detonationTargets, enemySink, actor.id, tb);
+}
+```
+
+- [ ] **Step 4: Replace the enemy block with a call.**
+
+Grep the enemy loop (same marker near the enemy-attacker turn, uses `enemyPositionalDetonation` + `playerSink`). Replace with:
+```typescript
+if (enemyPositionalDetonation && enemyPositionalDetonation.dets.length > 0) {
+    applyPerVictimDetonation(enemyPositionalDetonation, detonationTargets, playerSink, actor.id, tb);
+}
+```
+
+- [ ] **Step 5: tsc + lint + full suite — prove inert.**
+
+Run: `npx tsc --noEmit && npm run lint && npm test 2>&1 | tail -20`
+Expected: tsc clean, lint clean, suite green with the **exact same count** as Step 1, ZERO `.snap` moved.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/utils/combat/engine.ts
+git commit -m "refactor(combat): extract shared per-victim detonation closure
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task A2: Walked-team per-victim detonation (new behavior)
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts` (positional-hint gate — grep `a.id === focusActorId || a.side === 'enemy'`, ~`:3667`; walked-team branch — grep `WALKED TEAM TURN`, ~`:4618`; walked-team detonation credit — grep `creditDamage(actor.id, 'detonation', teamTurn.detonationDamage)`, ~`:4761`)
+- Test: `src/utils/combat/__tests__/perVictimWalkedTeamDetonation.integration.test.ts` (new)
+
+- [ ] **Step 1: Write the failing integration test.**
+
+Model on `perVictimEnemyDetonation.integration.test.ts`. Use `__testTapActors` seeding, crit 0 for exact integers. Cases:
+1. A **walked-team ally** (not the focus attacker), positioned with a parsed target+pattern, casts a detonate-dot skill; seed bombs on a covered footprint victim → assert that victim's bombs detonate against its own HP (covered victim no longer ignored).
+2. Seed corrosion on a victim → assert it uses that victim's own HP (`min(victimHp,500k)`), bypasses shield.
+3. Detonation kills a covered victim → assert death event + bomb-splash-on-death chain.
+4. Credit attributed per applier; `bomb-detonated`/`dot-detonated` emit per victim with own `targetId`.
+5. **Non-positional regression pin:** a walked-team detonate in non-positional mode still surfaces `detonationDamage` via the legacy aggregate path (assert unchanged).
+6. **isPositional-gate negative pin:** walked-team actor with target but NO pattern stays on legacy path (no per-victim detonation) — prove non-vacuous by asserting the legacy credit fires.
+
+- [ ] **Step 2: Run it — verify it fails.**
+
+Run: `npx vitest run src/utils/combat/__tests__/perVictimWalkedTeamDetonation.integration.test.ts`
+Expected: FAIL — covered victim's bombs ignored / no per-victim detonation (walked-team still on anchor path).
+
+- [ ] **Step 3: Widen the positional-hint gate.**
+
+Grep `a.id === focusActorId || a.side === 'enemy'`. Extend to include positioned walked-team players. Confirm the exact predicate the focus/enemy sites use; the walked-team condition should mirror the `teamPositional` gate (`a.kind === 'team'` and positioned vs `enemyAttackerActors`). Verify (read playerTurn.ts `buildTurnArgs`/`runPlayerTurn`) that `positional:true` ONLY swaps `detonate()` for the recipe build — no other behavior change — exactly as PR3 verified.
+
+- [ ] **Step 4: Collect `detonationTargets` in the walked-team apply hook.**
+
+In the walked-team branch, in the existing `drivePositionalApply` `onVictimResolved` callback (grep `teamFocusEnemyHit = true`), add (mirroring the focus site) a `const detonationTargets = new Map<string, CombatActor>();` before the call and `detonationTargets.set(victim.id, victim);` inside the hook.
+
+- [ ] **Step 5: Call the shared closure + suppress the aggregate credit.**
+
+After `drivePositionalApply` in the walked-team branch, add:
+```typescript
+const teamDetonationRecipe = teamTurn.positionalDetonation;
+if (teamDetonationRecipe && teamDetonationRecipe.dets.length > 0) {
+    applyPerVictimDetonation(teamDetonationRecipe, detonationTargets, enemySink, actor.id, tb);
+}
+```
+Then move the existing `creditDamage(actor.id, 'detonation', teamTurn.detonationDamage)` (grep it, ~`:4761`) INTO the `if (!teamPositional)` block — mirror exactly how the focus site nests detonation credit in `if (!positional)`.
+
+- [ ] **Step 6: Run the new test — verify it passes.**
+
+Run: `npx vitest run src/utils/combat/__tests__/perVictimWalkedTeamDetonation.integration.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: tsc + lint + full suite audit.**
+
+Run: `npx tsc --noEmit && npm run lint && npm test 2>&1 | tail -30`
+Expected: clean; only the new test added; ZERO existing `.snap` moved.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add src/utils/combat/engine.ts src/utils/combat/__tests__/perVictimWalkedTeamDetonation.integration.test.ts
+git commit -m "feat(combat): walked-team per-victim skill-triggered detonation
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task A3: Changelog + docs
+
+**Files:**
+- Modify: `src/constants/changelog.ts` (`UNRELEASED_CHANGES`)
+- Modify: `src/pages/DocumentationPage.tsx` if the positional-sim section describes detonation coverage
+
+- [ ] **Step 1:** Add a plain-English `UNRELEASED_CHANGES` entry: positioned ally ships now detonate their targets' bombs/DoTs per-victim (previously only the focus attacker and enemies did).
+- [ ] **Step 2:** Commit `docs(combat): changelog for walked-team per-victim detonation`.
+
+### Task A4: Review + PR
+
+- [ ] **Step 1:** Final holistic review (the parent epic's practice: confirm the four detonation sites are now mutually consistent, no cumulativeDamage double-count, symmetry intact). Use superpowers:requesting-code-review.
+- [ ] **Step 2:** `gh auth switch --user TheSusort`; push; open PR-A stacked on #170 (base `feat/combat-positional-detonation-pr3-enemy`).
+
+---
+
+## PR-B — Positioned-player timed bursts (OUTLINE — detail in-place after PR-A lands)
+
+**Branch:** off PR-A. Mirror of PR2 (grep `PER-POSITIONED-ENEMY TIMED BURST`, ~`:4886`) onto the player attacker (grep `ATTACKER TURN`, ~`:4314`) and walked-team (grep `WALKED TEAM TURN`) branches.
+
+**Shape (per site):** at the start of the turn body, after `firstActivatorId ??=`, inside the `!isTurnBlocked` gate:
+- Gate `(actor.pendingBombs.length > 0 || actor.pendingAccumulators.length > 0) && isPositional(actor.position, enemyAttackerActors)`.
+- `processBombs` + `processAccumulators` callbacks route via `applyVictimDamage(dmg, actor, playerSink, { killerId: sourceId, byDirectDamage:true, bombPortion: dmg, shieldPenetrationPct:0 })` (accumulator same flags), `roundPerTargetDamage[actor.id]`, `perActorDetonation[sourceId]` (applier-keyed). NEVER `creditDamage('detonation')`.
+- Accumulator gather input: reuse `allPlayersDirect` with inline `// symmetric input TBD — inert, no fixture` note.
+- Dead-after-burst guard on `actor.destroyedRound !== undefined` (+ healTarget carve-out). Focus attacker: lethal self-burst still `pushSynthesizedFocusSkipTurn()`.
+
+**Tests:** `perVictimPlayerTimedDetonation.integration.test.ts` — burst on positioned player (focus + walked-team) via `playerSink`; lethal burst → death/splash; non-positional + gate-negative pins.
+
+**Detailing checklist when PR-B starts:** re-grep all anchors (shifted by PR-A); decide whether the two player sites share a helper closure like A1 did (likely yes — extract `applyPositionedTimedBurst` if the focus/walked-team/enemy timed blocks triplicate); confirm `pushSynthesizedFocusSkipTurn` ordering vs the burst.
+
+---
+
+## PR-C — Per-victim DoT ticks, both sides (OUTLINE — detail in-place after PR-B lands)
+
+**Branch:** off PR-B. **Highest risk** — Task 0 is a blocking written deliverable before any apply code.
+
+### Task C0 (BLOCKING, written deliverable, reviewed before code)
+Produce a channel-map: which `creditDamage` channels (`dot-inferno`, `dot-corrosion`, …) feed `cumulativeDamage` and thus the line-5326/5432 `enemy.currentHp` overwrite. Confirm the per-victim display story — the DPS DoT breakdown (`dot-*` totals) must still reflect per-victim ticks for the focus actor WITHOUT feeding HP twice (the detonation precedent: HP via `applyVictimDamage`, display via `roundPerTargetDamage` + per-victim path, aggregate credit suppressed in positional). Commit as a plan note; review before C.1/C.2.
+
+### C.1 — player→enemy (positioned enemies)
+Add `tickDoTs` at the enemy-attacker turn-start, ahead of PR2's timed block (canonical order `tickDoTs → processBombs → processAccumulators`). HP via `applyVictimDamage(dmg, actor, enemySink, { byDirectDamage:false })`; per-applier ctx via `lastTurnCtxByActor`; corrosion `baseHp = recipientMaxHp(actor.id)`; per-victim `dot-ticked`; suppress the cumulativeDamage feed for positioned enemies (per C0). Gate: positioned enemy with non-empty DoT containers.
+
+### C.2 — enemy→player (unify the heal-target path)
+Replace the heal-target prologue (grep `Task 11b: tick the HEAL TARGET's own enemy-applied DoTs`, ~`:4248`) with ONE per-victim DoT-tick path at every positioned player's turn-start (attacker + walked-team). Routes via `playerSink`/`applyIncomingToTarget` (`byDirectDamage:false`); per-applier ctx; corrosion `baseHp = recipientMaxHp(victim.id)`; per-victim Vortex Veil `incomingDotReductionPct`. Heal-target stays a branch: `tankDotSnapshot`, `tankDotDamage`→incoming healing accounting, `handleDeadTargetSkip` all fire when victim IS the heal target. Single path keyed per turning actor → structural double-tick guard.
+
+**Tests:** `perVictimDotTick.integration.test.ts` — C.1 enemy own-HP tick (corrosion uses own HP) + lethal tick→death; C.2 non-heal-target player tick + heal-target still ticks once with accounting/snapshot/dead-skip intact (unification regression); E5-symmetry pin (same carrier ticks identical integers/events both sides); non-positional + DPS-mode regression pins.
+
+**Detailing checklist when PR-C starts:** complete C0 first and get it reviewed; re-grep all anchors; design the per-victim DoT-tick closure (it will be called at 3+ sites — enemy, attacker, walked-team — so extract like A1/B); carefully preserve every heal-target side-effect during unification (the highest golden-move risk in the epic).
+
+---
+
+## Done criteria (whole epic)
+- Skill detonation, timed bursts, and DoT ticks all resolve per-victim at every applicable turn-branch site, both directions.
+- Every PR byte-identical for non-positional/DPS goldens (ZERO `.snap` moved per PR).
+- E5-symmetry pins green (same ship behaves identically on either side) for detonation (existing), timed bursts (PR-B), and DoT ticks (PR-C).
+- tsc + lint (max-warnings 0) clean; full `npm test` green.

--- a/docs/superpowers/specs/2026-06-27-positional-per-victim-stored-damage-completion-design.md
+++ b/docs/superpowers/specs/2026-06-27-positional-per-victim-stored-damage-completion-design.md
@@ -1,0 +1,254 @@
+# Positional Per-Victim Stored-Damage Resolution — Completion — Design
+
+**Date:** 2026-06-27
+**Status:** Approved (design); spec under review
+**Epic:** Combat realism — positional battle sim. Direct follow-up to the positional
+per-victim **detonation** spec (`2026-06-27-positional-per-victim-detonation-design.md`,
+PR1 #168 / PR2 #169 / PR3 #170).
+
+## Problem
+
+The detonation epic (PR1–PR3) made **skill-triggered** detonation land per-victim at the focus
+attacker site (PR1, player→enemy), the timed-burst enemy site (PR2, per positioned enemy), and
+the enemy-attacker skill site (PR3, enemy→player). Three stored/continuous-damage gaps remain —
+the siblings PR3 explicitly flagged as deferred. Mapped against the four turn-branch sites:
+
+| Mechanic | focus attacker | walked-team | focus-dummy / anchor | enemy-attacker |
+|---|---|---|---|---|
+| Skill detonation | ✓ PR1 | **✗ — Feature A** | n/a (legacy) | ✓ PR3 |
+| Timed bombs / accumulators | **✗ — Feature B** | **✗ — Feature B** | ✓ legacy | ✓ PR2 |
+| DoT ticks (`tickDoTs`) | **✗ — Feature C** | **✗ — Feature C** | ✓ anchor only | partial (heal-target only) |
+
+1. **Walked-team skill detonation (A).** The walked-team branch (`engine.ts:4618`) drives the
+   per-victim firing hit (`drivePositionalApply`) but has **no** per-victim detonation loop. The
+   positional-hint gate (`engine.ts:3667`) excludes walked-team players, so they stay on the
+   legacy `detonate()` → `creditDamage(actor.id,'detonation', teamTurn.detonationDamage)` aggregate
+   path (`engine.ts:4761`) against the **anchor**. A positioned ally's stored bombs/DoTs detonate
+   against the wrong target and can't kill positioned footprint victims. This is the deferred
+   "4th loop" — and PR3 deferred the shared-helper extraction "to when the 4th site lands."
+
+2. **Positioned-player timed bursts (B).** PR2 lifted timed `processBombs`/`processAccumulators`
+   to each **positioned enemy** (`engine.ts:4886`). The symmetric player case — a positioned
+   player carrying **enemy-seeded** timed bombs/accumulators bursting them on its own turn via
+   `playerSink` — was never added. The player attacker + walked-team branches never burst their
+   own timed containers.
+
+3. **DoT ticks (C).** `tickDoTs` runs only on the anchor enemy (`engine.ts:4807`) and the
+   heal-target (`engine.ts:4264`). DoT/bomb **application** lands on the parsed primary target
+   `tgt` (a real positioned victim's own containers, via `runPlayerTurn`), so positioned victims
+   **do** accumulate their own DoT containers — but:
+   - A positioned **enemy** that received player DoTs never ticks them (the anchor focus-dummy is
+     the empty `legacyVictim` in positional; the enemy-attacker branch has no `tickDoTs`).
+   - A **non-heal-target** positioned player that received enemy DoTs never ticks them (the
+     enemy footprint targets `allPlayerActors`, not just the heal target).
+   DoT ticks were explicitly carved out of PR1–PR3 — this is a genuinely new per-victim mechanic,
+   and it hits the same `cumulativeDamage` / line-5326 crux seam detonation did.
+
+## Goal
+
+Complete per-victim resolution of **all** stored/continuous damage across **all four** turn-branch
+sites, both directions — each footprint victim resolves its own stored containers against its own
+`currentHp` via `applyVictimDamage`, so detonation/bursts/ticks can kill positioned victims and
+fire per-victim death/reactives — honoring the engine team-symmetry rule (a ship behaves
+identically on either side).
+
+## Locked decisions (inherited from the parent epic + ratified 2026-06-27)
+
+- **Approach A** — route each victim's payout through the existing per-victim sink
+  `applyVictimDamage` (HP/shield/Barrier/Cheat-Death/death/per-victim reactives +
+  `roundPerTargetDamage` come free). Not re-litigated.
+- **No role-scale** — origin and covered footprint victims detonate/burst/tick the **full** stored
+  stacks. Bombs/DoTs are not affinity/AoE-role-scaled; only direct hits are.
+- **Both directions, symmetric** — player→enemy AND enemy→player, per
+  team-symmetry.
+- **Per-type apply flags** — bomb = full shield drain, **no penetration** (`bombPortion=full`,
+  `shieldPenetrationPct:0`); inferno/corrosion = **bypass** shield (`byDirectDamage:false`),
+  detonating-attacker scalars, corrosion `baseHp = min(victimHp, 500_000)`; accumulator =
+  bomb-style full-drain.
+- **Golden discipline** — hand-validate **every** positional delta; **never** `vitest -u`; run the
+  **whole** `npm test` suite for the audit (fixtures live outside `src/utils/combat` too); each PR
+  byte-identical for non-positional goldens.
+
+This spec covers three stacked PRs (A→B→C), each stacked on PR3's branch
+(`feat/combat-positional-detonation-pr3-enemy`, #170).
+
+---
+
+## PR-A — Walked-team skill detonation + shared-helper extraction
+
+**Decision:** refactor-first, then add the walked-team site.
+
+### Commit 1 — byte-identical refactor
+
+The per-victim skill-detonation loop currently exists as two near-identical copies — the focus
+block (`engine.ts:4494-4547`) and the PR3 enemy block — differing only by the sink
+(`enemySink`/`playerSink`) and recipe source. Extract into one helper:
+
+```
+applyPerVictimDetonation({ recipe, victims, sink, actorId, bus, round, tb,
+                           perActorDetonation, roundPerTargetDamage })
+```
+
+The body is the existing loop verbatim: skip victims dead to the firing hit (`currentHp <= 0`);
+`detonateContainers` against each victim's own containers + `tb.victimMaxHpFor(victim)`; apply
+bomb (`byDirectDamage:true, bombPortion:result.bomb, shieldPenetrationPct:0`) and
+inferno+corrosion (`byDirectDamage:false`) via `applyVictimDamage(_, victim, sink, …)`; emit
+per-victim `bomb-detonated` / `dot-detonated`; record `roundPerTargetDamage[victim.id]` and
+`perActorDetonation[actorId]`. The focus and PR3 enemy blocks call it. **Zero golden movement.**
+
+### Commit 2 — walked-team site (new behavior)
+
+- **Widen the positional-hint gate** (`engine.ts:3667`) from
+  `(a.id === focusActorId || a.side === 'enemy')` to also include positioned walked-team players,
+  so a walked-team ally's `runPlayerTurn` returns `positional:true` (skips `detonate()`, returns
+  the recipe, `detonationDamage=0`). Verify (as PR3 did) that `positional:true` *only* swaps
+  `detonate()` for the recipe build.
+- In the walked-team branch (`engine.ts:4618`), collect `detonationTargets` in the existing
+  `drivePositionalApply` `onVictimResolved` hook (mirror the focus site), then call
+  `applyPerVictimDetonation` with the walked-team `actor` as `actorId`, `enemySink`, and
+  `teamTurn.positionalDetonation` as the recipe.
+- **Suppress the aggregate detonation credit** at `engine.ts:4761` for the positional case — move
+  `creditDamage(actor.id,'detonation', teamTurn.detonationDamage)` into the existing
+  `if (!teamPositional)` block, exactly as the focus site moved it into `if (!positional)`.
+  Non-positional keeps the legacy `detonate()` credit → byte-identical.
+
+After PR-A, skill detonation is per-victim at all four sites.
+
+### Tests
+`perVictimWalkedTeamDetonation.integration.test.ts` (mirror `perVictimEnemyDetonation`): seed
+bombs/inferno/corrosion on covered + origin footprint victims of a **walked-team ally**'s cast;
+assert each detonates full against its own HP; covered victim killed → death + bomb-splash chain;
+credit per applier; per-victim events; non-positional regression pin (positional surfaces
+`detonationDamage` aggregate as before for legacy path). Refactor commit guarded by the full
+existing detonation suite staying byte-identical.
+
+---
+
+## PR-B — Positioned-player timed bursts
+
+The byte-for-byte mirror of PR2 (`engine.ts:4886-4978`) on the **player** side: a positioned
+player carrying **enemy-seeded** `pendingBombs`/`pendingAccumulators` bursts them on its own turn
+via `playerSink`.
+
+### Sites & placement
+Player attacker branch (`engine.ts:4331+`) and walked-team branch (`engine.ts:4631+`), at the
+**start** of the turn body (right after `firstActivatorId ??=`), **inside** the `!isTurnBlocked`
+stasis gate — same placement PR2 used for the enemy.
+
+- **Gate:** `(actor.pendingBombs.length > 0 || actor.pendingAccumulators.length > 0) &&
+  isPositional(actor.position, enemyAttackerActors)`. Strict no-op (byte-identical) for every
+  existing fixture — none seed player-actor timed containers.
+- **Route:** `applyVictimDamage(dmg, actor, playerSink, …)` + `roundPerTargetDamage[actor.id]` +
+  `perActorDetonation[sourceId]` (applier-keyed, matching PR2). **Never**
+  `creditDamage(…,'detonation')` (that feeds `cumulativeDamage` → the focus-dummy HP overwrite →
+  double-hit).
+- **Flags:** bomb = full-drain/no-pen; accumulator = bomb-style full-drain.
+- **Dead-after-burst guard:** keys on `actor.destroyedRound !== undefined` (the PR2 lesson —
+  *not* `currentHp > 0`, since bare actors carry `currentHp 0`), with the `healTarget` carve-out
+  mirroring the top-of-turn guard. For the **focus attacker**, a lethal self-burst must still
+  `pushSynthesizedFocusSkipTurn()` so the round assembles; walked-team needs no focus synthesis.
+
+### Open sub-decision (ratified) — accumulator gather input
+PR2's enemy accumulator gathers `allPlayersDirect` (round-global player-direct sum). The clean
+symmetric counterpart for a player-carried accumulator would be an all-enemies-direct sum, which
+the engine doesn't expose as a tidy value, and **no fixture/known ability applies accumulators to
+players**. Decision: spec the **bomb** path concretely; reuse the same `allPlayersDirect`
+expression for the player-side accumulator with an inline `// symmetric input TBD — inert, no
+fixture` note, keeping B a true structural mirror of PR2 without inventing an enemy-direct sum
+nothing exercises.
+
+### Tests
+`perVictimPlayerTimedDetonation.integration.test.ts` (mirror `perVictimTimedDetonation`): seed
+timed bombs on a positioned player (focus + walked-team); assert they burst against its own HP on
+its own turn via `playerSink`; lethal burst → death/splash; non-positional regression pin;
+`isPositional`-gate negative pin (proven non-vacuous by flipping the gate).
+
+---
+
+## PR-C — Per-victim DoT ticks (both sides)
+
+DoTs tick at the afflicted ship's turn-start. PR-C makes every positioned victim tick its own
+containers at its own turn-start. **Highest-risk PR** (touches the heavily-golden heal-target path
++ the cumulativeDamage seam) — `Task 0` resolves the seam before any apply lands.
+
+### Canonical per-victim turn-start order
+`tickDoTs → processBombs → processAccumulators` (matching the focus-dummy at
+`engine.ts:4807→4827→4848`). So the DoT tick runs **before** PR-B's player timed block and before
+PR2's enemy timed block.
+
+### Task 0 (blocking) — the cumulativeDamage seam
+The focus-dummy `tickDoTs` (`engine.ts:4807`) credits `creditDamage(sourceId, dotType, dmg)`, and
+that channel feeds `cumulativeDamage` → the line-5326/5432 HP overwrite. Per-victim must **stop
+feeding** that for positioned victims (else double-drain) — the exact detonation seam. Task 0
+verifies precisely which channels feed 5326, and confirms the display story (the DPS DoT
+breakdown — `dot-inferno`/`dot-corrosion` totals — must still reflect per-victim ticks for the
+focus actor without feeding HP twice), mirroring how detonation split display (`perActorDetonation`
++ `roundPerTargetDamage`) from HP (`applyVictimDamage`) with the aggregate credit suppressed.
+
+### C.1 — player→enemy (positioned enemies)
+Add `tickDoTs` at the enemy-attacker turn-start (`engine.ts:4880+`), ahead of the PR2 timed block,
+on `actor`'s own `corrosionEntries`/`infernoEntries`:
+- HP via `applyVictimDamage(dmg, actor, enemySink, { byDirectDamage:false })` (DoTs bypass shield);
+  per-applier ctx via `lastTurnCtxByActor`; corrosion `baseHp = recipientMaxHp(actor.id)`.
+- Display via `roundPerTargetDamage[actor.id]` + a per-victim DoT display path (the channel handling
+  Task 0 confirms); **no** `creditDamage` feed into `cumulativeDamage`.
+- Per-victim `dot-ticked` events (own `targetId`/payout); `expireStacks` inside `tickDoTs` ages
+  that victim's entries on its own turn.
+- Gate: positioned enemy with non-empty DoT containers → strict no-op otherwise.
+
+### C.2 — enemy→player (unify the heal-target path)
+**Decision:** unify. Replace the heal-target special case (`engine.ts:4248-4312`) with **one**
+per-victim DoT-tick path that runs for every positioned player at its turn-start (attacker +
+walked-team prologues):
+- Routes via `playerSink`/`applyIncomingToTarget` (`byDirectDamage:false`); per-applier ctx;
+  corrosion `baseHp = recipientMaxHp(victim.id)`; per-victim Vortex Veil `incomingDotReductionPct`
+  (the existing heal-target query, now keyed per victim).
+- **Heal-target preserved as a branch of the unified path:** `tankDotSnapshot` (display),
+  `tankDotDamage` → incoming healing accounting, and the post-tick dead-target re-skip
+  (`handleDeadTargetSkip`) all still fire when the victim *is* the heal target. Non-heal-target
+  positioned players get the tick (new behavior) with damage to their own HP only.
+- **Double-tick guard is structural:** a single path keyed per turning actor ticks each victim
+  exactly once.
+
+### Out of scope (carried forward)
+Per-victim **new** DoT/bomb application stays primary-target (`tgt`) only — application is a
+separate concern; per-victim ticking is meaningful regardless (containers accumulate on the
+primary target across rounds/attackers).
+
+### Tests
+`perVictimDotTick.integration.test.ts`: (C.1) seed inferno+corrosion on a non-focus positioned
+enemy → ticks against its own HP at its own turn (corrosion uses its own HP); lethal tick → death.
+(C.2) seed enemy DoTs on a non-heal-target positioned player → ticks at its turn; heal-target
+still ticks once with healing-accounting/snapshot/dead-skip intact (the unification regression).
+Plus the **E5-symmetry pin**: the same DoT carrier ticks identical per-victim integers/events as
+player vs enemy. Non-positional + DPS-mode regression pins (focus-dummy/heal-target paths
+byte-identical where positional doesn't apply).
+
+---
+
+## Risks & sequencing
+
+- **PR-A** is lowest risk (refactor is provably inert; the new site mirrors PR3).
+- **PR-B** is low risk (strict no-op gate; mirror of PR2).
+- **PR-C** is highest risk: Task 0 (the cumulativeDamage seam) is blocking, and the heal-target
+  unification touches the most-golden path. Land it last.
+- Stack: A on #170, B on A, C on B — continuing the established stack. If the upstream stack
+  (#165–#170) is slow to merge, the new PRs can rebase forward as each upstream lands.
+
+## Key file references
+- `src/utils/combat/engine.ts:3667` — positional-hint gate (PR-A widens it for walked-team).
+- `src/utils/combat/engine.ts:4494-4547` — focus per-victim detonation loop (PR-A extracts it).
+- `src/utils/combat/engine.ts:4618-4796` — walked-team branch (PR-A new site; PR-B player timed;
+  PR-C player DoT tick).
+- `src/utils/combat/engine.ts:4761` — walked-team aggregate detonation credit (PR-A suppresses).
+- `src/utils/combat/engine.ts:4331+` — focus attacker branch (PR-B player timed; PR-C player DoT).
+- `src/utils/combat/engine.ts:4248-4312` — heal-target DoT-tick prologue (PR-C unifies it).
+- `src/utils/combat/engine.ts:4807-4853` — focus-dummy `tickDoTs`/`processBombs`/
+  `processAccumulators` (PR-C order reference; the cumulativeDamage-feed crux).
+- `src/utils/combat/engine.ts:4880-4978` — PR2 per-positioned-enemy timed burst (PR-B mirror;
+  PR-C.1 ticks before it).
+- `src/utils/combat/engine.ts:5326/5432` — `cumulativeDamage` → `enemy.currentHp` overwrite (the
+  PR-C Task 0 seam).
+- `src/utils/combat/__tests__/perVictimLeech.test.ts`,
+  `perVictimEnemyDetonation.integration.test.ts`,
+  `perVictimTimedDetonation.integration.test.ts` — test-harness templates.

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -52,6 +52,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator: in positioned battles, bomb/Inferno/Corrosion detonation now damages each ship the skill hits individually — every target detonates its own stored bombs and damage-over-time effects against its own HP, so a detonation can now kill secondary (splash) targets and trigger their on-death effects, instead of only counting against the primary target.',
     'Combat simulator: in positioned battles, timed bombs and Echoing Burst accumulators now burst on each enemy ship individually — every affected ship detonates its own timed bombs and accumulators against its own HP on its own turn, so a timed burst can now kill that ship and trigger its on-death effects, instead of only counting against the primary target.',
     'Combat simulator: in positioned battles, enemy detonation skills now damage each of your ships they hit individually — every targeted ship detonates its own stored bombs and damage-over-time effects against its own HP, mirroring how your ships detonate enemies, so an enemy detonation can now kill secondary (splash) targets and trigger their on-death effects.',
+    'Combat simulator: in positioned battles, ally ships (the non-focus members of your fleet) now detonate per-victim — each ship the ally hits detonates its own stored bombs and damage-over-time effects against its own HP, so an ally detonation can now kill secondary targets and trigger their on-death effects such as bomb-splash-on-death.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3176,8 +3176,13 @@ const DocumentationPage: React.FC = () => {
                                     <strong>both teams</strong>: enemy detonation skills now damage
                                     each of your ships they hit individually too, so an enemy
                                     detonation can kill secondary (splash) targets and trigger their
-                                    on-death effects. More implant and gear-set effects will be
-                                    added in future updates.
+                                    on-death effects. Ally ships (the non-focus members of your
+                                    fleet) also detonate per-victim — each ship they hit detonates
+                                    its own stored bombs and damage-over-time effects against its
+                                    own HP, so an ally detonation can kill secondary targets and
+                                    trigger their on-death effects such as bomb-splash-on-death.
+                                    More implant and gear-set effects will be added in future
+                                    updates.
                                 </p>
                             </div>
                         </div>

--- a/src/utils/combat/__tests__/perVictimWalkedTeamDetonation.integration.test.ts
+++ b/src/utils/combat/__tests__/perVictimWalkedTeamDetonation.integration.test.ts
@@ -1,0 +1,425 @@
+/**
+ * Per-victim skill-triggered detonation on the POSITIONAL apply path (WALKED-TEAM ally → enemy).
+ *
+ * The THIRD cast-site mirror of perVictimDetonation.integration.test.ts (focus player → enemy) and
+ * perVictimEnemyDetonation.integration.test.ts (enemy → player). PR1 (#168) made the FOCUS attacker's
+ * positional detonate skill land per footprint enemy victim; PR3 (#170) wired the SAME for an ENEMY
+ * attacker. THIS suite wires the last remaining cast-site: a WALKED-TEAM ally (a non-focus player
+ * actor with `kind: 'team'`, its own board position + parsed target + parsed pattern) firing a
+ * positional AoE detonate skill at the enemy team. EACH enemy footprint victim HIT by the firing
+ * damage (and still alive) detonates its OWN stored containers — bombs (full shield drain, no pen)
+ * and inferno+corrosion (BYPASS shield, DoT semantics) — landing on that victim's own HP via
+ * `applyVictimDamage`, routed through `enemySink` (player→enemy), emitting per-victim
+ * `bomb-detonated` / `dot-detonated`, and surfacing on the per-round `perActorDetonation` tally
+ * credited to the WALKED-TEAM ally.
+ *
+ * Before this task the walked-team positional path applied ONLY the firing hit per-victim and DROPPED
+ * the detonation slice (it stayed on the legacy aggregate anchor credit because it had no per-victim
+ * loop and `positional` was withheld from its turn args).
+ *
+ * SEEDING: containers cannot be applied per-footprint-victim via abilities, so each ENEMY victim's
+ * `pendingBombs` / `corrosionEntries` / `infernoEntries` is pre-seeded directly through the
+ * `__testTapActors` construction hook (the same approach the focus + enemy tests use). The walked-team
+ * ally fires a Line-Range-1 AoE detonate skill at `front`, anchored at the front enemy (M4) covering
+ * M3 — both are HIT by the firing damage.
+ *
+ * Crit 0 keeps every credited value an exact integer.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { CombatActor, PendingBomb, ActiveDoTStack } from '../state';
+import type { CombatStatBlock } from '../../../types/calculator';
+import type { CombatEvent } from '../events';
+import { createEventBus } from '../events';
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `pvwt${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+// A small single-hit basic attack (multiplier 100%, 1 hit). attack is kept tiny so the FIRING hit
+// touches every footprint victim (marking them "hit") WITHOUT killing the high-HP ones.
+const basicAttack = (): Ability =>
+    ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } });
+
+const detonate = (dotType: 'bomb' | 'inferno' | 'corrosion', powerPct = 100): Ability =>
+    ab({
+        type: 'detonate-dot',
+        target: 'enemy',
+        config: { type: 'detonate-dot', dotType, powerPct },
+    });
+
+// An active slot: a basic attack (so the firing hit lands per-victim) plus the requested detonate
+// abilities (which the engine turns into the per-victim detonation recipe in positional mode).
+const detonateSlot = (...dets: Ability[]): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [basicAttack(), ...dets],
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+// AoE pattern: origin + one covered cell one step toward back (Pattern-Line-Range-1). Anchored at
+// the FRONT enemy (M4) it covers M3 — both are HIT by the firing damage.
+const lineRange1Pattern = (): ParsedPattern => ({
+    raw: 'line-range-1',
+    shape: 'line',
+    range: 1,
+    modifiers: {},
+});
+
+const TEAM_ATTACK = 100; // tiny firing hit — marks victims hit without killing high-HP ones.
+
+// A positioned, zero-offense, finite-HP enemy victim (a stationary, damageable target).
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+const enemyAt = (id: string, position: Position, hp: number): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        shipSkills: { slots: [] } as ShipSkills,
+    }) as EnemyAttacker;
+
+// The detonating WALKED-TEAM ally: a positioned, offensive player team actor (kind 'team') whose
+// active slot is a basic attack + the requested detonate abilities. target/pattern on the team-actor
+// input feed parsedTargetFor/parsedPatternFor → it takes the positional apply path.
+const teamStats = (): CombatStatBlock => ({
+    attack: TEAM_ATTACK,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    hacking: 0,
+});
+
+const teamDetonator = (id: string, position: Position, dets: Ability[]): TeamActorEngineInput =>
+    ({
+        id,
+        speed: 100, // acts each round
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        target: parsedTarget('front'),
+        pattern: lineRange1Pattern(),
+        walk: {
+            shipSkills: { slots: [detonateSlot(...dets)] },
+            stats: teamStats(),
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+            healModifier: 0,
+        },
+    }) as TeamActorEngineInput;
+
+// A pre-seeded bomb with all multipliers neutral (bomb payout = stacks × damagePerStack × powerPct).
+const bomb = (damagePerStack: number, stacks: number, sourceId = 'team-det'): PendingBomb => ({
+    countdown: 5, // never decremented to 0 before detonation
+    damagePerStack,
+    stacks,
+    tier: 100,
+    sourceId,
+    affinityMult: 1,
+    detonationDamageModifier: 0,
+    splashModifier: 0,
+});
+
+// A pre-seeded corrosion entry. Detonation corrosion payout (powerPct 100, neutral mults) =
+// stacks × (tier/100) × min(victimHp, 500_000) × remainingRounds.
+const corrosion = (tier: number, stacks: number, remainingRounds: number): ActiveDoTStack => ({
+    stacks,
+    tier,
+    remainingRounds,
+    sourceId: 'team-det',
+});
+
+// The focus player attacker is zero-offense and parked OUT of the enemy footprint (M1, isolated):
+// it fires nothing meaningful (empty active slot) so the only damage source is the WALKED-TEAM ally.
+// The team detonator sits at M4 (origin of the Line-Range-1 anchored at the front enemy). The two
+// enemy victims occupy the front column (M4) and the cell behind (M3): the M4-anchored Line-Range-1
+// footprint covers BOTH.
+const BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    // Focus player attacker: zero-offense, empty slot, parked at M1 (out of the footprint). It is
+    // the heal target. It deals no damage → the team ally is the only detonator.
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healModifier: 0,
+    healTargetId: 'attacker',
+    position: 'M1',
+    teamActors: [teamDetonator('team-det', 'M1', [detonate('bomb')])],
+    enemyAttackers: [
+        enemyAt('enemy-front', 'M4', 1_000_000_000),
+        enemyAt('enemy-mid', 'M3', 1_000_000_000),
+    ],
+    ...overrides,
+});
+
+// Tap an ordered event log.
+const collect = (input: CombatEngineInput) => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    const types: CombatEvent['type'][] = ['bomb-detonated', 'dot-detonated', 'ship-destroyed'];
+    for (const t of types) bus.on(t, (e) => events.push(e as CombatEvent));
+    const result = runCombat({ ...input, bus });
+    return { events, result };
+};
+
+describe('per-victim skill-triggered detonation (positional WALKED-TEAM ally → enemy)', () => {
+    it('BOTH the origin and the covered enemy victim detonate their OWN bombs (covered no longer ignored)', () => {
+        idc = 0;
+        // Each victim carries a 2 × 1000 bomb → detonates for 2000 (powerPct 100, neutral mults).
+        const { events, result } = collect(
+            BASE({
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors.find((a) => a.id === 'enemy-front')?.pendingBombs.push(bomb(1000, 2));
+                    actors.find((a) => a.id === 'enemy-mid')?.pendingBombs.push(bomb(1000, 2));
+                },
+            })
+        );
+        const round = result.rounds[0];
+        // Per-target damage = firing hit (origin full 100 / covered half 50) + detonation 2000 each.
+        expect(round.perTargetDamage?.['enemy-front']).toBe(100 + 2000);
+        expect(round.perTargetDamage?.['enemy-mid']).toBe(50 + 2000);
+        // The per-round detonation tally credits the WALKED-TEAM ally the SUM across both victims.
+        expect(round.perActorDetonation?.['team-det']).toBe(4000);
+        // bomb-detonated emitted per victim (one per bomb-carrying victim hit), crediting the ally.
+        const bombDet = events.filter((e) => e.type === 'bomb-detonated');
+        expect(bombDet.length).toBe(2);
+        for (const e of bombDet) {
+            expect(e.actorId).toBe('team-det');
+            expect(e.damage).toBe(2000);
+        }
+    });
+
+    it("corrosion detonation uses the VICTIM's own HP for min(hp, 500k)", () => {
+        idc = 0;
+        // Only the covered victim (enemy-mid, HP 300_000) carries corrosion: tier 100, 1 stack,
+        // remainingRounds 1 → payout = 1 × (100/100) × min(300_000, 500_000) × 1 = 300_000.
+        const { result } = collect(
+            BASE({
+                teamActors: [teamDetonator('team-det', 'M1', [detonate('corrosion')])],
+                enemyAttackers: [
+                    enemyAt('enemy-front', 'M4', 1_000_000_000),
+                    enemyAt('enemy-mid', 'M3', 300_000),
+                ],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'enemy-mid')
+                        ?.corrosionEntries.push(corrosion(100, 1, 1));
+                },
+            })
+        );
+        const round = result.rounds[0];
+        // covered victim: firing hit 50 (half of 100) + corrosion detonation 300_000 (bypass).
+        expect(round.perTargetDamage?.['enemy-mid']).toBe(50 + 300_000);
+        expect(round.perActorDetonation?.['team-det']).toBe(300_000);
+    });
+
+    it('an enemy victim whose detonation exceeds its HP DIES; a leftover bomb then splashes its ally', () => {
+        idc = 0;
+        // Covered victim enemy-mid (HP 1000) carries BOTH a corrosion entry (detonated this cast —
+        // tier 100, 1 stack, 1 round, hp-capped 1000 → 1000 damage, lethal) AND a leftover bomb the
+        // CORROSION-typed detonate does NOT consume. The detonate skill detonates ONLY corrosion, so
+        // the bomb survives → enemy-mid dies from the corrosion detonation while still carrying the
+        // bomb → bomb-splash-on-death fires to its adjacent ally (enemy-back at M2, a hex-neighbour of
+        // M3 but OUTSIDE the M4-anchored Line-Range-1 footprint → it took no firing/detonation damage,
+        // isolating the splash). enemy-front (origin, huge HP) just detonates nothing extra.
+        const leftover = bomb(800, 1, 'enemy-mid'); // splash = 1 × 800 × (100/4)/100 = 200
+        const { events, result } = collect(
+            BASE({
+                teamActors: [teamDetonator('team-det', 'M1', [detonate('corrosion')])],
+                enemyAttackers: [
+                    enemyAt('enemy-front', 'M4', 1_000_000_000),
+                    enemyAt('enemy-mid', 'M3', 1000),
+                    enemyAt('enemy-back', 'M2', 1_000_000_000), // adjacent to M3, outside footprint
+                ],
+                __testTapActors: (actors: CombatActor[]) => {
+                    const mid = actors.find((a) => a.id === 'enemy-mid');
+                    mid?.corrosionEntries.push(corrosion(100, 1, 1)); // 1000 → lethal
+                    mid?.pendingBombs.push(leftover); // NOT consumed by the corrosion detonate
+                },
+            })
+        );
+        const round = result.rounds[0];
+        // enemy-mid died this round.
+        const destroyed = events.filter((e) => e.type === 'ship-destroyed');
+        expect(destroyed.some((e) => e.actorId === 'enemy-mid')).toBe(true);
+        // Its leftover bomb splashed the adjacent ally (bomb-splash-on-death chain).
+        expect(round.perActorSplash?.['enemy-back']).toBe(200);
+    });
+
+    it("dot-detonated emits per victim carrying that victim's id (inferno bypass)", () => {
+        idc = 0;
+        // enemy-mid carries an inferno entry; the detonate skill detonates inferno. Inferno payout =
+        // stacks × (tier/100) × effectiveAttack × remainingRounds × dotMult × affinityMult × pct ×
+        // detonationMult. With dotMult/affinityMult/detonationMult = 1, effectiveAttack = the team
+        // ally's attack 100: 1 × (100/100) × 100 × 1 = 100.
+        const { events, result } = collect(
+            BASE({
+                teamActors: [teamDetonator('team-det', 'M1', [detonate('inferno')])],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'enemy-mid')
+                        ?.infernoEntries.push({
+                            stacks: 1,
+                            tier: 100,
+                            remainingRounds: 1,
+                            sourceId: 'team-det',
+                        });
+                },
+            })
+        );
+        const round = result.rounds[0];
+        const dotDet = events.filter((e) => e.type === 'dot-detonated');
+        // Exactly one dot-detonated, carrying the covered victim's id.
+        expect(dotDet.length).toBe(1);
+        expect(dotDet[0].targetId).toBe('enemy-mid');
+        expect(dotDet[0].damage).toBe(100);
+        // Covered victim took firing 50 + inferno bypass 100.
+        expect(round.perTargetDamage?.['enemy-mid']).toBe(50 + 100);
+        expect(round.perActorDetonation?.['team-det']).toBe(100);
+    });
+
+    it('REGRESSION: a NON-positional walked-team detonate still surfaces detonationDamage via the legacy aggregate path', () => {
+        idc = 0;
+        // No positioned enemy victims (only the dummy `enemy` sink exists). The walked-team ally has a
+        // target but NO pattern AND no positioned roster → selectTurnTarget falls back to the legacy
+        // dummy victim → teamPositional is false → it stays on the legacy single-anchor path: the team
+        // turn detonates the dummy `enemy` sink's seeded bomb (2 × 1000 = 2000) and the credit folds
+        // into teamTurn.detonationDamage (legacy creditDamage → the aggregate teamDamage number). No
+        // positional → the positional-only surfaces (perActorDetonation / perTargetDamage) stay
+        // absent. This pins the legacy aggregate path byte-identical.
+        const { events, result } = collect(
+            BASE({
+                // No positioned enemy victims; the lone enemy is the dummy sink (no enemyAttackers).
+                enemyAttackers: undefined,
+                teamActors: [
+                    {
+                        id: 'team-det',
+                        speed: 100,
+                        chargeCount: 0,
+                        startCharged: false,
+                        selfBuffs: [],
+                        enemyDebuffs: [],
+                        // position + target present but NO pattern → non-positional legacy path.
+                        position: 'M1',
+                        target: parsedTarget('front'),
+                        walk: {
+                            shipSkills: { slots: [detonateSlot(detonate('bomb'))] },
+                            stats: teamStats(),
+                            selfDotModifier: 0,
+                            defensePenetrationBuff: 0,
+                            affinityDamageModifier: 0,
+                            affinityCritCap: 100,
+                            affinityCritPenalty: 0,
+                            hasChargedSkill: false,
+                            healModifier: 0,
+                        },
+                    } as TeamActorEngineInput,
+                ],
+                __testTapActors: (actors: CombatActor[]) => {
+                    // Seed the dummy enemy sink's bomb (the legacy anchor target).
+                    actors.find((a) => a.id === 'enemy')?.pendingBombs.push(bomb(1000, 2));
+                },
+            })
+        );
+        const round = result.rounds[0];
+        // Legacy aggregate path: exactly ONE bomb-detonated (the single anchor = the dummy enemy),
+        // crediting the team ally for 2000.
+        const bombDet = events.filter((e) => e.type === 'bomb-detonated');
+        expect(bombDet.length).toBe(1);
+        expect(bombDet[0].actorId).toBe('team-det');
+        expect(bombDet[0].damage).toBe(2000);
+        // The aggregate teamDamage number (firing hit + detonation) reflects the legacy detonation:
+        // firing direct 100 + detonation 2000 = 2100.
+        expect(round.teamDamage).toBe(2100);
+        // Non-positional → both positional-only surfaces stay absent (proves the positional branch is
+        // non-vacuous: it is the ONLY path that populates perActorDetonation / perTargetDamage).
+        expect(round.perActorDetonation).toBeUndefined();
+        expect(round.perTargetDamage).toBeUndefined();
+    });
+
+    it('GATE-NEGATIVE: a walked-team detonate with a target but NO pattern stays on the legacy single-anchor path (no per-victim detonation)', () => {
+        idc = 0;
+        // Positioned enemy victims carry seeded bombs, but the walked-team ally has NO pattern →
+        // teamPositional is false → it never enters the per-victim loop. The legacy path detonates
+        // ONLY the SINGLE resolved anchor (target 'front' resolves to enemy-front) — NOT the covered
+        // enemy-mid. So enemy-mid's seeded bomb is NEVER detonated and the positional-only surfaces
+        // (perActorDetonation / perTargetDamage) stay absent. This proves the change is genuinely
+        // gated on the pattern (the per-victim path does NOT fire without it).
+        const { events, result } = collect(
+            BASE({
+                teamActors: [
+                    {
+                        id: 'team-det',
+                        speed: 100,
+                        chargeCount: 0,
+                        startCharged: false,
+                        selfBuffs: [],
+                        enemyDebuffs: [],
+                        position: 'M1',
+                        target: parsedTarget('front'), // target but NO pattern
+                        walk: {
+                            shipSkills: { slots: [detonateSlot(detonate('bomb'))] },
+                            stats: teamStats(),
+                            selfDotModifier: 0,
+                            defensePenetrationBuff: 0,
+                            affinityDamageModifier: 0,
+                            affinityCritCap: 100,
+                            affinityCritPenalty: 0,
+                            hasChargedSkill: false,
+                            healModifier: 0,
+                        },
+                    } as TeamActorEngineInput,
+                ],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors.find((a) => a.id === 'enemy-front')?.pendingBombs.push(bomb(1000, 2));
+                    actors.find((a) => a.id === 'enemy-mid')?.pendingBombs.push(bomb(1000, 2));
+                },
+            })
+        );
+        const round = result.rounds[0];
+        // Legacy single-anchor path: EXACTLY ONE bomb-detonated (the resolved anchor enemy-front).
+        // The covered enemy-mid's seeded bomb is NOT detonated (no per-victim loop without a pattern).
+        const bombDet = events.filter((e) => e.type === 'bomb-detonated');
+        expect(bombDet.length).toBe(1);
+        // Non-positional → positional-only surfaces stay absent (the per-victim path did NOT fire).
+        expect(round.perActorDetonation).toBeUndefined();
+        expect(round.perTargetDamage).toBeUndefined();
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3720,16 +3720,14 @@ export function runCombat(input: CombatEngineInput): {
                 // returns a `positionalDetonation` recipe for the per-victim detonation loop below
                 // to apply. Conditional spread → non-positional turns omit the key → byte-identical.
                 //
-                // SCOPED TO THE FOCUS ATTACKER + ENEMY SIDE (PR1 + PR3): the focus-turn site (PR1)
-                // and now the enemy-attacker site (PR3) both consume the recipe via a per-victim
-                // detonation loop, so they get `positional: true` (runPlayerTurn SKIPS the anchor
-                // detonation and returns the recipe; detonationDamage stays 0 — the loop applies it
-                // per footprint victim). The WALKED-TEAM players (side 'player', id !== focusActorId)
-                // are the ONLY site without such a loop yet, so setting `positional` for them would
-                // skip their anchor detonation and silently DROP it (recipe ignored). They stay on
-                // the prior anchor-detonation path (byte-identical) until a future PR wires the loop
-                // to the walked-team site symmetrically.
-                ...((a.id === focusActorId || a.side === 'enemy') &&
+                // ALL THREE CAST-SITES (PR1 + PR3 + PR4): the focus-turn site (PR1), the enemy-
+                // attacker site (PR3), and now the WALKED-TEAM site (PR4 — `a.kind === 'team'`) each
+                // consume the recipe via their own per-victim detonation loop, so all three get
+                // `positional: true` (runPlayerTurn SKIPS the anchor detonation and returns the
+                // recipe; detonationDamage stays 0 — the loop applies it per footprint victim). With
+                // the walked-team loop now wired, every positional cast-site lands detonation per
+                // footprint victim symmetrically; no cast-site silently drops the recipe.
+                ...((a.id === focusActorId || a.side === 'enemy' || a.kind === 'team') &&
                 aoePattern != null &&
                 aoeTarget != null &&
                 tgt.position != null
@@ -4712,6 +4710,12 @@ export function runCombat(input: CombatEngineInput): {
                             let teamFocusEnemyDamage = 0;
                             let teamFocusEnemyShieldWasHit = false;
                             let teamFocusEnemyHit = false;
+                            // Per-victim detonation (positional): collect EVERY footprint victim hit
+                            // by this cast's firing damage (unique by id), so each can detonate its
+                            // OWN containers after the firing hits land. Populated in the
+                            // onVictimResolved hook below alongside the standing-leech proc (mirror
+                            // of the focus site).
+                            const detonationTargets = new Map<string, CombatActor>();
                             drivePositionalApply({
                                 scalars: teamTurn.positionalScalars!,
                                 hitCrits: teamTurn.hitCrits,
@@ -4727,6 +4731,7 @@ export function runCombat(input: CombatEngineInput): {
                                 // proc as the focus site.
                                 onVictimResolved: (victim, damage, outcome) => {
                                     procStandingLeechesPerVictim(actor.id, damage);
+                                    detonationTargets.set(victim.id, victim);
                                     if (victim.id === tgt.id) {
                                         teamFocusEnemyHit = true;
                                         teamFocusEnemyDamage += damage;
@@ -4757,6 +4762,26 @@ export function runCombat(input: CombatEngineInput): {
                                     damage: teamFocusEnemyDamage,
                                 });
                             }
+
+                            // Per-victim skill-triggered detonation (positional) — mirror of the
+                            // focus site, keyed to THIS walked team actor. Each enemy victim HIT by
+                            // this cast that is STILL ALIVE detonates its OWN containers (no role-
+                            // scale — full stored stacks). Bombs = full shield drain/no pen; inferno+
+                            // corrosion BYPASS the shield (DoT semantics). Credited to the walked-team
+                            // actor's per-round detonation tally + roundPerTargetDamage; NOT into
+                            // cumulativeDamage (HP lands per-victim via applyVictimDamage). `tb`
+                            // resolves player→enemy → enemySink is the correct sink. recipe present
+                            // only when a detonate-dot ability fired (else dets empty).
+                            const teamDetonationRecipe = teamTurn.positionalDetonation;
+                            if (teamDetonationRecipe && teamDetonationRecipe.dets.length > 0) {
+                                applyPerVictimDetonation(
+                                    teamDetonationRecipe,
+                                    detonationTargets,
+                                    enemySink,
+                                    actor.id,
+                                    tb
+                                );
+                            }
                         }
 
                         // Fold the team turn's damage into ITS OWN map entry (post-round assembly
@@ -4775,8 +4800,12 @@ export function runCombat(input: CombatEngineInput): {
                             td.secondary += teamTurn.secondaryDamage;
                             td.conditional += teamTurn.conditionalDamage;
                             creditDamage(actor.id, 'direct', teamTurn.directDamage);
+                            // Detonation credit is suppressed in positional mode (teamTurn.detonationDamage
+                            // is 0 there anyway — runPlayerTurn returns the recipe instead). Keeping it
+                            // inside this guard documents intent and keeps per-victim detonation out of
+                            // cumulativeDamage (it lands per-victim via applyVictimDamage above).
+                            creditDamage(actor.id, 'detonation', teamTurn.detonationDamage);
                         }
-                        creditDamage(actor.id, 'detonation', teamTurn.detonationDamage);
 
                         // The team turn's result row fields (action/roundCrit/etc.) are NOT consumed
                         // beyond damage + resisted routing + ctx. Stage its resisted enemy applications

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3565,6 +3565,68 @@ export function runCombat(input: CombatEngineInput): {
         const turnBindings = (side: Side): TurnBindings =>
             side === 'player' ? playerTurnBindings : enemyTurnBindings;
 
+        // Shared per-victim skill-triggered detonation loop. Each victim hit by the cast
+        // that is STILL ALIVE detonates its OWN containers (no role-scale). Bombs = full
+        // shield drain/no pen; inferno+corrosion BYPASS shield. Credited to the detonating
+        // actor's per-round detonation tally + roundPerTargetDamage; NOT into cumulativeDamage
+        // (HP lands per-victim via applyVictimDamage). Used by the focus (player→enemy),
+        // enemy (enemy→player), and walked-team (player→enemy) sites — the ONLY difference
+        // between call sites is the sink + the recipe source + the per-side tb.
+        const applyPerVictimDetonation = (
+            recipe: DetonationRecipe,
+            victims: Map<string, CombatActor>,
+            sink: DamageAccountingSink,
+            actorId: string,
+            tb: TurnBindings
+        ): void => {
+            for (const victim of victims.values()) {
+                if (victim.currentHp <= 0) continue; // died to the firing hit (already splashed)
+                const result = detonateContainers(recipe, {
+                    corrosionEntries: victim.corrosionEntries,
+                    infernoEntries: victim.infernoEntries,
+                    pendingBombs: victim.pendingBombs,
+                    victimHp: tb.victimMaxHpFor(victim),
+                });
+                if (result.bomb > 0) {
+                    applyVictimDamage(result.bomb, victim, sink, {
+                        killerId: actorId,
+                        byDirectDamage: true,
+                        bombPortion: result.bomb, // full shield drain, no pen
+                        shieldPenetrationPct: 0,
+                    });
+                    bus.emit({
+                        type: 'bomb-detonated',
+                        actorId,
+                        round: r,
+                        stacks: result.bombStacks,
+                        damage: result.bomb,
+                    });
+                    roundPerTargetDamage.set(
+                        victim.id,
+                        (roundPerTargetDamage.get(victim.id) ?? 0) + result.bomb
+                    );
+                }
+                const bypass = result.inferno + result.corrosion;
+                if (bypass > 0) {
+                    applyVictimDamage(bypass, victim, sink, { byDirectDamage: false }); // DoT → bypass shield
+                    bus.emit({
+                        type: 'dot-detonated',
+                        targetId: victim.id,
+                        round: r,
+                        damage: bypass,
+                    });
+                    roundPerTargetDamage.set(
+                        victim.id,
+                        (roundPerTargetDamage.get(victim.id) ?? 0) + bypass
+                    );
+                }
+                const dealt = result.bomb + bypass;
+                if (dealt > 0) {
+                    perActorDetonation.set(actorId, (perActorDetonation.get(actorId) ?? 0) + dealt);
+                }
+            }
+        };
+
         // Unified positional target selection (bySide unification PR6a). Reproduces the
         // focus(C1)/team(C2)/enemy(C3) selection: resolve the actor's parsed target against
         // its opposing roster, else fall back to the side's legacy victim (dummy / heal target).
@@ -4493,57 +4555,13 @@ export function runCombat(input: CombatEngineInput): {
                             // recipe present only when a detonate-dot ability fired (else dets empty).
                             const detonationRecipe = turn.positionalDetonation;
                             if (detonationRecipe && detonationRecipe.dets.length > 0) {
-                                for (const victim of detonationTargets.values()) {
-                                    if (victim.currentHp <= 0) continue; // died to the firing hit (already splashed)
-                                    const result = detonateContainers(detonationRecipe, {
-                                        corrosionEntries: victim.corrosionEntries,
-                                        infernoEntries: victim.infernoEntries,
-                                        pendingBombs: victim.pendingBombs,
-                                        victimHp: tb.victimMaxHpFor(victim),
-                                    });
-                                    if (result.bomb > 0) {
-                                        applyVictimDamage(result.bomb, victim, enemySink, {
-                                            killerId: actor.id,
-                                            byDirectDamage: true,
-                                            bombPortion: result.bomb, // full shield drain, no pen
-                                            shieldPenetrationPct: 0,
-                                        });
-                                        bus.emit({
-                                            type: 'bomb-detonated',
-                                            actorId: actor.id,
-                                            round: r,
-                                            stacks: result.bombStacks,
-                                            damage: result.bomb,
-                                        });
-                                        roundPerTargetDamage.set(
-                                            victim.id,
-                                            (roundPerTargetDamage.get(victim.id) ?? 0) + result.bomb
-                                        );
-                                    }
-                                    const bypass = result.inferno + result.corrosion;
-                                    if (bypass > 0) {
-                                        applyVictimDamage(bypass, victim, enemySink, {
-                                            byDirectDamage: false, // DoT → bypass shield
-                                        });
-                                        bus.emit({
-                                            type: 'dot-detonated',
-                                            targetId: victim.id,
-                                            round: r,
-                                            damage: bypass,
-                                        });
-                                        roundPerTargetDamage.set(
-                                            victim.id,
-                                            (roundPerTargetDamage.get(victim.id) ?? 0) + bypass
-                                        );
-                                    }
-                                    const dealt = result.bomb + bypass;
-                                    if (dealt > 0) {
-                                        perActorDetonation.set(
-                                            actor.id,
-                                            (perActorDetonation.get(actor.id) ?? 0) + dealt
-                                        );
-                                    }
-                                }
+                                applyPerVictimDetonation(
+                                    detonationRecipe,
+                                    detonationTargets,
+                                    enemySink,
+                                    actor.id,
+                                    tb
+                                );
                             }
                         }
 
@@ -5313,62 +5331,13 @@ export function runCombat(input: CombatEngineInput): {
                                         enemyPositionalDetonation &&
                                         enemyPositionalDetonation.dets.length > 0
                                     ) {
-                                        for (const victim of detonationTargets.values()) {
-                                            if (victim.currentHp <= 0) continue; // died to firing hit (already splashed)
-                                            const result = detonateContainers(
-                                                enemyPositionalDetonation,
-                                                {
-                                                    corrosionEntries: victim.corrosionEntries,
-                                                    infernoEntries: victim.infernoEntries,
-                                                    pendingBombs: victim.pendingBombs,
-                                                    victimHp: tb.victimMaxHpFor(victim),
-                                                }
-                                            );
-                                            if (result.bomb > 0) {
-                                                applyVictimDamage(result.bomb, victim, playerSink, {
-                                                    killerId: actor.id,
-                                                    byDirectDamage: true,
-                                                    bombPortion: result.bomb, // full shield drain, no pen
-                                                    shieldPenetrationPct: 0,
-                                                });
-                                                bus.emit({
-                                                    type: 'bomb-detonated',
-                                                    actorId: actor.id,
-                                                    round: r,
-                                                    stacks: result.bombStacks,
-                                                    damage: result.bomb,
-                                                });
-                                                roundPerTargetDamage.set(
-                                                    victim.id,
-                                                    (roundPerTargetDamage.get(victim.id) ?? 0) +
-                                                        result.bomb
-                                                );
-                                            }
-                                            const bypass = result.inferno + result.corrosion;
-                                            if (bypass > 0) {
-                                                applyVictimDamage(bypass, victim, playerSink, {
-                                                    byDirectDamage: false, // DoT → bypass shield
-                                                });
-                                                bus.emit({
-                                                    type: 'dot-detonated',
-                                                    targetId: victim.id,
-                                                    round: r,
-                                                    damage: bypass,
-                                                });
-                                                roundPerTargetDamage.set(
-                                                    victim.id,
-                                                    (roundPerTargetDamage.get(victim.id) ?? 0) +
-                                                        bypass
-                                                );
-                                            }
-                                            const dealt = result.bomb + bypass;
-                                            if (dealt > 0) {
-                                                perActorDetonation.set(
-                                                    actor.id,
-                                                    (perActorDetonation.get(actor.id) ?? 0) + dealt
-                                                );
-                                            }
-                                        }
+                                        applyPerVictimDetonation(
+                                            enemyPositionalDetonation,
+                                            detonationTargets,
+                                            playerSink,
+                                            actor.id,
+                                            tb
+                                        );
                                     }
                                 } else {
                                     ({ shieldBefore, hpDamage, barriered } = applyIncomingToTarget(


### PR DESCRIPTION
## What

PR-A of the **positional per-victim stored-damage completion** epic — completes per-victim skill-triggered bomb/DoT detonation across **all three** cast-sites in the positional battle simulator. Walked-team allies (the non-focus members of your fleet) now detonate per-victim, mirroring the focus attacker (PR1 #168) and enemy ships (PR3 #170).

Stacked on #170 (base `feat/combat-positional-detonation-pr3-enemy`).

## Commits

1. **`refactor`** — extract the duplicated focus + enemy per-victim detonation loops into one shared closure `applyPerVictimDetonation(recipe, victims, sink, actorId, tb)`. Byte-identical (3477→3477, zero goldens moved). `tb` is passed per-call-site, not captured — the focus/walked-team sites resolve player→enemy bindings, the enemy site enemy→player.
2. **`feat`** — walked-team per-victim detonation:
   - Widen the `positional:true` hint gate to include `kind:'team'` actors (the `aoePattern/aoeTarget/position` preconditions already guard it; non-positional turns omit the key → byte-identical).
   - Add the per-victim detonation loop in the walked-team turn branch, collecting `detonationTargets` in the existing `drivePositionalApply` `onVictimResolved` hook and calling the shared helper with `enemySink`.
   - Move the aggregate `creditDamage(...,'detonation',...)` into `if (!teamPositional)` so positional HP (landed per-victim via `applyVictimDamage`) is never double-counted through `cumulativeDamage`.
   - New test `perVictimWalkedTeamDetonation.integration.test.ts` (6 cases): covered+origin victims each detonate own bombs; corrosion uses victim's own HP (`min(hp,500k)`) + shield bypass; lethal detonation → death + bomb-splash chain; per-applier credit + per-victim events; non-positional regression pin; gate-negative pin (non-vacuous).
3. **`docs`** — changelog + DocumentationPage entry.

## Safety

- **Byte-identical for non-positional / DPS runs** — zero `.snap` moved across the whole PR; legacy aggregate detonation credit preserved when not positional.
- **No drop-bug:** every actor kind that matches the widened gate has a consuming per-victim loop; legacy team actors and the dummy enemy never call `buildTurnArgs`, so they can't receive (or drop) a recipe.
- 3483 tests green; tsc + lint (max-warnings 0) clean.
- Reviewed: each task two-stage (spec + quality), plus a final holistic pass — all approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
