### PR TITLE
feat(combat): Wildfire dotDamage crit-power scaling parse + self-crit-power condition (sub-project I, PR I4a)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -15,6 +15,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: team-wide damage auras now actually reach the team. Lodolite's +15% damage vs Concentrate Fire (or Stealth) and Panguan's +40% damage for Stealthed units apply to every living ally who qualifies, not just the caster's own attacks.",
     "Combat sim: Selenite's bonus direct damage now scales with the number of Stealthed enemies (10% per enemy), instead of a flat 10% whenever at least one enemy was Stealthed.",
     "Combat sim: Lodolite's charged skill now purges all buffs from the enemy with the most buffs, and her legendary refit strips 100% of that enemy's shield when she does.",
+    'Combat sim: Wildfire now deals bonus Inferno damage against an enemy with Scorching Radiation, scaling with her own crit power (1% per 10% crit power, 2% with her refit) — applied when she attacks that enemy directly.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -239,7 +239,17 @@ export type ConditionSubject =
     // damage for every enemy with Stealth" (perUnit 10, no cap). Live-derived by the
     // combat engine from ConditionContext.stealthedEnemyCount; defaults to 0 (DPS mode
     // has no enemy attackers to count) — inert/byte-identical there. Always derivable:true.
-    | 'enemy-stealth-count';
+    | 'enemy-stealth-count'
+    // SCALING-SOURCE subject (sub-project I, PR I4a): the ACTING unit's own live crit
+    // power (effective critDamage stat, e.g. 150), as a continuous magnitude — not a
+    // count of entities like the other scaling sources above. Used by Wildfire's
+    // "…for every 10% crit power" dotDamage bonus (perUnit 0.1 → critDamage 150 scales
+    // to +15). As a BARE gate (no scaling rule) it reads sensibly too: any crit power
+    // > 0 satisfies the default count>0 presence rule. Live-derived by
+    // ConditionContext.selfCritPower (runPlayerTurn's modifierCtx only); defaults to 0
+    // elsewhere (no other ConditionContext builder populates it — inert/byte-identical
+    // for every ship that doesn't reference this subject). Always derivable:true.
+    | 'self-crit-power';
 
 export interface Condition {
     subject: ConditionSubject;

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -913,6 +913,80 @@ describe('buildShipAbilities', () => {
         expect(mod.target).toBe('self'); // self-scoped — no team distribution, no per-victim
     });
 
+    describe('Wildfire dotDamage crit-power scaling (sub-project I, PR I4a)', () => {
+        // Real CSV text (docs/ship-skills.csv row 156, first/second_passive_skill_text).
+        const baseText =
+            'When an enemy has <unit-skill>Scorching Radiation</unit-skill>, this Unit deals <unit-damage>1% additional</unit-damage> <unit-skill>Inferno</unit-skill> <unit-damage>damage</unit-damage> to that unit for every 10% crit power.';
+        const refitText =
+            'When an enemy has <unit-skill>Scorching Radiation</unit-skill>, this Unit deals <unit-damage>2% additional</unit-damage> <unit-skill>Inferno</unit-skill> <unit-damage>damage</unit-damage> to that unit for every 10% crit power.';
+
+        it('base passive (0 refits): dotDamage modifier scaling 1% per 10% crit power, gated on the NAMED enemy debuff', () => {
+            const s = ship({
+                refits: [],
+                firstPassiveSkillText: baseText,
+                secondPassiveSkillText: refitText,
+            });
+            const mod = abilityOfType(
+                slot(buildShipAbilities(s).slots, 'passive')!.abilities,
+                'modifier'
+            )!;
+            expect(mod.config).toMatchObject({
+                type: 'modifier',
+                channel: 'dotDamage',
+                value: 0,
+            });
+            expect(mod.target).toBe('self');
+            expect(mod.conditions).toHaveLength(2);
+            // The Scorching-Radiation gate reuses the SAME enemyEffectConditions path as
+            // Tygr/Incinerator (I1 name-specific `enemy-debuff` gating) — "Scorching
+            // Radiation" is a real named debuff in src/constants/buffs.ts.
+            expect(mod.conditions[0]).toMatchObject({
+                subject: 'enemy-debuff',
+                derivable: true,
+                buffName: 'Scorching Radiation',
+            });
+            expect(mod.conditions[1]).toMatchObject({
+                subject: 'self-crit-power',
+                derivable: true,
+            });
+            expect(mod.scaling).toMatchObject({ conditionIndex: 1, perUnit: 0.1 });
+        });
+
+        it('refit passive (2+ refits): resolves to the SECOND passive row, scaling 2% per 10% crit power', () => {
+            const s = ship({
+                refits: [{}, {}] as Ship['refits'],
+                firstPassiveSkillText: baseText,
+                secondPassiveSkillText: refitText,
+            });
+            const mod = abilityOfType(
+                slot(buildShipAbilities(s).slots, 'passive')!.abilities,
+                'modifier'
+            )!;
+            expect(mod.conditions[0]).toMatchObject({
+                subject: 'enemy-debuff',
+                buffName: 'Scorching Radiation',
+            });
+            expect(mod.conditions[1]).toMatchObject({ subject: 'self-crit-power' });
+            expect(mod.scaling).toMatchObject({ conditionIndex: 1, perUnit: 0.2 });
+        });
+
+        it('does not change an unrelated "% more damage to enemies with <debuff>" ship parse (no regression)', () => {
+            // Tygr-shape clause — must keep parsing as a plain outgoingDamage modifier with
+            // no scaling, proving the new "% additional <DoT> damage … crit power" branch
+            // above is narrowly scoped and does not intercept this shape.
+            const s = ship({
+                firstPassiveSkillText:
+                    'This Unit deals <unit-damage>30% more direct damage</unit-damage> to enemies with <unit-skill>Stasis</unit-skill>.',
+            });
+            const mod = abilityOfType(
+                slot(buildShipAbilities(s).slots, 'passive')!.abilities,
+                'modifier'
+            )!;
+            expect(mod.config).toMatchObject({ channel: 'outgoingDamage', value: 30 });
+            expect(mod.scaling).toBeUndefined();
+        });
+    });
+
     describe('HP-proportional modifiers (Akula / Tithonus)', () => {
         it('Akula passive: outgoing damage scaling with CURRENT enemy HP% (up to 30%)', () => {
             const akula = ship({

--- a/src/utils/abilities/__tests__/evaluateConditions.test.ts
+++ b/src/utils/abilities/__tests__/evaluateConditions.test.ts
@@ -121,6 +121,38 @@ describe('evaluateCondition', () => {
         });
     });
 
+    describe("'self-crit-power' (sub-project I, PR I4a)", () => {
+        it('returns the live selfCritPower magnitude (a stat value, not an entity count)', () => {
+            const c = makeConditionContext({ selfCritPower: 150 });
+            expect(
+                evaluateCondition(cond({ subject: 'self-crit-power', derivable: true }), c)
+            ).toBe(150);
+        });
+
+        it('defaults to 0 when unset (no other ConditionContext builder populates it)', () => {
+            const c = makeConditionContext();
+            expect(c.selfCritPower).toBeUndefined();
+            expect(
+                evaluateCondition(cond({ subject: 'self-crit-power', derivable: true }), c)
+            ).toBe(0);
+        });
+
+        it('as a bare gate, any crit power > 0 satisfies the default count>0 presence rule', () => {
+            expect(
+                conditionMet(
+                    cond({ subject: 'self-crit-power', derivable: true }),
+                    makeConditionContext({ selfCritPower: 1 })
+                )
+            ).toBe(true);
+            expect(
+                conditionMet(
+                    cond({ subject: 'self-crit-power', derivable: true }),
+                    makeConditionContext({ selfCritPower: 0 })
+                )
+            ).toBe(false);
+        });
+    });
+
     it("'self-crit' is effective crit rate / 100", () => {
         expect(
             evaluateCondition(
@@ -368,6 +400,22 @@ describe('scaledBonus', () => {
         expect(scaledBonus(a, makeConditionContext({ stealthedEnemyCount: 2 }))).toBe(20);
         // Uncapped — the skill text states no maximum.
         expect(scaledBonus(a, makeConditionContext({ stealthedEnemyCount: 5 }))).toBe(50);
+    });
+
+    it('Wildfire-shape: 1%/2% additional Inferno damage per 10% crit power (sub-project I, PR I4a)', () => {
+        // Base passive: perUnit = 1/10 = 0.1. Refit passive: perUnit = 2/10 = 0.2.
+        const base = dmg([cond({ subject: 'self-crit-power', derivable: true })], {
+            conditionIndex: 0,
+            perUnit: 0.1,
+        });
+        const refit = dmg([cond({ subject: 'self-crit-power', derivable: true })], {
+            conditionIndex: 0,
+            perUnit: 0.2,
+        });
+        expect(scaledBonus(base, makeConditionContext({ selfCritPower: 150 }))).toBe(15);
+        expect(scaledBonus(refit, makeConditionContext({ selfCritPower: 150 }))).toBe(30);
+        // 0 crit power → 0 bonus (uncapped, but inert at the floor).
+        expect(scaledBonus(base, makeConditionContext({ selfCritPower: 0 }))).toBe(0);
     });
 
     it('scaling reads only the indexed condition, even inside an anyOf OR-group', () => {

--- a/src/utils/abilities/__tests__/roundContext.test.ts
+++ b/src/utils/abilities/__tests__/roundContext.test.ts
@@ -46,6 +46,20 @@ describe('buildRoundContext', () => {
         expect(ctx.enemyDestroyedCount).toBe(0);
         expect(ctx.selfHpPct).toBe(100);
         expect(ctx.enemyHpPct).toBe(100);
+        expect(ctx.selfCritPower).toBe(0);
+    });
+
+    it('passes through selfCritPower when provided (sub-project I, PR I4a)', () => {
+        const ctx = buildRoundContext({
+            selfBuffNames: [],
+            landedEnemyDebuffCount: 0,
+            corrosionEntryCount: 0,
+            infernoEntryCount: 0,
+            bombCount: 0,
+            effectiveCritRate: 0,
+            selfCritPower: 150,
+        });
+        expect(ctx.selfCritPower).toBe(150);
     });
 
     it('leaves enemyType undefined when not provided', () => {

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -192,6 +192,22 @@ function enemyEffectNamesFromClause(rawText: string): string[] {
 }
 
 /**
+ * Sub-project I, PR I4a — effect names in a "When an enemy has <status>," PREFIX clause,
+ * read from the raw <unit-skill> tag. Distinct from `enemyEffectNamesFromClause`'s "enemies
+ * with <effect>" phrasing (which scans to the END of the sentence): Wildfire's gate reads
+ * "When an enemy has Scorching Radiation, this Unit deals 1% additional Inferno damage…" —
+ * the status name sits in a COMMA-SEPARATED PREFIX, and the damage clause that follows ALSO
+ * wraps its DoT name ("Inferno") in a <unit-skill> tag. Scanning to end-of-sentence (like
+ * enemyEffectNamesFromClause) would incorrectly pick up "Inferno" as a second gate name, so
+ * this helper stops at the first COMMA instead.
+ */
+function enemyHasNamesFromClause(rawText: string): string[] {
+    const m = rawText.match(/\bwhen\s+an?\s+enem(?:y|ies)\s+has\b([^,]*)/i);
+    if (!m) return [];
+    return [...m[1].matchAll(/<unit-skill>([^<]+)<\/unit-skill>/gi)].map((t) => t[1].trim());
+}
+
+/**
  * Effect names gating a "deals N% damage to enemies (with|afflicted with) <effect>" clause.
  * Scoped to the damage clause (no sentence break between) so it only gates that damage ability.
  */
@@ -457,6 +473,56 @@ function parseModifiers(text: string): ParsedModifier[] {
             target: isAllyScoped ? 'all-allies' : 'self',
             conditions,
         });
+    }
+
+    // Sub-project I, PR I4a: "N% additional <DoT> damage … for every M% crit power"
+    // (Wildfire: "When an enemy has Scorching Radiation, this Unit deals 1% additional
+    // Inferno damage to that unit for every 10% crit power") → a dotDamage-channel modifier
+    // whose bonus SCALES with the CASTER's own live crit power, gated on the named enemy
+    // status via the existing enemyEffectConditions path (Scorching Radiation → name-specific
+    // 'enemy-debuff', composing with I1). Narrow shape — requires the literal "additional
+    // <word> damage" phrase together with "crit power" in the SAME sentence — confirmed
+    // unique to Wildfire in docs/ship-skills.csv (only ship using "% additional" at all), so
+    // no other ship's outgoingDamage/critDamage branches above are affected.
+    //
+    // I4a SCOPE (see the sub-project I design doc §9): single-target/cast-time only. The
+    // enemy-status gate is baked ONCE per cast against the primary target's modifierCtx
+    // (existing behavior — this ability folds through the same mod.dotDamage →
+    // selfDotDamageModifier path as any other dotDamage modifier) and the resulting bonus
+    // applies to ALL of the caster's Inferno/Corrosion ticks this turn.
+    //   I4b: per-tick / per-victim(AoE) re-evaluation of the enemy-status gate is NOT done
+    //        here — this is the documented cast-time approximation.
+    //   I4c: the refit-3 "all allies deal…" team-aura text below ALSO matches this branch
+    //        (isAllyScoped → target:'all-allies'), but the dotDamage channel has no
+    //        distribution seam yet (I3 only wired outgoingDamage/critDamage) — today it only
+    //        self-applies (same as target:'self', via the unconditional self-inclusion of an
+    //        actor's own firing/passive abilities). Distributing it to OTHER allies is I4c.
+    const dotCritPowerM = plain.match(/(\d+(?:\.\d+)?)%\s+additional\s+([A-Za-z]+)\s+damage\b/i);
+    if (dotCritPowerM) {
+        const sentence = sentenceContaining(plain, dotCritPowerM.index!);
+        const critPowerM = sentence.match(/for\s+every\s+(\d+(?:\.\d+)?)%\s+crit\s+power/i);
+        if (critPowerM) {
+            const dotValue = parseFloat(dotCritPowerM[1]);
+            const per = parseFloat(critPowerM[1]);
+            const isAllyScoped = /friendly|all allies|allies/i.test(sentence);
+            const statusConditions = enemyEffectConditions(enemyHasNamesFromClause(text));
+            const conditions: Condition[] = [
+                ...statusConditions,
+                // I4b: evaluated once per cast against the primary target — see the scope note
+                // above. Bare (no countComparator) → scales only, never gates (gateConditions
+                // strips it; a 0-crit-power unit still passes the enemy-status gate, just with
+                // a 0 bonus).
+                { subject: 'self-crit-power', derivable: true },
+            ];
+            out.push({
+                channel: 'dotDamage',
+                value: 0,
+                isMultiplicative: false,
+                target: isAllyScoped ? 'all-allies' : 'self',
+                conditions,
+                scaling: { conditionIndex: conditions.length - 1, perUnit: dotValue / per },
+            });
+        }
     }
 
     // "increases [outgoing] [direct] Damage by [up to] N% [to enemies with <effect> / below X% HP]"

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -481,9 +481,11 @@ function parseModifiers(text: string): ParsedModifier[] {
     // whose bonus SCALES with the CASTER's own live crit power, gated on the named enemy
     // status via the existing enemyEffectConditions path (Scorching Radiation → name-specific
     // 'enemy-debuff', composing with I1). Narrow shape — requires the literal "additional
-    // <word> damage" phrase together with "crit power" in the SAME sentence — confirmed
-    // unique to Wildfire in docs/ship-skills.csv (only ship using "% additional" at all), so
-    // no other ship's outgoingDamage/critDamage branches above are affected.
+    // <word> damage" phrase together with "crit power" in the SAME sentence — this two-conjunct
+    // guard is confirmed unique to Wildfire in docs/ship-skills.csv (other ships use "additional"
+    // or "for every … crit power" separately — e.g. Bayah/Butcher, Amartya — but none combine
+    // "N% additional <word> damage" WITH "for every % crit power"), so no other ship's
+    // outgoingDamage/critDamage branches above are affected.
     //
     // I4a SCOPE (see the sub-project I design doc §9): single-target/cast-time only. The
     // enemy-status gate is baked ONCE per cast against the primary target's modifierCtx

--- a/src/utils/abilities/evaluateConditions.ts
+++ b/src/utils/abilities/evaluateConditions.ts
@@ -62,6 +62,16 @@ export interface ConditionContext {
      *  (DPS mode has no enemy attackers to count) — the scaling contributes 0, byte-
      *  identical to today. */
     stealthedEnemyCount?: number;
+    /** Sub-project I, PR I4a — the ACTING unit's own live crit power (effective critDamage
+     *  stat, e.g. 150), a continuous MAGNITUDE scaling source (distinct from every other
+     *  scaling source above, which are entity COUNTS). Used by Wildfire's dotDamage-channel
+     *  "…for every 10% crit power" bonus. Populated ONLY by runPlayerTurn's modifierCtx, from
+     *  a PRE-modifier estimate (layers 1+2+3 of the critDamage fold — mirrors critBuffForGates'
+     *  same pre-modifier-layer treatment of effectiveCritRate, avoiding a self-referential
+     *  gate since this ctx also feeds the layer-4 modifier fold that could in principle alter
+     *  critDamage itself). Defaults to 0 everywhere else (DPS-safe: no other ConditionContext
+     *  builder populates it, so it's inert for every ship besides Wildfire). */
+    selfCritPower?: number;
 }
 
 /** Resolve one condition to a count (>= 0). 0 means "not met". */
@@ -106,6 +116,8 @@ export function evaluateCondition(cond: Condition, ctx: ConditionContext): numbe
             return ctx.enemyDestroyedCount;
         case 'enemy-stealth-count':
             return ctx.stealthedEnemyCount ?? 0;
+        case 'self-crit-power':
+            return ctx.selfCritPower ?? 0;
         case 'hp-threshold':
             return evalHpThreshold(cond, ctx) ? 1 : 0;
         // HP-percentage counts: the enemy's current/missing HP% (0..100). Used as

--- a/src/utils/abilities/roundContext.ts
+++ b/src/utils/abilities/roundContext.ts
@@ -57,6 +57,11 @@ export function buildRoundContext(state: {
      *  self-buff. Default 0 (DPS-assumption: no enemy attackers to count). Populated live by
      *  the combat engine. See ConditionContext.stealthedEnemyCount. */
     stealthedEnemyCount?: number;
+    /** Sub-project I, PR I4a — the acting unit's own live crit power (effective critDamage),
+     *  for Wildfire's "…for every 10% crit power" dotDamage scaling. Default 0 (no live crit
+     *  power known to this caller — DPS-safe / inert for every ship besides Wildfire). Only
+     *  runPlayerTurn's modifierCtx passes a real value. See ConditionContext.selfCritPower. */
+    selfCritPower?: number;
 }): ConditionContext {
     return {
         selfBuffNames: state.selfBuffNames,
@@ -84,6 +89,7 @@ export function buildRoundContext(state: {
         isLastStanding: state.lastStanding ?? false,
         turnsTaken: state.turnsTaken ?? 0,
         stealthedEnemyCount: state.stealthedEnemyCount ?? 0,
+        selfCritPower: state.selfCritPower ?? 0,
         ...(state.roundCrit !== undefined ? { roundCrit: state.roundCrit } : {}),
         // Sentinel spread (sub-project I, PR I1): only set the key when the caller passed a
         // real array — an explicit `undefined` value would collapse to the same runtime

--- a/src/utils/calculators/__tests__/dpsSimulator.test.ts
+++ b/src/utils/calculators/__tests__/dpsSimulator.test.ts
@@ -1868,6 +1868,76 @@ describe('simulateDPS', () => {
             );
         });
 
+        it('DPS-parity (sub-project I, PR I4a): a self-crit-power dotDamage scaling modifier composes with the enemy-debuff sentinel', () => {
+            // Mirrors Wildfire's "…additional Inferno damage to enemies with Scorching
+            // Radiation, for every 10% crit power" — a dotDamage-channel modifier gated on a
+            // buffName-tagged enemy-debuff condition (reuses the SAME DPS-parity sentinel
+            // proven for Tygr/I1 above: the DPS simulator never populates
+            // ConditionContext.enemyDebuffNames, so ANY enemy debuff satisfies the gate, not
+            // just one literally named 'Scorching Radiation') PLUS the new self-crit-power
+            // scaling source. Unlike Selenite's stealthedEnemyCount (an opposing-roster count
+            // that is structurally 0 in DPS mode), self-crit-power IS populated in DPS mode —
+            // it is the caster's OWN live crit power, always known, not enemy-roster-dependent.
+            // baseInput.critDamage = 150, perUnit 0.1 → +15pp dotDamage when the gate is met.
+            const wildfireModifier: Ability = {
+                id: 'm',
+                type: 'modifier',
+                target: 'self',
+                trigger: 'on-cast',
+                conditions: [
+                    { subject: 'enemy-debuff', derivable: true, buffName: 'Scorching Radiation' },
+                    { subject: 'self-crit-power', derivable: true },
+                ],
+                scaling: { conditionIndex: 1, perUnit: 0.1 },
+                config: {
+                    type: 'modifier',
+                    channel: 'dotDamage',
+                    value: 0,
+                    isMultiplicative: false,
+                },
+            };
+            // NOTE: `activeDoTs` (DPSSimulationInput) is only read by the flatInputToAbilities
+            // fallback — a caller supplying `shipSkills` (as this test does) must express the
+            // DoT as its own 'dot'-type ability instead (mirrors the combat-engine integration
+            // test's `payloadAbilities`).
+            const dotAbility: Ability = {
+                id: 'dot',
+                type: 'dot',
+                target: 'enemy',
+                trigger: 'on-cast',
+                conditions: [],
+                config: { type: 'dot', dotType: 'inferno', tier: 30, stacks: 1, duration: 2 },
+            };
+            const dotBase = {
+                ...baseInput,
+                shipSkills: activeSkills([damageAbility('d', 100), dotAbility, wildfireModifier]),
+            };
+            // Deliberately UNRELATED debuff name — never 'Scorching Radiation'.
+            const unrelatedDebuff = makeAlwaysBuff('security-down', { defense: -10 });
+
+            const withUnrelatedDebuff = simulateDPS({
+                ...dotBase,
+                enemyDebuffs: [unrelatedDebuff],
+            });
+            const withNoDebuff = simulateDPS({ ...dotBase, enemyDebuffs: [] });
+
+            // Round 1 only: `enemyDebuffCount` also folds in this ship's OWN just-applied
+            // Inferno entry from round 2 onward (the legacy count-agnostic fallback counts
+            // ANY landed enemy debuff/DoT, including a self-inflicted one) — so by round 2
+            // BOTH runs satisfy the gate regardless of `enemyDebuffs`, collapsing the
+            // difference this test is isolating. Round 1's modifierCtx is built BEFORE that
+            // turn's own Inferno application lands, so it is the one round where the STATIC
+            // `enemyDebuffs` config is the sole gate source — cleanly isolating the
+            // crit-power scaling contribution.
+            expect(withNoDebuff.rounds[0].infernoDamage).toBeGreaterThan(0);
+            // Legacy/name-agnostic behavior preserved (any debuff satisfies the gate) AND the
+            // crit-power scaling contributes exactly +15% on top.
+            expect(withUnrelatedDebuff.rounds[0].infernoDamage).toBeCloseTo(
+                withNoDebuff.rounds[0].infernoDamage * 1.15,
+                5
+            );
+        });
+
         it('multi-hit damage equals a single hit with the summed multiplier', () => {
             const multiHit = simulateDPS({
                 ...baseInput,

--- a/src/utils/combat/__tests__/wildfireDotDamageCritPower.integration.test.ts
+++ b/src/utils/combat/__tests__/wildfireDotDamageCritPower.integration.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Sub-project I, PR I4a — Wildfire's `dotDamage`-channel crit-power scaling, combat-engine
+ * integration.
+ *
+ * Locks the FOUNDATION shape: "when an enemy has Scorching Radiation, this Unit deals N%
+ * additional Inferno damage to that unit for every 10% crit power" — a `dotDamage` modifier
+ * gated on the NAMED enemy debuff (reusing I1's name-specific `enemy-debuff` gating, same as
+ * Incinerator/Tygr) and SCALED by the caster's own live crit power (the new 'self-crit-power'
+ * condition subject, evaluateConditions.ts).
+ *
+ * I4a SCOPE (single-target / cast-time approximation, per the sub-project I design doc §9):
+ *   - The gate is evaluated ONCE per cast against the primary target's modifierCtx (mirrors
+ *     the Incinerator/Tygr I1 integration test: round 1 has nothing pre-existing on the
+ *     target BEFORE this turn → gate false; round 2 reads round 1's own infliction as
+ *     pre-existing → gate true).
+ *   - Per-tick / per-victim(AoE) re-evaluation is I4b; distributing the bonus to OTHER
+ *     allies (the refit-3 "all allies deal…" team-aura text) is I4c. NEITHER is exercised
+ *     here — this test only proves the single-target, single-caster foundation.
+ *
+ * Comparison strategy: two runs with IDENTICAL DoT application/stacking dynamics (same
+ * active skill firing the same debuff + dot abilities every round) — one WITH the new
+ * dotDamage-scaling modifier ability, one WITHOUT. Because both runs apply the exact same
+ * DoT entries each round, any difference in `infernoDamage` is attributable ONLY to the
+ * modifier's dotMult delta — sidestepping cross-round DoT-stacking arithmetic entirely.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import type { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `wfdp${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+// A single positioned, passive (attack:0) enemy — the sole recipient of the focus attacker's
+// positional cast. security:0 so the Scorching Radiation debuff-inflict always lands.
+const passiveEnemyAt = (position: Position): EnemyAttacker =>
+    ({
+        id: 'enemy-front',
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 1,
+            security: 0,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        shipSkills: { slots: [{ slot: 'active', abilities: [] }] },
+    }) as EnemyAttacker;
+
+// critDamage: 150 — the caster's own crit power. With perUnit 0.1 (Wildfire's base passive,
+// "1% additional … for every 10% crit power") the scaling contributes 150 * 0.1 = +15%.
+const engineBase = (shipSkills: ShipSkills): CombatEngineInput => ({
+    attack: 10_000,
+    crit: 0,
+    critDamage: 150,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills,
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 2,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    // hacking 200 vs enemy security 0 → inflict landing chance clamp((200-0)/100) = 1.0.
+    hacking: 200,
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    enemyAttackers: [passiveEnemyAt('M4')],
+});
+
+/** Shared payload abilities: a plain hit + a Scorching Radiation inflict + an Inferno DoT,
+ *  fired every round (identical in both the "with modifier" and "control" skill lists). */
+function payloadAbilities(): Ability[] {
+    return [
+        ab({ type: 'damage', config: { type: 'damage', multiplier: 100 } }),
+        ab({
+            type: 'debuff',
+            config: {
+                type: 'debuff',
+                buffName: 'Scorching Radiation',
+                application: 'inflict',
+                duration: 5,
+                stacks: 1,
+                isStackable: false,
+                parsedEffects: {},
+            },
+        }),
+        ab({
+            type: 'dot',
+            config: { type: 'dot', dotType: 'inferno', tier: 10, stacks: 1, duration: 5 },
+        }),
+    ];
+}
+
+/** The Wildfire-shape modifier: dotDamage, gated on the named enemy debuff + scaled by the
+ *  caster's own live crit power (perUnit 0.1 = the base passive's "1% … per 10% crit power"). */
+function wildfireModifier(): Ability {
+    return ab({
+        target: 'self',
+        type: 'modifier',
+        conditions: [
+            { subject: 'enemy-debuff', derivable: true, buffName: 'Scorching Radiation' },
+            { subject: 'self-crit-power', derivable: true },
+        ],
+        scaling: { conditionIndex: 1, perUnit: 0.1 },
+        config: { type: 'modifier', channel: 'dotDamage', value: 0, isMultiplicative: false },
+    });
+}
+
+describe('Wildfire dotDamage crit-power scaling (sub-project I, PR I4a) — engine integration', () => {
+    it('round 1 (no pre-existing Scorching Radiation): the modifier contributes NO boost', () => {
+        idc = 0;
+        const withMod: ShipSkills = {
+            slots: [{ slot: 'active', abilities: [...payloadAbilities(), wildfireModifier()] }],
+        };
+        const control: ShipSkills = { slots: [{ slot: 'active', abilities: payloadAbilities() }] };
+
+        const withModResult = runCombat(engineBase(withMod));
+        const controlResult = runCombat(engineBase(control));
+
+        // Nothing pre-exists on the target before round 1's own infliction → the gate reads
+        // false this round (mirrors the I1 Incinerator/Tygr integration test) → byte-identical
+        // to the control (no modifier at all).
+        expect(withModResult.rounds[0].infernoDamage).toBe(controlResult.rounds[0].infernoDamage);
+        expect(withModResult.rounds[0].infernoDamage).toBeGreaterThan(0);
+    });
+
+    it('round 2 (Scorching Radiation now pre-existing): Inferno ticks are boosted by critPower × perUnit%', () => {
+        idc = 0;
+        const withMod: ShipSkills = {
+            slots: [{ slot: 'active', abilities: [...payloadAbilities(), wildfireModifier()] }],
+        };
+        const control: ShipSkills = { slots: [{ slot: 'active', abilities: payloadAbilities() }] };
+
+        const withModResult = runCombat(engineBase(withMod));
+        const controlResult = runCombat(engineBase(control));
+
+        // Round 1's own Scorching Radiation infliction is now pre-existing at the start of
+        // round 2 → the gate reads true → dotMult gains +15pp (critDamage 150 * perUnit 0.1).
+        // Both runs apply IDENTICAL DoT entries/stacking each round, so the ratio isolates the
+        // modifier's delta cleanly regardless of how many entries are actively ticking.
+        expect(controlResult.rounds[1].infernoDamage).toBeGreaterThan(0);
+        expect(withModResult.rounds[1].infernoDamage).toBeCloseTo(
+            controlResult.rounds[1].infernoDamage * 1.15,
+            0
+        );
+    });
+
+    it('an enemy WITHOUT Scorching Radiation never gets the boost, even across many rounds', () => {
+        // Same modifier + crit power, but the skill never inflicts the named debuff at all
+        // (only the plain hit + Inferno DoT) — the enemy-debuff gate never lands.
+        idc = 0;
+        const noStatusPayload = (): Ability[] => [
+            ab({ type: 'damage', config: { type: 'damage', multiplier: 100 } }),
+            ab({
+                type: 'dot',
+                config: { type: 'dot', dotType: 'inferno', tier: 10, stacks: 1, duration: 5 },
+            }),
+        ];
+        const withMod: ShipSkills = {
+            slots: [{ slot: 'active', abilities: [...noStatusPayload(), wildfireModifier()] }],
+        };
+        const control: ShipSkills = {
+            slots: [{ slot: 'active', abilities: noStatusPayload() }],
+        };
+
+        const withModResult = runCombat({ ...engineBase(withMod), numRounds: 3 });
+        const controlResult = runCombat({ ...engineBase(control), numRounds: 3 });
+
+        for (let r = 0; r < 3; r++) {
+            expect(withModResult.rounds[r].infernoDamage).toBe(
+                controlResult.rounds[r].infernoDamage
+            );
+        }
+    });
+});

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1022,6 +1022,13 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     // Partial crit-buff total for the gate estimates: starts at layer 1, then gains
     // layers 2+3 (abilityTotalsForGates) before the modifier gate at the modifierCtx.
     let critBuffForGates = scheduledTotals.critBuff;
+    // I4a: parallel PRE-modifier critDAMAGE (crit power) estimate — layers 1+2+3, mirroring
+    // critBuffForGates above. Feeds modifierCtx.selfCritPower (Wildfire's "for every 10%
+    // crit power" dotDamage scaling) without a self-referential dependency on dmgStats
+    // (which is computed FROM modifierCtx, further down). Exact for Wildfire (its own
+    // ability only touches the dotDamage channel, never critDamage), same documented
+    // approximation as critBuffForGates for any OTHER self-crit-gated modifier condition.
+    let critDamageForGates = scheduledTotals.critDamageBuff;
 
     // Per-round landing roll, drawn ONCE and memoized across this round's
     // consumers (the RECURRING/aura partition + DoT landing). Lazy so the
@@ -1353,6 +1360,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     // full four-layer fold (and the other channels) is owned by effectiveDamageStatsOf.
     const abilityTotalsForGates = calculateBuffTotals(toSimBuffs(abilitySelfEffects));
     critBuffForGates += abilityTotalsForGates.critBuff;
+    critDamageForGates += abilityTotalsForGates.critDamageBuff;
 
     // Snapshot lists for this round / context: ability statuses appended AFTER
     // scheduled ones (KNOWN-DIFF c ordering).
@@ -1394,6 +1402,12 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         // across the delta computation — no per-victim distribution, matching the design
         // (this is a global count, not a per-target gate).
         stealthedEnemyCount: stealthedEnemyCountArg,
+        // Sub-project I, PR I4a: the acting unit's own live crit power (Wildfire's
+        // dotDamage scaling source). Only modifierCtx needs it — same "only the modifier
+        // ctx needs this" rationale as stealthedEnemyCount above. critDamageForGates is the
+        // PRE-modifier (layers 1+2+3) estimate; see its declaration for why layer 4 is
+        // deliberately excluded (self-referential-gate avoidance, mirrors critBuffForGates).
+        selfCritPower: critDamage + critDamageForGates,
     });
     const passiveSkill = shipSkills.slots.find((s) => s.slot === 'passive');
     // Sub-project I, PR I3 (Layer 1): distributed all-allies auras (Lodolite/Panguan-shape)


### PR DESCRIPTION
## Sub-project I, PR I4a — Wildfire dotDamage crit-power scaling parse + `self-crit-power` condition

First of the 3-part Wildfire sub-epic (I4a/b/c). Spec §5.2/§9. Wildfire was found to be a mini-epic (new DoT-tick timing machinery), not wiring — this PR lays the foundation.

### What this adds
1. **New scaling-source condition subject `self-crit-power`** — returns the acting unit's effective **critDamage** (crit power) as a continuous scaling magnitude (not a count). Plugs into the existing `scaledBonus` machinery. Threaded into `modifierCtx.selfCritPower` via a new `critDamageForGates` accumulator (layers 1+2+3 of the critDamage fold), mirroring the existing `critBuffForGates` pattern so there's no self-reference on `dmgStats`.
2. **New `dotDamage`-channel conditional-modifier parse branch** — matches "N% additional `<DoT>` damage … for every M% crit power" (Wildfire's "…1% additional Inferno damage … for every 10% crit power"). Emits `{channel:'dotDamage', value:0, scaling:{perUnit: N/M}}` gated on the named enemy status (Scorching Radiation → I1 name-specific `enemy-debuff` via the reused `enemyEffectConditions`). Shape is **Wildfire-unique** in the corpus (verified) — no other ship's parse changes.

### Scope — single-target / cast-time ONLY
Folds through the existing `mod.dotDamage → selfDotDamageModifier → dotMult` path (baked at cast time against the primary target's status). `// I4b:` and `// I4c:` seams mark where per-tick per-victim gating and cross-actor team-aura distribution attach in the follow-up PRs.

### DPS note
`selfCritPower` is populated with a real value in DPS mode too (it's the caster's own intrinsic stat, unlike an opposing-roster count). This is safe because no other ship references the subject, so every other ship's behavior is provably unchanged; Wildfire's own Inferno bonus correctly reflects in its DPS.

### Tests
Unit (`self-crit-power` eval + `scaledBonus` 150×0.1→15, ×0.2→30), parser (real CSV base/refit perUnit + regression), combat integration (round1-no-status vs round2-with-Scorching-Radiation), DPS parity.

### Validation
tsc · lint (0) · full suite (3884) · `audit:skills` (0). Goldens **byte-identical**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPheh4qisgdG9PazKJMkiF
