### PR TITLE
feat(combat): pre-fight modifier channels + shield seeding (sub-project F, PR F3)

### DIFF
--- a/src/utils/calculators/__tests__/battleSimulatorPreFightModifiers.test.ts
+++ b/src/utils/calculators/__tests__/battleSimulatorPreFightModifiers.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Sub-project F, PR F3: squad-leader MODIFIER channels reach the battle — integration
+ * tests through `simulateBattle` with real SQUAD_LEADERS data (fixture style copied from
+ * battleSimulatorSquadLeaders.test.ts).
+ *
+ * Channel → leader under test (each isolates its modifier by comparing the stage that
+ * ADDS the modifier against the stage just below it, so the shared stat stages cancel):
+ *   - outgoingDamage        → XAOC "Predator" stage III (+5% outgoing direct damage)
+ *   - incomingCritDamage    → TERRAN_COMBINE "Optimizer" stage III (-10% incoming crit damage)
+ *   - outgoingCritDamage    → ATLAS_SYNDICATE "Negotiator" stage III (enemies lose 10% crit
+ *                             damage — the crit-conditional damage modifier, NOT Crit Power)
+ *   - startingShieldPctOfHp → ATLAS_SYNDICATE "Broker" stage III (start shielded 20% max HP)
+ *   - incomingDamage        → covered in battleSimulatorSquadLeaders.test.ts (Midas stage II)
+ *   - outgoingHeal/incomingHeal → engine-level tests (preFightModifiersEngine.test.ts) — no
+ *     battle-sim fixture ship carries a parseable heal skill.
+ *
+ * Plus the F3 inertness proof: a STAT-ONLY leader run is deep-equal to a no-leader run
+ * with the same stats pre-multiplied by hand (the modifier plumbing attaches nothing when
+ * every channel is zero).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { setRateGateRng, resetRateGateRng } from '../rateAccumulator';
+import { simulateBattle, BattlePlacement, BattleSimulationInput } from '../battleSimulator';
+import type { Ship } from '../../../types/ship';
+import type { FactionName } from '../../../constants/factions';
+import type { Position } from '../../../types/encounters';
+
+beforeEach(() => setRateGateRng(() => 0.999999));
+afterEach(() => resetRateGateRng());
+
+const makeShip = (
+    id: string,
+    name: string,
+    faction: FactionName,
+    opts: { activeTarget: string; activePattern: string }
+): Ship => ({
+    id,
+    name,
+    rarity: 'legendary',
+    faction,
+    type: 'Attacker',
+    baseStats: {
+        hp: 0,
+        attack: 0,
+        defence: 0,
+        hacking: 200,
+        security: 100,
+        crit: 0,
+        critDamage: 0,
+        speed: 100,
+    },
+    equipment: {},
+    implants: {},
+    refits: [],
+    affinity: 'antimatter',
+    activeSkillText: 'This Unit deals <unit-damage>100% damage</unit-damage>.',
+    chargeSkillCharge: 0,
+    activeTarget: opts.activeTarget,
+    activePattern: opts.activePattern,
+});
+
+const placement = (
+    ship: Ship,
+    position: Position,
+    stats: { attack: number; hp: number; crit?: number; critDamage?: number }
+): BattlePlacement => ({
+    ship,
+    position,
+    statOverrides: {
+        attack: stats.attack,
+        crit: stats.crit ?? 0,
+        critDamage: stats.critDamage ?? 0,
+        defensePenetration: 0,
+        hacking: 200,
+        defence: 0,
+        hp: stats.hp,
+    },
+});
+
+const FRONT = { activeTarget: 'front', activePattern: 'Pattern-Base' } as const;
+const BACK = { activeTarget: 'back', activePattern: 'Pattern-Base' } as const;
+
+/** 2v2 board: p1 = leader-faction focus up front, p2 = off-faction (MPL) in the back. */
+const buildTeams = (
+    p1Faction: FactionName,
+    enemyStats: { attack: number; crit?: number; critDamage?: number } = { attack: 2000 }
+): Pick<BattleSimulationInput, 'playerTeam' | 'enemyTeam'> => ({
+    playerTeam: [
+        placement(makeShip('p1', 'Player Front', p1Faction, FRONT), 'M4', {
+            attack: 5000,
+            hp: 100_000,
+        }),
+        placement(makeShip('p2', 'Player Back', 'MPL', BACK), 'M3', {
+            attack: 4000,
+            hp: 100_000,
+        }),
+    ],
+    enemyTeam: [
+        placement(makeShip('e1', 'Enemy Front', 'MPL', FRONT), 'M4', {
+            ...enemyStats,
+            hp: 100_000,
+        }),
+        placement(makeShip('e2', 'Enemy Back', 'MPL', BACK), 'M1', {
+            ...enemyStats,
+            hp: 100_000,
+        }),
+    ],
+});
+
+const round1 = (result: ReturnType<typeof simulateBattle>, actorId: string) => {
+    const row = result.rounds[0].ships.find((s) => s.actorId === actorId);
+    if (!row) throw new Error(`no round-1 row for ${actorId}`);
+    return row;
+};
+
+describe('simulateBattle pre-fight modifiers — outgoingDamage (Predator III)', () => {
+    it('adds exactly +5% to the XAOC ship’s dealt damage on top of the stage-II stat folds', () => {
+        // Stage II (+8% HP, +8% attack) vs stage III (adds ONLY the +5% outgoing modifier):
+        // the stat stages cancel in the ratio, isolating the channel.
+        const stage2 = simulateBattle({
+            ...buildTeams('XAOC'),
+            rounds: 2,
+            playerSquadLeader: { faction: 'XAOC', name: 'Predator', stage: 2 },
+        });
+        const stage3 = simulateBattle({
+            ...buildTeams('XAOC'),
+            rounds: 2,
+            playerSquadLeader: { faction: 'XAOC', name: 'Predator', stage: 3 },
+        });
+
+        expect(round1(stage2, 'attacker').damageDealt).toBeGreaterThan(0);
+        expect(round1(stage3, 'attacker').damageDealt).toBeCloseTo(
+            1.05 * round1(stage2, 'attacker').damageDealt
+        );
+        // Off-faction teammate untouched by the channel.
+        expect(round1(stage3, 'p:p2:1').damageDealt).toBe(round1(stage2, 'p:p2:1').damageDealt);
+        // Fully simulated → no unsimulated report.
+        expect('preFight' in stage3).toBe(false);
+    });
+});
+
+describe('simulateBattle pre-fight modifiers — incomingCritDamage (Optimizer III)', () => {
+    // Optimizer: I +8% Defence (fixture defence 0 → inert), II +20 Security (no debuffs →
+    // inert), III -10% incoming crit damage. Stage III vs II isolates the channel.
+    const CRIT_ENEMIES = { attack: 2000, crit: 100, critDamage: 50 };
+    const NOCRIT_ENEMIES = { attack: 2000, crit: 0, critDamage: 50 };
+
+    it('crit-only: Terran allies take exactly 10% smaller CRIT hits', () => {
+        const stage2 = simulateBattle({
+            ...buildTeams('TERRAN_COMBINE', CRIT_ENEMIES),
+            rounds: 2,
+            playerSquadLeader: { faction: 'TERRAN_COMBINE', name: 'Optimizer', stage: 2 },
+        });
+        const stage3 = simulateBattle({
+            ...buildTeams('TERRAN_COMBINE', CRIT_ENEMIES),
+            rounds: 2,
+            playerSquadLeader: { faction: 'TERRAN_COMBINE', name: 'Optimizer', stage: 3 },
+        });
+        // crit 100 → every enemy hit crits → the whole damage taken scales ×0.9.
+        expect(round1(stage2, 'attacker').damageTaken).toBeGreaterThan(0);
+        expect(round1(stage3, 'attacker').damageTaken).toBeCloseTo(
+            0.9 * round1(stage2, 'attacker').damageTaken
+        );
+        // Off-faction teammate untouched.
+        expect(round1(stage3, 'p:p2:1').damageTaken).toBe(round1(stage2, 'p:p2:1').damageTaken);
+    });
+
+    it('non-crit hits are NOT reduced (crit-conditionality)', () => {
+        const stage2 = simulateBattle({
+            ...buildTeams('TERRAN_COMBINE', NOCRIT_ENEMIES),
+            rounds: 2,
+            playerSquadLeader: { faction: 'TERRAN_COMBINE', name: 'Optimizer', stage: 2 },
+        });
+        const stage3 = simulateBattle({
+            ...buildTeams('TERRAN_COMBINE', NOCRIT_ENEMIES),
+            rounds: 2,
+            playerSquadLeader: { faction: 'TERRAN_COMBINE', name: 'Optimizer', stage: 3 },
+        });
+        expect(round1(stage2, 'attacker').damageTaken).toBeGreaterThan(0);
+        expect(round1(stage3, 'attacker').damageTaken).toBe(
+            round1(stage2, 'attacker').damageTaken
+        );
+    });
+});
+
+describe('simulateBattle pre-fight modifiers — outgoingCritDamage (Negotiator III enemy debuff)', () => {
+    // Negotiator III: "Enemy units lose 10% crit damage" — a crit-conditional damage
+    // modifier on the ENEMIES' outgoing damage (their crits deal 10% less), NOT the
+    // critDamage stat. Stage III vs II isolates it (the stage-III speed debuff does not
+    // change per-hit damage; players already precede enemies at equal speed).
+    const CRIT_ENEMIES = { attack: 2000, crit: 100, critDamage: 50 };
+    const NOCRIT_ENEMIES = { attack: 2000, crit: 0, critDamage: 50 };
+
+    it('crit-only: enemy CRIT hits on every player ship deal exactly 10% less', () => {
+        const stage2 = simulateBattle({
+            ...buildTeams('ATLAS_SYNDICATE', CRIT_ENEMIES),
+            rounds: 2,
+            playerSquadLeader: { faction: 'ATLAS_SYNDICATE', name: 'Negotiator', stage: 2 },
+        });
+        const stage3 = simulateBattle({
+            ...buildTeams('ATLAS_SYNDICATE', CRIT_ENEMIES),
+            rounds: 2,
+            playerSquadLeader: { faction: 'ATLAS_SYNDICATE', name: 'Negotiator', stage: 3 },
+        });
+        expect(round1(stage2, 'attacker').damageTaken).toBeGreaterThan(0);
+        // The debuff rides the ENEMY attackers, so BOTH player victims (leader-faction and
+        // off-faction alike) take 10% smaller crits.
+        expect(round1(stage3, 'attacker').damageTaken).toBeCloseTo(
+            0.9 * round1(stage2, 'attacker').damageTaken
+        );
+        expect(round1(stage3, 'p:p2:1').damageTaken).toBeCloseTo(
+            0.9 * round1(stage2, 'p:p2:1').damageTaken
+        );
+    });
+
+    it('non-crit enemy hits are NOT reduced (crit-conditionality)', () => {
+        const stage2 = simulateBattle({
+            ...buildTeams('ATLAS_SYNDICATE', NOCRIT_ENEMIES),
+            rounds: 2,
+            playerSquadLeader: { faction: 'ATLAS_SYNDICATE', name: 'Negotiator', stage: 2 },
+        });
+        const stage3 = simulateBattle({
+            ...buildTeams('ATLAS_SYNDICATE', NOCRIT_ENEMIES),
+            rounds: 2,
+            playerSquadLeader: { faction: 'ATLAS_SYNDICATE', name: 'Negotiator', stage: 3 },
+        });
+        expect(round1(stage3, 'attacker').damageTaken).toBe(
+            round1(stage2, 'attacker').damageTaken
+        );
+    });
+});
+
+describe('simulateBattle pre-fight modifiers — starting shield (Broker III)', () => {
+    it('seeds 20% of post-leader max HP as a shield pool that absorbs before HP', () => {
+        // Broker: I +8% attack, II +8% Crit Power, III start shielded 20% of max HP.
+        // Broker never modifies HP, so the seed is 20% of the raw 100k = 20,000 — far more
+        // than one round of incoming damage (2,000 per enemy hit), so HP stays untouched.
+        const stage2 = simulateBattle({
+            ...buildTeams('ATLAS_SYNDICATE'),
+            rounds: 2,
+            playerSquadLeader: { faction: 'ATLAS_SYNDICATE', name: 'Broker', stage: 2 },
+        });
+        const stage3 = simulateBattle({
+            ...buildTeams('ATLAS_SYNDICATE'),
+            rounds: 2,
+            playerSquadLeader: { faction: 'ATLAS_SYNDICATE', name: 'Broker', stage: 3 },
+        });
+
+        const shielded = round1(stage3, 'attacker');
+        const unshielded = round1(stage2, 'attacker');
+
+        // Without the seed the ATLAS ship bleeds HP round 1; with it the shield absorbs
+        // the full intake and HP stays at 100%.
+        expect(unshielded.hpPct).toBeLessThan(100);
+        expect(shielded.hpPct).toBe(100);
+        expect(shielded.incomingShieldAbsorbed).toBeGreaterThan(0);
+        // End-of-round pool = the 20% seed minus what round 1 drained.
+        expect(shielded.currentShieldPool).toBeCloseTo(
+            0.2 * 100_000 - shielded.incomingShieldAbsorbed
+        );
+        // The off-faction teammate gets NO seed (faction-scoped ally effect).
+        expect(round1(stage3, 'p:p2:1').currentShieldPool).toBe(0);
+        expect('preFight' in stage3).toBe(false);
+    });
+});
+
+describe('simulateBattle pre-fight modifiers — inertness (stat-only leader)', () => {
+    it('a stat-only leader run is deep-equal to a no-leader run with the stats pre-multiplied by hand', () => {
+        // Midas stage 1 = +10% HP & +10% attack on MPL allies, NO modifier effects. The F3
+        // plumbing must attach nothing (hasAnyPreFightModifier false everywhere), so the run
+        // is IDENTICAL to applying the same multipliers directly to the placement stats.
+        const withLeader = simulateBattle({
+            playerTeam: [
+                placement(makeShip('p1', 'Player Front', 'MPL', FRONT), 'M4', {
+                    attack: 5000,
+                    hp: 100_000,
+                }),
+            ],
+            enemyTeam: [
+                placement(makeShip('e1', 'Enemy Front', 'MPL', FRONT), 'M4', {
+                    attack: 2000,
+                    hp: 100_000,
+                }),
+            ],
+            rounds: 3,
+            playerSquadLeader: { faction: 'MPL', name: 'Midas', stage: 1 },
+        });
+        const handScaled = simulateBattle({
+            playerTeam: [
+                placement(makeShip('p1', 'Player Front', 'MPL', FRONT), 'M4', {
+                    attack: 5000 * 1.1,
+                    hp: 100_000 * 1.1,
+                }),
+            ],
+            enemyTeam: [
+                placement(makeShip('e1', 'Enemy Front', 'MPL', FRONT), 'M4', {
+                    attack: 2000,
+                    hp: 100_000,
+                }),
+            ],
+            rounds: 3,
+        });
+        expect(withLeader).toEqual(handScaled);
+        expect('preFight' in withLeader).toBe(false);
+    });
+});

