### PR TITLE
fix(combat): roll anchor crit at resolved target's real affinity

### DIFF
--- a/src/utils/combat/__tests__/anchorCritRealAffinity.test.ts
+++ b/src/utils/combat/__tests__/anchorCritRealAffinity.test.ts
@@ -154,7 +154,7 @@ describe('anchor crit at real affinity (deferAbilityPerformedToEngine)', () => {
 
         setRateGateRng(() => draw);
 
-        const nonPositional = runPlayerTurn(makeArgs(runtime, false));
+        const nonPositional = runPlayerTurn(makeArgs(makeRuntime(crit), false));
         expect(nonPositional.hitCrits).toEqual([true]);
     });
 });

--- a/src/utils/combat/__tests__/anchorCritRealAffinity.test.ts
+++ b/src/utils/combat/__tests__/anchorCritRealAffinity.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Anchor crit at real affinity (Strategy A): when deferAbilityPerformedToEngine is true,
+ * hitCrits[] rolls use the bound anchor's affinity cap/penalty, not the representative
+ * affinityCritCap/affinityCritPenalty scalars.
+ */
+import { describe, expect, it, afterEach } from 'vitest';
+import { runPlayerTurn, PlayerActorRuntime, PlayerTurnArgs } from '../playerTurn';
+import { createActor } from '../state';
+import { createStatusEngine } from '../statusEngine';
+import { createEventBus } from '../events';
+import { makeRateGate, setRateGateRng, resetRateGateRng } from '../../calculators/rateAccumulator';
+import { ShipSkills } from '../../../types/abilities';
+import { computeAffinityModifiers } from '../../calculators/affinityUtils';
+
+const damageSkill: ShipSkills = {
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                {
+                    id: 'dmg-anchor-crit',
+                    type: 'damage',
+                    target: 'enemy',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config: { type: 'damage', multiplier: 100, hits: 1 },
+                },
+            ],
+        },
+    ],
+};
+
+function makeRuntime(crit: number): PlayerActorRuntime {
+    const actor = createActor({
+        id: 'attacker',
+        side: 'player',
+        kind: 'attacker',
+        stats: {
+            attack: 10000,
+            crit,
+            critDamage: 100,
+            defensePenetration: 0,
+            shieldPenetration: 0,
+            defence: 0,
+            hp: 20000,
+            speed: 100,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        affinity: 'chemical',
+    });
+
+    return {
+        actor,
+        focus: true,
+        castSkills: damageSkill,
+        reactiveAbilities: [],
+        timedSelfBySlot: [],
+        timedEnemyBySlot: [],
+        hasChargedSkill: false,
+        attack: 10000,
+        crit,
+        critDamage: 100,
+        defensePenetration: 0,
+        defence: 0,
+        hp: 20000,
+        healModifier: 0,
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        affinityDamageModifier: 0,
+        // Representative matchup scalars (neutral — as if enemy[0] were same-affinity).
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        affinityDisadvantage: false,
+        attackerAffinity: 'chemical',
+        activeCritGate: makeRateGate(),
+        chargedCritGate: makeRateGate(),
+        activeHealCritGate: makeRateGate(),
+        chargedHealCritGate: makeRateGate(),
+        debuffLandingGate: makeRateGate(),
+        extendChanceGate: makeRateGate(),
+        landsTimedEnemyApplication: () => true,
+        selfBuffLookup: new Map(),
+        enemyDebuffLookup: new Map(),
+    };
+}
+
+function makeArgs(
+    runtime: PlayerActorRuntime,
+    deferAbilityPerformedToEngine: boolean
+): PlayerTurnArgs {
+    // Anchor at affinity disadvantage vs chemical attacker (thermal > chemical).
+    const enemy = createActor({
+        id: 'anchor',
+        side: 'enemy',
+        kind: 'enemy',
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            shieldPenetration: 0,
+            defence: 0,
+            hp: 10_000_000,
+            speed: 50,
+        },
+        affinity: 'thermal',
+    });
+
+    const statusEngine = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+    statusEngine.beginRound(1);
+
+    return {
+        runtime,
+        enemy,
+        statusEngine,
+        corrosionEntries: [],
+        infernoEntries: [],
+        pendingBombs: [],
+        pendingAccumulators: [],
+        enemyDefense: 0,
+        enemyHp: 10_000_000,
+        enemyType: undefined,
+        bus: createEventBus(),
+        round: 1,
+        deferAbilityPerformedToEngine,
+    };
+}
+
+describe('anchor crit at real affinity (deferAbilityPerformedToEngine)', () => {
+    afterEach(() => resetRateGateRng());
+
+    it('positional cast rolls hitCrits at anchor affinity, not representative cap', () => {
+        const crit = 80;
+        const runtime = makeRuntime(crit);
+
+        const repRate =
+            Math.min(runtime.affinityCritCap, Math.max(0, crit - runtime.affinityCritPenalty)) /
+            100;
+        const anchorMods = computeAffinityModifiers('chemical', 'thermal');
+        const anchorRate =
+            Math.min(anchorMods.critCap, Math.max(0, crit - anchorMods.critPenalty)) / 100;
+
+        // Straddle: crits at representative rate, fails at anchor rate.
+        expect(repRate).toBeGreaterThan(anchorRate);
+        const draw = (repRate + anchorRate) / 2;
+        expect(draw).toBeLessThan(repRate);
+        expect(draw).toBeGreaterThanOrEqual(anchorRate);
+
+        setRateGateRng(() => draw);
+
+        const positional = runPlayerTurn(makeArgs(runtime, true));
+        expect(positional.hitCrits).toEqual([false]);
+
+        setRateGateRng(() => draw);
+
+        const nonPositional = runPlayerTurn(makeArgs(runtime, false));
+        expect(nonPositional.hitCrits).toEqual([true]);
+    });
+});

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -861,18 +861,17 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     const entry = statusEngine.snapshot(actor.id);
 
     // Effective crit rate from a given crit-buff total, clamped by affinity.
