### PR TITLE
feat(combat): positioned-player timed bomb/accumulator bursts (PR-B)

### DIFF
--- a/docs/superpowers/plans/2026-06-27-positional-per-victim-stored-damage-completion.md
+++ b/docs/superpowers/plans/2026-06-27-positional-per-victim-stored-damage-completion.md
@@ -214,19 +214,214 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 ---
 
-## PR-B — Positioned-player timed bursts (OUTLINE — detail in-place after PR-A lands)
+## PR-B — Positioned-player timed bursts
 
-**Branch:** off PR-A. Mirror of PR2 (grep `PER-POSITIONED-ENEMY TIMED BURST`, ~`:4886`) onto the player attacker (grep `ATTACKER TURN`, ~`:4314`) and walked-team (grep `WALKED TEAM TURN`) branches.
+**Branch:** `feat/combat-positional-detonation-pr5-player-timed` off PR-A (`feat/combat-positional-detonation-pr4-walked-team`, #171). Worktree at `.worktrees/pr5-player-timed` (this epic ran in-place before; PR-B uses a worktree because the main dir is busy rebasing the upstream stack). Worktree setup already done: `node_modules` symlinked, `.env` + `docs/*.csv` copied.
 
-**Shape (per site):** at the start of the turn body, after `firstActivatorId ??=`, inside the `!isTurnBlocked` gate:
-- Gate `(actor.pendingBombs.length > 0 || actor.pendingAccumulators.length > 0) && isPositional(actor.position, enemyAttackerActors)`.
-- `processBombs` + `processAccumulators` callbacks route via `applyVictimDamage(dmg, actor, playerSink, { killerId: sourceId, byDirectDamage:true, bombPortion: dmg, shieldPenetrationPct:0 })` (accumulator same flags), `roundPerTargetDamage[actor.id]`, `perActorDetonation[sourceId]` (applier-keyed). NEVER `creditDamage('detonation')`.
-- Accumulator gather input: reuse `allPlayersDirect` with inline `// symmetric input TBD — inert, no fixture` note.
-- Dead-after-burst guard on `actor.destroyedRound !== undefined` (+ healTarget carve-out). Focus attacker: lethal self-burst still `pushSynthesizedFocusSkipTurn()`.
+**What it does:** the byte-for-byte mirror of PR2 (per-positioned-**enemy** timed burst) onto the **player** side. A positioned player (focus attacker OR walked-team ally) carrying **enemy-seeded** `pendingBombs`/`pendingAccumulators` bursts them at the START of its own turn, against its OWN HP, via `playerSink` — instead of those timed containers never firing.
 
-**Tests:** `perVictimPlayerTimedDetonation.integration.test.ts` — burst on positioned player (focus + walked-team) via `playerSink`; lethal burst → death/splash; non-positional + gate-negative pins.
+**Decision (detailing checklist resolved):** **Extract-first**, like PR-A. The timed-burst block exists today at exactly ONE site (PR2 enemy). Extract it into a shared `applyPositionedTimedBurst(actor, sink, opposingRoster)` closure (commit 1, byte-identical — enemy site adopts), then add the two player sites that call it (commit 2). After extraction the burst is shared by 3 sites (enemy + focus + walked-team), parameterized only by `sink` + `opposingRoster`. The accumulator gather input (`allPlayersDirect`) is computed inside the helper — correct for the enemy site, the ratified inert placeholder for the player side (no enemy-direct sum exists; no fixture/ability applies accumulators to players).
 
-**Detailing checklist when PR-B starts:** re-grep all anchors (shifted by PR-A); decide whether the two player sites share a helper closure like A1 did (likely yes — extract `applyPositionedTimedBurst` if the focus/walked-team/enemy timed blocks triplicate); confirm `pushSynthesizedFocusSkipTurn` ordering vs the burst.
+**Anchor re-grep (PR-A-shifted, in this PR-B base; all `:NNNN` are grep-anchors — verify before editing):**
+- PR2 enemy timed block: grep `PER-POSITIONED-ENEMY TIMED BURST` (~`:4933`); its dead-after-burst guard: grep `burstDestroyedActor` (~`:5040`).
+- Shared-closure neighborhood: grep `const applyPerVictimDetonation =` (~`:3575`) — place the new helper immediately after it (same in-round-loop scope; closes over `r`/`roundPerTargetDamage`/`perActorDetonation`/`roundDamage`/`bus`, which rebind per round BEFORE any turn-loop call — same safety PR-A verified).
+- Focus attacker site: grep `ATTACKER TURN` (~`:4376`) → `firstActivatorId ??= actor.id;` (~`:4394`); body runs through `processExtraActionGrants(actor, turn.extraActionGrants);` to the stasis `} else {` at ~`:4612`.
+- Walked-team site: grep `WALKED TEAM TURN` (~`:4636`) → `firstActivatorId ??= actor.id;` (~`:4650`).
+- `pushSynthesizedFocusSkipTurn` helper: grep it (~`:3810`).
+- Sinks: `playerSink` (~`:3160`), `enemySink` (~`:3213`); type `DamageAccountingSink` (~`:1141`); `focusActorId = 'attacker'` (~`:1292`).
+
+**Why NO positional-hint-gate change (unlike PR-A):** PR-A widened the `engine.ts:3730` hint because skill detonation rides the `runPlayerTurn` recipe. Timed bursts do NOT — they read `actor.pendingBombs`/`pendingAccumulators` directly in the engine turn body. The only gate is the burst's own `isPositional(actor.position, enemyAttackerActors)` + non-empty-container check. **No `runPlayerTurn`/playerTurn.ts change at all.**
+
+### Task B1: Extract the shared positioned timed-burst closure (byte-identical refactor)
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts` (helper decl + PR2 enemy call site)
+- Test: the whole existing suite is the guard (provably-inert refactor — no new test)
+
+- [ ] **Step 1: Green baseline.** Run `npm test 2>&1 | tail -20`; record the exact count (e.g. `3483 passed`). B1 must not change it.
+
+- [ ] **Step 2: Define the shared closure.** Add immediately after `applyPerVictimDetonation` (grep `const applyPerVictimDetonation =`). The body is the PR2 enemy burst verbatim, parameterized by `sink` + `opposingRoster`; the gate + the internal `allPlayersDirect` computation move inside:
+
+```typescript
+// Shared positioned timed-burst loop. A POSITIONED actor carrying timed
+// pendingBombs/pendingAccumulators (seeded by the opposing side's earlier bomb/accumulator
+// applications) bursts them at the START of its own turn — against its OWN HP — via
+// applyVictimDamage (the per-victim sink). Bombs + accumulators = full shield drain, NO
+// penetration (bomb-splash precedent). Credited to the per-round detonation tally keyed by
+// the bomb's APPLIER (sourceId, unchanged attribution) + roundPerTargetDamage on the
+// bursting actor. NEVER routed through creditDamage(actor.id,'detonation') — that feeds
+// cumulativeDamage → the focus-dummy HP overwrite (~:5432) → double-hit (HP already drained
+// inside applyVictimDamage). STRICT no-op (byte-identical) when the actor carries no timed
+// containers OR is not positioned vs opposingRoster — no fixture seeds actor-side timed
+// containers. Used by the enemy site (PR2: sink=enemySink, roster=allPlayerActors) and the
+// focus attacker + walked-team sites (PR-B: sink=playerSink, roster=enemyAttackerActors).
+const applyPositionedTimedBurst = (
+    actor: CombatActor,
+    sink: DamageAccountingSink,
+    opposingRoster: CombatActor[]
+): void => {
+    const hasTimedContainers =
+        actor.pendingBombs.length > 0 || actor.pendingAccumulators.length > 0;
+    if (!hasTimedContainers || !isPositional(actor.position, opposingRoster)) return;
+
+    processBombs({
+        pendingBombs: actor.pendingBombs,
+        emitBombDetonated: (actorId, stacks, damage) =>
+            bus.emit({ type: 'bomb-detonated', actorId, round: r, stacks, damage }),
+        creditDetonation: (sourceId, damage) => {
+            applyVictimDamage(damage, actor, sink, {
+                killerId: sourceId,
+                byDirectDamage: true,
+                bombPortion: damage, // full shield drain, no pen
+                shieldPenetrationPct: 0,
+            });
+            roundPerTargetDamage.set(
+                actor.id,
+                (roundPerTargetDamage.get(actor.id) ?? 0) + damage
+            );
+            perActorDetonation.set(
+                sourceId,
+                (perActorDetonation.get(sourceId) ?? 0) + damage
+            );
+        },
+    });
+
+    // Accumulator gather input: the round-global player-DIRECT sum (same expression as the
+    // focus-dummy path). CORRECT for the enemy site; for the player side it is an INERT
+    // placeholder — the symmetric all-enemies-direct sum is not exposed and no fixture/ability
+    // applies accumulators to players. // symmetric input TBD — inert, no fixture
+    const allPlayersDirect = [...roundDamage.values()].reduce((s, d) => s + d.direct, 0);
+    processAccumulators({
+        pendingAccumulators: actor.pendingAccumulators,
+        allPlayersDirect,
+        creditDetonation: (sourceId, damage) => {
+            applyVictimDamage(damage, actor, sink, {
+                killerId: sourceId,
+                byDirectDamage: true,
+                bombPortion: damage, // full shield drain, no pen (bomb-style)
+                shieldPenetrationPct: 0,
+            });
+            roundPerTargetDamage.set(
+                actor.id,
+                (roundPerTargetDamage.get(actor.id) ?? 0) + damage
+            );
+            perActorDetonation.set(
+                sourceId,
+                (perActorDetonation.get(sourceId) ?? 0) + damage
+            );
+        },
+    });
+};
+```
+
+> **Capture guard:** the body must reference ONLY its params (`actor`, `sink`, `opposingRoster`) plus the legitimately-shared closures (`processBombs`, `processAccumulators`, `applyVictimDamage`, `bus`, `r`, `roundPerTargetDamage`, `perActorDetonation`, `roundDamage`, `isPositional`). After extracting, scan the body to confirm no accidental outer capture of the enemy site's `actor`/`enemySink`/`allPlayerActors`. Confirm the shared helpers are in scope: `isPositional` is a module-level import; `processBombs`/`processAccumulators` are module-level function declarations (grep their `function`/`const` decls). All are reachable from the helper.
+
+- [ ] **Step 3: Replace the PR2 enemy block with a call.** Grep `PER-POSITIONED-ENEMY TIMED BURST`. Replace the inline gate + `processBombs` + `allPlayersDirect` + `processAccumulators` block (the `const enemyHasTimedContainers = …` line through the closing `}` of the `if (enemyHasTimedContainers && isPositional(...)) { … }`) with:
+```typescript
+applyPositionedTimedBurst(actor, enemySink, allPlayerActors);
+```
+Leave the dead-after-burst guard (`const burstDestroyedActor = …` and its `if (!burstDestroyedActor) { … }` wrap of the enemy action body) exactly as-is — that stays per-site.
+
+- [ ] **Step 4: tsc + lint + full suite — prove inert.** Run `npx tsc --noEmit && npm run lint && npm test 2>&1 | tail -20`. Expected: clean; suite green with the **exact same count** as Step 1; ZERO `.snap` moved.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add src/utils/combat/engine.ts
+git commit -m "refactor(combat): extract shared positioned timed-burst closure
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task B2: Positioned-player timed bursts at the focus + walked-team sites (new behavior)
+
+**Files:**
+- Modify: `src/utils/combat/engine.ts` (focus attacker body, walked-team body)
+- Test: `src/utils/combat/__tests__/perVictimPlayerTimedDetonation.integration.test.ts` (new)
+
+- [ ] **Step 1: Write the failing integration test.** Model on `perVictimTimedDetonation.integration.test.ts` (its helpers: `timedBomb`, `accumulator`, `enemyAt`, `lineRange1Pattern`, `POSITIONAL_BASE`, and `__testTapActors` to push containers onto an actor by id). Crit 0 → exact integers. The KEY DIFFERENCE from PR2: tap the **player** actor (`'attacker'` for focus, or a walked-team ally id) instead of an enemy, and the positional base must include `enemyAttackers` so `isPositional(playerActor.position, enemyAttackerActors)` is true. Cases:
+  1. **Focus attacker timed bomb:** `__testTapActors` pushes a `timedBomb` (countdown reaching 0 within `numRounds`) onto `'attacker'`; focus positioned with `enemyAttackers` present → assert it bursts against the focus attacker's OWN HP via `playerSink` (its `currentHp` drops by the burst; `perActorDetonation[applier]` + `roundPerTargetDamage['attacker']` reflect it); `bomb-detonated` emits with the applier `actorId`.
+  2. **Focus attacker accumulator:** push `accumulator(accumulated, pct, roundsRemaining=1)` onto `'attacker'` → bursts for `(accumulated + Σ allPlayersDirect over its active runs) × pct/100`. **CAUTION — unlike the PR2 enemy case, `allPlayersDirect` is NOT 0 on the player side** (the focus's own direct credit may be non-zero unless suppressed). Pick a base where the focus does no creditable direct at the burst turn (e.g. a non-positional-apply firing path / attack 0 for that turn), OR read `roundDamage` at the burst turn position and assert the exact computed value. Document the chosen value's derivation in a comment.
+  3. **Walked-team ally timed bomb:** seed a `team`/`teamActors` input with a positioned ally; tap its id with a `timedBomb` → bursts against ITS own HP via `playerSink` on its own turn.
+  4. **Lethal self-burst (focus):** seed a bomb whose burst ≥ focus HP → focus dies; assert death event + bomb-splash-on-death chain fires, AND the round still assembles (synthesized focus turn — no throw on the post-round `focusTurns.length` guard).
+  5. **Lethal self-burst (walked-team):** ally dies to its burst → death/splash; round assembles (no focus synthesis; its action body is skipped).
+  6. **Non-positional regression pin:** tap a player-actor timed container in NON-positional mode → it does NOT burst at the player turn (`isPositional` false) — assert no per-victim burst, and the legacy focus-dummy timed path (grep `:4807`-area `tickDoTs`/`processBombs` on the dummy enemy) is unchanged.
+  7. **isPositional-gate negative pin:** positioned player WITH a timed container but `enemyAttackers` empty (or the player not positioned vs them) → no burst. Prove non-vacuous by temporarily flipping the helper's gate to `if (!hasTimedContainers) return;` and confirming this case THEN bursts; document the flip in a comment and revert before commit.
+
+- [ ] **Step 2: Run it — verify it fails.** Run `npx vitest run src/utils/combat/__tests__/perVictimPlayerTimedDetonation.integration.test.ts`. Expected: positional cases (1–5) FAIL (player timed containers never burst today); regression/negative pins (6,7) PASS.
+
+- [ ] **Step 3: Add the burst + dead-after-burst guard at the focus attacker site.** Grep `ATTACKER TURN` → the `if (!isTurnBlocked(actor.id)) {` body. Right after `firstActivatorId ??= actor.id;` insert the burst, then WRAP the existing action body (from `const target = parsedTargetFor(actor);` through `processExtraActionGrants(actor, turn.extraActionGrants);`) in the dead-after-burst guard. Net shape:
+
+```typescript
+firstActivatorId ??= actor.id;
+
+// PR-B: PER-POSITIONED-PLAYER TIMED BURST (enemy-seeded bombs/accumulators on the focus
+// attacker burst against its OWN HP at its turn-start, via playerSink). Mirror of the PR2
+// enemy site; strict no-op for every existing fixture (none seed player-actor timed
+// containers). Canonical turn-start order is tickDoTs → processBombs → processAccumulators;
+// PR-C will add tickDoTs AHEAD of this burst.
+applyPositionedTimedBurst(actor, playerSink, enemyAttackerActors);
+
+// Dead-after-burst guard (PR2 lesson): a lethal self-burst stamped destroyedRound inside
+// applyVictimDamage AFTER the top-of-turn dead-skip already ran, so it cannot be caught
+// there. Key off destroyedRound (canonical death signal), NOT currentHp > 0 (bare actors
+// carry currentHp 0). healTarget carve-out mirrors the top-of-turn guard. A focus actor
+// killed by its own burst must still push a synthesized focus turn so the post-round
+// focusTurns.length guard does not throw.
+const burstDestroyedActor =
+    actor.destroyedRound !== undefined &&
+    !(healTarget && actor.id === healTarget.id);
+if (!burstDestroyedActor) {
+    const target = parsedTargetFor(actor);
+    /* …existing focus action body, unchanged, re-indented one level… */
+    processExtraActionGrants(actor, turn.extraActionGrants);
+} else if (actor.id === focusActorId) {
+    pushSynthesizedFocusSkipTurn();
+}
+```
+The existing stasis `} else { … }` at the `if (!isTurnBlocked)` level is untouched (it handles `isTurnBlocked` true; the new guard nests inside the `!isTurnBlocked` true branch). The re-indent of the action body must move ZERO goldens — verify in Step 6.
+
+- [ ] **Step 4: Add the burst + guard at the walked-team site.** Grep `WALKED TEAM TURN` → `firstActivatorId ??= actor.id;`. Insert the same burst call, then wrap the walked-team action body. No focus synthesis — a walked-team actor is never the focus:
+```typescript
+firstActivatorId ??= actor.id;
+
+// PR-B: per-positioned-player timed burst (walked-team ally). Same as the focus site; no
+// focusTurns synthesis (a walked-team actor is never the focus). tickDoTs added ahead by PR-C.
+applyPositionedTimedBurst(actor, playerSink, enemyAttackerActors);
+const burstDestroyedActor =
+    actor.destroyedRound !== undefined &&
+    !(healTarget && actor.id === healTarget.id);
+if (!burstDestroyedActor) {
+    const teamTarget = parsedTargetFor(actor);
+    /* …existing walked-team action body, unchanged, re-indented one level… */
+}
+```
+> **Shadowing note:** each player site declares a local `burstDestroyedActor`; the enemy site already has one. All three are in separate block scopes (different branches of the turn-kind `if/else if`) — no collision. Confirm with tsc.
+
+- [ ] **Step 5: Run the new test — verify it passes.** Run `npx vitest run src/utils/combat/__tests__/perVictimPlayerTimedDetonation.integration.test.ts`. Expected: PASS (all cases).
+
+- [ ] **Step 6: tsc + lint + full suite audit.** Run `npx tsc --noEmit && npm run lint && npm test 2>&1 | tail -30`. Expected: clean; only the new test added; ZERO existing `.snap` moved (the action-body re-indentation alone must not move any golden).
+
+- [ ] **Step 7: Commit.**
+```bash
+git add src/utils/combat/engine.ts src/utils/combat/__tests__/perVictimPlayerTimedDetonation.integration.test.ts
+git commit -m "feat(combat): positioned-player timed bomb/accumulator burst
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task B3: Changelog + docs
+
+**Files:**
+- Modify: `src/constants/changelog.ts` (`UNRELEASED_CHANGES`)
+- Modify: `src/pages/DocumentationPage.tsx` only if the positional-sim section enumerates timed-burst coverage
+
+- [ ] **Step 1:** Add a plain-English `UNRELEASED_CHANGES` entry: timed bombs/accumulators stored on a positioned player ship now burst against that ship on its own turn (previously only positioned enemies and the focus dummy did).
+- [ ] **Step 2:** Commit `docs(combat): changelog for positioned-player timed bursts` (docs-only → `--no-verify`; husky runs the full vitest suite on commit).
+
+### Task B4: Review + PR
+
+- [ ] **Step 1:** Final holistic review (superpowers:requesting-code-review): confirm the three timed-burst sites (enemy/focus/walked-team) are mutually consistent through the shared closure, no `cumulativeDamage` double-count, dead-after-burst guard correct at each site (focus synthesizes, walked-team/enemy don't), E5-symmetry intact (same carrier bursts identical integers as player vs enemy — case 3 vs the PR2 enemy fixture).
+- [ ] **Step 2:** `gh auth switch --user TheSusort`; push; open PR-B stacked on PR-A (#171, base `feat/combat-positional-detonation-pr4-walked-team`).
 
 ---
 

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -53,6 +53,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator: in positioned battles, timed bombs and Echoing Burst accumulators now burst on each enemy ship individually — every affected ship detonates its own timed bombs and accumulators against its own HP on its own turn, so a timed burst can now kill that ship and trigger its on-death effects, instead of only counting against the primary target.',
     'Combat simulator: in positioned battles, enemy detonation skills now damage each of your ships they hit individually — every targeted ship detonates its own stored bombs and damage-over-time effects against its own HP, mirroring how your ships detonate enemies, so an enemy detonation can now kill secondary (splash) targets and trigger their on-death effects.',
     'Combat simulator: in positioned battles, ally ships (the non-focus members of your fleet) now detonate per-victim — each ship the ally hits detonates its own stored bombs and damage-over-time effects against its own HP, so an ally detonation can now kill secondary targets and trigger their on-death effects such as bomb-splash-on-death.',
+    'Combat simulator: in positioned battles, timed bombs and Echoing Burst accumulators planted on your own ships now burst on each of your ships individually — every affected ship detonates its timed bombs and accumulators against its own HP on its own turn, mirroring how enemy ships already do, so a timed burst can now kill that ship and trigger its on-death effects.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3170,9 +3170,9 @@ const DocumentationPage: React.FC = () => {
                                     detonation can kill secondary (splash) targets and trigger their
                                     on-death effects, rather than only counting against the primary
                                     target. Timed bombs and Echoing Burst accumulators likewise
-                                    burst on each enemy individually — every affected ship detonates
-                                    its own timed bombs and accumulators against its own HP on its
-                                    own turn. This per-ship detonation works for{' '}
+                                    burst on each affected ship individually — on both teams — every
+                                    ship detonates its own timed bombs and accumulators against its
+                                    own HP on its own turn. This per-ship detonation works for{' '}
                                     <strong>both teams</strong>: enemy detonation skills now damage
                                     each of your ships they hit individually too, so an enemy
                                     detonation can kill secondary (splash) targets and trigger their

--- a/src/utils/combat/__tests__/perVictimPlayerTimedDetonation.integration.test.ts
+++ b/src/utils/combat/__tests__/perVictimPlayerTimedDetonation.integration.test.ts
@@ -441,6 +441,71 @@ describe('per-positioned-player timed detonation (PR-B B2, enemy → player)', (
         });
     });
 
