### PR TITLE
feat(combat): control classification unification — recognize Provoke/Taunt/CF/Disable as control abilities + effect-aware badge

### DIFF
--- a/docs/superpowers/plans/2026-06-28-control-classification-unification.md
+++ b/docs/superpowers/plans/2026-06-28-control-classification-unification.md
@@ -1,0 +1,377 @@
+# Control Classification Unification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recognize Provoke / Taunt / Concentrate Fire / Disable as first-class `type:'control'` abilities (additively, alongside their existing named-status application) and make the editor's "Not simulated" badge effect-aware, so `control` is no longer falsely flagged.
+
+**Architecture:** Additive only. Control statuses already *land* via the named-debuff/buff path (`statusEngine.applyTimedAbilityStatus`); a `type:'control'` ability is event-only (`control-applied`). We extend the parser/builder to also emit a control ability per recognized effect (mirroring how Stasis already double-parses), resolve the Block-Debuff resist ownership so the four new effects stay byte-identical, and swap the badge's blanket type check for an effect-aware predicate. No engine application/targeting/lockout code changes.
+
+**Tech Stack:** TypeScript, Vitest, React (editor card). Combat sim under `src/utils/combat`, parser under `src/utils`, ability builder under `src/utils/abilities`, editor under `src/components/skills`.
+
+**Spec:** `docs/superpowers/specs/2026-06-28-control-classification-unification-design.md`
+
+**Workflow reminders:**
+- `gh auth switch --hostname github.com --user TheSusort` before any `gh`.
+- Branch `feat/combat-control-classification-unification` (already created off main, holds the spec).
+- Docs are gitignored → `git add -f` + `git commit --no-verify` for docs-only commits.
+- Byte-identical combat goldens are the gate. Never blind `vitest -u`. Run the WHOLE `npm test` suite for the audit. `audit:skills`, `lint`, `tsc` clean every task.
+
+---
+
+## Reference: real corpus phrasings (from `docs/ship-skills.csv`)
+
+The matcher must align with the application verbs the named-status path already
+handles (these are why the statuses work today). Enumerated tag-adjacent forms:
+
+| Effect | Phrasings | Side |
+|---|---|---|
+| Stasis | `inflicts/applies <tag>Stasis` | enemy |
+| Provoke | `applies <tag>Provoke`, `apply <tag>Provoke` | enemy |
+| Concentrate Fire | `applies/apply <tag>Concentrate Fire`, `applied with <tag>Concentrate Fire` | enemy |
+| Disable | `inflicts <tag>Disable`, `inflicted with <tag>Disable`, `applies <tag>Disable` | enemy |
+| Taunt | `gains <tag>Taunt`, `grants <tag>Taunt` | self |
+
+`<tag>` = `<unit-skill>` (optionally with whitespace). Tag is immediately
+adjacent to the verb (≤ a couple words), unlike the existing Stasis regex's
+sentence-wide `[^.]*?` span — the new matcher uses a tight adjacency window to
+avoid matching a control word that appears in a *condition* clause.
+
+---
+
+## File Structure
+
+- **Modify** `src/types/abilities.ts` — add `'disable'` to `ControlEffect`.
+- **Modify** `src/utils/combat/debuffImmunity.ts` — add `disable` to `CONTROL_EFFECT_LABEL`.
+- **Modify** `src/utils/skillTextParser.ts` — generalize control matching into `parseControlInflicts(text): { effect: ControlEffect; pos: number; side: 'enemy' | 'self' }[]`; keep `parseControlInflict` (or fold it) so Stasis output is byte-identical; rewrite the stale Stasis-only docstring.
+- **Modify** `src/utils/abilities/buildShipAbilities.ts` — replace the single-effect control block (`:987-1015`) with a loop over `parseControlInflicts`, setting `target` per side; rewrite the stale comment.
+- **Modify** `src/utils/combat/playerTurn.ts` — resolve Block-Debuff resist ownership in the control emission loop (`:1277-1290`): drop the control-loop `emitBlockDebuffResist` (named-status path owns resists); skip the enemy-immune gate for self-target controls.
+- **Modify** `src/components/skills/simCoverage.ts` — add `SIMULATED_CONTROL_EFFECTS` + effect-aware `isAbilityNotSimulated(ability)`; remove `'control'` from `NOT_SIMULATED_TYPES`.
+- **Modify** `src/components/skills/AbilityCard.tsx` (`:766-768`) — render the badge via the predicate.
+- **Modify** `src/components/skills/__tests__/AbilityCard.test.tsx` — update the badge precedent test (`~:489`) to the new predicate.
+- **Tests (new):** parser unit tests, builder unit tests, sim-coverage unit tests, a control-emission/Block-Debuff integration test.
+- **Modify** `src/constants/changelog.ts` — `UNRELEASED_CHANGES` entry.
+- **Modify** `src/pages/DocumentationPage.tsx` — if control/skill-coverage is documented there.
+
+---
+
+## Task 1: Add `disable` to the ControlEffect type + label
+
+**Files:**
+- Modify: `src/types/abilities.ts:537`
+- Modify: `src/utils/combat/debuffImmunity.ts:33-40`
+- Test: `src/utils/combat/__tests__/debuffImmunity.test.ts` (or the nearest existing label test)
+
+- [ ] **Step 1: Write the failing test** — `controlEffectLabel('disable')` returns `'Disable'`.
+
+```ts
+import { controlEffectLabel } from '../debuffImmunity';
+it('labels the disable control effect', () => {
+    expect(controlEffectLabel('disable')).toBe('Disable');
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `npx vitest run src/utils/combat/__tests__/debuffImmunity.test.ts` → type error / fail (`'disable'` not assignable to `ControlEffect`).
+
+- [ ] **Step 3: Implement** — extend the union and the label map:
+
+```ts
+// src/types/abilities.ts
+export type ControlEffect = 'provoke' | 'taunt' | 'stasis' | 'overload' | 'concentrate-fire' | 'disable';
+```
+```ts
+// src/utils/combat/debuffImmunity.ts CONTROL_EFFECT_LABEL
+disable: 'Disable',
+```
+
+- [ ] **Step 4: Run `npx tsc --noEmit`** — fix any newly-surfaced non-exhaustive `switch`/`Record<ControlEffect, …>` the compiler flags (exhaustiveness is our safety net here). Then the test PASSES.
+
+- [ ] **Step 5: Commit** — `feat(combat): add 'disable' to ControlEffect + label`.
+
+---
+
+## Task 2: Generalize the control-infliction parser
+
+**Files:**
+- Modify: `src/utils/skillTextParser.ts` (around `:1018-1031`, `STASIS_INFLICT_RE` / `parseControlInflict`)
+- Test: `src/utils/__tests__/skillTextParser.test.ts` (control section; co-locate with existing parser tests)
+
+**Design:** add `parseControlInflicts(text): { effect: ControlEffect; pos: number; side: 'enemy' | 'self' }[]`. Build a small table mapping each `ControlEffect` to its buff tag-name + side + verb set, scan the text with a tight adjacency regex per effect, and return one entry per match (multiple effects per skill → multiple entries). Keep `parseControlInflict` exported (delegating to the new fn, returning the Stasis entry) only if other call sites need it; otherwise inline. **Stasis's emitted entry (effect `'stasis'`, side `'enemy'`, `pos` = position of the Stasis tag) MUST be byte-identical to today.**
+
+- [ ] **Step 1: Write failing tests** — one per effect + Stasis-unchanged + negatives:
+
+```ts
+it('recognizes each inflicted control effect', () => {
+    expect(parseControlInflicts('Deals damage and applies <unit-skill>Provoke</unit-skill> for 1 turn'))
+        .toEqual([{ effect: 'provoke', side: 'enemy', pos: expect.any(Number) }]);
+    expect(parseControlInflicts('inflicts <unit-skill>Disable</unit-skill> for 2 turns')[0].effect).toBe('disable');
+    expect(parseControlInflicts('apply <unit-skill>Concentrate Fire</unit-skill> for 1 turn')[0].effect).toBe('concentrate-fire');
+});
+it('recognizes Taunt as a self-grant', () => {
+    expect(parseControlInflicts('This Unit gains <unit-skill>Taunt</unit-skill> for 1 turn'))
+        .toEqual([{ effect: 'taunt', side: 'self', pos: expect.any(Number) }]);
+});
+it('keeps Stasis byte-identical', () => {
+    expect(parseControlInflicts('inflicts <unit-skill>Stasis</unit-skill> for 2 turns'))
+        .toEqual([{ effect: 'stasis', side: 'enemy', pos: expect.any(Number) }]);
+});
+it('does NOT match a control word in a condition clause (no application verb adjacency)', () => {
+    expect(parseControlInflicts('If the target has <unit-skill>Provoke</unit-skill>, deal +20% damage')).toEqual([]);
+});
+it('returns [] for non-control text', () => {
+    expect(parseControlInflicts('Deals 300% damage')).toEqual([]);
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `npx vitest run src/utils/__tests__/skillTextParser.test.ts -t control`.
+
+- [ ] **Step 3: Implement** — table + tight matcher. Sketch:
+
+```ts
+const CONTROL_INFLICTS: { effect: ControlEffect; tag: string; side: 'enemy' | 'self'; re: RegExp }[] = [
+    { effect: 'stasis',           tag: 'Stasis',           side: 'enemy', re: /\b(?:inflicts?|appl(?:ies|y)|inflicted with|applied with)\s+<unit-skill>\s*Stasis\b/i },
+    { effect: 'provoke',          tag: 'Provoke',          side: 'enemy', re: /\b(?:inflicts?|appl(?:ies|y)|inflicted with|applied with)\s+<unit-skill>\s*Provoke\b/i },
+    { effect: 'concentrate-fire', tag: 'Concentrate Fire', side: 'enemy', re: /\b(?:inflicts?|appl(?:ies|y)|inflicted with|applied with)\s+<unit-skill>\s*Concentrate Fire\b/i },
+    { effect: 'disable',          tag: 'Disable',          side: 'enemy', re: /\b(?:inflicts?|appl(?:ies|y)|inflicted with|applied with)\s+<unit-skill>\s*Disable\b/i },
+    { effect: 'taunt',            tag: 'Taunt',            side: 'self',  re: /\b(?:gains?|grants?)\s+<unit-skill>\s*Taunt\b/i },
+];
+
+export function parseControlInflicts(text: string | null | undefined) {
+    if (!text) return [];
+    const out: { effect: ControlEffect; pos: number; side: 'enemy' | 'self' }[] = [];
+    for (const c of CONTROL_INFLICTS) {
+        if (c.re.test(text)) {
+            const pos = text.search(new RegExp(`<unit-skill>\\s*${c.tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i'));
+            out.push({ effect: c.effect, pos: pos >= 0 ? pos : Number.MAX_SAFE_INTEGER, side: c.side });
+        }
+    }
+    return out;
+}
+```
+
+(Reuse the file's existing `MAX_POS` constant rather than `MAX_SAFE_INTEGER` if present. Keep the Stasis row first so its `pos` matches the prior `text.search(/<unit-skill>\s*Stasis\b/i)`.) Rewrite the stale docstring at `:1018-1023` to describe all five effects and the gate-path-vs-application-path distinction (per spec §4.1).
+
+- [ ] **Step 4: Run, expect PASS** — control tests green; `npx tsc --noEmit` clean.
+
+- [ ] **Step 5: Commit** — `feat(combat): parse all control inflictions (provoke/taunt/CF/disable + stasis)`.
+
+---
+
+## Task 3: Emit control abilities for every recognized effect (builder)
+
+**Files:**
+- Modify: `src/utils/abilities/buildShipAbilities.ts:987-1015`
+- Test: `src/utils/abilities/__tests__/buildShipAbilities.test.ts` (or the nearest build-fixture test)
+
+- [ ] **Step 1: Write failing tests** — a skill that applies each effect emits a `type:'control'` ability with the right `effect`/`target`, AND the named-status ability is still produced unchanged.
+
+```ts
+it('emits a control ability for an applied Provoke (alongside the named debuff)', () => {
+    const abilities = buildShipAbilities(shipWithActive('applies <unit-skill>Provoke</unit-skill> for 1 turn'));
+    const control = abilities.find(a => a.type === 'control');
+    expect(control?.config).toMatchObject({ type: 'control', effect: 'provoke' });
+    expect(control?.target).toBe('enemy');
+    // named debuff still present (the actual application)
+    expect(abilities.some(a => a.type === 'debuff' && a.config.type === 'debuff' && a.config.buffName === 'Provoke')).toBe(true);
+});
+it('emits a self-target control ability for a gained Taunt', () => {
+    const abilities = buildShipAbilities(shipWithActive('This Unit gains <unit-skill>Taunt</unit-skill> for 1 turn'));
+    const control = abilities.find(a => a.type === 'control');
+    expect(control?.config).toMatchObject({ type: 'control', effect: 'taunt' });
+    expect(control?.target).toBe('self');
+});
+it('keeps the Stasis control ability byte-identical', () => {
+    const abilities = buildShipAbilities(shipWithCharged('inflicts <unit-skill>Stasis</unit-skill> for 1 turn'));
+    const control = abilities.find(a => a.type === 'control');
+    expect(control?.config).toMatchObject({ type: 'control', effect: 'stasis' });
+    expect(control?.target).toBe('enemy');
+});
+```
+
+(Use the test file's existing ship-fixture helpers; the names above are placeholders — match the real helper API.)
+
+- [ ] **Step 2: Run, expect FAIL** — `npx vitest run src/utils/abilities/__tests__/buildShipAbilities.test.ts -t control`.
+
+- [ ] **Step 3: Implement** — replace the `:987-1015` block:
+
+```ts
+// Control inflictions: emit a `type:'control'` ability per recognized effect (stasis,
+// provoke, taunt, concentrate-fire, disable). This is ADDITIVE — the parallel named
+// status (parseSkillEffects → applyTimedAbilityStatus) still performs the actual
+// lockout/forced-targeting. The control ability only sources the `control-applied`
+// event (reaction substrate, e.g. Defiant's shield-on-Stasis). Carries no conditions
+// (see the gated-Stasis caveat below); no damage/modifier → DPS pipeline ignores it.
+for (const ctrl of parseControlInflicts(text)) {
+    out.push({
+        ability: {
+            id: nextId(),
+            type: 'control',
+            target: ctrl.side, // 'enemy' for inflicted, 'self' for Taunt
+            trigger: 'on-cast',
+            conditions: [], // gated-control caveat: see original comment, preserved below
+            config: { type: 'control', effect: ctrl.effect },
+            autoFilled: true,
+        },
+        pos: ctrl.pos,
+    });
+}
+```
+
+Preserve the existing gated-Stasis caveat comment. Rewrite the stale lead comment (no longer "only Stasis … Provoke/Taunt stay conditions").
+
+- [ ] **Step 4: Run, expect PASS** — control build tests green; `npx tsc --noEmit` clean; `npx eslint` clean on touched files.
+
+- [ ] **Step 5: Commit** — `feat(combat): emit control abilities for all inflicted control effects`.
+
+---
+
+## Task 4: Resolve Block-Debuff resist ownership in the emission loop
+
+**Files:**
+- Modify: `src/utils/combat/playerTurn.ts:1277-1290`
+- Test (new): `src/utils/combat/__tests__/controlClassificationEmission.integration.test.ts`
+
+**Why:** today the control loop emits its own `emitBlockDebuffResist` when the enemy is Block-Debuff-immune. The parallel named-status path ALSO resists the same buff (symmetric with every debuff type). For Stasis that means two resist events today; adding control abilities for Provoke/etc. would give them a second resist too → behavior change. Fix: the control loop stops owning resists (named-status path owns them); it only emits `control-applied` on the success path. Self-target controls (Taunt) skip the enemy-immune gate entirely.
+
+- [ ] **Step 1: Write failing/locking tests:**
+
+```ts
+// (a) success: each enemy-inflicted effect emits control-applied with its effect
+it('emits control-applied for an applied Provoke', () => { /* run a cast, assert a control-applied{effect:'provoke'} on the bus */ });
+// (b) self Taunt: emits control-applied even though there is no enemy debuff target
+it('emits control-applied for a self Taunt regardless of enemy immunity', () => { /* ... */ });
+// (c) Block-Debuff immune target receiving Provoke emits EXACTLY ONE debuff-resisted
+//     (named-status path), NOT a second from the control loop
+it('does not double-emit a resist for a blocked control infliction', () => { /* immune target; assert resisted count for 'Provoke' === 1 */ });
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `(a)`/`(b)` fail (no control ability fired the event yet for these effects pre-Task-3 is done, so these may already pass after Task 3; the load-bearing new assertion is `(c)`, which fails because the control loop currently emits a second resist).
+
+- [ ] **Step 3: Implement** — rewrite the loop:
+
+```ts
+// Control inflictions: emit `control-applied` so reactions (on-stasis-applied) can fire.
+// Emission ONLY — the named-status path performs the actual lockout/targeting AND owns the
+// Block-Debuff resist (symmetric with every debuff type), so the control loop does NOT emit
+// its own resist (that would double-count). On a blocked enemy infliction we simply skip the
+// success event. Self-target controls (Taunt) have no enemy debuff target → no immune gate.
+for (const ctrl of controlAbilitiesFromSkill(gatedSkill)) {
+    if (ctrl.config.type !== 'control') continue;
+    if (ctrl.target === 'enemy' && targetImmuneToDebuffs) continue; // resist owned by named-status path
+    bus.emit({ type: 'control-applied', casterId: actor.id, effect: ctrl.config.effect, round: r });
+}
+```
+
+(Confirm `controlAbilitiesFromSkill` returns the new self-target Taunt control abilities; if it filters by target, widen it. Confirm `ctrl.target` is accessible on the returned shape.)
+
+- [ ] **Step 4: Run, expect PASS** — new integration tests green.
+
+- [ ] **Step 5: Full-suite golden check** — `npm test`. **Expected: byte-identical (zero `.snap` moved).** The one behavior change is Stasis no longer double-emitting a resist under Block-Debuff; if a fixture pairs Block-Debuff immunity with Stasis a golden will move — STOP and surface it (per spec §6.1) rather than refreshing. Record the green count.
+
+- [ ] **Step 6: Commit** — `feat(combat): control loop emits success event only; named-status path owns resists`.
+
+---
+
+## Task 5: Effect-aware "Not simulated" badge
+
+**Files:**
+- Modify: `src/components/skills/simCoverage.ts`
+- Modify: `src/components/skills/AbilityCard.tsx:766-768`
+- Modify: `src/components/skills/__tests__/AbilityCard.test.tsx` (~`:489`)
+- Test (new): `src/components/skills/__tests__/simCoverage.test.ts`
+
+- [ ] **Step 1: Write failing unit tests** for the predicate:
+
+```ts
+import { isAbilityNotSimulated, SIMULATED_CONTROL_EFFECTS } from '../simCoverage';
+it('treats modeled control effects as simulated', () => {
+    for (const effect of ['stasis','provoke','taunt','concentrate-fire','disable'] as const) {
+        expect(isAbilityNotSimulated({ type: 'control', config: { type: 'control', effect } } as any)).toBe(false);
+    }
+});
+it('still flags an unmodeled control effect (overload)', () => {
+    expect(isAbilityNotSimulated({ type: 'control', config: { type: 'control', effect: 'overload' } } as any)).toBe(true);
+});
+it('leaves non-control types as before', () => {
+    expect(isAbilityNotSimulated({ type: 'damage' } as any)).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `npx vitest run src/components/skills/__tests__/simCoverage.test.ts`.
+
+- [ ] **Step 3: Implement** in `simCoverage.ts`:
+
+```ts
+import { Ability, AbilityType, ControlEffect } from '../../types/abilities';
+
+export const SIMULATED_CONTROL_EFFECTS: ReadonlySet<ControlEffect> = new Set([
+    'stasis', 'provoke', 'taunt', 'concentrate-fire', 'disable',
+]);
+
+// `control` removed: its simulation is now decided per-effect by the predicate below.
+export const NOT_SIMULATED_TYPES: ReadonlySet<AbilityType> = new Set([]);
+
+export function isAbilityNotSimulated(ability: Ability): boolean {
+    if (ability.type === 'control' && ability.config.type === 'control') {
+        return !SIMULATED_CONTROL_EFFECTS.has(ability.config.effect);
+    }
+    return NOT_SIMULATED_TYPES.has(ability.type);
+}
+```
+
+Keep `NOT_SIMULATED_NOTE`. Update the file's leading doc comment (it currently explains why `control` is flagged) to describe the effect-aware rule.
+
+- [ ] **Step 4: Wire the card** — `AbilityCard.tsx:766-768`:
+
+```tsx
+{isAbilityNotSimulated(ability) && (
+    <p className="text-xs text-theme-text-secondary">{NOT_SIMULATED_NOTE}</p>
+)}
+```
+
+- [ ] **Step 5: Update `AbilityCard.test.tsx`** — the badge precedent test (~`:489`) that asserts via `NOT_SIMULATED_TYPES` membership: re-point it to the predicate (e.g. assert a control/stasis ability does NOT render the note, and a synthetic control/overload ability DOES). Keep the test asserting real component output, not the raw set.
+
+- [ ] **Step 6: Run, expect PASS** — `npx vitest run src/components/skills/__tests__/simCoverage.test.ts src/components/skills/__tests__/AbilityCard.test.tsx`; `npx tsc --noEmit`; `npx eslint` clean.
+
+- [ ] **Step 7: Commit** — `feat(skills): effect-aware Not-Simulated badge for control abilities`.
+
+---
+
+## Task 6: Changelog + docs + stale-comment sweep
+
+**Files:**
+- Modify: `src/constants/changelog.ts` (`UNRELEASED_CHANGES`)
+- Modify: `src/pages/DocumentationPage.tsx` (if control/skill-coverage is documented)
+- Sweep: any remaining stale "Provoke/Taunt are conditions, not control abilities" comments.
+
+- [ ] **Step 1: Add changelog entry** (user-facing: the editor now correctly shows Provoke/Taunt/Concentrate Fire/Disable/Stasis control effects as simulated):
+
+```ts
+'Skill editor: Provoke, Taunt, Concentrate Fire, Disable and Stasis are now recognized as control effects and no longer marked "Not simulated" — their combat impact is reflected in the battle simulator.',
+```
+
+- [ ] **Step 2: Update DocumentationPage** if it lists simulated/unsimulated ability types — reflect that control (except Overload) is simulated.
+
+- [ ] **Step 3: grep for stale comments** — `git grep -n "stay handled as targeting-status CONDITIONS"` and any "only Stasis" control comments; rewrite to the additive reality.
+
+- [ ] **Step 4: Run `npm run lint` + `npx tsc --noEmit`** — clean.
+
+- [ ] **Step 5: Commit** — `docs(combat): changelog + docs for control classification`.
+
+---
+
+## Task 7: Full-suite audit + holistic review + PR
+
+- [ ] **Step 1: Full audit** — `npm test` (record pass count; expect prior-base + new tests, ZERO `.snap` moved), `npm run lint`, `npx tsc --noEmit`, `npm run audit:skills` (expect 0 errors / 141 unchanged or current baseline).
+- [ ] **Step 2: Confirm goldens byte-identical** — `git diff origin/main...HEAD --stat -- src/` shows only the intended files; no `.snap` in the diff.
+- [ ] **Step 3: Holistic self-review** against the spec (§3 scope kept; §6 risks each addressed: Block-Debuff dual-emit resolved in Task 4; over-matching pinned in Task 2 negatives; Taunt self-grant via `gains/grants`; `NOT_SIMULATED_TYPES` consumers re-pointed).
+- [ ] **Step 4: requesting-code-review** — REQUIRED SUB-SKILL: `@superpowers:requesting-code-review`.
+- [ ] **Step 5: Open PR** — `gh pr create --base main`, stacked on nothing (branches off main). Include the byte-identical claim + the one intended behavior change (Stasis resist de-dup) in the description.
+
+---
+
+## Risks recap (from spec §6)
+
+1. **Block-Debuff resist dual-emit** — resolved in Task 4 (control loop drops resist ownership). Golden-verified in Task 4 Step 5; surface any Stasis+immune golden move.
+2. **Parser over-matching** — mitigated by the tight adjacency regex (Task 2) + negative tests (condition-clause case).
+3. **Taunt self-grant** — handled via the `gains|grants` verb set + `side:'self'` (Task 2/3).
+4. **`NOT_SIMULATED_TYPES` removal** — emptied, predicate is the single source of truth; `AbilityCard.test.tsx` consumer re-pointed (Task 5). grep for other consumers in Task 7 Step 2.

--- a/docs/superpowers/plans/2026-06-28-control-classification-unification.md
+++ b/docs/superpowers/plans/2026-06-28-control-classification-unification.md
@@ -95,7 +95,7 @@ disable: 'Disable',
 - Modify: `src/utils/skillTextParser.ts` (around `:1018-1031`, `STASIS_INFLICT_RE` / `parseControlInflict`)
 - Test: `src/utils/__tests__/skillTextParser.test.ts` (control section; co-locate with existing parser tests)
 
-**Design:** add `parseControlInflicts(text): { effect: ControlEffect; pos: number; side: 'enemy' | 'self' }[]`. Build a small table mapping each `ControlEffect` to its buff tag-name + side + verb set, scan the text with a tight adjacency regex per effect, and return one entry per match (multiple effects per skill → multiple entries). Keep `parseControlInflict` exported (delegating to the new fn, returning the Stasis entry) only if other call sites need it; otherwise inline. **Stasis's emitted entry (effect `'stasis'`, side `'enemy'`, `pos` = position of the Stasis tag) MUST be byte-identical to today.**
+**Design:** add `parseControlInflicts(text): { effect: ControlEffect; pos: number; side: 'enemy' | 'self' }[]`. Build a small table mapping each new `ControlEffect` to its buff tag-name + side + verb set, scan the text with a tight adjacency regex per effect, and return one entry per match (multiple effects per skill → multiple entries). **Zero-churn rule for Stasis:** keep the existing `STASIS_INFLICT_RE` regex VERBATIM and use it for the stasis entry — do NOT retype Stasis into the tight form. (Corpus check done: the four new effects' verbs are always tag-adjacent — `applies/apply/applied with/inflicts/inflicted with` for enemy effects, `gains/grants` for Taunt — so tight adjacency loses nothing; Stasis stays on its own regex purely to guarantee byte-identity.) `pos` is the raw `text.search(<tag>)` result (may be `-1`); the **builder** maps `-1 → MAX_POS` exactly as it does today (so Stasis's pos handling is unchanged). **Stasis's emitted entry (effect `'stasis'`, side `'enemy'`, same `pos`) MUST be byte-identical to today.**
 
 - [ ] **Step 1: Write failing tests** — one per effect + Stasis-unchanged + negatives:
 
@@ -127,28 +127,32 @@ it('returns [] for non-control text', () => {
 - [ ] **Step 3: Implement** — table + tight matcher. Sketch:
 
 ```ts
