### PR TITLE
fix(combat): per-target debuff landing in positional sim (SP2)

### DIFF
--- a/src/utils/combat/__tests__/anchorDebuffLandingRealAffinity.test.ts
+++ b/src/utils/combat/__tests__/anchorDebuffLandingRealAffinity.test.ts
@@ -1,0 +1,237 @@
+/**
+ * SP2a: positional on-turn debuff landing uses anchor affinity, not representative.
+ */
+import { describe, expect, it, afterEach } from 'vitest';
+import { runPlayerTurn, PlayerActorRuntime, PlayerTurnArgs } from '../playerTurn';
+import { createActor } from '../state';
+import { createStatusEngine } from '../statusEngine';
+import { createEventBus } from '../events';
+import { makeRateGate, setRateGateRng, resetRateGateRng } from '../../calculators/rateAccumulator';
+import { ShipSkills } from '../../../types/abilities';
+import { computeAffinityModifiers } from '../../calculators/affinityUtils';
+
+const applyDebuffSkill: ShipSkills = {
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                {
+                    id: 'apply-down',
+                    type: 'debuff',
+                    target: 'enemy',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config: {
+                        type: 'debuff',
+                        buffName: 'Defense Down',
+                        parsedEffects: { defense: -50 },
+                        stacks: 1,
+                        isStackable: false,
+                        application: 'apply',
+                        duration: 3,
+                    },
+                },
+            ],
+        },
+    ],
+};
+
+const inflictDebuffSkill: ShipSkills = {
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                {
+                    id: 'inflict-down',
+                    type: 'debuff',
+                    target: 'enemy',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config: {
+                        type: 'debuff',
+                        buffName: 'Disable',
+                        parsedEffects: {},
+                        stacks: 1,
+                        isStackable: false,
+                        application: 'inflict',
+                        duration: 2,
+                    },
+                },
+            ],
+        },
+    ],
+};
+
+function timedEnemySlot(
+    buffName: string,
+    application: 'apply' | 'inflict'
+): PlayerActorRuntime['timedEnemyBySlot'] {
+    return [
+        {
+            kind: 'timed',
+            duration: application === 'apply' ? 3 : 2,
+            side: 'enemy',
+            sourceSlot: 'active',
+            conditions: [],
+            payload: {
+                buffName,
+                parsedEffects: application === 'apply' ? { defense: -50 } : {},
+                application,
+                stacks: 1,
+            },
+        },
+    ];
+}
+
+function makeRuntime(
+    skills: ShipSkills,
+    timedEnemyBySlot: PlayerActorRuntime['timedEnemyBySlot']
+): PlayerActorRuntime {
+    const actor = createActor({
+        id: 'attacker',
+        side: 'player',
+        kind: 'attacker',
+        stats: {
+            attack: 1000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            shieldPenetration: 0,
+            defence: 0,
+            hp: 20000,
+            speed: 100,
+            hacking: 200,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        affinity: 'chemical',
+    });
+    return {
+        actor,
+        focus: true,
+        castSkills: skills,
+        reactiveAbilities: [],
+        timedSelfBySlot: [],
+        timedEnemyBySlot,
+        hasChargedSkill: false,
+        attack: 1000,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        defence: 0,
+        hp: 20000,
+        healModifier: 0,
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        affinityDisadvantage: false,
+        attackerAffinity: 'chemical',
+        activeCritGate: makeRateGate(),
+        chargedCritGate: makeRateGate(),
+        activeHealCritGate: makeRateGate(),
+        chargedHealCritGate: makeRateGate(),
+        debuffLandingGate: makeRateGate(),
+        extendChanceGate: makeRateGate(),
+        landsTimedEnemyApplication: () => true,
+        selfBuffLookup: new Map(),
+        enemyDebuffLookup: new Map(),
+    };
+}
+
+function makeArgs(
+    runtime: PlayerActorRuntime,
+    defer: boolean,
+    enemySecurity = 100
+): { args: PlayerTurnArgs; outcomes: string[] } {
+    const enemy = createActor({
+        id: 'anchor',
+        side: 'enemy',
+        kind: 'enemy',
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            shieldPenetration: 0,
+            defence: 0,
+            hp: 1e9,
+            speed: 50,
+            security: enemySecurity,
+        },
+        affinity: 'thermal',
+    });
+    const statusEngine = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+    statusEngine.beginRound(1);
+    const bus = createEventBus();
+    const outcomes: string[] = [];
+    bus.on('debuff-applied', () => outcomes.push('applied'));
+    bus.on('debuff-resisted', () => outcomes.push('resisted'));
+    return {
+        args: {
+            runtime,
+            enemy,
+            statusEngine,
+            corrosionEntries: [],
+            infernoEntries: [],
+            pendingBombs: [],
+            pendingAccumulators: [],
+            enemyDefense: 0,
+            enemyHp: 1e9,
+            enemyType: undefined,
+            bus,
+            round: 1,
+            targetId: 'anchor',
+            deferAbilityPerformedToEngine: defer,
+        },
+        outcomes,
+    };
+}
+
+describe('anchor debuff landing at real affinity (SP2a)', () => {
+    afterEach(() => resetRateGateRng());
+
+    it("'apply' debuff resists on positional path when anchor is disadvantage; lands on non-positional", () => {
+        const runtime = makeRuntime(applyDebuffSkill, timedEnemySlot('Defense Down', 'apply'));
+
+        const { args: posArgs, outcomes: posOutcomes } = makeArgs(runtime, true);
+        runPlayerTurn(posArgs);
+        expect(posOutcomes).toEqual(['resisted']);
+
+        const { args: npArgs, outcomes: npOutcomes } = makeArgs(
+            makeRuntime(applyDebuffSkill, timedEnemySlot('Defense Down', 'apply')),
+            false
+        );
+        runPlayerTurn(npArgs);
+        expect(npOutcomes).toEqual(['applied']);
+    });
+
+    it("'inflict' debuff lands at representative rate but resists at anchor disadvantage rate", () => {
+        const security = 150;
+        const repRate = Math.min(1, Math.max(0, (200 - security) / 100));
+        const anchorMod = computeAffinityModifiers('chemical', 'thermal').damageModifier;
+        const anchorRate = Math.min(1, Math.max(0, (200 * (1 + anchorMod / 100) - security) / 100));
+        expect(repRate).toBeGreaterThan(anchorRate);
+        const draw = (repRate + anchorRate) / 2;
+        expect(draw).toBeLessThan(repRate);
+        expect(draw).toBeGreaterThanOrEqual(anchorRate);
+
+        setRateGateRng(() => draw);
+
+        const runtime = makeRuntime(inflictDebuffSkill, timedEnemySlot('Disable', 'inflict'));
+        const { args: posArgs, outcomes: posOutcomes } = makeArgs(runtime, true, security);
+        runPlayerTurn(posArgs);
+        expect(posOutcomes).toEqual(['resisted']);
+
+        setRateGateRng(() => draw);
+
+        const { args: npArgs, outcomes: npOutcomes } = makeArgs(
+            makeRuntime(inflictDebuffSkill, timedEnemySlot('Disable', 'inflict')),
+            false,
+            security
+        );
+        runPlayerTurn(npArgs);
+        expect(npOutcomes).toEqual(['applied']);
+    });
+});

