### PR TITLE
feat(skills): parse pre-combat stat passives (sub-project F, PR F4)

### DIFF
--- a/scripts/auditSkills.ts
+++ b/scripts/auditSkills.ts
@@ -55,6 +55,14 @@ interface ShipRow {
     slots: { slot: string; text: string }[];
 }
 
+// KNOWN GAP (pre-existing, verified 2026-07-02): this reader is line-per-record, but six
+// CSV records (Centurion, Enforcer, Chimei, …) carry literal newlines inside quoted passive
+// texts and are silently dropped (141 of 147 records audited). A quote-parity record-joining
+// fix recovers them but surfaces two pre-existing findings on the recovered ships (Chimei
+// active: the detonation keyword false-positives on the "Out. Detonation Damage Up III" buff
+// NAME; Lingshe passive1: ungated bomb→Stealth grant) — fix those first, then join records.
+// The pre-combat-stat rule below was verified out-of-band against all 147 records: it hits
+// exactly Lionheart/Centurion/Enforcer/Defiant/Stalwart, all handled.
 function readShips(): ShipRow[] {
     const lines = readFileSync(CSV_PATH, 'utf8').split('\n').filter(Boolean);
     const rows: ShipRow[] = [];
@@ -169,6 +177,30 @@ const RULES: Rule[] = [
         severity: 'high',
         keyword: (t) => /echoing burst/i.test(t),
         handled: (a) => hasType(a, 'accumulate-detonate'),
+    },
+    {
+        id: 'pre-combat-stat',
+        severity: 'high',
+        // PR F4: permanent pre-fight base-stat passives. Hits exactly the corpus shapes —
+        // start-of-combat attack-per-adjacent-ally (Centurion), start-of-combat %-of-HP
+        // grant to adjacent allies (Lionheart), and role-gated "adjacent to a <role> …
+        // gains" self grants in either ordering (Enforcer trailing gate, Defiant/Stalwart
+        // leading gate). Madax's "receives 30% more Repairs" carries no "gains" list and
+        // is deliberately out of scope.
+        keyword: (t) =>
+            /at the start of combat,?\s*this unit gains \d[\d,]*\s*attack per adjacent ally/i.test(
+                t
+            ) ||
+            /at the start of combat,?\s*this unit grants all adjacent allies \d+(?:\.\d+)?%\s*of its (?:max\s*)?hp/i.test(
+                t
+            ) ||
+            /this unit gains [^.;]+?\s(?:if|when|while)\s+adjacent to an?\s+(?:supporter|defender|attacker|debuffer)\b/i.test(
+                t
+            ) ||
+            /when (?:this unit is )?adjacent to an?\s+(?:supporter|defender|attacker|debuffer),\s*this unit gains \d/i.test(
+                t
+            ),
+        handled: (a) => hasType(a, 'pre-combat-stat'),
     },
 ];
 

