### PR TITLE
feat(combat): per-tick per-victim Scorching-Radiation gate for Wildfire dot bonus (sub-project I, PR I4b)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -15,7 +15,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: team-wide damage auras now actually reach the team. Lodolite's +15% damage vs Concentrate Fire (or Stealth) and Panguan's +40% damage for Stealthed units apply to every living ally who qualifies, not just the caster's own attacks.",
     "Combat sim: Selenite's bonus direct damage now scales with the number of Stealthed enemies (10% per enemy), instead of a flat 10% whenever at least one enemy was Stealthed.",
     "Combat sim: Lodolite's charged skill now purges all buffs from the enemy with the most buffs, and her legendary refit strips 100% of that enemy's shield when she does.",
-    'Combat sim: Wildfire now deals bonus Inferno damage against an enemy with Scorching Radiation, scaling with her own crit power (1% per 10% crit power, 2% with her refit) — applied when she attacks that enemy directly.',
+    "Combat sim: Wildfire's bonus Inferno damage against an enemy with Scorching Radiation (scaling with her own crit power, 1% per 10% crit power, 2% with her refit) is now re-checked on every Inferno tick against each affected enemy individually — a target that never had Scorching Radiation (or whose Scorching Radiation has since expired) no longer gets the bonus just because another of her targets currently has it.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/abilities/applyAbilities.ts
+++ b/src/utils/abilities/applyAbilities.ts
@@ -90,6 +90,44 @@ export function modifierTotalsFromAbilities(
     return totals;
 }
 
