### PR TITLE
feat(combat): per-victim enemy-status-gated outgoing modifiers (sub-project I, PR I2)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -11,6 +11,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Battle Simulator: pick a squad leader for each team (faction, leader, and upgrade stage, remembered between visits) — faction-scoped stat bonuses, and legendary stage-3 enemy debuffs, now apply in the simulation. A live preview under each board shows which placed ships each effect hits, and effects the sim can't model yet are marked 'Not simulated'.",
     "Battle Simulator: pre-fight ship passives are now simulated — Lionheart grants adjacent allies 10% of its HP, Centurion gains attack per adjacent ally, and Enforcer/Defiant/Stalwart gain their bonuses when placed next to a Supporter. Bonuses fold in after squad-leader auras, before round 1, and are permanent (they survive the granting ship's death). Ships whose skills say they start combat fully charged (e.g. Chimei) now begin the battle fully charged and fire their charged skill on round 1.",
     'Combat sim: damage bonuses that target enemies with a specific status now check for that exact status. Tygr, Rikra, Incinerator, Wrecker, and Lodolite only get their bonus damage against the named status (Stasis/Disable, Taunt/Provoke, Inferno, or Concentrate Fire) rather than against any debuffed enemy.',
+    "Combat sim: in a multi-target attack, a damage bonus gated on a named enemy status (e.g. Tygr's bonus vs Stasis/Disable) is now checked against each hit target individually — a target without the status no longer gets the bonus just because another target in the same attack has it.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/combat/__tests__/perVictimOutgoingModifierGate.integration.test.ts
+++ b/src/utils/combat/__tests__/perVictimOutgoingModifierGate.integration.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Sub-project I, PR I2 — per-victim evaluation of enemy-status-gated OUTGOING-DAMAGE
+ * modifiers (Layer 3), combat-engine integration.
+ *
+ * I1 (PR c5d52d07) made `enemy-debuff` gating NAME-specific but still evaluated ONCE per
+ * turn against the primary (bound) target — `positionalScalars.outgoingDamageBuffPct` is a
+ * single fixed value applied uniformly to every AoE footprint victim. This is wrong for a
+ * Tygr/Incinerator/Lodolite-shape aura ("+N% to enemies with <named status>"): in an AoE only
+ * the victims that CURRENTLY carry the named status should get the bonus (spec §2 locked rule).
+ *
+ * This suite locks the fix: `engine.ts`'s `perVictimOutgoingDeltaPct` re-folds the SAME
+ * `modifierAbilities` against a per-victim ctx (that victim's OWN enemy-debuff names) and
+ * subtracts the primary-ctx fold, producing a DELTA that `victimHitDamage` (victimDamage.ts)
+ * applies additively alongside the fixed per-turn `outgoingDamageBuffPct`.
+ *
+ * Fixture shape (mirrors enemyDebuffNameSpecificGate.integration.test.ts's Tygr-shape,
+ * extended to TWO footprint victims via a whole-team ('all' shape) damage pattern):
+ *   - The damage ability is AoE ('all' pattern) → hits BOTH enemy attackers every round.
+ *   - The debuff-inflict ability targets 'enemy' (single-target, NOT AoE) → lands ONLY on the
+ *     resolved anchor ('front', bound via the parsed `target`).
+ *   - The modifier is gated on `enemy-debuff` (buffName: 'Stasis').
+ *
+ * Round 1: neither victim carries Stasis pre-turn → gate false for both → both take BASE
+ *          damage. The round's own inflict lands on 'front' (anti-causality — I1 invariant).
+ * Round 2: 'front' now carries the round-1 infliction (pre-existing) → gate TRUE for 'front'
+ *          only → 'front' takes base × 1.30; 'covered' (never debuffed) stays at base damage.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import type { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `pvog${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+// AoE whole-team pattern (shape:'all' ignores geometry — every occupied cell is 'origin',
+// so BOTH footprint victims take FULL (roleScale 1.0) damage; only the per-victim outgoing
+// delta under test can make their damage diverge).
+const allPattern = (): ParsedPattern => ({ raw: 'all', shape: 'all', range: 'all', modifiers: {} });
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+// A single positioned, passive (attack:0) enemy — security:0 so any inflict-type debuff
+// always lands (mirrors enemyDebuffNameSpecificGate.integration.test.ts).
+const passiveEnemyAt = (id: string, position: Position): EnemyAttacker =>
+    ({
+        id,
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 1,
+            security: 0,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        shipSkills: { slots: [{ slot: 'active', abilities: [] }] },
+    }) as EnemyAttacker;
+
+const engineBase = (
+    shipSkills: ShipSkills,
+    enemyAttackers: EnemyAttacker[]
+): CombatEngineInput => ({
+    attack: 10_000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills,
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 2,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    // hacking 200 vs enemy security 0 → inflict landing chance clamp((200-0)/100) = 1.0.
+    hacking: 200,
+    healTargetId: 'attacker',
+    position: 'M4',
+    // The single-target debuff ability resolves against THIS parsed target ('front') —
+    // whichever enemy attacker occupies the front-most position becomes the anchor.
+    target: parsedTarget('front'),
+    // The top-level pattern drives the DAMAGE ability's footprint expansion (AoE, both victims).
+    pattern: allPattern(),
+    enemyAttackers,
+});
+
+/** Shared skill set: AoE damage + single-target Stasis inflict + a self modifier gated on
+ *  the named 'enemy-debuff' Stasis, folded into the outgoingDamage channel. */
+const skillsWithGate = (): ShipSkills => ({
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                ab({
+                    type: 'damage',
+                    config: { type: 'damage', multiplier: 100 },
+                }),
+                ab({
+                    type: 'debuff',
+                    config: {
+                        type: 'debuff',
+                        buffName: 'Stasis',
+                        application: 'inflict',
+                        duration: 5,
+                        stacks: 1,
+                        isStackable: false,
+                        parsedEffects: {},
+                    },
+                }),
+                ab({
+                    target: 'self',
+                    type: 'modifier',
+                    conditions: [{ subject: 'enemy-debuff', derivable: true, buffName: 'Stasis' }],
+                    config: {
+                        type: 'modifier',
+                        channel: 'outgoingDamage',
+                        value: 30,
+                        isMultiplicative: true,
+                    },
+                }),
+            ],
+        },
+    ],
+});
+
+describe('per-victim outgoing-modifier gate (sub-project I, PR I2) — AoE mixed-victim', () => {
+    it('only the victim carrying the named debuff gets the bonus; the other AoE victim stays at base damage', () => {
+        idc = 0;
+        const result = runCombat(
+            engineBase(skillsWithGate(), [
+                passiveEnemyAt('front', 'M4'),
+                passiveEnemyAt('covered', 'M3'),
+            ])
+        );
+
+        expect(result.rounds).toHaveLength(2);
+
+        // Round 1: nothing pre-exists on EITHER victim before this turn → gate false for both →
+        // both take BASE damage (100% of 10000 attack = 10000). The round's own Stasis
+        // infliction lands on 'front' but does not retroactively satisfy this turn's gate.
+        expect(result.rounds[0].perTargetDamage?.['front']).toBe(10_000);
+        expect(result.rounds[0].perTargetDamage?.['covered']).toBe(10_000);
+
+        // Round 2: 'front' now carries the round-1 infliction (pre-existing) → its OWN gate
+        // reads true → +30% (13000). 'covered' never received Stasis → its OWN gate reads
+        // false → stays at BASE damage (10000), even though the primary-target ctx (front)
+        // satisfies the condition. This is the core per-victim assertion: the bonus does NOT
+        // bleed from the primary target onto an untouched AoE victim.
+        expect(result.rounds[1].perTargetDamage?.['front']).toBe(13_000);
+        expect(result.rounds[1].perTargetDamage?.['covered']).toBe(10_000);
+    });
+
+    it('single-victim regression: delta is 0 through the positional/AoE plumbing — identical to I1', () => {
+        idc = 0;
+        // Only ONE enemy attacker present: the victim IS the primary target, so the per-victim
+        // ctx is IDENTICAL to the primary ctx by construction (delta = 0 always). Proves the
+        // new perVictimOutgoing plumbing does not perturb the single-victim case.
+        const result = runCombat(engineBase(skillsWithGate(), [passiveEnemyAt('front', 'M4')]));
+
+        expect(result.rounds).toHaveLength(2);
+        expect(result.rounds[0].perTargetDamage?.['front']).toBe(10_000); // no pre-existing Stasis
+        expect(result.rounds[1].perTargetDamage?.['front']).toBe(13_000); // pre-existing → +30%
+    });
+
+    it('no enemy-status-gated modifier present → delta is 0 for every AoE victim (byte-identical fast path)', () => {
+        idc = 0;
+        // Same AoE damage ability, but NO modifier ability at all — perVictimOutgoing carries
+        // an empty modifierAbilities list, so perVictimOutgoingDeltaPct short-circuits to 0.
+        const plainSkills: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        ab({ type: 'damage', config: { type: 'damage', multiplier: 100 } }),
+                    ],
+                },
+            ],
+        };
+        const result = runCombat(
+            engineBase(plainSkills, [
+                passiveEnemyAt('front', 'M4'),
+                passiveEnemyAt('covered', 'M3'),
+            ])
+        );
+
+        expect(result.rounds).toHaveLength(2);
+        for (const round of result.rounds) {
+            expect(round.perTargetDamage?.['front']).toBe(10_000);
+            expect(round.perTargetDamage?.['covered']).toBe(10_000);
+        }
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -18,8 +18,9 @@ import {
     type ExtraActionGrant,
     selectFiringSkill,
     damageInputsFromSkill,
+    modifierTotalsFromAbilities,
 } from '../abilities/applyAbilities';
-import { conditionsMet } from '../abilities/evaluateConditions';
+import { conditionsMet, type ConditionContext } from '../abilities/evaluateConditions';
 import { foldActorBuffTotals, effectiveStatsOf } from './effectiveStats';
 import {
     ActiveDoTStack,
@@ -3617,6 +3618,94 @@ export function runCombat(input: CombatEngineInput): {
         input.__testTapVictimEnemyModifiers?.(victimIncomingModifiers);
         input.__testTapIsStasised?.(isStasised);
 
+        // Sub-project I, PR I2 (Layer 3) — per-victim OUTGOING modifier delta for enemy-
+        // status-gated auras (Tygr "+30% to Stasis/Disable enemies", Incinerator "+30% to
+        // Inferno enemies", Lodolite "+15% to Concentrate Fire/Stealth enemies"). The firing
+        // turn's `positionalScalars.outgoingDamageBuffPct` already folds `modifierAbilities`
+        // ONCE against `primaryCtx` (the bound/primary target's enemy-status, I1). Here we
+        // re-fold the SAME abilities against a per-victim ctx (only the enemy-status fields
+        // swapped to THIS victim's own status) and subtract the primary-ctx fold — every
+        // non-enemy-status modifier (attack/crit/self-buff-gated outgoing, etc.) contributes
+        // identically to both folds and cancels, isolating the pure per-victim delta.
+        //
+        // CAUSALITY: the per-victim status MUST be a PRE-TURN snapshot, not a live re-read at
+        // apply time. `drivePositionalApply` runs AFTER `runPlayerTurn` returns, by which point
+        // this turn's OWN debuff-inflict ability has already mutated the status engine — a live
+        // read at that point would let a skill's own same-turn infliction retroactively satisfy
+        // its own per-victim gate (exactly the anti-causality bug I1 guards against for the
+        // PRIMARY target via buildTurnArgs's pre-turn `enemyDebuffNamesForTarget(tgt)` call).
+        // `snapshotPreTurnVictimStatus` is called by each of the three turn sites BEFORE their
+        // `runPlayerTurn` call, capturing every living opposing actor's status at that moment;
+        // `perVictimOutgoingDeltaPct` below reads ONLY from that frozen snapshot.
+        //
+        //  - enemyDebuffNames: rebuilt from the snapshot (I1's per-target name read,
+        //    `enemyDebuffNamesForTarget`), but ONLY when primaryCtx already carries the array
+        //    (the DPS-parity sentinel: undefined means "not opted in" and must stay undefined
+        //    here too — though this path only runs from the positional apply branch, where the
+        //    primary ctx is always real/positional and the array is always populated).
+        //  - enemyBuffNames: rebuilt from the snapshot for JUST this victim (the per-turn
+        //    primaryCtx uses a UNION across every living enemy attacker — see
+        //    enemyBuffNamesUnion above — which is correct for "does an enemy have X" REACTIVE
+        //    gates but not for a per-victim OUTGOING-damage aura; the locked game rule (spec §2)
+        //    requires each victim's OWN status here).
+        //  - enemyHpPct: rebuilt from the snapshot's pre-turn currentHp/stats.hp reading (the
+        //    primary ctx's value is a turn-start snapshot of the BOUND target only).
+        //  - enemyType: NOT rebuilt — no per-enemy-attacker class field is plumbed on
+        //    positional inputs today (only one fight-wide `input.enemyType`), so every victim
+        //    reuses the primary ctx's value. Inert for every I2-scoped ship (none gate their
+        //    outgoing modifier on `enemy-type`); a future enemy-type-gated per-victim aura
+        //    needs real per-actor class plumbing first (deferred, not modeled here).
+        //
+        // For the PRIMARY target in a single-enemy fight this ctx is IDENTICAL to primaryCtx
+        // (delta = 0) — byte-identical to I1. A ship with no enemy-status-gated outgoing
+        // modifier also gets delta = 0 for every victim (the fold never differs by ctx).
+        interface PreTurnVictimStatusSnapshot {
+            enemyDebuffNames: string[];
+            enemyBuffNames: string[];
+            enemyHpPct: number;
+        }
+        const snapshotPreTurnVictimStatus = (
+            opposingLiving: CombatActor[]
+        ): Map<string, PreTurnVictimStatusSnapshot> =>
+            new Map(
+                opposingLiving.map((v) => [
+                    v.id,
+                    {
+                        enemyDebuffNames: enemyDebuffNamesForTarget(v),
+                        enemyBuffNames: selfBuffNamesForOwners(statusEngine, [v.id]),
+                        enemyHpPct:
+                            v.stats.hp > 0
+                                ? Math.max(0, Math.min(100, (100 * v.currentHp) / v.stats.hp))
+                                : 100,
+                    },
+                ])
+            );
+        const perVictimOutgoingDeltaPct = (
+            perVictimOutgoing: PlayerTurnResult['perVictimOutgoing'],
+            preTurnStatus: Map<string, PreTurnVictimStatusSnapshot> | undefined,
+            victim: CombatActor
+        ): number => {
+            if (!perVictimOutgoing) return 0;
+            const { modifierAbilities, primaryCtx } = perVictimOutgoing;
+            if (modifierAbilities.length === 0) return 0; // fast path — nothing to re-fold
+            // Defensive fallback: a victim absent from the snapshot (should never happen — the
+            // snapshot covers the FULL opposing roster captured pre-turn) contributes delta 0
+            // rather than crashing.
+            const snap = preTurnStatus?.get(victim.id);
+            if (!snap) return 0;
+            const victimCtx: ConditionContext = {
+                ...primaryCtx,
+                ...(primaryCtx.enemyDebuffNames !== undefined
+                    ? { enemyDebuffNames: snap.enemyDebuffNames }
+                    : {}),
+                enemyBuffNames: snap.enemyBuffNames,
+                enemyHpPct: snap.enemyHpPct,
+            };
+            const full = modifierTotalsFromAbilities(modifierAbilities, victimCtx).outgoingDamage;
+            const base = modifierTotalsFromAbilities(modifierAbilities, primaryCtx).outgoingDamage;
+            return full - base;
+        };
+
         // Shared positional-apply driver (Task 9, Step A) — the ONE place the three attack
         // sites (focus / walked-team / enemy) drive `applyPositionalDamage`. Each site has
         // already GATED (isPositional + non-null target/pattern/positionalScalars) and computed
@@ -3662,6 +3751,16 @@ export function runCombat(input: CombatEngineInput): {
             // capped rate via this callback. Unsupplied → every victim uses hitCrits[h] →
             // byte-identical. Each call site supplies the firing turn's rollVictimCrit.
             rollVictimCrit?: (victim: CombatActor) => boolean;
+            // Sub-project I, PR I2: this turn's enemy-status-gated outgoing-modifier ingredients
+            // (modifierAbilities + primaryCtx), forwarded from `turn.perVictimOutgoing`.
+            // Unsupplied/undefined → perVictimOutgoingDeltaPct short-circuits to 0 for every
+            // victim → byte-identical.
+            perVictimOutgoing?: PlayerTurnResult['perVictimOutgoing'];
+            // Sub-project I, PR I2: the PRE-TURN per-victim status snapshot (captured by the
+            // call site via `snapshotPreTurnVictimStatus` BEFORE `runPlayerTurn` ran this turn),
+            // keyed by victim id. Required for a non-zero delta — see the causality note above
+            // perVictimOutgoingDeltaPct. Unsupplied → delta stays 0 for every victim.
+            preTurnVictimStatus?: Map<string, PreTurnVictimStatusSnapshot>;
         }): { anyCrit: boolean; critPairs: number } => {
             return applyPositionalDamage({
                 hitCrits: args.hitCrits ?? [],
@@ -3688,6 +3787,13 @@ export function runCombat(input: CombatEngineInput): {
                         // Down/Up). Attacker-sourced scalars (outgoing buff, pen) stay attacker-fixed.
                         incomingDamageModifierPct: m.incomingDamageModifier,
                         affinity: v.affinity ?? 'antimatter',
+                        // Sub-project I, PR I2: this footprint victim's own enemy-status-gated
+                        // outgoing-modifier delta vs the attacker-fixed positionalScalars term.
+                        outgoingDamageDeltaPct: perVictimOutgoingDeltaPct(
+                            args.perVictimOutgoing,
+                            args.preTurnVictimStatus,
+                            v
+                        ),
                     };
                 },
                 applyToVictim: args.applyToVictim,
@@ -4968,6 +5074,12 @@ export function runCombat(input: CombatEngineInput): {
                                 isPositional(actor.position, enemyAttackerActors) &&
                                 target != null &&
                                 pattern != null;
+                            // Sub-project I, PR I2: snapshot the opposing roster's enemy-status
+                            // BEFORE this turn runs (see the causality note above
+                            // perVictimOutgoingDeltaPct) — this turn's own debuff-inflict must
+                            // not retroactively satisfy its own per-victim outgoing gate.
+                            const preTurnVictimStatus =
+                                snapshotPreTurnVictimStatus(enemyAttackerActors);
                             const turn = runPlayerTurn({
                                 ...buildTurnArgs(actor, tgt),
                                 deferAbilityPerformedToEngine: willApplyPositionally,
@@ -5065,6 +5177,8 @@ export function runCombat(input: CombatEngineInput): {
                                     actingId: actor.id,
                                     opposingLiving: tb.opposingRoster,
                                     applyToVictim: tb.applyToVictim,
+                                    perVictimOutgoing: turn.perVictimOutgoing,
+                                    preTurnVictimStatus,
                                     // Per-victim crit: each covered footprint victim rolls at ITS own
                                     // affinity-capped rate against THIS attacker.
                                     rollVictimCrit: (v) =>
@@ -5287,6 +5401,9 @@ export function runCombat(input: CombatEngineInput): {
                                 isPositional(actor.position, enemyAttackerActors) &&
                                 teamTarget != null &&
                                 teamPattern != null;
+                            // Sub-project I, PR I2: pre-turn snapshot (mirrors the focus site).
+                            const teamPreTurnVictimStatus =
+                                snapshotPreTurnVictimStatus(enemyAttackerActors);
                             const teamTurn = runPlayerTurn({
                                 ...buildTurnArgs(actor, tgt),
                                 deferAbilityPerformedToEngine: teamWillApplyPositionally,
@@ -5361,6 +5478,8 @@ export function runCombat(input: CombatEngineInput): {
                                     actingId: actor.id,
                                     opposingLiving: tb.opposingRoster,
                                     applyToVictim: tb.applyToVictim,
+                                    perVictimOutgoing: teamTurn.perVictimOutgoing,
+                                    preTurnVictimStatus: teamPreTurnVictimStatus,
                                     // Per-victim crit: each covered footprint victim rolls at ITS own
                                     // affinity-capped rate against THIS walked team attacker.
                                     rollVictimCrit: (v) =>
@@ -5678,6 +5797,18 @@ export function runCombat(input: CombatEngineInput): {
                             // dead-target path and whenever the enemy is non-positional → legacy single-apply.
                             let enemyPositional = false;
                             let enemyScalars: AttackerDamageScalars | undefined;
+                            // Sub-project I, PR I2: the enemy turn's per-victim outgoing-modifier
+                            // ingredients, hoisted out of the else block (enemyTurn is scoped inside
+                            // it) so the enemy drivePositionalApply site can pass it. Undefined on the
+                            // dead-target / non-positional paths → perVictimOutgoingDeltaPct returns 0
+                            // for every victim (byte-identical).
+                            let enemyPerVictimOutgoing: PlayerTurnResult['perVictimOutgoing'];
+                            // Sub-project I, PR I2: the pre-turn per-victim status snapshot
+                            // (team-symmetric mirror of the focus/team sites' preTurnVictimStatus),
+                            // captured just before `runPlayerTurn` below mutates the status engine.
+                            let enemyPreTurnVictimStatus:
+                                | Map<string, PreTurnVictimStatusSnapshot>
+                                | undefined;
                             // Per-victim crit: the enemy turn's per-victim crit resolver, hoisted out
                             // of the else block (enemyTurn is scoped inside it) so the enemy
                             // drivePositionalApply site can pass it. Undefined on the dead-target /
@@ -5774,6 +5905,10 @@ export function runCombat(input: CombatEngineInput): {
                                     incomingReductionCritAll -
                                     incomingReductionNonCritPct +
                                     preFightCritFamilyPct;
+                                // Sub-project I, PR I2: snapshot BEFORE runPlayerTurn (the enemy's
+                                // opposing roster is the PLAYER team — allPlayerActors).
+                                enemyPreTurnVictimStatus =
+                                    snapshotPreTurnVictimStatus(allPlayerActors);
                                 const enemyTurn = runPlayerTurn({
                                     ...buildTurnArgs(actor, tgt),
                                     deferAbilityPerformedToEngine: enemyWillApplyPositionally,
@@ -5816,6 +5951,10 @@ export function runCombat(input: CombatEngineInput): {
                                     enemyPattern != null &&
                                     enemyTurn.positionalScalars != null;
                                 enemyScalars = enemyTurn.positionalScalars;
+                                // Sub-project I, PR I2: capture the enemy turn's per-victim
+                                // outgoing-modifier ingredients (team-symmetric mirror of the
+                                // focus/team sites).
+                                enemyPerVictimOutgoing = enemyTurn.perVictimOutgoing;
                                 // Per-victim crit: capture the enemy turn's per-victim crit resolver.
                                 enemyRollVictimCrit = enemyTurn.rollVictimCrit;
                                 // Task 5: capture the deferred ability-performed payload (present ⟺ the
@@ -5990,6 +6129,8 @@ export function runCombat(input: CombatEngineInput): {
                                         actingId: actor.id,
                                         opposingLiving: tb.opposingRoster,
                                         applyToVictim: tb.applyToVictim,
+                                        perVictimOutgoing: enemyPerVictimOutgoing,
+                                        preTurnVictimStatus: enemyPreTurnVictimStatus,
                                         // Per-victim crit: each covered footprint victim rolls at ITS own
                                         // affinity-capped rate against THIS enemy attacker.
                                         rollVictimCrit: enemyRollVictimCrit

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -162,6 +162,18 @@ export interface PlayerTurnResult {
      *  engine branch (Task 8); non-positional callers ignore it → goldens byte-identical.
      *  Present whenever a damage ability fired this cast (else undefined). */
     positionalScalars?: AttackerDamageScalars;
+    /** Sub-project I, PR I2 (Layer 3) — ingredients for the engine's per-victim outgoing-
+     *  modifier delta (Tygr/Incinerator/Lodolite-shape "+N% to enemies with <named status>"
+     *  gates). `primaryCtx` is the SAME `modifierCtx` folded into `positionalScalars.
+     *  outgoingDamageBuffPct` above (built against the primary/bound target's enemy-status);
+     *  `modifierAbilities` is the same list folded into `dmgStats`. The engine rebuilds a
+     *  per-victim ConditionContext (enemy-status fields only) from `primaryCtx`, re-folds
+     *  `modifierAbilities` against it, and subtracts the primary-ctx fold to isolate the
+     *  per-victim enemy-status delta (non-enemy-status modifiers cancel identically in both
+     *  folds). Present ONLY when a damage ability fired this cast (mirrors positionalScalars).
+     *  Absent → the engine skips the per-victim fold (byte-identical to I1's single-ctx
+     *  behavior); read ONLY by the positional engine branch. */
+    perVictimOutgoing?: { modifierAbilities: Ability[]; primaryCtx: ConditionContext };
     /** Per-victim crit resolver for the positional AoE apply path (per-victim crit).
      *  Rolls THIS attacker's crit gate at the given victim's affinity-capped rate, so a
      *  covered victim the attacker is at an affinity disadvantage against crits less often
@@ -2389,6 +2401,13 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
           }
         : undefined;
 
+    // PR I2: same guard as positionalScalars — only meaningful when a damage ability fired.
+    // Carries the exact ingredients (modifierAbilities + the per-turn modifierCtx) the engine
+    // needs to re-fold outgoingDamage against each footprint victim's OWN enemy-status.
+    const perVictimOutgoing: PlayerTurnResult['perVictimOutgoing'] = hasDamageAbility
+        ? { modifierAbilities, primaryCtx: modifierCtx }
+        : undefined;
+
     return {
         action,
         roundCrit,
@@ -2406,6 +2425,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         detonationDamage,
         extraActionGrants,
         positionalScalars,
+        perVictimOutgoing,
         rollVictimCrit,
         ...(positionalDetonation ? { positionalDetonation } : {}),
         // Task 5: when the inline emit was SUPPRESSED (engine will resolve positionally), hand the

--- a/src/utils/combat/victimDamage.ts
+++ b/src/utils/combat/victimDamage.ts
@@ -58,6 +58,20 @@ export interface VictimDefenseProfile {
     affinity: AffinityName;
     /** per-victim incoming-damage debuff; when present, overrides the attacker-fixed scalar — B1/PR7b */
     incomingDamageModifierPct?: number;
+    /**
+     * Sub-project I, PR I2 (Layer 3) — this victim's outgoing-damage-modifier DELTA vs the
+     * attacker-fixed `s.outgoingDamageBuffPct`. `s.outgoingDamageBuffPct` is folded ONCE per
+     * turn against the primary (bound) target's enemy-status; an enemy-status-gated modifier
+     * (Tygr's "+30% to enemies with Stasis/Disable", Incinerator's "+30% to Inferno enemies",
+     * Lodolite's "+15% to enemies with Concentrate Fire") must instead vary PER FOOTPRINT
+     * VICTIM in an AoE. Rather than re-deriving the full outgoing term per victim, the engine
+     * computes ONLY the delta between that victim's own enemy-status ctx and the primary
+     * target's ctx (non-enemy-status modifiers cancel identically in both folds, isolating the
+     * per-victim enemy-status variation) and passes it here. Defaults to 0 → byte-identical
+     * for the primary target (delta is 0 by construction) and for any attacker with no
+     * enemy-status-gated outgoing modifier.
+     */
+    outgoingDamageDeltaPct?: number;
 }
 
 /**
@@ -100,11 +114,13 @@ export function victimHitDamage(
     const incoming =
         (v.incomingDamageModifierPct ?? s.incomingDamageModifierPct) - equipReductionPct;
 
+    // PR I2: fold the per-victim enemy-status-gated delta additively into the same
+    // percentage term as the attacker-fixed outgoing buff — both are additive-percentage
+    // contributions to the SAME `(1 + x/100)` multiplier, so there is no rounding
+    // divergence from a single-victim (delta === 0) evaluation.
+    const outgoingPct = s.outgoingDamageBuffPct + (v.outgoingDamageDeltaPct ?? 0);
     const nonCritFactor =
-        (1 - damageReduction / 100) *
-        (1 + s.outgoingDamageBuffPct / 100) *
-        (1 + incoming / 100) *
-        affinityMult;
+        (1 - damageReduction / 100) * (1 + outgoingPct / 100) * (1 + incoming / 100) * affinityMult;
 
     const hitCritMultiplier = 1 + (didCrit ? 1 : 0) * (s.effectiveCritDamage / 100);
 


### PR DESCRIPTION
## Sub-project I, PR I2 — per-victim enemy-status-gated outgoing modifiers (Layer 3)

**Stacked on #194 (I1).** Second PR of conditional-aura fidelity. Spec: `docs/superpowers/specs/2026-07-02-conditional-aura-fidelity-i-design.md` §5.3.

### Problem
I1 made `enemy-debuff` gating name-specific, but the outgoing-damage buff is folded **once per turn** against the primary target and applied uniformly to every AoE victim. So in a multi-target hit, a bonus gated on the victim's status (Tygr vs Stasis/Disable, Incinerator vs Inferno) wrongly applied to *all* victims based on the primary target's status.

### Change — per-victim delta
Keeps the full per-turn value in the fixed scalar (DPS/aggregate paths untouched) and adds a per-victim delta in the engine's positional apply loop:

    delta(victim) = fold(modifierAbilities, victimCtx).outgoingDamage − fold(modifierAbilities, primaryCtx).outgoingDamage

Non-enemy-status modifiers cancel in both folds → the delta isolates pure per-victim enemy-status variation. **Delta is 0 for the primary target and for any attacker with no enemy-status-gated outgoing modifier → single-target byte-identical.**

### Causality fix (deviation from the naive design)
A live status re-read at apply time would let a skill's own same-turn debuff-infliction retroactively satisfy its own gate (`drivePositionalApply` runs *after* `runPlayerTurn` mutates the status engine). Fixed with `snapshotPreTurnVictimStatus` — every opposing actor's status is frozen **before** `runPlayerTurn`, mirroring how I1 captures the primary target's names in `buildTurnArgs`. Team-symmetric (enemy site snapshots the player roster).

### Scope
Corrects the AoE/footprint case for the outgoing-**modifier** channel. **Rikra deferred** (flagged): its cone-AoE "+60%/+80% vs Taunted/Provoked" rides the firing-skill `conditionalBonusPct` channel, not the modifier-ability channel — needs a separate per-victim multiplier delta in a follow-up. Per-victim crit-damage gating also deferred (spec §5.3).

### Tests
New `perVictimOutgoingModifierGate.integration.test.ts`: AoE mixed-victim (only the Stasis-carrying victim gets +30%, the other stays at base) + single-victim delta=0 regression + no-modifier fast-path.

### Validation
tsc · lint (0 warnings) · full suite (3838 tests) · `audit:skills` (0). Goldens **byte-identical**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPheh4qisgdG9PazKJMkiF
