### PR TITLE
feat(combat): per-victim DoT ticks resolve at each positioned ship's turn-start (PR-C)

### DIFF
--- a/docs/superpowers/plans/2026-06-27-positional-per-victim-stored-damage-completion.md
+++ b/docs/superpowers/plans/2026-06-27-positional-per-victim-stored-damage-completion.md
@@ -432,11 +432,61 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ### Task C0 (BLOCKING, written deliverable, reviewed before code)
 Produce a channel-map: which `creditDamage` channels (`dot-inferno`, `dot-corrosion`, …) feed `cumulativeDamage` and thus the line-5326/5432 `enemy.currentHp` overwrite. Confirm the per-victim display story — the DPS DoT breakdown (`dot-*` totals) must still reflect per-victim ticks for the focus actor WITHOUT feeding HP twice (the detonation precedent: HP via `applyVictimDamage`, display via `roundPerTargetDamage` + per-victim path, aggregate credit suppressed in positional). Commit as a plan note; review before C.1/C.2.
 
+#### Task C0 — DELIVERABLE (channel-map, verified against the PR-B-base `engine.ts` in this worktree)
+
+> Line numbers are this worktree's (`feat/combat-positional-detonation-pr6-dot-ticks`, off PR-B). Re-grep the symbolic anchors before C.1/C.2 — a later refactor in this PR will shift them.
+
+**Q1 — Which channels feed the `enemy.currentHp` overwrite?**
+
+The overwrite is `engine.ts:5673`:
+```
+enemy.currentHp = Math.max(0, enemyHp - enemyHpDecline);   // enemyHpDecline = cumulativeDamage + cumulativeTeamDamage  (:5672)
+```
+Its two inputs accumulate per round from the `roundDamage` map only:
+- `cumulativeDamage += totalRoundDamage` (`:5644`), where `totalRoundDamage = focus.direct + focus.corrosion + focus.inferno + focus.detonation` (`:5643`).
+- `cumulativeTeamDamage += teamRoundDamage` (`:5666`), where `teamRoundDamage = Σ_{id≠focus} (d.direct + d.corrosion + d.inferno + d.detonation)` (`:5662-5664`).
+
+`roundDamage[id][channel]` is written through **exactly one** seam — `creditDamage(id, channel, amount)` (`:2640-2643` → `dmg(id)[channel] += amount`). So:
+
+> **The four channels that drain the dummy `enemy.currentHp` are `direct`, `corrosion`, `inferno`, `detonation`, summed over focus + team. Any `creditDamage(_, 'corrosion'|'inferno', _)` call feeds the line-5673 overwrite.**
+
+The focus-dummy `tickDoTs` (`:4966-4981`) credits via `credit: (sourceId, dotType, dmg) => creditDamage(sourceId, dotType, dmg)` — i.e. it is precisely the legacy aggregate DoT→HP path.
+
+**Q2 — Does a per-victim DoT tick double-drain if it also credits?** Yes.
+
+C.1 drains the positioned enemy's **own** `currentHp` via `applyVictimDamage(..., enemySink, { byDirectDamage:false })`. If the same tick also called `creditDamage(sourceId, 'corrosion'|'inferno', _)`, that amount re-enters `cumulativeDamage` and drains the dummy `enemy.currentHp` a *second* time at `:5673`.
+
+> **Locked rule (identical to the detonation seam): positioned per-victim DoT ticks MUST NOT call `creditDamage` for the `corrosion`/`inferno` channels.** This is the DoT analog of PR1–PR3 moving `creditDamage(_,'detonation',_)` inside `if(!positional)` / never calling it on the per-victim path.
+
+**Q3 — Display story (keep focus DoT DPS without double-feeding HP).** Mirror detonation exactly.
+
+- The DoT DPS breakdown reads `totalCorrosionRaw`/`totalInfernoRaw` (`:5650-5651`, surfaced `:5888-5889`); the RoundData row reads `corrosionDamage = focus.corrosion` / `infernoDamage = focus.inferno` (`:5627-5628`). All sourced from `focus.{corrosion,inferno}` in the `roundDamage` map.
+- **In positional mode this is already 0:** the focus-dummy `tickDoTs` ticks `enemy.corrosionEntries`/`infernoEntries` (bound `:1664-1665` to the dummy/`legacyVictim`), which stay **empty** because positional DoT application lands on `tgt.corrosionEntries` (positioned victims, `:3766`). So positional DoT builds currently under-report focus DoT DPS — the same gap detonation had before PR1.
+- **Detonation's split (the template):** HP via `applyVictimDamage`; DISPLAY via the `perActorDetonation` map (init `:1944`, per-round reset `:3832`, keyed by caster/applier), folded into the focus row as `focus.detonation + perActorDetonation[focus]` (`:5629-5630`) and into `totalDetonationRaw` (`:5656`) — while `totalRoundDamage`/`cumulativeDamage` deliberately use `focus.detonation` **only** (`:5643`, guard comment `:5652-5655`).
+- **DoT analog — introduce `perActorDot: Map<string, { corrosion: number; inferno: number }>`** (per-round reset alongside `perActorDetonation` at `:3832`; init near `:1944`), keyed by the DoT entry's `sourceId` (matches the focus-dummy `credit(sourceId, …)` attribution). On a positioned per-victim tick, the per-victim `credit` callback:
+  1. applies HP: `applyVictimDamage(damage, victim, sink, { byDirectDamage:false })`;
+  2. records per-target display: `roundPerTargetDamage[victim.id] += damage`;
+  3. records focus-DPS display: `perActorDot[sourceId][channel] += damage`;
+  and **never** calls `creditDamage`.
+  Then at post-round assembly fold focus's share into the row + raw totals, NOT into the HP-feeding sums:
+  - `corrosionDamage = focus.corrosion + (perActorDot.get(focusActorId)?.corrosion ?? 0)`; `infernoDamage` likewise.
+  - `totalCorrosionRaw += <that>`; `totalInfernoRaw += <that>`.
+  - **`totalRoundDamage`/`cumulativeDamage` stay `focus.{direct,corrosion,inferno,detonation}` ONLY** — `perActorDot` is never added there (the exact `:5652-5655` detonation guard, extended to DoTs).
+- Non-positional / DPS-mode: `perActorDot` is empty (no positioned per-victim ticks) → byte-identical, ZERO `.snap` moved. `tickDoTs` already computes final (post-Vortex-Veil) damage and `applyVictimDamage` applies it to HP as-is (the block step is gated on `byDirectDamage`, skipped for DoTs, `:2773`) → no re-scaling.
+
+**Q4 — C.2 (enemy→player) has NO `cumulativeDamage` seam.** DoTs applied *by enemies* are never the focus player's DPS, so they never touch `roundDamage`/`creditDamage`. They route via `playerSink`/`applyIncomingToTarget(..., { byDirectDamage:false })` into the victim's HP + healing-mode intake accounting. The heal-target prologue already does exactly this (`:4400-4438`: `tickDoTs` → sum `tankDotDamage` → `applyIncomingToTarget`, **not** `creditDamage`). The `enemy.currentHp` overwrite is a focus-DUMMY concept irrelevant to player victims. C.2's only display surface is the heal-target healing-accounting branch (`tankDotSnapshot`/`tankDotDamage`→incoming/`handleDeadTargetSkip`), preserved as a branch of the unified path; non-heal-target positioned players just take HP damage.
+
+**Decisions locked for C.1/C.2 code:**
+1. HP-feeding channels: `direct`/`corrosion`/`inferno`/`detonation` over focus + team via `roundDamage`.
+2. C.1: HP via `applyVictimDamage(enemySink, byDirectDamage:false)`; display via NEW `perActorDot` (sourceId-keyed, per channel) + `roundPerTargetDamage[victim]`; NEVER `creditDamage(corrosion/inferno)`. Fold `perActorDot[focus]` into the focus corrosion/inferno row + raw totals at post-round assembly, NOT into `totalRoundDamage`/`cumulativeDamage`.
+3. C.2: HP via `playerSink`/`applyIncomingToTarget(byDirectDamage:false)`; no `creditDamage`, no `cumulativeDamage` interaction; heal-target keeps `tankDotSnapshot`/`tankDotDamage`→incoming-accounting/`handleDeadTargetSkip`.
+4. The per-victim `tickDoTs` invocation passes `enemyHp: recipientMaxHp(victim.id)` (corrosion scales with the victim's own max HP), `ctxFor: lastTurnCtxByActor`, per-victim `emitTicked` (`targetId = victim.id`), and `incomingDotReductionPct` for the victim's Vortex Veil. `tickDoTs` mutates + `expireStacks`-ages that victim's own entries on its own turn.
+
 ### C.1 — player→enemy (positioned enemies)
 Add `tickDoTs` at the enemy-attacker turn-start, ahead of PR2's timed block (canonical order `tickDoTs → processBombs → processAccumulators`). HP via `applyVictimDamage(dmg, actor, enemySink, { byDirectDamage:false })`; per-applier ctx via `lastTurnCtxByActor`; corrosion `baseHp = recipientMaxHp(actor.id)`; per-victim `dot-ticked`; suppress the cumulativeDamage feed for positioned enemies (per C0). Gate: positioned enemy with non-empty DoT containers.
 
 ### C.2 — enemy→player (unify the heal-target path)
-Replace the heal-target prologue (grep `Task 11b: tick the HEAL TARGET's own enemy-applied DoTs`, ~`:4248`) with ONE per-victim DoT-tick path at every positioned player's turn-start (attacker + walked-team). Routes via `playerSink`/`applyIncomingToTarget` (`byDirectDamage:false`); per-applier ctx; corrosion `baseHp = recipientMaxHp(victim.id)`; per-victim Vortex Veil `incomingDotReductionPct`. Heal-target stays a branch: `tankDotSnapshot`, `tankDotDamage`→incoming healing accounting, `handleDeadTargetSkip` all fire when victim IS the heal target. Single path keyed per turning actor → structural double-tick guard.
+Replace the heal-target prologue (grep `Task 11b: tick the HEAL TARGET's own enemy-applied DoTs`, ~`:4373`) with ONE per-victim DoT-tick path at every positioned player's turn-start (attacker + walked-team). Routes via `playerSink`/`applyIncomingToTarget` (`byDirectDamage:false`); per-applier ctx; corrosion `baseHp = recipientMaxHp(victim.id)`; per-victim Vortex Veil `incomingDotReductionPct`. Heal-target stays a branch: `tankDotSnapshot`, `tankDotDamage`→incoming healing accounting, `handleDeadTargetSkip` all fire when victim IS the heal target. Single path keyed per turning actor → structural double-tick guard.
 
 **Tests:** `perVictimDotTick.integration.test.ts` — C.1 enemy own-HP tick (corrosion uses own HP) + lethal tick→death; C.2 non-heal-target player tick + heal-target still ticks once with accounting/snapshot/dead-skip intact (unification regression); E5-symmetry pin (same carrier ticks identical integers/events both sides); non-positional + DPS-mode regression pins.
 

--- a/docs/superpowers/plans/2026-06-27-positional-per-victim-stored-damage-completion.md
+++ b/docs/superpowers/plans/2026-06-27-positional-per-victim-stored-damage-completion.md
@@ -482,15 +482,102 @@ C.1 drains the positioned enemy's **own** `currentHp` via `applyVictimDamage(...
 3. C.2: HP via `playerSink`/`applyIncomingToTarget(byDirectDamage:false)`; no `creditDamage`, no `cumulativeDamage` interaction; heal-target keeps `tankDotSnapshot`/`tankDotDamage`→incoming-accounting/`handleDeadTargetSkip`.
 4. The per-victim `tickDoTs` invocation passes `enemyHp: recipientMaxHp(victim.id)` (corrosion scales with the victim's own max HP), `ctxFor: lastTurnCtxByActor`, per-victim `emitTicked` (`targetId = victim.id`), and `incomingDotReductionPct` for the victim's Vortex Veil. `tickDoTs` mutates + `expireStacks`-ages that victim's own entries on its own turn.
 
-### C.1 — player→enemy (positioned enemies)
-Add `tickDoTs` at the enemy-attacker turn-start, ahead of PR2's timed block (canonical order `tickDoTs → processBombs → processAccumulators`). HP via `applyVictimDamage(dmg, actor, enemySink, { byDirectDamage:false })`; per-applier ctx via `lastTurnCtxByActor`; corrosion `baseHp = recipientMaxHp(actor.id)`; per-victim `dot-ticked`; suppress the cumulativeDamage feed for positioned enemies (per C0). Gate: positioned enemy with non-empty DoT containers.
+### PLAN REFINEMENT (resolved during detailing 2026-06-27, user-approved + C0-reviewed)
 
-### C.2 — enemy→player (unify the heal-target path)
-Replace the heal-target prologue (grep `Task 11b: tick the HEAL TARGET's own enemy-applied DoTs`, ~`:4373`) with ONE per-victim DoT-tick path at every positioned player's turn-start (attacker + walked-team). Routes via `playerSink`/`applyIncomingToTarget` (`byDirectDamage:false`); per-applier ctx; corrosion `baseHp = recipientMaxHp(victim.id)`; per-victim Vortex Veil `incomingDotReductionPct`. Heal-target stays a branch: `tankDotSnapshot`, `tankDotDamage`→incoming healing accounting, `handleDeadTargetSkip` all fire when victim IS the heal target. Single path keyed per turning actor → structural double-tick guard.
+**Unify C.1 + C.2 into the SINGLE shared `:4373` turn-start prologue — NOT two sites.** The spec's literal C.1 ("enemy tick ahead of the PR2 timed block") would place the enemy DoT tick *inside* the enemy stasis gate (`:5039`), so a stasised positioned enemy would NOT tick — contradicting the heal-target/dummy precedent (DoTs tick at turn-start *regardless* of stasis; the `:4373` prologue + the `:4966` dummy tick both sit OUTSIDE the `!isTurnBlocked` action-body gate, confirmed by the `:4462` comment) and breaking the E5-symmetry invariant.
 
-**Tests:** `perVictimDotTick.integration.test.ts` — C.1 enemy own-HP tick (corrosion uses own HP) + lethal tick→death; C.2 non-heal-target player tick + heal-target still ticks once with accounting/snapshot/dead-skip intact (unification regression); E5-symmetry pin (same carrier ticks identical integers/events both sides); non-positional + DPS-mode regression pins.
+The `:4373` prologue runs once per actor at top-of-turn, BEFORE the kind-branches (attacker `:4452`, walked-team `:4737`, enemy-attacker `:5015`) and OUTSIDE every stasis gate. Widening it to all positioned non-dummy actors therefore covers attacker + walked-team + enemy in **one** site, ticks regardless of stasis on both sides (symmetric), and *is* the "unify the heal-target path" the spec locked for C.2. The dummy enemy (`actor.id === enemy.id`) is excluded → keeps its legacy `:4966` aggregate tick byte-identical. Canonical order is preserved: tick at `:4373` precedes every timed burst (`:4478`/`:4756`/`:5066`, all stasis-gated).
 
-**Detailing checklist when PR-C starts:** complete C0 first and get it reviewed; re-grep all anchors; design the per-victim DoT-tick closure (it will be called at 3+ sites — enemy, attacker, walked-team — so extract like A1/B); carefully preserve every heal-target side-effect during unification (the highest golden-move risk in the epic).
+This still satisfies every spec-locked decision: per-victim HP via `applyVictimDamage`; cumulativeDamage feed suppressed (C0); heal-target side-effects preserved as a branch; both directions symmetric.
+
+### Anchors (this worktree `pr6-dot-ticks`, off PR-B — re-grep before coding)
+- Shared prologue to widen: grep `Task 11b: tick the HEAL TARGET` (~`:4373`), block `:4384-4448`.
+- `perActorDetonation` init (~`:1944`), per-round reset (~`:3832`) — `perActorDot` rides alongside both.
+- Post-round fold: `focus.corrosion`/`focus.inferno` row locals (`:5627-5628`), `totalRoundDamage` (`:5643`, MUST stay focus-only), `totalCorrosionRaw`/`totalInfernoRaw` (`:5650-5651`), surfaced (`:5888-5889`). Mirror the `perActorDetonation` fold at `:5629-5630`/`:5656`.
+- `tickDoTs` def (`:752`); `recipientMaxHp` (`:1948`); `lastTurnCtxByActor` (`:1679`); `playerSink` (`:3160`)/`enemySink` (`:3213`)/`applyIncomingToTarget` (`:3176`); `allPlayerActors` (`:1632`)/`enemyAttackerActors` (`:1739`); `isPositional` usage (`:3649`); `handleDeadTargetSkip` (`:3869`, heal-target-specific — returns false otherwise); `pushSynthesizedFocusSkipTurn()` (`:3886`, no args); Vortex Veil `incomingReductionForHit(incomingAbilitiesOf(id), {…dotType})` (`:4424`); `actor.side` (`'player'|'enemy'`, `:1248`/`:1272`).
+
+### Task C1 — `perActorDot` display plumbing (inert; suite is the guard)
+**Files:** `src/utils/combat/engine.ts`.
+- [ ] Green baseline: `npm test 2>&1 | tail -20`; record count (PR-B base = `3491 passed`). C1 must not change it.
+- [ ] Add `let perActorDot = new Map<string, { corrosion: number; inferno: number }>();` beside `perActorDetonation` (`:1944`).
+- [ ] Reset per round alongside `perActorDetonation` (`:3832`): `perActorDot = new Map();`.
+- [ ] Post-round fold (`:5627-5656`), mirroring `focusPositionalDetonation`:
+  ```ts
+  const focusDot = perActorDot.get(focusActorId);
+  const corrosionDamage = focus.corrosion + (focusDot?.corrosion ?? 0);
+  const infernoDamage   = focus.inferno   + (focusDot?.inferno   ?? 0);
+  ```
+  Use `corrosionDamage`/`infernoDamage` for the RoundData row + `totalCorrosionRaw += corrosionDamage` / `totalInfernoRaw += infernoDamage`. **DO NOT touch `totalRoundDamage`/`cumulativeDamage`** (stay `focus.corrosion`/`focus.inferno` only — the C0 double-feed guard, identical to the `:5652-5655` detonation comment; add the analogous comment).
+- [ ] `npm test` — count unchanged (`perActorDot` empty everywhere until C2 populates it → `focusDot` undefined → +0). ZERO `.snap` moved.
+
+### Task C2 — unified turn-start DoT-tick prologue (the feature, TDD)
+**Files:** `src/utils/combat/engine.ts`; NEW `src/utils/combat/__tests__/perVictimDotTick.integration.test.ts`.
+
+- [ ] **RED:** author `perVictimDotTick.integration.test.ts` (template: `perVictimTimedDetonation.integration.test.ts` / `perVictimLeech.test.ts` — positioned actors via `__testTapActors`, seed `corrosionEntries`/`infernoEntries`, crit 0 → exact integers). Cases:
+  1. **C.1 enemy own-HP tick:** positioned enemy seeded with focus-applied corrosion+inferno → ticks at its turn against its OWN HP; corrosion baseHp = enemy's own maxHp; `dot-ticked` `targetId = enemy`; `perTargetDamage[enemy]` = tick; focus DPS DoT breakdown reflects the tick (perActorDot fold); the dummy `enemy.currentHp` overwrite is NOT double-fed (assert dummy decline excludes the per-victim tick).
+  2. **C.1 lethal:** tick ≥ enemy HP → `destroyedRound` set, `ship-destroyed` emitted, the enemy's turn skipped (no burst/action).
+  3. **C.2 non-heal-target player:** positioned player seeded with enemy-applied DoTs → ticks at its turn via playerSink against own HP; `dot-ticked` `targetId = player`; NOT in focus DPS (perActorDot stays empty for player-side ticks).
+  4. **C.2 heal-target regression:** heal target still ticks exactly once with `tankDotSnapshot` + healing-accounting (`tankDotDamage`→incoming) + `handleDeadTargetSkip` intact (byte-identical to pre-C2 — the unification regression).
+  5. **E5-symmetry pin:** the SAME DoT carrier (same tier/stacks, same applier ctx) ticks identical integers + `dot-ticked` events as enemy-victim vs player-victim.
+  6. **Stasis pin (the refinement's key decision):** a STASISED positioned victim STILL ticks its DoTs — assert on both a stasised enemy and a stasised player (proves the tick is outside the stasis gate). Non-vacuity: temporarily move the tick inside a gate → this case fails.
+  7. **Non-positional regression:** DPS-mode + healing-mode (dummy `:4966` + heal-target `:4373`) byte-identical (suite-wide + an explicit pin).
+- [ ] **GREEN:** rewrite the `:4384` block (`if (healTarget && actor.id === healTarget.id) { … }`) into the unified prologue. Recommended extraction for clarity (one call site, so optional): inline is fine. Shape:
+  ```ts
+  if (actor.id !== enemy.id) {                       // dummy keeps legacy :4966 tick
+      const isHealTarget = !!healTarget && actor.id === healTarget.id;
+      if (isHealTarget) {
+          // EXISTING heal-target branch — verbatim/UNCHANGED (snapshot + tickDoTs(credit→tankDotDamage)
+          //   + applyIncomingToTarget + handleDeadTargetSkip). Byte-identical; NOT gated on positional.
+      } else {
+          const sideIsPlayer = actor.side === 'player';
+          const opposing = sideIsPlayer ? enemyAttackerActors : allPlayerActors;
+          const hasDots = actor.corrosionEntries.length > 0 || actor.infernoEntries.length > 0;
+          if (hasDots && isPositional(actor.position, opposing)) {
+              let total = 0;
+              tickDoTs({
+                  corrosionEntries: actor.corrosionEntries,
+                  infernoEntries: actor.infernoEntries,
+                  enemyHp: recipientMaxHp(actor.id),               // corrosion baseHp = victim's own max HP
+                  ctxFor: (sourceId) => lastTurnCtxByActor.get(sourceId),
+                  emitTicked: (dotType, damage) =>
+                      bus.emit({ type: 'dot-ticked', targetId: actor.id, round: r, dotType, damage }),
+                  credit: (sourceId, dotType, damage) => {
+                      total += damage;
+                      if (!sideIsPlayer) {                          // player-applied DoTs on enemy → focus DPS
+                          const e = perActorDot.get(sourceId) ?? { corrosion: 0, inferno: 0 };
+                          e[dotType] += damage;
+                          perActorDot.set(sourceId, e);
+                      }
+                  },
+                  incomingDotReductionPct: (dotType) =>
+                      incomingReductionForHit(incomingAbilitiesOf(actor.id), { didCrit:false,
+                          attackerStealthed:false, victimStealthed:false, victimStasised:false,
+                          hitIndexThisRound:0, dotType }),
+              });
+              if (total > 0) {
+                  applyVictimDamage(total, actor, sideIsPlayer ? playerSink : enemySink,
+                      { byDirectDamage: false });                  // DoT bypass shield; aggregate (no single killer)
+                  roundPerTargetDamage.set(actor.id, (roundPerTargetDamage.get(actor.id) ?? 0) + total);
+              }
+              if (actor.destroyedRound !== undefined) {             // lethal turn-start tick → skip rest of turn
+                  if (actor.id === focusActorId) pushSynthesizedFocusSkipTurn();
+                  continue;
+              }
+          }
+      }
+  }
+  ```
+  - **Verify** `applyVictimDamage(total, actor, playerSink, {byDirectDamage:false})` is equivalent to the heal-target's `applyIncomingToTarget(total, actor, {byDirectDamage:false})` for the non-heal-target player case (PR-B used `applyVictimDamage(_, _, playerSink)` directly — same primitive; confirm the intake-bucket/penetration accounting matches). If not equivalent, use `applyIncomingToTarget` for the player branch.
+  - The credit callback receives post-Vortex-Veil damage; `tickDoTs` ages entries via `expireStacks` internally (per-victim, once).
+- [ ] Hand-validate EVERY positional delta; NEVER `vitest -u`. Run the WHOLE `npm test` (detonation/DoT fixtures live outside `src/utils/combat` too — `healingGoldenParity`). tsc + lint (max-warnings 0) clean. ZERO `.snap` moved.
+
+### Task C3 — changelog + docs
+- [ ] `UNRELEASED_CHANGES` (`src/constants/changelog.ts`): per-victim DoT ticks now resolve on positioned ships at their own turn-start, both teams (mirror PR-B's wording).
+- [ ] `DocumentationPage.tsx`: extend the DoT-tick clause to "both teams / positioned ships".
+
+### Final: holistic review → open PR-C stacked on PR-B #172.
+
+**NOTE:** pre-commit husky runs full vitest — use `--no-verify` for docs-only commits.
 
 ---
 

--- a/docs/superpowers/plans/2026-06-27-positional-per-victim-stored-damage-completion.md
+++ b/docs/superpowers/plans/2026-06-27-positional-per-victim-stored-damage-completion.md
@@ -439,7 +439,7 @@ Produce a channel-map: which `creditDamage` channels (`dot-inferno`, `dot-corros
 **Q1 — Which channels feed the `enemy.currentHp` overwrite?**
 
 The overwrite is `engine.ts:5673`:
-```
+```ts
 enemy.currentHp = Math.max(0, enemyHp - enemyHpDecline);   // enemyHpDecline = cumulativeDamage + cumulativeTeamDamage  (:5672)
 ```
 Its two inputs accumulate per round from the `roundDamage` map only:

--- a/docs/superpowers/plans/2026-06-27-positional-per-victim-stored-damage-completion.md
+++ b/docs/superpowers/plans/2026-06-27-positional-per-victim-stored-damage-completion.md
@@ -521,6 +521,9 @@ This still satisfies every spec-locked decision: per-victim HP via `applyVictimD
   5. **E5-symmetry pin:** the SAME DoT carrier (same tier/stacks, same applier ctx) ticks identical integers + `dot-ticked` events as enemy-victim vs player-victim.
   6. **Stasis pin (the refinement's key decision):** a STASISED positioned victim STILL ticks its DoTs — assert on both a stasised enemy and a stasised player (proves the tick is outside the stasis gate). Non-vacuity: temporarily move the tick inside a gate → this case fails.
   7. **Non-positional regression:** DPS-mode + healing-mode (dummy `:4966` + heal-target `:4373`) byte-identical (suite-wide + an explicit pin).
+  8. **Positioned AND heal-target (branch-collision pin):** a victim that is BOTH positioned AND the heal target ticks EXACTLY ONCE via the heal-target branch (`isHealTarget` precedes the positional branch → no double-tick); assert `tankDotSnapshot`/accounting present and the tick is NOT also counted in `perTargetDamage` via the positional branch.
+  9. **Round-1 faster-victim, no applier ctx:** seed a DoT whose applier has not acted yet → `tickDoTs` skips the entry (no ctx), `total === 0` (no `applyVictimDamage`/`roundPerTargetDamage`), but `expireStacks` still ages it. Pin the skip-but-age behavior.
+  10. **Team-applier DoT on a positioned enemy:** a NON-focus team ship's DoT ticks on the enemy → HP drains via `enemySink`, `perActorDot` keyed under the team source → the focus-DPS fold (`perActorDot.get(focusActorId)`) correctly IGNORES it (focus DoT total unchanged).
 - [ ] **GREEN:** rewrite the `:4384` block (`if (healTarget && actor.id === healTarget.id) { … }`) into the unified prologue. Recommended extraction for clarity (one call site, so optional): inline is fine. Shape:
   ```ts
   if (actor.id !== enemy.id) {                       // dummy keeps legacy :4966 tick
@@ -569,6 +572,7 @@ This still satisfies every spec-locked decision: per-victim HP via `applyVictimD
   ```
   - **Verify** `applyVictimDamage(total, actor, playerSink, {byDirectDamage:false})` is equivalent to the heal-target's `applyIncomingToTarget(total, actor, {byDirectDamage:false})` for the non-heal-target player case (PR-B used `applyVictimDamage(_, _, playerSink)` directly — same primitive; confirm the intake-bucket/penetration accounting matches). If not equivalent, use `applyIncomingToTarget` for the player branch.
   - The credit callback receives post-Vortex-Veil damage; `tickDoTs` ages entries via `expireStacks` internally (per-victim, once).
+  - **Lethal-tick `continue` is INTENTIONAL and follows the heal-target lethal-tick convention** (`:4445-4447` `handleDeadTargetSkip`→`continue`, which skips the shared post-turn block: `drainIntents`/`decrement*`/`turn-ended`). This DIVERGES from the PR2/PR-B timed-burst lethal path (`:5081+`), which does NOT `continue` (lets post-turn decrements + `turn-ended` run). A DoT tick is a turn-START event (like the heal-target tick) → skip the rest of the turn; do NOT "fix" it to match the burst convention.
 - [ ] Hand-validate EVERY positional delta; NEVER `vitest -u`. Run the WHOLE `npm test` (detonation/DoT fixtures live outside `src/utils/combat` too — `healingGoldenParity`). tsc + lint (max-warnings 0) clean. ZERO `.snap` moved.
 
 ### Task C3 — changelog + docs

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -54,6 +54,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator: in positioned battles, enemy detonation skills now damage each of your ships they hit individually — every targeted ship detonates its own stored bombs and damage-over-time effects against its own HP, mirroring how your ships detonate enemies, so an enemy detonation can now kill secondary (splash) targets and trigger their on-death effects.',
     'Combat simulator: in positioned battles, ally ships (the non-focus members of your fleet) now detonate per-victim — each ship the ally hits detonates its own stored bombs and damage-over-time effects against its own HP, so an ally detonation can now kill secondary targets and trigger their on-death effects such as bomb-splash-on-death.',
     'Combat simulator: in positioned battles, timed bombs and Echoing Burst accumulators planted on your own ships now burst on each of your ships individually — every affected ship detonates its timed bombs and accumulators against its own HP on its own turn, mirroring how enemy ships already do, so a timed burst can now kill that ship and trigger its on-death effects.',
+    'Combat simulator: in positioned battles, Inferno and Corrosion damage-over-time now ticks on every affected ship individually — each ship takes its own DoT damage against its own HP at the start of its turn (on both your fleet and the enemy), so a DoT can now wear down and kill secondary ships and trigger their on-death effects, instead of only counting against the primary target.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3181,8 +3181,13 @@ const DocumentationPage: React.FC = () => {
                                     its own stored bombs and damage-over-time effects against its
                                     own HP, so an ally detonation can kill secondary targets and
                                     trigger their on-death effects such as bomb-splash-on-death.
-                                    More implant and gear-set effects will be added in future
-                                    updates.
+                                    Inferno and Corrosion <strong>damage-over-time ticks</strong>{' '}
+                                    likewise resolve per ship — on <strong>both teams</strong>, each
+                                    affected ship takes its own DoT damage against its own HP at the
+                                    start of its turn (even while in Stasis), so a DoT can wear down
+                                    and kill secondary ships and trigger their on-death effects,
+                                    instead of only counting against the primary target. More
+                                    implant and gear-set effects will be added in future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/utils/combat/__tests__/perVictimDotTick.integration.test.ts
+++ b/src/utils/combat/__tests__/perVictimDotTick.integration.test.ts
@@ -1,0 +1,707 @@
+/**
+ * PR-C Task C2 — per-victim DoT TICKS resolve at each positioned ship's turn-start (both sides).
+ *
+ * Today DoTs (corrosion / inferno) tick only on (a) the focus DUMMY enemy (`engine.ts` ~:4966,
+ * legacy aggregate via `creditDamage`) and (b) the heal-target (`~:4380` prologue, healing-mode
+ * accounting). Every OTHER positioned victim's DoTs never tick. C2 widens the shared `~:4380`
+ * turn-start prologue so that EVERY positioned non-dummy actor (attacker, walked-team, enemy
+ * attacker) ticks its OWN containers against its OWN HP at its turn-start:
+ *   - enemy victims drain own HP via `enemySink`, surface in the focus DoT DPS via `perActorDot`
+ *     (keyed by the DoT APPLIER — only player-applied DoTs reach the focus DPS fold);
+ *   - player victims drain own HP via `playerSink` (NOT counted in focus DPS);
+ *   - the heal-target branch (snapshot + tankDotDamage accounting + dead-skip) is preserved
+ *     VERBATIM — a victim that is BOTH positioned AND the heal target ticks via that branch ONLY.
+ * The tick sits OUTSIDE every stasis gate (like the heal-target/dummy precedent) → a stasised
+ * victim STILL ticks (E5-symmetric). The per-victim path NEVER calls `creditDamage` (no
+ * cumulativeDamage double-feed against the dummy HP overwrite).
+ *
+ * Crit 0 keeps every credited value an exact integer.
+ *
+ * --- DoT-tick arithmetic (read before the cases) ---
+ * Inside tickDoTs (engine.ts ~:752):
+ *   corrosion tick = Σ entries:  stacks × (tier/100) × min(victimOwnMaxHp, 500_000) × dotMult × affinityMult
+ *   inferno   tick = Σ entries:  stacks × (tier/100) × applierEffectiveAttack × dotMult × affinityMult
+ * `remainingRounds` does NOT scale the per-tick value (it only governs expiry via expireStacks).
+ * With neutral mults (dotMult 1, affinityMult 1, no Vortex Veil) the factors collapse cleanly.
+ *   - Focus 'attacker' applier: effectiveAttack = its `attack` (no buffs), dotMult 1, affinityMult 1.
+ *   - A victim's OWN max HP = recipientMaxHp(victim) → its seeded `hp` before it has acted.
+ * So a corrosion entry (tier 5, stacks 1) on a victim with maxHp 10000 ticks 0.05 × 10000 = 500.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { ShipSkills, Ability } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { CombatActor, ActiveDoTStack } from '../state';
+import type { CombatStatBlock } from '../../../types/calculator';
+import type { CombatEvent } from '../events';
+import { createEventBus } from '../events';
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `pvdt${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+// A small single-hit basic attack (multiplier 100%, 1 hit). attack is kept tiny so the FIRING hit
+// touches every footprint victim WITHOUT killing the high-HP ones (and without obscuring the tick).
+const basicAttack = (): Ability =>
+    ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } });
+
+// An active slot carrying only a basic attack — no skill-triggered detonate (C2 is about DoT TICKS
+// on the victim's own turn, NOT skill-triggered detonation on the focus cast).
+const basicSlot = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [basicAttack()],
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+// AoE pattern: origin + one covered cell one step toward back (Pattern-Line-Range-1). Anchored at
+// the FRONT enemy (M4) it covers M3 — both are HIT by the firing damage (origin 100, covered 50).
+const lineRange1Pattern = (): ParsedPattern => ({
+    raw: 'line-range-1',
+    shape: 'line',
+    range: 1,
+    modifiers: {},
+});
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+// A positioned, zero-offense, finite-HP enemy victim. speed 1 → it takes a turn each round (so its
+// OWN-turn DoT tick can fire). attack 0 → it contributes 0 direct.
+const enemyAt = (id: string, position: Position, hp: number): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        shipSkills: { slots: [] } as ShipSkills,
+    }) as EnemyAttacker;
+
+// A pre-seeded corrosion stack. tick = stacks × (tier/100) × min(victimOwnMaxHp, 500_000) (neutral mults).
+const corrosion = (
+    tier: number,
+    stacks: number,
+    remainingRounds: number,
+    sourceId: string
+): ActiveDoTStack => ({ tier, stacks, remainingRounds, sourceId });
+
+// A pre-seeded inferno stack. tick = stacks × (tier/100) × applierEffectiveAttack (neutral mults).
+const inferno = (
+    tier: number,
+    stacks: number,
+    remainingRounds: number,
+    sourceId: string
+): ActiveDoTStack => ({ tier, stacks, remainingRounds, sourceId });
+
+const FOCUS_ATTACK = 100; // tiny firing hit — marks victims hit without killing high-HP ones.
+
+// Positional BASE: focus at M4 fires a Line-Range-1 basic attack at `front` (M4) covering M3.
+const POSITIONAL_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: FOCUS_ATTACK,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [basicSlot()] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 2,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healModifier: 0,
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedTarget('front'),
+    pattern: lineRange1Pattern(),
+    enemyAttackers: [
+        enemyAt('enemy-front', 'M4', 1_000_000_000),
+        enemyAt('enemy-mid', 'M3', 1_000_000_000),
+    ],
+    ...overrides,
+});
+
+// Non-positional BASE: a single focus dummy enemy, NO position/target/pattern/enemyAttackers — the
+// legacy DPS path. DoT containers are seeded on the focus dummy ('enemy') for the dummy-tick path.
+const NONPOS_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: FOCUS_ATTACK,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [basicSlot()] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 2,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healModifier: 0,
+    ...overrides,
+});
+
+// A walked-team ally: a positioned, offensive player team actor with its own board position/target/
+// pattern + a basic-attack active slot. It takes a turn each round (speed 100).
+const teamStats = (hp: number): CombatStatBlock => ({
+    attack: FOCUS_ATTACK,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    defence: 0,
+    hp,
+    hacking: 0,
+});
+
+const teamAlly = (id: string, position: Position, hp: number): TeamActorEngineInput =>
+    ({
+        id,
+        speed: 100,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        target: parsedTarget('front'),
+        pattern: lineRange1Pattern(),
+        walk: {
+            shipSkills: { slots: [basicSlot()] },
+            stats: teamStats(hp),
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+            healModifier: 0,
+        },
+    }) as TeamActorEngineInput;
+
+// Tap an ordered event log.
+const collect = (input: CombatEngineInput) => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    const types: CombatEvent['type'][] = ['dot-ticked', 'ship-destroyed', 'turn-started'];
+    for (const t of types) bus.on(t, (e) => events.push(e as CombatEvent));
+    const result = runCombat({ ...input, bus });
+    return { events, result };
+};
+
+describe('per-victim DoT ticks at each positioned ship’s turn-start (PR-C C2)', () => {
+    it('C.1 enemy own-HP tick: a positioned enemy ticks focus-applied corrosion+inferno against its OWN HP, surfaced in focus DoT DPS', () => {
+        idc = 0;
+        // enemy-back at M2 — OUTSIDE the Line-Range-1 footprint (M4+M3), so it takes NO firing hit:
+        // its perTargetDamage this round is the pure DoT tick. maxHp 10000.
+        //   corrosion (tier 5, stacks 1, applier 'attacker') → 0.05 × 10000 = 500.
+        //   inferno   (tier 10, stacks 1, applier 'attacker') → 0.10 × 100 (focus attack) = 10.
+        // total tick = 510, lands on enemy-back's own HP via enemySink at ITS turn-start.
+        const { events, result } = collect(
+            POSITIONAL_BASE({
+                enemyAttackers: [
+                    enemyAt('enemy-front', 'M4', 1_000_000_000),
+                    enemyAt('enemy-mid', 'M3', 1_000_000_000),
+                    enemyAt('enemy-back', 'M2', 10000), // outside footprint
+                ],
+                __testTapActors: (actors: CombatActor[]) => {
+                    const back = actors.find((a) => a.id === 'enemy-back');
+                    back?.corrosionEntries.push(corrosion(5, 1, 5, 'attacker'));
+                    back?.infernoEntries.push(inferno(10, 1, 5, 'attacker'));
+                },
+            })
+        );
+
+        // Round 1: tick 500 + 10 = 510 on enemy-back's own HP (no firing hit — outside footprint).
+        const round1 = result.rounds[0];
+        expect(round1.perTargetDamage?.['enemy-back']).toBe(510);
+        // NOT double-fed into the dummy aggregate: the dummy 'enemy' takes no perTargetDamage,
+        // and the dummy HP overwrite (cumulativeDamage) is not fed (focus.corrosion stays 0).
+        expect(round1.perTargetDamage?.['enemy']).toBeUndefined();
+
+        // dot-ticked events target enemy-back, one per dot type.
+        const ticks = events.filter(
+            (e) =>
+                e.type === 'dot-ticked' &&
+                (e as CombatEvent & { targetId: string }).targetId === 'enemy-back'
+        );
+        expect(ticks.length).toBeGreaterThanOrEqual(2); // corrosion + inferno per round (≥ round 1)
+
+        // The focus DoT DPS breakdown reflects the tick via the C1 perActorDot fold (applier
+        // 'attacker' === focus): corrosionDamage 500 + infernoDamage 10 surface on the round row.
+        expect(round1.corrosionDamage).toBe(500);
+        expect(round1.infernoDamage).toBe(10);
+    });
+
+    it('C.1 lethal: a turn-start DoT tick ≥ the enemy’s HP destroys it and skips the rest of its turn', () => {
+        idc = 0;
+        // enemy-back at M2 (outside footprint), HP 400. corrosion tier 5 stacks 1 → 0.05 × 400 = 20.
+        // 20 < 400 is NOT lethal — bump to a lethal tick: corrosion against its own maxHp 400 with
+        // stacks 30 tier 100 would be huge; simpler: maxHp 400, tier 100, stacks 1 → 0.05? no.
+        // Use a high tier: tier 100 stacks 1 → 1.00 × min(400,500000) = 400 == HP → lethal.
+        const { events, result } = collect(
+            POSITIONAL_BASE({
+                enemyAttackers: [
+                    enemyAt('enemy-front', 'M4', 1_000_000_000),
+                    enemyAt('enemy-mid', 'M3', 1_000_000_000),
+                    enemyAt('enemy-back', 'M2', 400),
+                ],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'enemy-back')
+                        ?.corrosionEntries.push(corrosion(100, 1, 5, 'attacker')); // 400 → lethal
+                },
+            })
+        );
+
+        // enemy-back died (turn-start tick was lethal).
+        const destroyed = events.filter((e) => e.type === 'ship-destroyed');
+        expect(
+            destroyed.some((e) => (e as CombatEvent & { actorId: string }).actorId === 'enemy-back')
+        ).toBe(true);
+
+        // It took exactly ONE turn (round 1, the lethal tick) — the rest of its turn was skipped and
+        // it must NOT take a round-2 turn.
+        const backTurns = events.filter(
+            (e) =>
+                e.type === 'turn-started' &&
+                (e as CombatEvent & { actorId: string }).actorId === 'enemy-back'
+        );
+        expect(backTurns.length).toBe(1);
+
+        const round1 = result.rounds[0];
+        expect(round1.perTargetDamage?.['enemy-back']).toBe(400);
+    });
+
+    it('C.2 non-heal-target player: a positioned ally ticks enemy-applied DoTs against own HP via playerSink, NOT in focus DPS', () => {
+        idc = 0;
+        // team-ally at M2 (player side), maxHp 10000. healTargetId is 'attacker' (the focus), so the
+        // ally is NOT the heal target → it ticks via the per-victim playerSink branch. corrosion
+        // (tier 5, stacks 1, applier 'enemy-front') → 0.05 × 10000 = 500 on the ally's own HP. The
+        // enemy applier acts AFTER the players in round 1 (no ctx → skip), so the tick first lands
+        // in round 2.
+        const { events, result } = collect(
+            POSITIONAL_BASE({
+                teamActors: [teamAlly('team-ally', 'M2', 10000)],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'team-ally')
+                        ?.corrosionEntries.push(corrosion(5, 1, 5, 'enemy-front'));
+                },
+            })
+        );
+
+        const round2 = result.rounds[1];
+        // The ally's own HP drained 500 via playerSink (round 2 — applier had ctx by then).
+        expect(round2.perTargetDamage?.['team-ally']).toBe(500);
+        // dot-ticked targets the ally.
+        const ticks = events.filter(
+            (e) =>
+                e.type === 'dot-ticked' &&
+                (e as CombatEvent & { targetId: string }).targetId === 'team-ally'
+        );
+        expect(ticks.length).toBeGreaterThanOrEqual(1);
+
+        // NOT counted in the focus DoT DPS — perActorDot stays empty for player-side ticks
+        // (enemy-applied DoT is not the focus player's outgoing DPS).
+        expect(round2.corrosionDamage).toBe(0);
+        expect(round2.infernoDamage).toBe(0);
+    });
+
+    it('C.2 heal-target regression: the heal target still ticks once via the tankDotSnapshot + healing accounting branch', () => {
+        idc = 0;
+        // Healing mode: the focus 'attacker' is the heal target and carries an enemy-applied
+        // corrosion (tier 5, stacks 1, applier 'enemy-mid'). maxHp 10000 → tick 500. The applier
+        // 'enemy-mid' acts AFTER the focus in round 1 (no ctx → faster-victim skip), so the tick
+        // first lands in round 2 — byte-identical to pre-C2 behaviour, ticked via the heal-target
+        // branch and routed into the tank's INCOMING accounting (NOT a player damage row).
+        const { events, result } = collect(
+            NONPOS_BASE({
+                healTargetId: 'attacker',
+                hp: 10000,
+                numRounds: 3,
+                enemyAttackers: [enemyAt('enemy-mid', 'M3', 1_000_000_000)],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'attacker')
+                        ?.corrosionEntries.push(corrosion(5, 1, 5, 'enemy-mid'));
+                },
+            })
+        );
+
+        // The heal target ticked: a dot-ticked event targets the tank (the heal-target branch),
+        // first in round 2.
+        const ticks = events.filter(
+            (e) =>
+                e.type === 'dot-ticked' &&
+                (e as CombatEvent & { targetId: string }).targetId === 'attacker'
+        );
+        expect(ticks.length).toBeGreaterThanOrEqual(1);
+        expect((ticks[0] as CombatEvent & { round: number }).round).toBe(2);
+
+        // Healing-mode accounting: the tank's INCOMING intake recorded the 500 DoT tick in round 2
+        // (routed via applyIncomingToTarget → playerSink, NOT a player damage row).
+        const healing = (result as { healing?: { rounds: { incomingDamage: number }[] } }).healing;
+        expect(healing).toBeDefined();
+        expect(healing?.rounds[0].incomingDamage).toBe(0); // round 1: applier had no ctx yet
+        expect(healing?.rounds[1].incomingDamage).toBe(500); // round 2: ticks
+
+        // The heal-target tick is NOT surfaced as the focus player's outgoing DoT DPS.
+        expect(result.rounds[1].corrosionDamage).toBe(0);
+    });
+
+    it('E5 symmetry: the same DoT carrier ticks identical integers + events on the player side and the enemy side', () => {
+        idc = 0;
+        // The SAME corrosion carrier (tier 5, stacks 1) on a positioned victim of maxHp 10000 ticks
+        // 0.05 × 10000 = 500 regardless of side. Player run: on a walked-team ally at M2. Enemy run:
+        // on an enemy-back at M2. Both outside the firing footprint → pure-tick perTargetDamage. The
+        // tick value is round-independent (the player victim's enemy applier acts a round later than
+        // the enemy victim's focus applier, so each ticks in a different round — we pick each side's
+        // own tick round). The E5 invariant is the DAMAGE: identical integer + identical event.
+        const firstTick = (
+            rounds: { perTargetDamage?: Record<string, number> }[],
+            id: string
+        ): number | undefined =>
+            rounds.map((rd) => rd.perTargetDamage?.[id]).find((v) => v != null);
+
+        // --- PLAYER side ---
+        const playerRun = collect(
+            POSITIONAL_BASE({
+                teamActors: [teamAlly('team-ally', 'M2', 10000)],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'team-ally')
+                        ?.corrosionEntries.push(corrosion(5, 1, 5, 'enemy-front'));
+                },
+            })
+        );
+        const playerTick = firstTick(playerRun.result.rounds, 'team-ally');
+        const playerDotTicks = playerRun.events.filter(
+            (e) =>
+                e.type === 'dot-ticked' &&
+                (e as CombatEvent & { targetId: string }).targetId === 'team-ally'
+        );
+
+        // --- ENEMY side ---
+        idc = 0;
+        const enemyRun = collect(
+            POSITIONAL_BASE({
+                enemyAttackers: [
+                    enemyAt('enemy-front', 'M4', 1_000_000_000),
+                    enemyAt('enemy-mid', 'M3', 1_000_000_000),
+                    enemyAt('enemy-back', 'M2', 10000),
+                ],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'enemy-back')
+                        ?.corrosionEntries.push(corrosion(5, 1, 5, 'attacker'));
+                },
+            })
+        );
+        const enemyTick = firstTick(enemyRun.result.rounds, 'enemy-back');
+        const enemyDotTicks = enemyRun.events.filter(
+            (e) =>
+                e.type === 'dot-ticked' &&
+                (e as CombatEvent & { targetId: string }).targetId === 'enemy-back'
+        );
+
+        // Identical tick INTEGER on both sides (the E5 invariant). The dot-ticked COUNT differs only
+        // because the player victim's enemy applier acts a round later than the enemy victim's focus
+        // applier (a turn-ordering artifact, not an asymmetry), so we compare the per-tick DAMAGE.
+        expect(playerTick).toBe(500);
+        expect(enemyTick).toBe(500);
+        expect(playerTick).toBe(enemyTick);
+        // Both sides emit at least one dot-ticked, and the first tick's damage is identical.
+        expect(playerDotTicks.length).toBeGreaterThanOrEqual(1);
+        expect(enemyDotTicks.length).toBeGreaterThanOrEqual(1);
+        const pTickDmg = (playerDotTicks[0] as CombatEvent & { damage: number }).damage;
+        const eTickDmg = (enemyDotTicks[0] as CombatEvent & { damage: number }).damage;
+        expect(pTickDmg).toBe(eTickDmg);
+        expect(pTickDmg).toBe(500);
+    });
+
+    it('Stasis pin: a STASISED positioned victim STILL ticks its DoTs (both sides) — the tick sits OUTSIDE the stasis gate', () => {
+        // KEY DECISION non-vacuity: the tick lives at the shared turn-start prologue, OUTSIDE every
+        // `if (!isTurnBlocked)` stasis gate. Moving it INSIDE the stasis gate would make a stasised
+        // victim NOT tick → these assertions would fail. We inflict REAL Stasis on the victim via a
+        // dedicated long-duration Stasis-inflict cast (verified live via __testTapIsStasised) and
+        // confirm the victim's DoT STILL ticks while it is turn-blocked.
+        idc = 0;
+        // A pure (non-damaging) Stasis-inflict active skill targeting `front`. No damage ability →
+        // the victim is not directly hit by the inflicter, so the Stasis is not broken by a hit.
+        const stasisOnlyInflict = (turns: number): ShipSkills['slots'][number] => ({
+            slot: 'active',
+            abilities: [
+                {
+                    id: `st${++idc}`,
+                    target: 'enemy',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    type: 'debuff',
+                    config: {
+                        type: 'debuff',
+                        buffName: 'Stasis',
+                        application: 'inflict',
+                        duration: turns,
+                        stacks: 1,
+                        isStackable: false,
+                        parsedEffects: {},
+                    },
+                } as Ability,
+            ],
+        });
+
+        // --- ENEMY side: the focus stasises enemy-front, which carries a focus-applied DoT.
+        // The focus fires a pure Stasis-inflict at `front` (enemy-front, M4) — no firing damage to
+        // break the Stasis. enemy-front is the DoT carrier (applier 'attacker', present round 1).
+        let enemyStasised: ((id: string) => boolean) | undefined;
+        const enemyRun = (() => {
+            const bus = createEventBus();
+            const events: CombatEvent[] = [];
+            bus.on('dot-ticked', (e) => events.push(e as CombatEvent));
+            const result = runCombat({
+                ...POSITIONAL_BASE({
+                    shipSkills: { slots: [stasisOnlyInflict(9)] },
+                    hacking: 200, // inflict landing 1.0 vs security 0
+                    numRounds: 3,
+                    enemyAttackers: [enemyAt('enemy-front', 'M4', 10000)],
+                    __testTapActors: (actors: CombatActor[]) => {
+                        actors
+                            .find((a) => a.id === 'enemy-front')
+                            ?.corrosionEntries.push(corrosion(5, 1, 9, 'attacker'));
+                    },
+                }),
+                __testTapIsStasised: (fn) => {
+                    enemyStasised = fn;
+                },
+                bus,
+            } as CombatEngineInput);
+            return { result, events };
+        })();
+        // The victim is genuinely stasised at end-of-run (Stasis duration 9 spans all 3 rounds).
+        expect(enemyStasised?.('enemy-front')).toBe(true);
+        // …and it STILL ticked its DoT every round (500 each), proving the tick is outside the gate.
+        const enemyFirstTick = enemyRun.result.rounds
+            .map((rd) => rd.perTargetDamage?.['enemy-front'])
+            .find((v) => v != null);
+        expect(enemyFirstTick).toBe(500);
+
+        // --- PLAYER side: an enemy stasises a WALKED-TEAM ally (NOT the heal target), which carries
+        // an enemy-applied DoT. The ally is the front-most player (M4) so the enemy's `front` targets
+        // it; the focus is moved to M3 and remains the heal target (so the ally ticks via the
+        // per-victim playerSink branch, surfacing on perTargetDamage). The Stasis-inflicter deals no
+        // damage → the ally is never directly hit → its Stasis is not broken.
+        idc = 0;
+        let playerStasised: ((id: string) => boolean) | undefined;
+        const playerRun = (() => {
+            const bus = createEventBus();
+            const result = runCombat({
+                ...POSITIONAL_BASE({
+                    position: 'M3', // focus moved back so the front-most player is the ally
+                    hacking: 0,
+                    numRounds: 3,
+                    teamActors: [teamAlly('team-ally', 'M4', 10000)], // front-most player
+                    enemyAttackers: [
+                        {
+                            id: 'enemy-stasiser',
+                            stats: {
+                                attack: 0,
+                                crit: 0,
+                                critDamage: 0,
+                                defence: 0,
+                                hp: 1_000_000_000,
+                                speed: 1,
+                                hacking: 200,
+                            },
+                            chargeCount: 0,
+                            startCharged: false,
+                            position: 'M4',
+                            target: parsedTarget('front'),
+                            pattern: { raw: 'base', shape: 'base', range: 0, modifiers: {} },
+                            shipSkills: { slots: [stasisOnlyInflict(9)] },
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        } as any,
+                    ],
+                    __testTapActors: (actors: CombatActor[]) => {
+                        actors
+                            .find((a) => a.id === 'team-ally')
+                            ?.corrosionEntries.push(corrosion(5, 1, 9, 'enemy-stasiser'));
+                    },
+                }),
+                __testTapIsStasised: (fn) => {
+                    playerStasised = fn;
+                },
+                bus,
+            } as CombatEngineInput);
+            return { result };
+        })();
+        expect(playerStasised?.('team-ally')).toBe(true);
+        // The stasised ally STILL ticks its enemy-applied DoT (the applier acts after the players in
+        // round 1 → first tick in a later round). It surfaces via playerSink on the ally's own HP.
+        const playerFirstTick = playerRun.result.rounds
+            .map((rd) => rd.perTargetDamage?.['team-ally'])
+            .find((v) => v != null);
+        expect(playerFirstTick).toBe(500);
+    });
+
+    it('Non-positional regression: the dummy DoT path + heal-target DoT path are unchanged', () => {
+        idc = 0;
+        // DPS mode: a corrosion on the focus DUMMY ('enemy', enemyHp 10000) ticks via the legacy
+        // :4966 dummy path → focus.corrosion (creditDamage). tick = 0.05 × min(10000,500000) = 500.
+        const { result } = collect(
+            NONPOS_BASE({
+                enemyHp: 10000,
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'enemy')
+                        ?.corrosionEntries.push(corrosion(5, 1, 5, 'attacker'));
+                },
+            })
+        );
+        // Round 1: dummy ticks 500 surfaced via the focus corrosion channel (RoundData field).
+        expect(result.rounds[0].corrosionDamage).toBe(500);
+        // It fed the dummy aggregate (cumulativeDamage advanced) — legacy behaviour.
+        expect(result.rounds[0].cumulativeDamage).toBeGreaterThanOrEqual(500);
+    });
+
+    it('Positioned AND heal-target (branch-collision): a victim that is both ticks EXACTLY ONCE via the heal-target branch', () => {
+        idc = 0;
+        // The walked-team ally 'team-ally' is BOTH positioned (M2) AND the heal target. It must tick
+        // EXACTLY ONCE per ticking round — via the heal-target branch (isHealTarget short-circuits
+        // the per-victim path) — NOT twice. corrosion (tier 5, stacks 1, applier 'enemy-front'),
+        // ally maxHp 10000 → 500. The applier acts after the team in round 1 → first tick round 2.
+        const { events, result } = collect(
+            POSITIONAL_BASE({
+                healTargetId: 'team-ally',
+                numRounds: 3,
+                teamActors: [teamAlly('team-ally', 'M2', 10000)],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'team-ally')
+                        ?.corrosionEntries.push(corrosion(5, 1, 9, 'enemy-front'));
+                },
+            })
+        );
+
+        // In EVERY round there is AT MOST ONE corrosion dot-ticked targeting the ally (a double-tick
+        // — heal-target branch AND per-victim branch firing — would produce two per round).
+        for (let round = 1; round <= 3; round++) {
+            const perRound = events.filter(
+                (e) =>
+                    e.type === 'dot-ticked' &&
+                    (e as CombatEvent & { targetId: string }).targetId === 'team-ally' &&
+                    (e as CombatEvent & { round: number }).round === round &&
+                    (e as CombatEvent & { dotType: string }).dotType === 'corrosion'
+            );
+            expect(perRound.length).toBeLessThanOrEqual(1);
+        }
+        // It DID tick (at least once across the run) — the heal-target branch fired.
+        const totalCorrosionTicks = events.filter(
+            (e) =>
+                e.type === 'dot-ticked' &&
+                (e as CombatEvent & { targetId: string }).targetId === 'team-ally' &&
+                (e as CombatEvent & { dotType: string }).dotType === 'corrosion'
+        );
+        expect(totalCorrosionTicks.length).toBeGreaterThanOrEqual(1);
+
+        // The heal-target branch routes the tick into the tank's INCOMING accounting (NOT a player
+        // damage row) — so perTargetDamage['team-ally'] is NEVER populated by a per-victim DoT tick.
+        // (The ally takes no firing hit at M2, so the key stays absent every round — proving no
+        // per-victim DoT row was written for the heal-target carrier.)
+        for (const round of result.rounds) {
+            expect(round.perTargetDamage?.['team-ally']).toBeUndefined();
+        }
+    });
+
+    it('Round-1 faster-victim, no applier ctx: tickDoTs skips the entry (no HP/row) but still ages the stack', () => {
+        idc = 0;
+        // A DoT whose applier has not acted yet: a SLOW focus (speed implied by turn order) vs a FAST
+        // enemy-back. We seed corrosion applied by 'enemy-mid' (an enemy that acts AFTER enemy-back in
+        // round 1 ordering is not guaranteed); to make this deterministic we use an applier id that
+        // NEVER acts — a non-existent 'ghost-applier' has no ctx in lastTurnCtxByActor in ANY round.
+        // tickDoTs `if (!ctx) continue` skips it → no HP drain, no perTargetDamage — but expireStacks
+        // still ages it (remainingRounds 1 → 0 → removed after round 1). We can only assert the
+        // observable: no HP drain and no perTargetDamage for the victim across both rounds.
+        const { events, result } = collect(
+            POSITIONAL_BASE({
+                enemyAttackers: [
+                    enemyAt('enemy-front', 'M4', 1_000_000_000),
+                    enemyAt('enemy-mid', 'M3', 1_000_000_000),
+                    enemyAt('enemy-back', 'M2', 10000),
+                ],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'enemy-back')
+                        ?.corrosionEntries.push(corrosion(5, 1, 1, 'ghost-applier'));
+                },
+            })
+        );
+
+        // No applier ctx → entry skipped: no HP drain, no perTargetDamage for enemy-back (no firing
+        // hit either — outside footprint).
+        for (const round of result.rounds) {
+            expect(round.perTargetDamage?.['enemy-back']).toBeUndefined();
+        }
+        // No dot-ticked event fired for the skipped entry.
+        const ticks = events.filter(
+            (e) =>
+                e.type === 'dot-ticked' &&
+                (e as CombatEvent & { targetId: string }).targetId === 'enemy-back'
+        );
+        expect(ticks.length).toBe(0);
+    });
+
+    it('Team-applier DoT on a positioned enemy: HP drains via enemySink + perActorDot keyed to the TEAM source → focus DoT DPS IGNORES it', () => {
+        idc = 0;
+        // A NON-focus team ship 'team-ally' applies a corrosion on the enemy victim 'enemy-back'.
+        // The tick drains enemy-back's HP (enemySink) and is keyed under the team source in
+        // perActorDot, so the focus-DPS fold (perActorDot.get(focusActorId='attacker')) IGNORES it —
+        // the focus DoT total stays 0. tick = 0.05 × 10000 = 500.
+        const { result } = collect(
+            POSITIONAL_BASE({
+                teamActors: [teamAlly('team-ally', 'M3', 1_000_000_000)],
+                enemyAttackers: [
+                    enemyAt('enemy-front', 'M4', 1_000_000_000),
+                    enemyAt('enemy-mid', 'M3', 1_000_000_000),
+                    enemyAt('enemy-back', 'M2', 10000), // outside footprint
+                ],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors
+                        .find((a) => a.id === 'enemy-back')
+                        ?.corrosionEntries.push(corrosion(5, 1, 5, 'team-ally'));
+                },
+            })
+        );
+
+        const round1 = result.rounds[0];
+        // enemy-back's HP drained 500 via enemySink.
+        expect(round1.perTargetDamage?.['enemy-back']).toBe(500);
+        // The focus DoT DPS (perActorDot.get('attacker')) is UNCHANGED — the team source key is
+        // ignored by the focus fold.
+        expect(round1.corrosionDamage).toBe(0);
+        expect(round1.infernoDamage).toBe(0);
+    });
+});

--- a/src/utils/combat/__tests__/perVictimDotTick.integration.test.ts
+++ b/src/utils/combat/__tests__/perVictimDotTick.integration.test.ts
@@ -542,8 +542,7 @@ describe('per-victim DoT ticks at each positioned ship’s turn-start (PR-C C2)'
                             target: parsedTarget('front'),
                             pattern: { raw: 'base', shape: 'base', range: 0, modifiers: {} },
                             shipSkills: { slots: [stasisOnlyInflict(9)] },
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        } as any,
+                        } as EnemyAttacker,
                     ],
                     __testTapActors: (actors: CombatActor[]) => {
                         actors

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -4447,8 +4447,8 @@ export function runCombat(input: CombatEngineInput): {
                                 incomingReductionForHit(incomingAbilitiesOf(healTarget.id), {
                                     didCrit: false,
                                     attackerStealthed: false,
-                                    victimStealthed: false,
-                                    victimStasised: false,
+                                    victimStealthed: isStealthed(healTarget.id),
+                                    victimStasised: isStasised(healTarget.id),
                                     hitIndexThisRound: 0,
                                     dotType,
                                 }),
@@ -4515,8 +4515,8 @@ export function runCombat(input: CombatEngineInput): {
                                     incomingReductionForHit(incomingAbilitiesOf(actor.id), {
                                         didCrit: false,
                                         attackerStealthed: false,
-                                        victimStealthed: false,
-                                        victimStasised: false,
+                                        victimStealthed: isStealthed(actor.id),
+                                        victimStasised: isStasised(actor.id),
                                         hitIndexThisRound: 0,
                                         dotType,
                                     }),

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -4388,69 +4388,162 @@ export function runCombat(input: CombatEngineInput): {
                 // (the tank's) max HP. The dead-target guard above already skipped a destroyed tank,
                 // so the tank is alive here. DPS mode / no enemy-applied DoTs → empty containers →
                 // a no-op (goldens byte-identical).
-                if (healTarget && actor.id === healTarget.id) {
-                    // Snapshot BEFORE tickDoTs so expiring entries still appear in the
-                    // display panel (mergeDoTsForDisplay + buildEnemyRoundEffects read it).
-                    tankDotSnapshot = {
-                        corrosion: healTarget.corrosionEntries.map((e) => ({
-                            sourceId: e.sourceId,
-                            tier: e.tier,
-                            stacks: e.stacks,
-                        })),
-                        inferno: healTarget.infernoEntries.map((e) => ({
-                            sourceId: e.sourceId,
-                            tier: e.tier,
-                            stacks: e.stacks,
-                        })),
-                    };
-                    let tankDotDamage = 0;
-                    tickDoTs({
-                        corrosionEntries: healTarget.corrosionEntries,
-                        infernoEntries: healTarget.infernoEntries,
-                        // Corrosion scales with the afflicted ship's HP — the tank's own max HP.
-                        enemyHp: recipientMaxHp(healTarget.id),
-                        ctxFor: (sourceId) => lastTurnCtxByActor.get(sourceId),
-                        emitTicked: (dotType, damage) =>
-                            bus.emit({
-                                type: 'dot-ticked',
-                                targetId: healTarget.id,
-                                round: r,
-                                dotType,
-                                damage,
-                            }),
-                        // Sum the ticked damage across all appliers; route it as INCOMING to the tank
-                        // (NOT into a player damage row). expireStacks inside tickDoTs ages the entries.
-                        credit: (_sourceId, _dotType, damage) => {
-                            tankDotDamage += damage;
-                        },
-                        // D-PR3 (Vortex Veil): reduce the carrier's incoming DoT ticks when
-                        // the tank equips Vortex Veil. The condition 'dot-inferno-corrosion'
-                        // gates on dotType being set, so querying with either dotType returns
-                        // the same %. Absent → 0 → byte-identical for all existing tests.
-                        incomingDotReductionPct: (dotType) =>
-                            incomingReductionForHit(incomingAbilitiesOf(healTarget.id), {
-                                didCrit: false,
-                                attackerStealthed: false,
-                                victimStealthed: false,
-                                victimStasised: false,
-                                hitIndexThisRound: 0,
-                                dotType,
-                            }),
-                    });
-                    if (tankDotDamage > 0) {
-                        // C2b-2 T5: a DoT-tick batch is an AGGREGATE of multiple appliers with no
-                        // single killer → byDirectDamage:false, killerId undefined (overrides the
-                        // wrapper's direct-damage default). A defaulted true would wrongly tag a
-                        // DoT kill as a direct hit (Faust, Task 6, distinguishes them).
-                        applyIncomingToTarget(tankDotDamage, healTarget, { byDirectDamage: false });
-                    }
-                    // Dead-is-dead: if the turn-start DoT tick was LETHAL the tank just died
-                    // (recordDestroyed fired inside applyIncomingToTarget). It must NOT fall through
-                    // and take a full turn — re-run the SAME dead-target skip as the top-of-turn
-                    // guard. (With Cheat Death the intercept floored HP at 1 → not dead → false → it
-                    // acts normally.)
-                    if (handleDeadTargetSkip(actor)) {
-                        continue;
+                // PR-C C2: unified per-victim DoT-tick prologue. EVERY positioned non-dummy actor
+                // (attacker, walked-team ally, enemy attacker) ticks its OWN DoT containers against
+                // its OWN HP at its turn-start — the last per-victim gap after the firing hit +
+                // skill detonation + timed bursts. The dummy `enemy` (actor.id === enemy.id) keeps
+                // its legacy aggregate tick at the enemy-turn branch (~:4966, byte-identical via
+                // creditDamage); only the dummy is excluded here. The heal-target branch is preserved
+                // VERBATIM (snapshot + tankDotDamage healing accounting + dead-skip). The per-victim
+                // branch lands HP via applyVictimDamage (DoT → bypass shield) and NEVER calls
+                // creditDamage (no cumulativeDamage double-feed against the dummy HP overwrite).
+                //
+                // OUTSIDE every `if (!isTurnBlocked)` stasis gate (this prologue precedes all
+                // kind-branches) → a STASISED victim STILL ticks, matching the heal-target/dummy
+                // precedent and the E5-symmetry invariant. Moving this inside a stasis gate would
+                // wrongly silence a stasised victim's DoTs.
+                if (actor.id !== enemy.id) {
+                    const isHealTarget = !!healTarget && actor.id === healTarget.id;
+                    if (isHealTarget) {
+                        // Snapshot BEFORE tickDoTs so expiring entries still appear in the
+                        // display panel (mergeDoTsForDisplay + buildEnemyRoundEffects read it).
+                        tankDotSnapshot = {
+                            corrosion: healTarget.corrosionEntries.map((e) => ({
+                                sourceId: e.sourceId,
+                                tier: e.tier,
+                                stacks: e.stacks,
+                            })),
+                            inferno: healTarget.infernoEntries.map((e) => ({
+                                sourceId: e.sourceId,
+                                tier: e.tier,
+                                stacks: e.stacks,
+                            })),
+                        };
+                        let tankDotDamage = 0;
+                        tickDoTs({
+                            corrosionEntries: healTarget.corrosionEntries,
+                            infernoEntries: healTarget.infernoEntries,
+                            // Corrosion scales with the afflicted ship's HP — the tank's own max HP.
+                            enemyHp: recipientMaxHp(healTarget.id),
+                            ctxFor: (sourceId) => lastTurnCtxByActor.get(sourceId),
+                            emitTicked: (dotType, damage) =>
+                                bus.emit({
+                                    type: 'dot-ticked',
+                                    targetId: healTarget.id,
+                                    round: r,
+                                    dotType,
+                                    damage,
+                                }),
+                            // Sum the ticked damage across all appliers; route it as INCOMING to the tank
+                            // (NOT into a player damage row). expireStacks inside tickDoTs ages the entries.
+                            credit: (_sourceId, _dotType, damage) => {
+                                tankDotDamage += damage;
+                            },
+                            // D-PR3 (Vortex Veil): reduce the carrier's incoming DoT ticks when
+                            // the tank equips Vortex Veil. The condition 'dot-inferno-corrosion'
+                            // gates on dotType being set, so querying with either dotType returns
+                            // the same %. Absent → 0 → byte-identical for all existing tests.
+                            incomingDotReductionPct: (dotType) =>
+                                incomingReductionForHit(incomingAbilitiesOf(healTarget.id), {
+                                    didCrit: false,
+                                    attackerStealthed: false,
+                                    victimStealthed: false,
+                                    victimStasised: false,
+                                    hitIndexThisRound: 0,
+                                    dotType,
+                                }),
+                        });
+                        if (tankDotDamage > 0) {
+                            // C2b-2 T5: a DoT-tick batch is an AGGREGATE of multiple appliers with no
+                            // single killer → byDirectDamage:false, killerId undefined (overrides the
+                            // wrapper's direct-damage default). A defaulted true would wrongly tag a
+                            // DoT kill as a direct hit (Faust, Task 6, distinguishes them).
+                            applyIncomingToTarget(tankDotDamage, healTarget, {
+                                byDirectDamage: false,
+                            });
+                        }
+                        // Dead-is-dead: if the turn-start DoT tick was LETHAL the tank just died
+                        // (recordDestroyed fired inside applyIncomingToTarget). It must NOT fall through
+                        // and take a full turn — re-run the SAME dead-target skip as the top-of-turn
+                        // guard. (With Cheat Death the intercept floored HP at 1 → not dead → false → it
+                        // acts normally.)
+                        if (handleDeadTargetSkip(actor)) {
+                            continue;
+                        }
+                    } else {
+                        // Per-victim DoT tick (both sides). The actor ticks its OWN containers
+                        // against its OWN HP only when it is POSITIONAL against its opposing roster
+                        // (DPS/healing-only mode has no positioned opposing actors → no-op →
+                        // byte-identical for non-positional fixtures).
+                        const sideIsPlayer = actor.side === 'player';
+                        const opposing = sideIsPlayer ? enemyAttackerActors : allPlayerActors;
+                        const hasDots =
+                            actor.corrosionEntries.length > 0 || actor.infernoEntries.length > 0;
+                        if (hasDots && isPositional(actor.position, opposing)) {
+                            let total = 0;
+                            tickDoTs({
+                                corrosionEntries: actor.corrosionEntries,
+                                infernoEntries: actor.infernoEntries,
+                                // Corrosion scales with the AFFLICTED ship's own max HP.
+                                enemyHp: recipientMaxHp(actor.id),
+                                ctxFor: (sourceId) => lastTurnCtxByActor.get(sourceId),
+                                emitTicked: (dotType, damage) =>
+                                    bus.emit({
+                                        type: 'dot-ticked',
+                                        targetId: actor.id,
+                                        round: r,
+                                        dotType,
+                                        damage,
+                                    }),
+                                credit: (sourceId, dotType, damage) => {
+                                    total += damage;
+                                    // Only PLAYER-applied DoTs ticking on an ENEMY victim are the
+                                    // focus player's outgoing DPS → surface via perActorDot (keyed
+                                    // by the DoT APPLIER; the C1 fold reads perActorDot[focus]).
+                                    // Enemy-applied DoTs on a player victim are NOT the focus's DPS.
+                                    if (!sideIsPlayer) {
+                                        const e = perActorDot.get(sourceId) ?? {
+                                            corrosion: 0,
+                                            inferno: 0,
+                                        };
+                                        e[dotType] += damage;
+                                        perActorDot.set(sourceId, e);
+                                    }
+                                },
+                                // D-PR3 (Vortex Veil): reduce this carrier's incoming DoT ticks.
+                                incomingDotReductionPct: (dotType) =>
+                                    incomingReductionForHit(incomingAbilitiesOf(actor.id), {
+                                        didCrit: false,
+                                        attackerStealthed: false,
+                                        victimStealthed: false,
+                                        victimStasised: false,
+                                        hitIndexThisRound: 0,
+                                        dotType,
+                                    }),
+                            });
+                            if (total > 0) {
+                                // DoT batch: bypass shield (byDirectDamage:false), aggregate of
+                                // appliers with no single killer. Mirrors the heal-target route
+                                // (applyIncomingToTarget == applyVictimDamage + playerSink + pen 0).
+                                applyVictimDamage(
+                                    total,
+                                    actor,
+                                    sideIsPlayer ? playerSink : enemySink,
+                                    { byDirectDamage: false }
+                                );
+                                roundPerTargetDamage.set(
+                                    actor.id,
+                                    (roundPerTargetDamage.get(actor.id) ?? 0) + total
+                                );
+                            }
+                            // Lethal turn-start tick → skip the rest of the turn. INTENTIONALLY
+                            // follows the heal-target lethal convention (skip the shared post-turn
+                            // block: decrements / turn-ended), NOT the timed-burst convention.
+                            if (actor.destroyedRound !== undefined) {
+                                if (actor.id === focusActorId) pushSynthesizedFocusSkipTurn();
+                                continue;
+                            }
+                        }
                     }
                 }
 

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -1942,6 +1942,12 @@ export function runCombat(input: CombatEngineInput): {
     // mode (focus.detonation is 0 there — the aggregate credit is suppressed). Absent when empty
     // → non-positional rounds byte-identical.
     let perActorDetonation = new Map<string, number>();
+    // Per-round per-applier DoT-tick display tally (sourceId → {corrosion, inferno}). Populated
+    // ONLY by the positional per-victim DoT-tick path (Task C2); folded into the FOCUS actor's
+    // corrosion/inferno display + raw totals at post-round assembly WITHOUT feeding cumulativeDamage
+    // (the per-victim HP already lands via applyVictimDamage — exact mirror of perActorDetonation).
+    // Empty on non-positional rounds → byte-identical.
+    let perActorDot = new Map<string, { corrosion: number; inferno: number }>();
 
     // Recipient's CURRENT effective max HP: prefer the actor's last-turn ctx (live buffs),
     // else its base HP (pre-first-turn). Same pattern for incoming-heal % (ctx value ?? 0).
@@ -3830,6 +3836,7 @@ export function runCombat(input: CombatEngineInput): {
         // carry-over never over-reports splash. Written only by the death-seam splash block.
         perActorSplash = new Map<string, number>();
         perActorDetonation = new Map<string, number>();
+        perActorDot = new Map();
         if (healTarget) {
             currentRoundHealing = new Map<string, ActorHealing>();
             const targetMaxHp = recipientMaxHp(healTarget.id);
@@ -5624,8 +5631,9 @@ export function runCombat(input: CombatEngineInput): {
         // Row fields sourced from the focus entry. secondary/conditional go only to
         // rawTotals (RoundData has no sub-bucket columns) so they're read inline below.
         const directDamage = focus.direct;
-        const corrosionDamage = focus.corrosion;
-        const infernoDamage = focus.inferno;
+        const focusDot = perActorDot.get(focusActorId);
+        const corrosionDamage = focus.corrosion + (focusDot?.corrosion ?? 0);
+        const infernoDamage = focus.inferno + (focusDot?.inferno ?? 0);
         const focusPositionalDetonation = perActorDetonation.get(focusActorId) ?? 0;
         const detonationDamage = focus.detonation + focusPositionalDetonation;
 
@@ -5640,6 +5648,10 @@ export function runCombat(input: CombatEngineInput): {
             });
         }
 
+        // Deliberately uses focus.corrosion/focus.inferno ONLY (not the perActorDot-folded
+        // corrosionDamage/infernoDamage locals) — per-victim DoT ticks land via applyVictimDamage,
+        // so folding perActorDot here would double-drain the dummy HP overwrite (same guard as the
+        // focusPositionalDetonation/detonation comment below).
         const totalRoundDamage = focus.direct + focus.corrosion + focus.inferno + focus.detonation;
         cumulativeDamage += totalRoundDamage;
         // Row/summary rawTotals stay FOCUS-only — only the focus actor reaches summary DPS
@@ -5647,8 +5659,8 @@ export function runCombat(input: CombatEngineInput): {
         totalDirectRaw += focus.direct;
         totalSecondaryRaw += focus.secondary;
         totalConditionalRaw += focus.conditional;
-        totalCorrosionRaw += focus.corrosion;
-        totalInfernoRaw += focus.inferno;
+        totalCorrosionRaw += corrosionDamage;
+        totalInfernoRaw += infernoDamage;
         // Summary detonation reflects per-victim positional detonation too (focusPositionalDetonation
         // is 0 non-positionally → byte-identical). NOTE: cumulativeDamage/totalRoundDamage above
         // deliberately use focus.detonation ONLY — per-victim detonation lands via applyVictimDamage,


### PR DESCRIPTION
## What

Final sibling of the **positional per-victim stored-damage completion** epic (after skill detonation #168/#170/#171 and timed bursts #169/#172). Makes **Inferno/Corrosion damage-over-time ticks resolve per-victim** against each positioned ship's own HP at its own turn-start — on **both teams** — instead of only counting against the primary/anchor target.

Previously DoTs ticked only on the focus-dummy enemy (legacy aggregate) and the heal-target. Every other positioned victim's stored DoTs never ticked, so a DoT could not wear down or kill a secondary ship or trigger its on-death effects.

## How

Unifies the shared **`:4384` turn-start DoT-tick prologue** (rather than adding two separate sites): widened to all positioned non-dummy actors, branching by side.

- **Enemy victims** drain their own HP via `enemySink`; player-applied DoTs surface in the focus DPS breakdown via a new `perActorDot` display map.
- **Player victims** drain via `playerSink`; the heal-target accounting branch (`tankDotSnapshot` + healing-incoming + dead-skip) is preserved **verbatim**.
- HP lands per-victim via `applyVictimDamage(..., { byDirectDamage: false })` (DoTs bypass shield). The per-victim path **never** calls `creditDamage`, so it never double-feeds the dummy `enemy.currentHp` overwrite (the same seam detonation/bursts solved).
- The prologue sits **outside the stasis gate** — so a stasised victim still ticks, matching the heal-target/dummy precedent and preserving the **E5-symmetry** invariant (same carrier ticks identically on either side).
- The dummy enemy keeps its legacy aggregate tick (byte-identical).

### Task C0 (blocking channel-map)
A reviewed written deliverable established that `direct/corrosion/inferno/detonation` (focus+team in `roundDamage`) feed the dummy HP overwrite, so per-victim DoT ticks must suppress that feed while still surfacing focus DoT DPS via `perActorDot` (mirroring `perActorDetonation`). See the plan doc.

## Tests
New `perVictimDotTick.integration.test.ts` — 10 cases: enemy own-HP tick (+ focus-DPS surfacing), lethal tick→death+skip, non-heal-target player tick, **heal-target unification regression**, **E5-symmetry pin**, **stasis-still-ticks pin** (both sides, non-vacuous), non-positional regression, positioned-AND-heal-target branch-collision, round-1 no-ctx skip-but-age, team-applier fold-ignores-non-focus.

**3501 passed (265 files)**, ZERO existing `.snap` moved, `tsc`/lint clean. Stacked work rebased onto main (PR-A #171 + PR-B #172 already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)