### PR TITLE
feat(combat): Lodolite charged purge + shield strip on purge (sub-project I, PR I6)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -14,6 +14,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: in a multi-target attack, a damage bonus gated on a named enemy status (e.g. Tygr's bonus vs Stasis/Disable) is now checked against each hit target individually — a target without the status no longer gets the bonus just because another target in the same attack has it.",
     "Combat sim: team-wide damage auras now actually reach the team. Lodolite's +15% damage vs Concentrate Fire (or Stealth) and Panguan's +40% damage for Stealthed units apply to every living ally who qualifies, not just the caster's own attacks.",
     "Combat sim: Selenite's bonus direct damage now scales with the number of Stealthed enemies (10% per enemy), instead of a flat 10% whenever at least one enemy was Stealthed.",
+    "Combat sim: Lodolite's charged skill now purges all buffs from the enemy with the most buffs, and her legendary refit strips 100% of that enemy's shield when she does.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -468,6 +468,15 @@ export type AbilityConfig =
           mode?: 'remove' | 'reduce-duration';
           /** Turns to reduce in 'reduce-duration' mode (default 1). cleanse-only. */
           durationTurns?: number;
+          /** I6: when this unit lands a purge (this ability), it also removes 100% of the
+           *  purged victim's shield (Lodolite legendary refit: "When this Unit Purges a buff
+           *  from an enemy, it removes 100% of the enemy's shield"). Set on EVERY 'purge'-type
+           *  config buildShipAbilities emits for a ship whose skill text carries that clause
+           *  (parseable via detectPurgeStripsShield) — gated on the parsed ability, never a
+           *  hardcoded ship name. purge-only; cleanse never sets this. Consumed at the
+           *  purge-performed apply site in playerTurn.ts, same victim id, right after the purge
+           *  resolves. Absent → byte-identical (no ship besides Lodolite carries it today). */
+          stripsShield?: boolean;
       }
     | {
           type: 'control';

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -35,6 +35,8 @@ import {
     parseHealAbilities,
     parseCleanse,
     parsePurge,
+    detectPassiveVoicePurge,
+    detectPurgeStripsShield,
     parseHealNoCrit,
     statusEffectCondition,
     parseControlInflicts,
@@ -3601,6 +3603,90 @@ describe('parsePurge — E4 crit-power scaling', () => {
         const [p] = parsePurge('This Unit purges 2 buffs from the enemy.');
         expect(p.count).toBe(2);
         expect(p.countScaling).toBeUndefined();
+    });
+});
+
+// I6: Lodolite charged purge + legendary-refit shield strip. RAW strings verbatim from
+// docs/ship-skills.csv (Lodolite row).
+const LODOLITE_CHARGED_RAW =
+    "This Unit deals <unit-damage>310% damage</unit-damage> and additional damage equal to <unit-damage>10%</unit-damage> of this Unit's max HP. Then, the enemy with the most <unit-aid>Buffs</unit-aid> is Purged of all buffs.<br />This attack can target <unit-aid>Stealthed</unit-aid> enemies.";
+const LODOLITE_R4_PASSIVE_RAW =
+    "This Unit ignores <unit-skill>Stealth</unit-skill> effects.<br /><br />This Unit deals <unit-damage>10% more critical damage</unit-damage> to defenders, all allies deal <unit-damage>15% more direct damage</unit-damage> to enemies with <unit-skill>Concentrate Fire</unit-skill> or <unit-skill>Stealth</unit-skill>.<br /><br />When this Unit <unit-aid>Purges a buff</unit-aid> from an enemy, it <unit-damage>removes 100%</unit-damage> of the enemy's shield.";
+
+describe('detectPassiveVoicePurge (I6 — Lodolite charged purge)', () => {
+    it('parses the bare phrase "is Purged of all buffs" → count all, target enemy', () => {
+        expect(detectPassiveVoicePurge('is Purged of all buffs')).toEqual([
+            { count: 'all', target: 'enemy', explicitTarget: true },
+        ]);
+    });
+
+    it('parses a numeric count: "is purged of 2 buffs"', () => {
+        expect(detectPassiveVoicePurge('is purged of 2 buffs')).toEqual([
+            { count: 2, target: 'enemy', explicitTarget: true },
+        ]);
+    });
+
+    it('parses Lodolite charged RAW text (with tags) → count all, target enemy', () => {
+        expect(detectPassiveVoicePurge(LODOLITE_CHARGED_RAW)).toEqual([
+            { count: 'all', target: 'enemy', explicitTarget: true },
+        ]);
+    });
+
+    it('returns [] for text with no passive-voice purge phrase', () => {
+        expect(detectPassiveVoicePurge('This Unit purges 1 buff from the enemy.')).toEqual([]);
+        expect(detectPassiveVoicePurge('This Unit deals 100% damage.')).toEqual([]);
+    });
+
+    it('returns [] for null/undefined', () => {
+        expect(detectPassiveVoicePurge(null)).toEqual([]);
+        expect(detectPassiveVoicePurge(undefined)).toEqual([]);
+    });
+});
+
+describe('detectPurgeStripsShield (I6 — Lodolite legendary refit)', () => {
+    it('recognizes the RAW Lodolite R4 passive clause ("removes 100% of the enemy\'s shield")', () => {
+        expect(detectPurgeStripsShield(LODOLITE_R4_PASSIVE_RAW)).toBe(true);
+    });
+
+    it('recognizes the bare clause without surrounding text', () => {
+        expect(
+            detectPurgeStripsShield(
+                "When this Unit purges a buff from an enemy, it removes 100% of the enemy's shield."
+            )
+        ).toBe(true);
+    });
+
+    it('does NOT fire for a shield-removal clause with no purge language (guard against false positives)', () => {
+        // Real corpus lines (docs/ship-skills.csv) — "removes N% … Shield" with no self-purge trigger.
+        expect(
+            detectPurgeStripsShield(
+                'removes 30% of the enemy Shield, and inflicts Speed Down II and Crit Power Down III for 2 turns'
+            )
+        ).toBe(false);
+        expect(
+            detectPurgeStripsShield('removes 40% of the enemy Shield and deals 150% damage')
+        ).toBe(false);
+    });
+
+    it('does NOT fire for a purge-self clause with no shield-removal consequence (guard)', () => {
+        expect(
+            detectPurgeStripsShield(
+                'When this Unit purges a buff from an enemy, it repairs itself for 8% Max HP.'
+            )
+        ).toBe(false);
+    });
+
+    it('does NOT fire when the removed percentage is not 100 (locked game rule: full strip only)', () => {
+        expect(
+            detectPurgeStripsShield(
+                "When this Unit purges a buff from an enemy, it removes 50% of the enemy's shield."
+            )
+        ).toBe(false);
+    });
+
+    it('returns false for null/undefined', () => {
+        expect(detectPurgeStripsShield(null)).toBe(false);
+        expect(detectPurgeStripsShield(undefined)).toBe(false);
     });
 });
 

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -3428,6 +3428,75 @@ describe('buildShipAbilities — Rhodium end-of-round most-buffs purge (C2b-2 T4
 });
 
 // ---------------------------------------------------------------------------