--- a/src/utils/combat/__tests__/anchorDebuffLandingRealAffinity.test.ts
+++ b/src/utils/combat/__tests__/anchorDebuffLandingRealAffinity.test.ts
@@ -9,6 +9,7 @@ import { createEventBus } from '../events';
 import { makeRateGate, setRateGateRng, resetRateGateRng } from '../../calculators/rateAccumulator';
 import { ShipSkills } from '../../../types/abilities';
 import { computeAffinityModifiers } from '../../calculators/affinityUtils';
+import { liveDebuffLandingChance } from '../effectiveStats';
 
 const applyDebuffSkill: ShipSkills = {
     slots: [
@@ -209,9 +210,57 @@ describe('anchor debuff landing at real affinity (SP2a)', () => {
 
     it("'inflict' debuff lands at representative rate but resists at anchor disadvantage rate", () => {
         const security = 150;
-        const repRate = Math.min(1, Math.max(0, (200 - security) / 100));
+        const landingAttacker = createActor({
+            id: 'attacker',
+            side: 'player',
+            kind: 'attacker',
+            stats: {
+                attack: 1000,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                shieldPenetration: 0,
+                defence: 0,
+                hp: 20000,
+                speed: 100,
+                hacking: 200,
+            },
+            affinity: 'chemical',
+        });
+        const landingDefender = createActor({
+            id: 'anchor',
+            side: 'enemy',
+            kind: 'enemy',
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                shieldPenetration: 0,
+                defence: 0,
+                hp: 1e9,
+                speed: 50,
+                security,
+            },
+            affinity: 'thermal',
+        });
+        const landingEngine = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        landingEngine.beginRound(1);
+        const repRate = liveDebuffLandingChance(
+            landingEngine,
+            new Map(),
+            landingAttacker,
+            landingDefender,
+            0
+        );
         const anchorMod = computeAffinityModifiers('chemical', 'thermal').damageModifier;
-        const anchorRate = Math.min(1, Math.max(0, (200 * (1 + anchorMod / 100) - security) / 100));
+        const anchorRate = liveDebuffLandingChance(
+            landingEngine,
+            new Map(),
+            landingAttacker,
+            landingDefender,
+            anchorMod
+        );
         expect(repRate).toBeGreaterThan(anchorRate);
         const draw = (repRate + anchorRate) / 2;
         expect(draw).toBeLessThan(repRate);

--- a/src/utils/combat/__tests__/perVictimDebuffLanding.test.ts
+++ b/src/utils/combat/__tests__/perVictimDebuffLanding.test.ts
@@ -1,0 +1,203 @@
+/**
+ * SP2b: per-victim debuff landing + apply on AoE footprint.
+ * - 'all-enemies' inflict: independent hacking roll per footprint victim
+ * - 'all-enemies' apply: independent affinity check per footprint victim
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, type CombatEvent } from '../events';
+import type { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { AffinityName } from '../../../types/ship';
+import { resetRateGateRng } from '../../calculators/rateAccumulator';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `pvdl${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+const lineRange3Pattern = (): ParsedPattern => ({
+    raw: 'line-range-3',
+    shape: 'line',
+    range: 3,
+    modifiers: {},
+});
+
+const basicEnemyAt = (
+    id: string,
+    position: Position,
+    selection: ParsedTarget['selection'],
+    opts: { security?: number; affinity?: AffinityName } = {}
+): EnemyAttacker =>
+    ({
+        id,
+        stats: {
+            attack: 1000,
+            crit: 0,
+            critDamage: 0,
+            defence: 0,
+            hp: 10_000_000,
+            speed: 1,
+            security: opts.security,
+        },
+        affinity: opts.affinity,
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget(selection),
+        pattern: lineRange3Pattern(),
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        ab({
+                            type: 'damage',
+                            target: 'enemy',
+                            config: { type: 'damage', multiplier: 100 },
+                        }),
+                    ],
+                },
+            ],
+        },
+    }) as EnemyAttacker;
+
+const runPositionalRound = (shipSkills: ShipSkills, enemyAttackers: EnemyAttacker[]) => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    bus.on('debuff-applied', (e) => events.push(e));
+    bus.on('debuff-resisted', (e) => events.push(e));
+    runCombat({
+        attack: 1000,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills,
+        enemyDefense: 0,
+        enemyHp: 10_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        affinity: 'chemical',
+        defence: 0,
+        hp: 10_000_000,
+        hacking: 200,
+        healTargetId: 'attacker',
+        position: 'M4',
+        target: parsedTarget('front'),
+        pattern: lineRange3Pattern(),
+        enemyAttackers,
+        bus,
+    });
+    return events.filter((e) => e.type === 'debuff-applied' || e.type === 'debuff-resisted');
+};
+
+describe('SP2b — per-victim debuff landing on footprint', () => {
+    afterEach(() => resetRateGateRng());
+
+    it("'all-enemies' inflict debuff: independent hacking roll per footprint victim", () => {
+        idc = 0;
+        const shipSkills: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        ab({
+                            type: 'damage',
+                            target: 'enemy',
+                            config: { type: 'damage', multiplier: 100 },
+                        }),
+                        ab({
+                            type: 'debuff',
+                            target: 'all-enemies',
+                            config: {
+                                type: 'debuff',
+                                buffName: 'Disable',
+                                parsedEffects: {},
+                                stacks: 1,
+                                isStackable: false,
+                                application: 'inflict',
+                                duration: 2,
+                            },
+                        }),
+                    ],
+                },
+            ],
+        };
+
+        const events = runPositionalRound(shipSkills, [
+            basicEnemyAt('enemy-front', 'M4', 'front', { security: 100 }),
+            basicEnemyAt('enemy-back', 'M1', 'back', { security: 250 }),
+        ]);
+
+        const applied = events.filter((e) => e.type === 'debuff-applied');
+        const resisted = events.filter((e) => e.type === 'debuff-resisted');
+
+        expect(applied.map((e) => e.targetId)).toEqual(['enemy-front']);
+        expect(resisted.map((e) => e.targetId)).toEqual(['enemy-back']);
+    });
+
+    it("'all-enemies' apply debuff: independent affinity check per footprint victim", () => {
+        idc = 0;
+        const shipSkills: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        ab({
+                            type: 'damage',
+                            target: 'enemy',
+                            config: { type: 'damage', multiplier: 100 },
+                        }),
+                        ab({
+                            type: 'debuff',
+                            target: 'all-enemies',
+                            config: {
+                                type: 'debuff',
+                                buffName: 'Defense Down',
+                                parsedEffects: { defense: -50 },
+                                stacks: 1,
+                                isStackable: false,
+                                application: 'apply',
+                                duration: 3,
+                            },
+                        }),
+                    ],
+                },
+            ],
+        };
+
+        const events = runPositionalRound(shipSkills, [
+            // chemical attacker vs thermal front → disadvantage; vs chemical back → neutral
+            basicEnemyAt('enemy-front', 'M4', 'front', { affinity: 'thermal' }),
+            basicEnemyAt('enemy-back', 'M1', 'back', { affinity: 'chemical' }),
+        ]);
+
+        const applied = events.filter((e) => e.type === 'debuff-applied');
+        const resisted = events.filter((e) => e.type === 'debuff-resisted');
+
+        expect(applied.map((e) => e.targetId)).toEqual(['enemy-back']);
+        expect(resisted.map((e) => e.targetId)).toEqual(['enemy-front']);
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3921,6 +3921,8 @@ export function runCombat(input: CombatEngineInput): {
                           (h) => h.victim.id
                       )
                     : undefined;
+            const opposingVictimById =
+                tgt.position != null ? new Map(tb.opposingRoster.map((v) => [v.id, v])) : undefined;
             return {
                 runtime: rt,
                 enemy: tgt,
@@ -3960,6 +3962,7 @@ export function runCombat(input: CombatEngineInput): {
                 enemyBuffNames: tb.enemyBuffNamesUnion(),
                 selfDebuffNames: ownerDebuffNames(a.id),
                 ...(aoeVictimIds ? { aoeVictimIds } : {}),
+                ...(opposingVictimById ? { opposingVictimById } : {}),
                 // Positional detonation hint: when the engine will take the positional apply path
                 // (same predicate that computes aoeVictimIds — pattern + target + position all set),
                 // runPlayerTurn SKIPS the anchor detonation (no consume/credit/emit) and instead

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1064,11 +1064,15 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         );
         const isAllEnemies = matchingAbility?.target === 'all-enemies';
         const recipientIds: (string | undefined)[] =
-            isAllEnemies && aoeVictimIds && aoeVictimIds.length > 0
-                ? aoeVictimIds
-                : targetId !== undefined
-                  ? [targetId]
-                  : [undefined];
+            positionalLanding && isAllEnemies
+                ? (aoeVictimIds ?? [])
+                : isAllEnemies && aoeVictimIds && aoeVictimIds.length > 0
+                  ? aoeVictimIds
+                  : targetId !== undefined
+                    ? [targetId]
+                    : positionalLanding
+                      ? []
+                      : [undefined];
 
         let anyLanded = false;
         for (const vid of recipientIds) {

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -346,6 +346,9 @@ export interface PlayerTurnArgs {
      * single `targetId`. Absent for non-positional callers → single-anchor (byte-identical).
      */
     aoeVictimIds?: string[];
+    /** SP2b: living opposing actors keyed by id — per-victim debuff landing/application in
+     *  positional mode. Supplied from the side's opposing roster. Absent → anchor-only path. */
+    opposingVictimById?: Map<string, CombatActor>;
     /** Positional mode (per-victim detonation): when true, runPlayerTurn does NOT detonate the
      *  anchor enemy's containers (no consume, no credit, no bomb-detonated emit) and instead
      *  returns a `positionalDetonation` recipe for the engine to apply per footprint victim.
@@ -718,6 +721,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         healEventOnly = false,
         onHitBreakStasis,
         aoeVictimIds,
+        opposingVictimById,
         positional,
     } = args;
 
@@ -791,13 +795,13 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         damageInputsFromSkill(firingSkill);
     const hasDamageAbility = damageAbility !== undefined;
 
-    const emitDebuffResisted = (buffName: string) =>
-        bus.emit({ type: 'debuff-resisted', targetId: enemy.id, round: r, buffName });
+    const emitDebuffResisted = (buffName: string, victimId: string = enemy.id) =>
+        bus.emit({ type: 'debuff-resisted', targetId: victimId, round: r, buffName });
     // emitDebuffApplied: discrete-infliction-only (Phase 3 retiming). `sourceId` is the
     // actor that inflicted the debuff. NOT called for recurring/aura per-round re-applications
     // or for every round a standing timed status is active — only at the infliction site.
-    const emitDebuffApplied = (sourceId: string, buffName: string) =>
-        bus.emit({ type: 'debuff-applied', sourceId, targetId: enemy.id, round: r, buffName });
+    const emitDebuffApplied = (sourceId: string, buffName: string, victimId: string = enemy.id) =>
+        bus.emit({ type: 'debuff-applied', sourceId, targetId: victimId, round: r, buffName });
 
     // LIVE per-target debuff-landing chance (A2 Task 4 / A-closeout). The sole producer of
     // landing chance: recomputed each turn from the acting actor's effective hacking (× this
@@ -840,6 +844,25 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
             : application === 'apply'
               ? !landingAtDisadvantage
               : debuffLandingGate(liveLandingChance);
+    const landsDebuffOnVictim = (
+        application: 'inflict' | 'apply' | undefined,
+        victim: CombatActor
+    ): boolean => {
+        if (targetCarriesBlockDebuff(statusEngine, victim.id)) return false;
+        const victimAff = victim.affinity ?? 'antimatter';
+        const victimAffinityMod = computeAffinityModifiers(attackerAff, victimAff).damageModifier;
+        if (application === 'apply') {
+            return victimAffinityMod >= 0;
+        }
+        const chance = liveDebuffLandingChance(
+            statusEngine,
+            selfBuffLookup,
+            actor,
+            victim,
+            victimAffinityMod
+        );
+        return debuffLandingGate(chance);
+    };
     // Publish the live chance onto the runtime so the REACTIVE (triggers.ts) path — which draws
     // the OWNER's landing gate via owner.debuffLandingGate(owner.liveDebuffLandingChance ?? 1) —
     // uses the same live value. Always set now (the live path is unconditional).
@@ -1035,22 +1058,55 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     for (const status of timedEnemyBySlot) {
         if (status.sourceSlot !== action) continue;
         if (!conditionsMet(status.conditions, preDebuffGateCtx)) continue;
-        if (landsTimedEnemyApplicationLive(status.payload.application)) {
-            statusEngine.applyTimedAbilityStatus(r, status, actor.id, targetId);
-            // Discrete infliction event — emit ONCE at this application site.
-            emitDebuffApplied(actor.id, status.payload.buffName);
-            inflictedEnemyDebuffs.push({
-                buffName: status.payload.buffName,
-                turnsRemaining: status.duration,
-            });
-        } else {
-            // status.duration is guaranteed numeric by the timed variant.
+
+        const matchingAbility = firingSkill?.abilities.find(
+            (a) => a.config.type === 'debuff' && a.config.buffName === status.payload.buffName
+        );
+        const isAllEnemies = matchingAbility?.target === 'all-enemies';
+        const recipientIds: (string | undefined)[] =
+            isAllEnemies && aoeVictimIds && aoeVictimIds.length > 0
+                ? aoeVictimIds
+                : targetId !== undefined
+                  ? [targetId]
+                  : [undefined];
+
+        let anyLanded = false;
+        for (const vid of recipientIds) {
+            const victim =
+                vid !== undefined
+                    ? (opposingVictimById?.get(vid) ?? (vid === enemy.id ? enemy : undefined))
+                    : enemy;
+            const usePerVictim =
+                positionalLanding && opposingVictimById != null && vid !== undefined;
+            if (usePerVictim && victim === undefined) continue;
+            const resolvedVictim = victim ?? enemy;
+            const emitTargetId = vid ?? resolvedVictim.id;
+
+            const lands = usePerVictim
+                ? landsDebuffOnVictim(status.payload.application, resolvedVictim)
+                : landsTimedEnemyApplicationLive(status.payload.application);
+
+            if (lands) {
+                statusEngine.applyTimedAbilityStatus(r, status, actor.id, vid);
+                emitDebuffApplied(actor.id, status.payload.buffName, emitTargetId);
+                if (!anyLanded) {
+                    inflictedEnemyDebuffs.push({
+                        buffName: status.payload.buffName,
+                        turnsRemaining: status.duration,
+                    });
+                }
+                anyLanded = true;
+            } else {
+                emitDebuffResisted(status.payload.buffName, emitTargetId);
+            }
+        }
+
+        if (!anyLanded && recipientIds.length > 0) {
             resistedAbilityTimedEnemy.push({
                 buffName: status.payload.buffName,
                 turnsRemaining: status.duration,
             });
             resistedTimedEnemyNames.push(status.payload.buffName);
-            emitDebuffResisted(status.payload.buffName);
         }
     }
 

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -807,12 +807,20 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     // `selfBuffLookup` folds scheduled self-buffs; timed ability statuses (the hacking/security
     // buffs that move landing) fold lookup-free from the status engine. Cached once per turn here
     // — every landing consumer below reads this value.
+    // SP2a: positional casts re-resolve affinity vs the bound anchor; non-positional keeps
+    // representative scalars (DPS byte-identical).
+    const attackerAff = attackerAffinity ?? actor.affinity ?? 'antimatter';
+    const positionalLanding = args.deferAbilityPerformedToEngine === true;
+    const landingAffinityMod = positionalLanding
+        ? computeAffinityModifiers(attackerAff, enemy.affinity ?? 'antimatter').damageModifier
+        : affinityDamageModifier;
+    const landingAtDisadvantage = positionalLanding ? landingAffinityMod < 0 : affinityDisadvantage;
     const liveLandingChance = liveDebuffLandingChance(
         statusEngine,
         selfBuffLookup,
         actor,
         enemy,
-        affinityDamageModifier
+        landingAffinityMod
     );
     // Block Debuff: an immune turn-target auto-resists every timed/persistent application.
     // Computed ONCE per turn (the turn target `enemy` is fixed for this turn) — the immune
@@ -830,7 +838,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         targetImmuneToDebuffs
             ? false
             : application === 'apply'
-              ? !affinityDisadvantage
+              ? !landingAtDisadvantage
               : debuffLandingGate(liveLandingChance);
     // Publish the live chance onto the runtime so the REACTIVE (triggers.ts) path — which draws
     // the OWNER's landing gate via owner.debuffLandingGate(owner.liveDebuffLandingChance ?? 1) —
@@ -919,7 +927,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     const recurringEnemy = resolveEnemyDebuffs({
         activeEnemyDebuffs: recurringEnemySnap,
         enemyDebuffLookup,
-        affinityDisadvantage,
+        affinityDisadvantage: landingAtDisadvantage,
         roundDebuffLanded,
         emitResisted: emitDebuffResisted,
         // No emitApplied: recurring/aura per-round re-applications are NOT discrete inflictions.
@@ -1106,7 +1114,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     for (const s of recurringAbilityEnemy) {
         const sb = payloadToSelectedBuff(s.payload);
         const isApply = sb.application === 'apply';
-        const lands = isApply ? !affinityDisadvantage : roundDebuffLanded();
+        const lands = isApply ? !landingAtDisadvantage : roundDebuffLanded();
         if (!lands) {
             resistedAbilityEnemy.push(s.active);
             emitDebuffResisted(s.payload.buffName);
@@ -1259,7 +1267,6 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     // attacker is at an affinity disadvantage against crits less often. The UNCAPPED crit total
     // (before any affinity cap) is `crit + dmgStats.totals.critBuff`; we cap it against THIS
     // victim's matchup (NOT the representative cappedCrit, which uses the bound target's cap).
-    const attackerAff = attackerAffinity ?? actor.affinity ?? 'antimatter';
     const uncappedCritTotal = crit + dmgStats.totals.critBuff;
     const rollVictimCrit = (victimAffinity: AffinityName): boolean => {
         // A noCrit attack can never crit — mirror the anchor (drawHits=0 → hitCrits empty


### PR DESCRIPTION
## Summary
- **SP2a:** Positional on-turn debuff landing re-resolves `'apply'` affinity and `'inflict'` hacking-vs-security against the bound anchor (not `enemy[0]` representative scalars). DPS/non-positional paths stay byte-identical.
- **SP2b:** `'all-enemies'` timed debuffs fan over footprint victims (purge E3 pattern) with **one inflict draw per victim** and **one affinity check per victim**. Engine threads `opposingVictimById` for victim security/affinity/Block Debuff resolution.
- Also includes **SP1** anchor crit at real affinity (`662c3b3c`) — same commit as #184; rebase onto `main` after #184 merges if needed.

## Test plan
- [x] `anchorDebuffLandingRealAffinity.test.ts` — apply + inflict anchor vs representative divergence
- [x] `perVictimDebuffLanding.test.ts` — all-enemies inflict (per-victim security) + apply (per-victim affinity)
- [x] `perVictimDebuffRouting.test.ts`, `targetIdRouting.test.ts` — regression
- [x] Full suite (3709 tests); DPS + healing goldens byte-identical


Made with [Cursor](https://cursor.com)