+// Stasis row reuses the EXISTING regex verbatim (zero churn). The four new effects use a
+// tight verb-adjacent matcher (verb immediately before the <unit-skill> tag, optional "with").
 const CONTROL_INFLICTS: { effect: ControlEffect; tag: string; side: 'enemy' | 'self'; re: RegExp }[] = [
-    { effect: 'stasis',           tag: 'Stasis',           side: 'enemy', re: /\b(?:inflicts?|appl(?:ies|y)|inflicted with|applied with)\s+<unit-skill>\s*Stasis\b/i },
-    { effect: 'provoke',          tag: 'Provoke',          side: 'enemy', re: /\b(?:inflicts?|appl(?:ies|y)|inflicted with|applied with)\s+<unit-skill>\s*Provoke\b/i },
-    { effect: 'concentrate-fire', tag: 'Concentrate Fire', side: 'enemy', re: /\b(?:inflicts?|appl(?:ies|y)|inflicted with|applied with)\s+<unit-skill>\s*Concentrate Fire\b/i },
-    { effect: 'disable',          tag: 'Disable',          side: 'enemy', re: /\b(?:inflicts?|appl(?:ies|y)|inflicted with|applied with)\s+<unit-skill>\s*Disable\b/i },
+    { effect: 'stasis',           tag: 'Stasis',           side: 'enemy', re: STASIS_INFLICT_RE },
+    { effect: 'provoke',          tag: 'Provoke',          side: 'enemy', re: /\b(?:inflicts?|appl(?:ies|y)|(?:inflicted|applied) with)\s+<unit-skill>\s*Provoke\b/i },
+    { effect: 'concentrate-fire', tag: 'Concentrate Fire', side: 'enemy', re: /\b(?:inflicts?|appl(?:ies|y)|(?:inflicted|applied) with)\s+<unit-skill>\s*Concentrate Fire\b/i },
+    { effect: 'disable',          tag: 'Disable',          side: 'enemy', re: /\b(?:inflicts?|appl(?:ies|y)|(?:inflicted|applied) with)\s+<unit-skill>\s*Disable\b/i },
     { effect: 'taunt',            tag: 'Taunt',            side: 'self',  re: /\b(?:gains?|grants?)\s+<unit-skill>\s*Taunt\b/i },
 ];
 
