### PR TITLE
chore(audit): report stale allowlist entries + prune 5 dead ones

### DIFF
--- a/scripts/auditSkills.allowlist.ts
+++ b/scripts/auditSkills.allowlist.ts
@@ -15,31 +15,21 @@ export const ALLOWLIST: AllowEntry[] = [
     {
         ship: 'Lingshe',
         rules: ['detonation'],
-        reason: 'Countdown-reduction + crit-scaling Bomb detonation (charged skill). The "gains Stealth on detonating a Bomb" passive now carries an on-bomb-detonated trigger (no longer ungated).',
+        reason: 'Countdown-reduction + crit-scaling Bomb detonation (charged skill). The "gains Stealth on detonating a Bomb" passive now carries an on-bomb-detonated trigger (no longer ungated). (NOTE: currently a multi-line CSV record dropped by the audit reader — kept until the reader is fixed.)',
     },
 
     // ── ungated-effect-with-trigger: intentionally not auto-gated ───────────────
     // Reactive triggers (on-cleanse / on-kill / on-damaged / enemy-uses-charged / on-resist /
     // on-death) — modelled manually by the user, never auto-derived in single-ship DPS.
     {
-        ship: 'Howler',
-        rules: ['ungated-effect-with-trigger'],
-        reason: 'Reactive: when an ally crits.',
-    },
-    {
         ship: 'Ravager',
         rules: ['ungated-effect-with-trigger'],
         reason: 'Reactive: when its debuff is resisted.',
     },
     {
-        ship: 'Nayra',
-        rules: ['ungated-effect-with-trigger'],
-        reason: 'Source typo "When directly damage" (missing -d) — outside the parser\'s self-damage-reaction phrasing (DR_DIRECT_DAMAGE_RE matches "damaged"), so Terran Bolster III stays unmodeled; the enemy-repair reaction (Out. Repair Down) is also unmodeled.',
-    },
-    {
         ship: 'Curator',
         rules: ['ungated-effect-with-trigger'],
-        reason: 'Reactive: when an enemy uses its Charged skill.',
+        reason: 'Reactive: when an enemy uses its Charged skill. (NOTE: currently a multi-line CSV record dropped by the audit reader — kept until the reader is fixed.)',
     },
     {
         ship: 'Paracelsus',
@@ -50,21 +40,6 @@ export const ALLOWLIST: AllowEntry[] = [
         ship: 'Yazid',
         rules: ['ungated-effect-with-trigger'],
         reason: 'Recurring/reactive: start of combat / Cheat Death.',
-    },
-    {
-        ship: 'Arum',
-        rules: ['ungated-effect-with-trigger'],
-        reason: 'Reactive: when an enemy cleanses a debuff.',
-    },
-    {
-        ship: 'Yarrow',
-        rules: ['ungated-effect-with-trigger'],
-        reason: 'Reactive: when an enemy cleanses a debuff.',
-    },
-    {
-        ship: 'Larkspur',
-        rules: ['ungated-effect-with-trigger'],
-        reason: 'Reactive: when an enemy cleanses a debuff.',
     },
     {
         ship: 'Nosorog',

--- a/scripts/auditSkills.ts
+++ b/scripts/auditSkills.ts
@@ -311,8 +311,38 @@ export interface Finding {
     clause: string;
 }
 
+// Records every (ship, ruleId) pair for which a finding WOULD have been reported absent the
+// allowlist (i.e. the keyword matched, the parser did NOT handle it, so isAllowed was consulted).
+// Lets `unusedAllowlistEntries` flag allowlist rows that no longer suppress anything (stale) —
+// e.g. after the reference CSV is refreshed and a source typo the entry existed for is fixed.
+// Cleared at the start of every `collectFindings` pass so repeated calls don't accumulate.
+const consultedAllowKeys = new Set<string>();
+// Ship names actually audited in the last pass. Guards `unusedAllowlistPairs` against
+// false-flagging entries for ships the CSV reader DROPPED (multi-line records — see readShips):
+// a dropped ship produces no finding only because it wasn't audited, not because the entry is
+// stale, so removing its allowlist row would break the audit once the reader is fixed.
+const auditedShipNames = new Set<string>();
+const allowKey = (ship: string, ruleId: string): string => `${ship}::${ruleId}`;
+
 function isAllowed(ship: string, ruleId: string): boolean {
+    consultedAllowKeys.add(allowKey(ship, ruleId));
     return ALLOWLIST.some((a) => a.ship === ship && a.rules.includes(ruleId));
+}
+
+/** Allowlist (ship, ruleId) pairs that are stale: the ship WAS audited but the rule no longer
+ *  produces a raw finding, so the entry suppresses nothing and can be removed. Entries for ships
+ *  the reader dropped are excluded (unknowable, not stale). Call AFTER `collectFindings`. */
+export function unusedAllowlistPairs(): { ship: string; rule: string; reason: string }[] {
+    const out: { ship: string; rule: string; reason: string }[] = [];
+    for (const entry of ALLOWLIST) {
+        if (!auditedShipNames.has(entry.ship)) continue; // dropped ship → can't judge
+        for (const rule of entry.rules) {
+            if (!consultedAllowKeys.has(allowKey(entry.ship, rule))) {
+                out.push({ ship: entry.ship, rule, reason: entry.reason });
+            }
+        }
+    }
+    return out;
 }
 
 /** True when the (gitignored) reference CSV is present — false in CI/clean checkouts. */
@@ -322,7 +352,10 @@ export function csvAvailable(): boolean {
 
 /** Pure pass: every coverage finding across all ships (no I/O side effects beyond reading the CSV). */
 export function collectFindings(): { findings: Finding[]; shipCount: number } {
+    consultedAllowKeys.clear();
+    auditedShipNames.clear();
     const ships = readShips();
+    for (const s of ships) auditedShipNames.add(s.name);
     const findings: Finding[] = [];
 
     for (const ship of ships) {
@@ -451,6 +484,15 @@ function run() {
     for (const ruleId of sortedRules) {
         console.log(`  ${ruleId.padEnd(28)} ${byRule.get(ruleId)!.length}`);
     }
+
+    // Hygiene: allowlist rows that no longer suppress anything (stale — safe to delete). Keeps
+    // the allowlist honest after the reference CSV is refreshed and a source issue is fixed.
+    const unused = unusedAllowlistPairs();
+    if (unused.length) {
+        console.log(`\n⚠ ${unused.length} STALE allowlist entr${unused.length === 1 ? 'y' : 'ies'} (no longer produce a finding — remove from auditSkills.allowlist.ts):`);
+        for (const u of unused) console.log(`  - ${u.ship} · ${u.rule}`);
+    }
+
     console.log(`\nFull report: docs/skill-audit.md`);
 }
 


### PR DESCRIPTION
## chore(audit): report stale allowlist entries + prune 5 dead ones

Housekeeping on the skill-audit allowlist (`scripts/auditSkills.allowlist.ts`), prompted by the observation that a refreshed reference CSV can silently make allowlist rows obsolete.

### New: stale-entry detection
`auditSkills` now tracks which `(ship, rule)` pairs are actually **consulted** (a finding would fire absent the allowlist) and reports allowlist rows that no longer suppress anything. It **excludes ships the CSV reader drops** (multi-line records — see the known 141/147 reader gap) so those aren't false-flagged as stale. This prevents dead entries silently accumulating (and guards against the "someone half-regenerated the allowlist" churn we hit earlier).

### Pruned 5 genuinely-stale entries
These ships are audited but no longer produce their `ungated-effect-with-trigger` finding — the epic's reactive-trigger modeling and a CSV refresh resolved them:
- **Nayra** — the source typo `"When directly damage"` was fixed to `"damaged"` in the current data, so `DR_DIRECT_DAMAGE_RE` now gates it; the entry existed *because of* that typo.
- **Howler / Arum / Yarrow / Larkspur** — reactive on-ally-crit / on-enemy-cleanse triggers now recognized (no longer flagged ungated).

### Kept (false-positive guard)
- **Lingshe** (`detonation`) and **Curator** (`ungated-effect-with-trigger`) are currently **dropped by the CSV reader** (multi-line records), so they produce no finding only because they aren't audited. Kept, with a note, until the reader is fixed.

### Validation
`npm run audit:skills` → 141 ships, **0 findings**, no stale warnings. tsc + lint clean; full suite green (`skillAuditCoverage` still asserts 0 non-allowlisted findings). Internal tooling only — no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPheh4qisgdG9PazKJMkiF