+/**
+ * Sub-project I, PR I4b — split `dotDamage`-channel modifier abilities into (a) abilities
+ * whose gate is a name-specific enemy-status condition (Wildfire's "when an enemy has
+ * Scorching Radiation… for every N% crit power" bonus) and (b) everything else. Layer 2 (I1)
+ * name-gates a `dotDamage` modifier the same way it gates any other channel — via a GATE
+ * condition (`gateConditions`, post scaling-index strip so the paired `self-crit-power`
+ * scaling condition never disqualifies it) whose subject is `enemy-debuff`/`enemy-buff` AND
+ * carries a `buffName`.
+ *
+ * WHY THE SPLIT: `modifierTotalsFromAbilities` folds every dotDamage-channel ability against
+ * ONE ctx (today, the cast-time primary target's `modifierCtx`) — correct for an
+ * UNCONDITIONAL dotDamage source (Decimation set gear) but wrong for a per-victim-gated one
+ * (Wildfire), whose gate must be re-evaluated per TICK against the ticking victim's OWN
+ * live status (see `PlayerRoundCtx.victimGatedDotDamage` / `tickDoTs` in engine.ts). Callers
+ * feed `unconditional` into the normal `effectiveDamageStatsOf` fold (baking `dotMult` as
+ * before) and stash `conditional` + the cast-time ctx for later per-victim resolution.
+ * Empty `conditional` (the overwhelming common case — every non-Wildfire-shaped ship) is a
+ * byte-identical no-op: `unconditional` is the full original list.
+ */
+export function partitionDotDamageAbilities(abilities: Ability[]): {
+    unconditional: Ability[];
+    conditional: Ability[];
+} {
+    const unconditional: Ability[] = [];
+    const conditional: Ability[] = [];
+    for (const ability of abilities) {
+        const isNameGatedDotDamage =
+            ability.type === 'modifier' &&
+            ability.config.type === 'modifier' &&
+            ability.config.channel === 'dotDamage' &&
+            gateConditions(ability).some(
+                (c) => (c.subject === 'enemy-debuff' || c.subject === 'enemy-buff') && !!c.buffName
+            );
+        (isNameGatedDotDamage ? conditional : unconditional).push(ability);
+    }
+    return { unconditional, conditional };
+}
+
 /** The skill in the slot matching the round's action, or undefined if absent. */
 export function selectFiringSkill(
     shipSkills: ShipSkills,

--- a/src/utils/combat/__tests__/wildfireDotDamageCritPower.integration.test.ts
+++ b/src/utils/combat/__tests__/wildfireDotDamageCritPower.integration.test.ts
@@ -1,21 +1,28 @@
 /**
- * Sub-project I, PR I4a — Wildfire's `dotDamage`-channel crit-power scaling, combat-engine
+ * Sub-project I, PR I4a/I4b — Wildfire's `dotDamage`-channel crit-power scaling, combat-engine
  * integration.
  *
  * Locks the FOUNDATION shape: "when an enemy has Scorching Radiation, this Unit deals N%
  * additional Inferno damage to that unit for every 10% crit power" — a `dotDamage` modifier
  * gated on the NAMED enemy debuff (reusing I1's name-specific `enemy-debuff` gating, same as
- * Incinerator/Tygr) and SCALED by the caster's own live crit power (the new 'self-crit-power'
+ * Incinerator/Tygr) and SCALED by the caster's own live crit power (the 'self-crit-power'
  * condition subject, evaluateConditions.ts).
  *
- * I4a SCOPE (single-target / cast-time approximation, per the sub-project I design doc §9):
- *   - The gate is evaluated ONCE per cast against the primary target's modifierCtx (mirrors
- *     the Incinerator/Tygr I1 integration test: round 1 has nothing pre-existing on the
- *     target BEFORE this turn → gate false; round 2 reads round 1's own infliction as
- *     pre-existing → gate true).
- *   - Per-tick / per-victim(AoE) re-evaluation is I4b; distributing the bonus to OTHER
- *     allies (the refit-3 "all allies deal…" team-aura text) is I4c. NEITHER is exercised
- *     here — this test only proves the single-target, single-caster foundation.
+ * I4a SHIPPED a single-target / cast-time approximation (per the sub-project I design doc §9):
+ * the gate was baked ONCE per cast against the primary target's modifierCtx, so an inferno tick
+ * later in the SAME round as its own Scorching-Radiation infliction was (incorrectly) NOT
+ * boosted — a same-turn causality guard that made sense for an outgoing-damage-style CAST gate
+ * (I1) but not for a DoT TICK, which is a genuinely LATER, separate event.
+ *
+ * I4b (this file, updated) fixes that: the gate is now re-evaluated PER VICTIM PER TICK against
+ * that victim's CURRENT live status (see `victimDotMult` in engine.ts) — a DoT tick has no
+ * anti-causality concern about seeing that SAME round's own earlier infliction, because ticking
+ * happens strictly AFTER casting within a round (default speeds: attacker 100 > enemy 50, so the
+ * attacker's cast — infliction + inferno application — always precedes the enemy's own tick this
+ * round). Round 1 below is now boosted (the gate is live and Scorching Radiation already landed
+ * earlier in round 1's own cast); Per-victim(AoE) scoping and the expiring-mid-fight case are the
+ * I4b-specific tests further down. Distributing the bonus to OTHER allies (the refit-3 "all
+ * allies deal…" team-aura text) remains deferred to I4c.
  *
  * Comparison strategy: two runs with IDENTICAL DoT application/stacking dynamics (same
  * active skill firing the same debuff + dot abilities every round) — one WITH the new
@@ -28,6 +35,7 @@ import { runCombat, CombatEngineInput } from '../engine';
 import type { Ability, ShipSkills } from '../../../types/abilities';
 import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
 import type { Position } from '../../../types/encounters';
+import type { CombatActor, ActiveDoTStack } from '../state';
 
 let idc = 0;
 const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
@@ -140,8 +148,8 @@ function wildfireModifier(): Ability {
     });
 }
 
-describe('Wildfire dotDamage crit-power scaling (sub-project I, PR I4a) — engine integration', () => {
-    it('round 1 (no pre-existing Scorching Radiation): the modifier contributes NO boost', () => {
+describe('Wildfire dotDamage crit-power scaling (sub-project I, PR I4a/I4b) — engine integration', () => {
+    it("I4b: round 1 IS boosted — the tick happens after this round's own infliction, live", () => {
         idc = 0;
         const withMod: ShipSkills = {
             slots: [{ slot: 'active', abilities: [...payloadAbilities(), wildfireModifier()] }],
@@ -151,14 +159,21 @@ describe('Wildfire dotDamage crit-power scaling (sub-project I, PR I4a) — engi
         const withModResult = runCombat(engineBase(withMod));
         const controlResult = runCombat(engineBase(control));
 
-        // Nothing pre-exists on the target before round 1's own infliction → the gate reads
-        // false this round (mirrors the I1 Incinerator/Tygr integration test) → byte-identical
-        // to the control (no modifier at all).
-        expect(withModResult.rounds[0].infernoDamage).toBe(controlResult.rounds[0].infernoDamage);
-        expect(withModResult.rounds[0].infernoDamage).toBeGreaterThan(0);
+        // At default speeds the attacker (100) acts before the enemy (50) every round, so by
+        // the time the enemy dummy TICKS its inferno entries this round, the attacker's OWN
+        // cast (earlier this same round) has already inflicted Scorching Radiation. I4b reads
+        // the victim's status LIVE at tick time (no pre-turn snapshot — a tick is a genuinely
+        // later event than the cast that applied it, unlike a same-cast outgoing-modifier gate)
+        // → the gate is already true in round 1. This supersedes I4a's cast-time approximation,
+        // which incorrectly read false here (see the file header).
+        expect(controlResult.rounds[0].infernoDamage).toBeGreaterThan(0);
+        expect(withModResult.rounds[0].infernoDamage).toBeCloseTo(
+            controlResult.rounds[0].infernoDamage * 1.15,
+            0
+        );
     });
 
-    it('round 2 (Scorching Radiation now pre-existing): Inferno ticks are boosted by critPower × perUnit%', () => {
+    it('round 2 (Scorching Radiation still present): Inferno ticks are boosted by critPower × perUnit%', () => {
         idc = 0;
         const withMod: ShipSkills = {
             slots: [{ slot: 'active', abilities: [...payloadAbilities(), wildfireModifier()] }],
@@ -177,6 +192,32 @@ describe('Wildfire dotDamage crit-power scaling (sub-project I, PR I4a) — engi
             controlResult.rounds[1].infernoDamage * 1.15,
             0
         );
+    });
+
+    it('I4b single-target equivalence: when Scorching Radiation is present for the WHOLE fight, every round gets the SAME critPower × perUnit% boost (matches what I4a intended for its scoped case)', () => {
+        // payloadAbilities() re-inflicts Scorching Radiation every round (duration 5, refreshed
+        // before it can expire) → the victim carries the status for the entire fight. Per-tick
+        // live evaluation (I4b) then agrees with a cast-time bake (I4a) on EVERY round, because
+        // the gate is true regardless of WHEN it is read. This is the regression the design doc
+        // asks for: I4b must not diverge from I4a's numbers once the cast-time/tick-time
+        // distinction stops mattering (status always present).
+        idc = 0;
+        const withMod: ShipSkills = {
+            slots: [{ slot: 'active', abilities: [...payloadAbilities(), wildfireModifier()] }],
+        };
+        const control: ShipSkills = { slots: [{ slot: 'active', abilities: payloadAbilities() }] };
+        const numRounds = 4;
+
+        const withModResult = runCombat({ ...engineBase(withMod), numRounds });
+        const controlResult = runCombat({ ...engineBase(control), numRounds });
+
+        for (let r = 0; r < numRounds; r++) {
+            expect(controlResult.rounds[r].infernoDamage).toBeGreaterThan(0);
+            expect(withModResult.rounds[r].infernoDamage).toBeCloseTo(
+                controlResult.rounds[r].infernoDamage * 1.15,
+                0
+            );
+        }
     });
 
     it('an enemy WITHOUT Scorching Radiation never gets the boost, even across many rounds', () => {
@@ -203,6 +244,205 @@ describe('Wildfire dotDamage crit-power scaling (sub-project I, PR I4a) — engi
         for (let r = 0; r < 3; r++) {
             expect(withModResult.rounds[r].infernoDamage).toBe(
                 controlResult.rounds[r].infernoDamage
+            );
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// I4b — per-VICTIM gating. The cast-time approximation (I4a) baked ONE dotMult from the
+// PRIMARY target's gate and applied it to every tick the caster's DoTs produced, on ANY
+// victim. These tests prove the fix: the SAME applier's ctx produces a DIFFERENT effective
+// dotMult depending on which victim is ticking, based on THAT victim's own live status.
+// ---------------------------------------------------------------------------
+describe('Wildfire dotDamage crit-power scaling — I4b per-victim/per-tick gating', () => {
+    // A passive, high-HP, positioned enemy — reused for both the (targeted) front victim and
+    // the (untouched) covered victim in the AoE test below.
+    const passiveVictimAt = (id: string, position: Position, security = 0): EnemyAttacker =>
+        ({
+            id,
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defence: 0,
+                hp: 1_000_000_000,
+                speed: 1,
+                security,
+            },
+            chargeCount: 0,
+            startCharged: false,
+            position,
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            shipSkills: { slots: [{ slot: 'active', abilities: [] }] },
+        }) as EnemyAttacker;
+
+    it('AoE mixed-victim: the SAME applier ctx boosts a tick on a Scorching-Radiation victim but NOT a tick on an untouched victim', () => {
+        idc = 0;
+        // The focus's OWN cast (hit + Scorching Radiation inflict + Inferno DoT, all single-
+        // target 'enemy' — top-level pattern stays non-AoE 'base') only ever touches the
+        // resolved anchor 'front'. 'covered' is NEVER hit or debuffed by the focus's normal
+        // cast; instead we seed an Inferno entry directly onto it (__testTapActors) sourced
+        // from the SAME applier ('attacker') — proving the gate is evaluated per VICTIM, not
+        // baked once into the applier's ctx.
+        const shipSkills: ShipSkills = {
+            slots: [{ slot: 'active', abilities: [...payloadAbilities(), wildfireModifier()] }],
+        };
+        const result = runCombat({
+            attack: 10_000,
+            crit: 0,
+            critDamage: 150,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills,
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            hacking: 200,
+            healTargetId: 'attacker',
+            position: 'M4',
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            enemyAttackers: [passiveVictimAt('front', 'M4'), passiveVictimAt('covered', 'M3')],
+            __testTapActors: (actors: CombatActor[]) => {
+                const covered = actors.find((a) => a.id === 'covered');
+                covered?.infernoEntries.push({
+                    tier: 10,
+                    stacks: 1,
+                    remainingRounds: 5,
+                    sourceId: 'attacker',
+                } as ActiveDoTStack);
+            },
+        } as CombatEngineInput);
+
+        // 'front': direct hit (10000) + BOOSTED inferno tick (10000 × 0.10 × 1.15 = 1150), since
+        // this round's own Scorching-Radiation infliction is already live by tick time (I4b).
+        expect(result.rounds[0].perTargetDamage?.['front']).toBe(11_150);
+        // 'covered': no direct hit (non-AoE cast never touches it) — pure UNBOOSTED inferno tick
+        // (10000 × 0.10 × 1.00 = 1000), from the SAME applier 'attacker' whose ctx carries the
+        // Wildfire modifier. If the gate were still baked once per applier (I4a), 'covered' would
+        // wrongly inherit 'front'’s boost.
+        expect(result.rounds[0].perTargetDamage?.['covered']).toBe(1_000);
+    });
+
+    it('expiry: the bonus drops on a later tick once Scorching Radiation expires on the victim, even though the Inferno DoT itself keeps ticking', () => {
+        idc = 0;
+        // Scorching Radiation is inflicted ONLY on turn 1 (every-n-turns period 99 offset 1 —
+        // matches turnsTaken===1, never again) with a SHORT duration so it expires quickly and is
+        // never refreshed. The Inferno DoT (long duration 10) is applied every round so a single
+        // long-lived entry keeps ticking well past the status's expiry.
+        const onceOnTurn1 = {
+            subject: 'every-n-turns' as const,
+            derivable: true,
+            period: 99,
+            offset: 1,
+        };
+        const skills: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        ab({ type: 'damage', config: { type: 'damage', multiplier: 100 } }),
+                        ab({
+                            type: 'debuff',
+                            conditions: [onceOnTurn1],
+                            config: {
+                                type: 'debuff',
+                                buffName: 'Scorching Radiation',
+                                application: 'inflict',
+                                duration: 1,
+                                stacks: 1,
+                                isStackable: false,
+                                parsedEffects: {},
+                            },
+                        }),
+                        ab({
+                            type: 'dot',
+                            config: {
+                                type: 'dot',
+                                dotType: 'inferno',
+                                tier: 10,
+                                stacks: 1,
+                                duration: 10,
+                            },
+                        }),
+                        wildfireModifier(),
+                    ],
+                },
+            ],
+        };
+
+        const numRounds = 4;
+        const withModResult = runCombat({ ...engineBase(skills), numRounds });
+        const control: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        ab({ type: 'damage', config: { type: 'damage', multiplier: 100 } }),
+                        ab({
+                            type: 'debuff',
+                            conditions: [onceOnTurn1],
+                            config: {
+                                type: 'debuff',
+                                buffName: 'Scorching Radiation',
+                                application: 'inflict',
+                                duration: 1,
+                                stacks: 1,
+                                isStackable: false,
+                                parsedEffects: {},
+                            },
+                        }),
+                        ab({
+                            type: 'dot',
+                            config: {
+                                type: 'dot',
+                                dotType: 'inferno',
+                                tier: 10,
+                                stacks: 1,
+                                duration: 10,
+                            },
+                        }),
+                    ],
+                },
+            ],
+        };
+        const controlResult = runCombat({ ...engineBase(control), numRounds });
+
+        // Round 1: Scorching Radiation just inflicted this round, live by tick time → boosted.
+        expect(controlResult.rounds[0].infernoDamage).toBeGreaterThan(0);
+        expect(withModResult.rounds[0].infernoDamage).toBeCloseTo(
+            controlResult.rounds[0].infernoDamage * 1.15,
+            0
+        );
+        // From SOME later round onward the 1-turn-duration status has expired and is never
+        // refreshed (onceOnTurn1 never fires again) — the boost disappears even though the
+        // long-lived (duration 10) Inferno entry keeps ticking every round at the SAME
+        // (unboosted) rate as the control. Find the first round the ratio drops to 1.0 and
+        // assert every round from there on stays unboosted.
+        const ratios = withModResult.rounds.map((rd, r) =>
+            controlResult.rounds[r].infernoDamage > 0
+                ? rd.infernoDamage / controlResult.rounds[r].infernoDamage
+                : undefined
+        );
+        const droppedIdx = ratios.findIndex((ratio) => ratio !== undefined && ratio < 1.1);
+        expect(droppedIdx).toBeGreaterThan(0); // boosted for at least round 1, drops LATER
+        for (let r = droppedIdx; r < numRounds; r++) {
+            expect(withModResult.rounds[r].infernoDamage).toBeCloseTo(
+                controlResult.rounds[r].infernoDamage,
+                0
             );
         }
     });

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -770,6 +770,11 @@ function processAccumulators(args: {
 // credited per applier via `credit`; the `dot-ticked` event carries the per-dotType SUMMED
 // damage (preserving the pre-Task-4 single-event-per-type emission). At attacker-only this
 // produces byte-identical totals (exactly one applier → same sums).
+//
+// Sub-project I, PR I4b: `dotMultFor(ctx)` replaces the bare `ctx.dotMult` read for BOTH
+// dotTypes — it re-folds any enemy-status-name-gated dotDamage modifier (Wildfire) against
+// THIS call's ticking victim, live, at tick time (see `victimDotMult`). Every call site that
+// doesn't pass it (or an applier ctx with no such modifier) is unaffected: `ctx.dotMult` alone.
 function tickDoTs(args: {
     corrosionEntries: ActiveDoTStack[];
     infernoEntries: ActiveDoTStack[];
@@ -780,7 +785,14 @@ function tickDoTs(args: {
     /** D-PR3 (Vortex Veil): % reduction applied to this carrier's DoT ticks of the given type.
      *  Absent → 0 → byte-identical. */
     incomingDotReductionPct?: (dotType: 'corrosion' | 'inferno') => number;
+    /** Sub-project I, PR I4b — resolves the EFFECTIVE dotMult for one applier's ctx, given the
+     *  ticking VICTIM (this tickDoTs call's whole entries list belongs to ONE victim, so the
+     *  victim is fixed for the call; only the per-entry applier ctx varies). Defaults to the
+     *  applier's `ctx.dotMult` unchanged — every call site that doesn't (yet) pass this stays
+     *  byte-identical. Production call sites pass the engine's `victimDotMult` closure. */
+    dotMultFor?: (ctx: PlayerRoundCtx) => number;
 }): void {
+    const dotMultFor = args.dotMultFor ?? ((ctx: PlayerRoundCtx) => ctx.dotMult);
     // Step 4: Tick corrosion (scales with enemy HP, capped at 5000 dmg per 1%)
     const corrosionBaseHp = Math.min(args.enemyHp, 500_000);
     const corrosionCredits: Array<{ sourceId: string; d: number }> = [];
@@ -788,7 +800,7 @@ function tickDoTs(args: {
     for (const e of args.corrosionEntries) {
         const ctx = args.ctxFor(e.sourceId);
         if (!ctx) continue; // applier has not acted yet this run (faster-enemy round 1)
-        const d = e.stacks * (e.tier / 100) * corrosionBaseHp * ctx.dotMult * ctx.affinityMult;
+        const d = e.stacks * (e.tier / 100) * corrosionBaseHp * dotMultFor(ctx) * ctx.affinityMult;
         corrosionCredits.push({ sourceId: e.sourceId, d });
         corrosionSum += d;
     }
@@ -806,7 +818,8 @@ function tickDoTs(args: {
     for (const e of args.infernoEntries) {
         const ctx = args.ctxFor(e.sourceId);
         if (!ctx) continue;
-        const d = e.stacks * (e.tier / 100) * ctx.effectiveAttack * ctx.dotMult * ctx.affinityMult;
+        const d =
+            e.stacks * (e.tier / 100) * ctx.effectiveAttack * dotMultFor(ctx) * ctx.affinityMult;
         infernoCredits.push({ sourceId: e.sourceId, d });
         infernoSum += d;
     }
@@ -1918,6 +1931,32 @@ export function runCombat(input: CombatEngineInput): {
         ...(target.corrosionEntries.length > 0 ? ['Corrosion'] : []),
         ...(target.pendingBombs.length > 0 ? ['Bomb'] : []),
     ];
+    // Sub-project I, PR I4b — per-VICTIM, per-TICK resolution of an applier's dotMult. Reads
+    // `ctx.victimGatedDotDamage` (set by runPlayerTurn ONLY when the applier's cast carried an
+    // enemy-status-name-gated dotDamage modifier — Wildfire's Scorching Radiation crit-power
+    // bonus). The fast path (no such modifier — every other ship) returns `ctx.dotMult`
+    // unchanged: byte-identical. When present, re-folds `abilities` against a ctx whose
+    // enemy-status fields are swapped to `victim`'s OWN CURRENT live status (read fresh at
+    // TICK time via `enemyDebuffNamesForTarget`/`selfBuffNamesForOwners` — deliberately NOT a
+    // pre-turn snapshot: a DoT tick is a later, separate event from the cast that applied it,
+    // so there is no anti-causality concern about it seeing that SAME cast's own debuff-
+    // infliction, unlike I2's positional-apply delta). Since the ability was EXCLUDED from the
+    // cast-time `dotMult` bake (see `partitionDotDamageAbilities`), the fresh fold is ADDED
+    // directly — no base-ctx subtraction needed (contrast I2's `perVictimOutgoingDeltaPct`,
+    // which must subtract because its abilities stay baked into the aggregate).
+    const victimDotMult = (ctx: PlayerRoundCtx, victim: CombatActor): number => {
+        const gated = ctx.victimGatedDotDamage;
+        if (!gated || gated.abilities.length === 0) return ctx.dotMult;
+        const victimCtx: ConditionContext = {
+            ...gated.ctx,
+            ...(gated.ctx.enemyDebuffNames !== undefined
+                ? { enemyDebuffNames: enemyDebuffNamesForTarget(victim) }
+                : {}),
+            enemyBuffNames: selfBuffNamesForOwners(statusEngine, [victim.id]),
+        };
+        const bonus = modifierTotalsFromAbilities(gated.abilities, victimCtx).dotDamage;
+        return ctx.dotMult + bonus / 100;
+    };
     const isStasised = (actorId: string): boolean => ownerDebuffNames(actorId).some(isStasis);
     const isDisabled = (actorId: string): boolean => ownerDebuffNames(actorId).some(isDisable);
     /** Turn-blocked = cannot take its scheduled action this turn (Stasis OR Disable). Used by the
@@ -4961,6 +5000,8 @@ export function runCombat(input: CombatEngineInput): {
                                     hitIndexThisRound: 0,
                                     dotType,
                                 }),
+                            // PR I4b: the tank is the ticking victim.
+                            dotMultFor: (ctx) => victimDotMult(ctx, healTarget),
                         });
                         if (tankDotDamage > 0) {
                             // C2b-2 T5: a DoT-tick batch is an AGGREGATE of multiple appliers with no
@@ -5029,6 +5070,8 @@ export function runCombat(input: CombatEngineInput): {
                                         hitIndexThisRound: 0,
                                         dotType,
                                     }),
+                                // PR I4b: this actor IS the ticking victim.
+                                dotMultFor: (ctx) => victimDotMult(ctx, actor),
                             });
                             if (total > 0) {
                                 // DoT batch: bypass shield (byDirectDamage:false), aggregate of
@@ -5712,6 +5755,8 @@ export function runCombat(input: CombatEngineInput): {
                             }),
                         credit: (sourceId, dotType, damage) =>
                             creditDamage(sourceId, dotType, damage),
+                        // PR I4b: the dummy sink `enemy` is the ticking victim.
+                        dotMultFor: (ctx) => victimDotMult(ctx, enemy),
                     });
 
                     // Bombs: per-entry burst credited to the applier's detonation channel,

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -17,6 +17,7 @@ import {
     accumulatorsFromSkill,
     gateFiringAbilities,
     extraActionsFromSkill,
+    partitionDotDamageAbilities,
     type ExtraActionGrant,
 } from '../abilities/applyAbilities';
 import { toSimBuffs, toEnemyModifiers, toEnemyDotModifier } from '../calculators/dpsBuffHelpers';
@@ -89,6 +90,18 @@ export interface PlayerRoundCtx {
     effectiveMaxHp: number;
     outgoingHealPct: number;
     incomingHealPct: number;
+    /** Sub-project I, PR I4b — `dotDamage`-channel modifier abilities whose GATE is a
+     *  name-specific enemy-status condition (Wildfire's "when an enemy has Scorching
+     *  Radiation… for every N% crit power" bonus), plus the cast-time ctx used to fold them
+     *  (`partitionDotDamageAbilities` — see its jsdoc for the shape check). EXCLUDED from
+     *  `dotMult` above, which bakes only the UNCONDITIONAL dotDamage contribution (e.g.
+     *  Decimation set gear). The engine re-folds `abilities` against a per-VICTIM,
+     *  per-TICK ctx (only the enemy-status fields swapped to that victim's own CURRENT live
+     *  status — see `tickDoTs`/`victimDotMult` in engine.ts) so the bonus applies to a tick
+     *  only while the ticking victim currently carries the required status. Undefined/empty
+     *  `abilities` → tick math is `dotMult` alone, byte-identical for every non-Wildfire-
+     *  shaped ship (and for the DPS simulator, which never reads this field). */
+    victimGatedDotDamage?: { abilities: Ability[]; ctx: ConditionContext };
 }
 
 /** Healing-mode context threaded into player turns (and later the executor). The ENGINE
@@ -1421,6 +1434,16 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         ...(passiveSkill?.abilities ?? []),
         ...(args.allyModifierAbilities ?? []),
     ];
+    // Sub-project I, PR I4b: pull the enemy-status-name-gated dotDamage abilities (Wildfire's
+    // Scorching Radiation crit-power bonus) OUT of the abilities fed to the cast-time fold
+    // below — they must be re-evaluated per VICTIM per TICK against that victim's own live
+    // status (turnCtx.victimGatedDotDamage, resolved in engine.ts's tickDoTs), not baked once
+    // against the primary target. `dotDamageUnconditional` carries every OTHER ability
+    // unchanged (all channels, plus any non-name-gated dotDamage source e.g. Decimation set
+    // gear) — for every ship without such a modifier this equals `modifierAbilities` and the
+    // fold below is byte-identical to before.
+    const { unconditional: dotDamageUnconditional, conditional: dotDamageConditional } =
+        partitionDotDamageAbilities(modifierAbilities);
     // Final four-layer effective-stat fold (layer 1 scheduledTotals + layers 2+3
     // abilitySelfEffects + layer 4 modifierAbilities gated by modifierCtx). The accessor
     // reproduces the prior inline fold byte-for-byte; the turn loop owns gating/side effects.
@@ -1428,7 +1451,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         base: { attack, defence, crit, critDamage, hp, defensePenetration, defensePenetrationBuff },
         scheduledTotals,
         abilitySelfEffects,
-        modifierAbilities,
+        modifierAbilities: dotDamageUnconditional,
         modifierCtx,
     });
     const effectiveAttack = dmgStats.attack;
@@ -2464,6 +2487,12 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         effectiveMaxHp: effectiveHp,
         outgoingHealPct: dmgStats.totals.outgoingHealBuff,
         incomingHealPct: dmgStats.totals.incomingHealBuff,
+        // PR I4b: only set when this cast actually carries a victim-gated dotDamage ability —
+        // undefined for every ship without one (the common case), so tickDoTs' fast path
+        // (`ctx.victimGatedDotDamage` falsy → use `dotMult` unchanged) is byte-identical.
+        ...(dotDamageConditional.length > 0
+            ? { victimGatedDotDamage: { abilities: dotDamageConditional, ctx: modifierCtx } }
+            : {}),
     };
 
     // Per-cast attacker-side scalars for the positional apply path (Task 7). Sourced from


### PR DESCRIPTION
## Sub-project I, PR I4b — per-tick per-victim Scorching-Radiation gate for Wildfire's dot bonus

Second of the 3-part Wildfire sub-epic (I4a merged; I4c next). Spec §5.2/§9.

### Problem (the I4a approximation)
I4a's Wildfire `dotDamage` bonus was baked once per cast against the **primary target's** status, then applied uniformly to every Inferno/Corrosion tick the caster had out — even on victims without Scorching Radiation, and on later rounds after it expired.

### Change — separate the gate from the magnitude
- `partitionDotDamageAbilities` (`applyAbilities.ts`) splits `dotDamage` modifiers into **unconditional** (flat gear dotDamage, self Out. DoT) vs **conditional** (a `dotDamage` modifier with an `enemy-debuff`/`enemy-buff` gate carrying a `buffName` — i.e. Wildfire's Scorching-Radiation bonus). Only the **unconditional** part bakes into `PlayerRoundCtx.dotMult` → **byte-identical for every non-Wildfire ship**.
- The conditional part rides `PlayerRoundCtx.victimGatedDotDamage = { abilities, ctx }`.
- `tickDoTs` gains a `dotMultFor(ctx)` callback (default `ctx.dotMult` → byte-identical fast path). All three tick sites pass the engine's `victimDotMult(ctx, victim)`, which re-folds the conditional abilities against a ctx whose `enemyDebuffNames`/`enemyBuffNames` are rebuilt **live from the ticking victim** (reusing I1's `enemyDebuffNamesForTarget`), returning `ctx.dotMult + bonus/100`.
- Magnitude (crit-power scaling) unchanged from I4a (cast-time `selfCritPower`); only the **gate** becomes per-victim/live.

### Behavior (expected)
A DoT tick fires strictly *after* the cast within a round, so a live per-tick read has no anti-causality concern — round-1 ticks are legitimately boosted (Scorching Radiation inflicted that round is live by tick time). Single-target with the status present all fight = identical to I4a.

### Tests
Updated the I4a integration test (round-1 now boosted, explained) + added AoE mixed-victim (one boosted / one not, same applier), status-expiry (boost drops mid-DoT once the victim loses Scorching Radiation), and single-target equivalence-to-I4a regression.

### Validation
tsc · lint (0) · full suite (3887) · `audit:skills` (0). Goldens **byte-identical**. `lastTurnCtxByActor` keying untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPheh4qisgdG9PazKJMkiF