--- a/src/components/skills/AbilityCard.tsx
+++ b/src/components/skills/AbilityCard.tsx
@@ -62,6 +62,7 @@ const ABILITY_TYPE_LABELS: Record<Ability['type'], string> = {
     'outgoing-amplification': 'Outgoing Amplification',
     'heal-amplification': 'Heal Amplification',
     'incoming-heal-amplification': 'Incoming Heal Amplification',
+    'pre-combat-stat': 'Pre-Combat Stat',
 };
 
 const TARGET_OPTIONS: { value: AbilityTarget; label: string }[] = [
@@ -128,6 +129,22 @@ const ROLE_FILTER_OPTIONS: { value: ShipRoleCategory; label: string }[] = [
     { value: 'DEFENDER', label: 'Defender' },
     { value: 'DEBUFFER', label: 'Debuffer' },
     { value: 'SUPPORTER', label: 'Supporter' },
+];
+
+const PRE_COMBAT_STAT_OPTIONS: { value: 'hp' | 'attack' | 'crit' | 'hacking'; label: string }[] = [
+    { value: 'hp', label: 'HP' },
+    { value: 'attack', label: 'Attack' },
+    { value: 'crit', label: 'Crit Rate' },
+    { value: 'hacking', label: 'Hacking' },
+];
+
+const PRE_COMBAT_VALUE_KIND_OPTIONS: {
+    value: 'flat' | 'percent-of-own' | 'percent-of-donor';
+    label: string;
+}[] = [
+    { value: 'flat', label: 'Flat points' },
+    { value: 'percent-of-own', label: "% of recipient's stat" },
+    { value: 'percent-of-donor', label: "% of granting ship's stat" },
 ];
 
 const TRIGGER_OPTIONS: { value: AbilityTrigger; label: string }[] = [
@@ -690,6 +707,76 @@ export const AbilityCard: React.FC<Props> = ({
                             updateConfig({ ...config, count: toNumber(e.target.value) })
                         }
                     />
+                );
+
+            case 'pre-combat-stat':
+                return (
+                    <div className="space-y-2">
+                        <p className="text-xs text-theme-text-secondary">
+                            Permanent base-stat grant applied before round 1 (battle simulator
+                            only). Hidden and non-purgeable — never a timed status.
+                        </p>
+                        <div className="flex flex-wrap gap-2">
+                            <Select
+                                label="Stat"
+                                value={config.stat}
+                                options={PRE_COMBAT_STAT_OPTIONS}
+                                onChange={(value) =>
+                                    updateConfig({
+                                        ...config,
+                                        stat: value as 'hp' | 'attack' | 'crit' | 'hacking',
+                                    })
+                                }
+                            />
+                            <Input
+                                label="Value"
+                                type="number"
+                                step="0.01"
+                                value={config.value}
+                                onChange={(e) =>
+                                    updateConfig({ ...config, value: toNumber(e.target.value) })
+                                }
+                            />
+                            <Select
+                                label="Value kind"
+                                helpLabel="Flat = absolute points (crit rate is always flat). % of recipient = scales the receiving ship's own pre-fight stat. % of granting ship = scales the donor's stat (Lionheart)."
+                                value={config.valueKind}
+                                options={PRE_COMBAT_VALUE_KIND_OPTIONS}
+                                onChange={(value) =>
+                                    updateConfig({
+                                        ...config,
+                                        valueKind: value as
+                                            | 'flat'
+                                            | 'percent-of-own'
+                                            | 'percent-of-donor',
+                                    })
+                                }
+                            />
+                        </div>
+                        <Checkbox
+                            label="Multiply by adjacent-ally count"
+                            checked={config.perAdjacentAlly ?? false}
+                            onChange={(checked) =>
+                                updateConfig({
+                                    ...config,
+                                    perAdjacentAlly: checked ? true : undefined,
+                                })
+                            }
+                        />
+                        <Select
+                            label="Requires adjacent role"
+                            helpLabel="Grant applies only while adjacent to at least one living ally of this role category. None = unconditional."
+                            value={config.requiresAdjacentRole ?? 'none'}
+                            options={[{ value: 'none', label: 'None' }, ...ROLE_FILTER_OPTIONS]}
+                            onChange={(value) =>
+                                updateConfig({
+                                    ...config,
+                                    requiresAdjacentRole:
+                                        value === 'none' ? undefined : (value as ShipRoleCategory),
+                                })
+                            }
+                        />
+                    </div>
                 );
 
             default:

--- a/src/components/skills/AbilityTypePicker.tsx
+++ b/src/components/skills/AbilityTypePicker.tsx
@@ -32,6 +32,7 @@ const TYPE_LABELS: Record<AbilityType, string> = {
     'outgoing-amplification': 'Outgoing Amplification',
     'heal-amplification': 'Heal Amplification',
     'incoming-heal-amplification': 'Incoming Heal Amplification',
+    'pre-combat-stat': 'Pre-Combat Stat',
 };
 
 const CATEGORIES: { label: string; types: AbilityType[]; note?: string }[] = [
@@ -53,6 +54,11 @@ const CATEGORIES: { label: string; types: AbilityType[]; note?: string }[] = [
         label: 'Utility',
         types: ['heal', 'shield', 'cleanse', 'purge', 'control'],
         note: NOT_SIMULATED_NOTE,
+    },
+    {
+        label: 'Pre-Combat',
+        types: ['pre-combat-stat'],
+        note: 'Permanent base-stat grant applied before round 1 — battle simulator only.',
     },
 ];
 

--- a/src/components/skills/abilityDefaults.ts
+++ b/src/components/skills/abilityDefaults.ts
@@ -89,6 +89,8 @@ const makeDefaultConfig = (type: AbilityType): AbilityConfig => {
             return { type: 'heal-amplification', condition: 'target-hp-below-self', ampPct: 0 };
         case 'incoming-heal-amplification':
             return { type, ampPct: 0, procChance: 0 };
+        case 'pre-combat-stat':
+            return { type, stat: 'attack', value: 0, valueKind: 'flat' };
     }
 };
 
@@ -117,6 +119,7 @@ const DEFAULT_TARGETS: Record<AbilityType, AbilityTarget> = {
     'outgoing-amplification': 'self',
     'heal-amplification': 'self',
     'incoming-heal-amplification': 'self',
+    'pre-combat-stat': 'self',
 };
 
 /**
@@ -131,8 +134,11 @@ export const makeDefaultAbility = (type: AbilityType, id: string = nextId()): Ab
     // A counter only ever fires on the victim-side `on-attacked` path (the parser builds it
     // that way and the combat executor reads that trigger), so default it correctly — the
     // helper should always yield a semantically valid ability, even though counters are
-    // currently parser-generated rather than authored via the picker.
-    trigger: type === 'counter' ? 'on-attacked' : 'on-cast',
+    // currently parser-generated rather than authored via the picker. Likewise a
+    // pre-combat-stat grant only ever rides the annotation-only 'pre-combat' trigger
+    // (the battle sim's pre-fight layer reads it before any combat event exists).
+    trigger:
+        type === 'counter' ? 'on-attacked' : type === 'pre-combat-stat' ? 'pre-combat' : 'on-cast',
     conditions: [],
     config: makeDefaultConfig(type),
 });

--- a/src/types/__tests__/abilities.test.ts
+++ b/src/types/__tests__/abilities.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { Ability } from '../abilities';
 import { SELENITE, LODOLITE, LIONHEART } from '../../utils/abilities/abilityFixtures';
+import { buildShipAbilities } from '../../utils/abilities/buildShipAbilities';
+import { Ship } from '../ship';
 
 describe('ability model shape', () => {
     it('Selenite has a conditional self charge ability gated on enemy Stealth', () => {
@@ -17,15 +19,19 @@ describe('ability model shape', () => {
         expect(dmg.scaling).toEqual({ conditionIndex: 0, perUnit: 10, cap: 30 });
     });
 
-    it('Lionheart is an unconditional all-allies HP modifier', () => {
-        const mod = LIONHEART.slots[0].abilities[0];
-        expect(mod.target).toBe('all-allies');
-        expect(mod.config).toEqual({
-            type: 'modifier',
-            channel: 'hp',
-            value: 10,
-            isMultiplicative: true,
-        });
+    it('Lionheart fixture equals the parser output for the real passive text (PR F4)', () => {
+        const ship = {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ...({} as any),
+            refits: [],
+            firstPassiveSkillText:
+                'At the start of combat, this Unit grants all adjacent allies 10% of its HP.',
+        } as Ship;
+        const passive = buildShipAbilities(ship).slots.find((s) => s.slot === 'passive');
+        expect(passive).toBeDefined();
+        // Generated ids differ per run — compare everything else.
+        const stripIds = (abilities: Ability[]) => abilities.map(({ id: _id, ...rest }) => rest);
+        expect(stripIds(passive!.abilities)).toEqual(stripIds(LIONHEART.slots[0].abilities));
     });
 
     it('buff ability wraps a game-buff payload', () => {

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -27,7 +27,12 @@ export type AbilityType =
     | 'incoming-shield-grant'
     | 'outgoing-amplification'
     | 'heal-amplification'
-    | 'incoming-heal-amplification';
+    | 'incoming-heal-amplification'
+    // PR F4: permanent pre-fight base-stat grant, adjacency-conditioned (Lionheart/Centurion/
+    // Enforcer/Defiant/Stalwart "At the start of combat …" / "when adjacent to a Supporter …"
+    // passives). Applied ONCE to PlacementPlan stats by the battle sim's pre-fight layer (F5) —
+    // never a status (hidden, non-purgeable, not reset on death). DPS calculators ignore it.
+    | 'pre-combat-stat';
 
 export type AbilityTarget =
     | 'self'
@@ -111,7 +116,12 @@ export type AbilityTrigger =
     // Fired once per shield-application CAST. Reaction is keyed on the granter (acting actor)
     // and targets the shield recipient set — used by Resonating Fury to grant Crit Power Up 3
     // to everyone the carrier just shielded.
-    | 'on-shield-applied';
+    | 'on-shield-applied'
+    // PR F4: annotation-only marker for pre-fight stat grants ("At the start of combat, …").
+    // Deliberately NOT in LIVE_TRIGGERS — there is no combat event for it; the battle sim's
+    // pre-fight layer (F5) reads these abilities off the plan BEFORE actors exist, so the
+    // engine's reactive listener machinery must never bind it.
+    | 'pre-combat';
 
 /**
  * Triggers the combat engine consumes via listeners (the machinery lives in
@@ -533,6 +543,22 @@ export type AbilityConfig =
           type: 'buff-duration-extension';
           /** Extra turns added to buffs this wearer applies (Boost = 1). */
           turns: number;
+      }
+    // PR F4: pre-fight base-stat grant (trigger 'pre-combat', target 'self'/'adjacent-allies').
+    // Consumed ONCE by the battle sim's pre-fight layer (F5), which mutates plan stats from a
+    // frozen post-leader snapshot; adjacency gates live HERE (evaluated against board geometry
+    // at apply time), so `conditions` stays empty.
+    | {
+          type: 'pre-combat-stat';
+          stat: 'hp' | 'attack' | 'crit' | 'hacking';
+          value: number;
+          /** 'flat': absolute points. 'percent-of-own': % of the RECIPIENT's pre-fight stat.
+           *  'percent-of-donor': % of the GRANTING ship's pre-fight stat (Lionheart). */
+          valueKind: 'flat' | 'percent-of-own' | 'percent-of-donor';
+          /** Multiply value by count of adjacent living allies (Centurion). */
+          perAdjacentAlly?: boolean;
+          /** Gate: at least one adjacent ally of this role category (Enforcer/Defiant/Stalwart). */
+          requiresAdjacentRole?: ShipRoleCategory;
       };
 
 /** Crowd-control effects a `control` ability can apply. The combat effect of each

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -44,6 +44,7 @@ import {
     parseEnemyChargedCastReaction,
     parseCounterAbilities,
     parseSelfBuffRemovals,
+    parsePreCombatStatGrants,
 } from '../skillTextParser';
 import type { Ship } from '../../types/ship';
 
@@ -143,6 +144,176 @@ describe('detectFullyCharged', () => {
 
     it('returns false when all entries are undefined', () => {
         expect(detectFullyCharged([undefined, undefined])).toBe(false);
+    });
+});
+
+// PR F4: permanent pre-fight base-stat passives. Every positive case below is the EXACT
+// docs/ship-skills.csv text (markup included) — the CSV is the parser's source of truth.
+describe('parsePreCombatStatGrants', () => {
+    it('returns [] for null/undefined/empty', () => {
+        expect(parsePreCombatStatGrants(null)).toEqual([]);
+        expect(parsePreCombatStatGrants(undefined)).toEqual([]);
+        expect(parsePreCombatStatGrants('')).toEqual([]);
+    });
+
+    it('Lionheart P1: donor-scaled HP grant to adjacent allies', () => {
+        const grants = parsePreCombatStatGrants(
+            'At the start of combat, this Unit grants all adjacent allies 10% of its HP.'
+        );
+        expect(grants).toEqual([
+            {
+                stat: 'hp',
+                value: 10,
+                valueKind: 'percent-of-donor',
+                target: 'adjacent-allies',
+                pos: 0,
+            },
+        ]);
+    });
+
+    it('Lionheart P2 (multi-sentence with Protection stacks): only the HP grant parses', () => {
+        const grants = parsePreCombatStatGrants(
+            'At the start of combat, this Unit grants all adjacent allies 10% of its HP.<br /><br />At the start of the round, this Unit gains 10 stacks of <unit-skill>Protection</unit-skill>.<br />After taking damage redirected through <unit-skill>Protection</unit-skill>, all <unit-skill>Protection</unit-skill> is removed.'
+        );
+        expect(grants).toEqual([
+            {
+                stat: 'hp',
+                value: 10,
+                valueKind: 'percent-of-donor',
+                target: 'adjacent-allies',
+                pos: 0,
+            },
+        ]);
+    });
+
+    it('Centurion P1: flat attack per adjacent ally, self', () => {
+        const grants = parsePreCombatStatGrants(
+            'At the start of combat, this Unit gains 500 attack per adjacent ally.'
+        );
+        expect(grants).toEqual([
+            {
+                stat: 'attack',
+                value: 500,
+                valueKind: 'flat',
+                target: 'self',
+                perAdjacentAlly: true,
+                pos: 0,
+            },
+        ]);
+    });
+
+    it('Centurion P2 (with retaliate clause + embedded newlines): 750 attack per adjacent ally', () => {
+        const grants = parsePreCombatStatGrants(
+            'At the start of combat, this Unit gains 750 attack per adjacent ally.\n<br /><br />\nWhen this Unit or an adjacent ally is directly damaged, this Unit retaliates dealing <unit-damage>50%</unit-damage>.'
+        );
+        expect(grants).toEqual([
+            {
+                stat: 'attack',
+                value: 750,
+                valueKind: 'flat',
+                target: 'self',
+                perAdjacentAlly: true,
+                pos: 0,
+            },
+        ]);
+    });
+
+    it('Centurion P3: 1000 attack per adjacent ally', () => {
+        const grants = parsePreCombatStatGrants(
+            'At the start of combat, this Unit gains 1000 attack per adjacent ally.\n<br /><br />\nWhen this Unit or an adjacent ally is directly damaged, this Unit retaliates dealing <unit-damage>100%</unit-damage>.'
+        );
+        expect(grants).toHaveLength(1);
+        expect(grants[0]).toMatchObject({
+            stat: 'attack',
+            value: 1000,
+            valueKind: 'flat',
+            target: 'self',
+            perAdjacentAlly: true,
+        });
+    });
+
+    it('Enforcer P2 (full multi-sentence row): trailing supporter gate yields crit (flat) + hacking (percent-of-own)', () => {
+        const grants = parsePreCombatStatGrants(
+            'When this Unit critically hits an enemy it inflicts <unit-skill>Defense Shred</unit-skill> for 3 turns.<br /><br />\nIf an attack destroys an enemy, then this Units remaining attacks that turn will target a new enemy.<br /><br />\nAt the start of combat this Unit gains +15% crit rate and +10% hacking if adjacent to a supporter.'
+        );
+        expect(grants).toHaveLength(2);
+        expect(grants[0]).toMatchObject({
+            stat: 'crit',
+            value: 15,
+            valueKind: 'flat',
+            target: 'self',
+            requiresAdjacentRole: 'SUPPORTER',
+        });
+        expect(grants[1]).toMatchObject({
+            stat: 'hacking',
+            value: 10,
+            valueKind: 'percent-of-own',
+            target: 'self',
+            requiresAdjacentRole: 'SUPPORTER',
+        });
+        // pos anchors keep the crit grant before the hacking grant (stable ability order).
+        expect(grants[0].pos).toBeLessThan(grants[1].pos);
+    });
+
+    it('Defiant P2 (full row): leading supporter gate yields HP percent-of-own; shield clause untouched', () => {
+        const grants = parsePreCombatStatGrants(
+            'When adjacent to a Supporter, this Unit gains 20% HP. This Unit gains <unit-damage>Shield equal to 30%</unit-damage> of its Max HP when applying Stasis.'
+        );
+        expect(grants).toEqual([
+            {
+                stat: 'hp',
+                value: 20,
+                valueKind: 'percent-of-own',
+                target: 'self',
+                requiresAdjacentRole: 'SUPPORTER',
+                pos: expect.any(Number),
+            },
+        ]);
+    });
+
+    it('Stalwart P2 (full row): leading "this Unit is adjacent" gate yields attack percent-of-own', () => {
+        const grants = parsePreCombatStatGrants(
+            'When this Unit is directly damaged as a primary target, it deals <unit-damage>70% damage</unit-damage> to that enemy and gains <unit-skill>Legion Discipline II</unit-skill> for 3 turns.<br /><br />Additionally, when this Unit is adjacent to a Supporter, this Unit gains 20% Attack.'
+        );
+        expect(grants).toEqual([
+            {
+                stat: 'attack',
+                value: 20,
+                valueKind: 'percent-of-own',
+                target: 'self',
+                requiresAdjacentRole: 'SUPPORTER',
+                pos: expect.any(Number),
+            },
+        ]);
+    });
+
+    it('does NOT match Centurion charged Core-Charge adjacent-ally grant', () => {
+        expect(
+            parsePreCombatStatGrants(
+                'This Unit gains 4 stacks of <unit-skill>Core Charge I</unit-skill> and grants all adjacent allies 2 stacks of <unit-skill>Core Charge I</unit-skill> then deals <unit-damage>150% damage</unit-damage> wth an additional <unit-damage>30%</unit-damage> for each adjacent ally.'
+            )
+        ).toEqual([]);
+    });
+
+    it('does NOT match Tier-B start-of-combat timed statuses ("gains N stacks of X")', () => {
+        expect(
+            parsePreCombatStatGrants(
+                'At the start of combat, this Unit gains 2 stacks of <unit-skill>Blast</unit-skill>.'
+            )
+        ).toEqual([]);
+        expect(
+            parsePreCombatStatGrants(
+                'At the start of combat, this Unit gains a <unit-damage>Shield equal to 20%</unit-damage> of its Max HP.'
+            )
+        ).toEqual([]);
+    });
+
+    it('does NOT match Madax P2 ("receives 30% more Repairs" — deliberately out of scope)', () => {
+        expect(
+            parsePreCombatStatGrants(
+                "This Unit <unit-damage>repairs itself for 13%</unit-damage> of its Max HP when an enemy dies.<br /><br />When adjacent to a Supporter, this Unit receives 30% more Repairs and increases that Supporter's Defense by 20% of this Unit's Defense."
+            )
+        ).toEqual([]);
     });
 });
 

--- a/src/utils/abilities/__tests__/buildShipAbilities.coverage.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.coverage.test.ts
@@ -22,9 +22,17 @@ const VALID_TYPES: AbilityType[] = [
     'cleanse',
     'purge',
     'control',
+    'pre-combat-stat',
 ];
 
-const VALID_TARGETS: AbilityTarget[] = ['self', 'ally', 'all-allies', 'enemy', 'all-enemies'];
+const VALID_TARGETS: AbilityTarget[] = [
+    'self',
+    'ally',
+    'all-allies',
+    'adjacent-allies',
+    'enemy',
+    'all-enemies',
+];
 
 const VALID_TRIGGERS: AbilityTrigger[] = [
     'on-cast',
@@ -33,6 +41,7 @@ const VALID_TRIGGERS: AbilityTrigger[] = [
     'on-attacked',
     'on-ally-destroyed',
     'on-destroyed',
+    'pre-combat',
 ];
 
 /**

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -1709,10 +1709,24 @@ describe('buildShipAbilities', () => {
                 requireDamagedAllyAdjacent: true,
             });
 
-            // M1 non-regression: the co-located "750 attack per adjacent ally" start-of-combat
-            // clause produces NO spurious damage/buff ability (it is unparsed today and stays so).
+            // Non-regression: the co-located "750 attack per adjacent ally" start-of-combat
+            // clause produces NO spurious damage/buff ability — since PR F4 it parses as a
+            // pre-combat-stat grant instead (flat 750 attack × adjacent-ally count, self).
             expect(all.filter((a) => a.type === 'damage')).toHaveLength(0);
             expect(all.filter((a) => a.type === 'buff')).toHaveLength(0);
+            expect(all.filter((a) => a.type === 'pre-combat-stat')).toMatchObject([
+                {
+                    target: 'self',
+                    trigger: 'pre-combat',
+                    config: {
+                        type: 'pre-combat-stat',
+                        stat: 'attack',
+                        value: 750,
+                        valueKind: 'flat',
+                        perAdjacentAlly: true,
+                    },
+                },
+            ]);
         });
 
         it('Centurion third passive (100%): self/adjacent-ally counters at multiplier 100', () => {
@@ -1732,6 +1746,18 @@ describe('buildShipAbilities', () => {
             });
             expect(all.filter((a) => a.type === 'damage')).toHaveLength(0);
             expect(all.filter((a) => a.type === 'buff')).toHaveLength(0);
+            // PR F4: the start-of-combat clause parses as a flat 1000-attack per-adjacent grant.
+            expect(all.filter((a) => a.type === 'pre-combat-stat')).toMatchObject([
+                {
+                    config: {
+                        type: 'pre-combat-stat',
+                        stat: 'attack',
+                        value: 1000,
+                        valueKind: 'flat',
+                        perAdjacentAlly: true,
+                    },
+                },
+            ]);
         });
 
         it('false-positive guard: a "directly damaged" passive that HEALS does not produce a counter', () => {
@@ -2441,7 +2467,7 @@ describe('buildShipAbilities', () => {
             });
         });
 
-        it('R2 passive parses ONLY the shield-on-Stasis clause (adjacency HP grant left unparsed)', () => {
+        it('R2 passive parses the shield-on-Stasis clause AND the adjacency HP grant (PR F4)', () => {
             const s = ship({
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 refits: [{}, {}] as any,
@@ -2455,6 +2481,23 @@ describe('buildShipAbilities', () => {
                 target: 'self',
                 trigger: 'on-stasis-applied',
                 config: { type: 'shield', pct: 30, basis: 'hp' },
+            });
+            // PR F4: "When adjacent to a Supporter, this Unit gains 20% HP" is now parsed as a
+            // permanent pre-fight stat grant (percent-of-own, Supporter-gated), applied by the
+            // battle sim's pre-fight layer in F5.
+            const preCombat = passive?.abilities.find((a) => a.type === 'pre-combat-stat');
+            expect(preCombat).toMatchObject({
+                type: 'pre-combat-stat',
+                target: 'self',
+                trigger: 'pre-combat',
+                conditions: [],
+                config: {
+                    type: 'pre-combat-stat',
+                    stat: 'hp',
+                    value: 20,
+                    valueKind: 'percent-of-own',
+                    requiresAdjacentRole: 'SUPPORTER',
+                },
             });
         });
     });

--- a/src/utils/abilities/abilityFixtures.ts
+++ b/src/utils/abilities/abilityFixtures.ts
@@ -95,9 +95,11 @@ export const LODOLITE: ShipSkills = {
     ],
 };
 
-// Lionheart: ILLUSTRATIVE hand-built shape only (a +10% HP all-allies aura) to
-// lock the `modifier` shape. The real Lionheart text is a start-of-combat grant
-// of 10% HP to *adjacent* allies — do NOT use this as a parser-output assertion.
+// Lionheart: the REAL parser-output shape (PR F4) for the pre-fight passive
+// "At the start of combat, this Unit grants all adjacent allies 10% of its HP."
+// — a donor-scaled permanent HP grant to adjacent allies, applied to plan stats
+// by the battle sim's pre-fight layer (F5). Asserted equal to buildShipAbilities
+// output (modulo generated id) in src/types/__tests__/abilities.test.ts.
 export const LIONHEART: ShipSkills = {
     slots: [
         {
@@ -105,11 +107,17 @@ export const LIONHEART: ShipSkills = {
             abilities: [
                 {
                     id: 'h1',
-                    type: 'modifier',
-                    target: 'all-allies',
-                    trigger: 'on-cast',
+                    type: 'pre-combat-stat',
+                    target: 'adjacent-allies',
+                    trigger: 'pre-combat',
                     conditions: [],
-                    config: { type: 'modifier', channel: 'hp', value: 10, isMultiplicative: true },
+                    config: {
+                        type: 'pre-combat-stat',
+                        stat: 'hp',
+                        value: 10,
+                        valueKind: 'percent-of-donor',
+                    },
+                    autoFilled: true,
                 },
             ],
         },

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -69,6 +69,7 @@ import {
     parseSkillEffects,
     classifyEnemyEffect,
     statusEffectCondition,
+    parsePreCombatStatGrants,
 } from '../skillTextParser';
 import {
     buildDoTAutoFill,
@@ -1499,6 +1500,38 @@ function abilitiesFromText(
                 autoFilled: true,
             },
             pos: critRedPos >= 0 ? critRedPos : MAX_POS,
+        });
+    }
+
+    // PR F4: permanent pre-fight base-stat passives ("At the start of combat, …" /
+    // role-gated adjacency grants — Lionheart/Centurion/Enforcer/Defiant/Stalwart).
+    // Annotation-only until the battle sim's pre-fight layer (F5) applies them to plan
+    // stats; the DPS pipeline ignores the type by construction (modifierTotalsFromAbilities
+    // type-filters, no firing-skill extractor / status registration / reactive listener
+    // matches 'pre-combat-stat', and 'pre-combat' is not in LIVE_TRIGGERS). No slot gate —
+    // passive-slot refit resolution is already handled by getSkillRowForSlot. The grant's
+    // pos indexes the TAG-STRIPPED text (≤ raw index) — cosmetic editor order only.
+    for (const grant of parsePreCombatStatGrants(text)) {
+        out.push({
+            ability: {
+                id: nextId(),
+                type: 'pre-combat-stat',
+                target: grant.target,
+                trigger: 'pre-combat',
+                conditions: [],
+                config: {
+                    type: 'pre-combat-stat',
+                    stat: grant.stat,
+                    value: grant.value,
+                    valueKind: grant.valueKind,
+                    ...(grant.perAdjacentAlly ? { perAdjacentAlly: true } : {}),
+                    ...(grant.requiresAdjacentRole
+                        ? { requiresAdjacentRole: grant.requiresAdjacentRole }
+                        : {}),
+                },
+                autoFilled: true,
+            },
+            pos: grant.pos,
         });
     }
 

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -2734,6 +2734,129 @@ export function detectFullyCharged(texts: (string | undefined)[]): boolean {
     return texts.some((t) => t?.toLowerCase().includes('fully charged') ?? false);
 }
 
+/**
+ * PR F4: a permanent pre-fight base-stat grant parsed from a ship passive. Consumed by
+ * buildShipAbilities into a `pre-combat-stat` ability (trigger 'pre-combat'); the battle
+ * sim's pre-fight layer (F5) applies it to plan stats before round 1. Corpus (docs/
+ * ship-skills.csv): Lionheart, Centurion, Enforcer, Defiant, Stalwart.
+ */
+export interface PreCombatStatGrant {
+    stat: 'hp' | 'attack' | 'crit' | 'hacking';
+    value: number;
+    /** 'flat': absolute points. 'percent-of-own': % of the RECIPIENT's pre-fight stat.
+     *  'percent-of-donor': % of the GRANTING ship's pre-fight stat (Lionheart). */
+    valueKind: 'flat' | 'percent-of-own' | 'percent-of-donor';
+    target: 'self' | 'adjacent-allies';
+    /** Multiply value by count of adjacent living allies (Centurion). */
+    perAdjacentAlly?: boolean;
+    /** Gate: at least one adjacent ally of this role category (Enforcer/Defiant/Stalwart). */
+    requiresAdjacentRole?: ShipRoleCategory;
+    /** Match index in the tag-stripped text — stable ability ordering in buildShipAbilities. */
+    pos: number;
+}
+
+// Pattern A (Lionheart): "At the start of combat, this Unit grants all adjacent allies
+// 10% of its HP." — donor-scaled HP grant to adjacent allies.
+const PRE_COMBAT_DONOR_HP_RE =
+    /at the start of combat,?\s*this unit grants all adjacent allies (\d+(?:\.\d+)?)%\s*of its (?:max\s*)?hp/gi;
+
+// Pattern B (Centurion): "At the start of combat, this Unit gains 500 attack per adjacent
+// ally." — flat attack × adjacent-ally count, self. Number may carry thousands commas.
+const PRE_COMBAT_PER_ADJACENT_ATTACK_RE =
+    /at the start of combat,?\s*this unit gains (\d[\d,]*)\s*attack per adjacent ally/gi;
+
+// Pattern C: role-gated self grants, both orderings. The stat-list capture is bounded to its
+// own sentence ([^.;]+?) so it can't swallow neighbouring clauses in multi-sentence passives.
+//   C1 trailing gate (Enforcer): "… this Unit gains +15% crit rate and +10% hacking if
+//   adjacent to a supporter."
+//   C2 leading gate (Defiant/Stalwart): "When (this Unit is) adjacent to a Supporter, this
+//   Unit gains 20% HP/Attack." — Madax's "receives 30% more Repairs…" has no "gains" and
+//   deliberately stays unparsed (out of scope).
+const PRE_COMBAT_ROLE_GATE_TRAILING_RE =
+    /this unit gains ([^.;]+?)\s+(?:if|when|while)\s+adjacent to an?\s+(supporter|defender|attacker|debuffer)\b/gi;
+const PRE_COMBAT_ROLE_GATE_LEADING_RE =
+    /when (?:this unit is )?adjacent to an?\s+(supporter|defender|attacker|debuffer),\s*this unit gains ([^.;]+?)(?=[.;]|$)/gi;
+
+// Stat-list splitter for pattern C: "+15% crit rate and +10% hacking" / "20% HP" / "20% Attack".
+// crit rate is a percentage-only stat, so "+15% crit rate" is a FLAT 15-point grant; hacking/
+// hp/attack scale the recipient's own stat (percent-of-own).
+const PRE_COMBAT_STAT_LIST_RE = /\+?(\d+(?:\.\d+)?)%\s*(crit(?:ical)?\s*rate|hacking|hp|attack)/gi;
+
+function preCombatStatFromKeyword(keyword: string): {
+    stat: 'hp' | 'attack' | 'crit' | 'hacking';
+    valueKind: 'flat' | 'percent-of-own';
+} {
+    const k = keyword.toLowerCase();
+    if (k.startsWith('crit')) return { stat: 'crit', valueKind: 'flat' };
+    if (k === 'hacking') return { stat: 'hacking', valueKind: 'percent-of-own' };
+    if (k === 'hp') return { stat: 'hp', valueKind: 'percent-of-own' };
+    return { stat: 'attack', valueKind: 'percent-of-own' };
+}
+
+/**
+ * Parses permanent pre-fight base-stat passives ("At the start of combat, …" grants and
+ * role-gated adjacency grants). Reference data: docs/ship-skills.csv — matches exactly
+ * Lionheart (A), Centurion (B), Enforcer (C1), Defiant/Stalwart (C2). Timed start-of-combat
+ * statuses ("gains N stacks of X", "gains a Shield/Taunt…") and Centurion's charged
+ * Core-Charge grant have no matching shape here and stay with their existing parsers.
+ */
+export function parsePreCombatStatGrants(text: string | null | undefined): PreCombatStatGrant[] {
+    if (!text) return [];
+    const plain = stripUnitTags(text).replace(/<br\s*\/?>/gi, '. ');
+    const results: PreCombatStatGrant[] = [];
+    let m: RegExpExecArray | null;
+
+    PRE_COMBAT_DONOR_HP_RE.lastIndex = 0;
+    while ((m = PRE_COMBAT_DONOR_HP_RE.exec(plain)) !== null) {
+        results.push({
+            stat: 'hp',
+            value: parseFloat(m[1]),
+            valueKind: 'percent-of-donor',
+            target: 'adjacent-allies',
+            pos: m.index,
+        });
+    }
+
+    PRE_COMBAT_PER_ADJACENT_ATTACK_RE.lastIndex = 0;
+    while ((m = PRE_COMBAT_PER_ADJACENT_ATTACK_RE.exec(plain)) !== null) {
+        results.push({
+            stat: 'attack',
+            value: parseInt(m[1].replace(/,/g, ''), 10),
+            valueKind: 'flat',
+            target: 'self',
+            perAdjacentAlly: true,
+            pos: m.index,
+        });
+    }
+
+    const emitRoleGated = (list: string, listPos: number, role: string) => {
+        const requiresAdjacentRole = role.toUpperCase() as ShipRoleCategory;
+        PRE_COMBAT_STAT_LIST_RE.lastIndex = 0;
+        let sm: RegExpExecArray | null;
+        while ((sm = PRE_COMBAT_STAT_LIST_RE.exec(list)) !== null) {
+            results.push({
+                ...preCombatStatFromKeyword(sm[2]),
+                value: parseFloat(sm[1]),
+                target: 'self',
+                requiresAdjacentRole,
+                pos: listPos + sm.index,
+            });
+        }
+    };
+
+    PRE_COMBAT_ROLE_GATE_TRAILING_RE.lastIndex = 0;
+    while ((m = PRE_COMBAT_ROLE_GATE_TRAILING_RE.exec(plain)) !== null) {
+        emitRoleGated(m[1], m.index + m[0].indexOf(m[1]), m[2]);
+    }
+
+    PRE_COMBAT_ROLE_GATE_LEADING_RE.lastIndex = 0;
+    while ((m = PRE_COMBAT_ROLE_GATE_LEADING_RE.exec(plain)) !== null) {
+        emitRoleGated(m[2], m.index + m[0].indexOf(m[2]), m[1]);
+    }
+
+    return results;
+}
+
 export type SkillSource = 'active' | 'charge' | 'passive1' | 'passive2' | 'passive3';
 
 export interface SkillEffect {


### PR DESCRIPTION
## Summary

Parser half of the pre-fight ship passives (combat-realism sub-project F). Zero sim behavior change — application follows in PR F5.

- New `AbilityType` `'pre-combat-stat'` + annotation-only trigger `'pre-combat'` (excluded from `LIVE_TRIGGERS`, so the engine can never bind it)
- `parsePreCombatStatGrants()` in skillTextParser: three corpus-anchored patterns — donor-scaled HP grants (Lionheart), flat attack per adjacent ally (Centurion), role-gated self grants in both sentence orderings (Enforcer/Defiant/Stalwart)
- Unit semantics: crit rate → flat points; hacking/hp/attack → percent-of-own; Lionheart → percent-of-donor
- `buildShipAbilities` emits the abilities; DPS/engine ignore them by construction (verified against `modifierTotalsFromAbilities`, firing-skill extractors, status registration, reactive binding)
- Audit rule `pre-combat-stat` — 0 findings, no allowlist entries
- LIONHEART fixture replaced with the real parser shape + equality test against `buildShipAbilities` output
- Ability-editor surface (TypePicker category, defaults, AbilityCard form case with existing ui/ primitives)

## Corpus verification

Full-corpus sweep (all 147 CSV records, quote-aware): the parser fires on **exactly 8 rows on exactly the 5 corpus ships**, zero false positives; all near-miss texts (Tier-B timed statuses, Centurion's charged Core-Charge, Madax) verified non-matching.

Also documents a pre-existing audit gap: the audit's CSV reader silently drops 6 multi-line records (141/147 ships audited) — tracked as a follow-up outside this epic.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (max-warnings 0)
- [x] `npm test` — 287 files / 3744 tests pass, zero `__snapshots__` churn
- [x] `npm run audit:skills` — 0 findings
- [x] Parser units on exact CSV texts (with markup) + negatives; Defiant/Centurion ability tests updated from 'unparsed' to concrete assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wd1aeh2x3P7KK84pfhrnA6