+// I6: Lodolite charged purge (passive-voice "is Purged of all buffs") + legendary-refit
+// shield strip. RAW strings verbatim from docs/ship-skills.csv (Lodolite row).
+// ---------------------------------------------------------------------------
+describe('buildShipAbilities — Lodolite charged purge + shield strip (I6)', () => {
+    const LODOLITE_CHARGED_RAW =
+        "This Unit deals <unit-damage>310% damage</unit-damage> and additional damage equal to <unit-damage>10%</unit-damage> of this Unit's max HP. Then, the enemy with the most <unit-aid>Buffs</unit-aid> is Purged of all buffs.<br />This attack can target <unit-aid>Stealthed</unit-aid> enemies.";
+    const LODOLITE_R4_PASSIVE_RAW =
+        "This Unit ignores <unit-skill>Stealth</unit-skill> effects.<br /><br />This Unit deals <unit-damage>10% more critical damage</unit-damage> to defenders, all allies deal <unit-damage>15% more direct damage</unit-damage> to enemies with <unit-skill>Concentrate Fire</unit-skill> or <unit-skill>Stealth</unit-skill>.<br /><br />When this Unit <unit-aid>Purges a buff</unit-aid> from an enemy, it <unit-damage>removes 100%</unit-damage> of the enemy's shield.";
+
+    // Default `ship()` helper seeds refits: [{}, {}, {}, {}] (4 refits) → thirdPassiveSkillText
+    // (R4, legendary refit) is the active passive per getShipSkillRows.
+    const lodolite = () =>
+        ship({
+            chargeSkillText: LODOLITE_CHARGED_RAW,
+            chargeSkillCharge: 3,
+            thirdPassiveSkillText: LODOLITE_R4_PASSIVE_RAW,
+        });
+
+    it('charged skill emits a purge ability: target enemy-most-buffs, count all, trigger on-cast', () => {
+        const charged = slot(buildShipAbilities(lodolite()).slots, 'charged')!;
+        const purges = charged.abilities.filter((a) => a.type === 'purge');
+        expect(purges).toHaveLength(1);
+        const purge = purges[0];
+        expect(purge.trigger).toBe('on-cast');
+        expect(purge.target).toBe('enemy-most-buffs');
+        expect(purge.config).toMatchObject({ type: 'purge', count: 'all' });
+    });
+
+    it('the charged purge config carries stripsShield (from the R4 legendary passive clause)', () => {
+        const charged = slot(buildShipAbilities(lodolite()).slots, 'charged')!;
+        const purge = charged.abilities.find((a) => a.type === 'purge')!;
+        expect(purge.config).toMatchObject({ stripsShield: true });
+    });
+
+    it('the R4 passive itself does NOT ALSO emit a spurious purge ability', () => {
+        const passive = slot(buildShipAbilities(lodolite()).slots, 'passive');
+        const purges = (passive?.abilities ?? []).filter((a) => a.type === 'purge');
+        expect(purges).toHaveLength(0);
+    });
+
+    it('WITHOUT the R4 legendary refit (2 refits, R2 passive without the shield clause) the charged purge has NO stripsShield', () => {
+        const nonLegendary = ship({
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            refits: [{}, {}] as any,
+            chargeSkillText: LODOLITE_CHARGED_RAW,
+            chargeSkillCharge: 3,
+            secondPassiveSkillText:
+                'This Unit ignores <unit-skill>Stealth</unit-skill> effects.<br /><br />This Unit deals <unit-damage>10% more critical damage</unit-damage> to defenders, all allies deal <unit-damage>15% more direct damage</unit-damage> to enemies with <unit-skill>Concentrate Fire</unit-skill>.',
+            thirdPassiveSkillText: LODOLITE_R4_PASSIVE_RAW,
+        });
+        const charged = slot(buildShipAbilities(nonLegendary).slots, 'charged')!;
+        const purge = charged.abilities.find((a) => a.type === 'purge')!;
+        expect(purge.config).toMatchObject({ type: 'purge', count: 'all' });
+        expect((purge.config as { stripsShield?: boolean }).stripsShield).toBeUndefined();
+    });
+
+    describe('guard: a passive slot that merely MENTIONS being purged does NOT emit a spurious purge', () => {
+        it('a hypothetical "When this Unit is Purged of a buff, it repairs 10% Max HP" passive yields NO purge ability', () => {
+            const s = ship({
+                firstPassiveSkillText: 'When this Unit is Purged of a buff, it repairs 10% Max HP.',
+            });
+            const { slots } = buildShipAbilities(s);
+            const allAbilities = slots.flatMap((sk) => sk.abilities);
+            expect(allAbilities.filter((a) => a.type === 'purge')).toHaveLength(0);
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
 // C2b-2 T6: Faust on-destroyed killed-by-direct-damage purge build tests.
 // RAW strings from docs/ship-skills.csv (Faust row, passive 1 & 2).
 // ---------------------------------------------------------------------------

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -65,6 +65,8 @@ import {
     parseHealAbilities,
     parseCleanse,
     parsePurge,
+    detectPassiveVoicePurge,
+    detectPurgeStripsShield,
     parseHealNoCrit,
     parseSkillEffects,
     classifyEnemyEffect,
@@ -740,7 +742,13 @@ function flipBareSupportShieldTarget(
 function abilitiesFromText(
     text: string,
     slot: SkillSlot,
-    role?: ShipTypeName
+    role?: ShipTypeName,
+    // I6: true when ANY of this ship's skill rows carries the "when this Unit Purges a buff
+    // from an enemy, it removes 100% of the enemy's shield" clause (Lodolite legendary refit).
+    // Computed ONCE by the caller (buildShipAbilities, which alone sees all rows via
+    // getShipSkillRows) and threaded down so every 'purge'-type config built here — regardless
+    // of WHICH slot's text produced it — carries the flag. Absent/false → byte-identical.
+    purgeStripsShield?: boolean
 ): PositionedAbility[] {
     // Build the list in construction order first (so out[0]?.type === 'damage' checks work
     // for condition/scaling attachment). Positions are computed in parallel and applied
@@ -1251,10 +1259,16 @@ function abilitiesFromText(
     // Task 3 populates targetRepairedThisRound on ConditionContext. Until then the condition
     // always evaluates false, keeping production byte-identical (no Nayra fixture in any golden).
     //
-    // C2a under-approximation (still open): the passive-voice "is Purged of all buffs" form
-    // (Lodolite charged) is NOT matched by PURGE_RE and therefore not emitted here — deferred.
-    // Amartya count-scaling under-counts to 1 — SAFE under direction.
-    for (const p of parsePurge(text)) {
+    // I6: the passive-voice "is Purged of all buffs" form (Lodolite charged) is picked up by
+    // detectPassiveVoicePurge, merged in ONLY for the on-cast (active/charged) slots — the
+    // passive-slot trigger-detection loop below never sees it (see detectPassiveVoicePurge's
+    // doc comment for why that separation matters). Amartya count-scaling under-counts to 1 —
+    // SAFE under direction.
+    const purgeMatches =
+        slot === 'active' || slot === 'charged'
+            ? [...parsePurge(text), ...detectPassiveVoicePurge(text)]
+            : parsePurge(text);
+    for (const p of purgeMatches) {
         const purgePos = text.search(/purge/i);
         const passiveTrigger: AbilityTrigger | undefined =
             // Iridium: self-subject "when directly damaged" → on-attacked. (Ignore the
@@ -1283,6 +1297,7 @@ function abilitiesFromText(
                     type: 'purge',
                     count: p.count,
                     ...(p.countScaling ? { countScaling: p.countScaling } : {}),
+                    ...(purgeStripsShield ? { stripsShield: true } : {}),
                 },
                 autoFilled: true,
             },
@@ -1311,7 +1326,11 @@ function abilitiesFromText(
                         target: 'enemy',
                         trigger: 'on-enemy-purged',
                         conditions: [],
-                        config: { type: 'purge', count },
+                        config: {
+                            type: 'purge',
+                            count,
+                            ...(purgeStripsShield ? { stripsShield: true } : {}),
+                        },
                         autoFilled: true,
                     },
                     pos: purgeMorePos,
@@ -1690,11 +1709,18 @@ export function buildShipAbilities(ship: Ship): ShipSkills {
     const dotsForSlot = (slot: SkillSlot): DoTApplicationEntry[] =>
         slot === 'active' ? activeDoTs : slot === 'charged' ? chargedDoTs : [];
 
+    // I6: computed once across ALL of the ship's (refit-resolved) skill rows so it applies to
+    // every 'purge'-type ability this ship's kit emits, regardless of which slot's text produced
+    // the purge (Lodolite's is on the charged slot; the declaring clause lives on the passive).
+    const purgeStripsShield = getShipSkillRows(ship).some((row) =>
+        detectPurgeStripsShield(row.text)
+    );
+
     const bySlot = new Map<SkillSlot, PositionedAbility[]>();
     for (const row of getShipSkillRows(ship)) {
         const slot = slotFor(row.label);
         if (!slot) continue;
-        const positioned = abilitiesFromText(row.text, slot, ship.type);
+        const positioned = abilitiesFromText(row.text, slot, ship.type, purgeStripsShield);
         pushToSlot(bySlot, slot, positioned);
     }
 

--- a/src/utils/combat/__tests__/lodolitePurgeShieldStrip.integration.test.ts
+++ b/src/utils/combat/__tests__/lodolitePurgeShieldStrip.integration.test.ts
@@ -1,0 +1,301 @@
+/**
+ * lodolitePurgeShieldStrip.integration.test.ts — sub-project I, PR I6.
+ *
+ * Lodolite's charged skill purges the enemy with the most buffs (target:
+ * 'enemy-most-buffs', count 'all', trigger 'on-cast' — see
+ * buildShipAbilities.test.ts's "Lodolite charged purge + shield strip (I6)" for the
+ * text-parsing coverage). Its legendary refit ("When this Unit Purges a buff from an
+ * enemy, it removes 100% of the enemy's shield") is modeled as a `stripsShield` flag
+ * on the purge ability's config (detectPurgeStripsShield / buildShipAbilities), consumed
+ * at the purge-performed apply site in playerTurn.ts: the SAME victim id that was just
+ * purged has its shieldPool zeroed.
+ *
+ * Two engine-level facts this file proves that the parser-level tests cannot:
+ *   1. The 'enemy-most-buffs' SELECTOR target resolves correctly for an ON-CAST purge
+ *      (Lodolite) — previously this selector only worked for REACTIVE purge triggers
+ *      (Rhodium's end-of-round), routed through triggers.ts. Lodolite's on-cast purge
+ *      stays on the castSkills path (playerTurn.ts) and needed its OWN resolution
+ *      (engine.ts buildTurnArgs' new `enemyMostBuffsId`, mostBuffsAmong over the
+ *      opposing roster) — this test is a regression guard for that routing.
+ *   2. shieldPool actually reaches 0 on the purged victim, and an untouched sibling
+ *      enemy (no buffs, so never selected) keeps its own shield intact.
+ *
+ * Harness mirrors aoePurge.test.ts / amartyaCritPurge.test.ts (positional two-team
+ * battle-sim, ability injected directly rather than routed through the text parser) and
+ * enemyOnCastShield.integration.test.ts (self-shield ability shape + __testTapActors).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { CombatActor } from '../state';
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `i6p${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+const hit = (): Ability =>
+    ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 10 } });
+
+const selfBuff = (): Ability =>
+    ab({
+        type: 'buff',
+        target: 'self',
+        config: {
+            type: 'buff',
+            buffName: 'Attack Up',
+            parsedEffects: { attack: 30 },
+            stacks: 1,
+            isStackable: false,
+            duration: 99,
+        },
+    });
+
+// Self-shield (50% of max HP), same shape as enemyOnCastShield.integration.test.ts.
+const selfShield = (): Ability =>
+    ab({
+        type: 'shield',
+        target: 'self',
+        config: { type: 'shield', pct: 50, basis: 'hp' },
+    });
+
+// Lodolite-shape: on-cast purge (target enemy-most-buffs, count all, stripsShield) + a hit
+// so the positional harness always resolves a real anchor.
+const lodolitePurgeSkills = (): ShipSkills => ({
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                ab({
+                    type: 'purge',
+                    target: 'enemy-most-buffs',
+                    config: { type: 'purge', count: 'all', stripsShield: true },
+                }),
+                hit(),
+            ],
+        },
+    ],
+});
+
+// The enemy WITH the most buffs: self-buffs + self-shields every round, then hits.
+// Speed 200 (> focus 100) so it acts BEFORE the focus each round — the purge that
+// follows is the LAST thing to touch its buff/shield state this round.
+const buffedShieldedEnemy = (id: string, position: Position) => ({
+    id,
+    stats: { attack: 100, crit: 0, critDamage: 0, defence: 0, hp: 100_000, speed: 200 },
+    chargeCount: 0,
+    startCharged: false,
+    position,
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    shipSkills: {
+        slots: [{ slot: 'active' as const, abilities: [selfBuff(), selfShield(), hit()] }],
+    },
+});
+
+// The CONTROL enemy: no buffs, but DOES self-shield every round — never the
+// most-buffed target, so its shield must survive untouched.
+const plainShieldedEnemy = (id: string, position: Position) => ({
+    id,
+    stats: { attack: 100, crit: 0, critDamage: 0, defence: 0, hp: 100_000, speed: 10 },
+    chargeCount: 0,
+    startCharged: false,
+    position,
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    shipSkills: { slots: [{ slot: 'active' as const, abilities: [selfShield(), hit()] }] },
+});
+
+const BASE: CombatEngineInput = {
+    attack: 5000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: lodolitePurgeSkills(),
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 2,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    enemyAttackers: [
+        buffedShieldedEnemy('enemy-buffed', 'M3'),
+        plainShieldedEnemy('enemy-plain', 'M4'),
+    ],
+};
+
+describe('I6: Lodolite-shape on-cast enemy-most-buffs purge + shield strip', () => {
+    it('purges the most-buffed enemy AND zeroes its shieldPool', () => {
+        let captured: CombatActor[] = [];
+        runCombat({
+            ...BASE,
+            __testTapActors: (actors) => {
+                captured = actors;
+            },
+        });
+        const buffed = captured.find((a) => a.id === 'enemy-buffed');
+        expect(buffed?.shieldPool ?? -1).toBe(0);
+    });
+
+    it('leaves the untouched (non-most-buffed) enemy shield intact', () => {
+        let captured: CombatActor[] = [];
+        runCombat({
+            ...BASE,
+            __testTapActors: (actors) => {
+                captured = actors;
+            },
+        });
+        const plain = captured.find((a) => a.id === 'enemy-plain');
+        expect(plain?.shieldPool ?? 0).toBeGreaterThan(0);
+    });
+
+    it('CONTROL: without stripsShield on the config, the purged victim keeps its shield', () => {
+        const noStripSkills: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        ab({
+                            type: 'purge',
+                            target: 'enemy-most-buffs',
+                            config: { type: 'purge', count: 'all' }, // no stripsShield
+                        }),
+                        hit(),
+                    ],
+                },
+            ],
+        };
+        let captured: CombatActor[] = [];
+        runCombat({
+            ...BASE,
+            shipSkills: noStripSkills,
+            __testTapActors: (actors) => {
+                captured = actors;
+            },
+        });
+        const buffed = captured.find((a) => a.id === 'enemy-buffed');
+        // The buff was still purged (proves the purge itself fired), but its OWN shield
+        // (re-granted every round via its own active) survives — proving the strip is
+        // gated on the config flag, not an unconditional side effect of any purge.
+        expect(buffed?.shieldPool ?? 0).toBeGreaterThan(0);
+    });
+});
+
+describe('I6: team-symmetry — an ENEMY-sourced Lodolite-shape purge strips a PLAYER shield', () => {
+    // Mirror of the player-side harness: the focus self-buffs + self-shields (most-buffed),
+    // a walked team actor only self-shields (control). A single enemy purges
+    // 'enemy-most-buffs' with stripsShield. Enemy speed 50 < both players' speed 100, so
+    // BOTH players act first each round (buff/shield), then the enemy purges+strips.
+    const selfBuffShieldThenHitSkills = (): ShipSkills => ({
+        slots: [{ slot: 'active', abilities: [selfBuff(), selfShield(), hit()] }],
+    });
+    const selfShieldThenHitSkills = (): ShipSkills => ({
+        slots: [{ slot: 'active', abilities: [selfShield(), hit()] }],
+    });
+
+    const purgingEnemy = () => ({
+        id: 'enemy-front',
+        stats: { attack: 100, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000, speed: 50 },
+        chargeCount: 0,
+        startCharged: false,
+        position: 'M4' as Position,
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        shipSkills: lodolitePurgeSkills(),
+    });
+
+    const teamActor = (): TeamActorEngineInput => ({
+        id: 'player-team',
+        speed: 100,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position: 'M3',
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        walk: {
+            shipSkills: selfShieldThenHitSkills(), // control: shield only, no buff
+            stats: {
+                attack: 500,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 200,
+                defence: 0,
+                hp: 100_000,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    });
+
+    it('the enemy purge strips the MOST-BUFFED player (focus) shield, leaves the team actor untouched', () => {
+        let captured: CombatActor[] = [];
+        runCombat({
+            attack: 5000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: selfBuffShieldThenHitSkills(),
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 2,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 100_000,
+            healTargetId: 'attacker',
+            position: 'M4',
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            teamActors: [teamActor()],
+            enemyAttackers: [purgingEnemy()],
+            __testTapActors: (actors) => {
+                captured = actors;
+            },
+        });
+        const focus = captured.find((a) => a.id === 'attacker');
+        const team = captured.find((a) => a.id === 'player-team');
+        expect(focus?.shieldPool ?? -1).toBe(0); // most-buffed → purged + stripped
+        expect(team?.shieldPool ?? 0).toBeGreaterThan(0); // never the most-buffed target → untouched
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -4195,9 +4195,20 @@ export function runCombat(input: CombatEngineInput): {
                     : undefined;
             const opposingVictimById =
                 tgt.position != null ? new Map(tb.opposingRoster.map((v) => [v.id, v])) : undefined;
+            // I6: resolve the enemy-most-buffs selector target for an ON-CAST purge (Lodolite's
+            // charged skill). mostBuffsAmong (§C2b-2, Rhodium) previously only fed the REACTIVE
+            // purge path (triggers.ts's ctx.enemyWithMostBuffs, for end-of-round/on-attacked
+            // triggers) — Lodolite's purge trigger is 'on-cast', which stays on THIS (castSkills)
+            // path and never reaches triggers.ts. Computed fresh per turn (buff state changes
+            // round to round) from THIS actor's opposing roster — same roster mostBuffsAmong's
+            // other two call sites use for the reactive path. Undefined for a DPS-mode/empty
+            // roster (mostBuffsAmong's own no-buffs-anywhere case) or a non-purge cast — the
+            // playerTurn purge loop falls back to the anchor `targetId` in that case.
+            const enemyMostBuffsId = mostBuffsAmong(tb.opposingRoster);
             return {
                 runtime: rt,
                 enemy: tgt,
+                enemyMostBuffsId,
                 // B1/PR7b: thread targetId for BOTH directions so player-applied ABILITY debuffs route
                 // to the resolved victim's per-actor store (applyTimedAbilityStatus keys off targetId;
                 // the aggregate ability-read timedAbilityStatuses('enemy',actor.id,targetId) follows

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1975,7 +1975,12 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                         // "side-symmetric" note above), so an enemy-side ship carrying this
                         // config strips a player shield the same way. Mirrors the victim-lookup
                         // fallback used by the per-victim debuff-landing loop above (opposingVictimById
-                        // in positional mode; the anchor `enemy` actor otherwise).
+                        // in positional mode; the anchor `enemy` actor otherwise). This makes the
+                        // strip POSITIONAL-SCOPED by the same design as every other per-victim effect:
+                        // in a non-positional cast opposingVictimById is absent and per-victim
+                        // resolution intentionally no-ops (the sim's per-victim fidelity is a
+                        // positional feature) — the real battle sim always positions actors, so a
+                        // resolved enemy-most-buffs victim is always in opposingVictimById.
                         if (ab.config.stripsShield) {
                             const victim =
                                 opposingVictimById?.get(vid) ??

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -423,6 +423,15 @@ export interface PlayerTurnArgs {
      *  DAMAGE modifier (not the Crit Power stat), consumed at the engine's crit-family
      *  damage sites. Absent → byte-identical. */
     preFight?: PreFightCombatModifiers;
+    /** I6: the opposing actor with the most buffs (Rhodium's §C2b-2 `mostBuffsAmong`), resolved
+     *  fresh per turn from THIS actor's opposing roster. Feeds an ON-CAST purge ability whose
+     *  `target` is `'enemy-most-buffs'` (Lodolite's charged skill) — the reactive counterpart
+     *  (end-of-round/on-attacked triggers, e.g. Rhodium) resolves this itself via
+     *  triggers.ts's `ctx.enemyWithMostBuffs`, which this on-cast path never reaches. Undefined
+     *  when no living opposing actor carries a buff, or for non-positional/DPS callers that never
+     *  supply it — the purge loop then falls back to the anchor `targetId` (byte-identical to
+     *  pre-I6 behavior for every ship without an enemy-most-buffs on-cast purge). */
+    enemyMostBuffsId?: string;
     /** Sub-project I, PR I3 (Layer 1) — `all-allies`-targeted passive `modifier` abilities
      *  gathered from THIS actor's living same-side allies (source excluded — see
      *  engine.ts's `buildTurnArgs`). Merged into `modifierAbilities` below alongside the
@@ -774,6 +783,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         targetHpPct: targetHpPctArg = 100,
         targetRepairedThisRound: targetRepairedThisRoundArg = false,
         targetId,
+        enemyMostBuffsId,
         enemyBuffNames: enemyBuffNamesArg = [],
         stealthedEnemyCount: stealthedEnemyCountArg = 0,
         // No default — undefined is the DPS-parity sentinel (see PlayerTurnArgs doc).
@@ -1915,8 +1925,19 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 // `targetId`. Each victim emits its own purge-performed (Salvation/Sefuba are
                 // victim-scoped). (Amartya's per-victim COUNT scaling is E4; this ships at the
                 // parsed count.)
+                // I6: an 'enemy-most-buffs' purge (Lodolite's charged skill) resolves to the
+                // engine-supplied enemyMostBuffsId instead of the normal positional anchor
+                // (targetId) — the reactive counterpart (Rhodium, end-of-round) resolves this
+                // itself via triggers.ts and never reaches this on-cast path. Falls back to the
+                // anchor when no living opposing actor carries a buff (mostBuffsAmong's
+                // no-buffs-anywhere case) or for a non-positional/DPS caller that never supplies
+                // enemyMostBuffsId — byte-identical to pre-I6 behavior in both cases.
                 const recipients =
-                    ab.target === 'all-enemies' && aoeVictimIds ? aoeVictimIds : [targetId];
+                    ab.target === 'all-enemies' && aoeVictimIds
+                        ? aoeVictimIds
+                        : ab.target === 'enemy-most-buffs' && enemyMostBuffsId !== undefined
+                          ? [enemyMostBuffsId]
+                          : [targetId];
                 // E4: when the purge scales on crit power, total purged per victim =
                 // count × floor(live effectiveCritDamage / per). effectiveCritDamage (~line 1104 =
                 // dmgStats.critDamage) is the caster's LIVE crit power (buffs/debuffs folded),
@@ -1945,6 +1966,22 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                             count: removed,
                             round: r,
                         });
+                        // I6: Lodolite legendary refit — "When this Unit Purges a buff from an
+                        // enemy, it removes 100% of the enemy's shield." Gated on the parsed
+                        // ability config (stripsShield), never a hardcoded ship name — see
+                        // detectPurgeStripsShield/buildShipAbilities. Strips AFTER the purge
+                        // resolves, on the SAME victim id (vid). Team-symmetric for free: this
+                        // function runs identically for player and enemy casters (see the
+                        // "side-symmetric" note above), so an enemy-side ship carrying this
+                        // config strips a player shield the same way. Mirrors the victim-lookup
+                        // fallback used by the per-victim debuff-landing loop above (opposingVictimById
+                        // in positional mode; the anchor `enemy` actor otherwise).
+                        if (ab.config.stripsShield) {
+                            const victim =
+                                opposingVictimById?.get(vid) ??
+                                (vid === enemy.id ? enemy : undefined);
+                            if (victim) victim.shieldPool = 0;
+                        }
                     }
                 }
             }

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -2623,7 +2623,8 @@ const CLEANSE_RE = /\bcleanses?\s+(\d+|all)\b/gi;
  * Target from the sentence: "all enemies" → all-enemies, else "enemy".
  * explicitTarget is always true (purge has no support-flip, kept for shape parity with parseCleanse).
  * Does NOT match "cleanses". Passive-voice "is Purged of all buffs" has no "purges" token and is
- * excluded naturally — handled in C2b. Reference data: docs/ship-skills.csv.
+ * excluded naturally — see detectPassiveVoicePurge (I6) for that shape, merged in by callers
+ * (buildShipAbilities) only on the active/charged slots. Reference data: docs/ship-skills.csv.
  *
  * NOTE: parsePurge is context-free. Reactive/conditional purge text in passives (Sefuba p2,
  * Faust, Iridium, etc.) will produce matches here. The active/charged slot-gate in
@@ -2675,6 +2676,76 @@ export function parsePurge(text: string | null | undefined): {
         });
     }
     return results;
+}
+
+// I6: "<subject> is Purged of (N|all) buffs" — Lodolite's charged skill: "Then, the enemy with
+// the most Buffs is Purged of all buffs." No "purges" verb token, so the active-verb-only
+// PURGE_RE does not match it (by design — see PURGE_RE's comment). Kept as a SEPARATE detector
+// (rather than folded into PURGE_RE/parsePurge) because parsePurge is context-free and consumed
+// for every slot of every ship (including passive text scanned for REACTIVE purge triggers, e.g.
+// Sefuba/Rhodium/Faust/Salvation/Nayra) — widening that shared, corpus-wide regex risks absorbing
+// a future passive's self-referential "when this Unit is Purged of a buff…" (an INCOMING purge
+// reaction, a different semantic than Lodolite's outgoing "the enemy … is Purged"). This detector
+// is wired ONLY into the active/charged on-cast path (buildShipAbilities), never the passive-slot
+// trigger-detection loop, so it cannot pick up a hypothetical passive-voice self-reaction even if
+// the corpus grows one later. Corpus today has exactly ONE "is Purged" occurrence (Lodolite;
+// verified via `grep -io "is purged[^.]*" docs/ship-skills.csv`).
+const PASSIVE_VOICE_PURGE_RE = /\bis\s+purged\s+of\s+(\d+|all)\s+buffs?\b/gi;
+
+/**
+ * Parses the passive-voice purge shape ("<subject> is Purged of N/all buffs") — the counterpart
+ * to parsePurge's active-verb form, restricted to on-cast (active/charged) callers. Same result
+ * shape as parsePurge so callers can merge the two lists. Reference data: docs/ship-skills.csv
+ * (Lodolite charged skill).
+ */
+export function detectPassiveVoicePurge(text: string | null | undefined): {
+    count: number | 'all';
+    target: 'enemy' | 'all-enemies';
+    explicitTarget: boolean;
+    countScaling?: { stat: 'critDamage'; per: number };
+}[] {
+    if (!text) return [];
+    const plain = stripUnitTags(text).replace(/<br\s*\/?>/gi, '. ');
+    const results: {
+        count: number | 'all';
+        target: 'enemy' | 'all-enemies';
+        explicitTarget: boolean;
+        countScaling?: { stat: 'critDamage'; per: number };
+    }[] = [];
+    PASSIVE_VOICE_PURGE_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = PASSIVE_VOICE_PURGE_RE.exec(plain)) !== null) {
+        const raw = m[1].toLowerCase();
+        const count: number | 'all' = raw === 'all' ? 'all' : parseInt(raw, 10);
+        if (count !== 'all' && (!count || isNaN(count))) continue;
+        const sentence = sentenceAround(plain, m.index).toLowerCase();
+        const target: 'enemy' | 'all-enemies' = /all\s+enemies/.test(sentence)
+            ? 'all-enemies'
+            : 'enemy';
+        results.push({ count, target, explicitTarget: true });
+    }
+    return results;
+}
+
+// I6: "When this Unit Purges a buff from an enemy, it removes N% of the enemy's shield" —
+// Lodolite's legendary-refit (R4) passive. Scoped to the SAME self-purge-reactive phrase shape as
+// ENEMY_PURGED_RE ("when this unit … purges … enem[y]"), extended to require a shield-percentage
+// removal clause in the same sentence. Verified against RAW CSV (Lodolite third_passive_skill_text
+// is the only corpus row matching both a purge-self clause AND a "removes N% … shield" clause —
+// the other 3 "removes N% … Shield" rows in the corpus carry no purge language at all).
+const PURGE_STRIPS_SHIELD_RE =
+    /\bwhen\s+this\s+unit\b[^.;]*\bpurges?\b[^.;]*\benem[^.;]*\bremoves\s+(\d+)\s*%[^.;]*\bshield/i;
+
+/**
+ * True when `text` declares "when this Unit purges a buff from an enemy, it removes 100% of the
+ * enemy's shield" (Lodolite's legendary refit). Percentage is captured but only the 100% (full
+ * strip) case is modeled per the locked game rule — anything else is left unflagged rather than
+ * guessed at, since no corpus ship carries a partial-strip variant today.
+ */
+export function detectPurgeStripsShield(text: string | null | undefined): boolean {
+    if (!text) return false;
+    const m = PURGE_STRIPS_SHIELD_RE.exec(text);
+    return m !== null && m[1] === '100';
 }
 
 /**

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -2744,7 +2744,11 @@ const PURGE_STRIPS_SHIELD_RE =
  */
 export function detectPurgeStripsShield(text: string | null | undefined): boolean {
     if (!text) return false;
-    const m = PURGE_STRIPS_SHIELD_RE.exec(text);
+    // Normalize before matching (strip unit tags + <br/> → '. ') so the RE's [^.;]* sentence
+    // scoping can't span an un-punctuated <br/> into an unrelated clause — matches the
+    // convention used by parsePurge/detectPassiveVoicePurge above.
+    const plain = stripUnitTags(text).replace(/<br\s*\/?>/gi, '. ');
+    const m = PURGE_STRIPS_SHIELD_RE.exec(plain);
     return m !== null && m[1] === '100';
 }
 


### PR DESCRIPTION
## Sub-project I, PR I6 — Lodolite charged purge + shield strip on purge

Sixth PR of conditional-aura fidelity (self-contained). Spec §5.5. Rebased onto main after I5.

### Piece A — passive-voice charged purge
Lodolite's charged skill ("…the enemy with the most Buffs **is Purged of all buffs**") uses passive voice, which `PURGE_RE`/`parsePurge` deliberately excludes. Added a dedicated `detectPassiveVoicePurge` (`PASSIVE_VOICE_PURGE_RE = /\bis\s+purged\s+of\s+(\d+|all)\s+buffs?\b/`), wired **only** into the active/charged on-cast path — the shared context-free purge parse (used by every ship's passive-slot trigger detection) is untouched. Guarded: a synthetic passive "when this Unit is Purged of a buff…" emits **zero** purge abilities (test).

### Piece B — shield strip on purge
Legendary refit "When this Unit Purges a buff from an enemy, it removes 100% of the enemy's shield" → a `stripsShield` flag on the purge ability config (`detectPurgeStripsShield`, corpus-verified only Lodolite matches, only 100% modeled). Consumed at the `purge-performed` apply site to zero the purged enemy's `shieldPool` — gated on the parsed config (not a ship name), applied to the same victim after the purge, **team-symmetric**.

### Bug fix (found while testing)
`enemy-most-buffs` targeting only resolved for **reactive** purge triggers (Rhodium end-of-round). Lodolite's purge is **on-cast**, which stayed on the castSkills path and silently fell back to the positional anchor — hitting the wrong enemy. Fixed by computing `enemyMostBuffsId` (via the existing `mostBuffsAmong` helper) in `buildTurnArgs` and consuming it in the on-cast purge-recipient resolution.

### Tests
Parser (+11): passive-voice purge shapes, most-buffs target, on-cast slot, false-positive guard. Parser build (+5). New `lodolitePurgeShieldStrip.integration.test.ts` (+4): charged cast purges most-buffed enemy + zeroes its shield; other enemy untouched; team-symmetry.

### Validation (post-rebase onto main w/ I1–I3+I5)
tsc · lint (0) · full suite (3872) · `audit:skills` (0). Goldens **byte-identical**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPheh4qisgdG9PazKJMkiF