+    it('E5 symmetry: the same timed bomb bursts for identical damage + event on the player side and the enemy side', () => {
+        idc = 0;
+        // The SAME timed bomb (2 × 1000, countdown 2) is placed on a positioned PLAYER actor in one
+        // runCombat invocation and on a positioned ENEMY actor in a second invocation. Both burst on
+        // round 2. Crit 0 → exact integers. The only difference between the two runs is WHICH SIDE
+        // carries the bomb — everything else (board shape, countdown, params) is identical.
+        //
+        // Player side: bomb on 'attacker' (positioned at M4, HP 1e9). The focus actor receives no
+        // firing damage via perTargetDamage (its OWN firing hit is not self-inflicted), so in round 2
+        // perTargetDamage['attacker'] = 2000 (burst only).
+        //
+        // Enemy side: bomb on 'enemy-back' (positioned at M2, HP 1e9). M2 is OUTSIDE the Line-
+        // Range-1 footprint anchored at M4 (which covers M4 and M3 only), so it receives no firing
+        // damage. In round 2 perTargetDamage['enemy-back'] = 2000 (burst only).
+        //
+        // Both bomb-detonated events must carry identical stacks (2) and damage (2000).
+
+        // --- PLAYER side ---
+        const playerRun = collect(
+            POSITIONAL_BASE({
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'attacker')
+                        ?.pendingBombs.push(timedBomb(1000, 2, 2, 'enemy-applier'));
+                },
+            })
+        );
+        const playerBurst = playerRun.result.rounds[1].perTargetDamage?.['attacker'];
+        const playerBombDet = playerRun.events.filter((e) => e.type === 'bomb-detonated');
+        // Sanity: exactly one event, on round 2.
+        expect(playerBombDet.length).toBe(1);
+        expect(playerBombDet[0]).toMatchObject({ round: 2, stacks: 2, damage: 2000 });
+        expect(playerBurst).toBe(2000);
+
+        // --- ENEMY side ---
+        // Use a third enemy actor at M2 (outside the firing footprint) so its perTargetDamage
+        // in round 2 is pure burst with no firing-hit contamination — a clean mirror of the player.
+        idc = 0;
+        const enemyRun = collect(
+            POSITIONAL_BASE({
+                enemyAttackers: [
+                    enemyAt('enemy-front', 'M4', 1_000_000_000),
+                    enemyAt('enemy-mid', 'M3', 1_000_000_000),
+                    enemyAt('enemy-back', 'M2', 1_000_000_000), // outside footprint → no firing hit
+                ],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'enemy-back')
+                        ?.pendingBombs.push(timedBomb(1000, 2, 2, 'attacker'));
+                },
+            })
+        );
+        const enemyBurst = enemyRun.result.rounds[1].perTargetDamage?.['enemy-back'];
+        const enemyBombDet = enemyRun.events.filter((e) => e.type === 'bomb-detonated');
+        // Sanity: exactly one event, on round 2.
+        expect(enemyBombDet.length).toBe(1);
+        expect(enemyBombDet[0]).toMatchObject({ round: 2, stacks: 2, damage: 2000 });
+        expect(enemyBurst).toBe(2000);
+
+        // --- Cross-side equality assertion (the E5 symmetry pin) ---
+        expect(playerBurst).toBe(enemyBurst);
+        expect(playerBombDet[0].damage).toBe(enemyBombDet[0].damage);
+        expect(playerBombDet[0].stacks).toBe(enemyBombDet[0].stacks);
+    });
+
     it('case 7: GATE-NEGATIVE — a positioned player WITH a timed container but enemyAttackers EMPTY does NOT burst', () => {
         idc = 0;
         // GATE PIN — the `isPositional` half. The new per-positioned-player burst is gated on

--- a/src/utils/combat/__tests__/perVictimPlayerTimedDetonation.integration.test.ts
+++ b/src/utils/combat/__tests__/perVictimPlayerTimedDetonation.integration.test.ts
@@ -1,0 +1,488 @@
+/**
+ * PR-B Task B2 — TIMED bomb / accumulator detonation per POSITIONED PLAYER (enemy → player).
+ *
+ * The SYMMETRIC mirror of perVictimTimedDetonation.integration.test.ts (PR2, player → enemy).
+ * PR2 made a timed bomb/accumulator stored on a positioned ENEMY burst at the START of that
+ * enemy's own turn against its own HP via `enemySink`. THIS suite wires the same for a positioned
+ * PLAYER actor: a focus attacker OR a walked-team ally carrying ENEMY-seeded timed containers
+ * bursts them on its OWN turn against its OWN HP via `playerSink`.
+ *
+ * Today `applyPositionedTimedBurst` (the shared closure extracted in B1) is called ONLY at the
+ * enemy-attacker turn site. The focus-attacker and walked-team turn sites never burst their own
+ * timed containers → a timed bomb stored on a positioned PLAYER actor NEVER fires.
+ *
+ * B2 adds the burst call (+ dead-after-burst guard) at the focus-attacker and walked-team sites.
+ * The POSITIONAL cases (1–5) MUST FAIL today. The NON-positional regression pin (case 6) and the
+ * isPositional-gate negative pin (case 7) MUST PASS today (they guard existing behaviour / prove
+ * the gate is non-vacuous).
+ *
+ * Crit 0 keeps every credited value an exact integer.
+ *
+ * --- The accumulator caveat (read before case 2) ---
+ * `processAccumulators` does, per run: `acc.accumulated += allPlayersDirect; acc.roundsRemaining
+ * -= 1;` and on `roundsRemaining <= 0` bursts `acc.accumulated * (acc.pct/100)`. The closure's
+ * `allPlayersDirect` = `[...roundDamage.values()].reduce((s,d)=>s+d.direct,0)` — the round-global
+ * sum of all players' DIRECT damage credited so far this round. In POSITIONAL mode the focus
+ * attacker's direct credit is SUPPRESSED (`engine.ts` — the `if (!positional)` guard skips
+ * `creditDamage(actor.id,'direct',…)`; the firing hit lands per-victim via `roundPerTargetDamage`
+ * instead), and the enemy victims have attack 0. So `allPlayersDirect` is 0 → a positional player
+ * accumulator's `accumulated` grows by 0 → it bursts for exactly its PRE-SEEDED
+ * `accumulated * pct/100`. We exploit that for clean integers (mirrors the PR2 enemy case).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { ShipSkills, Ability } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { CombatActor, PendingBomb, PendingAccumulator } from '../state';
+import type { CombatStatBlock } from '../../../types/calculator';
+import type { CombatEvent } from '../events';
+import { createEventBus } from '../events';
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `pvpt${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+// A small single-hit basic attack (multiplier 100%, 1 hit). attack is kept tiny so the firing hit
+// touches every footprint victim WITHOUT killing the high-HP ones (and without obscuring the burst).
+const basicAttack = (): Ability =>
+    ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } });
+
+// An active slot carrying only a basic attack — no skill-triggered detonate (B2 is about TIMED
+// bursts on the player's own turn, NOT skill-triggered detonation on the focus cast).
+const basicSlot = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [basicAttack()],
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+// AoE pattern: origin + one covered cell one step toward back (Pattern-Line-Range-1).
+const lineRange1Pattern = (): ParsedPattern => ({
+    raw: 'line-range-1',
+    shape: 'line',
+    range: 1,
+    modifiers: {},
+});
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+// A positioned, zero-offense, finite-HP enemy victim. speed 1 → it takes a turn each round. attack 0
+// → it contributes 0 direct (keeps allPlayersDirect clean). Present so the PLAYER actors are
+// positional against it (isPositional(playerActor.position, enemyAttackerActors) is true).
+const enemyAt = (id: string, position: Position, hp: number): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        shipSkills: { slots: [] } as ShipSkills,
+    }) as EnemyAttacker;
+
+// A pre-seeded TIMED bomb. burst = stacks × damagePerStack × affinityMult × (1 + detMod/100).
+// With neutral mults: burst = stacks × damagePerStack. countdown drives the timed expiry.
+const timedBomb = (
+    damagePerStack: number,
+    stacks: number,
+    countdown: number,
+    sourceId = 'enemy-applier'
+): PendingBomb => ({
+    countdown,
+    damagePerStack,
+    stacks,
+    tier: 100,
+    sourceId,
+    affinityMult: 1,
+    detonationDamageModifier: 0,
+    splashModifier: 0,
+});
+
+// A pre-seeded accumulator. On the run that drops roundsRemaining to <= 0 it bursts for
+// (accumulated + Σ allPlayersDirect over its active runs) × pct/100. In positional mode
+// allPlayersDirect is 0 (see header caveat) → burst = accumulated × pct/100.
+const accumulator = (
+    accumulated: number,
+    pct: number,
+    roundsRemaining: number,
+    sourceId = 'enemy-applier'
+): PendingAccumulator => ({ accumulated, pct, roundsRemaining, sourceId });
+
+const FOCUS_ATTACK = 100; // tiny firing hit.
+
+// Positional BASE: focus at M4 fires a Line-Range-1 basic attack at `front` (M4) covering M3, with
+// positioned enemy victims present so the focus is positional. The focus has HUGE HP by default so
+// its OWN timed burst does not kill it.
+const POSITIONAL_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: FOCUS_ATTACK,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [basicSlot()] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 2,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healModifier: 0,
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedTarget('front'),
+    pattern: lineRange1Pattern(),
+    enemyAttackers: [
+        enemyAt('enemy-front', 'M4', 1_000_000_000),
+        enemyAt('enemy-mid', 'M3', 1_000_000_000),
+    ],
+    ...overrides,
+});
+
+// Non-positional BASE: a single focus dummy enemy, NO position/target/pattern/enemyAttackers — the
+// legacy focus-dummy timed path. Timed containers are seeded on the focus dummy ('enemy').
+const NONPOS_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: FOCUS_ATTACK,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [basicSlot()] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 2,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healModifier: 0,
+    ...overrides,
+});
+
+// A walked-team ally: a positioned, offensive player team actor (kind 'team') with its own board
+// position/target/pattern + a basic-attack active slot. It takes a turn each round (speed 100).
+const teamStats = (hp: number): CombatStatBlock => ({
+    attack: FOCUS_ATTACK,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    defence: 0,
+    hp,
+    hacking: 0,
+});
+
+const teamAlly = (id: string, position: Position, hp: number): TeamActorEngineInput =>
+    ({
+        id,
+        speed: 100, // acts each round
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        target: parsedTarget('front'),
+        pattern: lineRange1Pattern(),
+        walk: {
+            shipSkills: { slots: [basicSlot()] },
+            stats: teamStats(hp),
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+            healModifier: 0,
+        },
+    }) as TeamActorEngineInput;
+
+// Tap an ordered event log.
+const collect = (input: CombatEngineInput) => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    const types: CombatEvent['type'][] = [
+        'bomb-detonated',
+        'dot-detonated',
+        'ship-destroyed',
+        'turn-started',
+    ];
+    for (const t of types) bus.on(t, (e) => events.push(e as CombatEvent));
+    const result = runCombat({ ...input, bus });
+    return { events, result };
+};
+
+describe('per-positioned-player timed detonation (PR-B B2, enemy → player)', () => {
+    it('case 1: a TIMED bomb bursts on the positioned FOCUS attacker’s OWN turn against its OWN HP', () => {
+        idc = 0;
+        // The focus 'attacker' (HP 1e9, won't die) carries a 2 × 1000 timed bomb with countdown 2.
+        // On its OWN turn the countdown decrements: round 1 → 1 (no burst), round 2 → 0 (BURST).
+        // burst = 2 × 1000 × 1 × (1 + 0/100) = 2000. Lands on the focus's OWN HP via playerSink.
+        const { events, result } = collect(
+            POSITIONAL_BASE({
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'attacker')
+                        ?.pendingBombs.push(timedBomb(1000, 2, 2, 'enemy-applier'));
+                },
+            })
+        );
+
+        // Round 1: bomb only decremented (countdown 2 → 1), no burst.
+        const round1 = result.rounds[0];
+        expect(round1.perTargetDamage?.['attacker']).toBeUndefined();
+        expect(round1.perActorDetonation?.['enemy-applier']).toBeUndefined();
+
+        // Round 2: countdown → 0 → burst 2000 lands on the focus's OWN HP via applyVictimDamage,
+        // recorded into THIS round's perTargetDamage['attacker'] + perActorDetonation[applier].
+        const round2 = result.rounds[1];
+        expect(round2.perTargetDamage?.['attacker']).toBe(2000);
+        // Credited to the applier ('enemy-applier'), NOT the victim.
+        expect(round2.perActorDetonation?.['enemy-applier']).toBe(2000);
+
+        // Exactly one bomb-detonated, in round 2, attributed to the applier, damage 2000.
+        const bombDet = events.filter((e) => e.type === 'bomb-detonated');
+        expect(bombDet.length).toBe(1);
+        expect(bombDet[0]).toMatchObject({
+            actorId: 'enemy-applier',
+            round: 2,
+            damage: 2000,
+            stacks: 2,
+        });
+    });
+
+    it('case 2: an ACCUMULATOR bursts for accumulated × pct/100 on the FOCUS turn, credited to its applier', () => {
+        idc = 0;
+        // The focus 'attacker' carries a pre-loaded accumulator: accumulated 5000, pct 50,
+        // roundsRemaining 1. On its FIRST own turn (round 1) the burst fires at turn-start, BEFORE
+        // the focus's firing hit. In positional mode the focus's direct credit is suppressed and the
+        // enemy victims have attack 0, so allPlayersDirect = 0 at that moment → accumulated += 0 →
+        // 5000, roundsRemaining → 0 → BURST = 5000 × 50/100 = 2500. Lands on the focus's OWN HP.
+        const { result } = collect(
+            POSITIONAL_BASE({
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'attacker')
+                        ?.pendingAccumulators.push(accumulator(5000, 50, 1, 'enemy-applier'));
+                },
+            })
+        );
+
+        // Round 1: accumulator burst 2500 on the focus's own HP.
+        const round1 = result.rounds[0];
+        expect(round1.perTargetDamage?.['attacker']).toBe(2500);
+        expect(round1.perActorDetonation?.['enemy-applier']).toBe(2500);
+    });
+
+    it('case 3: a TIMED bomb bursts on the positioned WALKED-TEAM ally’s OWN turn against its OWN HP', () => {
+        idc = 0;
+        // A walked-team ally 'team-ally' (positioned M3, HP 1e9) carries a 2 × 1000 timed bomb with
+        // countdown 2. On its OWN turn the countdown decrements: round 1 → 1 (no burst), round 2 → 0
+        // (BURST = 2000). Lands on the ally's OWN HP via playerSink.
+        const { events, result } = collect(
+            POSITIONAL_BASE({
+                teamActors: [teamAlly('team-ally', 'M3', 1_000_000_000)],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'team-ally')
+                        ?.pendingBombs.push(timedBomb(1000, 2, 2, 'enemy-applier'));
+                },
+            })
+        );
+
+        // Round 1: bomb only decremented.
+        expect(result.rounds[0].perTargetDamage?.['team-ally']).toBeUndefined();
+        // Round 2: burst 2000 on the ally's own HP.
+        const round2 = result.rounds[1];
+        expect(round2.perTargetDamage?.['team-ally']).toBe(2000);
+        expect(round2.perActorDetonation?.['enemy-applier']).toBe(2000);
+
+        const bombDet = events.filter((e) => e.type === 'bomb-detonated');
+        expect(bombDet.length).toBe(1);
+        expect(bombDet[0]).toMatchObject({
+            actorId: 'enemy-applier',
+            round: 2,
+            damage: 2000,
+            stacks: 2,
+        });
+    });
+
+    it('case 4: a LETHAL self-burst kills the FOCUS attacker; the round still assembles; a leftover bomb splashes its ally', () => {
+        idc = 0;
+        // The focus 'attacker' (HP 1000) carries a LETHAL accumulator (accumulated 2000, pct 100,
+        // 1 round → burst 2000 > 1000 HP) AND a LEFTOVER timed bomb (countdown 5, never reaches 0).
+        // The accumulator burst does NOT touch pendingBombs, so the leftover bomb is intact when
+        // recordDestroyed fires → bomb-splash-on-death chains to the adjacent PLAYER ally 'team-ally'
+        // (at M3, adjacent to the focus at M4 but a walked-team actor that takes no firing damage from
+        // its own basic attack against itself). leftover splash = 1 × 800 × (tier/4)/100 =
+        // 800 × 25/100 = 200. The focus dying must still let the round assemble (synthesized focus
+        // turn) without a throw.
+        const leftover = timedBomb(800, 1, 5, 'attacker');
+        const { events, result } = collect(
+            POSITIONAL_BASE({
+                hp: 1000,
+                teamActors: [teamAlly('team-ally', 'M3', 1_000_000_000)],
+                __testTapActors: (actors: CombatActor[]) => {
+                    const focus = actors.find((a) => a.id === 'attacker');
+                    focus?.pendingAccumulators.push(accumulator(2000, 100, 1, 'enemy-applier')); // lethal
+                    focus?.pendingBombs.push(leftover); // NOT consumed by the accumulator burst
+                },
+            })
+        );
+
+        // The focus died this round (round 1 — accumulator bursts on its first own turn).
+        const destroyed = events.filter((e) => e.type === 'ship-destroyed');
+        expect(destroyed.some((e) => e.actorId === 'attacker')).toBe(true);
+
+        // The round still assembled (no throw): result.rounds[0] exists with the focus burst recorded.
+        const round1 = result.rounds[0];
+        expect(round1).toBeDefined();
+        expect(round1.perActorDetonation?.['enemy-applier']).toBe(2000);
+
+        // Its leftover bomb splashed the adjacent PLAYER ally (bomb-splash-on-death chain → playerSink).
+        expect(round1.perActorSplash?.['team-ally']).toBe(200);
+    });
+
+    it('case 5: a LETHAL self-burst kills the WALKED-TEAM ally; the round still assembles', () => {
+        idc = 0;
+        // The walked-team ally 'team-ally' (HP 1000) carries a LETHAL accumulator (2000, pct 100,
+        // 1 round → 2000 > 1000). On its first own turn it bursts and dies. No focus synthesis needed
+        // (a walked-team actor is never the focus). The round must still assemble.
+        const { events, result } = collect(
+            POSITIONAL_BASE({
+                teamActors: [teamAlly('team-ally', 'M3', 1000)],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'team-ally')
+                        ?.pendingAccumulators.push(accumulator(2000, 100, 1, 'enemy-applier'));
+                },
+            })
+        );
+
+        const destroyed = events.filter((e) => e.type === 'ship-destroyed');
+        expect(destroyed.some((e) => e.actorId === 'team-ally')).toBe(true);
+
+        const round1 = result.rounds[0];
+        expect(round1).toBeDefined();
+        expect(round1.perTargetDamage?.['team-ally']).toBe(2000);
+        expect(round1.perActorDetonation?.['enemy-applier']).toBe(2000);
+
+        // The dead ally does not act afterward: a positioned ally with attack 100 against the dummy
+        // sink produces no SECOND turn-started after death. It died on its round-1 turn (turn-started
+        // fired once before the burst) and must NOT take a round-2 turn.
+        const allyTurns = events.filter(
+            (e) => e.type === 'turn-started' && e.actorId === 'team-ally'
+        );
+        expect(allyTurns.length).toBe(1);
+    });
+
+    it('case 6: REGRESSION (non-positional) — a player-actor timed container is INERT at the player turn (legacy focus-dummy path unchanged)', () => {
+        idc = 0;
+        // PIN — MUST PASS today. No position/target/pattern/enemyAttackers → the focus is
+        // non-positional. We tap the PLAYER focus 'attacker' with a timed bomb. Without the B2
+        // burst (and even with it — it is gated on isPositional), the non-positional player turn does
+        // NOT burst the focus's own container. We separately seed the focus DUMMY ('enemy') with a
+        // bomb to confirm the legacy focus-dummy timed path is unchanged (bursts on the dummy's turn).
+        const { events, result } = collect(
+            NONPOS_BASE({
+                __testTapActors: (actors: CombatActor[]) => {
+                    // Player focus actor's own container — must NOT burst (no positional path).
+                    actors
+                        .find((a) => a.id === 'attacker')
+                        ?.pendingBombs.push(timedBomb(1000, 7, 2, 'enemy-applier'));
+                    // Legacy focus-dummy timed path: 3 × 1000 bomb on the dummy → bursts round 2.
+                    actors
+                        .find((a) => a.id === 'enemy')
+                        ?.pendingBombs.push(timedBomb(1000, 3, 2, 'attacker'));
+                },
+            })
+        );
+
+        // The player focus actor's bomb did NOT burst via any positional path (no per-victim surface).
+        for (const round of result.rounds) {
+            expect(round.perTargetDamage?.['attacker']).toBeUndefined();
+            expect(round.perActorDetonation?.['enemy-applier']).toBeUndefined();
+        }
+
+        // Legacy focus-dummy path unchanged: round 1 no burst, round 2 burst 3000 via detonationDamage.
+        expect(result.rounds[0].detonationDamage).toBe(0);
+        expect(result.rounds[1].detonationDamage).toBe(3000);
+
+        // Exactly one bomb-detonated (the dummy's), in round 2, attributed to the applier, damage 3000.
+        // The focus actor's 7 × 1000 bomb produced NO event.
+        const bombDet = events.filter((e) => e.type === 'bomb-detonated');
+        expect(bombDet.length).toBe(1);
+        expect(bombDet[0]).toMatchObject({
+            actorId: 'attacker',
+            round: 2,
+            damage: 3000,
+            stacks: 3,
+        });
+    });
+
+    it('case 7: GATE-NEGATIVE — a positioned player WITH a timed container but enemyAttackers EMPTY does NOT burst', () => {
+        idc = 0;
+        // GATE PIN — the `isPositional` half. The new per-positioned-player burst is gated on
+        //   hasTimedContainers && isPositional(actor.position, opposingRoster)
+        // where opposingRoster = enemyAttackerActors for a player actor. isPositional(pos, opposing)
+        // = !!pos && opposing.some(a => a.position !== undefined). We make the SECOND conjunct false
+        // while keeping everything else true:
+        //   • The focus 'attacker' HAS a board position (M4) → first conjunct satisfied.
+        //   • It DOES carry a timed bomb → hasTimedContainers true.
+        //   • It DOES take its own turn every round.
+        //   • The ONLY thing false: enemyAttackers is EMPTY → enemyAttackerActors has no positioned
+        //     actor → isPositional false → the burst is suppressed.
+        //
+        // NON-VACUITY CHECK (performed during development): temporarily editing the closure's gate to
+        // `if (!hasTimedContainers) return;` (dropping the isPositional conjunct) makes THIS case burst
+        // 4000 and the assertions below fail. After confirming, the flip was REVERTED. So this pin is
+        // genuinely gated on isPositional, not vacuous.
+        const { events, result } = collect(
+            POSITIONAL_BASE({
+                enemyAttackers: [], // positioned focus, but NO positioned enemy → isPositional false
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'attacker')
+                        ?.pendingBombs.push(timedBomb(1000, 4, 2, 'enemy-applier'));
+                },
+            })
+        );
+
+        // The focus actor took a turn each of the 2 rounds (reached the turn body / the gate).
+        const focusTurns = events.filter(
+            (e) => e.type === 'turn-started' && e.actorId === 'attacker'
+        );
+        expect(focusTurns.length).toBeGreaterThanOrEqual(2);
+
+        // The timed bomb did NOT burst via the per-positioned path in EITHER round.
+        for (const round of result.rounds) {
+            expect(round.perTargetDamage?.['attacker']).toBeUndefined();
+            expect(round.perActorDetonation?.['enemy-applier']).toBeUndefined();
+        }
+
+        // And NO bomb-detonated event fired at all.
+        const bombDet = events.filter((e) => e.type === 'bomb-detonated');
+        expect(bombDet.length).toBe(0);
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -4468,223 +4468,248 @@ export function runCombat(input: CombatEngineInput): {
                         // D-PR14: first REAL activation of the round (Stasis/Disable-skipped
                         // actors never enter these blocks). ??= writes once.
                         firstActivatorId ??= actor.id;
-                        const target = parsedTargetFor(actor);
-                        const pattern = parsedPatternFor(actor);
-                        // Positional target selection (Task C1, GATED). When the focus attacker
-                        // (`actor`) carries a board position AND the positioned enemy roster
-                        // (`enemyAttackerActors`) has positioned actors, resolve the focus's parsed
-                        // target (`input.target`) to a single living enemy and bind THIS turn to it.
-                        // When the selection is null — not positional, OR positional but no living
-                        // positioned enemy target — we diverge NOTHING from the legacy dummy `enemy`
-                        // binding (keeps every existing path byte-identical; the null-target sub-case
-                        // is treated as a no-op fallthrough to legacy). No existing test passes
-                        // positions, so this branch never fires for them.
-                        // Positional target (phase 2): the selected enemy actor, else the dummy sink.
-                        // Both are full CombatActors, so all per-target bindings derive from `tgt`
-                        // uniformly. For the legacy (non-positional) path tgt === enemy, whose
-                        // stats.defence/stats.hp and DoT/bomb containers ARE the legacy module vars
-                        // (see ~line 1297) — so deriving every binding from `tgt` is byte-identical.
-                        // HP decline is no longer passed in (PR6b): runPlayerTurn derives it from the
-                        // struck victim's currentHp (max − currentHp), so the dummy-sink and real-victim
-                        // cases both read `tgt` uniformly — no separate decline ternary here.
-                        const { tgt } = selectTurnTarget(actor);
-                        // §4.5: inject break hook into runPlayerTurn. The hook marks stasisHitVictims
-                        // only when the victim was stasised at hit time. The actual statusEngine
-                        // removal happens AFTER drainIntents/drainEnemyIntents (below).
-                        // §4.5 Akula exception: if the ACTING ATTACKER has doesntBreakStasis, the
-                        // victim is never recorded → no break-mark, no stasisBreakPending entry.
-                        const tgtWasStasised = !actor.doesntBreakStasis && isStasised(tgt.id);
-                        // §4.5: `stasisHitVictims` collects ids of victims stasised at hit time.
-                        // Resolved AFTER runPlayerTurn returns (when inflictedEnemyDebuffs is available)
-                        // to compute the re-apply check, then stored in `stasisBreakPending` for the
-                        // victim's skip branch to consume.
-                        const turnStasisHitVictims = new Set<string>();
-                        const turn = runPlayerTurn({
-                            ...buildTurnArgs(actor, tgt),
-                            onHitBreakStasis: tgtWasStasised
-                                ? (targetId: string) => {
-                                      turnStasisHitVictims.add(targetId);
-                                  }
-                                : undefined,
-                        });
-                        if (turnStasisHitVictims.size > 0) {
-                            const reInflictedStasis = turn.inflictedEnemyDebuffs.some((ab) =>
-                                isStasis(ab.buffName)
-                            );
-                            if (!reInflictedStasis) {
-                                for (const victimId of turnStasisHitVictims) {
-                                    stasisBreakPending.set(victimId, true);
+
+                        // PR-B: PER-POSITIONED-PLAYER TIMED BURST (enemy-seeded bombs/accumulators
+                        // on the focus attacker burst against its OWN HP at its turn-start, via
+                        // playerSink). Mirror of the PR2 enemy site; strict no-op for every existing
+                        // fixture (none seed player-actor timed containers). Canonical turn-start
+                        // order is tickDoTs → processBombs → processAccumulators; PR-C will add
+                        // tickDoTs AHEAD of this burst.
+                        applyPositionedTimedBurst(actor, playerSink, enemyAttackerActors);
+
+                        // Dead-after-burst guard (PR2 lesson): a lethal self-burst stamps
+                        // destroyedRound inside applyVictimDamage AFTER the top-of-turn dead-skip
+                        // already ran. Key off destroyedRound (NOT currentHp > 0 — bare actors carry
+                        // currentHp 0). healTarget carve-out mirrors the top-of-turn guard. A focus
+                        // actor killed by its own burst must still push a synthesized focus turn so
+                        // the post-round focusTurns.length guard does not throw.
+                        const burstDestroyedActor =
+                            actor.destroyedRound !== undefined &&
+                            !(healTarget && actor.id === healTarget.id);
+                        if (!burstDestroyedActor) {
+                            const target = parsedTargetFor(actor);
+                            const pattern = parsedPatternFor(actor);
+                            // Positional target selection (Task C1, GATED). When the focus attacker
+                            // (`actor`) carries a board position AND the positioned enemy roster
+                            // (`enemyAttackerActors`) has positioned actors, resolve the focus's parsed
+                            // target (`input.target`) to a single living enemy and bind THIS turn to it.
+                            // When the selection is null — not positional, OR positional but no living
+                            // positioned enemy target — we diverge NOTHING from the legacy dummy `enemy`
+                            // binding (keeps every existing path byte-identical; the null-target sub-case
+                            // is treated as a no-op fallthrough to legacy). No existing test passes
+                            // positions, so this branch never fires for them.
+                            // Positional target (phase 2): the selected enemy actor, else the dummy sink.
+                            // Both are full CombatActors, so all per-target bindings derive from `tgt`
+                            // uniformly. For the legacy (non-positional) path tgt === enemy, whose
+                            // stats.defence/stats.hp and DoT/bomb containers ARE the legacy module vars
+                            // (see ~line 1297) — so deriving every binding from `tgt` is byte-identical.
+                            // HP decline is no longer passed in (PR6b): runPlayerTurn derives it from the
+                            // struck victim's currentHp (max − currentHp), so the dummy-sink and real-victim
+                            // cases both read `tgt` uniformly — no separate decline ternary here.
+                            const { tgt } = selectTurnTarget(actor);
+                            // §4.5: inject break hook into runPlayerTurn. The hook marks stasisHitVictims
+                            // only when the victim was stasised at hit time. The actual statusEngine
+                            // removal happens AFTER drainIntents/drainEnemyIntents (below).
+                            // §4.5 Akula exception: if the ACTING ATTACKER has doesntBreakStasis, the
+                            // victim is never recorded → no break-mark, no stasisBreakPending entry.
+                            const tgtWasStasised = !actor.doesntBreakStasis && isStasised(tgt.id);
+                            // §4.5: `stasisHitVictims` collects ids of victims stasised at hit time.
+                            // Resolved AFTER runPlayerTurn returns (when inflictedEnemyDebuffs is available)
+                            // to compute the re-apply check, then stored in `stasisBreakPending` for the
+                            // victim's skip branch to consume.
+                            const turnStasisHitVictims = new Set<string>();
+                            const turn = runPlayerTurn({
+                                ...buildTurnArgs(actor, tgt),
+                                onHitBreakStasis: tgtWasStasised
+                                    ? (targetId: string) => {
+                                          turnStasisHitVictims.add(targetId);
+                                      }
+                                    : undefined,
+                            });
+                            if (turnStasisHitVictims.size > 0) {
+                                const reInflictedStasis = turn.inflictedEnemyDebuffs.some((ab) =>
+                                    isStasis(ab.buffName)
+                                );
+                                if (!reInflictedStasis) {
+                                    for (const victimId of turnStasisHitVictims) {
+                                        stasisBreakPending.set(victimId, true);
+                                    }
+                                }
+                                // else: same-turn re-apply wins → break discarded, no pending mark.
+                            }
+
+                            // Drain any team-turn resisted entries staged BEFORE this attacker turn
+                            // (faster team actors) into the HEAD of this turn's resisted list — same
+                            // observable order as the old teamResistedEnemyDebuffs fold-in.
+                            if (pendingResisted.length > 0) {
+                                turn.resistedEnemyDebuffs.unshift(...pendingResisted);
+                                pendingResisted.length = 0;
+                            }
+
+                            // Positional APPLY (Task 8b, GATED). When the focus attacker is positional,
+                            // carries a parsed target, AND its firing hit produced scalars (a damage
+                            // ability fired → turn.positionalScalars is set), drive the per-victim apply
+                            // loop against the LIVE enemy roster. Re-resolves anchor + footprint per hit;
+                            // origin cells take full damage, covered cells half. Each victim's HP/shield/
+                            // Barrier/Cheat-Death/death is mutated through the real applyOutgoingToEnemy.
+                            // No production caller threads position+target+pattern yet, so this is false
+                            // for every existing test/golden → byte-identical.
+                            // The pattern is REQUIRED for footprint expansion — without it there is no
+                            // apply to perform (the existing positionalSelection tests set position+target
+                            // to exercise target binding only, never a pattern, so they keep the legacy
+                            // single-sink credit and never enter this branch).
+                            //
+                            // DELIBERATELY no `selectedEnemy != null` precondition (CodeRabbit raised this):
+                            // in positional/simulator mode there is NO dummy enemy sink to fall back to.
+                            // When per-hit resolution inside applyPositionalDamage finds no living opposing
+                            // actor, the correct behaviour is for the attacker to WHIFF (deal 0) — see the
+                            // death-fallback all-dead-whiff test. Gating `positional` on a pre-resolved
+                            // living target would instead route the firing hit back to the legacy dummy
+                            // sink, recording PHANTOM damage against a target that no longer exists. So we
+                            // enter the positional branch on pattern/target/scalars alone and let the
+                            // per-hit live re-resolution own the whiff. (Credit suppression below pairs with
+                            // this: the per-victim apply is the ONLY damage path here.)
+                            const positional =
+                                isPositional(actor.position, enemyAttackerActors) &&
+                                target != null &&
+                                pattern != null &&
+                                turn.positionalScalars != null;
+                            if (positional) {
+                                // Opposing roster + victim wrapper come from the per-side bindings
+                                // (player→enemy here). pattern/target are non-null via the `positional` gate.
+                                const tb = turnBindings(actor.side);
+                                // Player→enemy `attacked` capture: aggregate the FOCUS enemy victim's
+                                // per-attack damage + OR its shield-hit flag across the attack's hits so
+                                // the post-apply emit wakes the enemy's on-attacked reactives (counters +
+                                // self-repairs/defensive buffs). focusEnemyDamage is the per-victim
+                                // analogue of the enemy side's aggregate `damage` (Tenacity's >25%-maxHP
+                                // gate reads it). Matched by victim.id === tgt.id (first-hit-focus victim).
+                                let focusEnemyDamage = 0;
+                                let focusEnemyShieldWasHit = false;
+                                let focusEnemyHit = false;
+                                // Per-victim detonation (positional): collect EVERY footprint victim
+                                // hit by this cast's firing damage (unique by id), so each can detonate
+                                // its OWN containers after the firing hits land. Populated in the
+                                // onVictimResolved hook below alongside the standing-leech proc.
+                                const detonationTargets = new Map<string, CombatActor>();
+                                drivePositionalApply({
+                                    scalars: turn.positionalScalars!,
+                                    hitCrits: turn.hitCrits,
+                                    pattern: pattern,
+                                    target: target,
+                                    actingPosition: actor.position!,
+                                    ignoresForcedTargeting: actor.ignoresForcedTargeting,
+                                    actingId: actor.id,
+                                    opposingLiving: tb.opposingRoster,
+                                    applyToVictim: tb.applyToVictim,
+                                    // E2 Task 3: per-victim standing leech (player→enemy). The ACTING
+                                    // attacker's standing leeches proc off EACH footprint victim's
+                                    // role-scaled dealt damage (origin full, covered half) → restoring
+                                    // the leech the positional credit-suppression had silenced.
+                                    onVictimResolved: (victim, damage, outcome) => {
+                                        procStandingLeechesPerVictim(actor.id, damage);
+                                        detonationTargets.set(victim.id, victim);
+                                        if (victim.id === tgt.id) {
+                                            focusEnemyHit = true;
+                                            focusEnemyDamage += damage;
+                                            focusEnemyShieldWasHit =
+                                                focusEnemyShieldWasHit ||
+                                                (!outcome.barriered &&
+                                                    outcome.shieldBefore > 0 &&
+                                                    outcome.hpDamage < damage);
+                                        }
+                                    },
+                                });
+                                // Player→enemy `attacked` emit (Task 3 — the symmetric reaction). Fires
+                                // once per hit (mirrors the enemy-turn empty-hitCrits fallback) for the
+                                // focus enemy victim → enemy Stalwart/Nyxen/Centurion counter the player
+                                // attacker, and enemy on-hit reactions (Second Wind, etc.) fire.
+                                if (focusEnemyHit) {
+                                    const hitOutcomes =
+                                        turn.hitCrits.length > 0 ? turn.hitCrits : [turn.roundCrit];
+                                    emitAttacked({
+                                        bus,
+                                        round: r,
+                                        targetId: tgt.id,
+                                        attackerId: actor.id,
+                                        hitOutcomes,
+                                        isPrimaryTarget: true,
+                                        shieldWasHit: focusEnemyShieldWasHit,
+                                        damage: focusEnemyDamage,
+                                    });
+                                }
+
+                                // Per-victim skill-triggered detonation (positional). Each victim HIT
+                                // by this cast that is STILL ALIVE detonates its OWN containers (no
+                                // role-scale — full stored stacks). Bombs = full shield drain/no pen;
+                                // inferno+corrosion BYPASS the shield (DoT semantics). Credited to the
+                                // detonating actor's per-round detonation tally + roundPerTargetDamage;
+                                // NOT into cumulativeDamage (HP lands per-victim via applyVictimDamage).
+                                // recipe present only when a detonate-dot ability fired (else dets empty).
+                                const detonationRecipe = turn.positionalDetonation;
+                                if (detonationRecipe && detonationRecipe.dets.length > 0) {
+                                    applyPerVictimDetonation(
+                                        detonationRecipe,
+                                        detonationTargets,
+                                        enemySink,
+                                        actor.id,
+                                        tb
+                                    );
                                 }
                             }
-                            // else: same-turn re-apply wins → break discarded, no pending mark.
-                        }
 
-                        // Drain any team-turn resisted entries staged BEFORE this attacker turn
-                        // (faster team actors) into the HEAD of this turn's resisted list — same
-                        // observable order as the old teamResistedEnemyDebuffs fold-in.
-                        if (pendingResisted.length > 0) {
-                            turn.resistedEnemyDebuffs.unshift(...pendingResisted);
-                            pendingResisted.length = 0;
-                        }
+                            // Fold the focus turn's numeric damage into the round accumulator.
+                            // += (not =) on detonation: with a FASTER enemy, the enemy's bomb/
+                            // accumulator bursts ran earlier this round — a plain assignment would
+                            // clobber them. direct/secondary/conditional are single-focus-turn
+                            // today; += keeps the 0..N-turn seam additive.
+                            const d = dmg(actor.id);
+                            // secondary/conditional are display sub-buckets already rolled into
+                            // turn.directDamage — they must NOT be routed through creditDamage or the
+                            // standing-leech hook would double-count them.
+                            //
+                            // Credit SUPPRESSION for the positional case (Task 8b): the firing-hit damage
+                            // now lands per-victim via applyPositionalDamage above, so it must NOT also be
+                            // folded into cumulativeDamage here (that would double-count it). Skip the
+                            // direct/secondary/conditional credits; KEEP detonation (bombs are a separate
+                            // mechanic, out of scope). The single-sink decline that used to be zeroed for
+                            // the positional path is now derived from the victim's own currentHp inside
+                            // runPlayerTurn (PR6b), so no separate decline suppression is needed here.
+                            if (!positional) {
+                                d.secondary += turn.secondaryDamage;
+                                d.conditional += turn.conditionalDamage;
+                                creditDamage(actor.id, 'direct', turn.directDamage);
+                                // Detonation credit is suppressed in positional mode (turn.detonationDamage
+                                // is 0 there anyway — runPlayerTurn returns the recipe instead). Keeping it
+                                // inside this guard documents intent and keeps per-victim detonation out of
+                                // cumulativeDamage (it lands per-victim via applyVictimDamage above).
+                                creditDamage(actor.id, 'detonation', turn.detonationDamage);
+                            }
+                            focusTurns.push(turn);
 
-                        // Positional APPLY (Task 8b, GATED). When the focus attacker is positional,
-                        // carries a parsed target, AND its firing hit produced scalars (a damage
-                        // ability fired → turn.positionalScalars is set), drive the per-victim apply
-                        // loop against the LIVE enemy roster. Re-resolves anchor + footprint per hit;
-                        // origin cells take full damage, covered cells half. Each victim's HP/shield/
-                        // Barrier/Cheat-Death/death is mutated through the real applyOutgoingToEnemy.
-                        // No production caller threads position+target+pattern yet, so this is false
-                        // for every existing test/golden → byte-identical.
-                        // The pattern is REQUIRED for footprint expansion — without it there is no
-                        // apply to perform (the existing positionalSelection tests set position+target
-                        // to exercise target binding only, never a pattern, so they keep the legacy
-                        // single-sink credit and never enter this branch).
-                        //
-                        // DELIBERATELY no `selectedEnemy != null` precondition (CodeRabbit raised this):
-                        // in positional/simulator mode there is NO dummy enemy sink to fall back to.
-                        // When per-hit resolution inside applyPositionalDamage finds no living opposing
-                        // actor, the correct behaviour is for the attacker to WHIFF (deal 0) — see the
-                        // death-fallback all-dead-whiff test. Gating `positional` on a pre-resolved
-                        // living target would instead route the firing hit back to the legacy dummy
-                        // sink, recording PHANTOM damage against a target that no longer exists. So we
-                        // enter the positional branch on pattern/target/scalars alone and let the
-                        // per-hit live re-resolution own the whiff. (Credit suppression below pairs with
-                        // this: the per-victim apply is the ONLY damage path here.)
-                        const positional =
-                            isPositional(actor.position, enemyAttackerActors) &&
-                            target != null &&
-                            pattern != null &&
-                            turn.positionalScalars != null;
-                        if (positional) {
-                            // Opposing roster + victim wrapper come from the per-side bindings
-                            // (player→enemy here). pattern/target are non-null via the `positional` gate.
-                            const tb = turnBindings(actor.side);
-                            // Player→enemy `attacked` capture: aggregate the FOCUS enemy victim's
-                            // per-attack damage + OR its shield-hit flag across the attack's hits so
-                            // the post-apply emit wakes the enemy's on-attacked reactives (counters +
-                            // self-repairs/defensive buffs). focusEnemyDamage is the per-victim
-                            // analogue of the enemy side's aggregate `damage` (Tenacity's >25%-maxHP
-                            // gate reads it). Matched by victim.id === tgt.id (first-hit-focus victim).
-                            let focusEnemyDamage = 0;
-                            let focusEnemyShieldWasHit = false;
-                            let focusEnemyHit = false;
-                            // Per-victim detonation (positional): collect EVERY footprint victim
-                            // hit by this cast's firing damage (unique by id), so each can detonate
-                            // its OWN containers after the firing hits land. Populated in the
-                            // onVictimResolved hook below alongside the standing-leech proc.
-                            const detonationTargets = new Map<string, CombatActor>();
-                            drivePositionalApply({
-                                scalars: turn.positionalScalars!,
-                                hitCrits: turn.hitCrits,
-                                pattern: pattern,
-                                target: target,
-                                actingPosition: actor.position!,
-                                ignoresForcedTargeting: actor.ignoresForcedTargeting,
-                                actingId: actor.id,
-                                opposingLiving: tb.opposingRoster,
-                                applyToVictim: tb.applyToVictim,
-                                // E2 Task 3: per-victim standing leech (player→enemy). The ACTING
-                                // attacker's standing leeches proc off EACH footprint victim's
-                                // role-scaled dealt damage (origin full, covered half) → restoring
-                                // the leech the positional credit-suppression had silenced.
-                                onVictimResolved: (victim, damage, outcome) => {
-                                    procStandingLeechesPerVictim(actor.id, damage);
-                                    detonationTargets.set(victim.id, victim);
-                                    if (victim.id === tgt.id) {
-                                        focusEnemyHit = true;
-                                        focusEnemyDamage += damage;
-                                        focusEnemyShieldWasHit =
-                                            focusEnemyShieldWasHit ||
-                                            (!outcome.barriered &&
-                                                outcome.shieldBefore > 0 &&
-                                                outcome.hpDamage < damage);
-                                    }
-                                },
-                            });
-                            // Player→enemy `attacked` emit (Task 3 — the symmetric reaction). Fires
-                            // once per hit (mirrors the enemy-turn empty-hitCrits fallback) for the
-                            // focus enemy victim → enemy Stalwart/Nyxen/Centurion counter the player
-                            // attacker, and enemy on-hit reactions (Second Wind, etc.) fire.
-                            if (focusEnemyHit) {
-                                const hitOutcomes =
-                                    turn.hitCrits.length > 0 ? turn.hitCrits : [turn.roundCrit];
-                                emitAttacked({
-                                    bus,
-                                    round: r,
-                                    targetId: tgt.id,
-                                    attackerId: actor.id,
-                                    hitOutcomes,
-                                    isPrimaryTarget: true,
-                                    shieldWasHit: focusEnemyShieldWasHit,
-                                    damage: focusEnemyDamage,
-                                });
+                            // Heal-target buffs: if this focus actor IS the heal target (self-heal case),
+                            // its comprehensive activeSelfBuffs are the target's own buffs for the round.
+                            if (healTarget && actor.id === healTarget.id) {
+                                healTargetBuffs = turn.activeSelfBuffs;
                             }
 
-                            // Per-victim skill-triggered detonation (positional). Each victim HIT
-                            // by this cast that is STILL ALIVE detonates its OWN containers (no
-                            // role-scale — full stored stacks). Bombs = full shield drain/no pen;
-                            // inferno+corrosion BYPASS the shield (DoT semantics). Credited to the
-                            // detonating actor's per-round detonation tally + roundPerTargetDamage;
-                            // NOT into cumulativeDamage (HP lands per-victim via applyVictimDamage).
-                            // recipe present only when a detonate-dot ability fired (else dets empty).
-                            const detonationRecipe = turn.positionalDetonation;
-                            if (detonationRecipe && detonationRecipe.dets.length > 0) {
-                                applyPerVictimDetonation(
-                                    detonationRecipe,
-                                    detonationTargets,
-                                    enemySink,
-                                    actor.id,
-                                    tb
-                                );
-                            }
-                        }
+                            // Record this actor's round-scoped ctx for the enemy's DoT-tick attribution.
+                            lastTurnCtxByActor.set(actor.id, turn.turnCtx);
 
-                        // Fold the focus turn's numeric damage into the round accumulator.
-                        // += (not =) on detonation: with a FASTER enemy, the enemy's bomb/
-                        // accumulator bursts ran earlier this round — a plain assignment would
-                        // clobber them. direct/secondary/conditional are single-focus-turn
-                        // today; += keeps the 0..N-turn seam additive.
-                        const d = dmg(actor.id);
-                        // secondary/conditional are display sub-buckets already rolled into
-                        // turn.directDamage — they must NOT be routed through creditDamage or the
-                        // standing-leech hook would double-count them.
-                        //
-                        // Credit SUPPRESSION for the positional case (Task 8b): the firing-hit damage
-                        // now lands per-victim via applyPositionalDamage above, so it must NOT also be
-                        // folded into cumulativeDamage here (that would double-count it). Skip the
-                        // direct/secondary/conditional credits; KEEP detonation (bombs are a separate
-                        // mechanic, out of scope). The single-sink decline that used to be zeroed for
-                        // the positional path is now derived from the victim's own currentHp inside
-                        // runPlayerTurn (PR6b), so no separate decline suppression is needed here.
-                        if (!positional) {
-                            d.secondary += turn.secondaryDamage;
-                            d.conditional += turn.conditionalDamage;
-                            creditDamage(actor.id, 'direct', turn.directDamage);
-                            // Detonation credit is suppressed in positional mode (turn.detonationDamage
-                            // is 0 there anyway — runPlayerTurn returns the recipe instead). Keeping it
-                            // inside this guard documents intent and keeps per-victim detonation out of
-                            // cumulativeDamage (it lands per-victim via applyVictimDamage above).
-                            creditDamage(actor.id, 'detonation', turn.detonationDamage);
-                        }
-                        focusTurns.push(turn);
-
-                        // Heal-target buffs: if this focus actor IS the heal target (self-heal case),
-                        // its comprehensive activeSelfBuffs are the target's own buffs for the round.
-                        if (healTarget && actor.id === healTarget.id) {
-                            healTargetBuffs = turn.activeSelfBuffs;
-                        }
-
-                        // Record this actor's round-scoped ctx for the enemy's DoT-tick attribution.
-                        lastTurnCtxByActor.set(actor.id, turn.turnCtx);
-
-                        // Extra-action grants from this turn bump the attacker's pending-action
-                        // count, so selectNextBySpeed re-picks it at its live speed-rank (full extra
-                        // turn — charge cadence, post-turn decrement, and triggers all run again on
-                        // the re-picked iteration).
-                        // The extra turn intentionally re-fires statusEngine.sourceFired too:
-                        // re-applying timed buffs, adding persistent stacks, and ticking
-                        // accumulators are all correct for a real second turn.
-                        processExtraActionGrants(actor, turn.extraActionGrants);
+                            // Extra-action grants from this turn bump the attacker's pending-action
+                            // count, so selectNextBySpeed re-picks it at its live speed-rank (full extra
+                            // turn — charge cadence, post-turn decrement, and triggers all run again on
+                            // the re-picked iteration).
+                            // The extra turn intentionally re-fires statusEngine.sourceFired too:
+                            // re-applying timed buffs, adding persistent stacks, and ticking
+                            // accumulators are all correct for a real second turn.
+                            processExtraActionGrants(actor, turn.extraActionGrants);
+                        } else if (actor.id === focusActorId) {
+                            // The focus killed itself with its own timed burst → synthesize a
+                            // no-action focus turn so the post-round focusTurns.length guard does
+                            // not throw (it did not act). A walked-team actor is never the focus.
+                            pushSynthesizedFocusSkipTurn();
+                        } // end dead-after-burst guard (!burstDestroyedActor)
                     } else {
                         // Stasised focus/attacker turn: skip the action body.
                         // §4.3 STASIS GATE (B2 Task 3).
@@ -4724,191 +4749,202 @@ export function runCombat(input: CombatEngineInput): {
                         // D-PR14: first REAL activation of the round (Stasis/Disable-skipped
                         // actors never enter these blocks). ??= writes once.
                         firstActivatorId ??= actor.id;
-                        // Positional target selection (Task C2, GATED). Mirrors the focus-turn
-                        // branch (C1) but keyed to THIS team actor's own board position
-                        // (`actor.position`) and parsed target (`teamTargetById` lookup), not the
-                        // focus attacker's. When `selectedTeamEnemy` is null — not positional, no
-                        // parsed target, or no living positioned enemy — we diverge NOTHING from the
-                        // legacy dummy `enemy` binding. No existing test threads a team target →
-                        // this branch never fires for them (goldens byte-identical).
-                        const teamTarget = parsedTargetFor(actor);
-                        // Same `tgt` consolidation as the focus turn: both branches are full
-                        // CombatActors, so every per-target binding derives from `tgt` uniformly.
-                        // Legacy path tgt === enemy, whose stats/containers ARE the legacy module
-                        // vars (enemyDefense/enemyHp/corrosionEntries/…) → byte-identical.
-                        const { tgt } = selectTurnTarget(actor);
-                        const teamPattern = parsedPatternFor(actor);
-                        // §4.5: inject break hook into runPlayerTurn (mirrors focus site).
-                        // §4.5 Akula exception: if the ACTING ATTACKER has doesntBreakStasis,
-                        // the victim is never recorded → no break-mark, no stasisBreakPending.
-                        const teamTgtWasStasised = !actor.doesntBreakStasis && isStasised(tgt.id);
-                        const teamTurnStasisHitVictims = new Set<string>();
-                        const teamTurn = runPlayerTurn({
-                            ...buildTurnArgs(actor, tgt),
-                            onHitBreakStasis: teamTgtWasStasised
-                                ? (targetId: string) => {
-                                      teamTurnStasisHitVictims.add(targetId);
-                                  }
-                                : undefined,
-                        });
-                        if (teamTurnStasisHitVictims.size > 0) {
-                            const reInflictedStasis = teamTurn.inflictedEnemyDebuffs.some((ab) =>
-                                isStasis(ab.buffName)
-                            );
-                            if (!reInflictedStasis) {
-                                for (const victimId of teamTurnStasisHitVictims) {
-                                    stasisBreakPending.set(victimId, true);
+
+                        // PR-B: per-positioned-player timed burst (walked-team ally). Same as the
+                        // focus site; no focusTurns synthesis (a walked-team actor is never the
+                        // focus). tickDoTs added ahead by PR-C.
+                        applyPositionedTimedBurst(actor, playerSink, enemyAttackerActors);
+                        const burstDestroyedActor =
+                            actor.destroyedRound !== undefined &&
+                            !(healTarget && actor.id === healTarget.id);
+                        if (!burstDestroyedActor) {
+                            // Positional target selection (Task C2, GATED). Mirrors the focus-turn
+                            // branch (C1) but keyed to THIS team actor's own board position
+                            // (`actor.position`) and parsed target (`teamTargetById` lookup), not the
+                            // focus attacker's. When `selectedTeamEnemy` is null — not positional, no
+                            // parsed target, or no living positioned enemy — we diverge NOTHING from the
+                            // legacy dummy `enemy` binding. No existing test threads a team target →
+                            // this branch never fires for them (goldens byte-identical).
+                            const teamTarget = parsedTargetFor(actor);
+                            // Same `tgt` consolidation as the focus turn: both branches are full
+                            // CombatActors, so every per-target binding derives from `tgt` uniformly.
+                            // Legacy path tgt === enemy, whose stats/containers ARE the legacy module
+                            // vars (enemyDefense/enemyHp/corrosionEntries/…) → byte-identical.
+                            const { tgt } = selectTurnTarget(actor);
+                            const teamPattern = parsedPatternFor(actor);
+                            // §4.5: inject break hook into runPlayerTurn (mirrors focus site).
+                            // §4.5 Akula exception: if the ACTING ATTACKER has doesntBreakStasis,
+                            // the victim is never recorded → no break-mark, no stasisBreakPending.
+                            const teamTgtWasStasised =
+                                !actor.doesntBreakStasis && isStasised(tgt.id);
+                            const teamTurnStasisHitVictims = new Set<string>();
+                            const teamTurn = runPlayerTurn({
+                                ...buildTurnArgs(actor, tgt),
+                                onHitBreakStasis: teamTgtWasStasised
+                                    ? (targetId: string) => {
+                                          teamTurnStasisHitVictims.add(targetId);
+                                      }
+                                    : undefined,
+                            });
+                            if (teamTurnStasisHitVictims.size > 0) {
+                                const reInflictedStasis = teamTurn.inflictedEnemyDebuffs.some(
+                                    (ab) => isStasis(ab.buffName)
+                                );
+                                if (!reInflictedStasis) {
+                                    for (const victimId of teamTurnStasisHitVictims) {
+                                        stasisBreakPending.set(victimId, true);
+                                    }
                                 }
                             }
-                        }
 
-                        // Positional APPLY (Task 8b, GATED) — mirror of the focus site, keyed to THIS
-                        // team actor's own position / parsed target (teamTargetById) / parsed pattern
-                        // (teamPatternById). Drives the per-victim apply loop against the LIVE enemy
-                        // roster when this walked team actor is positional, has a parsed target, AND its
-                        // firing hit produced scalars. No production caller threads these yet → false for
-                        // every existing test/golden → byte-identical.
-                        // The pattern (teamPatternById) is REQUIRED for footprint expansion — without
-                        // it there is no apply to perform (the positionalSelection C2 test sets
-                        // position+target only, never a pattern, so it keeps the legacy single-sink
-                        // credit and never enters this branch).
-                        const teamPositional =
-                            isPositional(actor.position, enemyAttackerActors) &&
-                            teamTarget != null &&
-                            teamPattern != null &&
-                            teamTurn.positionalScalars != null;
-                        if (teamPositional) {
-                            // Same direction as the focus site (player→enemy); keyed to THIS team
-                            // actor's position / parsed target / parsed pattern. Non-null via the gate.
-                            const tb = turnBindings(actor.side);
-                            // Player→enemy `attacked` capture (Task 3) — mirror of the focus site,
-                            // keyed to THIS walked team actor's focus enemy victim (teamTarget tgt).
-                            let teamFocusEnemyDamage = 0;
-                            let teamFocusEnemyShieldWasHit = false;
-                            let teamFocusEnemyHit = false;
-                            // Per-victim detonation (positional): collect EVERY footprint victim hit
-                            // by this cast's firing damage (unique by id), so each can detonate its
-                            // OWN containers after the firing hits land. Populated in the
-                            // onVictimResolved hook below alongside the standing-leech proc (mirror
-                            // of the focus site).
-                            const detonationTargets = new Map<string, CombatActor>();
-                            drivePositionalApply({
-                                scalars: teamTurn.positionalScalars!,
-                                hitCrits: teamTurn.hitCrits,
-                                pattern: teamPattern,
-                                target: teamTarget,
-                                actingPosition: actor.position!,
-                                ignoresForcedTargeting: actor.ignoresForcedTargeting,
-                                actingId: actor.id,
-                                opposingLiving: tb.opposingRoster,
-                                applyToVictim: tb.applyToVictim,
-                                // E2 Task 3: per-victim standing leech (player→enemy), keyed to
-                                // THIS walked team actor as the acting attacker. Same per-victim
-                                // proc as the focus site.
-                                onVictimResolved: (victim, damage, outcome) => {
-                                    procStandingLeechesPerVictim(actor.id, damage);
-                                    detonationTargets.set(victim.id, victim);
-                                    if (victim.id === tgt.id) {
-                                        teamFocusEnemyHit = true;
-                                        teamFocusEnemyDamage += damage;
-                                        teamFocusEnemyShieldWasHit =
-                                            teamFocusEnemyShieldWasHit ||
-                                            (!outcome.barriered &&
-                                                outcome.shieldBefore > 0 &&
-                                                outcome.hpDamage < damage);
-                                    }
-                                },
-                            });
-                            // Player→enemy `attacked` emit (Task 3) — one per walked team actor's
-                            // firing turn for its focus enemy victim. Wakes the enemy's on-attacked
-                            // reactives just like the focus site.
-                            if (teamFocusEnemyHit) {
-                                const hitOutcomes =
-                                    teamTurn.hitCrits.length > 0
-                                        ? teamTurn.hitCrits
-                                        : [teamTurn.roundCrit];
-                                emitAttacked({
-                                    bus,
-                                    round: r,
-                                    targetId: tgt.id,
-                                    attackerId: actor.id,
-                                    hitOutcomes,
-                                    isPrimaryTarget: true,
-                                    shieldWasHit: teamFocusEnemyShieldWasHit,
-                                    damage: teamFocusEnemyDamage,
+                            // Positional APPLY (Task 8b, GATED) — mirror of the focus site, keyed to THIS
+                            // team actor's own position / parsed target (teamTargetById) / parsed pattern
+                            // (teamPatternById). Drives the per-victim apply loop against the LIVE enemy
+                            // roster when this walked team actor is positional, has a parsed target, AND its
+                            // firing hit produced scalars. No production caller threads these yet → false for
+                            // every existing test/golden → byte-identical.
+                            // The pattern (teamPatternById) is REQUIRED for footprint expansion — without
+                            // it there is no apply to perform (the positionalSelection C2 test sets
+                            // position+target only, never a pattern, so it keeps the legacy single-sink
+                            // credit and never enters this branch).
+                            const teamPositional =
+                                isPositional(actor.position, enemyAttackerActors) &&
+                                teamTarget != null &&
+                                teamPattern != null &&
+                                teamTurn.positionalScalars != null;
+                            if (teamPositional) {
+                                // Same direction as the focus site (player→enemy); keyed to THIS team
+                                // actor's position / parsed target / parsed pattern. Non-null via the gate.
+                                const tb = turnBindings(actor.side);
+                                // Player→enemy `attacked` capture (Task 3) — mirror of the focus site,
+                                // keyed to THIS walked team actor's focus enemy victim (teamTarget tgt).
+                                let teamFocusEnemyDamage = 0;
+                                let teamFocusEnemyShieldWasHit = false;
+                                let teamFocusEnemyHit = false;
+                                // Per-victim detonation (positional): collect EVERY footprint victim hit
+                                // by this cast's firing damage (unique by id), so each can detonate its
+                                // OWN containers after the firing hits land. Populated in the
+                                // onVictimResolved hook below alongside the standing-leech proc (mirror
+                                // of the focus site).
+                                const detonationTargets = new Map<string, CombatActor>();
+                                drivePositionalApply({
+                                    scalars: teamTurn.positionalScalars!,
+                                    hitCrits: teamTurn.hitCrits,
+                                    pattern: teamPattern,
+                                    target: teamTarget,
+                                    actingPosition: actor.position!,
+                                    ignoresForcedTargeting: actor.ignoresForcedTargeting,
+                                    actingId: actor.id,
+                                    opposingLiving: tb.opposingRoster,
+                                    applyToVictim: tb.applyToVictim,
+                                    // E2 Task 3: per-victim standing leech (player→enemy), keyed to
+                                    // THIS walked team actor as the acting attacker. Same per-victim
+                                    // proc as the focus site.
+                                    onVictimResolved: (victim, damage, outcome) => {
+                                        procStandingLeechesPerVictim(actor.id, damage);
+                                        detonationTargets.set(victim.id, victim);
+                                        if (victim.id === tgt.id) {
+                                            teamFocusEnemyHit = true;
+                                            teamFocusEnemyDamage += damage;
+                                            teamFocusEnemyShieldWasHit =
+                                                teamFocusEnemyShieldWasHit ||
+                                                (!outcome.barriered &&
+                                                    outcome.shieldBefore > 0 &&
+                                                    outcome.hpDamage < damage);
+                                        }
+                                    },
                                 });
+                                // Player→enemy `attacked` emit (Task 3) — one per walked team actor's
+                                // firing turn for its focus enemy victim. Wakes the enemy's on-attacked
+                                // reactives just like the focus site.
+                                if (teamFocusEnemyHit) {
+                                    const hitOutcomes =
+                                        teamTurn.hitCrits.length > 0
+                                            ? teamTurn.hitCrits
+                                            : [teamTurn.roundCrit];
+                                    emitAttacked({
+                                        bus,
+                                        round: r,
+                                        targetId: tgt.id,
+                                        attackerId: actor.id,
+                                        hitOutcomes,
+                                        isPrimaryTarget: true,
+                                        shieldWasHit: teamFocusEnemyShieldWasHit,
+                                        damage: teamFocusEnemyDamage,
+                                    });
+                                }
+
+                                // Per-victim skill-triggered detonation (positional) — mirror of the
+                                // focus site, keyed to THIS walked team actor. Each enemy victim HIT by
+                                // this cast that is STILL ALIVE detonates its OWN containers (no role-
+                                // scale — full stored stacks). Bombs = full shield drain/no pen; inferno+
+                                // corrosion BYPASS the shield (DoT semantics). Credited to the walked-team
+                                // actor's per-round detonation tally + roundPerTargetDamage; NOT into
+                                // cumulativeDamage (HP lands per-victim via applyVictimDamage). `tb`
+                                // resolves player→enemy → enemySink is the correct sink. recipe present
+                                // only when a detonate-dot ability fired (else dets empty).
+                                const teamDetonationRecipe = teamTurn.positionalDetonation;
+                                if (teamDetonationRecipe && teamDetonationRecipe.dets.length > 0) {
+                                    applyPerVictimDetonation(
+                                        teamDetonationRecipe,
+                                        detonationTargets,
+                                        enemySink,
+                                        actor.id,
+                                        tb
+                                    );
+                                }
                             }
 
-                            // Per-victim skill-triggered detonation (positional) — mirror of the
-                            // focus site, keyed to THIS walked team actor. Each enemy victim HIT by
-                            // this cast that is STILL ALIVE detonates its OWN containers (no role-
-                            // scale — full stored stacks). Bombs = full shield drain/no pen; inferno+
-                            // corrosion BYPASS the shield (DoT semantics). Credited to the walked-team
-                            // actor's per-round detonation tally + roundPerTargetDamage; NOT into
-                            // cumulativeDamage (HP lands per-victim via applyVictimDamage). `tb`
-                            // resolves player→enemy → enemySink is the correct sink. recipe present
-                            // only when a detonate-dot ability fired (else dets empty).
-                            const teamDetonationRecipe = teamTurn.positionalDetonation;
-                            if (teamDetonationRecipe && teamDetonationRecipe.dets.length > 0) {
-                                applyPerVictimDetonation(
-                                    teamDetonationRecipe,
-                                    detonationTargets,
-                                    enemySink,
-                                    actor.id,
-                                    tb
-                                );
+                            // Fold the team turn's damage into ITS OWN map entry (post-round assembly
+                            // sums all non-focus entries into teamDamage). secondary/conditional are
+                            // sub-buckets of direct (do NOT double-add) but kept distinct for the
+                            // simulator-page seam.
+                            //
+                            // Credit SUPPRESSION for the positional case (Task 8b): same as the focus site —
+                            // the firing-hit damage already landed per-victim via applyPositionalDamage, so
+                            // skip the direct/secondary/conditional credit; KEEP detonation (bombs are out
+                            // of scope). The single-sink decline that used to be zeroed for the positional
+                            // path is now derived from the victim's own currentHp inside runPlayerTurn
+                            // (PR6b), so no separate decline suppression is needed here.
+                            const td = dmg(actor.id);
+                            if (!teamPositional) {
+                                td.secondary += teamTurn.secondaryDamage;
+                                td.conditional += teamTurn.conditionalDamage;
+                                creditDamage(actor.id, 'direct', teamTurn.directDamage);
+                                // Detonation credit is suppressed in positional mode (teamTurn.detonationDamage
+                                // is 0 there anyway — runPlayerTurn returns the recipe instead). Keeping it
+                                // inside this guard documents intent and keeps per-victim detonation out of
+                                // cumulativeDamage (it lands per-victim via applyVictimDamage above).
+                                creditDamage(actor.id, 'detonation', teamTurn.detonationDamage);
                             }
-                        }
 
-                        // Fold the team turn's damage into ITS OWN map entry (post-round assembly
-                        // sums all non-focus entries into teamDamage). secondary/conditional are
-                        // sub-buckets of direct (do NOT double-add) but kept distinct for the
-                        // simulator-page seam.
-                        //
-                        // Credit SUPPRESSION for the positional case (Task 8b): same as the focus site —
-                        // the firing-hit damage already landed per-victim via applyPositionalDamage, so
-                        // skip the direct/secondary/conditional credit; KEEP detonation (bombs are out
-                        // of scope). The single-sink decline that used to be zeroed for the positional
-                        // path is now derived from the victim's own currentHp inside runPlayerTurn
-                        // (PR6b), so no separate decline suppression is needed here.
-                        const td = dmg(actor.id);
-                        if (!teamPositional) {
-                            td.secondary += teamTurn.secondaryDamage;
-                            td.conditional += teamTurn.conditionalDamage;
-                            creditDamage(actor.id, 'direct', teamTurn.directDamage);
-                            // Detonation credit is suppressed in positional mode (teamTurn.detonationDamage
-                            // is 0 there anyway — runPlayerTurn returns the recipe instead). Keeping it
-                            // inside this guard documents intent and keeps per-victim detonation out of
-                            // cumulativeDamage (it lands per-victim via applyVictimDamage above).
-                            creditDamage(actor.id, 'detonation', teamTurn.detonationDamage);
-                        }
-
-                        // The team turn's result row fields (action/roundCrit/etc.) are NOT consumed
-                        // beyond damage + resisted routing + ctx. Stage its resisted enemy applications
-                        // EXACTLY like the legacy team block: before any focus turn → pendingResisted;
-                        // after → the last focus turn's list.
-                        if (teamTurn.resistedEnemyDebuffs.length > 0) {
-                            const lastTurn = focusTurns[focusTurns.length - 1];
-                            if (lastTurn) {
-                                lastTurn.resistedEnemyDebuffs.push(
-                                    ...teamTurn.resistedEnemyDebuffs
-                                );
-                            } else {
-                                pendingResisted.push(...teamTurn.resistedEnemyDebuffs);
+                            // The team turn's result row fields (action/roundCrit/etc.) are NOT consumed
+                            // beyond damage + resisted routing + ctx. Stage its resisted enemy applications
+                            // EXACTLY like the legacy team block: before any focus turn → pendingResisted;
+                            // after → the last focus turn's list.
+                            if (teamTurn.resistedEnemyDebuffs.length > 0) {
+                                const lastTurn = focusTurns[focusTurns.length - 1];
+                                if (lastTurn) {
+                                    lastTurn.resistedEnemyDebuffs.push(
+                                        ...teamTurn.resistedEnemyDebuffs
+                                    );
+                                } else {
+                                    pendingResisted.push(...teamTurn.resistedEnemyDebuffs);
+                                }
                             }
-                        }
 
-                        // Record this team actor's ctx for the enemy's per-entry DoT-tick attribution
-                        // (its inferno entries tick with ITS effectiveAttack/dotMult/affinityMult).
-                        lastTurnCtxByActor.set(actor.id, teamTurn.turnCtx);
+                            // Record this team actor's ctx for the enemy's per-entry DoT-tick attribution
+                            // (its inferno entries tick with ITS effectiveAttack/dotMult/affinityMult).
+                            lastTurnCtxByActor.set(actor.id, teamTurn.turnCtx);
 
-                        // Heal-target buffs: a walked team actor that IS the heal target surfaces its
-                        // own comprehensive activeSelfBuffs (incl. recurring Cheat Death/Everliving Regen).
-                        if (healTarget && actor.id === healTarget.id) {
-                            healTargetBuffs = teamTurn.activeSelfBuffs;
-                        }
+                            // Heal-target buffs: a walked team actor that IS the heal target surfaces its
+                            // own comprehensive activeSelfBuffs (incl. recurring Cheat Death/Everliving Regen).
+                            if (healTarget && actor.id === healTarget.id) {
+                                healTargetBuffs = teamTurn.activeSelfBuffs;
+                            }
 
-                        processExtraActionGrants(actor, teamTurn.extraActionGrants);
+                            processExtraActionGrants(actor, teamTurn.extraActionGrants);
+                        } // end dead-after-burst guard (!burstDestroyedActor)
                     } else {
                         // §4.5 Deferred break: consume any pending Stasis break (team skip).
                         if (stasisBreakPending.has(actor.id)) {

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3627,6 +3627,82 @@ export function runCombat(input: CombatEngineInput): {
             }
         };
 
+        // Shared positioned timed-burst loop. A POSITIONED actor carrying timed
+        // pendingBombs/pendingAccumulators (seeded by the opposing side's earlier bomb/accumulator
+        // applications) bursts them at the START of its own turn — against its OWN HP — via
+        // applyVictimDamage (the per-victim sink). Bombs + accumulators = full shield drain, NO
+        // penetration (bomb-splash precedent). Credited to the per-round detonation tally keyed by
+        // the bomb's APPLIER (sourceId, unchanged attribution) + roundPerTargetDamage on the
+        // bursting actor. NEVER routed through creditDamage(actor.id,'detonation') — that feeds
+        // cumulativeDamage → the focus-dummy HP overwrite → double-hit (HP already drained inside
+        // applyVictimDamage). STRICT no-op (byte-identical) when the actor carries no timed
+        // containers OR is not positioned vs opposingRoster — no fixture seeds actor-side timed
+        // containers. Used by the enemy site (PR2: sink=enemySink, roster=allPlayerActors) and the
+        // focus attacker + walked-team sites (PR-B: sink=playerSink, roster=enemyAttackerActors).
+        const applyPositionedTimedBurst = (
+            actor: CombatActor,
+            sink: DamageAccountingSink,
+            opposingRoster: CombatActor[]
+        ): void => {
+            const hasTimedContainers =
+                actor.pendingBombs.length > 0 || actor.pendingAccumulators.length > 0;
+            if (!hasTimedContainers || !isPositional(actor.position, opposingRoster)) return;
+
+            processBombs({
+                pendingBombs: actor.pendingBombs,
+                emitBombDetonated: (actorId, stacks, damage) =>
+                    bus.emit({
+                        type: 'bomb-detonated',
+                        actorId,
+                        round: r,
+                        stacks,
+                        damage,
+                    }),
+                creditDetonation: (sourceId, damage) => {
+                    applyVictimDamage(damage, actor, sink, {
+                        killerId: sourceId,
+                        byDirectDamage: true,
+                        bombPortion: damage, // full shield drain, no pen
+                        shieldPenetrationPct: 0,
+                    });
+                    roundPerTargetDamage.set(
+                        actor.id,
+                        (roundPerTargetDamage.get(actor.id) ?? 0) + damage
+                    );
+                    perActorDetonation.set(
+                        sourceId,
+                        (perActorDetonation.get(sourceId) ?? 0) + damage
+                    );
+                },
+            });
+
+            // Accumulator gather input: the round-global player-DIRECT sum (same expression as the
+            // focus-dummy path). CORRECT for the enemy site; for the player side it is an INERT
+            // placeholder — the symmetric all-enemies-direct sum is not exposed and no fixture/ability
+            // applies accumulators to players. // symmetric input TBD — inert, no fixture
+            const allPlayersDirect = [...roundDamage.values()].reduce((s, d) => s + d.direct, 0);
+            processAccumulators({
+                pendingAccumulators: actor.pendingAccumulators,
+                allPlayersDirect,
+                creditDetonation: (sourceId, damage) => {
+                    applyVictimDamage(damage, actor, sink, {
+                        killerId: sourceId,
+                        byDirectDamage: true,
+                        bombPortion: damage, // full shield drain, no pen (bomb-style)
+                        shieldPenetrationPct: 0,
+                    });
+                    roundPerTargetDamage.set(
+                        actor.id,
+                        (roundPerTargetDamage.get(actor.id) ?? 0) + damage
+                    );
+                    perActorDetonation.set(
+                        sourceId,
+                        (perActorDetonation.get(sourceId) ?? 0) + damage
+                    );
+                },
+            });
+        };
+
         // Unified positional target selection (bySide unification PR6a). Reproduces the
         // focus(C1)/team(C2)/enemy(C3) selection: resolve the actor's parsed target against
         // its opposing roster, else fall back to the side's legacy victim (dummy / heal target).
@@ -4951,78 +5027,7 @@ export function runCombat(input: CombatEngineInput): {
                         // Stasis: this burst sits INSIDE the `!isTurnBlocked` gate, so a stasised/
                         // disabled positioned enemy does NOT burst this turn (its whole turn is
                         // skipped per the locked combat rule).
-                        const enemyHasTimedContainers =
-                            actor.pendingBombs.length > 0 || actor.pendingAccumulators.length > 0;
-                        if (
-                            enemyHasTimedContainers &&
-                            isPositional(actor.position, allPlayerActors)
-                        ) {
-                            // Bombs: each burst lands full on the enemy's own HP (full shield
-                            // drain, no penetration — bomb-splash precedent). bomb-detonated
-                            // actorId is the bomb's applier (`bomb.sourceId`, unchanged
-                            // attribution). Credit the per-round detonation tally to the applier
-                            // + record the per-target damage on the bursting enemy.
-                            processBombs({
-                                pendingBombs: actor.pendingBombs,
-                                emitBombDetonated: (actorId, stacks, damage) =>
-                                    bus.emit({
-                                        type: 'bomb-detonated',
-                                        actorId,
-                                        round: r,
-                                        stacks,
-                                        damage,
-                                    }),
-                                creditDetonation: (sourceId, damage) => {
-                                    applyVictimDamage(damage, actor, enemySink, {
-                                        killerId: sourceId,
-                                        byDirectDamage: true,
-                                        bombPortion: damage, // full shield drain, no pen
-                                        shieldPenetrationPct: 0,
-                                    });
-                                    roundPerTargetDamage.set(
-                                        actor.id,
-                                        (roundPerTargetDamage.get(actor.id) ?? 0) + damage
-                                    );
-                                    perActorDetonation.set(
-                                        sourceId,
-                                        (perActorDetonation.get(sourceId) ?? 0) + damage
-                                    );
-                                },
-                            });
-
-                            // Accumulators (Echoing Burst): the gather INPUT is the summed
-                            // direct damage of ALL players this round, read at THIS enemy's
-                            // turn position (same expression as the focus-dummy path `:4841`).
-                            // The burst detonates LIKE A BOMB: full shield drain, no penetration
-                            // (bombPortion = full payout, byDirectDamage true) — same shield
-                            // interaction as the timed-bomb path above. No bomb-detonated/
-                            // dot-detonated event today (parity with the focus-dummy accumulator
-                            // path, which emits none).
-                            const allPlayersDirect = [...roundDamage.values()].reduce(
-                                (s, d) => s + d.direct,
-                                0
-                            );
-                            processAccumulators({
-                                pendingAccumulators: actor.pendingAccumulators,
-                                allPlayersDirect,
-                                creditDetonation: (sourceId, damage) => {
-                                    applyVictimDamage(damage, actor, enemySink, {
-                                        killerId: sourceId,
-                                        byDirectDamage: true,
-                                        bombPortion: damage, // full shield drain, no pen (bomb-style)
-                                        shieldPenetrationPct: 0,
-                                    });
-                                    roundPerTargetDamage.set(
-                                        actor.id,
-                                        (roundPerTargetDamage.get(actor.id) ?? 0) + damage
-                                    );
-                                    perActorDetonation.set(
-                                        sourceId,
-                                        (perActorDetonation.get(sourceId) ?? 0) + damage
-                                    );
-                                },
-                            });
-                        }
+                        applyPositionedTimedBurst(actor, enemySink, allPlayerActors);
 
                         // Dead-after-burst guard (spike Fact 3): a lethal timed burst above
                         // fires recordDestroyed inside applyVictimDamage, but the loop's


### PR DESCRIPTION
## What

Stored-damage completion epic, **PR-B** (stacked on PR-A #171). Adds positioned-**player** timed bursts to the combat engine, the byte-for-byte mirror of PR2's positioned-enemy bursts: a positioned focus attacker or walked-team ally carrying enemy-seeded `pendingBombs`/`pendingAccumulators` now bursts them at its own turn-start, against its own HP, via `playerSink` — instead of those timed containers silently never firing.

After this PR, per-ship **timed bursts** work on both teams (skill detonation already does, via PR1/PR3/PR-A).

## How (commits)

1. `refactor` — extract the lone PR2 enemy timed-burst block into a shared closure `applyPositionedTimedBurst(actor, sink, opposingRoster)`; enemy site adopts it (**byte-identical**, 3483→3483).
2. `feat` — call it at the focus-attacker and walked-team turn sites (`playerSink`, `enemyAttackerActors`), each wrapped in a dead-after-burst guard. Focus self-kill still synthesizes a focus skip-turn so the round assembles; walked-team needs no synthesis. New `perVictimPlayerTimedDetonation.integration.test.ts` (7 cases, TDD red→green).
3. `docs` — changelog + DocumentationPage (timed bursts now symmetric across both teams).
4. `test` — explicit E5 team-symmetry pin: same timed bomb bursts for identical damage (2000) + event on the player and enemy sides.

## Design notes

- **No positional-hint-gate / `playerTurn.ts` change** (unlike PR-A): timed bursts read `actor.pendingBombs` directly, not the `runPlayerTurn` detonation recipe.
- **No `cumulativeDamage` double-count**: HP via `applyVictimDamage`, display via `roundPerTargetDamage`/`perActorDetonation` (applier-keyed); never `creditDamage(…,'detonation')`.
- Burst sits inside `!isTurnBlocked` (a stasised ship doesn't burst) and before the action body. PR-C forward-pointer comments mark where `tickDoTs` will slot in (canonical order `tickDoTs → processBombs → processAccumulators`).
- Accumulator gather reuses `allPlayersDirect` as a ratified inert placeholder on the player side (no fixture/ability seeds player accumulators; documented in code + test).

## Verification

- `npm test`: **3491 passed (264 files)** = 3483 baseline + 7 (B2) + 1 (symmetry pin). **ZERO `.snap` moved** vs base.
- `tsc --noEmit` clean, `npm run lint` (max-warnings 0) clean.
- Two-stage reviewed per task (spec + code quality) + final holistic review — all approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)