-    // Positional casts (deferAbilityPerformedToEngine): cap/penalty from the bound anchor's
-    // real affinity — the engine passes `enemy: tgt` via buildTurnArgs. Non-positional (DPS,
-    // healing): keep the representative scalars from battleSimulator (byte-identical).
-    const cappedCrit = (critBuffTotal: number) => {
-        if (args.deferAbilityPerformedToEngine === true) {
-            const { critCap, critPenalty } = computeAffinityModifiers(
-                attackerAffinity ?? actor.affinity ?? 'antimatter',
-                enemy.affinity ?? 'antimatter'
-            );
-            return Math.min(critCap, Math.max(0, crit + critBuffTotal - critPenalty));
-        }
-        return Math.min(affinityCritCap, Math.max(0, crit + critBuffTotal - affinityCritPenalty));
+    // Gate/context estimates use representative scalars (byte-identical to pre-SP1). The actual
+    // per-hit roll below uses realAffinityCappedCrit when deferAbilityPerformedToEngine.
+    const cappedCrit = (critBuffTotal: number) =>
+        Math.min(affinityCritCap, Math.max(0, crit + critBuffTotal - affinityCritPenalty));
+
+    const realAffinityCappedCrit = (critBuffTotal: number) => {
+        const { critCap, critPenalty } = computeAffinityModifiers(
+            attackerAffinity ?? actor.affinity ?? 'antimatter',
+            enemy.affinity ?? 'antimatter'
+        );
+        return Math.min(critCap, Math.max(0, crit + critBuffTotal - critPenalty));
     };
 
     // --- Scheduled (manual + team) statuses: same path as before ---
@@ -1235,7 +1234,10 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     });
     const effectiveAttack = dmgStats.attack;
     // Full buff total at the final fold; equals the prior staged critBuff (layers 1+2+3+4).
-    const effectiveCrit = cappedCrit(dmgStats.totals.critBuff);
+    const effectiveCrit =
+        args.deferAbilityPerformedToEngine === true
+            ? realAffinityCappedCrit(dmgStats.totals.critBuff)
+            : cappedCrit(dmgStats.totals.critBuff);
     const effectiveCritDamage = dmgStats.critDamage;
     // Per-hit crit checks (game-verified 2026-06-06): each hit of a multi-hit skill
     // draws the deterministic crit gate INDIVIDUALLY. Draw count = the UNGATED firing

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -861,8 +861,19 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     const entry = statusEngine.snapshot(actor.id);
 
     // Effective crit rate from a given crit-buff total, clamped by affinity.
-    const cappedCrit = (critBuffTotal: number) =>
-        Math.min(affinityCritCap, Math.max(0, crit + critBuffTotal - affinityCritPenalty));
+    // Positional casts (deferAbilityPerformedToEngine): cap/penalty from the bound anchor's
+    // real affinity — the engine passes `enemy: tgt` via buildTurnArgs. Non-positional (DPS,
+    // healing): keep the representative scalars from battleSimulator (byte-identical).
+    const cappedCrit = (critBuffTotal: number) => {
+        if (args.deferAbilityPerformedToEngine === true) {
+            const { critCap, critPenalty } = computeAffinityModifiers(
+                attackerAffinity ?? actor.affinity ?? 'antimatter',
+                enemy.affinity ?? 'antimatter'
+            );
+            return Math.min(critCap, Math.max(0, crit + critBuffTotal - critPenalty));
+        }
+        return Math.min(affinityCritCap, Math.max(0, crit + critBuffTotal - affinityCritPenalty));
+    };
 
     // --- Scheduled (manual + team) statuses: same path as before ---
     // Scheduled self-buff names + totals.


### PR DESCRIPTION
## Summary
- Positional sim casts now cap `hitCrits[]` using the bound anchor's real affinity when `deferAbilityPerformedToEngine` is set, instead of the representative `enemy[0]`/`player[0]` scalars.
- DPS, healing, and non-positional paths keep representative `affinityCritCap`/`affinityCritPenalty` — byte-identical.
- Adds a unit test proving the positional vs non-positional crit-rate divergence at a straddling draw.

## Test plan
- [x] `npm test` — full suite passes (3705 tests)
- [x] DPS + healing golden snapshots byte-identical
- [x] `positionalApplyPerVictimCrit.test.ts` unchanged and passing
- [x] New `anchorCritRealAffinity.test.ts` covers Strategy A behaviour


Made with [Cursor](https://cursor.com)