+// Returns one entry per matched effect. `pos` is the raw tag index (may be -1); the BUILDER
+// maps -1 -> MAX_POS, identical to today's Stasis handling, so no MAX_POS dependency here.
 export function parseControlInflicts(text: string | null | undefined) {
     if (!text) return [];
     const out: { effect: ControlEffect; pos: number; side: 'enemy' | 'self' }[] = [];
     for (const c of CONTROL_INFLICTS) {
         if (c.re.test(text)) {
             const pos = text.search(new RegExp(`<unit-skill>\\s*${c.tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i'));
-            out.push({ effect: c.effect, pos: pos >= 0 ? pos : Number.MAX_SAFE_INTEGER, side: c.side });
+            out.push({ effect: c.effect, pos, side: c.side });
         }
     }
     return out;
 }
 ```
 
-(Reuse the file's existing `MAX_POS` constant rather than `MAX_SAFE_INTEGER` if present. Keep the Stasis row first so its `pos` matches the prior `text.search(/<unit-skill>\s*Stasis\b/i)`.) Rewrite the stale docstring at `:1018-1023` to describe all five effects and the gate-path-vs-application-path distinction (per spec §4.1).
+Note: `MAX_POS` does **not** exist in `skillTextParser.ts` (it lives in `buildShipAbilities.ts:591 = Number.MAX_SAFE_INTEGER`). The parser returns the raw `pos`; the builder applies the `pos >= 0 ? pos : MAX_POS` mapping it already uses. Rewrite the stale docstring at `:1018-1023` to describe all five effects and the gate-path-vs-application-path distinction (per spec §4.1).
 
 - [ ] **Step 4: Run, expect PASS** — control tests green; `npx tsc --noEmit` clean.
 
@@ -211,7 +215,7 @@ for (const ctrl of parseControlInflicts(text)) {
             config: { type: 'control', effect: ctrl.effect },
             autoFilled: true,
         },
-        pos: ctrl.pos,
+        pos: ctrl.pos >= 0 ? ctrl.pos : MAX_POS, // same mapping the block used for Stasis today
     });
 }
 ```

--- a/docs/superpowers/specs/2026-06-28-control-classification-unification-design.md
+++ b/docs/superpowers/specs/2026-06-28-control-classification-unification-design.md
@@ -1,0 +1,199 @@
+# Control Classification Unification — Design
+
+**Date:** 2026-06-28
+**Status:** Draft (pre-review)
+**Sub-project of:** combat-realism epic (the last unsimulated `AbilityType`, `'control'`)
+
+## 1. Goal
+
+Make the `control` ability type honest end-to-end so it is no longer the lone
+entry in `NOT_SIMULATED_TYPES`. Concretely: recognize all four *inflicted
+targeting/lockout* control effects (Provoke, Taunt, Concentrate Fire, Disable)
+as first-class `type:'control'` abilities — mirroring how Stasis is already
+modeled — and make the editor's "Not simulated" badge effect-aware so a control
+ability whose combat effect IS simulated stops being mislabeled.
+
+Overload (the fifth `ControlEffect`) is **out of scope** — it is a stacking
+self-buff with an unmodeled lifecycle (per-turn grant, lose-on-kill, stat fold,
+Marauder-Rage conversion), structurally unrelated to targeting-control, and gets
+its own follow-up spec.
+
+## 2. Current state (the key finding)
+
+Control statuses do **not** land via `type:'control'` abilities. They land via
+the **named-debuff / named-buff path**:
+
+- A `type:'control'` ability is **event-only**: on the cast path it emits a
+  `control-applied` event and does nothing else
+  (`src/utils/combat/playerTurn.ts:1270-1290` — *"Emission ONLY — the engine
+  does NOT simulate the control's combat effect"*). It never writes a status.
+- The actual lockout/targeting comes from a parallel `type:'debuff'` (or
+  `'buff'`) ability carrying the buff **name**, applied via
+  `statusEngine.applyTimedAbilityStatus` (`playerTurn.ts:965-984`). Enforcement:
+  - Stasis/Disable → `isTurnBlocked` reads the named debuff
+    (`engine.ts:1781-1786`).
+  - Provoke/Taunt/Concentrate Fire → forced-targeting status read in
+    `positionalBinding.ts:81-106`.
+
+So **Stasis is double-parsed today**: a `control` ability (event for
+`on-stasis-applied` reactions, e.g. Defiant's shield-on-Stasis) *and* a `'Stasis'`
+named-debuff (the real lockout). The other four control effects have only the
+named-debuff/buff representation.
+
+**Consequence for design:** converting the four effects *away from* the
+named-debuff path into control abilities would delete their working application
+and break them. The correct move is **additive** — add a control ability that
+rides *alongside* the existing named status, exactly as Stasis does. Application
+paths stay byte-identical.
+
+**Labeling reality:** because Provoke/Taunt/CF/Disable are already
+`type:'debuff'`/`'buff'`, they already render as "simulated" in the editor. The
+"Not simulated" badge only fires on `type:'control'` abilities
+(`AbilityCard.tsx:766-768`), which today is **Stasis alone** — and Stasis's
+effect IS simulated. So the badge is the one concretely-wrong piece today; the
+parser extension is about type-system consistency + a reaction substrate for the
+other four.
+
+## 3. Scope
+
+**In scope**
+- Recognize Provoke, Taunt, Concentrate Fire, Disable as `type:'control'`
+  abilities (additive — alongside the existing named status).
+- Add `'disable'` to the `ControlEffect` enum + `controlEffectLabel` map.
+- Effect-aware "Not simulated" badge.
+
+**Out of scope**
+- Overload lifecycle (separate follow-up).
+- Per-effect reaction triggers (`on-provoke-applied`, etc.) — **deferred
+  (YAGNI)**: zero ships currently react to these applications. Events are
+  emitted and available; a trigger can be added per-effect later, mirroring
+  `on-stasis-applied`, when a ship needs it.
+- Any change to the named-debuff/buff application, landing, resist, Block-Debuff,
+  or forced-targeting logic. Those stay byte-identical.
+
+## 4. Design
+
+### 4.1 Parser recognition (`skillTextParser.ts`, `buildShipAbilities.ts`)
+
+Generalize `parseControlInflict` (today: `STASIS_INFLICT_RE`, Stasis-only,
+`skillTextParser.ts:1024-1031`) into a small table-driven matcher over the
+modeled control effects:
+
+| Effect | Verb pattern (illustrative) | Control-ability target |
+|---|---|---|
+| stasis | `inflicts/applies … Stasis` | enemy |
+| provoke | `inflicts/applies … Provoke` | enemy |
+| concentrate-fire | `applies … Concentrate Fire` | enemy |
+| disable | `inflicts/applies … Disable` | enemy |
+| taunt | `gains … Taunt` (self-grant) | self |
+
+Note Taunt is a **self-grant** ("gains Taunt"), unlike the enemy-inflicted
+others — the matcher must handle both the inflict and the self-grant phrasing.
+The function returns the matched `ControlEffect` (and, where relevant, its text
+position for ordering, as today).
+
+In `buildShipAbilities.ts:987-1015`, the existing control-ability emission block
+generalizes to set `target` per the table and `config.effect` to the matched
+effect. The parallel named-status ability for the same text continues to be
+produced by the generic `parseSkillEffects` path **unchanged** — the control
+ability is purely additive output.
+
+### 4.2 Type system (`types/abilities.ts`)
+
+- Add `'disable'` to `ControlEffect`
+  (`abilities.ts:537` → `'provoke' | 'taunt' | 'stasis' | 'overload' |
+  'concentrate-fire' | 'disable'`).
+- Add `disable: 'Disable'` to `CONTROL_EFFECT_LABEL`
+  (`src/utils/combat/debuffImmunity.ts:33-40`) so `controlEffectLabel` stays
+  total.
+
+### 4.3 Cast-path emission (`playerTurn.ts`)
+
+**No new code.** The emission loop (`playerTurn.ts:1270-1290`) already iterates
+`controlAbilitiesFromSkill(gatedSkill)` and emits `control-applied` with
+`ctrl.config.effect`, and already routes the Block-Debuff resist through
+`controlEffectLabel(effect)`. The new effects flow through unchanged. Emitting
+`control-applied` with `effect !== 'stasis'` fires no listener today (only
+`on-stasis-applied` gates on `effect === 'stasis'`, `triggers.ts:467-471`) →
+**no behavior change, goldens byte-identical**.
+
+### 4.4 Effect-aware sim-coverage (`simCoverage.ts`, `AbilityCard.tsx`)
+
+Replace the blanket `NOT_SIMULATED_TYPES.has('control')` check with an
+effect-aware helper. Introduce a `SIMULATED_CONTROL_EFFECTS` set
+`{stasis, provoke, taunt, concentrate-fire, disable}` and a predicate, e.g.
+`isAbilitySimulated(ability)` that returns:
+- for `type:'control'`: `true` iff `config.effect ∈ SIMULATED_CONTROL_EFFECTS`
+  (so Overload — not in the set — still reads "not simulated" if it ever gets a
+  control ability);
+- for every other type: the existing `!NOT_SIMULATED_TYPES.has(type)` semantics.
+
+`AbilityCard.tsx:766-768` consumes the predicate instead of the raw set. Because
+all five non-Overload effects are in the simulated set and Stasis is the only
+control ability shipped today, the visible effect is: the Stasis control ability
+stops showing the false "Not simulated" note.
+
+`NOT_SIMULATED_TYPES` may stay defined (now effectively empty of practical
+consequence for control) or be removed once nothing else references it — the
+plan resolves this by grepping consumers. The `NOT_SIMULATED_NOTE` text is
+retained for the Overload-control future case.
+
+### 4.5 Components & boundaries
+
+- **Parser** (`parseControlInflict`): pure text → `ControlEffect | null` (+
+  position). Testable in isolation.
+- **Builder** (`buildShipAbilities` control block): `ControlEffect` →
+  `Ability{type:'control', target, config.effect}`, additive to the named
+  status. Testable via the build fixtures.
+- **Sim-coverage predicate** (`simCoverage.ts`): `Ability → boolean`. Pure,
+  unit-testable; the React card just renders it.
+- **Engine**: unchanged. Consumes named statuses (lockout/targeting) and the
+  pre-existing emission loop.
+
+## 5. Testing strategy
+
+- **Parser unit tests:** each effect's phrasing → correct `ControlEffect`;
+  Taunt self-grant vs enemy-inflict; non-matching text → `null`; abbreviation /
+  sentence-scoping guards consistent with existing parser tests.
+- **Builder tests:** a skill inflicting each effect produces BOTH a
+  `type:'control'` ability (right `effect`/`target`) AND the unchanged named
+  status ability. Assert the named-status ability is byte-identical to today
+  (no field drift).
+- **Sim-coverage unit tests:** `isAbilitySimulated` true for control abilities
+  of the five effects, false for a synthetic Overload control ability, and
+  unchanged for all other types.
+- **Engine regression:** full `npm test` byte-identical for combat goldens —
+  control abilities only emit unconsumed events. Cite that no `.snap` moves.
+- **Block-Debuff resist (risk pin, §6):** a test with a Block-Debuff-immune
+  target receiving each control effect, asserting the resist event count is
+  correct (no double-emit between the control ability and the named status).
+
+## 6. Risks & open questions (resolve in the plan)
+
+1. **Dual-representation Block-Debuff resist.** The control ability emits a
+   resist (`emitBlockDebuffResist`) when the target is immune, and the parallel
+   named-status path has its own Block-Debuff handling. For Stasis this already
+   coexists today — the plan MUST verify (with a test) that adding the four new
+   effects does not double-emit `debuff-resisted` / double-count a resist, and
+   document the existing Stasis behavior as the baseline.
+2. **Parser over-matching.** Generalizing `parseControlInflict` must not
+   reclassify text that should remain a plain named-debuff only. The control
+   ability is additive, so an over-match produces a spurious *extra* control
+   ability (and an unconsumed event), not a broken application — but the plan
+   should pin negative cases (e.g. "Provoke" appearing in a condition clause,
+   not an application clause) so we don't emit phantom control abilities.
+3. **Taunt self-grant detection.** Reuse the existing `detectGrantScope` /
+   self-grant machinery rather than a bespoke regex, to stay consistent with how
+   `gains <buff>` is parsed elsewhere.
+4. **`NOT_SIMULATED_TYPES` removal.** Grep all consumers before deleting; it may
+   be referenced by tests or other UI. Prefer keeping the symbol and making the
+   predicate the single source of truth if removal is risky.
+
+## 7. Golden discipline
+
+Byte-identical for all combat goldens (no `.snap` movement). The only intended
+behavioral deltas are: (a) new `type:'control'` ability outputs in
+`buildShipAbilities` (asserted by new tests), and (b) the editor badge no longer
+flagging simulated control effects (asserted by new sim-coverage tests). Run the
+whole `npm test` suite for the audit; never blind `vitest -u`. `audit:skills`,
+`lint`, `tsc` clean.

--- a/docs/superpowers/specs/2026-06-28-control-classification-unification-design.md
+++ b/docs/superpowers/specs/2026-06-28-control-classification-unification-design.md
@@ -98,6 +98,23 @@ effect. The parallel named-status ability for the same text continues to be
 produced by the generic `parseSkillEffects` path **unchanged** — the control
 ability is purely additive output.
 
+The exact verb/phrasing patterns above are **illustrative**. The plan must first
+enumerate the real phrasings from `docs/ship-skills.csv` for each effect
+(Concentrate Fire / Disable / Provoke / Taunt, plus Taunt's self-grant form)
+before writing regexes — this is a prerequisite plan task and directly mitigates
+the over-matching risk (§6.2).
+
+**Stale comments to update.** The current docstring at
+`skillTextParser.ts:1018-1023` and the comment at `buildShipAbilities.ts:987`
+explicitly state "Provoke/Taunt stay handled as targeting-status CONDITIONS
+(`statusEffectCondition`), not control abilities." These become contradictory
+once the matcher generalizes and must be rewritten by the plan. Note the
+distinction the comments blur: `statusEffectCondition` (`skillTextParser.ts:882`)
+is the *read/gate* path (does the actor have Provoke?), entirely separate from
+the *application* path (`parseSkillEffects` → named status). This design touches
+neither — it only adds the control-ability output — but the plan should make the
+two-path distinction explicit so a reader of the old comments isn't misled.
+
 ### 4.2 Type system (`types/abilities.ts`)
 
 - Add `'disable'` to `ControlEffect`

--- a/src/components/skills/AbilityCard.tsx
+++ b/src/components/skills/AbilityCard.tsx
@@ -19,7 +19,7 @@ import { Button } from '../ui/Button';
 import { ChevronUpIcon, ChevronDownIcon } from '../ui/icons/ChevronIcons';
 import { GameBuffPicker } from '../calculator/GameBuffPicker';
 import {
-    NOT_SIMULATED_TYPES,
+    isAbilityNotSimulated,
     PASSIVE_NOOP_TYPES,
     NOT_SIMULATED_NOTE,
     PASSIVE_NOOP_WARNING,
@@ -763,7 +763,7 @@ export const AbilityCard: React.FC<Props> = ({
             {/* Not-simulated note is independent of the field editor so it always
                 shows for flagged types even when a case provides editable fields
                 (e.g. purge: count is editable for annotation but not yet simulated). */}
-            {NOT_SIMULATED_TYPES.has(ability.type) && (
+            {isAbilityNotSimulated(ability) && (
                 <p className="text-xs text-theme-text-secondary">{NOT_SIMULATED_NOTE}</p>
             )}
 

--- a/src/components/skills/__tests__/AbilityCard.test.tsx
+++ b/src/components/skills/__tests__/AbilityCard.test.tsx
@@ -82,8 +82,24 @@ describe('AbilityCard', () => {
             config: { type: 'dot', dotType: 'corrosion', tier: 5, stacks: 1, duration: 2 },
         };
 
-        it('shows a not-simulated note for utility types', () => {
+        it('does NOT show a not-simulated note for a modeled control effect (provoke)', () => {
+            // provoke is in SIMULATED_CONTROL_EFFECTS — the badge must be absent.
             render(<AbilityCard ability={control} onChange={() => {}} onRemove={() => {}} />);
+            expect(
+                screen.queryByText(/not simulated in the calculators yet/i)
+            ).not.toBeInTheDocument();
+        });
+
+        it('shows a not-simulated note for an unmodeled control effect (overload)', () => {
+            const overload: Ability = {
+                id: 'a-overload',
+                type: 'control',
+                target: 'enemy',
+                trigger: 'on-cast',
+                conditions: [],
+                config: { type: 'control', effect: 'overload' },
+            };
+            render(<AbilityCard ability={overload} onChange={() => {}} onRemove={() => {}} />);
             expect(screen.getByText(/not simulated in the calculators yet/i)).toBeInTheDocument();
         });
 

--- a/src/components/skills/__tests__/simCoverage.test.ts
+++ b/src/components/skills/__tests__/simCoverage.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { isAbilityNotSimulated, SIMULATED_CONTROL_EFFECTS } from '../simCoverage';
+import { Ability } from '../../../types/abilities';
+
+describe('isAbilityNotSimulated', () => {
+    it('treats modeled control effects as simulated', () => {
+        for (const effect of [
+            'stasis',
+            'provoke',
+            'taunt',
+            'concentrate-fire',
+            'disable',
+        ] as const) {
+            expect(
+                isAbilityNotSimulated({
+                    type: 'control',
+                    config: { type: 'control', effect },
+                } as Ability)
+            ).toBe(false);
+        }
+    });
+
+    it('still flags an unmodeled control effect (overload)', () => {
+        expect(
+            isAbilityNotSimulated({
+                type: 'control',
+                config: { type: 'control', effect: 'overload' },
+            } as Ability)
+        ).toBe(true);
+    });
+
+    it('leaves non-control types simulated as before', () => {
+        expect(isAbilityNotSimulated({ type: 'damage' } as Ability)).toBe(false);
+    });
+});
+
+describe('SIMULATED_CONTROL_EFFECTS', () => {
+    it('contains all five modeled effects', () => {
+        expect(SIMULATED_CONTROL_EFFECTS.has('stasis')).toBe(true);
+        expect(SIMULATED_CONTROL_EFFECTS.has('provoke')).toBe(true);
+        expect(SIMULATED_CONTROL_EFFECTS.has('taunt')).toBe(true);
+        expect(SIMULATED_CONTROL_EFFECTS.has('concentrate-fire')).toBe(true);
+        expect(SIMULATED_CONTROL_EFFECTS.has('disable')).toBe(true);
+    });
+
+    it('does not contain overload', () => {
+        expect(SIMULATED_CONTROL_EFFECTS.has('overload')).toBe(false);
+    });
+});

--- a/src/components/skills/simCoverage.ts
+++ b/src/components/skills/simCoverage.ts
@@ -1,4 +1,4 @@
-import { AbilityType } from '../../types/abilities';
+import { Ability, AbilityType, ControlEffect } from '../../types/abilities';
 
 /**
  * Ability types not yet consumed by any calculator. They stay pickable in the
@@ -8,13 +8,43 @@ import { AbilityType } from '../../types/abilities';
  * healing calculator / combat sim consume them (heal/shield/cleanse in the
  * healing-calc work; purge in the C2a on-cast purge work, which removes enemy
  * buffs from the cast path).
- * `control` stays flagged because its OWN lockout/combat effect (Stasis/Taunt/
- * etc.) is still unsimulated — but it is now a TRIGGER SOURCE: the cast-path
- * emits a `control-applied` event that drives reactions (e.g. Defiant's
- * shield-on-Stasis). So the control's effect is unsimulated even though it can
- * fire a simulated reaction.
+ * `control` is NOT in this set: control simulation is now effect-aware (see
+ * SIMULATED_CONTROL_EFFECTS + isAbilityNotSimulated). The five named effects
+ * (stasis / provoke / taunt / concentrate-fire / disable) are simulated via the
+ * named-status path and emit `control-applied` events. Only Overload remains
+ * unmodeled and still shows the "Not simulated" badge.
  */
-export const NOT_SIMULATED_TYPES: ReadonlySet<AbilityType> = new Set(['control']);
+export const NOT_SIMULATED_TYPES: ReadonlySet<AbilityType> = new Set([]);
+
+/**
+ * The five control effects that are fully modeled in the combat engine.
+ * Overload is excluded — it is deferred to a future project.
+ */
+export const SIMULATED_CONTROL_EFFECTS: ReadonlySet<ControlEffect> = new Set([
+    'stasis',
+    'provoke',
+    'taunt',
+    'concentrate-fire',
+    'disable',
+]);
+
+/**
+ * Returns true when an ability should show the "Not simulated" badge.
+ *
+ * For `type:'control'` abilities the decision is per-effect:
+ *   - A modeled effect (stasis / provoke / taunt / concentrate-fire / disable)
+ *     returns false (IS simulated).
+ *   - An unmodeled effect (currently: overload) returns true (NOT simulated).
+ *
+ * All other ability types fall back to the NOT_SIMULATED_TYPES set (currently
+ * empty — all other ability types are simulated).
+ */
+export function isAbilityNotSimulated(ability: Ability): boolean {
+    if (ability.type === 'control' && ability.config.type === 'control') {
+        return !SIMULATED_CONTROL_EFFECTS.has(ability.config.effect);
+    }
+    return NOT_SIMULATED_TYPES.has(ability.type);
+}
 
 /**
  * Ability types the DPS sim sources from the FIRING skill only (active/charged).

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -55,6 +55,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator: in positioned battles, ally ships (the non-focus members of your fleet) now detonate per-victim — each ship the ally hits detonates its own stored bombs and damage-over-time effects against its own HP, so an ally detonation can now kill secondary targets and trigger their on-death effects such as bomb-splash-on-death.',
     'Combat simulator: in positioned battles, timed bombs and Echoing Burst accumulators planted on your own ships now burst on each of your ships individually — every affected ship detonates its timed bombs and accumulators against its own HP on its own turn, mirroring how enemy ships already do, so a timed burst can now kill that ship and trigger its on-death effects.',
     'Combat simulator: in positioned battles, Inferno and Corrosion damage-over-time now ticks on every affected ship individually — each ship takes its own DoT damage against its own HP at the start of its turn (on both your fleet and the enemy), so a DoT can now wear down and kill secondary ships and trigger their on-death effects, instead of only counting against the primary target.',
+    'Skill editor: Provoke, Taunt, Concentrate Fire, Disable and Stasis are now recognized as control effects and no longer marked "Not simulated" — their combat impact is reflected in the battle simulator.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -531,9 +531,11 @@ export type AbilityConfig =
           turns: number;
       };
 
-/** Crowd-control effects a `control` ability can apply. The engine does not simulate
- *  these combat effects; the `control-applied` event (events.ts) only exposes the
- *  application moment so reactions (e.g. Defiant's shield-on-Stasis) can fire. */
+/** Crowd-control effects a `control` ability can apply. The combat effect of each
+ *  (Stasis/Disable turn-lockout, Provoke/Taunt/Concentrate-Fire forced-targeting) is
+ *  simulated via the parallel named-status path; Overload is the sole deferred exception.
+ *  The `control-applied` event (events.ts) additionally exposes the application moment so
+ *  reactions (e.g. Defiant's shield-on-Stasis) can fire. */
 export type ControlEffect =
     | 'provoke'
     | 'taunt'

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -534,7 +534,13 @@ export type AbilityConfig =
 /** Crowd-control effects a `control` ability can apply. The engine does not simulate
  *  these combat effects; the `control-applied` event (events.ts) only exposes the
  *  application moment so reactions (e.g. Defiant's shield-on-Stasis) can fire. */
-export type ControlEffect = 'provoke' | 'taunt' | 'stasis' | 'overload' | 'concentrate-fire';
+export type ControlEffect =
+    | 'provoke'
+    | 'taunt'
+    | 'stasis'
+    | 'overload'
+    | 'concentrate-fire'
+    | 'disable';
 
 export interface Ability {
     id: string;

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -37,6 +37,7 @@ import {
     parsePurge,
     parseHealNoCrit,
     statusEffectCondition,
+    parseControlInflicts,
     detectIgnoresForcedTargeting,
     parseDoesntBreakStasis,
     parseChargeRemoval,
@@ -3919,5 +3920,46 @@ describe('parseCounterAbilities', () => {
     it('returns null for empty/unmatched text', () => {
         expect(parseCounterAbilities(null)).toBeNull();
         expect(parseCounterAbilities('This Unit gains a Shield when attacked.')).toBeNull();
+    });
+});
+
+describe('parseControlInflicts', () => {
+    it('recognizes each inflicted control effect', () => {
+        expect(
+            parseControlInflicts(
+                'Deals damage and applies <unit-skill>Provoke</unit-skill> for 1 turn'
+            )
+        ).toEqual([{ effect: 'provoke', pos: expect.any(Number), side: 'enemy' }]);
+        expect(
+            parseControlInflicts('inflicts <unit-skill>Disable</unit-skill> for 2 turns')[0].effect
+        ).toBe('disable');
+        expect(
+            parseControlInflicts('apply <unit-skill>Concentrate Fire</unit-skill> for 1 turn')[0]
+                .effect
+        ).toBe('concentrate-fire');
+    });
+
+    it('recognizes Taunt as a self-grant', () => {
+        expect(
+            parseControlInflicts('This Unit gains <unit-skill>Taunt</unit-skill> for 1 turn')
+        ).toEqual([{ effect: 'taunt', pos: expect.any(Number), side: 'self' }]);
+    });
+
+    it('keeps Stasis byte-identical', () => {
+        expect(
+            parseControlInflicts('inflicts <unit-skill>Stasis</unit-skill> for 2 turns')
+        ).toEqual([{ effect: 'stasis', pos: expect.any(Number), side: 'enemy' }]);
+    });
+
+    it('does NOT match a control word in a condition clause', () => {
+        expect(
+            parseControlInflicts(
+                'If the target has <unit-skill>Provoke</unit-skill>, deal +20% damage'
+            )
+        ).toEqual([]);
+    });
+
+    it('returns [] for non-control text', () => {
+        expect(parseControlInflicts('Deals 300% damage')).toEqual([]);
     });
 });

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -3966,6 +3966,22 @@ describe('parseControlInflicts', () => {
         ).toEqual([{ effect: 'stasis', pos: expect.any(Number), side: 'enemy' }]);
     });
 
+    it('anchors pos to the application tag for the common single-clause case', () => {
+        // 'inflicts ' is 9 chars → the <unit-skill>Stasis tag starts at index 9.
+        const text = 'inflicts <unit-skill>Stasis</unit-skill> for 2 turns';
+        expect(parseControlInflicts(text)[0].pos).toBe(text.indexOf('<unit-skill>Stasis'));
+    });
+
+    it('anchors pos to the APPLICATION clause when the status is named in a prior condition', () => {
+        // Stasis is mentioned first in a condition clause, then APPLIED later. pos must point at
+        // the application-clause tag (the 2nd occurrence), not the 1st (condition) occurrence.
+        const text =
+            'If the target has <unit-skill>Stasis</unit-skill>, this Unit inflicts <unit-skill>Stasis</unit-skill> for 2 turns';
+        const applicationTagPos = text.lastIndexOf('<unit-skill>Stasis');
+        expect(applicationTagPos).not.toBe(text.indexOf('<unit-skill>Stasis'));
+        expect(parseControlInflicts(text)[0].pos).toBe(applicationTagPos);
+    });
+
     it('recognizes a control effect applied via a shared verb in a coordinated list', () => {
         const text =
             'inflicts <unit-skill>Defense Down II</unit-skill> for 2 turns, and <unit-skill>Provoke</unit-skill> for 1 turn';

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -3951,6 +3951,12 @@ describe('parseControlInflicts', () => {
         ).toEqual([{ effect: 'stasis', pos: expect.any(Number), side: 'enemy' }]);
     });
 
+    it('recognizes a control effect applied via a shared verb in a coordinated list', () => {
+        const text =
+            'inflicts <unit-skill>Defense Down II</unit-skill> for 2 turns, and <unit-skill>Provoke</unit-skill> for 1 turn';
+        expect(parseControlInflicts(text).map((c) => c.effect)).toContain('provoke');
+    });
+
     it('does NOT match a control word in a condition clause', () => {
         expect(
             parseControlInflicts(

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -3945,6 +3945,21 @@ describe('parseControlInflicts', () => {
         ).toEqual([{ effect: 'taunt', pos: expect.any(Number), side: 'self' }]);
     });
 
+    it('does NOT treat an enemy-gains-Taunt condition as a self Taunt grant', () => {
+        expect(
+            parseControlInflicts(
+                'When an enemy defender gains <unit-skill>Taunt</unit-skill>, deal +20% damage'
+            )
+        ).toEqual([]);
+    });
+
+    it('still recognizes a self Taunt grant', () => {
+        expect(
+            parseControlInflicts('This Unit gains <unit-skill>Taunt</unit-skill> for 1 turn')[0]
+                .effect
+        ).toBe('taunt');
+    });
+
     it('keeps Stasis byte-identical', () => {
         expect(
             parseControlInflicts('inflicts <unit-skill>Stasis</unit-skill> for 2 turns')

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -2336,7 +2336,10 @@ describe('buildShipAbilities', () => {
             expect(dmg).toMatchObject({ config: { type: 'damage', multiplier: 195 } });
         });
 
-        it('active "applies Provoke" does NOT produce a stasis control ability', () => {
+        // Task 3: control abilities are now emitted ADDITIVELY for EVERY recognized inflicted
+        // effect (provoke/taunt/concentrate-fire/disable), not just Stasis. The parallel named
+        // status (debuff/buff) ability MUST stay byte-identical alongside the new control ability.
+        it('active "applies Provoke" emits a provoke control ability AND keeps the named Provoke debuff', () => {
             const s = ship({
                 activeSkillText:
                     'This Unit deals <unit-damage>145% damage</unit-damage> and applies <unit-skill>Provoke</unit-skill> for 1 turn.',
@@ -2345,7 +2348,60 @@ describe('buildShipAbilities', () => {
             const control = active?.abilities.find(
                 (a) => a.type === 'control' && a.config.type === 'control'
             );
-            expect(control).toBeUndefined();
+            expect(control).toMatchObject({
+                type: 'control',
+                target: 'enemy',
+                trigger: 'on-cast',
+                config: { type: 'control', effect: 'provoke' },
+            });
+            // The named-status debuff (the path that actually performs the targeting lockout) is
+            // still produced unchanged.
+            const debuff = active?.abilities.find(
+                (a) =>
+                    a.type === 'debuff' &&
+                    a.config.type === 'debuff' &&
+                    a.config.buffName === 'Provoke'
+            );
+            expect(debuff).toBeDefined();
+        });
+
+        it('active "This Unit gains Taunt" emits a self-targeted taunt control ability AND keeps the named Taunt buff', () => {
+            const s = ship({
+                activeSkillText:
+                    'This Unit deals <unit-damage>145% damage</unit-damage>. This Unit gains <unit-skill>Taunt</unit-skill> for 1 turn.',
+            });
+            const active = buildShipAbilities(s).slots.find((sl) => sl.slot === 'active');
+            const control = active?.abilities.find(
+                (a) => a.type === 'control' && a.config.type === 'control'
+            );
+            expect(control).toMatchObject({
+                type: 'control',
+                target: 'self',
+                trigger: 'on-cast',
+                config: { type: 'control', effect: 'taunt' },
+            });
+            // The named Taunt buff (self buff) is still produced.
+            const buff = active?.abilities.find(
+                (a) => a.config.type === 'buff' && a.config.buffName === 'Taunt'
+            );
+            expect(buff).toBeDefined();
+        });
+
+        it('active "inflicts Disable for 2 turns" emits a disable control ability targeting enemy', () => {
+            const s = ship({
+                activeSkillText:
+                    'This Unit deals <unit-damage>145% damage</unit-damage> and inflicts <unit-skill>Disable</unit-skill> for 2 turns.',
+            });
+            const active = buildShipAbilities(s).slots.find((sl) => sl.slot === 'active');
+            const control = active?.abilities.find(
+                (a) => a.type === 'control' && a.config.type === 'control'
+            );
+            expect(control).toMatchObject({
+                type: 'control',
+                target: 'enemy',
+                trigger: 'on-cast',
+                config: { type: 'control', effect: 'disable' },
+            });
         });
 
         it('R0 passive "Shield equal to 30% of Max HP when applying Stasis" → shield on-stasis-applied', () => {
@@ -3487,12 +3543,14 @@ describe('buildShipAbilities — D-PR3 Iridium incoming-reduction parser (T5)', 
     });
 });
 
-// D-PR13: 'inflicts Disable for N turns' in active skill text → named Disable DEBUFF, not control.
-// Locks the contract that parseControlInflict is Stasis-only, so Disable falls through to the
-// named-debuff parser. The engine's isTurnBlocked() then recognises any active 'Disable' buff by
-// name, so all five corpus ships (APEX, IonScorp, Makoli, Xcellence, Yuyan) light up for free.
-describe('buildShipAbilities — D-PR13 Disable active-skill: named debuff, not control', () => {
-    it('active skill "inflicts Disable for 1 turn" produces a named Disable DEBUFF, not a control ability', () => {
+// D-PR13: 'inflicts Disable for N turns' in active skill text → named Disable DEBUFF (the path that
+// performs the actual turn-block via isTurnBlocked recognising any active 'Disable' buff by name,
+// so all five corpus ships — APEX, IonScorp, Makoli, Xcellence, Yuyan — light up for free).
+// Task 3 update: Disable is now ALSO recognized by parseControlInflicts, so a `type:'control'`
+// ability is emitted ADDITIVELY alongside the named debuff (it only sources the control-applied
+// event; the named debuff still does the lockout). Both abilities must be present.
+describe('buildShipAbilities — D-PR13 Disable active-skill: named debuff + additive control', () => {
+    it('active skill "inflicts Disable for 1 turn" produces a named Disable DEBUFF and an additive control ability', () => {
         const s = ship({
             activeSkillText:
                 'This Unit deals <unit-damage>100% damage</unit-damage> and inflicts <unit-skill>Disable</unit-skill> for 1 turn.',
@@ -3515,10 +3573,14 @@ describe('buildShipAbilities — D-PR13 Disable active-skill: named debuff, not 
             },
         });
 
-        // Must NOT produce a control-type ability for Disable
-        // (parseControlInflict is Stasis-only; Disable must not be claimed by it).
+        // Task 3: ADDITIVELY produces a control ability for Disable (sources control-applied).
         const control = active!.abilities.find((a) => a.type === 'control');
-        expect(control).toBeUndefined();
+        expect(control).toMatchObject({
+            type: 'control',
+            target: 'enemy',
+            trigger: 'on-cast',
+            config: { type: 'control', effect: 'disable' },
+        });
     });
 });
 

--- a/src/utils/abilities/applyAbilities.ts
+++ b/src/utils/abilities/applyAbilities.ts
@@ -150,10 +150,11 @@ export function chargeAbilitiesFromSkill(skill: Skill | undefined): Ability[] {
     return skill?.abilities.filter((a) => a.type === 'charge') ?? [];
 }
 
-/** Cast-time `control` abilities on the skill (e.g. Defiant's charged Stasis inflict). The engine
- *  does NOT simulate the control effect; the cast path emits `control-applied` so reactions fire.
- *  Filters to `trigger === 'on-cast'` (mirrors extraActionsFromSkill) so a reactive or
- *  annotation-only control ability can't over-emit `control-applied` from the cast path. */
+/** Cast-time `control` abilities on the skill (e.g. Defiant's charged Stasis inflict). The control
+ *  effect itself is simulated via the parallel named-status path (Overload excepted); the cast path
+ *  additionally emits `control-applied` so reactions fire. Filters to `trigger === 'on-cast'`
+ *  (mirrors extraActionsFromSkill) so a reactive or annotation-only control ability can't
+ *  over-emit `control-applied` from the cast path. */
 export function controlAbilitiesFromSkill(skill: Skill | undefined): Ability[] {
     return skill?.abilities.filter((a) => a.type === 'control' && a.trigger === 'on-cast') ?? [];
 }

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -940,9 +940,9 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
             'on-destroyed',
             BATTLECRY_DURATION[rarity]
         ),
-    // Martyrdom: "Applies Disable for N turns on the enemy that killed this Unit." EMIT-ONLY:
-    // Disable is not a modeled turn-effect yet (only Stasis skips turns) — the debuff is applied to
-    // the killer + logged. Killer routing comes from the on-destroyed listener.
+    // Martyrdom: "Applies Disable for N turns on the enemy that killed this Unit."
+    // Disable skips the affected ship's turn (same as Stasis on that axis) — the debuff is applied
+    // to the killer + logged. Killer routing comes from the on-destroyed listener.
     MARTYRDOM: (rarity) => mkNamedDebuff('Disable', 'on-destroyed', MARTYRDOM_DURATION[rarity]),
     // D-PR8: Smokescreen — when directly damaged, X% chance to gain Stealth for 1 turn.
     // Rides `on-attacked` (direct hits only — DoTs route through dot-applied, never on-attacked).

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -49,7 +49,7 @@ import {
     detectMostBuffsTarget,
     detectRepairedThisRoundCondition,
     PURGE_MORE_RE,
-    parseControlInflict,
+    parseControlInflicts,
     detectAllyCritTrigger,
     parseNoCrit,
     parseDoesntBreakStasis,
@@ -984,33 +984,31 @@ function abilitiesFromText(
         });
     }
 
-    // Control inflictions — conservative: only Stasis ("inflicts/applies Stasis"). Provoke/Taunt
-    // stay handled as targeting-status CONDITIONS (statusEffectCondition), not control abilities.
-    // The engine does NOT simulate the control (Stasis stays unmodelled); the cast-path emission
-    // (playerTurn.ts) turns this into a `control-applied` event so reactions (Defiant's
-    // shield-on-Stasis) can fire. DPS unchanged: a control ability on a firing skill carries no
-    // damage/modifier, so the damage pipeline ignores it.
-    const controlEffect = parseControlInflict(text);
-    if (controlEffect) {
-        const controlPos = text.search(/<unit-skill>\s*Stasis\b/i);
+    // Control inflictions: emit a `type:'control'` ability per recognized effect (stasis,
+    // provoke, taunt, concentrate-fire, disable). ADDITIVE — the parallel named status
+    // (parseSkillEffects → applyTimedAbilityStatus) still performs the actual lockout/
+    // forced-targeting; the control ability only sources the `control-applied` event
+    // (reaction substrate, e.g. Defiant's shield-on-Stasis). Carries no conditions (see the
+    // gated-control caveat below); no damage/modifier → DPS pipeline ignores it.
+    for (const ctrl of parseControlInflicts(text)) {
         out.push({
             ability: {
                 id: nextId(),
                 type: 'control',
-                target: 'enemy',
+                target: ctrl.side, // 'enemy' for inflicted, 'self' for Taunt
                 trigger: 'on-cast',
-                // Control abilities carry no conditions: a GATED Stasis (e.g. Crocus "if target
-                // has >3 debuffs") therefore emits control-applied unconditionally on the cast
-                // path. Inert today (the only on-stasis-applied reactor, Defiant, has an
-                // UNCONDITIONAL Stasis, and no ship both gates its own Stasis and reacts to it).
-                // If a future ship pairs a gated Stasis with an own-stasis reaction, thread the
-                // inflicting ability's conditions onto the control ability so a gated-off Stasis
-                // doesn't over-fire the shield.
+                // Control abilities carry no conditions: a GATED control (e.g. Crocus's "if
+                // target has >3 debuffs" Stasis) therefore emits control-applied unconditionally
+                // on the cast path. Inert today (the only on-stasis-applied reactor, Defiant, has
+                // an UNCONDITIONAL Stasis, and no ship both gates its own control and reacts to
+                // it). If a future ship pairs a gated control with an own-control reaction, thread
+                // the inflicting ability's conditions onto the control ability so a gated-off
+                // control doesn't over-fire the reaction.
                 conditions: [],
-                config: { type: 'control', effect: controlEffect },
+                config: { type: 'control', effect: ctrl.effect },
                 autoFilled: true,
             },
-            pos: controlPos >= 0 ? controlPos : MAX_POS,
+            pos: ctrl.pos >= 0 ? ctrl.pos : MAX_POS,
         });
     }
 

--- a/src/utils/combat/__tests__/blockDebuff.test.ts
+++ b/src/utils/combat/__tests__/blockDebuff.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { dotResistLabel, isBlockDebuff } from '../debuffImmunity';
+import { dotResistLabel, isBlockDebuff, controlEffectLabel } from '../debuffImmunity';
 import { runCombat, CombatEngineInput } from '../engine';
 import { ShipSkills, Ability } from '../../../types/abilities';
 import { executeIntent, Intent, IntentExecContext } from '../triggers';
@@ -31,6 +31,12 @@ describe('debuffImmunity helpers', () => {
 
         it('formats bomb with no tier suffix', () => {
             expect(dotResistLabel('bomb', 0)).toBe('Bomb');
+        });
+    });
+
+    describe('controlEffectLabel', () => {
+        it('returns "Disable" for the disable control effect', () => {
+            expect(controlEffectLabel('disable')).toBe('Disable');
         });
     });
 });

--- a/src/utils/combat/__tests__/blockDebuff.test.ts
+++ b/src/utils/combat/__tests__/blockDebuff.test.ts
@@ -319,12 +319,17 @@ describe('Block Debuff — cast-side DoT block + resist event (engine)', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Block Debuff — cast-side control block + resist event (engine).
+// Block Debuff — cast-side control block (engine).
 //
 // A control infliction (cfg.type 'control', e.g. Stasis) emits `control-applied` so
-// reactions (on-stasis-applied) can fire. When the target carries `Block Debuff` the
-// control is a blocked debuff: NO `control-applied` (so reactions do NOT fire) and a
-// `debuff-resisted` labelled with the control effect — symmetric with the timed/DoT block.
+// reactions (on-stasis-applied) can fire. When the cast target carries `Block Debuff`
+// the control is blocked: NO `control-applied` (so reactions do NOT fire). The
+// control-classification unification moved Block-Debuff RESIST OWNERSHIP off the control
+// loop onto the PARALLEL named-status path (the control's named timed debuff, symmetric
+// with every debuff type) to avoid double-counting. This synthetic fixture carries the
+// control ability ONLY (no parallel named debuff), so a blocked cast emits NO resist here
+// — the named-status resist is asserted end-to-end by the "auto-resists an inflicted
+// Stasis" integration test below (which casts the named 'Stasis' debuff).
 // ─────────────────────────────────────────────────────────────────────────────
 
 const controlEnemy = (): EnemyAttacker =>
@@ -340,8 +345,8 @@ const runControlWith = (focusSkills: ShipSkills, bus: ReturnType<typeof createEv
         })
     );
 
-describe('Block Debuff — cast-side control block + resist event (engine)', () => {
-    it('immune target BLOCKS a control infliction: no control-applied, resisted Stasis event', () => {
+describe('Block Debuff — cast-side control block (engine)', () => {
+    it('immune target BLOCKS a control infliction: no control-applied (resist owned by named path)', () => {
         const bus = createEventBus();
         const events: CombatEvent[] = [];
         bus.on('control-applied', (e) => events.push(e as CombatEvent));
@@ -351,11 +356,10 @@ describe('Block Debuff — cast-side control block + resist event (engine)', () 
 
         // The control was blocked → on-stasis-applied reactions never get the signal.
         expect(events.some((e) => e.type === 'control-applied')).toBe(false);
-        // A debuff-resisted event fired, labelled with the blocked control effect.
-        const resisted = events.filter((e) => e.type === 'debuff-resisted');
-        expect(
-            resisted.map((e) => (e.type === 'debuff-resisted' ? e.buffName : '')).filter(Boolean)
-        ).toContain('Stasis');
+        // The control loop no longer owns the resist — this control-only fixture has no
+        // parallel named-status path, so NO debuff-resisted fires here. (The named-status
+        // resist is covered by the named-'Stasis' integration test below.)
+        expect(events.some((e) => e.type === 'debuff-resisted')).toBe(false);
     });
 
     it('control: WITHOUT Block Debuff the control fires (control-applied, NO resist) — non-vacuity', () => {

--- a/src/utils/combat/__tests__/controlClassificationEmission.integration.test.ts
+++ b/src/utils/combat/__tests__/controlClassificationEmission.integration.test.ts
@@ -85,6 +85,29 @@ const attackerWith = (...abilities: Ability[]): EnemyAttacker =>
         } as ShipSkills,
     }) as EnemyAttacker;
 
+/** Like attackerWith but with a custom `hacking` stat. hacking 150 vs the focus actor's default
+ *  security 100 → live landing chance 0.5. The deterministic back-loaded rate gate fails its
+ *  FIRST draw at 0.5 (acc 0.5 < 1) → an 'inflict' named status is RESISTED by landing roll on
+ *  round 1 (NOT Block-Debuff). */
+const attackerWithHacking = (hacking: number, ...abilities: Ability[]): EnemyAttacker =>
+    ({
+        id: 'e1',
+        stats: { attack: 1000, crit: 0, critDamage: 0, speed: 10, hacking },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        enemyAb({ type: 'damage', config: { type: 'damage', multiplier: 100 } }),
+                        ...abilities,
+                    ],
+                },
+            ],
+        } as ShipSkills,
+    }) as EnemyAttacker;
+
 /** Focus actor (heal target) shipSkills granting a recurring `Block Debuff` self-buff. */
 const blockDebuffSelfSkills = (): ShipSkills => ({
     slots: [
@@ -158,17 +181,19 @@ const tap = () => {
 };
 
 describe('control-classification emission — resist ownership (Task 4)', () => {
-    // (a) Success: an enemy-targeted control (Provoke) emits control-applied on a normal cast.
-    it('an enemy-targeted Provoke emits control-applied{effect:provoke} on a normal cast', () => {
+    // (a) Success: an enemy-targeted control (Provoke) whose paired named status LANDS emits
+    //     control-applied on a normal cast. Mirrors real builder output (named debuff + control
+    //     ability); default hacking 200 vs security 100 → 100% landing.
+    it('an enemy-targeted Provoke emits control-applied{effect:provoke} when its named status lands', () => {
         const { bus, events } = tap();
-        run({ slots: [] }, bus, attackerWith(controlAb('provoke')));
+        run({ slots: [] }, bus, attackerWith(namedControlDebuff('Provoke'), controlAb('provoke')));
 
         const controls = events.filter((e) => e.type === 'control-applied');
         expect(controls.length).toBeGreaterThan(0);
         expect(controls.some((e) => e.type === 'control-applied' && e.effect === 'provoke')).toBe(
             true
         );
-        // Normal cast → no resist.
+        // 100% landing → no resist.
         expect(events.some((e) => e.type === 'debuff-resisted')).toBe(false);
     });
 
@@ -203,5 +228,41 @@ describe('control-classification emission — resist ownership (Task 4)', () => 
         expect(provokeResists).toHaveLength(1);
         // Blocked → the control loop emits no success event.
         expect(events.some((e) => e.type === 'control-applied')).toBe(false);
+    });
+
+    // (d) Finding 1: a LANDING-ROLL resist (NOT Block Debuff) of the paired named status must
+    //     suppress control-applied. hacking 150 vs security 100 → 0.5 landing → round-1 'inflict'
+    //     fails the back-loaded gate, so the named Stasis is resisted and the control must NOT
+    //     emit (otherwise on-stasis-applied reactions fire for a Stasis that never landed).
+    it('a landing-roll-resisted Stasis (not Block Debuff) emits NO control-applied', () => {
+        const { bus, events } = tap();
+        run(
+            { slots: [] }, // NO Block Debuff on the target — the resist comes from the landing roll.
+            bus,
+            attackerWithHacking(150, namedControlDebuff('Stasis'), controlAb('stasis'))
+        );
+
+        // The named status was resisted by the landing roll → recorded resisted.
+        expect(events.some((e) => e.type === 'debuff-resisted' && e.buffName === 'Stasis')).toBe(
+            true
+        );
+        // ...and the control loop must NOT emit a success event for the un-landed Stasis.
+        expect(events.some((e) => e.type === 'control-applied' && e.effect === 'stasis')).toBe(
+            false
+        );
+    });
+
+    // (e) Finding 1 counterpart: full landing (hacking 200 → 100%) of the paired named status
+    //     DOES emit control-applied (the gate only suppresses genuine resists).
+    it('a fully-landing Stasis (no resist) emits control-applied{effect:stasis}', () => {
+        const { bus, events } = tap();
+        run({ slots: [] }, bus, attackerWith(namedControlDebuff('Stasis'), controlAb('stasis')));
+
+        expect(events.some((e) => e.type === 'debuff-resisted' && e.buffName === 'Stasis')).toBe(
+            false
+        );
+        expect(events.some((e) => e.type === 'control-applied' && e.effect === 'stasis')).toBe(
+            true
+        );
     });
 });

--- a/src/utils/combat/__tests__/controlClassificationEmission.integration.test.ts
+++ b/src/utils/combat/__tests__/controlClassificationEmission.integration.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { ShipSkills, Ability } from '../../../types/abilities';
+import { createEventBus, CombatEvent } from '../events';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Control-classification unification — Task 4: resist OWNERSHIP in the cast-path
+// control emission loop.
+//
+// Control inflictions (Stasis/Provoke/Taunt/CF/Disable) reach the engine BOTH as a
+// named timed debuff (its buffName, routed through the timed landing fold which owns
+// the Block-Debuff resist) AND, additively, as a `type:'control'` ability whose ONLY
+// job on the cast path is to emit `control-applied` so reactions (on-stasis-applied)
+// can fire.
+//
+// This task makes the control loop emit the SUCCESS event only:
+//   (a) a normal enemy-targeted control emits `control-applied`;
+//   (b) a SELF-target control (Taunt) always emits `control-applied` — it has no enemy
+//       debuff target, so it ignores enemy immunity entirely;
+//   (c) on a Block-Debuff-immune enemy target the control loop does NOT emit its own
+//       resist — the named-status path owns it → EXACTLY ONE `debuff-resisted`.
+//
+// Engine is team-symmetric, so we drive these via an enemy attacker casting at the
+// focus actor (the proven Block-Debuff harness direction) — the change applies to both
+// sides uniformly.
+// ─────────────────────────────────────────────────────────────────────────────
+
+let idCounter = 0;
+
+const engineBase = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 5000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [] },
+    enemyDefense: 0,
+    enemyHp: 10_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000,
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+const enemyAb = (partial: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `cce${++idCounter}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...partial,
+});
+
+/** An enemy attacker (speed 10 → acts AFTER the speed-100 focus actor, so the focus
+ *  actor's recurring Block Debuff self-buff is live before this enemy casts) whose kit
+ *  is a basic attack + the supplied control/debuff abilities. `hacking` omitted →
+ *  defaults to 200 → 100% landing (so the ONLY thing that can resist is Block Debuff). */
+const attackerWith = (...abilities: Ability[]): EnemyAttacker =>
+    ({
+        id: 'e1',
+        stats: { attack: 1000, crit: 0, critDamage: 0, speed: 10 },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        enemyAb({ type: 'damage', config: { type: 'damage', multiplier: 100 } }),
+                        ...abilities,
+                    ],
+                },
+            ],
+        } as ShipSkills,
+    }) as EnemyAttacker;
+
+/** Focus actor (heal target) shipSkills granting a recurring `Block Debuff` self-buff. */
+const blockDebuffSelfSkills = (): ShipSkills => ({
+    slots: [
+        {
+            slot: 'passive',
+            abilities: [
+                {
+                    id: 'block-debuff-self',
+                    type: 'buff',
+                    target: 'self',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config: {
+                        type: 'buff',
+                        buffName: 'Block Debuff',
+                        stacks: 1,
+                        isStackable: false,
+                        duration: 'recurring',
+                        parsedEffects: {},
+                    },
+                },
+            ],
+        },
+    ],
+});
+
+const controlAb = (effect: string, target: Ability['target'] = 'enemy'): Ability =>
+    enemyAb({
+        type: 'control',
+        target,
+        config: { type: 'control', effect: effect as never },
+    });
+
+/** A named timed debuff carrying the control effect's buffName — the PARALLEL named-status
+ *  path that owns the Block-Debuff resist (mirrors real builder output: control effects emit
+ *  both a named debuff and a control ability). */
+const namedControlDebuff = (buffName: string): Ability =>
+    enemyAb({
+        type: 'debuff',
+        config: {
+            type: 'debuff',
+            buffName,
+            parsedEffects: {},
+            stacks: 1,
+            isStackable: false,
+            application: 'inflict',
+            duration: 3,
+        },
+    });
+
+const run = (
+    focusSkills: ShipSkills,
+    bus: ReturnType<typeof createEventBus>,
+    attacker: EnemyAttacker
+) =>
+    runCombat(
+        engineBase({
+            numRounds: 1,
+            enemyAttackers: [attacker],
+            shipSkills: focusSkills,
+            bus,
+        })
+    );
+
+const tap = () => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    bus.on('control-applied', (e) => events.push(e as CombatEvent));
+    bus.on('debuff-resisted', (e) => events.push(e as CombatEvent));
+    return { bus, events };
+};
+
+describe('control-classification emission — resist ownership (Task 4)', () => {
+    // (a) Success: an enemy-targeted control (Provoke) emits control-applied on a normal cast.
+    it('an enemy-targeted Provoke emits control-applied{effect:provoke} on a normal cast', () => {
+        const { bus, events } = tap();
+        run({ slots: [] }, bus, attackerWith(controlAb('provoke')));
+
+        const controls = events.filter((e) => e.type === 'control-applied');
+        expect(controls.length).toBeGreaterThan(0);
+        expect(controls.some((e) => e.type === 'control-applied' && e.effect === 'provoke')).toBe(
+            true
+        );
+        // Normal cast → no resist.
+        expect(events.some((e) => e.type === 'debuff-resisted')).toBe(false);
+    });
+
+    // (b) Self-target Taunt emits control-applied even against a Block-Debuff-immune target:
+    //     it has no enemy debuff target, so the immune gate is skipped entirely.
+    it('a SELF-target Taunt emits control-applied{effect:taunt} regardless of target immunity', () => {
+        const { bus, events } = tap();
+        // Focus actor is Block-Debuff immune; the enemy still self-grants Taunt successfully.
+        run(blockDebuffSelfSkills(), bus, attackerWith(controlAb('taunt', 'self')));
+
+        const controls = events.filter((e) => e.type === 'control-applied');
+        expect(controls.some((e) => e.type === 'control-applied' && e.effect === 'taunt')).toBe(
+            true
+        );
+    });
+
+    // (c) NO double-resist: a Block-Debuff-immune target receiving Provoke (named debuff +
+    //     control ability, mirroring real builder output) produces EXACTLY ONE debuff-resisted
+    //     for 'Provoke' — from the named-status path, NOT a second from the control loop. And
+    //     because the control was blocked, NO control-applied fires.
+    it('Block-Debuff-immune Provoke → exactly ONE debuff-resisted (named path), no control-applied', () => {
+        const { bus, events } = tap();
+        run(
+            blockDebuffSelfSkills(),
+            bus,
+            attackerWith(namedControlDebuff('Provoke'), controlAb('provoke'))
+        );
+
+        const provokeResists = events.filter(
+            (e) => e.type === 'debuff-resisted' && e.buffName === 'Provoke'
+        );
+        expect(provokeResists).toHaveLength(1);
+        // Blocked → the control loop emits no success event.
+        expect(events.some((e) => e.type === 'control-applied')).toBe(false);
+    });
+});

