### PR TITLE
fix(combat): correct charge manip for Selenite, Graphite, and Liberator

### DIFF
--- a/src/components/simulator/RoundEventLog.tsx
+++ b/src/components/simulator/RoundEventLog.tsx
@@ -206,8 +206,9 @@ const RoundEventLog: React.FC<RoundEventLogProps> = ({ round, roster }) => {
     const ctx: FormatterCtx = { nameOf };
 
     const turns = round?.turns ?? [];
+    const startOfRound = round?.startOfRound ?? [];
     const endOfRound = round?.endOfRound ?? [];
-    const hasContent = turns.length > 0 || endOfRound.length > 0;
+    const hasContent = startOfRound.length > 0 || turns.length > 0 || endOfRound.length > 0;
 
     return (
         <div className="card">
@@ -216,6 +217,18 @@ const RoundEventLog: React.FC<RoundEventLogProps> = ({ round, roster }) => {
                 <p className="text-sm text-theme-text-secondary">No events this round.</p>
             ) : (
                 <ul className="max-h-[500px] overflow-y-auto space-y-1 text-sm">
+                    {startOfRound.length > 0 && (
+                        <li>
+                            <div className="text-theme-text-secondary font-semibold border-b border-dark-border mb-1 pb-1">
+                                — start of round —
+                            </div>
+                            <ul className="ml-2 space-y-1">
+                                {startOfRound.map((entry, i) => (
+                                    <EntryView key={i} entry={entry} ctx={ctx} />
+                                ))}
+                            </ul>
+                        </li>
+                    )}
                     {turns.map((turn, i) => (
                         <TurnView key={i} turn={turn} ctx={ctx} />
                     ))}

--- a/src/components/simulator/__tests__/RoundEventLog.test.tsx
+++ b/src/components/simulator/__tests__/RoundEventLog.test.tsx
@@ -15,6 +15,7 @@ const roster: BattleResult['roster'] = [
 // another) that triggers a reaction, a buff entry with a note, and an end-of-round DoT tick.
 const round: CombatLogRound = {
     round: 3,
+    startOfRound: [],
     turns: [
         {
             actorId: 'nova',
@@ -114,7 +115,7 @@ describe('RoundEventLog', () => {
     });
 
     it('shows a fallback message when the round has no content', () => {
-        const empty: CombatLogRound = { round: 1, turns: [], endOfRound: [] };
+        const empty: CombatLogRound = { round: 1, startOfRound: [], turns: [], endOfRound: [] };
         render(<RoundEventLog round={empty} roster={roster} />);
         expect(screen.getByText('No events this round.')).toBeInTheDocument();
     });

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -7,6 +7,7 @@ export const CURRENT_VERSION = '1.64.0';
 // and bump CURRENT_VERSION. All three steps must happen together.
 export const UNRELEASED_CHANGES: string[] = [
     'Combat sim: positioned board battles with skill-pattern targeting; shields and damage absorption; implants and gear set effects; control effects (Disable, Stasis, stealth); DoT, bombs, and detonations; counterattacks and enemy reactions; detailed combat log; affinity and charge rules; random crit/proc variance. DPS calculator now includes implant and gear set effects.',
+    'Combat sim charge fixes: Selenite only gains charge vs live Stealth; Graphite start-of-round grant requires a living stealthed enemy and logs at round start; Liberator ally-charge on enemy death fires once per round for any kill (including ally kills).',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/__tests__/SimulatorPage.playback.test.tsx
+++ b/src/pages/__tests__/SimulatorPage.playback.test.tsx
@@ -107,6 +107,7 @@ const battleResult: BattleResult = {
     combatLog: [
         {
             round: 1,
+            startOfRound: [],
             turns: [
                 {
                     actorId: 'attacker',
@@ -134,6 +135,7 @@ const battleResult: BattleResult = {
         },
         {
             round: 2,
+            startOfRound: [],
             turns: [
                 {
                     actorId: 'attacker',

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -1260,13 +1260,13 @@ describe('parseChargeGain', () => {
         });
     });
 
-    it('parses stealth condition as enemy-buff (manual) — Selenite', () => {
+    it('parses stealth condition as live enemy-buff — Selenite', () => {
         const text =
             "If any target is <unit-aid>Stealthed</unit-aid>, it <unit-aid>adds 1 charge</unit-aid> to this Unit's Charged Skill.";
         expect(parseChargeGain(text)).toEqual({
             amount: 1,
             condition: 'enemy-buff',
-            derivable: false,
+            derivable: true,
         });
     });
 
@@ -1621,9 +1621,9 @@ describe('detectReactiveTrigger — non-Marauder reclassifications (Overload-lif
 
 describe('parseSelfBuffRemovals', () => {
     it('emits for "loses Overload on kill"', () =>
-        expect(
-            parseSelfBuffRemovals('loses <unit-skill>Overload</unit-skill> on kill')
-        ).toEqual([{ buffName: 'Overload', trigger: 'on-enemy-destroyed' }]));
+        expect(parseSelfBuffRemovals('loses <unit-skill>Overload</unit-skill> on kill')).toEqual([
+            { buffName: 'Overload', trigger: 'on-enemy-destroyed' },
+        ]));
     it('emits for "removes Overload" (Ruiner)', () =>
         expect(
             parseSelfBuffRemovals(
@@ -1631,9 +1631,9 @@ describe('parseSelfBuffRemovals', () => {
             )
         ).toEqual([{ buffName: 'Overload', trigger: 'on-enemy-destroyed' }]));
     it('emits for passive "Overload is lost" (Butcher R2)', () =>
-        expect(
-            parseSelfBuffRemovals('On kill, <unit-skill>Overload</unit-skill> is lost')
-        ).toEqual([{ buffName: 'Overload', trigger: 'on-enemy-destroyed' }]));
+        expect(parseSelfBuffRemovals('On kill, <unit-skill>Overload</unit-skill> is lost')).toEqual(
+            [{ buffName: 'Overload', trigger: 'on-enemy-destroyed' }]
+        ));
     it('resolves the removal trigger by removal position, not first buff-name sentence (Asphyxiator)', () =>
         expect(
             parseSelfBuffRemovals(

--- a/src/utils/abilities/__tests__/applyAbilities.test.ts
+++ b/src/utils/abilities/__tests__/applyAbilities.test.ts
@@ -409,14 +409,17 @@ describe('accumulatorsFromSkill', () => {
 });
 
 describe('chargeAbilitiesFromSkill', () => {
-    it('extracts all charge abilities', () => {
+    it('extracts on-cast charge abilities only', () => {
         const c1 = charge('c1', 1);
-        const c2 = charge('c2', 2);
+        const reactive: Ability = {
+            ...charge('c2', 2),
+            trigger: 'on-enemy-destroyed',
+        };
         const skill: Skill = {
             slot: 'active',
-            abilities: [damage('a', 100), c1, c2],
+            abilities: [damage('a', 100), c1, reactive],
         };
-        expect(chargeAbilitiesFromSkill(skill)).toEqual([c1, c2]);
+        expect(chargeAbilitiesFromSkill(skill)).toEqual([c1]);
     });
 
     it('returns empty array when no charge abilities', () => {

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -55,7 +55,7 @@ describe('buildShipAbilities', () => {
         });
         expect(charge!.conditions[0]).toMatchObject({
             subject: 'enemy-buff',
-            derivable: false,
+            derivable: true,
             buffName: 'Stealth',
         });
     });
@@ -3015,6 +3015,7 @@ describe('buildShipAbilities — all-allies charge-bar grants (Hayyan / Graphite
             type: 'charge',
             target: 'all-allies',
             trigger: 'on-enemy-destroyed',
+            oncePerRound: true,
             config: { type: 'charge', amount: 1 },
         });
         // No spurious on-cast charge from parseAllyChargeGrant.

--- a/src/utils/abilities/applyAbilities.ts
+++ b/src/utils/abilities/applyAbilities.ts
@@ -145,9 +145,11 @@ export function dotsFromSkill(skill: Skill | undefined): DoTApplicationConfig {
     return config;
 }
 
-/** All `charge` abilities on the skill. */
+/** Cast-time `charge` abilities on the skill. Reactive charge grants (start-of-round,
+ *  on-enemy-destroyed, etc.) are partitioned out of castSkills — mirroring
+ *  controlAbilitiesFromSkill so the cast path never double-fires them. */
 export function chargeAbilitiesFromSkill(skill: Skill | undefined): Ability[] {
-    return skill?.abilities.filter((a) => a.type === 'charge') ?? [];
+    return skill?.abilities.filter((a) => a.type === 'charge' && a.trigger === 'on-cast') ?? [];
 }
 
 /** Cast-time `control` abilities on the skill (e.g. Defiant's charged Stasis inflict). The control

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -1377,6 +1377,8 @@ function abilitiesFromText(
                 trigger: 'on-enemy-destroyed',
                 conditions: [],
                 config: { type: 'charge', amount: allyCharge.amount },
+                // Once per round even when multiple enemies die in the same round (Liberator).
+                oncePerRound: true,
                 autoFilled: true,
             },
             pos: allyChargePos >= 0 ? allyChargePos : MAX_POS,

--- a/src/utils/combat/__tests__/allyChargeGrant.test.ts
+++ b/src/utils/combat/__tests__/allyChargeGrant.test.ts
@@ -393,6 +393,32 @@ describe('player-side Graphite gate + single-grant-per-round', () => {
         // pins exactly-one grant per round.
         expect(amt1Charged).toBe(2);
     });
+
+    it('gate OFF in a later round when the only Stealth holder died (corpse buff ignored)', () => {
+        // Positional kill: focus one-shots the stealthed enemy attacker in round 1. Later rounds
+        // must NOT treat the corpse's lingering Stealth as a live gate.
+        const positional = (enemy: EnemyAttacker): CombatEngineInput => ({
+            ...buildInput(2, enemy, 4),
+            attack: 50_000,
+            numRounds: 6,
+            position: 'M4',
+            target: { raw: 'front', side: 'enemy', selection: 'front' },
+            pattern: { raw: 'base', shape: 'base', range: 0, modifiers: {} },
+            enemyAttackers: [{ ...enemy, position: 'M4', stats: { ...enemy.stats, hp: 5000 } }],
+        });
+        const afterKill = runCombat(positional(stealthEnemy()));
+        const noStealthAlive = runCombat(
+            positional({
+                ...plainEnemy(),
+                id: 'e-plain-pos',
+            })
+        );
+
+        const chargedAfterKill = firstChargedRound(afterKill.rounds);
+        const chargedNoStealth = firstChargedRound(noStealthAlive.rounds);
+
+        expect(chargedAfterKill).toBe(chargedNoStealth);
+    });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/utils/combat/__tests__/reactiveExtraAction.test.ts
+++ b/src/utils/combat/__tests__/reactiveExtraAction.test.ts
@@ -185,6 +185,7 @@ describe('reactive death-triggered bridge', () => {
                             type: 'charge',
                             target: 'all-allies',
                             trigger: 'on-enemy-destroyed',
+                            oncePerRound: true,
                             config: { type: 'charge', amount: 1 },
                         }),
                     ],
@@ -224,7 +225,89 @@ describe('reactive death-triggered bridge', () => {
         expect(result.rounds[0].charges).toBeGreaterThan(baseline.rounds[0].charges);
     });
 
-    // ── Path A: Harvester on-ally-destroyed → SAME-round extra action ────────
+    it('Liberator on-enemy-death charge fires when an ally kills, once per round (not killer-scoped)', () => {
+        idCounter = 0;
+        const liberatorSkills: ShipSkills = {
+            slots: [
+                {
+                    slot: 'passive',
+                    abilities: [
+                        ab({
+                            type: 'charge',
+                            target: 'all-allies',
+                            trigger: 'on-enemy-destroyed',
+                            oncePerRound: true,
+                            config: { type: 'charge', amount: 1 },
+                        }),
+                    ],
+                },
+            ],
+        };
+        const killerWalk: TeamActorEngineInput = {
+            id: 'killer',
+            speed: 100,
+            chargeCount: 0,
+            startCharged: false,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            position: 'M4',
+            target: frontTarget(),
+            pattern: basePattern(),
+            walk: {
+                shipSkills: {
+                    slots: [
+                        {
+                            slot: 'active',
+                            abilities: [
+                                ab({
+                                    type: 'damage',
+                                    target: 'enemy',
+                                    config: { type: 'damage', multiplier: 100 },
+                                }),
+                            ],
+                        },
+                    ],
+                },
+                stats: {
+                    attack: 5000,
+                    crit: 0,
+                    critDamage: 0,
+                    defensePenetration: 0,
+                    hacking: 0,
+                    defence: 0,
+                    hp: 100_000,
+                },
+                selfDotModifier: 0,
+                defensePenetrationBuff: 0,
+                affinityDamageModifier: 0,
+                affinityCritCap: 100,
+                affinityCritPenalty: 0,
+                hasChargedSkill: false,
+            },
+        };
+        const withAllyKill = runCombat(
+            positionalKillBase(liberatorSkills, {
+                attack: 100,
+                speed: 50,
+                chargeCount: 4,
+                hasChargedSkill: true,
+                teamActors: [killerWalk],
+            })
+        );
+        const noPassive = runCombat(
+            positionalKillBase(
+                { slots: [] },
+                {
+                    attack: 100,
+                    speed: 50,
+                    chargeCount: 4,
+                    hasChargedSkill: true,
+                    teamActors: [killerWalk],
+                }
+            )
+        );
+        expect(withAllyKill.rounds[0].charges).toBeGreaterThan(noPassive.rounds[0].charges);
+    });
     // Path A fires when a death happens DURING a turn while the round queue is still walked.
     // In normal DPS the only death is the post-round enemy reconciliation (Path B); a PLAYER
     // ally dies mid-round only in HEALING mode, when an enemy attacker kills the heal target.

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -1839,8 +1839,12 @@ export function runCombat(input: CombatEngineInput): {
     //    by its id — the tank carries the enemy attacker's debuffs).
     //  - ENEMY actor's `enemy-buff` gate → opposing side = the player team (union of player
     //    self-buff names). `self-debuff` → its own per-target debuff store keyed by its id.
+    const livingEnemyAttackerIds = (): string[] =>
+        enemyAttackerActorIds.filter((id) => allActorsById.get(id)?.destroyedRound === undefined);
+    const isActorAlive = (actorId: string): boolean =>
+        allActorsById.get(actorId)?.destroyedRound === undefined;
     const playerEnemyBuffNames = (): string[] =>
-        selfBuffNamesForOwners(statusEngine, enemyAttackerActorIds);
+        selfBuffNamesForOwners(statusEngine, livingEnemyAttackerIds());
     const enemyEnemyBuffNames = (): string[] => selfBuffNamesForOwners(statusEngine, playerIds);
     const ownerDebuffNames = (ownerId: string): string[] =>
         ownerDebuffNamesFor(statusEngine, ownerId);
@@ -4279,6 +4283,7 @@ export function runCombat(input: CombatEngineInput): {
                         // Task 7: drain `enemy-buff` gates read the union of enemy attackers'
                         // self-buffs (names only). Empty in DPS mode → byte-identical.
                         enemyAttackerIds: enemyAttackerActorIds,
+                        isActorAlive,
                         lastTurnCtxByActor,
                         enemyType,
                         enemyHp,

--- a/src/utils/combat/log/__testutils__/flattenCombatLog.ts
+++ b/src/utils/combat/log/__testutils__/flattenCombatLog.ts
@@ -6,18 +6,20 @@ function visitEntry(entry: CombatLogEntry, out: CombatLogEntry[]): void {
     for (const re of entry.reactions) visitEntry(re, out);
 }
 
-/** All entries within one round: turn entries + their nested reactions + endOfRound. */
+/** All entries within one round: start-of-round + turn entries + nested reactions + endOfRound. */
 export function flattenRound(round: CombatLogRound): CombatLogEntry[] {
     const out: CombatLogEntry[] = [];
+    for (const e of round.startOfRound) visitEntry(e, out);
     for (const turn of round.turns) for (const e of turn.entries) visitEntry(e, out);
     for (const e of round.endOfRound) visitEntry(e, out);
     return out;
 }
 
-/** All entries across all rounds: turn entries + their nested reactions + endOfRound. */
+/** All entries across all rounds: start-of-round + turn entries + nested reactions + endOfRound. */
 export function flattenCombatLog(result: { combatLog: CombatLogRound[] }): CombatLogEntry[] {
     const out: CombatLogEntry[] = [];
     for (const round of result.combatLog) {
+        for (const e of round.startOfRound) visitEntry(e, out);
         for (const turn of round.turns) for (const e of turn.entries) visitEntry(e, out);
         for (const e of round.endOfRound) visitEntry(e, out);
     }

--- a/src/utils/combat/log/buildCombatLog.ts
+++ b/src/utils/combat/log/buildCombatLog.ts
@@ -14,6 +14,8 @@ interface BuildContext {
     currentRound: CombatLogRound | undefined;
     /** Mutable current-turn pointer — undefined outside a turn. */
     currentTurn: CombatLogTurn | undefined;
+    /** True from round-started until the first turn-started of that round. */
+    beforeFirstTurn: boolean;
     /** The most-recently opened attack entry (ability-performed → attacked window). */
     openAttackEntry: CombatLogEntry | undefined;
     /** The `damage` from the most-recent `ability-performed` (used for primary-target amount). */
@@ -105,6 +107,7 @@ function createBuildContext(
         rounds: [],
         currentRound: undefined,
         currentTurn: undefined,
+        beforeFirstTurn: false,
         openAttackEntry: undefined,
         openAttackAbilityDamage: undefined,
         openAttackAbilityTargetId: undefined,
@@ -119,14 +122,16 @@ function createBuildContext(
 
         openRound(round: number) {
             ctx.closeOpenAttack();
-            const r: CombatLogRound = { round, turns: [], endOfRound: [] };
+            const r: CombatLogRound = { round, startOfRound: [], turns: [], endOfRound: [] };
             ctx.rounds.push(r);
             ctx.currentRound = r;
             ctx.currentTurn = undefined;
+            ctx.beforeFirstTurn = true;
         },
 
         openTurn(actorId: string) {
             if (!ctx.currentRound) return;
+            ctx.beforeFirstTurn = false;
             ctx.closeOpenAttack(); // also clears pendingSkill
             const t: CombatLogTurn = {
                 actorId,
@@ -151,8 +156,11 @@ function createBuildContext(
                 ctx.currentTurn.entries.push(entry);
                 return;
             }
-            // No current turn and no stamp — round-end drain window.
-            if (ctx.currentRound) ctx.currentRound.endOfRound.push(entry);
+            // No current turn and no stamp — round-start vs round-end drain window.
+            if (ctx.currentRound) {
+                if (ctx.beforeFirstTurn) ctx.currentRound.startOfRound.push(entry);
+                else ctx.currentRound.endOfRound.push(entry);
+            }
         },
 
         routeReaction(entry: CombatLogEntry, stamp: { duringTurnOf: string }) {

--- a/src/utils/combat/log/types.ts
+++ b/src/utils/combat/log/types.ts
@@ -1,5 +1,7 @@
 export interface CombatLogRound {
     round: number;
+    /** Entries drained after round-started but before the first turn (start-of-round reactives). */
+    startOfRound: CombatLogEntry[];
     turns: CombatLogTurn[];
     endOfRound: CombatLogEntry[]; // round-end-drained entries with no enclosing turn (filled by a later task)
 }

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -784,6 +784,10 @@ export interface IntentExecContext {
      *  `enemy-buff` gate is the enemy attacker(s) — drain sources their UNION self-buff names from
      *  here. Empty/omitted in DPS mode (no enemy attackers) → drain `enemyBuffNames` stays []. */
     enemyAttackerIds?: string[];
+    /** When supplied, filters `enemyAttackerIds` to living opposing actors for the
+     *  drain-time `enemy-buff` gate (Graphite start-of-round Stealth check). Absent →
+     *  all ids pass through (byte-identical for callers that omit it). */
+    isActorAlive?: (actorId: string) => boolean;
     /** Per-actor last-turn ctx (effectiveAttack/affinityMult for bombs). Undefined for an
      *  owner that has not acted this run (faster enemy, round 1) → bomb follow-ups skip. */
     lastTurnCtxByActor: Map<string, PlayerRoundCtx>;
@@ -1012,7 +1016,10 @@ function buildDrainContext(ctx: IntentExecContext, ownerId: string) {
         // reads the UNION of enemy attackers' self-buffs; its `self-debuff` gate reads its OWN
         // enemy-applied debuffs (per-target store keyed by ownerId). Both empty in DPS mode
         // (no enemy attackers, no debuffs on player actors) → drain gating byte-identical.
-        enemyBuffNames: selfBuffNamesForOwners(ctx.statusEngine, ctx.enemyAttackerIds ?? []),
+        enemyBuffNames: selfBuffNamesForOwners(
+            ctx.statusEngine,
+            (ctx.enemyAttackerIds ?? []).filter((id) => ctx.isActorAlive?.(id) ?? true)
+        ),
         selfDebuffNames: ownerDebuffNamesFor(ctx.statusEngine, ownerId),
         // Phase 4c PR 6: live lowest-speed-ally gate (Chakara). Default true → DPS / no-delegate
         // paths keep the lone-actor assumption and stay byte-identical.
@@ -1477,6 +1484,7 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
     if (!conditionsMet(gateConditions, buildDrainContext(ctx, intent.ownerId))) return;
 
     if (cfg.type === 'charge') {
+        if (!passesOncePerRoundGate(intent, ctx)) return;
         if (intent.ability.target === 'enemy' || intent.ability.target === 'all-enemies') {
             // every-Nth-event gate (Zosimos "every second repair"): count per (owner, ability,
             // repairer); only act on the Nth event. Requires a repairer id and the counter map.

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -487,7 +487,9 @@ function classifyChargeCondition(
     // on-ally-debuff-inflicted), not as a per-standing enemy-debuff count condition. They never
     // reach classifyChargeCondition. Any other "inflict … debuff" charge text that slips through
     // falls to the always-true default below (a safe per-cast baseline).
-    if (p.includes('stealth')) return { condition: 'enemy-buff', derivable: false };
+    // Stealth-gated self charge (Selenite): live enemy-buff gate — derivable so the cast path
+    // reads the opposing side's current Stealth holders, not a static manualCount.
+    if (p.includes('stealth')) return { condition: 'enemy-buff', derivable: true };
     if (
         p.includes('buffs on the target') ||
         p.includes('buff on the target') ||
@@ -935,7 +937,8 @@ function detectRemovalTriggerAt(text: string, idx: number): AbilityTrigger {
             break;
         }
     }
-    const windowStart = containing > 0 ? segments[containing - 1].start : segments[containing].start;
+    const windowStart =
+        containing > 0 ? segments[containing - 1].start : segments[containing].start;
     const window = masked.slice(windowStart, segments[containing].end);
     // Order mirrors detectReactiveTrigger's reactive tail. For a REMOVAL window kill-first is safe:
     // the window excludes the earlier repair-grant segment (Ruiner), so it cannot match repair.


### PR DESCRIPTION
Stealth-gated charge gains now read live enemy buffs; start-of-round grants ignore dead stealthed corpses and log under start-of-round; Liberator's on-enemy-death ally charge fires once per round via the reactive executor.