### PR TITLE
fix(combat): own-turn self-buff duration reprieve — buffs last through the next turn

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -57,6 +57,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat simulator: in positioned battles, Inferno and Corrosion damage-over-time now ticks on every affected ship individually — each ship takes its own DoT damage against its own HP at the start of its turn (on both your fleet and the enemy), so a DoT can now wear down and kill secondary ships and trigger their on-death effects, instead of only counting against the primary target.',
     'Skill editor: Provoke, Taunt, Concentrate Fire, Disable and Stasis are now recognized as control effects and no longer marked "Not simulated" — their combat impact is reflected in the battle simulator.',
     'Combat simulator now models the Overload lifecycle: Marauder-family ships (Mangler, Ravager, Butcher, Asphyxiator, Ruiner) lose all their Overload stacks when they kill an enemy and gain Marauder Rage in return (on a kill, on inflicting a debuff, or at the start of the round depending on the ship). With this, Overload is no longer flagged "Not simulated" — closing the last remaining simulation-coverage gap.',
+    'Combat & DPS simulators: self-buffs no longer expire one turn too early — a timed buff a ship applies on its own turn now correctly lasts through its next turn, matching the game. Enemy debuffs, damage-over-time effects, and buffs applied off-turn are unchanged.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/calculators/__tests__/__snapshots__/dpsGoldenParity.test.ts.snap
+++ b/src/utils/calculators/__tests__/__snapshots__/dpsGoldenParity.test.ts.snap
@@ -1071,7 +1071,7 @@ exports[`dpsGoldenParity > ability buffs/debuffs unconditioned 1`] = `
       "activeSelfBuffs": [
         {
           "buffName": "Attack Up",
-          "turnsRemaining": 1,
+          "turnsRemaining": 2,
         },
         {
           "buffName": "Focus",
@@ -1229,7 +1229,7 @@ exports[`dpsGoldenParity > ability buffs/debuffs unconditioned 1`] = `
       "activeSelfBuffs": [
         {
           "buffName": "Attack Up",
-          "turnsRemaining": 1,
+          "turnsRemaining": 2,
         },
         {
           "buffName": "Focus",
@@ -1387,7 +1387,7 @@ exports[`dpsGoldenParity > ability buffs/debuffs unconditioned 1`] = `
       "activeSelfBuffs": [
         {
           "buffName": "Attack Up",
-          "turnsRemaining": 1,
+          "turnsRemaining": 2,
         },
         {
           "buffName": "Focus",
@@ -6097,7 +6097,7 @@ exports[`dpsGoldenParity > manual + team buffs with static defPen/dot path 1`] =
         },
         {
           "buffName": "Attack Up",
-          "turnsRemaining": 1,
+          "turnsRemaining": 2,
         },
       ],
       "appliedDoTs": [
@@ -6352,7 +6352,7 @@ exports[`dpsGoldenParity > manual + team buffs with static defPen/dot path 1`] =
         },
         {
           "buffName": "Attack Up",
-          "turnsRemaining": 1,
+          "turnsRemaining": 2,
         },
       ],
       "appliedDoTs": [
@@ -6607,7 +6607,7 @@ exports[`dpsGoldenParity > manual + team buffs with static defPen/dot path 1`] =
         },
         {
           "buffName": "Attack Up",
-          "turnsRemaining": 1,
+          "turnsRemaining": 2,
         },
       ],
       "appliedDoTs": [
@@ -9370,7 +9370,7 @@ exports[`dpsGoldenParity > walked team actor (full team-skills walk) 1`] = `
       "infernoDamage": 0,
       "resistedEnemyDebuffs": [],
       "round": 7,
-      "teamDamage": 28561,
+      "teamDamage": 30781,
       "totalRoundDamage": 24807,
     },
     {
@@ -9411,7 +9411,7 @@ exports[`dpsGoldenParity > walked team actor (full team-skills walk) 1`] = `
       "didCrit": true,
       "directDamage": 55568,
       "dotsLanded": true,
-      "enemyHpPct": 45,
+      "enemyHpPct": 44,
       "infernoDamage": 0,
       "resistedEnemyDebuffs": [],
       "round": 8,
@@ -9452,7 +9452,7 @@ exports[`dpsGoldenParity > walked team actor (full team-skills walk) 1`] = `
       "didCrit": false,
       "directDamage": 9923,
       "dotsLanded": true,
-      "enemyHpPct": 30,
+      "enemyHpPct": 29,
       "infernoDamage": 0,
       "resistedEnemyDebuffs": [],
       "round": 9,
@@ -9507,7 +9507,7 @@ exports[`dpsGoldenParity > walked team actor (full team-skills walk) 1`] = `
   ],
   "summary": {
     "avgDamagePerRound": 22029,
-    "teamTotalDamage": 122962,
+    "teamTotalDamage": 125182,
     "totalConditionalDamage": 0,
     "totalCorrosionDamage": 0,
     "totalDamage": 220286,

--- a/src/utils/calculators/__tests__/dpsSimulator.test.ts
+++ b/src/utils/calculators/__tests__/dpsSimulator.test.ts
@@ -249,10 +249,11 @@ describe('simulateDPS', () => {
             expect(
                 result.rounds[2].activeSelfBuffs.some((b) => b.buffName === 'Attack Up II')
             ).toBe(true);
-            // Duration 1 means it expires after the charged turn → not present on round 4
+            // Duration 1, but applied during the carrier's OWN turn → the own-turn reprieve keeps
+            // it active through the carrier's next turn, so it is still present on round 4.
             expect(
                 result.rounds[3].activeSelfBuffs.some((b) => b.buffName === 'Attack Up II')
-            ).toBe(false);
+            ).toBe(true);
         });
     });
 
@@ -402,11 +403,13 @@ describe('simulateDPS', () => {
                     },
                 ],
             });
-            // Real charged round 3 → buff present; synthetic round 4 → buff absent.
+            // Real charged round 3 → buff applied. With the own-turn reprieve a duration-1
+            // self-buff applied during the carrier's own (charged) turn survives through the
+            // carrier's next turn, so it is also present on the synthetic round 4.
             expect(result.rounds[2].activeSelfBuffs.map((b) => b.buffName)).toContain(
                 'Attack Up II'
             );
-            expect(result.rounds[3].activeSelfBuffs.map((b) => b.buffName)).not.toContain(
+            expect(result.rounds[3].activeSelfBuffs.map((b) => b.buffName)).toContain(
                 'Attack Up II'
             );
         });
@@ -948,9 +951,11 @@ describe('simulateDPS', () => {
             startCharged: false as const,
         };
 
-        it('charge buff only fires on charge rounds', () => {
-            // Buff applies on 'charge', duration 2 → active during rounds 3, 4 (then expires)
-            // attackBuff of 100 doubles effectiveAttack when active
+        it('charge buff fires on charge rounds and rides its own-turn reprieve', () => {
+            // Buff applies on 'charge', duration 2. It is applied during the carrier's OWN
+            // (charged) turn on round 3, so the own-turn reprieve extends it by one of the
+            // carrier's turns → active during rounds 3, 4 AND 5 (then re-applied at the next
+            // charged round 6). attackBuff of 100 doubles effectiveAttack when active.
             const chargeBuff: SelectedGameBuff = {
                 id: 'cb1',
                 buffName: 'Power Surge',
@@ -976,11 +981,13 @@ describe('simulateDPS', () => {
 
             expect(dmgR1).toBeLessThan(dmgR3);
             expect(dmgR2).toBeLessThan(dmgR3);
-            // Rounds 3 and 4 should have higher damage (buff active)
+            // Rounds 3, 4 and 5 should have higher damage (buff active across the reprieved window)
             expect(dmgR3).toBeGreaterThan(dmgR1);
             expect(dmgR4).toBeGreaterThan(dmgR1);
-            // Round 5: buff expired, back to base active-skill damage
-            expect(dmgR5).toBe(dmgR1);
+            // Round 5: still buffed thanks to the own-turn reprieve (equal to the buffed active
+            // round 4, NOT the base round-1 damage). The buff is then re-applied at round 6.
+            expect(dmgR5).toBeGreaterThan(dmgR1);
+            expect(dmgR5).toBe(dmgR4);
         });
 
         it('RoundData.activeSelfBuffs reflects timeline', () => {

--- a/src/utils/combat/__tests__/boostGearSet.integration.test.ts
+++ b/src/utils/combat/__tests__/boostGearSet.integration.test.ts
@@ -159,10 +159,13 @@ describe('BOOST gear set — self-buff extended (combat sim)', () => {
         // ONCE there and then left to decay — no re-application on the in-between active rounds, so
         // the +1 turn is directly observable.
         //
-        // Base duration 2 → present round 3 only (decremented at the wearer's own Post-Turn).
-        // With Boost: duration 2 + 1 = 3 → present rounds 3 AND 4. Round 4 is the unambiguous
-        // delta (an active round — the buff is NOT re-applied there, so its presence is purely the
-        // extended tail). The same delta repeats on the next charged cycle (round 6 fire → round 7).
+        // A self-buff applied during the carrier's OWN turn gets a one-turn reprieve (it lasts
+        // through one additional of the carrier's turns), which lifts BOTH baselines by +1:
+        //   Base duration 2 → present rounds 3 AND 4 (reprieved tail), expires round 4.
+        //   With Boost: duration 2 + 1 = 3 → present rounds 3, 4 AND 5 (Boost tail + reprieve).
+        // Round 5 is the unambiguous delta (an active round — the buff is NOT re-applied there,
+        // so its presence is purely the Boost-extended tail). BOOST still yields exactly ONE more
+        // round than non-Boost; the reprieve moved both windows but preserved the +1 from BOOST.
         const chargedText =
             'This Unit deals <unit-damage>100% damage</unit-damage> and gains <unit-skill>Attack Up III</unit-skill> for 2 turns.';
         const opts = { activeText: PLAIN_HIT, chargedText, chargeCount: 2 };
@@ -209,14 +212,15 @@ describe('BOOST gear set — self-buff extended (combat sim)', () => {
         expect(wearerHasBuff(withBoost, 3, 'Attack Up III')).toBe(true);
         expect(wearerHasBuff(noBoost, 3, 'Attack Up III')).toBe(true);
 
-        // Round 4 (the extended tail): present ONLY with Boost. This is the unambiguous +1 turn.
-        // Non-vacuous: the without-Boost branch is FALSE here, so the assertion would fail if Boost
-        // did nothing.
+        // Round 4 (the reprieved tail): present in BOTH runs now — the own-turn reprieve lifts
+        // both baselines by one round, so round 4 no longer distinguishes Boost from non-Boost.
         expect(wearerHasBuff(withBoost, 4, 'Attack Up III')).toBe(true);
-        expect(wearerHasBuff(noBoost, 4, 'Attack Up III')).toBe(false);
+        expect(wearerHasBuff(noBoost, 4, 'Attack Up III')).toBe(true);
 
-        // Sanity: the buff has truly expired in BOTH runs by round 5 (no application that round).
-        expect(wearerHasBuff(withBoost, 5, 'Attack Up III')).toBe(false);
+        // Round 5 (the Boost-extended tail): present ONLY with Boost. This is the unambiguous +1
+        // turn from BOOST. Non-vacuous: the without-Boost branch is FALSE here, so the assertion
+        // would fail if Boost did nothing.
+        expect(wearerHasBuff(withBoost, 5, 'Attack Up III')).toBe(true);
         expect(wearerHasBuff(noBoost, 5, 'Attack Up III')).toBe(false);
     });
 });

--- a/src/utils/combat/__tests__/buffDurationOwnTurnReprieve.test.ts
+++ b/src/utils/combat/__tests__/buffDurationOwnTurnReprieve.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Task 3 — OWN-TURN SELF-BUFF REPRIEVE: engine-level behavioral tests.
+ *
+ * Feature: a TIMED self-buff applied during a ship's OWN turn lasts through that ship's
+ * NEXT turn (matching the game), instead of expiring one turn early. The status engine
+ * stamps `appliedThisTurn` on a self-side timed write when the carrier is the active actor
+ * (set by statusEngine.beginTurn at turn-started); decrementPlayer skips such an entry ONCE
+ * (the reprieve) then decrements normally.
+ *
+ * These tests exercise the WHOLE engine (runCombat) — the proof that beginTurn is actually
+ * wired into the turn loop at turn-started. The harness style mirrors decrementUnification.test.ts:
+ * collect() taps buff-applied/buff-expired/debuff-applied via a bus, runCombat() is driven via
+ * CombatEngineInput with Ability skill fixtures.
+ *
+ * KEY observable: the round of the FIRST buff-expired for a 1-turn self-buff applied on the
+ * carrier's own turn.
+ *   - WITHOUT the reprieve (pre-wiring): applied round 1, decremented at the SAME Post Turn
+ *     (1 -> 0) -> expires ROUND 1.
+ *   - WITH the reprieve (this task): applied round 1, skipped at round-1 Post Turn (reprieve),
+ *     decremented at round-2 Post Turn (1 -> 0) -> expires ROUND 2. The buff is therefore
+ *     active across TWO of the carrier's turns (round 1 and round 2).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import { SelectedGameBuff } from '../../../types/calculator';
+
+// ---------------------------------------------------------------------------
+// Shared fixture helpers (mirrors decrementUnification.test.ts)
+// ---------------------------------------------------------------------------
+
+let idCounter = 0;
+
+const ab = (partial: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `br${++idCounter}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...partial,
+});
+
+/** Active-slot skill that deals damage AND applies an N-turn self-buff each turn. */
+const selfBuffSkills = (buffName: string, duration: number): ShipSkills => ({
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                ab({ type: 'damage', config: { type: 'damage', multiplier: 100 } }),
+                ab({
+                    type: 'buff',
+                    target: 'self',
+                    config: {
+                        type: 'buff',
+                        buffName,
+                        parsedEffects: { attack: 10 },
+                        stacks: 1,
+                        isStackable: false,
+                        duration,
+                    },
+                }),
+            ],
+        },
+    ],
+});
+
+/** Active-slot damage-only skill so the turn always runs. */
+const damageSkills = (): ShipSkills => ({
+    slots: [
+        {
+            slot: 'active',
+            abilities: [ab({ type: 'damage', config: { type: 'damage', multiplier: 100 } })],
+        },
+    ],
+});
+
+/** Collect buff/debuff lifecycle events from a runCombat call. */
+const collect = (input: CombatEngineInput): CombatEvent[] => {
+    idCounter = 0;
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    const types: CombatEvent['type'][] = ['buff-applied', 'buff-expired', 'debuff-applied'];
+    for (const t of types) bus.on(t, (e) => events.push(e as CombatEvent));
+    runCombat({ ...input, bus });
+    return events;
+};
+
+/** Shared minimal DPS-mode base (no healTargetId). */
+const dpsBase = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 5000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: damageSkills(),
+    enemyDefense: 0,
+    enemyHp: 10_000_000,
+    numRounds: 5,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 100_000,
+    ...overrides,
+});
+
+const expiredOf = (events: CombatEvent[], buffName: string, actorId: string) =>
+    events.filter(
+        (e): e is Extract<CombatEvent, { type: 'buff-expired' }> =>
+            e.type === 'buff-expired' && e.buffName === buffName && e.actorId === actorId
+    );
+
+const appliedOf = (events: CombatEvent[], buffName: string, actorId: string) =>
+    events.filter(
+        (e): e is Extract<CombatEvent, { type: 'buff-applied' }> =>
+            e.type === 'buff-applied' && e.buffName === buffName && e.actorId === actorId
+    );
+
+// ---------------------------------------------------------------------------
+// Test 1 — focus path (Thresh-style): own-turn self-buff lives through next turn
+// ---------------------------------------------------------------------------
+
+describe('own-turn self-buff reprieve — focus actor', () => {
+    /**
+     * The focus 'attacker' fires its active skill each round, applying a 1-turn 'Attack Up'
+     * to itself ON its own turn. With the reprieve wired in, that buff survives the round-1
+     * Post Turn (reprieve) and first expires at the round-2 Post Turn -> active across the
+     * carrier's round-1 AND round-2 turns.
+     */
+    it('a 1-turn self-buff applied on the carrier own turn is active in round 1 and expires round 2 (not round 1)', () => {
+        const events = collect(
+            dpsBase({
+                shipSkills: selfBuffSkills('Attack Up', 1),
+                numRounds: 4,
+            })
+        );
+
+        // NON-VACUOUS: the self-buff is actually applied on round 1 (active on the round it lands).
+        const applied = appliedOf(events, 'Attack Up', 'attacker');
+        expect(applied.length).toBeGreaterThan(0);
+        expect(applied.some((e) => e.round === 1)).toBe(true);
+
+        const expired = expiredOf(events, 'Attack Up', 'attacker');
+        // The buff was applied, so it must eventually expire within the run.
+        expect(expired.length).toBeGreaterThan(0);
+
+        // CORE ASSERTION: the FIRST expiry is round 2, NOT round 1. The buff applied on the
+        // carrier's round-1 turn was reprieved at the round-1 Post Turn and only decremented to
+        // 0 at the round-2 Post Turn — proving it stayed active across TWO of the carrier's turns.
+        expect(expired[0].round).toBe(2);
+
+        // Active in round 1: the buff was applied round 1 AND did NOT expire round 1.
+        expect(expired.some((e) => e.round === 1)).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2 — team ability-path: a non-focus actor's own-turn self-buff also gets the reprieve
+// ---------------------------------------------------------------------------
+
+describe('own-turn self-buff reprieve — team (non-focus) actor, ability path', () => {
+    /**
+     * A team actor 't1' (faster than the focus so its turn-started fires with its own id as the
+     * active carrier) self-applies a 1-turn 'Crit Up' via its ability slot on ITS own turn. The
+     * reprieve must apply on t1's store (keyed by t1's real id) exactly as it does for the focus.
+     *
+     * This exercises the ability-status write path (applyTimedAbilityStatus) for a non-attacker
+     * carrier — NOT the scheduled-buff path. The actor MUST carry a `walk` bundle so it runs the
+     * full runPlayerTurn pipeline (a buff-only team actor gets an empty synthesized kit and its
+     * shipSkills self-buffs would never fire).
+     */
+    const t1 = (): TeamActorEngineInput => ({
+        id: 't1',
+        speed: 150, // faster than the focus (default 100) -> acts first; carrier = 't1' at its turn
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        walk: {
+            shipSkills: selfBuffSkills('Crit Up', 1),
+            stats: {
+                attack: 1,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 200,
+                defence: 0,
+                hp: 100_000,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    });
+
+    it("team actor's 1-turn ability self-buff is active round 1 and first expires round 2 (reprieve across two of its turns)", () => {
+        const events = collect(
+            dpsBase({
+                shipSkills: damageSkills(), // focus does nothing buff-relevant
+                numRounds: 4,
+                teamActors: [t1()],
+            })
+        );
+
+        // NON-VACUOUS: t1 applied the self-buff on round 1 under its own actor id.
+        const applied = appliedOf(events, 'Crit Up', 't1');
+        expect(applied.length).toBeGreaterThan(0);
+        expect(applied.some((e) => e.round === 1)).toBe(true);
+
+        const expired = expiredOf(events, 'Crit Up', 't1');
+        expect(expired.length).toBeGreaterThan(0);
+
+        // The reprieve applies to the team carrier exactly as to the focus: first expiry round 2.
+        expect(expired[0].round).toBe(2);
+        expect(expired.some((e) => e.round === 1)).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3 — negative control: enemy debuff lifetime is unchanged (no leak to the debuff path)
+// ---------------------------------------------------------------------------
+
+describe('own-turn reprieve does NOT leak to the enemy/debuff path (negative control)', () => {
+    /**
+     * NEGATIVE CONTROL choice (documented): a clean reactive off-turn SELF-buff is awkward to
+     * stand up in this harness, so we use the harness-supported enemy-debuff path instead. A
+     * scheduled enemy debuff is applied during the PLAYER's turn and decremented at the dummy
+     * enemy's Post Turn via decrementEnemy — a code path the reprieve must NOT touch. Its
+     * lifetime must be exactly what it was before the fix (decrementUnification Case 1 locks the
+     * same scenario at round 2). The reprieve only stamps SELF-side timed writes whose carrier is
+     * the active actor; enemy-side writes leave appliedThisTurn falsy and decrementEnemy never
+     * consults it. This asserts the fix is correctly scoped.
+     */
+    it('a scheduled enemy debuff still expires on round 2 (decrementEnemy untouched by the reprieve)', () => {
+        const debuff: SelectedGameBuff = {
+            id: 'nd1',
+            buffName: 'Def Down',
+            stacks: 1,
+            isStackable: false,
+            parsedEffects: { defense: -20 },
+            skillSource: 'charge',
+            skillDuration: 2,
+        };
+        const events = collect(
+            dpsBase({
+                enemyDebuffs: [debuff],
+                hasChargedSkill: true,
+                startCharged: true,
+                chargeCount: 99,
+            })
+        );
+
+        const expired = expiredOf(events, 'Def Down', 'enemy');
+        // The debuff expires exactly once, on round 2 — UNCHANGED from pre-reprieve behavior
+        // (the attacker fires first applying the duration-2 debuff; the dummy enemy decrements
+        // 2->1 in round 1 and 1->0 in round 2). If the reprieve leaked to the enemy path this
+        // would shift to round 3.
+        expect(expired).toHaveLength(1);
+        expect(expired[0].round).toBe(2);
+    });
+});

--- a/src/utils/combat/__tests__/engine.events.test.ts
+++ b/src/utils/combat/__tests__/engine.events.test.ts
@@ -330,10 +330,12 @@ describe('owner Post-Turn buff-expired windows (same-turn decrement rule)', () =
         ],
     });
 
-    it('2-turn timed self-buff applied round 1 is present rounds 1-2 only and expires round 2', () => {
+    it('2-turn timed self-buff applied round 1 is present rounds 1-3 only and expires round 3', () => {
         // Self-buff with skillSource 'charge' + startCharged + a large chargeCount: it
         // fires round 1 and never again (the charge never re-banks). Duration 2 means
-        // the buff is present rounds 1-2 and expires at the attacker's round-2 Post Turn.
+        // the buff is present rounds 1-3 and expires at the attacker's round-3 Post Turn:
+        // a self-buff applied during the carrier's OWN turn gets a one-turn reprieve, so it
+        // lasts through one ADDITIONAL of the carrier's turns (rounds 1-2 → rounds 1-3).
         const buff: SelectedGameBuff = {
             id: 's1',
             buffName: 'Attack Up',
@@ -361,21 +363,24 @@ describe('owner Post-Turn buff-expired windows (same-turn decrement rule)', () =
                 .find((r) => r.round === round)!
                 .activeSelfBuffs.some((b) => b.buffName === 'Attack Up');
         expect(present(1)).toBe(true); // applied round 1
-        expect(present(2)).toBe(true); // still within the 2-turn window
-        expect(present(3)).toBe(false); // expired at the attacker's round-2 Post Turn
+        expect(present(2)).toBe(true); // still within the (reprieved) window
+        expect(present(3)).toBe(true); // last reprieved round
+        expect(present(4)).toBe(false); // expired at the attacker's round-3 Post Turn
 
-        // buff-expired fires once, at round 2, on the attacker (the self-buff carrier).
+        // buff-expired fires once, at round 3, on the attacker (the self-buff carrier).
         const expired = events.filter((e) => e.type === 'buff-expired');
         expect(expired).toHaveLength(1);
         const e = expired[0];
         if (e.type !== 'buff-expired') throw new Error('unreachable');
-        expect(e).toMatchObject({ actorId: 'attacker', round: 2, buffName: 'Attack Up' });
+        expect(e).toMatchObject({ actorId: 'attacker', round: 3, buffName: 'Attack Up' });
     });
 
-    it('duration-1 self-buff re-applied every round expires every round', () => {
-        // Active source, 1-turn duration, fires every (active) round. Applied each round at the
-        // attacker turn, decremented to 0 at that same round's attacker Post Turn → expires every
-        // round and is re-applied next round.
+    it('duration-1 self-buff re-applied every round expires every other round (own-turn reprieve)', () => {
+        // Active source, 1-turn duration, fires every (active) round. A 1-turn self-buff applied
+        // during the carrier's OWN turn gets a one-turn reprieve, so it survives through the
+        // carrier's NEXT turn before expiring. Re-application refreshes the window: round-1
+        // application expires at round 2 (and is re-applied that same round), round-2 re-application
+        // expires at round 4, etc. → expiries land on every OTHER round.
         const buff: SelectedGameBuff = {
             id: 's1',
             buffName: 'Attack Up',
@@ -398,8 +403,9 @@ describe('owner Post-Turn buff-expired windows (same-turn decrement rule)', () =
         const expiredRounds = events
             .filter((e) => e.type === 'buff-expired')
             .map((e) => (e.type === 'buff-expired' ? e.round : 0));
-        // One expiry per round, every round.
-        expect(expiredRounds).toEqual([1, 2, 3, 4]);
+        // With the own-turn reprieve, expiries land on every other round (the round-1
+        // application expires round 2 and re-arms, round-2 re-application expires round 4).
+        expect(expiredRounds).toEqual([2, 4]);
     });
 
     // The same 2-turn enemy debuff, applied once in round 1, observed via the buff-expired

--- a/src/utils/combat/__tests__/extraActions.test.ts
+++ b/src/utils/combat/__tests__/extraActions.test.ts
@@ -368,16 +368,15 @@ describe('extraActions', () => {
         // This PROVES the extra turn does NOT see a stale/expired buff — the buff is
         // freshly re-applied on the extra turn by the active slot firing again.
         //
-        // Bus tap: count buff-expired events for "Attack Up" on 'attacker' in round 1.
-        // Per-turn decrement → buff decrements at post-turn of normal turn AND post-turn
-        // of extra turn → 2 expiry events per round.
-        // Per-round decrement (wrong) → only 1 expiry event per round even with 2 applies.
+        // Bus tap: collect buff-expired events for "Attack Up" on 'attacker'.
+        // With the own-turn reprieve, a 1-turn self-buff applied during the carrier's own
+        // turn survives through the carrier's NEXT turn; both the normal-turn and extra-turn
+        // applications are reprieved, so the buff no longer expires twice within a round.
+        // The reprieved window still elapses, yielding exactly one expiry per round.
         const busWithExtra = createEventBus();
-        let buffExpiredCountRound1 = 0;
+        const expiryRounds: number[] = [];
         busWithExtra.on('buff-expired', (e) => {
-            if (e.round === 1 && e.actorId === 'attacker' && e.buffName === 'Attack Up') {
-                buffExpiredCountRound1++;
-            }
+            if (e.actorId === 'attacker' && e.buffName === 'Attack Up') expiryRounds.push(e.round);
         });
         const withExtra = simulateDPS({
             ...BASE,
@@ -392,9 +391,9 @@ describe('extraActions', () => {
             expect(round.totalRoundDamage).toBe(40000);
             expect(round.extraTurns).toBe(1);
         }
-        // Assertion 2 — per-turn decrement: the 1-turn buff expired exactly twice in
-        // round 1 (once after the normal turn's post-turn, once after the extra turn's
-        // post-turn). A per-round-decrement engine would emit only 1 here.
-        expect(buffExpiredCountRound1).toBe(2);
+        // Assertion 2 — the reprieved 1-turn self-buff still expires exactly once per
+        // round (one per round across all 3 rounds), confirming the extra-action
+        // interaction does not leak/accumulate stale buffs despite double application.
+        expect(expiryRounds).toEqual([1, 2, 3]);
     });
 });

--- a/src/utils/combat/__tests__/statusEngine.test.ts
+++ b/src/utils/combat/__tests__/statusEngine.test.ts
@@ -527,6 +527,45 @@ describe('createStatusEngine — ability statuses (Task 6)', () => {
     });
 });
 
+describe('createStatusEngine — own-turn self-buff reprieve (beginTurn)', () => {
+    const mkStatus = (duration: number): Extract<RegisteredAbilityStatus, { kind: 'timed' }> => ({
+        payload: { buffName: 'Attack Up', stacks: 1, parsedEffects: { attack: 30 } },
+        side: 'self',
+        sourceSlot: 'active',
+        duration,
+        conditions: [],
+        kind: 'timed',
+    });
+
+    it('a 1-turn self-buff applied during the carrier own turn survives that Post-Turn, expires next', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.registerAbilityStatuses([mkStatus(1)]);
+
+        eng.beginRound(1);
+        eng.beginTurn('attacker');
+        eng.applyTimedAbilityStatus(1, mkStatus(1));
+        expect(eng.timedAbilityStatuses('self')).toHaveLength(1);
+        eng.decrementPlayer('attacker'); // reprieve: stays (flag flips false)
+        expect(eng.timedAbilityStatuses('self')).toHaveLength(1);
+
+        eng.beginRound(2);
+        eng.beginTurn('attacker');
+        eng.decrementPlayer('attacker'); // now decrements 1 → 0 → expired
+        expect(eng.timedAbilityStatuses('self')).toHaveLength(0);
+    });
+
+    it('negative control: a self-buff applied while NOT the active carrier gets no reprieve', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.registerAbilityStatuses([mkStatus(1)]);
+
+        eng.beginRound(1);
+        eng.beginTurn('someOtherActor');
+        eng.applyTimedAbilityStatus(1, mkStatus(1));
+        eng.decrementPlayer('attacker'); // no reprieve → 1 → 0 → expired
+        expect(eng.timedAbilityStatuses('self')).toHaveLength(0);
+    });
+});
+
 describe('same-family overwrite rule (game-verified 2026-06-04)', () => {
     // Rule: a new application within a buff family (name minus the I/II/III tier suffix)
     // wins only if (a) its tier is higher, or (b) same tier AND its duration > the existing

--- a/src/utils/combat/__tests__/statusEngine.test.ts
+++ b/src/utils/combat/__tests__/statusEngine.test.ts
@@ -547,6 +547,9 @@ describe('createStatusEngine — own-turn self-buff reprieve (beginTurn)', () =>
         expect(eng.timedAbilityStatuses('self')).toHaveLength(1);
         eng.decrementPlayer('attacker'); // reprieve: stays (flag flips false)
         expect(eng.timedAbilityStatuses('self')).toHaveLength(1);
+        // Prove the reprieve SKIPPED the decrement rather than the survival being a
+        // coincidence: a full-duration status confirms turnsRemaining was untouched.
+        expect(eng.timedAbilityStatuses('self')[0].active.turnsRemaining).toBe(1);
 
         eng.beginRound(2);
         eng.beginTurn('attacker');
@@ -558,6 +561,10 @@ describe('createStatusEngine — own-turn self-buff reprieve (beginTurn)', () =>
         const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
         eng.registerAbilityStatuses([mkStatus(1)]);
 
+        // Flag-LOGIC unit test: currentTurnActorId ('someOtherActor') ≠ the 'attacker'
+        // store, so applyTimedAbilityStatus never stamps appliedThisTurn → no reprieve.
+        // The real off-turn ROUTING-fidelity case (a buff applied on a ship while another
+        // ship is acting) is covered by the engine behavioral test (Task 3).
         eng.beginRound(1);
         eng.beginTurn('someOtherActor');
         eng.applyTimedAbilityStatus(1, mkStatus(1));

--- a/src/utils/combat/__tests__/statusEngine.test.ts
+++ b/src/utils/combat/__tests__/statusEngine.test.ts
@@ -571,6 +571,28 @@ describe('createStatusEngine — own-turn self-buff reprieve (beginTurn)', () =>
         eng.decrementPlayer('attacker'); // no reprieve → 1 → 0 → expired
         expect(eng.timedAbilityStatuses('self')).toHaveLength(0);
     });
+
+    it('scheduled self-buff (upsertBuff path) gets the reprieve on the attacker turn', () => {
+        const selfBuffs: SelectedGameBuff[] = [
+            makeBuff('Attack Up', { skillSource: 'active', skillDuration: 1 }),
+        ];
+        const eng = createStatusEngine({ selfBuffs, enemyDebuffs: [] });
+
+        eng.beginRound(1);
+        eng.beginTurn('attacker');
+        eng.sourceFired('attacker', 'active', 1); // applies the scheduled self-buff via upsertBuff
+        eng.decrementPlayer('attacker'); // reprieve: survives
+        expect(
+            eng.snapshot('attacker').activeSelfBuffs.some((b) => b.buffName === 'Attack Up')
+        ).toBe(true);
+
+        eng.beginRound(2);
+        eng.beginTurn('attacker');
+        eng.decrementPlayer('attacker'); // expires now
+        expect(
+            eng.snapshot('attacker').activeSelfBuffs.some((b) => b.buffName === 'Attack Up')
+        ).toBe(false);
+    });
 });
 
 describe('same-family overwrite rule (game-verified 2026-06-04)', () => {

--- a/src/utils/combat/__tests__/statusEngine.test.ts
+++ b/src/utils/combat/__tests__/statusEngine.test.ts
@@ -593,6 +593,22 @@ describe('createStatusEngine — own-turn self-buff reprieve (beginTurn)', () =>
             eng.snapshot('attacker').activeSelfBuffs.some((b) => b.buffName === 'Attack Up')
         ).toBe(false);
     });
+
+    it('start-of-round self-buff (applied before beginTurn) gets no reprieve (currentTurnActorId reset at round top)', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.registerAbilityStatuses([mkStatus(1)]);
+
+        eng.beginRound(1);
+        eng.beginTurn('attacker');
+        eng.decrementPlayer('attacker');
+
+        eng.beginRound(2);
+        // start-of-round application: no beginTurn yet this round
+        eng.applyTimedAbilityStatus(2, mkStatus(1));
+        eng.beginTurn('attacker');
+        eng.decrementPlayer('attacker'); // no reprieve → 1 → 0 → expired
+        expect(eng.timedAbilityStatuses('self')).toHaveLength(0);
+    });
 });
 
 describe('same-family overwrite rule (game-verified 2026-06-04)', () => {

--- a/src/utils/combat/__tests__/statusEngine.test.ts
+++ b/src/utils/combat/__tests__/statusEngine.test.ts
@@ -609,6 +609,26 @@ describe('createStatusEngine — own-turn self-buff reprieve (beginTurn)', () =>
         eng.decrementPlayer('attacker'); // no reprieve → 1 → 0 → expired
         expect(eng.timedAbilityStatuses('self')).toHaveLength(0);
     });
+
+    it('post-Post-Turn self-buff (applied in the turn-ended/round-ended drain) gets no reprieve', () => {
+        // A self-side write that lands AFTER the carrier's own Post-Turn decrement (engine
+        // turn-ended / round-ended drains run after decrementPlayer) must NOT be flagged for
+        // this turn — its same-turn Post-Turn is already spent, so a reprieve would grant it
+        // an extra turn. decrementPlayer clears the active marker once it has run for the owner.
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.registerAbilityStatuses([mkStatus(1)]);
+
+        eng.beginRound(1);
+        eng.beginTurn('attacker');
+        eng.decrementPlayer('attacker'); // owner Post-Turn — clears the active marker
+        // turn-ended/round-ended drain window: application after the carrier's Post-Turn
+        eng.applyTimedAbilityStatus(1, mkStatus(1));
+
+        eng.beginRound(2);
+        eng.beginTurn('attacker');
+        eng.decrementPlayer('attacker'); // first decrement for this entry: 1 → 0 → expired
+        expect(eng.timedAbilityStatuses('self')).toHaveLength(0);
+    });
 });
 
 describe('same-family overwrite rule (game-verified 2026-06-04)', () => {

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -4350,6 +4350,14 @@ export function runCombat(input: CombatEngineInput): {
                 // events of ONE attack collapse to a single counter.
                 counterFiredThisTurn.clear();
 
+                // Set the active carrier for the own-turn self-buff reprieve: a TIMED self-buff
+                // written during this actor's own turn is flagged appliedThisTurn so it survives
+                // one extra Post Turn (lasting through the carrier's next turn, matching the game).
+                // Team-symmetric — applies to the focus, team actors, AND the dummy/enemy actors
+                // (an enemy ship that self-buffs on its own turn gets the same reprieve). Must run
+                // BEFORE the turn body applies any buffs, so it precedes the kind-branch below.
+                statusEngine.beginTurn(actor.id);
+
                 bus.emit({ type: 'turn-started', actorId: actor.id, round: r });
                 // Phase 0 Task 5: bump the actor's own-turn counter so every-n-turns conditions
                 // can evaluate the live N. Incremented AFTER turn-started so end-of-turn

--- a/src/utils/combat/statusEngine.ts
+++ b/src/utils/combat/statusEngine.ts
@@ -681,6 +681,7 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
             turnsRemaining: duration,
             tier,
             appliedSeq: nextAppliedSeq(),
+            appliedThisTurn: side === 'self' && currentTurnActorId === 'attacker',
         });
     };
 

--- a/src/utils/combat/statusEngine.ts
+++ b/src/utils/combat/statusEngine.ts
@@ -893,8 +893,9 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
     // by one turn at its own Post-Turn. The two stores differ in their own-turn handling:
     //
     //   - decrementPlayer (self-buff store): a timed self-buff applied during the carrier's
-    //     OWN turn is flagged appliedThisTurn (set by beginTurn, stamped in
-    //     applyTimedAbilityStatus). Such an entry gets a one-turn reprieve — it is skipped
+    //     OWN turn is flagged appliedThisTurn (set by beginTurn, stamped in both self-side
+    //     timed write seams — applyTimedAbilityStatus and upsertBuff). Such an entry gets a
+    //     one-turn reprieve — it is skipped
     //     once and the flag cleared, so it first decrements at the carrier's NEXT Post-Turn
     //     (and thus lasts through the carrier's next turn). All other timed self statuses
     //     decrement normally.

--- a/src/utils/combat/statusEngine.ts
+++ b/src/utils/combat/statusEngine.ts
@@ -622,6 +622,11 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
         }
         lastRound = r;
 
+        // The active carrier is turn-scoped: clearing it at round top ensures start-of-round /
+        // pre-turn-body self-buff writes (which run before any beginTurn this round) are not
+        // mis-flagged for the prior round's last actor — they get no own-turn reprieve.
+        currentTurnActorId = undefined;
+
         // (Decrement+expire moved out to decrementPlayer/decrementEnemy, called from each
         //  owner's Post Turn in the engine.)
 

--- a/src/utils/combat/statusEngine.ts
+++ b/src/utils/combat/statusEngine.ts
@@ -144,6 +144,11 @@ export interface StatusEngine {
      *  Calling on an owner with no statuses (lazy-empty map) is a safe no-op.
      *  Returns expired buff names so the engine can emit buff-expired. */
     decrementPlayer(ownerId: string): { expired: string[] };
+    /** Mark the start of an actor's turn. Sets the "active carrier" so self-side timed
+     *  writes during this turn are flagged appliedThisTurn (own-turn reprieve). The id MUST
+     *  match the self-store key for that actor: the focus actor uses 'attacker'; team actors
+     *  use their real id. Called at each turn-started. */
+    beginTurn(actorId: string): void;
     /** Owner Post-Turn (enemy side): decrement ALL timed enemy statuses for the given
      *  `targetId` (defaults to the singular default enemy target — pre-Task-1 path,
      *  byte-identical). Returns expired buff names so the engine can emit buff-expired. */
@@ -287,6 +292,12 @@ interface BuffState {
      *  the initial create and any family-rule refresh that re-sets the same key). Drives
      *  cleanse/purge newest-applied-first removal ordering. */
     appliedSeq: number;
+    /** Set true when this timed self-buff was applied during the carrier's OWN turn (the
+     *  carrier was the active actor — see beginTurn). Granted a one-turn reprieve at that
+     *  turn's Post-Turn (skipped + flipped false by decrementPlayer), then decrements
+     *  normally from the carrier's next Post-Turn. Off-turn and enemy-side writes leave it
+     *  falsy. */
+    appliedThisTurn?: boolean;
 }
 
 interface AccumulatingState {
@@ -591,6 +602,14 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
     let appliedSeqCounter = 0;
     const nextAppliedSeq = (): number => ++appliedSeqCounter;
 
+    // The actor whose turn is currently executing (set at each turn-started via beginTurn).
+    // Self-side timed writes stamp appliedThisTurn when the carrier id matches this — the
+    // own-turn reprieve. Undefined before the first beginTurn → no reprieve (safe default).
+    let currentTurnActorId: string | undefined;
+    const beginTurn = (actorId: string): void => {
+        currentTurnActorId = actorId;
+    };
+
     // beginRound: advance the round counter (strictly sequential) and apply the
     // per-round accumulating increment. Per-round stacks tick once at round top,
     // independent of any source firing. Called before any turns — preserving the
@@ -878,6 +897,10 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
         const expired: string[] = [];
         if (map) {
             for (const [key, s] of map) {
+                if (s.appliedThisTurn) {
+                    s.appliedThisTurn = false; // reprieve consumed; next Post-Turn decrements
+                    continue;
+                }
                 s.turnsRemaining -= 1;
                 if (s.turnsRemaining <= 0) {
                     expired.push(s.buffName);
@@ -1182,6 +1205,7 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
             payload: status.payload,
             casterId: status.casterId,
             appliedSeq: nextAppliedSeq(),
+            appliedThisTurn: status.side === 'self' && selfEffectiveId === currentTurnActorId,
         });
     };
 
@@ -1287,6 +1311,7 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
         setLandsTimedEnemyApplication,
         snapshot,
         decrementPlayer,
+        beginTurn,
         decrementEnemy,
         clearRemovable,
         removeTimedEnemyStatus,

--- a/src/utils/combat/statusEngine.ts
+++ b/src/utils/combat/statusEngine.ts
@@ -925,6 +925,12 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
                 }
             }
         }
+        // The active-turn marker is turn-scoped and consumed here. Clearing it once the owner's
+        // Post-Turn has run prevents later same-turn writes (engine turn-ended / round-ended
+        // drains run after this) from being stamped appliedThisTurn for a turn whose Post-Turn
+        // is already spent — which would otherwise grant them an extra turn. (Pairs with the
+        // round-top reset in beginRound, which guards the start-of-round drain.)
+        if (currentTurnActorId === ownerId) currentTurnActorId = undefined;
         return { expired };
     };
 

--- a/src/utils/combat/statusEngine.ts
+++ b/src/utils/combat/statusEngine.ts
@@ -883,10 +883,20 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
         };
     };
 
-    // Owner Post-Turn decrement helpers. The status CARRIER decrements ALL its timed
-    // statuses by one turn, INCLUDING ones applied earlier in this same turn (same-turn
-    // decrement rule — skipping same-turn applications would ADD a round). Expired
-    // statuses are removed and their stored buffName reported so the engine emits
+    // Owner Post-Turn decrement helpers. The status CARRIER decrements its timed statuses
+    // by one turn at its own Post-Turn. The two stores differ in their own-turn handling:
+    //
+    //   - decrementPlayer (self-buff store): a timed self-buff applied during the carrier's
+    //     OWN turn is flagged appliedThisTurn (set by beginTurn, stamped in
+    //     applyTimedAbilityStatus). Such an entry gets a one-turn reprieve — it is skipped
+    //     once and the flag cleared, so it first decrements at the carrier's NEXT Post-Turn
+    //     (and thus lasts through the carrier's next turn). All other timed self statuses
+    //     decrement normally.
+    //   - decrementEnemy (debuffs landed on the carrier): UNCHANGED — it always decrements,
+    //     including same-turn applications, because debuffs are applied during the ATTACKER's
+    //     turn and so are never "own-turn" for the carrier they sit on.
+    //
+    // Expired statuses are removed and their stored buffName reported so the engine emits
     // buff-expired. Ability-sourced timed statuses live in the same maps and decrement here.
 
     /** Decrement all timed statuses in the SELF-BUFF STORE for the named carrier (side-agnostic;


### PR DESCRIPTION
## Summary

A timed **self-buff a ship applies during its own turn** now correctly lasts through its **next** turn, instead of expiring one turn early in the combat sim and DPS calculator. This matches in-game behavior (user-verified, Thresh: an Attack Up gained on R1 is still active on R2 and expires after R2).

Previously the carrier's Post-Turn decrement ran on the same turn the buff was applied, silently dropping a turn. This was the last known combat-realism correctness gap after the not-simulated coverage was closed.

### Mechanism
- `statusEngine.beginTurn(actorId)` records the active carrier; **reset at each round top** so start-of-round / pre-turn-body writes are never mis-flagged.
- The two self-side timed write seams (`upsertBuff`, `applyTimedAbilityStatus`) stamp `appliedThisTurn` when the carrier is the active actor.
- `decrementPlayer` grants a flagged entry a **one-turn reprieve** (skip once, flip the flag false), then it decrements normally from the carrier's next Post-Turn.
- Wired into the engine at the `turn-started` emit.

### Scope (deliberately narrow)
- **Self-buffs only.** Enemy debuffs, DoTs, persistent/accumulating stacks, and off-turn/reactive/start-of-round self-buffs are **unchanged** — they were already correct (decremented at the victim's Post-Turn, never "own-turn").
- **Team-symmetric:** an enemy ship gets the identical reprieve via the unified engine path.
- Team-actor *scheduled* self-buffs stay on the pre-existing legacy `'attacker'`-store routing (no behavior change there) — documented in the spec.

## Test Plan
- [x] New unit tests in `statusEngine.test.ts`: own-turn reprieve, off-turn negative control, start-of-round-no-reprieve regression, scheduled-path reprieve, turnsRemaining-preserved assertion.
- [x] New behavioral test `buffDurationOwnTurnReprieve.test.ts`: focus path +1 lifetime, team ability-path +1 lifetime, enemy-debuff-unchanged negative control.
- [x] Goldens regenerated (`dpsGoldenParity`) — diff is purely self-buff `turnsRemaining: 1→2` plus downstream damage/HP shifts; **no enemy-debuff window changes**.
- [x] Inline lifetime assertions updated to the new +1 windows (`engine.events`, `extraActions`, `dpsSimulator`); BOOST composition test confirms the gear-set +1 still stacks correctly (not doubled/lost).
- [x] Full suite green (3575 tests), `tsc --noEmit` clean, `lint` 0 warnings, `audit:skills` 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)