--- a/src/utils/combat/debuffImmunity.ts
+++ b/src/utils/combat/debuffImmunity.ts
@@ -36,6 +36,7 @@ const CONTROL_EFFECT_LABEL: Record<ControlEffect, string> = {
     stasis: 'Stasis',
     overload: 'Overload',
     'concentrate-fire': 'Concentrate Fire',
+    disable: 'Disable',
 };
 export const controlEffectLabel = (effect: ControlEffect): string => CONTROL_EFFECT_LABEL[effect];
 

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1262,10 +1262,10 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     // round. Walked in text order with a same-cast DoT overlay (see applyAbilities).
     const { gatedSkill, ctxFor } = gateFiringAbilities(firingSkill, ctx);
 
-    // Control inflictions (e.g. Defiant's charged Stasis): emit `control-applied` so reactions
-    // (on-stasis-applied) can fire. Emission ONLY — the engine does NOT simulate the control's
-    // combat effect (Stasis/Taunt stay unmodelled). An emitted-but-unconsumed event changes
-    // nothing, so DPS-mode goldens are unaffected.
+    // Control inflictions (Stasis, Provoke, Taunt, Concentrate Fire, Disable): emit `control-applied`
+    // so reactions (on-stasis-applied) can fire. Each control effect's combat impact is modelled
+    // in the engine (Overload is the sole deferred exception). An emitted-but-unconsumed event
+    // changes nothing, so DPS-mode goldens are unaffected.
     //
     // A control effect reaches the engine BOTH as a named timed debuff (its buffName, routed
     // through the timed landing fold above which OWNS the Block-Debuff resist, symmetric with

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -40,7 +40,12 @@ import { buildActorConditionContext, type ReactiveAbility } from './triggers';
 import { recipientCarriesBlockBuff } from './blockBuffBuffs';
 import type { AttackerDamageScalars } from './victimDamage';
 import { effectiveDamageStatsOf, liveDebuffLandingChance } from './effectiveStats';