--- a/src/utils/calculators/__tests__/battleSimulatorSquadLeaders.test.ts
+++ b/src/utils/calculators/__tests__/battleSimulatorSquadLeaders.test.ts
@@ -8,7 +8,8 @@
  *
  * Leader under test: MPL "Midas" (legendary). Stage III active set =
  *   I:  +10% HP & +10% Attack (all MPL allies — stat fold),
- *   II: -7.5% incoming direct damage (MPL allies — protection modifier, unsimulated until F3),
+ *   II: -7.5% incoming direct damage (MPL allies — protection modifier, SIMULATED since F3
+ *       via the per-victim incomingDamage channel),
  *   III: enemies lose 15% crit rate (stat fold; inert here — fixture crit is 0).
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -145,12 +146,18 @@ describe('simulateBattle squad leaders — stat effects reach the battle', () =>
         );
         expect(round1(withLeader, 'p:p2:1').hpPct).toBe(round1(baseline, 'p:p2:1').hpPct);
 
-        // The stage-II ally protection modifier is NOT consumed in F1 → surfaced as
-        // unsimulated on the MPL ship only (F3 will remove this and apply the channel).
-        expect(withLeader.preFight).toBeDefined();
-        expect(withLeader.preFight?.unsimulated).toEqual([
-            { actorId: 'attacker', name: 'Player Front', texts: ['-7.5% incoming direct damage'] },
-        ]);
+        // Stage-II "-7.5% incoming direct damage" is CONSUMED since F3 (per-victim
+        // incomingDamage channel): the MPL ship's round-1 damage taken scales ×0.925
+        // exactly, the off-faction teammate's is untouched.
+        expect(round1(withLeader, 'attacker').damageTaken).toBeCloseTo(
+            0.925 * round1(baseline, 'attacker').damageTaken
+        );
+        expect(round1(withLeader, 'p:p2:1').damageTaken).toBe(
+            round1(baseline, 'p:p2:1').damageTaken
+        );
+
+        // With every Midas effect simulated, nothing is left to report → no preFight block.
+        expect('preFight' in withLeader).toBe(false);
     });
 
     it('faction gate integration: with no MPL ship on the player team, Midas changes NOTHING', () => {

--- a/src/utils/calculators/battleSimulator.ts
+++ b/src/utils/calculators/battleSimulator.ts
@@ -53,6 +53,8 @@ import {
     runPreFight,
     squadLeaderPass,
     emptyPreFightModifiers,
+    hasAnyPreFightModifier,
+    type PreFightCombatModifiers,
     type PreFightUnit,
     type SquadLeaderSelection,
 } from '../combat/preFight';
@@ -686,11 +688,20 @@ export function simulateBattle(
     runPreFight({ player: preFightPlayer, enemy: preFightEnemy }, [
         squadLeaderPass({ player: input.playerSquadLeader, enemy: input.enemySquadLeader }),
     ]);
-    // Kept for later PRs (F3 threads `modifiers` into the actors) and for the result's
-    // `preFight.unsimulated` block below.
+    // Kept for the modifier attachment below (F3) and the result's `preFight.unsimulated` block.
     const preFightById = new Map<string, PreFightUnit>(
         [...preFightPlayer, ...preFightEnemy].map((u) => [u.id, u])
     );
+    // F3: a unit's accumulated modifier channels ride onto its engine actor as the
+    // `preFight` baseline — but ONLY when at least one channel is non-zero, so a no-leader
+    // or stat-only-leader run passes NO preFight key anywhere (all engine folds inert →
+    // byte-identical to pre-F3 by construction).
+    const preFightModifiersFor = (
+        id: string
+    ): { preFight: PreFightCombatModifiers } | Record<string, never> => {
+        const m = preFightById.get(id)?.modifiers;
+        return m && hasAnyPreFightModifier(m) ? { preFight: m } : {};
+    };
 
     // Representative opposing affinity for each side's matchup resolution (first opponent).
     const enemyRepAffinity = enemyPlans[0]?.affinity;
@@ -721,6 +732,7 @@ export function simulateBattle(
             startCharged: false,
             selfBuffs: [],
             enemyDebuffs: [],
+            ...preFightModifiersFor(plan.id),
             position: plan.position,
             target: plan.targeting?.target,
             pattern: plan.targeting?.pattern,
@@ -752,6 +764,7 @@ export function simulateBattle(
                 chargeCount: plan.chargeCount,
                 startCharged: false,
                 shipSkills: plan.shipSkills,
+                ...preFightModifiersFor(plan.id),
                 // §4.5 Akula exception: thread doesntBreakStasis from ShipSkills into the
                 // engine input so the break-mark gate reads the flag from the CombatActor.
                 doesntBreakStasis: plan.shipSkills.doesntBreakStasis,
@@ -820,6 +833,7 @@ export function simulateBattle(
         // §4.5 Akula exception: thread doesntBreakStasis from ShipSkills.
         doesntBreakStasis: focus.shipSkills.doesntBreakStasis,
         chargeLossImmune: focus.shipSkills.chargeLossImmune,
+        ...preFightModifiersFor(focus.id),
         // VESTIGIAL: enemyAttackers only populate (and enemies only fire on players) when
         // healTargetId is set — the engine throws otherwise. Point it at the focus player id.
         healTargetId: focus.id,

--- a/src/utils/combat/__tests__/preFightModifiersEngine.test.ts
+++ b/src/utils/combat/__tests__/preFightModifiersEngine.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Sub-project F, PR F3 — engine-level tests for the `CombatActor.preFight` modifier
+ * baseline, exercising the fold sites the battle-sim integration tests cannot isolate:
+ *
+ *   1. createActor shield seeding (`startingShieldPctOfHp` → shieldPool; absent → 0).
+ *   2. Victim-side `incomingDamage` riding the per-victim D-PR12 channel, observed
+ *      through `__testTapVictimEnemyModifiers`.
+ *   3. Heal channels: caster `outgoingHeal` and recipient `incomingHeal` (incl. the
+ *      PRE-FIRST-TURN receipt via the engine's recipientIncomingHealPct fallback, and
+ *      the no-double-count proof once the recipient has a turn ctx).
+ *   4. The AGGREGATE (non-positional, legacy healing path) crit-family mirror for
+ *      `outgoingCritDamage` (attacker-side) and `incomingCritDamage` (victim-side).
+ *
+ * Harness patterns: shieldGrantBattleSim.test.ts (heal/team walk + __testTapActors) and
+ * victimEnemyModifiers.test.ts (modifier tap).
+ */
+import { describe, it, expect } from 'vitest';
+import { CombatActor, createActor } from '../state';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { deriveTeamEngineActors } from '../../calculators/dpsSimulator';
+import { emptyPreFightModifiers } from '../preFight';
+import type { PreFightCombatModifiers } from '../preFight';
+import { ShipSkills } from '../../../types/abilities';
+import { TeamActorInput } from '../../../types/calculator';
+
+const preFight = (overrides: Partial<PreFightCombatModifiers>): PreFightCombatModifiers => ({
+    ...emptyPreFightModifiers(),
+    ...overrides,
+});
+
+const BASE_STATS = {
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    shieldPenetration: 0,
+    defence: 0,
+    hp: 40_000,
+    speed: 100,
+};
+
+describe('F3 — createActor pre-fight shield seeding', () => {
+    it('seeds shieldPool = startingShieldPctOfHp% of max HP', () => {
+        const actor = createActor({
+            id: 'x',
+            side: 'player',
+            kind: 'attacker',
+            stats: { ...BASE_STATS },
+            preFight: preFight({ startingShieldPctOfHp: 20 }),
+        });
+        expect(actor.shieldPool).toBe(8_000);
+    });
+
+    it('absent preFight (and an all-zero block) → shieldPool 0 (byte-identical seeding)', () => {
+        const bare = createActor({
+            id: 'x',
+            side: 'player',
+            kind: 'attacker',
+            stats: { ...BASE_STATS },
+        });
+        expect(bare.shieldPool).toBe(0);
+        expect(bare.preFight).toBeUndefined();
+        const zeroed = createActor({
+            id: 'y',
+            side: 'enemy',
+            kind: 'enemy',
+            stats: { ...BASE_STATS },
+            preFight: emptyPreFightModifiers(),
+        });
+        expect(zeroed.shieldPool).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Shared runCombat harness
+// ---------------------------------------------------------------------------
+
+const emptySkills = (): ShipSkills => ({ slots: [{ slot: 'active', abilities: [] }] });
+
+const BASE_INPUT = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 1000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: emptySkills(),
+    enemyDefense: 0,
+    enemyHp: 10_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 40_000,
+    ...overrides,
+});
+
+describe('F3 — victim-side incomingDamage rides the per-victim modifier channel', () => {
+    it('folds the actor’s preFight.incomingDamage into victimIncomingModifiers (its own id only)', () => {
+        let captured:
+            | ((victimId: string) => {
+                  enemyDefenseModifier: number;
+                  incomingDamageModifier: number;
+              })
+            | undefined;
+        runCombat(
+            BASE_INPUT({
+                preFight: preFight({ incomingDamage: -5 }),
+                __testTapVictimEnemyModifiers: (fn) => {
+                    captured = fn;
+                },
+            })
+        );
+        expect(captured).toBeDefined();
+        // The focus actor's own per-victim read carries its pre-fight protection…
+        expect(captured!('attacker')).toEqual({
+            enemyDefenseModifier: 0,
+            incomingDamageModifier: -5,
+        });
+        // …and does NOT bleed onto other actors (the dummy enemy has no preFight).
+        expect(captured!('enemy')).toEqual({
+            enemyDefenseModifier: 0,
+            incomingDamageModifier: 0,
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Heal channels (healing mode: focus = heal target; a fast team healer casts an
+// ally-targeted 25%-of-own-HP repair each round → base heal 50,000 × 0.25 = 12,500).
+// ---------------------------------------------------------------------------
+
+const HEAL_ALLY_SKILLS = (): ShipSkills => ({
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                {
+                    id: 'team-heal',
+                    type: 'heal',
+                    target: 'ally',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config: { type: 'heal', pct: 25, basis: 'hp' },
+                },
+            ],
+        },
+    ],
+});
+
+const healerTeamInput = (): TeamActorInput[] => [
+    {
+        id: 'team1',
+        speed: 200, // acts BEFORE the focus heal target every round
+        selfBuffs: [],
+        enemyDebuffs: [],
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: HEAL_ALLY_SKILLS(),
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            shieldPenetration: 0,
+            hacking: 175,
+            defence: 0,
+            hp: 50_000,
+        },
+    },
+];
+
+/** Run a 2-round healing battle and return the round-order heal-performed amounts. */
+const healAmounts = (args: {
+    healerPreFight?: PreFightCombatModifiers;
+    focusPreFight?: PreFightCombatModifiers;
+}): number[] => {
+    const engineTeam = deriveTeamEngineActors(healerTeamInput(), undefined)!;
+    if (args.healerPreFight) {
+        engineTeam[0] = { ...engineTeam[0], preFight: args.healerPreFight };
+    }
+    const bus = createEventBus();
+    const amounts: number[] = [];
+    bus.on('heal-performed', (e) => amounts.push((e as CombatEvent & { amount: number }).amount));
+    runCombat(
+        BASE_INPUT({
+            numRounds: 2,
+            healTargetId: 'attacker',
+            teamActors: engineTeam,
+            ...(args.focusPreFight ? { preFight: args.focusPreFight } : {}),
+            bus,
+        })
+    );
+    return amounts;
+};
+
+describe('F3 — heal channels fold at heal time', () => {
+    it('baseline: the ally repair is 12,500 each round (no preFight)', () => {
+        expect(healAmounts({})).toEqual([12_500, 12_500]);
+    });
+
+    it('caster outgoingHeal (+15) scales the repair ×1.15', () => {
+        const amounts = healAmounts({ healerPreFight: preFight({ outgoingHeal: 15 }) });
+        expect(amounts).toHaveLength(2);
+        for (const a of amounts) expect(a).toBeCloseTo(14_375);
+    });
+
+    it('recipient incomingHeal (+20) applies from the PRE-FIRST-TURN receipt on, with no double-count once the ctx exists', () => {
+        // Round 1: the healer (speed 200) casts BEFORE the focus's first turn — the
+        // recipient has no turn ctx yet, so the engine's recipientIncomingHealPct falls
+        // back to preFight.incomingHeal. Round 2: the focus HAS a ctx, whose
+        // incomingHealPct now FOLDS the pre-fight baseline (playerTurn scheduledTotals).
+        // Equal amounts across rounds prove fallback and fold agree (a double-count
+        // would make round 2 land 12,500 × 1.4).
+        expect(healAmounts({ focusPreFight: preFight({ incomingHeal: 20 }) })).toEqual([
+            15_000, 15_000,
+        ]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Aggregate (non-positional legacy healing path) crit-family mirror: a bare enemy
+// attacker bombards the heal target with 1 hit of 100% × attack 1000, critDamage 50.
+// crit 100 → hit = 1000 × 1.5 = 1,500; a -10 crit-family modifier → ×0.9 = 1,350.
+// ---------------------------------------------------------------------------
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+const bareEnemy = (crit: number, pf?: PreFightCombatModifiers): EnemyAttacker => ({
+    id: 'e1',
+    stats: { attack: 1000, crit, critDamage: 50, speed: 50, defence: 0, hp: 10_000 },
+    chargeCount: 0,
+    startCharged: false,
+    ...(pf ? { preFight: pf } : {}),
+});
+
+const focusDamageTaken = (args: {
+    enemyCrit: number;
+    enemyPreFight?: PreFightCombatModifiers;
+    focusPreFight?: PreFightCombatModifiers;
+}): number => {
+    let captured: CombatActor[] = [];
+    runCombat(
+        BASE_INPUT({
+            healTargetId: 'attacker',
+            enemyAttackers: [bareEnemy(args.enemyCrit, args.enemyPreFight)],
+            ...(args.focusPreFight ? { preFight: args.focusPreFight } : {}),
+            __testTapActors: (actors) => {
+                captured = actors;
+            },
+        })
+    );
+    const focus = captured.find((a) => a.id === 'attacker');
+    if (!focus) throw new Error('no focus actor captured');
+    return 40_000 - focus.currentHp;
+};
+
+describe('F3 — aggregate crit-family mirror (legacy non-positional enemy path)', () => {
+    it('baseline: a critting bare enemy lands 1,500', () => {
+        expect(focusDamageTaken({ enemyCrit: 100 })).toBeCloseTo(1_500);
+    });
+
+    it('attacker-side outgoingCritDamage -10 → its crits deal exactly 10% less', () => {
+        expect(
+            focusDamageTaken({
+                enemyCrit: 100,
+                enemyPreFight: preFight({ outgoingCritDamage: -10 }),
+            })
+        ).toBeCloseTo(1_350);
+    });
+
+    it('victim-side incomingCritDamage -10 → the target takes exactly 10% smaller crits', () => {
+        expect(
+            focusDamageTaken({
+                enemyCrit: 100,
+                focusPreFight: preFight({ incomingCritDamage: -10 }),
+            })
+        ).toBeCloseTo(1_350);
+    });
+
+    it('both crit-family modifiers are INERT on non-crit hits', () => {
+        expect(
+            focusDamageTaken({
+                enemyCrit: 0,
+                enemyPreFight: preFight({ outgoingCritDamage: -10 }),
+                focusPreFight: preFight({ incomingCritDamage: -10 }),
+            })
+        ).toBeCloseTo(1_000);
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -94,6 +94,7 @@ import {
 } from './triggers';
 import { adjacentAllyIds } from './adjacency';
 import { supportFootprintAllyIds } from './supportFootprint';
+import type { PreFightCombatModifiers } from './preFight/types';
 
 /** Backstop for pathological extra-action loops (a non-once-per-round grant whose
  *  conditions stay true re-fires on the extra turn it granted). Real texts are
@@ -416,6 +417,9 @@ export interface EnemyActorInput {
      *  set but not yet consumed by apply). Threaded onto the runtime's attackerAffinity + the
      *  CombatActor.affinity. Absent → neutral default ('antimatter') downstream. */
     affinity?: AffinityName;
+    /** Pre-fight combat-modifier baseline (sub-project F, PR F3) — squad-leader modifier
+     *  channels for this enemy attacker. Absent → all folds inert (byte-identical). */
+    preFight?: PreFightCombatModifiers;
 }
 
 /** Build a full PlayerActorRuntime for a healing-mode enemy attacker.
@@ -507,6 +511,7 @@ export function buildEnemyPlayerActorRuntime(
         doesntBreakStasis: e.doesntBreakStasis,
         chargeLossImmune: e.chargeLossImmune,
         affinity: e.affinity,
+        preFight: e.preFight,
     });
 
     // Resolved affinity fields — pre-computed by the adapter via computeAffinityModifiers
@@ -860,6 +865,9 @@ export type TeamActorEngineInput = TeamActorInput & {
     pattern?: ParsedPattern;
     /** Pre-parsed charged-skill pattern when it differs from active; falls back to `pattern`. */
     chargedPattern?: ParsedPattern;
+    /** Pre-fight combat-modifier baseline (sub-project F, PR F3) — squad-leader modifier
+     *  channels for this team actor. Absent → all folds inert (byte-identical). */
+    preFight?: PreFightCombatModifiers;
 };
 
 export interface CombatEngineInput {
@@ -972,6 +980,9 @@ export interface CombatEngineInput {
          *  computeAffinityModifiers for `affinityDamageModifier` above (positional plumbing —
          *  set but not yet consumed by apply). Absent → neutral default ('antimatter') downstream. */
         affinity?: AffinityName;
+        /** Pre-fight combat-modifier baseline (sub-project F, PR F3) — squad-leader modifier
+         *  channels for this enemy attacker. Absent → all folds inert (byte-identical). */
+        preFight?: PreFightCombatModifiers;
     }[];
     /** Emit-only event tap. Listeners must not read or mutate combat state. */
     bus?: CombatEventBus;
@@ -998,6 +1009,9 @@ export interface CombatEngineInput {
      *  — set but not yet consumed by apply). Threaded onto the attacker runtime's attackerAffinity
      *  + the CombatActor.affinity. Absent → neutral default ('antimatter') downstream. */
     affinity?: AffinityName;
+    /** Pre-fight combat-modifier baseline (sub-project F, PR F3) — squad-leader modifier
+     *  channels for the focus attacker. Absent → all folds inert (byte-identical). */
+    preFight?: PreFightCombatModifiers;
     /** TEST-ONLY tap (Phase 4 PR1, Task 3): receives the genuine `applyOutgoingToEnemy` closure
      *  once on the first round it is built, so unit tests can exercise the player→enemy victim
      *  wrapper against a hand-built enemy actor. Never set by production code; the closure runs the
@@ -1304,6 +1318,7 @@ export function runCombat(input: CombatEngineInput): {
         doesntBreakStasis: input.doesntBreakStasis,
         chargeLossImmune: input.chargeLossImmune,
         affinity: input.affinity,
+        preFight: input.preFight,
     });
     const enemy = createActor({
         id: 'enemy',
@@ -1384,6 +1399,7 @@ export function runCombat(input: CombatEngineInput): {
             // RAW affinity rides on the walk bundle (set by the adapter from TeamActorInput.affinity
             // — the SAME source as the walk's affinityDamageModifier). Legacy (no walk) → undefined.
             affinity: t.walk?.affinity,
+            preFight: t.preFight,
         })
     );
 
@@ -2124,11 +2140,16 @@ export function runCombat(input: CombatEngineInput): {
     let perActorDot = new Map<string, { corrosion: number; inferno: number }>();
 
     // Recipient's CURRENT effective max HP: prefer the actor's last-turn ctx (live buffs),
-    // else its base HP (pre-first-turn). Same pattern for incoming-heal % (ctx value ?? 0).
+    // else its base HP (pre-first-turn). Same pattern for incoming-heal %: the ctx value
+    // already folds the actor's pre-fight incomingHeal baseline (playerTurn folds it into
+    // scheduledTotals), so the preFight fallback below fires ONLY before the actor's first
+    // turn — never double-counted (F3).
     const recipientMaxHp = (id: string): number =>
         lastTurnCtxByActor.get(id)?.effectiveMaxHp ?? baseHpFor(id);
     const recipientIncomingHealPct = (id: string): number =>
-        lastTurnCtxByActor.get(id)?.incomingHealPct ?? 0;
+        lastTurnCtxByActor.get(id)?.incomingHealPct ??
+        allActorsById.get(id)?.preFight?.incomingHeal ??
+        0;
 
     // Heal target's live HP% (0..100) for `hpSubject:'target'` cast-time gates (Task 5). Read at
     // the ACTING actor's turn start (pre-this-cast-heal): healTarget.currentHp already reflects
@@ -3558,9 +3579,18 @@ export function runCombat(input: CombatEngineInput): {
             const selfIncoming = toSelfIncomingDamageModifier(
                 victimSelfBuffs(statusEngine, victimId, selfBuffLookup)
             );
+            // F3: the victim's pre-fight incomingDamage baseline (squad-leader "±N% incoming
+            // direct damage") folds ADDITIVELY into the same per-victim channel the D-PR12
+            // self-buff term rides (consumed via defenseProfileOf → incomingDamageModifierPct).
+            // Sign convention matches the buff channel: negative = takes less damage
+            // (leader protections use negative values). Absent → 0 → byte-identical. Like
+            // the buff channel, this is DIRECT damage only (DoTs/bombs never read it).
+            const preFightIncoming =
+                allActorsById.get(victimId)?.preFight?.incomingDamage ?? 0;
             return {
                 enemyDefenseModifier: enemy.enemyDefenseModifier,
-                incomingDamageModifier: enemy.incomingDamageModifier + selfIncoming,
+                incomingDamageModifier:
+                    enemy.incomingDamageModifier + selfIncoming + preFightIncoming,
             };
         };
         // TEST-ONLY: expose victimIncomingModifiers (enemy-debuff + friendly self-buff term,
@@ -3664,14 +3694,30 @@ export function runCombat(input: CombatEngineInput): {
                 // across all three sites (focus / walked-team / enemy) since drivePositionalApply
                 // makes ONE applyPositionalDamage call. incomingReductionForHit returns 0 for actors
                 // with no incoming-reduction ability → byte-identical when no such equipment exists.
-                incomingReductionFor: (victim, didCrit) =>
-                    incomingReductionForHit(incomingAbilitiesOf(victim.id), {
+                incomingReductionFor: (victim, didCrit) => {
+                    const equip = incomingReductionForHit(incomingAbilitiesOf(victim.id), {
                         didCrit,
                         attackerStealthed: isStealthed(args.actingId),
                         victimStealthed: isStealthed(victim.id),
                         victimStasised: isStasised(victim.id),
                         hitIndexThisRound: 0, // unused by reduction (only block reads it)
-                    }),
+                    });
+                    if (!didCrit) return equip;
+                    // F3 crit-conditional pre-fight damage modifiers, gated per sub-hit on
+                    // didCrit — the SAME crit-family mechanism as the equip reduction above
+                    // (a hit that crits sees the extra reduction on its whole damage).
+                    // SIGN CONVENTION: this channel is a REDUCTION (positive = less damage),
+                    // while the leader data is benefit/penalty-phrased pct points:
+                    //   victim incomingCritDamage  -10 → takes 10% smaller crits → +10 reduction;
+                    //   attacker outgoingCritDamage -10 (Negotiator III on enemies) → its crits
+                    //   deal 10% less → +10 reduction; positive values invert symmetrically.
+                    // Hence both terms are NEGATED. Absent → 0 → byte-identical.
+                    const victimCritTerm = -(victim.preFight?.incomingCritDamage ?? 0);
+                    const attackerCritTerm = -(
+                        allActorsById.get(args.actingId)?.preFight?.outgoingCritDamage ?? 0
+                    );
+                    return equip + victimCritTerm + attackerCritTerm;
+                },
                 // D-PR4: attacker-side outgoing amplification (Menace/Giant Slayer), per footprint
                 // victim per sub-hit. outgoingAmplificationForHit returns 0 for attackers with no
                 // outgoing-amplification ability → byte-identical when no such equipment exists.
@@ -4056,6 +4102,11 @@ export function runCombat(input: CombatEngineInput): {
                 activePattern: parsedPatternFor(a),
                 chargedPattern: parsedChargedPatternFor(a),
                 sameSideLiving: sameSideLivingFor(a),
+                // F3: the acting actor's pre-fight modifier baseline (outgoingDamage /
+                // outgoingHeal / incomingHeal fold into its self-buff totals inside
+                // runPlayerTurn). Side-agnostic — enemy attackers walk the same path.
+                // Conditional spread → absent for every existing caller (byte-identical).
+                ...(a.preFight ? { preFight: a.preFight } : {}),
             };
         };
 
@@ -5681,8 +5732,20 @@ export function runCombat(input: CombatEngineInput): {
                                           hitIndexThisRound: 0,
                                       })
                                     : 0;
+                                // F3: crit-conditional pre-fight damage modifiers, mirrored from
+                                // the positional incomingReductionFor site (crit hits only, via
+                                // the crit-family delta). Same sign convention: the channel is a
+                                // REDUCTION, leader values are benefit/penalty-phrased, so both
+                                // terms are negated (victim incomingCritDamage -10 → +10 reduction
+                                // on crits; attacker outgoingCritDamage -10 → its crits deal 10%
+                                // less). Absent → 0 → byte-identical.
+                                const preFightCritFamilyPct =
+                                    -(tgt.preFight?.incomingCritDamage ?? 0) -
+                                    (actor.preFight?.outgoingCritDamage ?? 0);
                                 const incomingReductionCritFamilyPct =
-                                    incomingReductionCritAll - incomingReductionNonCritPct;
+                                    incomingReductionCritAll -
+                                    incomingReductionNonCritPct +
+                                    preFightCritFamilyPct;
                                 const enemyTurn = runPlayerTurn({
                                     ...buildTurnArgs(actor, tgt),
                                     deferAbilityPerformedToEngine: enemyWillApplyPositionally,

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -43,6 +43,7 @@ import { recipientCarriesBlockBuff } from './blockBuffBuffs';
 import { resolveSupportRecipients } from './supportRecipients';
 import { supportFootprintAllyIds } from './supportFootprint';
 import type { AttackerDamageScalars } from './victimDamage';
+import type { PreFightCombatModifiers } from './preFight/types';
 import { effectiveDamageStatsOf, liveDebuffLandingChance } from './effectiveStats';
 import {
     targetCarriesBlockDebuff,
@@ -387,6 +388,14 @@ export interface PlayerTurnArgs {
     chargedPattern?: ParsedPattern;
     /** Living same-side roster for support footprint resolution (positional mode). */
     sameSideLiving?: CombatActor[];
+    /** Pre-fight combat-modifier baseline for THIS acting actor (sub-project F, PR F3).
+     *  outgoingDamage/outgoingHeal/incomingHeal fold additively into the scheduled self-buff
+     *  totals right after resolveSelfBuffTotals, flowing through effectiveDamageStatsOf into
+     *  every existing damage/heal consumer (incl. turnCtx + positionalScalars). NOTE:
+     *  outgoingCritDamage is NOT folded here — "outgoing crit damage" is a crit-conditional
+     *  DAMAGE modifier (not the Crit Power stat), consumed at the engine's crit-family
+     *  damage sites. Absent → byte-identical. */
+    preFight?: PreFightCombatModifiers;
 }
 
 // ---------------------------------------------------------------------------
@@ -948,6 +957,18 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         activeSelfBuffs: entry.activeSelfBuffs,
         selfBuffLookup,
     });
+    // F3: fold the actor's pre-fight modifier baseline (squad leaders) into the layer-1
+    // totals — outgoingDamage → outgoing-damage buff, outgoingHeal/incomingHeal → the heal
+    // buffs. All three flow through effectiveDamageStatsOf into the existing consumers
+    // (damage assembly, heal block, turnCtx, positionalScalars) with buff-channel semantics
+    // (direct damage only; additive pct points). outgoingCritDamage is deliberately NOT
+    // folded (crit-conditional damage modifier — consumed at the engine's crit-family
+    // sites, never via critDamageBuff/effectiveDamageStatsOf). Absent → byte-identical.
+    if (args.preFight) {
+        scheduledTotals.outgoingDamageBuff += args.preFight.outgoingDamage;
+        scheduledTotals.outgoingHealBuff += args.preFight.outgoingHeal;
+        scheduledTotals.incomingHealBuff += args.preFight.incomingHeal;
+    }
     // Partial crit-buff total for the gate estimates: starts at layer 1, then gains
     // layers 2+3 (abilityTotalsForGates) before the modifier gate at the modifierCtx.
     let critBuffForGates = scheduledTotals.critBuff;

--- a/src/utils/combat/preFight/__tests__/squadLeaderPass.test.ts
+++ b/src/utils/combat/preFight/__tests__/squadLeaderPass.test.ts
@@ -70,7 +70,7 @@ const { SYNTHETIC_LEADER } = vi.hoisted(() => {
                     value: 5,
                     text: '+5% Damage Reduction',
                 },
-                // unconditional mapped modifier → accumulates AND is unsimulated (F1 caveat).
+                // unconditional mapped modifier → accumulates silently (simulated since F3).
                 {
                     kind: 'modifier',
                     target: 'all-allies',
@@ -317,7 +317,9 @@ describe('squadLeaderPass — skip rules (synthetic leader)', () => {
         expect(marauder.stats).toEqual({ ...BASE_STATS });
         expect(offFaction.stats).toEqual({ ...BASE_STATS });
 
-        // Every skipped effect surfaced verbatim on the faction recipient.
+        // Every skipped effect surfaced verbatim on the faction recipient. The unconditional
+        // MAPPED modifier ('+7% Outgoing direct damage') is SIMULATED since F3 — it
+        // accumulates silently and must NOT appear here.
         expect(marauder.unsimulated).toEqual([
             '+10% Attack while below 50% HP',
             'un-modelled weirdness',
@@ -325,11 +327,10 @@ describe('squadLeaderPass — skip rules (synthetic leader)', () => {
             'Self +5% Attack',
             '+10% Heal Modifier',
             '+5% Damage Reduction',
-            '+7% Outgoing direct damage',
         ]);
         expect(offFaction.unsimulated).toEqual([]);
 
-        // The unconditional mapped modifier accumulated (F1 caveat: ALSO unsimulated above);
+        // The unconditional mapped modifier accumulated (consumed by the engine since F3);
         // the per-round shieldGeneration did NOT.
         expect(marauder.modifiers.outgoingDamage).toBe(7);
         expect(marauder.modifiers.startingShieldPctOfHp).toBe(0);
@@ -346,13 +347,13 @@ describe('squadLeaderPass — skip rules (synthetic leader)', () => {
         expect(player[0].modifiers.outgoingDamage).toBe(0);
     });
 
-    it('an unconditional modifier (Malachi stage 2 outgoing repair) accumulates AND reports unsimulated', () => {
+    it('an unconditional modifier (Malachi stage 2 outgoing repair) accumulates WITHOUT reporting unsimulated (simulated since F3)', () => {
         const player = [makeUnit('p1', 'player', 'EVERLIVING')];
         runPass(player, [], {
             player: { faction: 'EVERLIVING', name: 'Malachi', stage: 2 },
         });
         expect(player[0].modifiers.outgoingHeal).toBe(15);
-        expect(player[0].unsimulated).toContain('+15% Outgoing repair');
+        expect(player[0].unsimulated).not.toContain('+15% Outgoing repair');
     });
 });
 
@@ -386,18 +387,20 @@ describe('squadLeaderPass — full-data sweep (real, unmocked SQUAD_LEADERS)', (
                         effect.kind === 'other' ||
                         effect.recurrence === 'per-round' ||
                         effect.target === 'self';
-                    if (skipped || effect.kind === 'modifier') {
-                        // Skipped and (F1 caveat) modifier effects must surface verbatim.
+                    if (skipped) {
+                        // Skipped effects must surface verbatim.
                         expect(surfaced, `${faction}/${leader.name}: "${effect.text}"`).toContain(
                             effect.text
                         );
                     } else {
-                        // Pure stat effects must FOLD (never fall to the defensive
-                        // unsimulated path) — proves every data stat name maps onto
-                        // PreFightStatBlock.
+                        // Everything else is SIMULATED (F3): stat effects fold into the
+                        // pre-fight block, unconditional modifier effects accumulate into
+                        // consumed channels — proving every real data stat name AND every
+                        // real modifier channel is mapped (the defensive unknown-stat /
+                        // unmapped-channel paths are covered by the synthetic leader above).
                         expect(
                             surfaced,
-                            `${faction}/${leader.name}: "${effect.text}" should have folded`
+                            `${faction}/${leader.name}: "${effect.text}" should be simulated`
                         ).not.toContain(effect.text);
                     }
                 }

--- a/src/utils/combat/preFight/index.ts
+++ b/src/utils/combat/preFight/index.ts
@@ -14,7 +14,7 @@ export type {
     PreFightPass,
     SquadLeaderSelection,
 } from './types';
-export { emptyPreFightModifiers } from './types';
+export { emptyPreFightModifiers, hasAnyPreFightModifier } from './types';
 export {
     squadLeaderPass,
     activeSquadLeaderEffects,

--- a/src/utils/combat/preFight/squadLeaderPass.ts
+++ b/src/utils/combat/preFight/squadLeaderPass.ts
@@ -109,11 +109,12 @@ export function squadLeaderEffectTargeting<T extends { faction: FactionName }>(
     return { scope: 'allies', recipients: own.filter((u) => u.faction === leaderFaction) };
 }
 
-/** Whether the pass SIMULATES an effect (folds it into stats) or surfaces it via
- *  `unsimulated`. Mirrors the pass's branch order exactly: conditional / 'other' /
- *  per-round / 'self' effects are unsimulated; stat effects are simulated iff the
- *  stat is in the pre-fight block; ALL modifier-channel effects are unsimulated
- *  until PR F3 wires the engine consumers (they still accumulate in the pass). */
+/** Whether the pass SIMULATES an effect (folds it into stats / a consumed modifier
+ *  channel) or surfaces it via `unsimulated`. Mirrors the pass's branch order exactly:
+ *  conditional / 'other' / per-round / 'self' effects are unsimulated; stat effects are
+ *  simulated iff the stat is in the pre-fight block; modifier effects are simulated iff
+ *  their channel maps onto a `PreFightCombatModifiers` field (the engine consumes every
+ *  mapped channel since PR F3 — unmapped channels stay unsimulated). */
 export function isSquadLeaderEffectSimulated(effect: SquadLeaderEffect): boolean {
     if (
         effect.condition !== undefined ||
@@ -124,8 +125,8 @@ export function isSquadLeaderEffectSimulated(effect: SquadLeaderEffect): boolean
         return false;
     }
     if (effect.kind === 'stat') return isPreFightStat(effect.stat);
-    // kind === 'modifier': accumulated but consumed only from PR F3 on.
-    return false;
+    // kind === 'modifier': mapped channels are consumed by the engine (PR F3).
+    return MODIFIER_FIELD_BY_CHANNEL[effect.channel] !== undefined;
 }
 
 /** Resolve ONE side's leader selection and fold its active effects into that side's
@@ -204,12 +205,12 @@ function applyLeaderForSide(
                 for (const unit of recipients) unit.unsimulated.push(effect.text);
                 continue;
             }
+            // SIMULATED (PR F3): every mapped channel is consumed by the engine — the
+            // battle simulator attaches the accumulated block to the unit's actor and
+            // the folds fire at the buff-channel/crit-family/shield-seed sites. Only
+            // conditional effects (filtered above) and unmapped channels stay unsimulated.
             for (const unit of recipients) {
                 unit.modifiers[field] += effect.value;
-                // TODO(F3): modifiers accumulate but nothing consumes them until PR F3
-                // wires the engine channels — report as unsimulated until then. F3
-                // removes this push (only conditional effects stay unsimulated).
-                unit.unsimulated.push(effect.text);
             }
         }
     }

--- a/src/utils/combat/preFight/types.ts
+++ b/src/utils/combat/preFight/types.ts
@@ -29,8 +29,12 @@ export interface PreFightStatBlock {
  * percentage points (0 = inert): outgoing/incoming damage, crit-damage and heal
  * scaling, plus `startingShieldPctOfHp` (starting shield pool as % of max HP).
  *
- * F1 accumulates these; the engine consumes them in PR F3. Until then any effect that
- * lands here is ALSO surfaced via `PreFightUnit.unsimulated`.
+ * The squad-leader pass accumulates these (F1); the battle simulator attaches the
+ * block to each unit's engine actor (`CombatActor.preFight`) and the engine folds
+ * every channel at its consumption site (F3): outgoingDamage/outgoingHeal/incomingHeal
+ * into the self-buff totals, incomingDamage into the per-victim incoming channel,
+ * incoming/outgoingCritDamage at the crit-family damage sites (crit-conditional damage
+ * modifiers — NOT the Crit Power stat), startingShieldPctOfHp as the starting shieldPool.
  */
 export interface PreFightCombatModifiers {
     outgoingDamage: number;
@@ -53,6 +57,13 @@ export function emptyPreFightModifiers(): PreFightCombatModifiers {
         incomingHeal: 0,
         startingShieldPctOfHp: 0,
     };
+}
+
+/** True when at least one modifier channel is non-zero. The battle simulator attaches a
+ *  unit's block to its engine actor ONLY in that case, so an all-zero block never rides
+ *  along (keeps stat-only-leader runs structurally identical to no-modifier runs). */
+export function hasAnyPreFightModifier(m: PreFightCombatModifiers): boolean {
+    return Object.values(m).some((v) => v !== 0);
 }
 
 /** One placed unit as the pre-fight passes see it. */

--- a/src/utils/combat/state.ts
+++ b/src/utils/combat/state.ts
@@ -1,6 +1,7 @@
 import type { Position } from '../../types/encounters';
 import type { AffinityName } from '../../types/ship';
 import type { CombatEventBus } from './events';
+import type { PreFightCombatModifiers } from './preFight/types';
 
 /** Per-actor damage contributions within one round (spec: per-actor accounting —
  *  the simulator-page seam). secondary/conditional are sub-buckets of direct
@@ -153,6 +154,12 @@ export interface CombatActor {
     /** When true, enemy-sourced charge removal is a no-op against this actor
      *  ("immune to charge loss effects"). Derived from ship skill text. */
     chargeLossImmune: boolean;
+    /** Pre-fight combat-modifier baseline (sub-project F, PR F3): squad-leader modifier
+     *  channels accumulated BEFORE combat (additive pct points). Hidden, permanent,
+     *  non-purgeable — deliberately NOT statuses (they would leak into logs/purge/cleanse).
+     *  Consumed via `?? 0` folds at the exact sites the regular buff channels are read;
+     *  absent on every existing caller (DPS/healing sims, fixtures) → all folds inert. */
+    preFight?: PreFightCombatModifiers;
 }
 
 export function createActor(
@@ -166,6 +173,7 @@ export function createActor(
         affinity?: AffinityName;
         indestructible?: boolean;
         chargeLossImmune?: boolean;
+        preFight?: PreFightCombatModifiers;
     }
 ): CombatActor {
     // startCharged is a one-shot initialiser (it seeds `charges`), deliberately NOT
@@ -174,7 +182,10 @@ export function createActor(
     return {
         ...rest,
         currentHp: partial.stats.hp,
-        shieldPool: 0,
+        // Pre-fight shield seeding (F3): "Start combat shielded for N% of max HP" — hp is
+        // already post-leader (the pre-fight stat pass mutated plan stats before actor
+        // construction). Absent preFight → 0 → byte-identical to the old literal 0.
+        shieldPool: partial.stats.hp * ((partial.preFight?.startingShieldPctOfHp ?? 0) / 100),
         turnMeter: 0,
         charges: startCharged ? chargeCount : 0,
         chargeCount,
@@ -189,6 +200,7 @@ export function createActor(
         indestructible: partial.indestructible,
         turnsTaken: 0,
         chargeLossImmune: partial.chargeLossImmune ?? false,
+        preFight: partial.preFight,
     };
 }
 

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1848,11 +1848,15 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
         const ownerCtx = ctx.lastTurnCtxByActor.get(intent.ownerId);
         // Owner outgoing-repair %; and recipient incoming-repair % (self → owner's own ctx,
         // any other recipient → its last-turn ctx via the runtime accessor). Mirrors the cast
-        // path's incomingPctFor (playerTurn.ts).
-        const ownerOutgoing = ownerCtx?.outgoingHealPct ?? 0;
+        // path's incomingPctFor (playerTurn.ts). F3: pre-first-turn (no ctx yet), fall back
+        // to the owner's pre-fight heal baseline — FALLBACK ONLY, never added to a ctx value
+        // (the ctx already folds preFight via playerTurn's scheduledTotals fold), so no
+        // double-count. The non-self recipient path inherits the same fallback from the
+        // engine's recipientIncomingHealPct.
+        const ownerOutgoing = ownerCtx?.outgoingHealPct ?? owner.actor.preFight?.outgoingHeal ?? 0;
         const incomingPctFor = (rid: string): number =>
             rid === intent.ownerId
-                ? (ownerCtx?.incomingHealPct ?? 0)
+                ? (ownerCtx?.incomingHealPct ?? owner.actor.preFight?.incomingHeal ?? 0)
                 : healing.recipientIncomingHealPct(rid);
         // Non-target-hp bases are owner-scoped → resolve ONCE. For 'target-hp' the basis is the
         // RECIPIENT's max HP, which differs per recipient for all-allies/self reactive heals, so


### PR DESCRIPTION
## Summary

Third PR of the squad-leader wiring (stacked on #190 → #188; merge order F1 → F2 → F3). Consumes the modifier-channel effects F1 accumulated: after this PR, 113 of 115 squad-leader effects are fully simulated — only the 2 conditional Marauder effects and the 2 Binderburg derived-value effects remain marked 'not simulated'.

**Mechanism**: optional `CombatActor.preFight` baseline (the D-PR3/D-PR4 static-field pattern) — hidden, permanent, unpurgeable by construction, invisible to cleanse/purge/logs. Every fold is `+ (preFight?.X ?? 0)`.

| Channel | Consumption site |
|---|---|
| outgoingDamage, outgoingHeal, incomingHeal | self buff totals fold in playerTurn (flows via effectiveDamageStatsOf; both sides symmetric) |
| incomingDamage (victim) | D-PR12 per-victim channel in victimIncomingModifiers |
| incomingCritDamage + outgoingCritDamage | crit-family reduction, gated per sub-hit on didCrit, positional + aggregate sites |
| shieldGeneration | shieldPool seed at createActor from post-leader max HP |
| incomingHeal (pre-first-turn) | fallback before first turn ctx exists (no-double-count proven by test) |

**Game-rule note**: 'incoming/outgoing crit damage' is a crit-conditional damage modifier, distinct from the Crit Power stat — `outgoingCritDamage` deliberately never touches `critDamageBuff`.

## Golden safety

Zero snapshot churn across the full suite. F1's no-leader deep-equal test passes untouched, plus a new test proving a stat-only leader run is byte-identical before/after this PR (zero-modifier plumbing attaches nothing).

## Test plan

- [x] `npx tsc --noEmit` / `npm run lint` (0 warnings) clean
- [x] `npm test` — 293 files / 3795 tests, zero `__snapshots__` churn
- [x] `npm run audit:skills` — 0 findings
- [x] 18 new tests: per-channel integration through `simulateBattle` with real leaders (Predator, Midas, Optimizer, Negotiator, Broker) + engine-level fold tests with exact-ratio assertions (×1.05, ×0.925, ×0.9, crit-0 unchanged, 20% shield seed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wd1aeh2x3P7KK84pfhrnA6