### PR TITLE
feat(combat): team-aura distribution for outgoing-damage modifiers (sub-project I, PR I3)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -12,6 +12,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Battle Simulator: pre-fight ship passives are now simulated — Lionheart grants adjacent allies 10% of its HP, Centurion gains attack per adjacent ally, and Enforcer/Defiant/Stalwart gain their bonuses when placed next to a Supporter. Bonuses fold in after squad-leader auras, before round 1, and are permanent (they survive the granting ship's death). Ships whose skills say they start combat fully charged (e.g. Chimei) now begin the battle fully charged and fire their charged skill on round 1.",
     'Combat sim: damage bonuses that target enemies with a specific status now check for that exact status. Tygr, Rikra, Incinerator, Wrecker, and Lodolite only get their bonus damage against the named status (Stasis/Disable, Taunt/Provoke, Inferno, or Concentrate Fire) rather than against any debuffed enemy.',
     "Combat sim: in a multi-target attack, a damage bonus gated on a named enemy status (e.g. Tygr's bonus vs Stasis/Disable) is now checked against each hit target individually — a target without the status no longer gets the bonus just because another target in the same attack has it.",
+    "Combat sim: team-wide damage auras now actually reach the team. Lodolite's +15% damage vs Concentrate Fire (or Stealth) and Panguan's +40% damage for Stealthed units apply to every living ally who qualifies, not just the caster's own attacks.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/combat/__tests__/teamAuraDistribution.integration.test.ts
+++ b/src/utils/combat/__tests__/teamAuraDistribution.integration.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Sub-project I, PR I3 — team-aura distribution for outgoing-damage `modifier` abilities
+ * (Layer 1), combat-engine integration.
+ *
+ * `modifierTotalsFromAbilities` (applyAbilities.ts) has always ignored the `target` field on
+ * a `modifier` ability — an `all-allies`-scoped aura ("all allies deal N% more damage…") only
+ * ever affected the CASTER's own attacks, because `runPlayerTurn`'s `modifierAbilities` was
+ * built from the acting actor's OWN firing + passive skills only (playerTurn.ts:1339, pre-I3).
+ *
+ * This suite locks the fix: `engine.ts`'s `buildTurnArgs` gathers `all-allies`-targeted
+ * PASSIVE `modifier` abilities from every LIVING same-side ally (excluding the recipient's own
+ * id — no double-count) and threads them as `allyModifierAbilities`, which `runPlayerTurn`
+ * merges into `modifierAbilities` (playerTurn.ts). Because that list feeds BOTH the per-turn
+ * `dmgStats` fold AND (PR I2) `perVictimOutgoing`, and is evaluated against the RECIPIENT's OWN
+ * `ConditionContext`, a self-buff gate (Panguan's own Stealth) and an enemy-status gate
+ * (Lodolite's Concentrate Fire) both resolve correctly from the recipient-attacker's
+ * perspective — this is what makes "Friendly … units" include the caster for free.
+ *
+ * Two ship shapes from the design spec (§3 Pattern B / Pattern A):
+ *   - Panguan-shape: "Friendly Stealthed units deal 40% more direct damage" — gated on the
+ *     RECIPIENT's own `self-buff` Stealth.
+ *   - Lodolite-shape: "all allies deal 15% more direct damage to enemies with Concentrate
+ *     Fire" — gated on the (I1/I2) per-target NAMED `enemy-debuff`, composing with the
+ *     existing name-specific + per-victim machinery.
+ *
+ * Damage is read off the `ability-performed` bus event (`damage` field), which fires once per
+ * firing cast for EVERY actor on EITHER side — the same measurement works uniformly for a
+ * walked-team ally and an enemy attacker, proving team-symmetry without bespoke plumbing.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import type { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { CombatStatBlock } from '../../../types/calculator';
+import type { CombatEvent } from '../events';
+import { createEventBus } from '../events';
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `tad${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+const basicDamage = (multiplier: number, id?: string): Ability =>
+    ab({ id, type: 'damage', target: 'enemy', config: { type: 'damage', multiplier } });
+
+// A self-cast Stealth grant (99-turn duration, refreshed every cast) — mirrors the pattern in
+// incomingBlockEngine.test.ts / allyChargeGrant.test.ts's `stealthEnemy`. Applied via the
+// SAME timedSelfBySlot → statusEngine → same-turn read pipeline that lets Panguan's own
+// Stealth gate its own attack the round it casts (no 2-round dance needed for self-buffs,
+// unlike the enemy-debuff anti-causality rule).
+const stealthSelfBuff = (id: string): Ability =>
+    ab({
+        id,
+        type: 'buff',
+        target: 'self',
+        config: {
+            type: 'buff',
+            buffName: 'Stealth',
+            parsedEffects: {},
+            stacks: 1,
+            isStackable: false,
+            duration: 99,
+        },
+    });
+
+// Panguan-shape aura: all-allies +40% outgoing damage, gated on the RECIPIENT's own Stealth.
+const panguanAura = (value = 40): Ability =>
+    ab({
+        id: 'panguan-aura',
+        type: 'modifier',
+        target: 'all-allies',
+        conditions: [{ subject: 'self-buff', buffName: 'Stealth', derivable: true }],
+        config: { type: 'modifier', channel: 'outgoingDamage', value, isMultiplicative: true },
+    });
+
+// Lodolite-shape aura: all-allies +15% outgoing damage, gated on the (I1/I2) per-target
+// NAMED enemy-debuff 'Concentrate Fire'.
+const lodoliteAura = (value = 15): Ability =>
+    ab({
+        id: 'lodolite-aura',
+        type: 'modifier',
+        target: 'all-allies',
+        conditions: [{ subject: 'enemy-debuff', buffName: 'Concentrate Fire', derivable: true }],
+        config: { type: 'modifier', channel: 'outgoingDamage', value, isMultiplicative: true },
+    });
+
+const cfDebuffInflict = (id: string): Ability =>
+    ab({
+        id,
+        type: 'debuff',
+        config: {
+            type: 'debuff',
+            buffName: 'Concentrate Fire',
+            application: 'inflict',
+            duration: 5,
+            stacks: 1,
+            isStackable: false,
+            parsedEffects: {},
+        },
+    });
+
+const passiveOnly = (...abilities: Ability[]): ShipSkills => ({
+    slots: [{ slot: 'passive', abilities }],
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+const teamStats = (attack: number): CombatStatBlock => ({
+    attack,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    hacking: 0,
+});
+
+// A walked, non-positional team ally with the given active slot and NO passive (never itself
+// an aura source). speed 100 so it acts every round like the focus.
+const teamAlly = (id: string, attack: number, skills: ShipSkills): TeamActorEngineInput =>
+    ({
+        id,
+        speed: 100,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        walk: {
+            shipSkills: skills,
+            stats: teamStats(attack),
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+            healModifier: 0,
+        },
+    }) as TeamActorEngineInput;
+
+// The aura-source team ally: passive-only (never fires a damage ability itself), so its own
+// contribution to any measured damage total is always 0 — isolates the DISTRIBUTED bonus on
+// the OTHER actor(s) being measured.
+const auraSourceTeamActor = (id: string, aura: Ability): TeamActorEngineInput =>
+    teamAlly(id, 0, passiveOnly(aura));
+
+const baseEngineInput = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+// Tap the event bus for `ability-performed`, indexed by actorId (each fires once per firing
+// cast; the FIRST entry per actor per test suffices since every fixture here is single-round
+// or reads only round 1/2 as noted per test).
+const abilityPerformedByActor = (result: { events: CombatEvent[] }): Map<string, number[]> => {
+    const map = new Map<string, number[]>();
+    for (const e of result.events) {
+        if (e.type !== 'ability-performed') continue;
+        const list = map.get(e.actorId) ?? [];
+        list.push(e.damage ?? 0);
+        map.set(e.actorId, list);
+    }
+    return map;
+};
+
+const collect = (input: CombatEngineInput) => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    bus.on('ability-performed', (e) => events.push(e as CombatEvent));
+    const result = runCombat({ ...input, bus });
+    return { events, result };
+};
+
+describe('team-aura distribution for outgoing-damage modifiers (sub-project I, PR I3)', () => {
+    describe('Panguan-shape (self-buff Stealth gate)', () => {
+        it('an ally that is NOT the aura source receives the bonus when IT is Stealthed', () => {
+            idc = 0;
+            const ATTACK = 10_000;
+            const { events } = collect(
+                baseEngineInput({
+                    teamActors: [
+                        auraSourceTeamActor('source', panguanAura()),
+                        teamAlly('ally', ATTACK, {
+                            slots: [
+                                {
+                                    slot: 'active',
+                                    abilities: [
+                                        basicDamage(100, 'ally-dmg'),
+                                        stealthSelfBuff('ally-stealth'),
+                                    ],
+                                },
+                            ],
+                        }),
+                    ],
+                })
+            );
+            const byActor = abilityPerformedByActor({ events });
+            expect(byActor.get('ally')?.[0]).toBe(ATTACK * 1.4);
+        });
+
+        it('the SAME ally does NOT receive the bonus when it is NOT Stealthed', () => {
+            idc = 0;
+            const ATTACK = 10_000;
+            const { events } = collect(
+                baseEngineInput({
+                    teamActors: [
+                        auraSourceTeamActor('source', panguanAura()),
+                        teamAlly('ally', ATTACK, {
+                            slots: [{ slot: 'active', abilities: [basicDamage(100, 'ally-dmg')] }],
+                        }),
+                    ],
+                })
+            );
+            const byActor = abilityPerformedByActor({ events });
+            expect(byActor.get('ally')?.[0]).toBe(ATTACK);
+        });
+
+        it('a Stealthed Panguan gets its OWN aura exactly once (source-exclusion, no double-count)', () => {
+            idc = 0;
+            const ATTACK = 10_000;
+            const { events } = collect(
+                baseEngineInput({
+                    attack: ATTACK,
+                    shipSkills: {
+                        slots: [
+                            {
+                                slot: 'active',
+                                abilities: [
+                                    basicDamage(100, 'panguan-dmg'),
+                                    stealthSelfBuff('panguan-stealth'),
+                                ],
+                            },
+                            { slot: 'passive', abilities: [panguanAura()] },
+                        ],
+                    },
+                })
+            );
+            const byActor = abilityPerformedByActor({ events });
+            // Exactly +40% (NOT +80% from a double-counted self + distributed fold).
+            expect(byActor.get('attacker')?.[0]).toBe(ATTACK * 1.4);
+        });
+
+        it('TEAM-SYMMETRY: the SAME aura source on the ENEMY side buffs its enemy ally identically', () => {
+            idc = 0;
+            const ATTACK = 10_000;
+            const sourceEnemy: EnemyAttacker = {
+                id: 'e-source',
+                stats: {
+                    attack: 0,
+                    crit: 0,
+                    critDamage: 0,
+                    defence: 0,
+                    hp: 1_000_000_000,
+                    speed: 100,
+                },
+                chargeCount: 0,
+                startCharged: false,
+                shipSkills: passiveOnly(panguanAura()),
+            } as EnemyAttacker;
+            const allyEnemy: EnemyAttacker = {
+                id: 'e-ally',
+                stats: {
+                    attack: ATTACK,
+                    crit: 0,
+                    critDamage: 0,
+                    defence: 0,
+                    hp: 1_000_000_000,
+                    speed: 100,
+                },
+                chargeCount: 0,
+                startCharged: false,
+                shipSkills: {
+                    slots: [
+                        {
+                            slot: 'active',
+                            abilities: [
+                                basicDamage(100, 'e-ally-dmg'),
+                                stealthSelfBuff('e-ally-stealth'),
+                            ],
+                        },
+                    ],
+                },
+            } as EnemyAttacker;
+            const { events } = collect(
+                baseEngineInput({
+                    hp: 1_000_000_000, // huge focus HP so the enemy's hits never destroy it
+                    enemyAttackers: [sourceEnemy, allyEnemy],
+                })
+            );
+            const byActor = abilityPerformedByActor({ events });
+            expect(byActor.get('e-ally')?.[0]).toBe(ATTACK * 1.4);
+        });
+    });
+
+    describe('Lodolite-shape (enemy-debuff Concentrate Fire gate, composes with I1/I2)', () => {
+        // A single positioned, passive (attack:0) enemy target — security:0 so the CF inflict
+        // always lands (mirrors enemyDebuffNameSpecificGate.integration.test.ts).
+        const passiveEnemyAt = (position: Position): EnemyAttacker =>
+            ({
+                id: 'enemy-front',
+                stats: {
+                    attack: 0,
+                    crit: 0,
+                    critDamage: 0,
+                    defence: 0,
+                    hp: 1_000_000_000,
+                    speed: 1,
+                    security: 0,
+                },
+                chargeCount: 0,
+                startCharged: false,
+                position,
+                shipSkills: { slots: [{ slot: 'active', abilities: [] }] },
+            }) as EnemyAttacker;
+
+        it('an ally that is NOT the aura source gets the bonus against a Concentrate-Fire enemy (I1 name-specific gate, per-turn)', () => {
+            idc = 0;
+            const ATTACK = 10_000;
+            const result = runCombat(
+                baseEngineInput({
+                    numRounds: 2,
+                    hacking: 200, // vs enemy security 0 → inflict always lands
+                    position: 'M4',
+                    target: parsedTarget('front'),
+                    pattern: basePattern(),
+                    attack: ATTACK,
+                    shipSkills: {
+                        slots: [
+                            {
+                                slot: 'active',
+                                abilities: [
+                                    basicDamage(180, 'ally-dmg'),
+                                    cfDebuffInflict('ally-cf'),
+                                ],
+                            },
+                        ],
+                    },
+                    teamActors: [auraSourceTeamActor('source', lodoliteAura())],
+                    enemyAttackers: [passiveEnemyAt('M4')],
+                })
+            );
+            // Round 1: nothing pre-exists on the target before this turn → gate false → base damage.
+            expect(result.rounds[0].perTargetDamage?.['enemy-front']).toBe(18_000); // 10000 * 1.80
+            // Round 2: round 1's own CF infliction is now pre-existing → the DISTRIBUTED aura
+            // gates true → +15% on top of the base 180% multiplier.
+            expect(result.rounds[1].perTargetDamage?.['enemy-front']).toBe(20_700); // 18000 * 1.15
+        });
+
+        it('the SAME ally does NOT get the bonus against a CLEAN enemy (never inflicts Concentrate Fire)', () => {
+            idc = 0;
+            const ATTACK = 10_000;
+            const result = runCombat(
+                baseEngineInput({
+                    numRounds: 2,
+                    hacking: 200,
+                    position: 'M4',
+                    target: parsedTarget('front'),
+                    pattern: basePattern(),
+                    attack: ATTACK,
+                    shipSkills: {
+                        slots: [{ slot: 'active', abilities: [basicDamage(180, 'ally-dmg')] }],
+                    },
+                    teamActors: [auraSourceTeamActor('source', lodoliteAura())],
+                    enemyAttackers: [passiveEnemyAt('M4')],
+                })
+            );
+            expect(result.rounds[0].perTargetDamage?.['enemy-front']).toBe(18_000);
+            expect(result.rounds[1].perTargetDamage?.['enemy-front']).toBe(18_000);
+        });
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -1512,6 +1512,30 @@ export function runCombat(input: CombatEngineInput): {
         ...(input.enemyAttackers ?? []).map((e) => ({ id: e.id, shipSkills: e.shipSkills })),
     ]);
 
+    // Sub-project I, PR I3 (Layer 1) — per-actor-id map of this actor's PASSIVE `all-allies`-
+    // targeted `modifier` abilities (Lodolite's "+15% to enemies with Concentrate Fire/
+    // Stealth", Panguan's "+40% to Stealthed allies"). Only PASSIVE-slot abilities are
+    // gathered — an aura is a standing kit property, not tied to the owner's firing skill
+    // this turn (mirrors how runPlayerTurn reads its OWN modifierAbilities from
+    // firingSkill + passiveSkill, but a non-acting ally never has a "firing skill" this
+    // round). Filtered to `target === 'all-allies'` — a `self`-targeted modifier already
+    // lives only in its owner's own list and must not leak to teammates. Keyed by the SAME
+    // actor set as `buffDurationExtensionByOwner` immediately above (attacker + walked team
+    // + enemy attackers) so distribution covers both sides symmetrically. `buildTurnArgs`
+    // below unions each acting actor's LIVING same-side allies (excluding itself, via
+    // `sameSideLivingFor`) through this map every turn.
+    const allAlliesModifierAbilitiesOf = (skills?: ShipSkills): Ability[] =>
+        (skills?.slots.find((s) => s.slot === 'passive')?.abilities ?? []).filter(
+            (a) => a.type === 'modifier' && a.target === 'all-allies'
+        );
+    const allAlliesModifierAbilitiesById = new Map<string, Ability[]>(
+        [
+            { id: 'attacker', shipSkills: input.shipSkills },
+            ...teamActors.map((t) => ({ id: t.id, shipSkills: t.walk?.shipSkills })),
+            ...(input.enemyAttackers ?? []).map((e) => ({ id: e.id, shipSkills: e.shipSkills })),
+        ].map(({ id, shipSkills }) => [id, allAlliesModifierAbilitiesOf(shipSkills)] as const)
+    );
+
     // Incremental status machine — replaces the precomputed computeBuffTimeline array.
     const statusEngine = createStatusEngine({
         selfBuffs,
@@ -4241,6 +4265,17 @@ export function runCombat(input: CombatEngineInput): {
                 // runPlayerTurn). Side-agnostic — enemy attackers walk the same path.
                 // Conditional spread → absent for every existing caller (byte-identical).
                 ...(a.preFight ? { preFight: a.preFight } : {}),
+                // Sub-project I, PR I3 (Layer 1): team-aura distribution. Union THIS actor's
+                // LIVING same-side allies' `all-allies` passive modifier abilities, EXCLUDING
+                // the actor's own id (its own aura is already in its own modifierAbilities —
+                // no double-count) — reuses `sameSideLivingFor` (the SAME same-side-living
+                // roster the support-footprint path uses; team-symmetric via `a.side`). Merged
+                // into `modifierAbilities` in playerTurn.ts, so it folds into BOTH the per-turn
+                // dmgStats AND (PR I2) perVictimOutgoing for free. Absent-source case → the
+                // flatMap is [] → byte-identical.
+                allyModifierAbilities: sameSideLivingFor(a)
+                    .filter((x) => x.id !== a.id)
+                    .flatMap((x) => allAlliesModifierAbilitiesById.get(x.id) ?? []),
             };
         };
 

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -417,6 +417,16 @@ export interface PlayerTurnArgs {
      *  DAMAGE modifier (not the Crit Power stat), consumed at the engine's crit-family
      *  damage sites. Absent → byte-identical. */
     preFight?: PreFightCombatModifiers;
+    /** Sub-project I, PR I3 (Layer 1) — `all-allies`-targeted passive `modifier` abilities
+     *  gathered from THIS actor's living same-side allies (source excluded — see
+     *  engine.ts's `buildTurnArgs`). Merged into `modifierAbilities` below alongside the
+     *  actor's own firing + passive abilities, so a team aura (Lodolite's "+15% to enemies
+     *  with Concentrate Fire", Panguan's "+40% to Stealthed allies") folds into the
+     *  RECIPIENT's own dmgStats fold AND (PR I2) `perVictimOutgoing`, evaluated against the
+     *  recipient's OWN ctx (self-buff/enemy-status gates resolve from the recipient's
+     *  perspective, not the source's). Defaults to `[]` — absent/empty is byte-identical to
+     *  pre-I3 behavior (no ship's all-allies modifier reaches teammates without this). */
+    allyModifierAbilities?: Ability[];
 }
 
 // ---------------------------------------------------------------------------
@@ -1362,9 +1372,16 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         turnsTaken: actor.turnsTaken,
     });
     const passiveSkill = shipSkills.slots.find((s) => s.slot === 'passive');
+    // Sub-project I, PR I3 (Layer 1): distributed all-allies auras (Lodolite/Panguan-shape)
+    // append AFTER this actor's own firing + passive abilities — array order only affects
+    // scaling-condition positional context (ctxFor in gateFiringAbilities, which this list
+    // does not feed), so ordering is inert here; every ability folds independently in
+    // modifierTotalsFromAbilities. Defaults to [] (pre-I3 callers / no ally aura present)
+    // → byte-identical.
     const modifierAbilities = [
         ...(firingSkill?.abilities ?? []),
         ...(passiveSkill?.abilities ?? []),
+        ...(args.allyModifierAbilities ?? []),
     ];
     // Final four-layer effective-stat fold (layer 1 scheduledTotals + layers 2+3
     // abilitySelfEffects + layer 4 modifierAbilities gated by modifierCtx). The accessor


### PR DESCRIPTION
## Sub-project I, PR I3 — team-aura distribution for outgoing-damage modifiers (Layer 1)

Third PR of conditional-aura fidelity (builds on merged #194 I1 + #195 I2). Spec: `docs/superpowers/specs/2026-07-02-conditional-aura-fidelity-i-design.md` §5.1.

### Problem
`modifierTotalsFromAbilities` ignores the ability `target` field, and each actor's `modifierAbilities` was its **own** skills only. So `all-allies`-targeted outgoing auras — Lodolite's "+15% vs Concentrate Fire/Stealth", Panguan's "+40% for Stealthed units" — only ever buffed the **caster's own** attacks, never teammates.

### Change
The engine builds a per-actor map of each ship's **passive** `target:'all-allies'` modifier abilities. In `buildTurnArgs`, each acting actor receives its **living same-side allies'** such abilities (excluding its own — already in its passive list) as `allyModifierAbilities`, which `runPlayerTurn` merges into `modifierAbilities`. Because that list feeds **both** the per-turn fold **and** I2's `perVictimOutgoing`, the distributed auras fold per-turn *and* re-evaluate per-victim for free, each against the **recipient's own** condition context:
- **Panguan** (self-buff Stealth gate) → only stealthed allies get +40%, **including a stealthed Panguan itself** (exactly once — source-excluded from the merge).
- **Lodolite** (enemy-status gate, composing with I1 name-specific + I2 per-victim) → an ally's hit against a Concentrate-Fire enemy gets +15%.

### Invariants
- **Source exclusion** (`x.id !== a.id`) — no double-count; a lone source gets its aura once.
- **All-allies only** — verified no modifier is parser-emitted with `target:'ally'`; `self` stays self-only.
- **Living-only** (`sameSideLivingFor` filters `currentHp > 0`) — a dead ship's regular passive aura ends. (Distinct from pre-fight/squad-leader auras, which persist.)
- **Team-symmetric** — the single `buildTurnArgs` dispatches on `a.side`; an aura source on either team buffs its own side identically.

### Tests
New `teamAuraDistribution.integration.test.ts` (6): Panguan self-buff distribution (stealthed ally yes / non-stealthed no / stealthed Panguan once), Lodolite enemy-status distribution (composes with I1), team-symmetry mirror, source-exclusion. Sanity-checked by disabling the merge → exactly the 3 distribution-dependent tests fail.

### Validation
tsc · lint (0) · full suite (3844) · `audit:skills` (0). Goldens **byte-identical**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPheh4qisgdG9PazKJMkiF