-import { targetCarriesBlockDebuff, emitBlockDebuffResist, dotResistLabel } from './debuffImmunity';
+import {
+    targetCarriesBlockDebuff,
+    emitBlockDebuffResist,
+    dotResistLabel,
+    controlEffectLabel,
+} from './debuffImmunity';
 import { outgoingAmplificationForHit } from './outgoingEffects';
 import { healAmplificationForCast } from './healAmplification';
 // Buff-fold leaf helpers. Imported for in-file use and re-exported to preserve the
@@ -957,6 +962,14 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     const inflictedEnemyDebuffs: ActiveBuff[] = scheduledEnemy.landedEnemyDebuffs.filter((ab) =>
         appliedScheduledSet.has(ab.buffName)
     );
+    // Buff NAMES of the ability-timed enemy debuffs the landing decision REJECTED this cast (the
+    // condition gate passed but the application was resisted — by affinity disadvantage, the
+    // landing-roll gate, or Block-Debuff immunity, since landsTimedEnemyApplicationLive folds all
+    // three). Unioned with the scheduled-path resisted names below to gate the control-applied
+    // emission: a control whose paired named status was RESISTED must NOT emit a success event
+    // (Finding 1). A control with NO paired named status leaves this set empty for that name, so it
+    // still emits (only Block-Debuff immunity gates a standalone control — preserved separately).
+    const resistedTimedEnemyNames: string[] = [];
     for (const status of timedEnemyBySlot) {
         if (status.sourceSlot !== action) continue;
         if (!conditionsMet(status.conditions, preDebuffGateCtx)) continue;
@@ -974,6 +987,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 buffName: status.payload.buffName,
                 turnsRemaining: status.duration,
             });
