### PR TITLE
feat(combat): Selenite stealthed-enemy count damage scaling (sub-project I, PR I5)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -13,6 +13,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat sim: damage bonuses that target enemies with a specific status now check for that exact status. Tygr, Rikra, Incinerator, Wrecker, and Lodolite only get their bonus damage against the named status (Stasis/Disable, Taunt/Provoke, Inferno, or Concentrate Fire) rather than against any debuffed enemy.',
     "Combat sim: in a multi-target attack, a damage bonus gated on a named enemy status (e.g. Tygr's bonus vs Stasis/Disable) is now checked against each hit target individually — a target without the status no longer gets the bonus just because another target in the same attack has it.",
     "Combat sim: team-wide damage auras now actually reach the team. Lodolite's +15% damage vs Concentrate Fire (or Stealth) and Panguan's +40% damage for Stealthed units apply to every living ally who qualifies, not just the caster's own attacks.",
+    "Combat sim: Selenite's bonus direct damage now scales with the number of Stealthed enemies (10% per enemy), instead of a flat 10% whenever at least one enemy was Stealthed.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -231,7 +231,15 @@ export type ConditionSubject =
     // Binary periodic gate: met when the owner's own-turn counter satisfies
     // turnsTaken % period === (offset ?? 0). period/offset live on Condition.
     // Used by Chrono Reaver (every other/third turn). Always derivable:true.
