### PR TITLE
feat(simulator): per-side squad-leader picker (sub-project F, PR F2)

### DIFF
--- a/src/components/simulator/SquadLeaderPicker.tsx
+++ b/src/components/simulator/SquadLeaderPicker.tsx
@@ -1,0 +1,198 @@
+import React, { useMemo } from 'react';
+import { Select } from '../ui/Select';
+import { FACTIONS } from '../../constants/factions';
+import { RARITIES } from '../../constants/rarities';
+import { SQUAD_LEADERS, SquadLeaderEffect } from '../../constants/squadLeaders';
+import {
+    activeSquadLeaderEffects,
+    isSquadLeaderEffectSimulated,
+    squadLeaderEffectTargeting,
+    SquadLeaderSelection,
+} from '../../utils/combat/preFight';
+import { Ship } from '../../types/ship';
+import { BoardState } from './PlacementBoard';
+
+/** Stage labels match SquadLeaderCard's STEP_LABELS. */
+const STAGE_LABELS = ['I', 'II', 'III'] as const;
+const STAGE_OPTIONS = STAGE_LABELS.map((label, i) => ({ value: String(i + 1), label }));
+
+/** Stage a leader defaults to when first picked: III (maxed — the common case, and the
+ *  only stage where legendary enemy debuffs exist, so the preview shows the full kit). */
+const DEFAULT_STAGE = 3;
+
+const factionLabel = (faction: string): string => FACTIONS[faction]?.name ?? faction;
+
+interface PreviewLine {
+    effect: SquadLeaderEffect;
+    /** Who the effect lands on, e.g. "2 Marauders ships" / "all enemy ships". */
+    targetLabel: string;
+    enemySide: boolean;
+    simulated: boolean;
+}
+
+interface Props {
+    side: 'player' | 'enemy';
+    /** The side's current selection; undefined = no leader. */
+    selection: SquadLeaderSelection | undefined;
+    onChange: (selection: SquadLeaderSelection | undefined) => void;
+    /** The side's placement board (drives the applied-effects preview + faction gate). */
+    board: BoardState;
+}
+
+/**
+ * Per-side squad-leader picker for the Combat Simulator: Faction (+None) → Leader →
+ * Stage selects, plus an applied-effects preview resolved against the CURRENT board
+ * via the same preFight targeting/classification helpers the sim pass uses.
+ */
+const SquadLeaderPicker: React.FC<Props> = ({ side, selection, onChange, board }) => {
+    const ships = useMemo(
+        () => Object.values(board).filter((ship): ship is Ship => ship !== undefined),
+        [board]
+    );
+
+    const factionOptions = useMemo(
+        () =>
+            Object.keys(SQUAD_LEADERS).map((faction) => ({
+                value: faction,
+                label: factionLabel(faction),
+            })),
+        []
+    );
+
+    const leaderOptions = useMemo(() => {
+        if (!selection) return [];
+        return (SQUAD_LEADERS[selection.faction] ?? []).map((leader) => ({
+            value: leader.name,
+            label: `${leader.name} (${RARITIES[leader.rarity]?.label ?? leader.rarity})`,
+        }));
+    }, [selection]);
+
+    const handleFactionChange = (faction: string) => {
+        if (!faction) {
+            onChange(undefined);
+            return;
+        }
+        const leaders = SQUAD_LEADERS[faction];
+        if (!leaders || leaders.length === 0) {
+            onChange(undefined);
+            return;
+        }
+        // Faction change resets the leader to the new faction's first (rare) leader so a
+        // stale name can never pair with the wrong faction; the stage carries over.
+        onChange({ faction, name: leaders[0].name, stage: selection?.stage ?? DEFAULT_STAGE });
+    };
+
+    const handleLeaderChange = (name: string) => {
+        if (!selection || !name) return;
+        onChange({ ...selection, name });
+    };
+
+    const handleStageChange = (stage: string) => {
+        if (!selection) return;
+        if (stage !== '1' && stage !== '2' && stage !== '3') return;
+        onChange({ ...selection, stage: Number(stage) as 1 | 2 | 3 });
+    };
+
+    // Applied-effects preview: resolve the active effects against the current board with
+    // the SAME targeting + classification rules as the sim's squadLeaderPass (imported
+    // from the preFight module — never reimplemented here).
+    const preview = useMemo(() => {
+        if (!selection) return undefined;
+        const leader = SQUAD_LEADERS[selection.faction]?.find((l) => l.name === selection.name);
+        if (!leader) return undefined;
+        const label = factionLabel(selection.faction);
+        const gateMet = ships.some((ship) => ship.faction === selection.faction);
+        const lines: PreviewLine[] = activeSquadLeaderEffects(leader, selection.stage).map(
+            (effect) => {
+                const targeting = squadLeaderEffectTargeting(effect, selection.faction, ships);
+                const targetLabel =
+                    targeting.scope === 'enemies'
+                        ? 'all enemy ships'
+                        : `${targeting.recipients.length} ${label} ship${
+                              targeting.recipients.length === 1 ? '' : 's'
+                          }`;
+                return {
+                    effect,
+                    targetLabel,
+                    enemySide: targeting.scope === 'enemies',
+                    simulated: isSquadLeaderEffectSimulated(effect),
+                };
+            }
+        );
+        return { lines, gateMet, factionLabel: label };
+    }, [selection, ships]);
+
+    return (
+        <div className="card space-y-3">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-theme-text-secondary">
+                Squad Leader
+            </h3>
+            <div className="flex flex-wrap gap-3">
+                <Select
+                    label="Faction"
+                    noDefaultSelection
+                    defaultOption="None"
+                    value={selection?.faction ?? ''}
+                    options={factionOptions}
+                    onChange={handleFactionChange}
+                    data-testid={`squad-leader-faction-${side}`}
+                />
+                <Select
+                    label="Leader"
+                    value={selection?.name ?? ''}
+                    options={leaderOptions}
+                    onChange={handleLeaderChange}
+                    disabled={!selection}
+                    data-testid={`squad-leader-name-${side}`}
+                />
+                <Select
+                    label="Stage"
+                    value={selection ? String(selection.stage) : ''}
+                    options={STAGE_OPTIONS}
+                    onChange={handleStageChange}
+                    disabled={!selection}
+                    data-testid={`squad-leader-stage-${side}`}
+                />
+            </div>
+            {preview && (
+                <div className="space-y-1">
+                    {!preview.gateMet && (
+                        <p className="text-sm text-amber-400">
+                            No {preview.factionLabel} ship on this team — leader effects inactive
+                            (enemy-targeting effects included).
+                        </p>
+                    )}
+                    <ul className="space-y-1">
+                        {preview.lines.map((line, index) => (
+                            <li
+                                key={index}
+                                className={`text-sm ${
+                                    // Gate unmet → nothing applies: dim every line. Otherwise
+                                    // mirror SquadLeaderCard: ally = green, enemy = red.
+                                    !preview.gateMet
+                                        ? 'text-theme-text-secondary'
+                                        : line.enemySide
+                                          ? 'text-red-400'
+                                          : 'text-green-400'
+                                }`}
+                            >
+                                {line.effect.text}
+                                <span className="text-theme-text-secondary">
+                                    {' '}
+                                    &rarr; {line.targetLabel}
+                                </span>
+                                {!line.simulated && (
+                                    <span className="ml-2 align-middle text-xs uppercase tracking-wide px-1.5 py-0.5 border border-amber-500/40 text-amber-400">
+                                        Not simulated
+                                    </span>
+                                )}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default SquadLeaderPicker;

--- a/src/components/simulator/__tests__/SquadLeaderPicker.test.tsx
+++ b/src/components/simulator/__tests__/SquadLeaderPicker.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SquadLeaderPicker from '../SquadLeaderPicker';
+import type { BoardState } from '../PlacementBoard';
+import type { Ship } from '../../../types/ship';
+import type { SquadLeaderSelection } from '../../../utils/combat/preFight';
+
+const marauderShip = (id: string): Ship => ({ id, name: id, faction: 'MARAUDERS' }) as Ship;
+const atlasShip = (id: string): Ship => ({ id, name: id, faction: 'ATLAS_SYNDICATE' }) as Ship;
+
+// 2 Marauders + 1 off-faction ship.
+const marauderBoard: BoardState = {
+    T1: marauderShip('m1'),
+    T2: marauderShip('m2'),
+    M1: atlasShip('a1'),
+};
+
+const renderPicker = (props: Partial<React.ComponentProps<typeof SquadLeaderPicker>> = {}) =>
+    render(
+        <SquadLeaderPicker
+            side="player"
+            selection={undefined}
+            onChange={vi.fn()}
+            board={{}}
+            {...props}
+        />
+    );
+
+const brandisherStage3: SquadLeaderSelection = {
+    faction: 'MARAUDERS',
+    name: 'Brandisher',
+    stage: 3,
+};
+
+describe('SquadLeaderPicker selects', () => {
+    it('lists all 10 factions plus a None option', () => {
+        renderPicker();
+        fireEvent.click(screen.getByRole('button', { name: /Faction/i }));
+        expect(screen.getByRole('option', { name: 'None' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Marauders' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Atlas Syndicate' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Terran Combine' })).toBeInTheDocument();
+        // 10 factions + None.
+        expect(screen.getAllByRole('option')).toHaveLength(11);
+    });
+
+    it('selecting a faction picks its first leader at the default stage', () => {
+        const onChange = vi.fn();
+        renderPicker({ onChange });
+        fireEvent.click(screen.getByRole('button', { name: /Faction/i }));
+        fireEvent.click(screen.getByRole('option', { name: 'Marauders' }));
+        expect(onChange).toHaveBeenCalledWith({ faction: 'MARAUDERS', name: 'Puppet', stage: 3 });
+    });
+
+    it('changing faction resets the leader to the new faction (stage carries over)', () => {
+        const onChange = vi.fn();
+        renderPicker({
+            selection: { faction: 'ATLAS_SYNDICATE', name: 'Negotiator', stage: 2 },
+            onChange,
+        });
+        fireEvent.click(screen.getByRole('button', { name: /Faction/i }));
+        fireEvent.click(screen.getByRole('option', { name: 'Marauders' }));
+        expect(onChange).toHaveBeenCalledWith({ faction: 'MARAUDERS', name: 'Puppet', stage: 2 });
+    });
+
+    it('selecting None clears the selection', () => {
+        const onChange = vi.fn();
+        renderPicker({ selection: brandisherStage3, onChange });
+        fireEvent.click(screen.getByRole('button', { name: /Faction/i }));
+        fireEvent.click(screen.getByRole('option', { name: 'None' }));
+        expect(onChange).toHaveBeenCalledWith(undefined);
+    });
+
+    it('lists the faction leaders with rarity labels and switches leader', () => {
+        const onChange = vi.fn();
+        renderPicker({ selection: brandisherStage3, onChange });
+        fireEvent.click(screen.getByRole('button', { name: /Leader/i }));
+        expect(screen.getByRole('option', { name: 'Puppet (Rare)' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Reaper (Epic)' })).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('option', { name: 'Reaper (Epic)' }));
+        expect(onChange).toHaveBeenCalledWith({ faction: 'MARAUDERS', name: 'Reaper', stage: 3 });
+    });
+
+    it('changes the stage via the I / II / III select', () => {
+        const onChange = vi.fn();
+        renderPicker({ selection: brandisherStage3, onChange });
+        fireEvent.click(screen.getByRole('button', { name: /Stage/i }));
+        fireEvent.click(screen.getByRole('option', { name: 'I' }));
+        expect(onChange).toHaveBeenCalledWith({ faction: 'MARAUDERS', name: 'Brandisher', stage: 1 });
+    });
+});
+
+describe('SquadLeaderPicker applied-effects preview', () => {
+    it('shows per-effect recipient counts for the current board', () => {
+        renderPicker({ selection: brandisherStage3, board: marauderBoard });
+        // Stage I ally stat effects land on the 2 placed Marauders (not the Atlas ship).
+        expect(screen.getByText('+10% Attack')).toBeInTheDocument();
+        expect(screen.getAllByText(/2 Marauders ships/).length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('shows enemy-targeting stage III effects as hitting all enemy ships', () => {
+        renderPicker({ selection: brandisherStage3, board: marauderBoard });
+        expect(screen.getByText('Enemy units lose 15 Security')).toBeInTheDocument();
+        expect(screen.getByText('Enemy units lose 10% Defence')).toBeInTheDocument();
+        expect(screen.getAllByText(/all enemy ships/)).toHaveLength(2);
+    });
+
+    it('marks effects the sim cannot model with a Not simulated tag', () => {
+        renderPicker({ selection: brandisherStage3, board: marauderBoard });
+        // Stage II "+25% direct damage to secondary targets" is conditional → unsimulated;
+        // the four stat effects (I ally buffs + III enemy debuffs) are simulated.
+        expect(
+            screen.getByText('+25% direct damage to secondary targets')
+        ).toBeInTheDocument();
+        expect(screen.getAllByText('Not simulated')).toHaveLength(1);
+    });
+
+    it('scopes the preview to the selected stage', () => {
+        renderPicker({
+            selection: { ...brandisherStage3, stage: 1 },
+            board: marauderBoard,
+        });
+        expect(screen.getByText('+10% Attack')).toBeInTheDocument();
+        expect(
+            screen.queryByText('+25% direct damage to secondary targets')
+        ).not.toBeInTheDocument();
+        expect(screen.queryByText('Enemy units lose 15 Security')).not.toBeInTheDocument();
+    });
+
+    it('warns when no leader-faction ship is placed (faction gate unmet)', () => {
+        renderPicker({ selection: brandisherStage3, board: { M1: atlasShip('a1') } });
+        expect(
+            screen.getByText(
+                /No Marauders ship on this team — leader effects inactive \(enemy-targeting effects included\)\./
+            )
+        ).toBeInTheDocument();
+    });
+
+    it('shows no gate warning while a faction ship is placed', () => {
+        renderPicker({ selection: brandisherStage3, board: marauderBoard });
+        expect(screen.queryByText(/leader effects inactive/)).not.toBeInTheDocument();
+    });
+
+    it('renders no preview without a selection', () => {
+        renderPicker({ board: marauderBoard });
+        expect(screen.queryByText(/ships/)).not.toBeInTheDocument();
+        expect(screen.queryByText('Not simulated')).not.toBeInTheDocument();
+    });
+});

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -8,6 +8,7 @@ export const CURRENT_VERSION = '1.64.0';
 export const UNRELEASED_CHANGES: string[] = [
     'Combat sim: positioned board battles with skill-pattern targeting; shields and damage absorption; implants and gear set effects; control effects (Disable, Stasis, stealth); DoT, bombs, and detonations; counterattacks and enemy reactions; detailed combat log; affinity and charge rules; random crit/proc variance. DPS calculator now includes implant and gear set effects.',
     'Combat sim charge fixes: Selenite only gains charge vs live Stealth; Graphite start-of-round grant requires a living stealthed enemy and logs at round start; Liberator ally-charge on enemy death fires once per round for any kill (including ally kills).',
+    "Battle Simulator: pick a squad leader for each team (faction, leader, and upgrade stage, remembered between visits) — faction-scoped stat bonuses, and legendary stage-3 enemy debuffs, now apply in the simulation. A live preview under each board shows which placed ships each effect hits, and effects the sim can't model yet are marked 'Not simulated'.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3049,6 +3049,39 @@ const DocumentationPage: React.FC = () => {
                             </div>
 
                             <div className="p-4 bg-dark-lighter">
+                                <h4 className="font-semibold text-primary mb-2">Squad Leaders</h4>
+                                <ul className="text-theme-text list-disc pl-4 space-y-1">
+                                    <li>
+                                        Pick one squad leader per team beneath each placement board
+                                        — faction, leader, and upgrade stage (stages are additive:
+                                        stage III includes stages I and II)
+                                    </li>
+                                    <li>
+                                        Ally bonuses apply only to ships of the leader&apos;s
+                                        faction — a leader with no faction ship on its own team
+                                        grants nothing
+                                    </li>
+                                    <li>
+                                        Enemy-targeting effects exist only on legendary leaders at
+                                        stage III; they hit every opposing ship, but also require at
+                                        least one leader-faction ship on the leader&apos;s own team
+                                    </li>
+                                    <li>
+                                        Leader bonuses are hidden pre-fight modifiers: they fold
+                                        into each ship&apos;s fully geared stats before round 1, are
+                                        permanent, never appear as buffs, and are never purged,
+                                        cleansed, or reset on death
+                                    </li>
+                                    <li>
+                                        Effects the simulator cannot model yet (conditional bonuses,
+                                        per-round effects, and damage/heal/shield modifiers) are
+                                        marked &quot;Not simulated&quot; in the picker preview and
+                                        listed after each run
+                                    </li>
+                                </ul>
+                            </div>
+
+                            <div className="p-4 bg-dark-lighter">
                                 <h4 className="font-semibold text-primary mb-2">
                                     Watching the Battle
                                 </h4>

--- a/src/pages/SimulatorPage.tsx
+++ b/src/pages/SimulatorPage.tsx
@@ -15,6 +15,13 @@ import {
 } from '../utils/calculators/battleSimulator';
 import PlacementBoard, { BoardState } from '../components/simulator/PlacementBoard';
 import BattlePlayback from '../components/simulator/BattlePlayback';
+import SquadLeaderPicker from '../components/simulator/SquadLeaderPicker';
+import { SquadLeaderSelection } from '../utils/combat/preFight';
+import {
+    SQUAD_LEADER_STORAGE_KEYS,
+    readStoredSquadLeaderSelection,
+    writeStoredSquadLeaderSelection,
+} from '../utils/simulator/squadLeaderSelection';
 
 type Side = 'player' | 'enemy';
 
@@ -32,6 +39,19 @@ const SimulatorPage: React.FC = () => {
     const [enemySelected, setEnemySelected] = useState<Position | undefined>(undefined);
     const [battleResult, setBattleResult] = useState<BattleResult | null>(null);
     const [runError, setRunError] = useState<string | null>(null);
+    // Per-side squad-leader selections (pre-fight faction auras), persisted to
+    // localStorage (validated on read — stale/hand-edited values fall back to none).
+    const [playerSquadLeader, setPlayerSquadLeader] = useState<SquadLeaderSelection | undefined>(
+        () => readStoredSquadLeaderSelection(SQUAD_LEADER_STORAGE_KEYS.player)
+    );
+    const [enemySquadLeader, setEnemySquadLeader] = useState<SquadLeaderSelection | undefined>(
+        () => readStoredSquadLeaderSelection(SQUAD_LEADER_STORAGE_KEYS.enemy)
+    );
+
+    const handleSquadLeaderChange = (side: Side, selection: SquadLeaderSelection | undefined) => {
+        (side === 'player' ? setPlayerSquadLeader : setEnemySquadLeader)(selection);
+        writeStoredSquadLeaderSelection(SQUAD_LEADER_STORAGE_KEYS[side], selection);
+    };
 
     // FormationGrid consumes ShipPosition[] (it resolves the full ship by id via useShips).
     const playerFormation = useMemo<ShipPosition[]>(
@@ -126,6 +146,8 @@ const SimulatorPage: React.FC = () => {
                 {
                     playerTeam: buildTeam(playerBoard),
                     enemyTeam: buildTeam(enemyBoard),
+                    playerSquadLeader,
+                    enemySquadLeader,
                 },
                 getGearPiece
             );
@@ -150,27 +172,43 @@ const SimulatorPage: React.FC = () => {
             >
                 <div className="space-y-6">
                     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                        <PlacementBoard
-                            title={`Your Team${playerCount > 0 ? ` (${playerCount})` : ''}`}
-                            formation={playerFormation}
-                            selectedPosition={playerSelected}
-                            onSelectPosition={(pos) => handleSelectPosition('player', pos)}
-                            onRemoveShip={(pos) => handleRemoveShip('player', pos)}
-                            onPickShip={(ship) => handlePickShip('player', ship)}
-                            onCloseSelector={() => setPlayerSelected(undefined)}
-                            onLoadEncounter={(board) => handleLoadEncounter('player', board)}
-                        />
-                        <PlacementBoard
-                            title={`Enemy Team${enemyCount > 0 ? ` (${enemyCount})` : ''}`}
-                            formation={enemyFormation}
-                            selectedPosition={enemySelected}
-                            onSelectPosition={(pos) => handleSelectPosition('enemy', pos)}
-                            onRemoveShip={(pos) => handleRemoveShip('enemy', pos)}
-                            onPickShip={(ship) => handlePickShip('enemy', ship)}
-                            onCloseSelector={() => setEnemySelected(undefined)}
-                            onLoadEncounter={(board) => handleLoadEncounter('enemy', board)}
-                            mirrored
-                        />
+                        <div className="space-y-4">
+                            <PlacementBoard
+                                title={`Your Team${playerCount > 0 ? ` (${playerCount})` : ''}`}
+                                formation={playerFormation}
+                                selectedPosition={playerSelected}
+                                onSelectPosition={(pos) => handleSelectPosition('player', pos)}
+                                onRemoveShip={(pos) => handleRemoveShip('player', pos)}
+                                onPickShip={(ship) => handlePickShip('player', ship)}
+                                onCloseSelector={() => setPlayerSelected(undefined)}
+                                onLoadEncounter={(board) => handleLoadEncounter('player', board)}
+                            />
+                            <SquadLeaderPicker
+                                side="player"
+                                selection={playerSquadLeader}
+                                onChange={(sel) => handleSquadLeaderChange('player', sel)}
+                                board={playerBoard}
+                            />
+                        </div>
+                        <div className="space-y-4">
+                            <PlacementBoard
+                                title={`Enemy Team${enemyCount > 0 ? ` (${enemyCount})` : ''}`}
+                                formation={enemyFormation}
+                                selectedPosition={enemySelected}
+                                onSelectPosition={(pos) => handleSelectPosition('enemy', pos)}
+                                onRemoveShip={(pos) => handleRemoveShip('enemy', pos)}
+                                onPickShip={(ship) => handlePickShip('enemy', ship)}
+                                onCloseSelector={() => setEnemySelected(undefined)}
+                                onLoadEncounter={(board) => handleLoadEncounter('enemy', board)}
+                                mirrored
+                            />
+                            <SquadLeaderPicker
+                                side="enemy"
+                                selection={enemySquadLeader}
+                                onChange={(sel) => handleSquadLeaderChange('enemy', sel)}
+                                board={enemyBoard}
+                            />
+                        </div>
                     </div>
 
                     <div className="flex items-center gap-4">
@@ -186,6 +224,29 @@ const SimulatorPage: React.FC = () => {
 
                     {runError && (
                         <div className="card text-red-400">Simulation error: {runError}</div>
+                    )}
+
+                    {/* Squad-leader effects the sim could not model this run (conditional /
+                        per-round / modifier-channel effects) — surfaced so the outcome is
+                        never mistaken for a full simulation of the selected leaders. */}
+                    {battleResult?.preFight && battleResult.preFight.unsimulated.length > 0 && (
+                        <div className="card border-amber-500/40 space-y-1">
+                            <p className="text-sm font-semibold text-amber-400">
+                                Squad leader effects not simulated this run
+                            </p>
+                            <ul className="text-sm space-y-1">
+                                {battleResult.preFight.unsimulated.map((entry) => (
+                                    <li key={entry.actorId}>
+                                        <span className="text-theme-text-secondary">
+                                            {entry.name}:{' '}
+                                        </span>
+                                        <span className="text-amber-400">
+                                            {entry.texts.join('; ')}
+                                        </span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
                     )}
 
                     {battleResult && <BattlePlayback result={battleResult} />}

--- a/src/utils/combat/preFight/index.ts
+++ b/src/utils/combat/preFight/index.ts
@@ -15,7 +15,13 @@ export type {
     SquadLeaderSelection,
 } from './types';
 export { emptyPreFightModifiers } from './types';
-export { squadLeaderPass } from './squadLeaderPass';
+export {
+    squadLeaderPass,
+    activeSquadLeaderEffects,
+    squadLeaderEffectTargeting,
+    isSquadLeaderEffectSimulated,
+} from './squadLeaderPass';
+export type { SquadLeaderEffectTargeting } from './squadLeaderPass';
 
 /** Run the pre-fight passes in order over both sides' units. */
 export function runPreFight(

--- a/src/utils/combat/preFight/squadLeaderPass.ts
+++ b/src/utils/combat/preFight/squadLeaderPass.ts
@@ -20,7 +20,12 @@
  * break side symmetry.
  */
 import { SQUAD_LEADERS } from '../../../constants/squadLeaders';
-import type { SquadLeaderModifierChannel } from '../../../constants/squadLeaders';
+import type {
+    SquadLeader,
+    SquadLeaderEffect,
+    SquadLeaderModifierChannel,
+} from '../../../constants/squadLeaders';
+import type { FactionName } from '../../../constants/factions';
 import type {
     PreFightCombatModifiers,
     PreFightPass,
@@ -70,6 +75,59 @@ const MODIFIER_FIELD_BY_CHANNEL: Partial<
 type StatAccumulator = Map<PreFightStatKey, { pct: number; flat: number }>;
 type SideStatAcc = Map<PreFightUnit, StatAccumulator>;
 
+// ---------------------------------------------------------------------------
+// Shared targeting/classification helpers — the SINGLE source of truth for both
+// the pass below and UI previews (SquadLeaderPicker). Keep in lock-step with
+// `applyLeaderForSide`; any rule change must land in exactly one place here.
+// ---------------------------------------------------------------------------
+
+/** The effects active at a stage. Stages are ADDITIVE deltas: stage III = I+II+III. */
+export function activeSquadLeaderEffects(
+    leader: SquadLeader,
+    stage: 1 | 2 | 3
+): SquadLeaderEffect[] {
+    return leader.stages.slice(0, stage).flat();
+}
+
+/** Who a squad-leader effect targets, given the leader's OWN side's units.
+ *  - 'allies'  : the own-side units of the leader's faction ('self' has no deployed
+ *                unit and attributes to the same set — see the pass comment below).
+ *  - 'enemies' : ALL opposing units, but only while `gateMet` (>=1 leader-faction
+ *                ship on the leader's own team) — gate unmet means inactive by game rule. */
+export type SquadLeaderEffectTargeting<T> =
+    | { scope: 'allies'; recipients: T[] }
+    | { scope: 'enemies'; gateMet: boolean };
+
+export function squadLeaderEffectTargeting<T extends { faction: FactionName }>(
+    effect: SquadLeaderEffect,
+    leaderFaction: FactionName,
+    own: readonly T[]
+): SquadLeaderEffectTargeting<T> {
+    if (effect.target === 'all-enemies') {
+        return { scope: 'enemies', gateMet: own.some((u) => u.faction === leaderFaction) };
+    }
+    return { scope: 'allies', recipients: own.filter((u) => u.faction === leaderFaction) };
+}
+
+/** Whether the pass SIMULATES an effect (folds it into stats) or surfaces it via
+ *  `unsimulated`. Mirrors the pass's branch order exactly: conditional / 'other' /
+ *  per-round / 'self' effects are unsimulated; stat effects are simulated iff the
+ *  stat is in the pre-fight block; ALL modifier-channel effects are unsimulated
+ *  until PR F3 wires the engine consumers (they still accumulate in the pass). */
+export function isSquadLeaderEffectSimulated(effect: SquadLeaderEffect): boolean {
+    if (
+        effect.condition !== undefined ||
+        effect.kind === 'other' ||
+        effect.recurrence === 'per-round' ||
+        effect.target === 'self'
+    ) {
+        return false;
+    }
+    if (effect.kind === 'stat') return isPreFightStat(effect.stat);
+    // kind === 'modifier': accumulated but consumed only from PR F3 on.
+    return false;
+}
+
 /** Resolve ONE side's leader selection and fold its active effects into that side's
  *  (and, for enemy effects, the opposing side's) units. Shared by both sides. Stat
  *  contributions accumulate into `statAcc` — OWNED BY THE PASS and shared across both
@@ -90,22 +148,21 @@ function applyLeaderForSide(
     }
 
     // Stages are additive deltas: everything up to and including the selected stage is live.
-    const effects = leader.stages.slice(0, sel.stage).flat();
-
-    // The all-enemies gate: enemy effects are live only while the leader's own team
-    // fields at least one ship of the leader's faction.
-    const factionPresent = own.some((u) => u.faction === sel.faction);
+    const effects = activeSquadLeaderEffects(leader, sel.stage);
 
     for (const effect of effects) {
-        // Recipients by targeting rule. 'self' has no deployed unit to land on (squad
-        // leaders are not on the board — 0 occurrences in data), so it attributes its
-        // unsimulated text to the own-side faction units, same as 'all-allies'.
+        // Recipients by the shared targeting rule. 'self' has no deployed unit to land on
+        // (squad leaders are not on the board — 0 occurrences in data), so it attributes
+        // its unsimulated text to the own-side faction units, same as 'all-allies'. The
+        // all-enemies gate: enemy effects are live only while the leader's own team
+        // fields at least one ship of the leader's faction.
+        const targeting = squadLeaderEffectTargeting(effect, sel.faction, own);
         let recipients: PreFightUnit[];
-        if (effect.target === 'all-enemies') {
-            if (!factionPresent) continue; // gate unmet → inactive by game rule, record nothing
+        if (targeting.scope === 'enemies') {
+            if (!targeting.gateMet) continue; // gate unmet → inactive by game rule, record nothing
             recipients = opposing;
         } else {
-            recipients = own.filter((u) => u.faction === sel.faction);
+            recipients = targeting.recipients;
         }
 
         // Not simulated in F1: conditional effects, the 'other' escape hatch, per-round

--- a/src/utils/simulator/__tests__/squadLeaderSelection.test.ts
+++ b/src/utils/simulator/__tests__/squadLeaderSelection.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { parseSquadLeaderSelection } from '../squadLeaderSelection';
+
+describe('parseSquadLeaderSelection', () => {
+    it('accepts a stored selection that matches the SQUAD_LEADERS data', () => {
+        const raw = JSON.stringify({ faction: 'MARAUDERS', name: 'Brandisher', stage: 3 });
+        expect(parseSquadLeaderSelection(raw)).toEqual({
+            faction: 'MARAUDERS',
+            name: 'Brandisher',
+            stage: 3,
+        });
+    });
+
+    it.each([1, 2, 3] as const)('accepts stage %i', (stage) => {
+        const raw = JSON.stringify({ faction: 'ATLAS_SYNDICATE', name: 'Intern', stage });
+        expect(parseSquadLeaderSelection(raw)?.stage).toBe(stage);
+    });
+
+    it('rejects null and empty input', () => {
+        expect(parseSquadLeaderSelection(null)).toBeUndefined();
+        expect(parseSquadLeaderSelection('')).toBeUndefined();
+    });
+
+    it('rejects malformed JSON', () => {
+        expect(parseSquadLeaderSelection('{not json')).toBeUndefined();
+    });
+
+    it('rejects non-object values', () => {
+        expect(parseSquadLeaderSelection(JSON.stringify('MARAUDERS'))).toBeUndefined();
+        expect(parseSquadLeaderSelection(JSON.stringify(null))).toBeUndefined();
+        expect(parseSquadLeaderSelection(JSON.stringify(42))).toBeUndefined();
+    });
+
+    it('rejects an unknown faction', () => {
+        const raw = JSON.stringify({ faction: 'NOT_A_FACTION', name: 'Brandisher', stage: 3 });
+        expect(parseSquadLeaderSelection(raw)).toBeUndefined();
+    });
+
+    it('rejects a leader name that does not belong to the faction', () => {
+        // Brandisher is a Marauders leader, not Atlas Syndicate.
+        const raw = JSON.stringify({ faction: 'ATLAS_SYNDICATE', name: 'Brandisher', stage: 3 });
+        expect(parseSquadLeaderSelection(raw)).toBeUndefined();
+    });
+
+    it('rejects out-of-range or non-numeric stages', () => {
+        for (const stage of [0, 4, -1, 1.5, '2', null, undefined]) {
+            const raw = JSON.stringify({ faction: 'MARAUDERS', name: 'Brandisher', stage });
+            expect(parseSquadLeaderSelection(raw)).toBeUndefined();
+        }
+    });
+
+    it('rejects missing fields', () => {
+        expect(parseSquadLeaderSelection(JSON.stringify({}))).toBeUndefined();
+        expect(
+            parseSquadLeaderSelection(JSON.stringify({ faction: 'MARAUDERS', stage: 1 }))
+        ).toBeUndefined();
+        expect(
+            parseSquadLeaderSelection(JSON.stringify({ name: 'Brandisher', stage: 1 }))
+        ).toBeUndefined();
+    });
+});

--- a/src/utils/simulator/squadLeaderSelection.ts
+++ b/src/utils/simulator/squadLeaderSelection.ts
@@ -1,0 +1,66 @@
+/**
+ * Squad-leader selection persistence for the Combat Simulator page (PR F2).
+ *
+ * The page keeps one `SquadLeaderSelection | undefined` per side in plain component
+ * state and mirrors it into localStorage under these keys (deliberately NOT the
+ * `useStorage` IndexedDB/Supabase pipeline — this is throwaway per-device UI state,
+ * same tier as view modes and filters).
+ *
+ * Stored values cross a trust boundary on read (localStorage is user-editable and
+ * survives data updates), so `parseSquadLeaderSelection` validates the full shape
+ * against the current SQUAD_LEADERS data: unknown faction, unknown leader name, or
+ * a bad stage all resolve to `undefined` rather than reaching `simulateBattle`
+ * (whose pass throws on unknown leaders).
+ */
+import { SQUAD_LEADERS } from '../../constants/squadLeaders';
+import type { SquadLeaderSelection } from '../combat/preFight';
+
+/** localStorage keys, one per board side. */
+export const SQUAD_LEADER_STORAGE_KEYS = {
+    player: 'simulator-squad-leader-player',
+    enemy: 'simulator-squad-leader-enemy',
+} as const;
+
+/** Parse + validate a raw stored value. Anything malformed or no longer present in
+ *  the SQUAD_LEADERS data → undefined (treated as "no leader selected"). */
+export function parseSquadLeaderSelection(raw: string | null): SquadLeaderSelection | undefined {
+    if (!raw) return undefined;
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return undefined;
+    }
+    if (typeof parsed !== 'object' || parsed === null) return undefined;
+    const { faction, name, stage } = parsed as Record<string, unknown>;
+    if (typeof faction !== 'string' || typeof name !== 'string') return undefined;
+    if (stage !== 1 && stage !== 2 && stage !== 3) return undefined;
+    const leaders = SQUAD_LEADERS[faction];
+    if (!leaders?.some((leader) => leader.name === name)) return undefined;
+    return { faction, name, stage };
+}
+
+/** Read + validate the stored selection for a key. Never throws (storage may be
+ *  unavailable, e.g. blocked third-party contexts) — falls back to undefined. */
+export function readStoredSquadLeaderSelection(key: string): SquadLeaderSelection | undefined {
+    try {
+        return parseSquadLeaderSelection(localStorage.getItem(key));
+    } catch {
+        return undefined;
+    }
+}
+
+/** Write-through for a selection change: persist the new value, or remove the key
+ *  when the selection is cleared. Never throws (private-mode storage quota etc. —
+ *  the in-memory selection still applies for the session). */
+export function writeStoredSquadLeaderSelection(
+    key: string,
+    selection: SquadLeaderSelection | undefined
+): void {
+    try {
+        if (selection) localStorage.setItem(key, JSON.stringify(selection));
+        else localStorage.removeItem(key);
+    } catch {
+        // Storage unavailable — keep the selection in memory only.
+    }
+}


### PR DESCRIPTION
Re-created #190 (auto-closed when the F1 base branch was deleted on merge; rebased onto main). Full description and browser-verification evidence in #190.

Summary: Squad Leader picker card beneath each placement board (Faction → Leader → Stage) with a live applied-effects preview driven by the same preFight helpers the sim uses, faction-gate warning, 'Not simulated' tags, per-side localStorage persistence, post-run unsimulated notice, changelog + docs.

Gates: tsc/lint clean, 3778 tests green, zero snapshot churn, audit 0 findings. Browser-verified: leader shifts Butcher's crit 69,517 → 79,042 (×1.137 = ×1.08 attack × ~1.053 crit power); no-leader run byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wd1aeh2x3P7KK84pfhrnA6