+            resistedTimedEnemyNames.push(status.payload.buffName);
             emitDebuffResisted(status.payload.buffName);
         }
     }
@@ -1268,15 +1282,36 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     // changes nothing, so DPS-mode goldens are unaffected.
     //
     // A control effect reaches the engine BOTH as a named timed debuff (its buffName, routed
-    // through the timed landing fold above which OWNS the Block-Debuff resist, symmetric with
+    // through the timed landing fold above which OWNS the resist decision — Block-Debuff immunity,
+    // affinity disadvantage on 'apply', and the landing-roll gate on 'inflict' — symmetric with
     // every debuff type) AND, additively, as this `type:'control'` ability. So the control loop
     // does NOT emit its own resist — that would double-count (the named-status path already emits
-    // `debuff-resisted`). On a blocked ENEMY infliction we simply skip the success event (no
-    // `control-applied`, so on-stasis-applied reactions stay dormant). SELF-target controls
-    // (Taunt) have no enemy debuff target → no immune gate; they always emit.
+    // `debuff-resisted`).
+    //
+    // We SUPPRESS the success event (`control-applied`) for an ENEMY-targeted control when its
+    // paired named status was RESISTED this cast — its buffName is in the union of the resisted
+    // names from the two enemy-debuff landing paths: the ability-timed loop (resistedTimedEnemyNames,
+    // which already folds affinity/landing-roll/Block-Debuff) and the scheduled path
+    // (resistedScheduledTimedNames). On a resist we skip the success event so on-stasis-applied
+    // (etc.) reactions stay dormant for a control that did not land (Finding 1).
+    //
+    // A control with NO paired named status (the engine's control-only fixtures: Defiant Stasis,
+    // etc.) has no entry in the resisted set, so it still emits — its ONLY suppression is
+    // Block-Debuff immunity on the turn target (targetImmuneToDebuffs), preserving the prior
+    // standalone-control behaviour. SELF-target controls (Taunt) are self-buffs (never resisted)
+    // and have no enemy debuff target → always emit.
+    const resistedEnemyDebuffNames = new Set([
+        ...resistedTimedEnemyNames,
+        ...resistedScheduledTimedNames,
+    ]);
     for (const ctrl of controlAbilitiesFromSkill(gatedSkill)) {
         if (ctrl.config.type !== 'control') continue;
-        if (ctrl.target === 'enemy' && targetImmuneToDebuffs) continue; // resist owned by named-status path
+        if (ctrl.target === 'enemy') {
+            // Standalone control with no named status: only Block-Debuff immunity gates it.
+            if (targetImmuneToDebuffs) continue;
+            // Paired named status resisted (affinity / landing-roll) → suppress the success event.
+            if (resistedEnemyDebuffNames.has(controlEffectLabel(ctrl.config.effect))) continue;
+        }
         bus.emit({
             type: 'control-applied',
             casterId: actor.id,

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -40,12 +40,7 @@ import { buildActorConditionContext, type ReactiveAbility } from './triggers';
 import { recipientCarriesBlockBuff } from './blockBuffBuffs';
 import type { AttackerDamageScalars } from './victimDamage';
 import { effectiveDamageStatsOf, liveDebuffLandingChance } from './effectiveStats';
-import {
-    targetCarriesBlockDebuff,
-    emitBlockDebuffResist,
-    dotResistLabel,
-    controlEffectLabel,
-} from './debuffImmunity';
+import { targetCarriesBlockDebuff, emitBlockDebuffResist, dotResistLabel } from './debuffImmunity';
 import { outgoingAmplificationForHit } from './outgoingEffects';
 import { healAmplificationForCast } from './healAmplification';
 // Buff-fold leaf helpers. Imported for in-file use and re-exported to preserve the
@@ -1271,22 +1266,23 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     // (on-stasis-applied) can fire. Emission ONLY — the engine does NOT simulate the control's
     // combat effect (Stasis/Taunt stay unmodelled). An emitted-but-unconsumed event changes
     // nothing, so DPS-mode goldens are unaffected.
-    // Block Debuff (D-PR15): a control infliction is a debuff — when the target is immune, BLOCK
-    // it (no `control-applied`, so on-stasis-applied reactions do NOT fire) and record a resist,
-    // symmetric with the timed/persistent/DoT block paths.
+    //
+    // A control effect reaches the engine BOTH as a named timed debuff (its buffName, routed
+    // through the timed landing fold above which OWNS the Block-Debuff resist, symmetric with
+    // every debuff type) AND, additively, as this `type:'control'` ability. So the control loop
+    // does NOT emit its own resist — that would double-count (the named-status path already emits
+    // `debuff-resisted`). On a blocked ENEMY infliction we simply skip the success event (no
+    // `control-applied`, so on-stasis-applied reactions stay dormant). SELF-target controls
+    // (Taunt) have no enemy debuff target → no immune gate; they always emit.
     for (const ctrl of controlAbilitiesFromSkill(gatedSkill)) {
-        if (ctrl.config.type === 'control') {
-            if (targetImmuneToDebuffs) {
-                emitBlockDebuffResist(bus, enemy.id, r, controlEffectLabel(ctrl.config.effect));
-                continue;
-            }
-            bus.emit({
-                type: 'control-applied',
-                casterId: actor.id,
-                effect: ctrl.config.effect,
-                round: r,
-            });
-        }
+        if (ctrl.config.type !== 'control') continue;
+        if (ctrl.target === 'enemy' && targetImmuneToDebuffs) continue; // resist owned by named-status path
+        bus.emit({
+            type: 'control-applied',
+            casterId: actor.id,
+            effect: ctrl.config.effect,
+            round: r,
+        });
     }
 
     const { multiplier: rawMultiplier, hits, scalingAbility } = damageInputsFromSkill(gatedSkill);

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1031,7 +1031,11 @@ export function detectDebuffInflictedTrigger(
 // turns]" items joined by commas/"and", then the target tag. This still ignores a control word in
 // a condition clause ("If the target has <unit-skill>Provoke…") — no application verb precedes it.
 // Taunt stays TIGHT (verb-adjacent only): no corpus text grants Taunt via a shared-verb compound
-// list, so the list-tolerant form would be unused surface area.
+// list, so the list-tolerant form would be unused surface area. It also carries a negative
+// lookbehind rejecting an `enemy` subject within a short window before the verb, so Amartya's
+// CONDITION clause "When an enemy defender gains <unit-skill>Taunt" (an enemy gaining Taunt, not a
+// self-grant) does not emit a phantom self `taunt` ability, while "This Unit gains/grants Taunt"
+// and "and grants Taunt" still match.
 // "applying" is deliberately omitted: it only appears in the passive reactive clause ("when
 // applying Stasis"), matched separately below.
 //
@@ -1086,7 +1090,7 @@ const CONTROL_INFLICTS: {
         effect: 'taunt',
         tag: 'Taunt',
         side: 'self',
-        re: /\b(?:gains?|grants?)\s+<unit-skill>\s*Taunt\b/i,
+        re: /(?<!\benemy\b[\s\w]{1,20})\b(?:gains?|grants?)\s+<unit-skill>\s*Taunt\b/i,
     },
 ];
 

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1024,12 +1024,21 @@ export function detectDebuffInflictedTrigger(
 //   - `parseSkillEffects` — the named-status *application* path that actually applies the debuff.
 // The control ability is purely additive; nothing here suppresses those other paths.
 //
-// Stasis keeps its ORIGINAL loose regex verbatim (byte-identity, zero golden churn). The four
-// other effects use tight verb-adjacent regexes: the infliction verb is always immediately
-// tag-adjacent (at most "with" between), so a control word in a condition clause ("If the target
-// has <unit-skill>Provoke…") has no preceding application verb adjacent and is correctly ignored.
+// Stasis keeps its ORIGINAL loose regex verbatim (byte-identity, zero golden churn). The three
+// enemy-side effects (Provoke / Concentrate Fire / Disable) anchor on an application verb that is
+// either immediately tag-adjacent OR governs a coordinated list ("inflicts <Defense Down II> for
+// 2 turns, and <Provoke>" — Kafa): the verb, then zero-or-more "<unit-skill>…</unit-skill> [for N
+// turns]" items joined by commas/"and", then the target tag. This still ignores a control word in
+// a condition clause ("If the target has <unit-skill>Provoke…") — no application verb precedes it.
+// Taunt stays TIGHT (verb-adjacent only): no corpus text grants Taunt via a shared-verb compound
+// list, so the list-tolerant form would be unused surface area.
 // "applying" is deliberately omitted: it only appears in the passive reactive clause ("when
 // applying Stasis"), matched separately below.
+//
+// Shared list-prefix between the verb and the target tag (zero-or-more coordinated items).
+const CONTROL_LIST_PREFIX =
+    '(?:\\s+<unit-skill>[^<]*<\\/unit-skill>(?:\\s+for\\s+\\d+\\s+turns?)?,?\\s+and)*';
+const ENEMY_INFLICT_VERB = '\\b(?:inflicts?|appl(?:ies|y)|(?:inflicted|applied) with)\\b';
 const STASIS_INFLICT_RE = /\b(?:inflicts?|applies)\b[^.]*?<unit-skill>\s*Stasis\b/i;
 
 /** Parses a Stasis control infliction → the control effect, or null when absent. Reference data:
@@ -1050,19 +1059,28 @@ const CONTROL_INFLICTS: {
         effect: 'provoke',
         tag: 'Provoke',
         side: 'enemy',
-        re: /\b(?:inflicts?|appl(?:ies|y)|(?:inflicted|applied) with)\s+<unit-skill>\s*Provoke\b/i,
+        re: new RegExp(
+            `${ENEMY_INFLICT_VERB}${CONTROL_LIST_PREFIX}\\s+<unit-skill>\\s*Provoke\\b`,
+            'i'
+        ),
     },
     {
         effect: 'concentrate-fire',
         tag: 'Concentrate Fire',
         side: 'enemy',
-        re: /\b(?:inflicts?|appl(?:ies|y)|(?:inflicted|applied) with)\s+<unit-skill>\s*Concentrate Fire\b/i,
+        re: new RegExp(
+            `${ENEMY_INFLICT_VERB}${CONTROL_LIST_PREFIX}\\s+<unit-skill>\\s*Concentrate Fire\\b`,
+            'i'
+        ),
     },
     {
         effect: 'disable',
         tag: 'Disable',
         side: 'enemy',
-        re: /\b(?:inflicts?|appl(?:ies|y)|(?:inflicted|applied) with)\s+<unit-skill>\s*Disable\b/i,
+        re: new RegExp(
+            `${ENEMY_INFLICT_VERB}${CONTROL_LIST_PREFIX}\\s+<unit-skill>\\s*Disable\\b`,
+            'i'
+        ),
     },
     {
         effect: 'taunt',

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1015,12 +1015,21 @@ export function detectDebuffInflictedTrigger(
     return phrasePosTrigger(text, ENEMY_DEBUFFED_RE, anchorPos, 'on-debuff-inflicted');
 }
 
-// "inflicts/applies Stasis" — a control infliction. Conservative: ONLY Stasis (the one control
-// any ship reacts to today, via Defiant's shield-on-Stasis). Provoke/Taunt stay handled as
-// targeting-status CONDITIONS (statusEffectCondition), NOT control abilities. The <unit-skill>
-// tags don't bracket the verb, so matching on raw text is safe.
-// "applying" deliberately omitted: the infliction verb is always "inflicts/applies"; "applying"
-// only appears in the passive reactive clause ("when applying Stasis"), matched separately below.
+// Control-infliction recognition for the control EVENT. A skill that inflicts/grants one of the
+// five control statuses (Stasis/Provoke/Concentrate Fire/Disable enemy-side, Taunt self-side)
+// produces a `type:'control'` event-only ability so reactions can listen for `control-applied`.
+//
+// This is recognition of the *application* for the control event — it is SEPARATE from:
+//   - `statusEffectCondition` — the read/gate path ("If the target HAS <unit-skill>Provoke…").
+//   - `parseSkillEffects` — the named-status *application* path that actually applies the debuff.
+// The control ability is purely additive; nothing here suppresses those other paths.
+//
+// Stasis keeps its ORIGINAL loose regex verbatim (byte-identity, zero golden churn). The four
+// other effects use tight verb-adjacent regexes: the infliction verb is always immediately
+// tag-adjacent (at most "with" between), so a control word in a condition clause ("If the target
+// has <unit-skill>Provoke…") has no preceding application verb adjacent and is correctly ignored.
+// "applying" is deliberately omitted: it only appears in the passive reactive clause ("when
+// applying Stasis"), matched separately below.
 const STASIS_INFLICT_RE = /\b(?:inflicts?|applies)\b[^.]*?<unit-skill>\s*Stasis\b/i;
 
 /** Parses a Stasis control infliction → the control effect, or null when absent. Reference data:
@@ -1028,6 +1037,66 @@ const STASIS_INFLICT_RE = /\b(?:inflicts?|applies)\b[^.]*?<unit-skill>\s*Stasis\
 export function parseControlInflict(text: string | null | undefined): ControlEffect | null {
     if (!text) return null;
     return STASIS_INFLICT_RE.test(text) ? 'stasis' : null;
+}
+
+const CONTROL_INFLICTS: {
+    effect: ControlEffect;
+    tag: string;
+    side: 'enemy' | 'self';
+    re: RegExp;
+}[] = [
+    { effect: 'stasis', tag: 'Stasis', side: 'enemy', re: STASIS_INFLICT_RE },
+    {
+        effect: 'provoke',
+        tag: 'Provoke',
+        side: 'enemy',
+        re: /\b(?:inflicts?|appl(?:ies|y)|(?:inflicted|applied) with)\s+<unit-skill>\s*Provoke\b/i,
+    },
+    {
+        effect: 'concentrate-fire',
+        tag: 'Concentrate Fire',
+        side: 'enemy',
+        re: /\b(?:inflicts?|appl(?:ies|y)|(?:inflicted|applied) with)\s+<unit-skill>\s*Concentrate Fire\b/i,
+    },
+    {
+        effect: 'disable',
+        tag: 'Disable',
+        side: 'enemy',
+        re: /\b(?:inflicts?|appl(?:ies|y)|(?:inflicted|applied) with)\s+<unit-skill>\s*Disable\b/i,
+    },
+    {
+        effect: 'taunt',
+        tag: 'Taunt',
+        side: 'self',
+        re: /\b(?:gains?|grants?)\s+<unit-skill>\s*Taunt\b/i,
+    },
+];
+
+/**
+ * Parses ALL control inflictions in `text` → one entry per matched effect. Each entry carries the
+ * control effect, its raw tag position (`text.search(<tag>)`, may be -1 — the builder maps -1 →
+ * MAX_POS), and the side the status lands on (Taunt is a self-grant; the rest hit the enemy).
+ * Recognizes the application for the control EVENT only; see CONTROL_INFLICTS comment above for
+ * how this differs from `statusEffectCondition` (read/gate) and `parseSkillEffects` (apply).
+ * Reference data: docs/ship-skills.csv.
+ */
+export function parseControlInflicts(
+    text: string | null | undefined
+): { effect: ControlEffect; pos: number; side: 'enemy' | 'self' }[] {
+    if (!text) return [];
+    const out: { effect: ControlEffect; pos: number; side: 'enemy' | 'self' }[] = [];
+    for (const c of CONTROL_INFLICTS) {
+        if (c.re.test(text)) {
+            const pos = text.search(
+                new RegExp(
+                    `<unit-skill>\\s*${c.tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`,
+                    'i'
+                )
+            );
+            out.push({ effect: c.effect, pos, side: c.side });
+        }
+    }
+    return out;
 }
 
 // "when applying Stasis" — the reactive trigger for a grant that procs when THIS unit applies

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1045,13 +1045,6 @@ const CONTROL_LIST_PREFIX =
 const ENEMY_INFLICT_VERB = '\\b(?:inflicts?|appl(?:ies|y)|(?:inflicted|applied) with)\\b';
 const STASIS_INFLICT_RE = /\b(?:inflicts?|applies)\b[^.]*?<unit-skill>\s*Stasis\b/i;
 
-/** Parses a Stasis control infliction → the control effect, or null when absent. Reference data:
- *  docs/ship-skills.csv (Defiant charged "inflicts Stasis for 1 turn"). */
-export function parseControlInflict(text: string | null | undefined): ControlEffect | null {
-    if (!text) return null;
-    return STASIS_INFLICT_RE.test(text) ? 'stasis' : null;
-}
-
 const CONTROL_INFLICTS: {
     effect: ControlEffect;
     tag: string;

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1101,15 +1101,23 @@ export function parseControlInflicts(
     if (!text) return [];
     const out: { effect: ControlEffect; pos: number; side: 'enemy' | 'self' }[] = [];
     for (const c of CONTROL_INFLICTS) {
-        if (c.re.test(text)) {
-            const pos = text.search(
-                new RegExp(
-                    `<unit-skill>\\s*${c.tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`,
-                    'i'
-                )
-            );
-            out.push({ effect: c.effect, pos, side: c.side });
-        }
+        // Match the APPLICATION clause (c.re anchors on the application verb) and locate the
+        // control tag WITHIN that match — not the first tag anywhere in the row. A status named
+        // in an earlier CONDITION clause ("If the target has <unit-skill>Stasis…") would otherwise
+        // pull `pos` back to the wrong clause, mis-ordering the emitted control ability (the
+        // builder sorts emission order by `pos`).
+        const match = c.re.exec(text);
+        if (!match) continue;
+        const tagRe = new RegExp(
+            `<unit-skill>\\s*${c.tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`,
+            'i'
+        );
+        const tagMatch = tagRe.exec(match[0]);
+        out.push({
+            effect: c.effect,
+            pos: tagMatch ? match.index + tagMatch.index : -1,
+            side: c.side,
+        });
     }
     return out;
 }


### PR DESCRIPTION
## What

Makes `control` no longer the last unsimulated `AbilityType`. Recognizes the four inflicted targeting/lockout control effects (**Provoke, Taunt, Concentrate Fire, Disable**) as first-class `type:'control'` abilities — **additively**, alongside their existing named-status application (mirroring how Stasis already double-parses) — and makes the editor "Not simulated" badge **effect-aware** so simulated control effects stop being falsely flagged.

This is the `control` sub-project of the combat-realism epic, following the positional per-victim stored-damage epic (#173).

## Why additive (not a refactor)

Control statuses already *land* via the named-debuff/buff path (`statusEngine.applyTimedAbilityStatus`): Stasis/Disable → `isTurnBlocked`; Provoke/Taunt/CF → forced-targeting in `positionalBinding`. A `type:'control'` ability is **event-only** (it sources `control-applied` for reactions like Defiant's shield-on-Stasis). So converting the four effects *into* control abilities would delete their working application — instead we add a control ability that rides alongside the named status. Provoke/Taunt/CF/Disable already render as "simulated" (they're `debuff`/`buff` abilities); the badge only mis-fired on `type:'control'` abilities, i.e. Stasis.

## Changes

- **`'disable'`** added to the `ControlEffect` enum + `CONTROL_EFFECT_LABEL`.
- **Parser:** `parseControlInflict` (Stasis-only) → `parseControlInflicts` recognizing all 5 effects. Stasis reuses its existing regex **verbatim** (zero golden churn); the four new effects use tight verb-adjacent matchers that also handle shared-verb coordinated lists (e.g. Kafa's `inflicts <X> for N turns, and <Provoke>`) and exclude condition clauses (e.g. Amartya's `When an enemy defender gains Taunt`).
- **Builder:** emits a `type:'control'` ability per recognized effect (`target` = enemy/self), additive to the named status.
- **Engine (resist ownership):** the control-emission loop no longer emits its own Block-Debuff resist — the named-status path owns resists (symmetric with every debuff type). This keeps the four new effects byte-identical on the resist path and de-duplicates Stasis's previously-redundant double-resist. Self-target Taunt skips the enemy-immune gate.
- **Badge:** `isAbilityNotSimulated` predicate — control abilities for the 5 modeled effects read as simulated; only Overload stays flagged.

## Deferred (out of scope)

- **Overload** (a stacking self-buff with an unmodeled per-turn-grant/lose-on-kill lifecycle — its own follow-up).
- **Per-effect reaction triggers** (`on-provoke-applied`, etc.) — YAGNI: zero ships currently react to these applications.

## Verification

- Full suite **3521 passed / 267 files**, **ZERO `.snap` moved** (byte-identical combat goldens — control abilities for non-stasis effects only emit unconsumed events).
- `tsc` clean, `lint` clean (max-warnings 0), `audit:skills` 0 findings.
- New tests: parser (compound-list + condition negatives), builder (control + unchanged named status), engine (no-double-resist via a real both-abilities fixture), predicate units.

Spec: `docs/superpowers/specs/2026-06-28-control-classification-unification-design.md`
Plan: `docs/superpowers/plans/2026-06-28-control-classification-unification.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)