-    | 'every-n-turns';
+    | 'every-n-turns'
+    // COUNT subject (sub-project I, PR I5): the number of living OPPOSING actors
+    // currently holding the Stealth self-buff. Distinct from 'enemy-buff' (which reads
+    // `enemyBuffNames`, a DEDUPED UNION — it can tell "is at least one enemy Stealthed"
+    // but never "how many"). Used as a SCALING source, e.g. Selenite's "10% more direct
+    // damage for every enemy with Stealth" (perUnit 10, no cap). Live-derived by the
+    // combat engine from ConditionContext.stealthedEnemyCount; defaults to 0 (DPS mode
+    // has no enemy attackers to count) — inert/byte-identical there. Always derivable:true.
+    | 'enemy-stealth-count';
 
 export interface Condition {
     subject: ConditionSubject;

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -890,6 +890,29 @@ describe('buildShipAbilities', () => {
         expect(mod.scaling).toMatchObject({ conditionIndex: 0, perUnit: 10, cap: 50 });
     });
 
+    it('Selenite passive: "for every enemy with Stealth" scales on the DERIVABLE stealthed-enemy count (sub-project I, PR I5)', () => {
+        // Real CSV text (docs/ship-skills.csv, first/second_passive_skill_text) — "for every",
+        // not "for each", and counting ENEMY UNITS with Stealth, not stacks on one target.
+        // A plain enemy-buff gate (pre-I5) can only tell "at least one enemy Stealthed", not
+        // how many — the dedicated count subject fixes that.
+        const s = ship({
+            firstPassiveSkillText:
+                'This Unit deals 10% more direct damage for every enemy with <unit-skill>Stealth</unit-skill>.',
+        });
+        const mod = abilityOfType(
+            slot(buildShipAbilities(s).slots, 'passive')!.abilities,
+            'modifier'
+        )!;
+        expect(mod.conditions[0]).toMatchObject({
+            subject: 'enemy-stealth-count',
+            derivable: true,
+        });
+        expect(mod.scaling).toMatchObject({ conditionIndex: 0, perUnit: 10 });
+        expect(mod.scaling?.cap).toBeUndefined(); // the text states no maximum
+        expect(mod.config).toMatchObject({ channel: 'outgoingDamage', value: 0 });
+        expect(mod.target).toBe('self'); // self-scoped — no team distribution, no per-victim
+    });
+
     describe('HP-proportional modifiers (Akula / Tithonus)', () => {
         it('Akula passive: outgoing damage scaling with CURRENT enemy HP% (up to 30%)', () => {
             const akula = ship({

--- a/src/utils/abilities/__tests__/evaluateConditions.test.ts
+++ b/src/utils/abilities/__tests__/evaluateConditions.test.ts
@@ -99,6 +99,28 @@ describe('evaluateCondition', () => {
         ).toBe(0);
     });
 
+    describe("'enemy-stealth-count' (sub-project I, PR I5)", () => {
+        it('returns the live stealthedEnemyCount, distinct from the enemyBuffNames union', () => {
+            const c = makeConditionContext({
+                // A deduped union can't distinguish 1 vs N stealthed enemies — the dedicated
+                // count field is what makes that distinction possible.
+                enemyBuffNames: ['Stealth'],
+                stealthedEnemyCount: 2,
+            });
+            expect(
+                evaluateCondition(cond({ subject: 'enemy-stealth-count', derivable: true }), c)
+            ).toBe(2);
+        });
+
+        it('defaults to 0 when unset (DPS-assumption)', () => {
+            const c = makeConditionContext();
+            expect(c.stealthedEnemyCount).toBeUndefined();
+            expect(
+                evaluateCondition(cond({ subject: 'enemy-stealth-count', derivable: true }), c)
+            ).toBe(0);
+        });
+    });
+
     it("'self-crit' is effective crit rate / 100", () => {
         expect(
             evaluateCondition(
@@ -335,6 +357,17 @@ describe('scaledBonus', () => {
 
     it('returns 0 when no scaling rule', () => {
         expect(scaledBonus(dmg([], undefined), makeConditionContext())).toBe(0);
+    });
+
+    it('Selenite-shape: 10% per stealthed enemy, uncapped (sub-project I, PR I5)', () => {
+        const a = dmg([cond({ subject: 'enemy-stealth-count', derivable: true })], {
+            conditionIndex: 0,
+            perUnit: 10,
+        });
+        expect(scaledBonus(a, makeConditionContext({ stealthedEnemyCount: 0 }))).toBe(0);
+        expect(scaledBonus(a, makeConditionContext({ stealthedEnemyCount: 2 }))).toBe(20);
+        // Uncapped — the skill text states no maximum.
+        expect(scaledBonus(a, makeConditionContext({ stealthedEnemyCount: 5 }))).toBe(50);
     });
 
     it('scaling reads only the indexed condition, even inside an anyOf OR-group', () => {

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -272,6 +272,28 @@ function forEachCondition(sentence: string): Condition | null {
 }
 
 /**
+ * Sub-project I, PR I5 — classifies Selenite's "…for every enemy with Stealth" into a
+ * COUNT-SCALING condition on the number of DISTINCT stealthed enemy UNITS, distinct from
+ * `forEachCondition`'s "for each <buff/debuff> on the enemy" (which counts effects present
+ * ON A SINGLE target). `enemyBuffNames` is a deduped union of names across every opposing
+ * actor, so it can answer "is at least one enemy Stealthed" but never "how many" — the sim
+ * tracks a dedicated live count (`ConditionContext.stealthedEnemyCount`, populated by the
+ * combat engine) for this shape instead. Scoped to the literal "for every enem(y|ies) with"
+ * phrasing (distinct from "for each", already handled above) and to a single named BUFF
+ * effect — only Stealth is engine-tracked this way today; any other named status (or a
+ * debuff, or multiple named effects) returns null so the caller falls back to the flat
+ * presence-gate modifier rather than silently mis-scaling on an untracked count.
+ */
+function forEveryEnemyStealthCondition(sentence: string, rawText: string): Condition | null {
+    if (!/for every\s+enem(?:y|ies)\s+with\b/i.test(sentence)) return null;
+    const names = enemyEffectNamesFromClause(rawText);
+    if (names.length !== 1) return null;
+    const [buffName] = names;
+    if (buffName !== 'Stealth' || classifyEnemyEffect(buffName) !== 'buff') return null;
+    return { subject: 'enemy-stealth-count', derivable: true };
+}
+
+/**
  * Detects an HP-proportional "up to X%" bonus: the value scales linearly with the
  * target's CURRENT HP% (Akula — "based on the target's current HP percentage; the
  * higher the percentage, the more") or MISSING HP% (Tithonus — "based on the
@@ -356,30 +378,52 @@ function parseModifiers(text: string): ParsedModifier[] {
                 });
             }
         } else {
-            const conditions: Condition[] = [];
-            // "to enemies (with|afflicted with) <effect> [or <effect>]" → the ENEMY has one of
-            // these effects, classified per effect type (debuff/DoT → enemy-debuff, buff → enemy-buff).
-            const enemyEffects = /\benem(?:y|ies)\b[^.]*\bwith\b/i.test(sentence)
-                ? enemyEffectNamesFromClause(text)
-                : [];
-            if (enemyEffects.length) {
-                conditions.push(...enemyEffectConditions(enemyEffects));
-            } else if (/stealth/i.test(sentence)) {
-                // "while Stealthed" (self) — the acting unit's own Stealth.
-                const subject =
-                    target === 'self' || target === 'all-allies' ? 'self-buff' : 'enemy-buff';
-                conditions.push({ subject, buffName: 'Stealth', derivable: true });
+            // Sub-project I, PR I5: "10% more direct damage for every enemy with Stealth"
+            // (Selenite) — a COUNT-SCALING modifier on the number of stealthed enemy UNITS,
+            // checked before the flat enemy-effect gate below (which would otherwise treat
+            // this as a binary "at least one enemy Stealthed" presence gate).
+            const stealthCountCond = forEveryEnemyStealthCondition(sentence, text);
+            if (stealthCountCond) {
+                out.push({
+                    channel: 'outgoingDamage',
+                    value: 0,
+                    isMultiplicative: true,
+                    target,
+                    conditions: [stealthCountCond],
+                    scaling: {
+                        conditionIndex: 0,
+                        perUnit: value,
+                        ...(capFromSentence(sentence) !== undefined
+                            ? { cap: capFromSentence(sentence) }
+                            : {}),
+                    },
+                });
+            } else {
+                const conditions: Condition[] = [];
+                // "to enemies (with|afflicted with) <effect> [or <effect>]" → the ENEMY has one of
+                // these effects, classified per effect type (debuff/DoT → enemy-debuff, buff → enemy-buff).
+                const enemyEffects = /\benem(?:y|ies)\b[^.]*\bwith\b/i.test(sentence)
+                    ? enemyEffectNamesFromClause(text)
+                    : [];
+                if (enemyEffects.length) {
+                    conditions.push(...enemyEffectConditions(enemyEffects));
+                } else if (/stealth/i.test(sentence)) {
+                    // "while Stealthed" (self) — the acting unit's own Stealth.
+                    const subject =
+                        target === 'self' || target === 'all-allies' ? 'self-buff' : 'enemy-buff';
+                    conditions.push({ subject, buffName: 'Stealth', derivable: true });
+                }
+                conditions.push(...affectedByConditions(sentence));
+                const hpCond = hpThresholdFromSentence(sentence);
+                if (hpCond) conditions.push(hpCond);
+                out.push({
+                    channel: 'outgoingDamage',
+                    value,
+                    isMultiplicative: true,
+                    target,
+                    conditions,
+                });
             }
-            conditions.push(...affectedByConditions(sentence));
-            const hpCond = hpThresholdFromSentence(sentence);
-            if (hpCond) conditions.push(hpCond);
-            out.push({
-                channel: 'outgoingDamage',
-                value,
-                isMultiplicative: true,
-                target,
-                conditions,
-            });
         }
     }
 

--- a/src/utils/abilities/evaluateConditions.ts
+++ b/src/utils/abilities/evaluateConditions.ts
@@ -53,6 +53,15 @@ export interface ConditionContext {
     /** The condition owner's own-turn counter (CombatActor.turnsTaken). Live-derived by
      *  the engine drain context; defaults 0 (DPS / no-delegate → period>=2 never met). */
     turnsTaken?: number;
+    /** Sub-project I, PR I5 — count of living OPPOSING actors whose self-buff set includes
+     *  'Stealth' (Selenite's "10% more direct damage for every enemy with Stealth" count-
+     *  scaling). Distinct from `enemyBuffNames`, which is a DEDUPED UNION of buff names
+     *  across every opposing actor — it can answer "does at least one enemy have Stealth"
+     *  but can never distinguish 1 stealthed enemy from N. Live-derived by the combat
+     *  engine (count of living opposing actors carrying Stealth); defaults to 0 elsewhere
+     *  (DPS mode has no enemy attackers to count) — the scaling contributes 0, byte-
+     *  identical to today. */
+    stealthedEnemyCount?: number;
 }
 
 /** Resolve one condition to a count (>= 0). 0 means "not met". */
@@ -95,6 +104,8 @@ export function evaluateCondition(cond: Condition, ctx: ConditionContext): numbe
             return ctx.enemyAdjacentCount;
         case 'enemy-destroyed':
             return ctx.enemyDestroyedCount;
+        case 'enemy-stealth-count':
+            return ctx.stealthedEnemyCount ?? 0;
         case 'hp-threshold':
             return evalHpThreshold(cond, ctx) ? 1 : 0;
         // HP-percentage counts: the enemy's current/missing HP% (0..100). Used as

--- a/src/utils/abilities/roundContext.ts
+++ b/src/utils/abilities/roundContext.ts
@@ -53,6 +53,10 @@ export function buildRoundContext(state: {
     /** The condition owner's own-turn counter. Default 0 (DPS-assumption: inert for
      *  period>=2 conditions). Populated live by the engine drain context. */
     turnsTaken?: number;
+    /** Sub-project I, PR I5 — count of living opposing actors currently holding the Stealth
+     *  self-buff. Default 0 (DPS-assumption: no enemy attackers to count). Populated live by
+     *  the combat engine. See ConditionContext.stealthedEnemyCount. */
+    stealthedEnemyCount?: number;
 }): ConditionContext {
     return {
         selfBuffNames: state.selfBuffNames,
@@ -79,6 +83,7 @@ export function buildRoundContext(state: {
         firstActivator: state.firstActivator ?? false,
         isLastStanding: state.lastStanding ?? false,
         turnsTaken: state.turnsTaken ?? 0,
+        stealthedEnemyCount: state.stealthedEnemyCount ?? 0,
         ...(state.roundCrit !== undefined ? { roundCrit: state.roundCrit } : {}),
         // Sentinel spread (sub-project I, PR I1): only set the key when the caller passed a
         // real array — an explicit `undefined` value would collapse to the same runtime

--- a/src/utils/calculators/__tests__/dpsSimulator.test.ts
+++ b/src/utils/calculators/__tests__/dpsSimulator.test.ts
@@ -1834,6 +1834,40 @@ describe('simulateDPS', () => {
             );
         });
 
+        it('DPS-parity (sub-project I, PR I5): an enemy-stealth-count scaling modifier contributes 0 in the DPS simulator', () => {
+            // Mirrors Selenite's "10% more direct damage for every enemy with Stealth" — a
+            // count-scaling modifier on ConditionContext.stealthedEnemyCount. The DPS simulator
+            // has no enemy-attacker roster to count (there is no DPS input field for it at all,
+            // unlike enemyDebuffs/enemyBuffs), so the field is never populated and always
+            // defaults to 0 — the scaling must contribute nothing, leaving directDamage
+            // byte-identical to the same skill set without the modifier at all.
+            const stealthCountModifier: Ability = {
+                id: 'm',
+                type: 'modifier',
+                target: 'self',
+                trigger: 'on-cast',
+                conditions: [{ subject: 'enemy-stealth-count', derivable: true }],
+                scaling: { conditionIndex: 0, perUnit: 10 },
+                config: {
+                    type: 'modifier',
+                    channel: 'outgoingDamage',
+                    value: 0,
+                    isMultiplicative: true,
+                },
+            };
+            const withModifier = simulateDPS({
+                ...baseInput,
+                shipSkills: activeSkills([damageAbility('d', 100), stealthCountModifier]),
+            });
+            const withoutModifier = simulateDPS({
+                ...baseInput,
+                shipSkills: activeSkills([damageAbility('d', 100)]),
+            });
+            expect(withModifier.rounds[0].directDamage).toBe(
+                withoutModifier.rounds[0].directDamage
+            );
+        });
+
         it('multi-hit damage equals a single hit with the summed multiplier', () => {
             const multiHit = simulateDPS({
                 ...baseInput,

--- a/src/utils/combat/__tests__/stealthedEnemyCountScaling.integration.test.ts
+++ b/src/utils/combat/__tests__/stealthedEnemyCountScaling.integration.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Sub-project I, PR I5 — Selenite-shape "10% more direct damage for every enemy with
+ * Stealth" count-scaling, combat-engine integration.
+ *
+ * `enemyBuffNames` is a DEDUPED UNION of buff names across every opposing actor — it can
+ * only answer "is at least one enemy Stealthed", never "how many". This suite locks the
+ * dedicated live count (`ConditionContext.stealthedEnemyCount`, sourced in `engine.ts` via
+ * `countOwnersWithSelfBuff` and threaded through `buildTurnArgs` → `runPlayerTurn` →
+ * `modifierCtx`) that lets a count-scaling modifier (`enemy-stealth-count` subject,
+ * `scaling.perUnit`) tell 1 stealthed enemy from N.
+ *
+ * The focus attacker is made SLOW (speed 1) and both enemy attackers FAST (speed 100) so
+ * the enemies' own self-cast Stealth grants land BEFORE the focus's turn is built within the
+ * same round — no multi-round dance needed (mirrors teamAuraDistribution's `stealthSelfBuff`
+ * pattern, applied here on the OPPOSING side instead of an ally).
+ *
+ * Damage is read off the `ability-performed` bus event for the focus actor ('attacker'), NOT
+ * `perTargetDamage` — the engine's positional targeting deliberately treats a Stealthed enemy
+ * as untargetable (positionalBinding.ts's stealth filter), so which enemy the attack actually
+ * LANDS on shifts once an enemy is Stealthed. Reading the attacker's own emitted damage sidesteps
+ * that entirely and proves the point directly: this is a GLOBAL count modifier on the CASTER's
+ * own attack, not a per-victim gate (spec §5.4: "no team distribution, no per-victim").
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import type { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { CombatEvent } from '../events';
+import { createEventBus } from '../events';
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `sec${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+// A self-cast Stealth grant (mirrors teamAuraDistribution.integration.test.ts's
+// stealthSelfBuff — applied here on an ENEMY attacker rather than an ally).
+const stealthSelfBuff = (id: string): Ability =>
+    ab({
+        id,
+        type: 'buff',
+        target: 'self',
+        config: {
+            type: 'buff',
+            buffName: 'Stealth',
+            parsedEffects: {},
+            stacks: 1,
+            isStackable: false,
+            duration: 99,
+        },
+    });
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+// Fast (speed 100) enemy attacker so it acts BEFORE the (slow, speed 1) focus attacker
+// within round 1. `abilities` is either empty (plain) or carries stealthSelfBuff (stealthed).
+const enemyAt = (id: string, position: Position, abilities: Ability[]): EnemyAttacker =>
+    ({
+        id,
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 100,
+            security: 0,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        shipSkills: { slots: [{ slot: 'active', abilities }] },
+    }) as EnemyAttacker;
+
+// Selenite-shape passive: self-scoped outgoing-damage modifier scaling 10% per stealthed
+// enemy, uncapped (the CSV text states no maximum).
+const seleniteStealthCountModifier = (): Ability =>
+    ab({
+        target: 'self',
+        type: 'modifier',
+        conditions: [{ subject: 'enemy-stealth-count', derivable: true }],
+        config: {
+            type: 'modifier',
+            channel: 'outgoingDamage',
+            value: 0,
+            isMultiplicative: true,
+        },
+        scaling: { conditionIndex: 0, perUnit: 10 },
+    });
+
+const skills = (): ShipSkills => ({
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                ab({ type: 'damage', config: { type: 'damage', multiplier: 100 } }),
+                seleniteStealthCountModifier(),
+            ],
+        },
+    ],
+});
+
+const engineBase = (enemyAttackers: EnemyAttacker[]): CombatEngineInput => ({
+    attack: 10_000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: skills(),
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    // Slow focus attacker: both enemy attackers (speed 100) act first each round, so a
+    // self-cast Stealth grant from an enemy's OWN turn is already live when this actor's
+    // turn is built (no multi-round dance needed, unlike the enemy-inflicted-debuff shapes).
+    speed: 1,
+    enemyAttackers,
+});
+
+// Focus actor's own emitted 'ability-performed' damage — target-agnostic, so it is unaffected
+// by the engine's Stealth-untargetable positional filter (positionalBinding.ts).
+const focusDamage = (input: CombatEngineInput): number => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    bus.on('ability-performed', (e) => events.push(e as CombatEvent));
+    runCombat({ ...input, bus });
+    const hit = events.find((e) => e.type === 'ability-performed' && e.actorId === 'attacker');
+    return hit && hit.type === 'ability-performed' ? (hit.damage ?? 0) : NaN;
+};
+
+describe('enemy-stealth-count scaling (sub-project I, PR I5) — engine integration', () => {
+    it('no enemy is Stealthed → base damage (0 × 10% = 0)', () => {
+        idc = 0;
+        const damage = focusDamage(
+            engineBase([enemyAt('front', 'M4', []), enemyAt('covered', 'M3', [])])
+        );
+        expect(damage).toBe(10_000); // 10000 * 1.00
+    });
+
+    it('exactly ONE stealthed enemy → +10%', () => {
+        idc = 0;
+        const damage = focusDamage(
+            engineBase([
+                enemyAt('front', 'M4', [stealthSelfBuff('front-stealth')]),
+                enemyAt('covered', 'M3', []),
+            ])
+        );
+        expect(damage).toBe(11_000); // 10000 * 1.10
+    });
+
+    it('TWO stealthed enemies → +20% (proves COUNT, not a binary union gate)', () => {
+        idc = 0;
+        const damage = focusDamage(
+            engineBase([
+                enemyAt('front', 'M4', [stealthSelfBuff('front-stealth')]),
+                enemyAt('covered', 'M3', [stealthSelfBuff('covered-stealth')]),
+            ])
+        );
+        // A deduped `enemyBuffNames` union would read the SAME (1 for "Stealth present") for
+        // both 1-stealthed and 2-stealthed cases; the dedicated count tells them apart: +20%.
+        expect(damage).toBe(12_000); // 10000 * 1.20
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -84,6 +84,7 @@ import {
     MAX_INTENT_GENERATIONS,
     buildActorConditionContext,
     buildForcedTargetingStatus,
+    countOwnersWithSelfBuff,
     executeIntent,
     ownerDebuffNamesFor,
     partitionReactiveAbilities,
@@ -1887,6 +1888,14 @@ export function runCombat(input: CombatEngineInput): {
     const playerEnemyBuffNames = (): string[] =>
         selfBuffNamesForOwners(statusEngine, livingEnemyAttackerIds());
     const enemyEnemyBuffNames = (): string[] => selfBuffNamesForOwners(statusEngine, playerIds);
+    // Sub-project I, PR I5 — count (not union) of opposing actors holding Stealth, for
+    // Selenite's "10% more direct damage for every enemy with Stealth" count-scaling.
+    // Same owner-id sourcing as the buff-NAME unions immediately above (team-symmetric);
+    // DPS mode has no enemy attackers → livingEnemyAttackerIds() is empty → 0, byte-identical.
+    const playerStealthedEnemyCount = (): number =>
+        countOwnersWithSelfBuff(statusEngine, livingEnemyAttackerIds(), 'Stealth');
+    const enemyStealthedEnemyCount = (): number =>
+        countOwnersWithSelfBuff(statusEngine, playerIds, 'Stealth');
     const ownerDebuffNames = (ownerId: string): string[] =>
         ownerDebuffNamesFor(statusEngine, ownerId);
     // Sub-project I, PR I1: NAMES on a resolved (real) opposing target for name-specific
@@ -3957,6 +3966,8 @@ export function runCombat(input: CombatEngineInput): {
             victimMaxHpFor: (tgt: CombatActor) => number;
             enemyTypeArg: EnemyBaseClass | undefined;
             enemyBuffNamesUnion: () => string[];
+            // Sub-project I, PR I5 — count (not union) of opposing actors holding Stealth.
+            stealthedEnemyCount: () => number;
             healEventOnly: boolean;
             // Matches drivePositionalApply's applyToVictim param type exactly. E2: returns the
             // resolved VictimDamageOutcome (both impls wrap applyOutgoingToEnemy /
@@ -3970,6 +3981,7 @@ export function runCombat(input: CombatEngineInput): {
             victimMaxHpFor: (tgt) => tgt.stats.hp,
             enemyTypeArg: enemyType,
             enemyBuffNamesUnion: playerEnemyBuffNames,
+            stealthedEnemyCount: playerStealthedEnemyCount,
             healEventOnly: false,
             applyToVictim: (victim, damage) => applyOutgoingToEnemy(damage, victim),
         };
@@ -3984,6 +3996,7 @@ export function runCombat(input: CombatEngineInput): {
             // UNION of PLAYER self-buff names (fed to the enemy's own `enemy-buff` gates). A bare
             // enemy has no such gate → inert today; computed for the full-kit enemy.
             enemyBuffNamesUnion: enemyEnemyBuffNames,
+            stealthedEnemyCount: enemyStealthedEnemyCount,
             healEventOnly: true,
             // An enemy supporter running runPlayerTurn grants charges to its OWN (enemy) team via
             // bySide('enemy').grantAllyCharges (resolved in buildTurnArgs by side), NEVER the player
@@ -4219,6 +4232,10 @@ export function runCombat(input: CombatEngineInput): {
                 // repaired enemy → false → byte-identical (the purge block guards on targetId).
                 targetRepairedThisRound: repairedThisRound.has(tgt.id),
                 enemyBuffNames: tb.enemyBuffNamesUnion(),
+                // Sub-project I, PR I5: count (not union) of opposing actors holding Stealth,
+                // for Selenite's "for every enemy with Stealth" count-scaling. Same per-turn
+                // cadence as enemyBuffNames above; 0 in DPS mode (no enemy attackers).
+                stealthedEnemyCount: tb.stealthedEnemyCount(),
                 // Sub-project I, PR I1: opt-in NAMES on the resolved target for name-specific
                 // `enemy-debuff` gates — SAME guard as targetId above (real/positional target
                 // only). When tgt is the dummy `enemy` sink (DPS mode / no positional

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -347,6 +347,12 @@ export interface PlayerTurnArgs {
      *  feed condition gates, never effect folding (no double-fold). Defaults to [] (DPS-assumption,
      *  byte-identical). Sourced by the engine via triggers.selfBuffNamesForOwners. */
     enemyBuffNames?: string[];
+    /** Sub-project I, PR I5 — count (not union) of living opposing actors currently holding
+     *  the Stealth self-buff, for this actor's `enemy-stealth-count` scaling condition
+     *  (Selenite's "10% more direct damage for every enemy with Stealth"). Same per-turn
+     *  cadence/sourcing as `enemyBuffNames` above (triggers.countOwnersWithSelfBuff). Defaults
+     *  to 0 (DPS-assumption: no enemy attackers to count) — byte-identical there. */
+    stealthedEnemyCount?: number;
     /** Sub-project I, PR I1 — NAMES on the opposing (primary) target for this actor's
      *  name-specific `enemy-debuff` condition gates (Tygr's "to enemies with Stasis or
      *  Disable", Incinerator's "to enemies afflicted with Inferno"). SENTINEL: `undefined`
@@ -769,6 +775,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         targetRepairedThisRound: targetRepairedThisRoundArg = false,
         targetId,
         enemyBuffNames: enemyBuffNamesArg = [],
+        stealthedEnemyCount: stealthedEnemyCountArg = 0,
         // No default — undefined is the DPS-parity sentinel (see PlayerTurnArgs doc).
         enemyDebuffNames: enemyDebuffNamesArg,
         selfDebuffNames: selfDebuffNamesArg = [],
@@ -1370,6 +1377,13 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         selfDebuffNames: selfDebuffNamesArg,
         selfShielded: actor.shieldPool > 0,
         turnsTaken: actor.turnsTaken,
+        // Sub-project I, PR I5: only the modifier ctx needs this — it feeds
+        // modifierAbilities/modifierTotalsFromAbilities (Selenite's count-scaling passive).
+        // The I2 per-victim re-fold spreads this ctx unchanged (only enemyDebuffNames/
+        // enemyBuffNames/enemyHpPct are swapped per victim), so it naturally stays constant
+        // across the delta computation — no per-victim distribution, matching the design
+        // (this is a global count, not a per-target gate).
+        stealthedEnemyCount: stealthedEnemyCountArg,
     });
     const passiveSkill = shipSkills.slots.find((s) => s.slot === 'passive');
     // Sub-project I, PR I3 (Layer 1): distributed all-allies auras (Lodolite/Panguan-shape)

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1100,6 +1100,35 @@ export function selfBuffNamesForOwners(statusEngine: StatusEngine, ownerIds: str
     return [...names];
 }
 
+/** Sub-project I, PR I5 — count of DISTINCT owners (out of the given owner ids) currently
+ *  holding the named self-buff. Reads the SAME three sources as {@link selfBuffNamesForOwners}
+ *  (scheduled activeSelfBuffs + timed ability statuses + aura/accum ability statuses) but per
+ *  OWNER rather than as a deduped name union — this is what lets Selenite's "10% more direct
+ *  damage for every enemy with Stealth" tell 1 stealthed enemy from N, which a name union
+ *  cannot. Each owner counts at most once even if the buff is present via multiple sources. */
+export function countOwnersWithSelfBuff(
+    statusEngine: StatusEngine,
+    ownerIds: string[],
+    buffName: string
+): number {
+    let count = 0;
+    for (const ownerId of ownerIds) {
+        const snap = statusEngine.snapshot(ownerId);
+        const hasIt =
+            snap.activeSelfBuffs.some(
+                (ab) => ab.buffName === buffName && (ab.stacks === undefined || ab.stacks > 0)
+            ) ||
+            statusEngine
+                .timedAbilityStatuses('self', ownerId)
+                .some((s) => s.active.buffName === buffName) ||
+            statusEngine
+                .activeAbilityStatuses('self', () => NEUTRAL_NAMES_CTX, ownerId)
+                .some((s) => s.active.buffName === buffName);
+        if (hasIt) count += 1;
+    }
+    return count;
+}
+
 /** Enemy-debuff NAMES carried in the per-TARGET store keyed by `targetId` (an actor's
  *  OWN debuffs). Scheduled non-payload debuffs come from snapshot(_, targetId).activeEnemyDebuffs;
  *  payload-carrying ability debuffs (timed + aura/accum) come from the ability-status reads


### PR DESCRIPTION
## Sub-project I, PR I5 — Selenite stealthed-enemy count damage scaling

Fifth PR of conditional-aura fidelity. Spec §5.4. Independent of I1–I3's mechanisms.

### Problem
Selenite's "10% more direct damage **for every enemy with Stealth**" parsed as a **flat** presence gate (any ≥1 stealthed enemy → full +10%), not a count scale — because `parseModifiers` only matched literal "for each" and Selenite's text says "for every", falling through to the flat enemy-effect-gate branch. `enemyBuffNames` is a deduped union, so it can't count multiple stealthed enemies anyway.

### Change
- New `forEveryEnemyStealthCondition` (narrowly gated: "for every enemies with" + exactly one named effect that is `Stealth` and classifies as a buff) → emits a `scaling` modifier (`perUnit: 10`, no cap) over a new condition subject. All other "for each/every" text falls through unchanged (verified: no other ship hits this branch).
- New `ConditionSubject` `'enemy-stealth-count'` + optional `ConditionContext.stealthedEnemyCount` (defaults 0).
- New `countOwnersWithSelfBuff` helper (counts **distinct** living owners carrying the buff, vs the deduped name-union). Engine sources `playerStealthedEnemyCount`/`enemyStealthedEnemyCount` team-symmetrically and threads through `TurnBindings` → `buildTurnArgs` → the modifier ctx.
- Self modifier (Selenite's own attacks) — no team distribution, no per-victim (global count, applied uniformly; I2's per-victim delta cancels it to 0 automatically).

### DPS parity
DPS mode has no enemy-attacker roster → count is always 0 → byte-identical. Locked by an explicit DPS-parity test.

### Tests
Unit (`enemy-stealth-count` eval + scaledBonus 0/2/5 → 0/20/50), parser (Selenite real CSV text → scaling shape), engine integration (0/1/2 stealthed → 0/+10/+20%, via the `ability-performed` bus event), DPS parity.

### Validation
tsc · lint (0) · full suite (3852) · `audit:skills` (0). Goldens **byte-identical**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPheh4qisgdG9PazKJMkiF
