### PR TITLE
feat(combat): Wildfire team-wide Inferno aura scaled by source crit power (sub-project I, PR I4c)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -16,6 +16,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Selenite's bonus direct damage now scales with the number of Stealthed enemies (10% per enemy), instead of a flat 10% whenever at least one enemy was Stealthed.",
     "Combat sim: Lodolite's charged skill now purges all buffs from the enemy with the most buffs, and her legendary refit strips 100% of that enemy's shield when she does.",
     "Combat sim: Wildfire's bonus Inferno damage against an enemy with Scorching Radiation (scaling with her own crit power, 1% per 10% crit power, 2% with her refit) is now re-checked on every Inferno tick against each affected enemy individually — a target that never had Scorching Radiation (or whose Scorching Radiation has since expired) no longer gets the bonus just because another of her targets currently has it.",
+    "Combat sim: Wildfire's refit-3 passive now actually reaches the team — every living ally's Inferno damage against an enemy with Scorching Radiation is boosted by 2% per 10% of Wildfire's own crit power (not the ally's), matching her skill text.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/combat/__tests__/wildfireTeamAuraCritPower.integration.test.ts
+++ b/src/utils/combat/__tests__/wildfireTeamAuraCritPower.integration.test.ts
@@ -1,0 +1,462 @@
+/**
+ * Sub-project I, PR I4c — Wildfire's refit-3 TEAM aura ("When an enemy has Scorching
+ * Radiation, all allies deal 2% additional Inferno damage to that Unit for every 10% crit
+ * power THIS UNIT has"), combat-engine integration.
+ *
+ * I4a/I4b (wildfireDotDamageCritPower.integration.test.ts) shipped the single-actor shape:
+ * a `dotDamage`-channel modifier, gated per-victim/per-tick on the named enemy debuff
+ * (Scorching Radiation) and scaled by the CASTER's own live crit power. That shape's ability
+ * is parsed with `target: 'self'` for the base passives and `target: 'all-allies'` for the
+ * refit-3 text (buildShipAbilities.ts's shared `dotCritPowerM` branch) — I3 (team-aura
+ * distribution) ALREADY threads an `all-allies` `modifier` ability into every living same-side
+ * ally's `modifierAbilities`, evaluated against the RECIPIENT's own ConditionContext. That is
+ * correct for every OTHER all-allies aura (Lodolite/Panguan — the gate reads the recipient's
+ * own status), but WRONG for Wildfire's refit-3 text: the LOCKED game rule (user-confirmed
+ * 2026-07-03) is that "for every 10% crit power" scales by WILDFIRE's (the aura SOURCE's) own
+ * crit power, never the dealing ally's.
+ *
+ * This suite locks the I4c fix: `engine.ts`'s `buildTurnArgs` now ALSO threads a per-source
+ * breakdown (`allyDotDamageAuraSources`) carrying each ally aura source's OWN live crit power;
+ * `runPlayerTurn` (playerTurn.ts) builds a `victimGatedDotDamage` LIST (one entry per source)
+ * instead of a single ctx, so `victimDotMult` (engine.ts) folds each distributed aura against a
+ * ctx whose `selfCritPower` is the SOURCE's, not the recipient/dealing-ally's.
+ *
+ * Since the flat `RoundData.infernoDamage` field is FOCUS-actor-only, a team ally's own Inferno
+ * tick is measured via the `dot-ticked` bus event (which reports the per-round, per-dotType
+ * SUMMED tick damage across every applier on the shared dummy enemy) — isolating it by ensuring
+ * ONLY the measured applier ever applies an Inferno DoT in a given fixture.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import type { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { CombatStatBlock } from '../../../types/calculator';
+import type { CombatEvent } from '../events';
+import { createEventBus } from '../events';
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `wtac${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+const basicDamage = (multiplier: number, id?: string): Ability =>
+    ab({ id, type: 'damage', config: { type: 'damage', multiplier } });
+
+const scorchingRadiationInflict = (id: string): Ability =>
+    ab({
+        id,
+        type: 'debuff',
+        config: {
+            type: 'debuff',
+            buffName: 'Scorching Radiation',
+            application: 'inflict',
+            duration: 5,
+            stacks: 1,
+            isStackable: false,
+            parsedEffects: {},
+        },
+    });
+
+const infernoDot = (id: string): Ability =>
+    ab({
+        id,
+        type: 'dot',
+        config: { type: 'dot', dotType: 'inferno', tier: 10, stacks: 1, duration: 5 },
+    });
+
+// Wildfire's refit-3 team aura: all-allies dotDamage, gated on the named enemy debuff
+// (Scorching Radiation) + scaled by the SOURCE's own live crit power. "2% additional … for
+// every 10% crit power" → perUnit 0.2 (distinguishes it from the base passives' 0.1/0.2
+// self-only shapes already locked by I4a/I4b).
+const wildfireTeamAura = (): Ability =>
+    ab({
+        id: 'wildfire-team-aura',
+        target: 'all-allies',
+        type: 'modifier',
+        conditions: [
+            { subject: 'enemy-debuff', derivable: true, buffName: 'Scorching Radiation' },
+            { subject: 'self-crit-power', derivable: true },
+        ],
+        scaling: { conditionIndex: 1, perUnit: 0.2 },
+        config: { type: 'modifier', channel: 'dotDamage', value: 0, isMultiplicative: false },
+    });
+
+const passiveOnly = (...abilities: Ability[]): ShipSkills => ({
+    slots: [{ slot: 'passive', abilities }],
+});
+
+// hacking 200 vs the dummy enemy's default security (100, unset) → any DoT/debuff-application
+// landing gate this actor rolls (e.g. the ally's own Inferno DoT application) always lands —
+// isolates the fixture from an UNRELATED landing-chance failure mode (0 hacking → 0% landing,
+// the tick would never occur at all and every assertion below would read 0 either way).
+const teamStats = (attack: number, critDamage: number): CombatStatBlock => ({
+    attack,
+    crit: 0,
+    critDamage,
+    defensePenetration: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    hacking: 200,
+});
+
+// A walked team actor. speed 100 so it acts every round like the focus. `positional`, when
+// supplied, targets the SAME resolved victim as the focus (position 'M4' / pattern base /
+// target 'front') — REQUIRED for the engine's I1 name-specific `enemy-debuff` gate to
+// populate (`enemyDebuffNames` is only threaded for a REAL resolved target, never the DPS
+// dummy `enemy` sink — see engine.ts's `buildTurnArgs` guard `tgt.id !== enemy.id`).
+const teamActor = (
+    id: string,
+    attack: number,
+    critDamage: number,
+    skills: ShipSkills,
+    positional = false
+): TeamActorEngineInput =>
+    ({
+        id,
+        speed: 100,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        ...(positional
+            ? { position: 'M4' as Position, target: parsedTarget('front'), pattern: basePattern() }
+            : {}),
+        walk: {
+            shipSkills: skills,
+            stats: teamStats(attack, critDamage),
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+            healModifier: 0,
+        },
+    }) as TeamActorEngineInput;
+
+// The Wildfire aura-source team actor: passive-only (never itself fires a damage ability), so
+// it never contributes an Inferno tick of its own — isolating the DISTRIBUTED bonus on the
+// OTHER team ally being measured. `critPower` is the aura's scaling source. Never positional —
+// it never fires a damage ability, so it has no resolved target of its own to gate on.
+const wildfireAuraSource = (
+    id: string,
+    critPower: number,
+    includeAura: boolean
+): TeamActorEngineInput =>
+    teamActor(id, 0, critPower, passiveOnly(...(includeAura ? [wildfireTeamAura()] : [])));
+
+// A single positioned, passive (attack:0) enemy — security:0 so a Scorching Radiation inflict
+// targeting it always lands (mirrors wildfireDotDamageCritPower.integration.test.ts).
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+const passiveEnemyAt = (position: Position): EnemyAttacker =>
+    ({
+        id: 'enemy-front',
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 1,
+            security: 0,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        shipSkills: { slots: [{ slot: 'active', abilities: [] }] },
+    }) as EnemyAttacker;
+
+const baseEngineInput = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [{ slot: 'active', abilities: [] }] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 2,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    // hacking 200 vs the dummy enemy's default security (100) → inflict landing chance
+    // clamp((200-100)/100) = 1.0 — the focus's Scorching Radiation inflict always lands.
+    hacking: 200,
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+// Per-ROUND summed Inferno tick damage (`dot-ticked` events), across every applier of the
+// fixture. Fixtures below are constructed so only ONE applier ever carries an Inferno DoT,
+// isolating that applier's tick cleanly (mirrors the "identical DoT dynamics, compare deltas"
+// strategy from wildfireDotDamageCritPower.integration.test.ts).
+const infernoTicksByRound = (input: CombatEngineInput): number[] => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    bus.on('dot-ticked', (e) => events.push(e as CombatEvent));
+    const result = runCombat({ ...input, bus });
+    const byRound: number[] = new Array(result.rounds.length).fill(0);
+    for (const e of events) {
+        if (e.type === 'dot-ticked' && e.dotType === 'inferno') {
+            byRound[e.round - 1] += e.damage;
+        }
+    }
+    return byRound;
+};
+
+describe('Wildfire refit-3 team-wide Inferno aura, scaled by the SOURCE crit power (sub-project I, PR I4c)', () => {
+    it("an ally (LOW crit power) applying Inferno to a Scorching-Radiation victim is boosted by WILDFIRE's (the source's) crit power, not its own", () => {
+        idc = 0;
+        const ALLY_ATTACK = 10_000;
+        const WILDFIRE_CRIT_POWER = 200; // → +40% (200 * perUnit 0.2)
+        const ALLY_CRIT_POWER = 0; // if the bug regresses, the bonus would read 0 → ratio 1.0
+
+        const focus: ShipSkills = {
+            slots: [{ slot: 'active', abilities: [scorchingRadiationInflict('focus-sr')] }],
+        };
+        const ally: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [basicDamage(100, 'ally-dmg'), infernoDot('ally-dot')],
+                },
+            ],
+        };
+        const positional = {
+            position: 'M4' as Position,
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            enemyAttackers: [passiveEnemyAt('M4')],
+        };
+
+        const withMod = infernoTicksByRound(
+            baseEngineInput({
+                ...positional,
+                shipSkills: focus,
+                teamActors: [
+                    teamActor('ally', ALLY_ATTACK, ALLY_CRIT_POWER, ally, true),
+                    wildfireAuraSource('wildfire', WILDFIRE_CRIT_POWER, true),
+                ],
+            })
+        );
+        const control = infernoTicksByRound(
+            baseEngineInput({
+                ...positional,
+                shipSkills: focus,
+                teamActors: [
+                    teamActor('ally', ALLY_ATTACK, ALLY_CRIT_POWER, ally, true),
+                    wildfireAuraSource('wildfire', WILDFIRE_CRIT_POWER, false),
+                ],
+            })
+        );
+
+        // Round 1: the focus's own Scorching-Radiation infliction (this same round) is already
+        // live by the time the shared dummy enemy ticks (I4b's per-tick live-status rule; the
+        // focus/ally act before the enemy's tick at default speeds) → boosted from round 1.
+        expect(control[0]).toBeGreaterThan(0);
+        expect(withMod[0]).toBeCloseTo(control[0] * 1.4, 0);
+        // Round 2: Scorching Radiation still present (duration 5, refreshed) → same +40%.
+        expect(control[1]).toBeGreaterThan(0);
+        expect(withMod[1]).toBeCloseTo(control[1] * 1.4, 0);
+    });
+
+    it('the SAME ally/aura pairing gets NO boost against a victim that never carries Scorching Radiation', () => {
+        idc = 0;
+        const ALLY_ATTACK = 10_000;
+        const WILDFIRE_CRIT_POWER = 200;
+
+        // The focus never inflicts Scorching Radiation at all.
+        const focus: ShipSkills = { slots: [{ slot: 'active', abilities: [] }] };
+        const ally: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [basicDamage(100, 'ally-dmg2'), infernoDot('ally-dot2')],
+                },
+            ],
+        };
+        const positional = {
+            position: 'M4' as Position,
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            enemyAttackers: [passiveEnemyAt('M4')],
+        };
+
+        const withMod = infernoTicksByRound(
+            baseEngineInput({
+                ...positional,
+                numRounds: 3,
+                shipSkills: focus,
+                teamActors: [
+                    teamActor('ally', ALLY_ATTACK, 0, ally, true),
+                    wildfireAuraSource('wildfire', WILDFIRE_CRIT_POWER, true),
+                ],
+            })
+        );
+        const control = infernoTicksByRound(
+            baseEngineInput({
+                ...positional,
+                numRounds: 3,
+                shipSkills: focus,
+                teamActors: [
+                    teamActor('ally', ALLY_ATTACK, 0, ally, true),
+                    wildfireAuraSource('wildfire', WILDFIRE_CRIT_POWER, false),
+                ],
+            })
+        );
+
+        for (let r = 0; r < 3; r++) {
+            expect(withMod[r]).toBe(control[r]);
+        }
+    });
+
+    it("Wildfire's OWN Inferno tick (single actor, target:'all-allies') is boosted EXACTLY once by its own crit power — no double-apply", () => {
+        idc = 0;
+        const CRIT_POWER = 150; // → +30% (150 * perUnit 0.2). A double-apply bug would read +60%.
+
+        const withAura: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        basicDamage(100, 'wf-dmg'),
+                        scorchingRadiationInflict('wf-sr'),
+                        infernoDot('wf-dot'),
+                    ],
+                },
+                { slot: 'passive', abilities: [wildfireTeamAura()] },
+            ],
+        };
+        const withoutAura: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        basicDamage(100, 'wf-dmg'),
+                        scorchingRadiationInflict('wf-sr'),
+                        infernoDot('wf-dot'),
+                    ],
+                },
+                { slot: 'passive', abilities: [] },
+            ],
+        };
+
+        const withModResult = runCombat(
+            baseEngineInput({ attack: 10_000, shipSkills: withAura, critDamage: CRIT_POWER })
+        );
+        const controlResult = runCombat(
+            baseEngineInput({ attack: 10_000, shipSkills: withoutAura, critDamage: CRIT_POWER })
+        );
+
+        // Round 2: Scorching Radiation (inflicted every round) is guaranteed pre-existing.
+        expect(controlResult.rounds[1].infernoDamage).toBeGreaterThan(0);
+        expect(withModResult.rounds[1].infernoDamage).toBeCloseTo(
+            controlResult.rounds[1].infernoDamage * 1.3,
+            0
+        );
+    });
+
+    it('TEAM-SYMMETRY: the SAME aura source on the ENEMY side boosts an enemy ally identically, scaled by the enemy aura SOURCE crit power', () => {
+        idc = 0;
+        const ALLY_ATTACK = 10_000;
+        const WILDFIRE_CRIT_POWER = 200; // → +40%
+
+        // Enemy hacking 300 vs the focus's default security (100, unset) → inflict landing
+        // chance clamp((300-100)/100) = 1.0 — always lands.
+        const dealerEnemy = (id: string, includeSr: boolean): EnemyAttacker =>
+            ({
+                id,
+                stats: {
+                    attack: ALLY_ATTACK,
+                    crit: 0,
+                    critDamage: 0,
+                    defence: 0,
+                    hp: 1_000_000_000,
+                    speed: 100,
+                    hacking: 300,
+                },
+                chargeCount: 0,
+                startCharged: false,
+                shipSkills: {
+                    slots: [
+                        {
+                            slot: 'active',
+                            abilities: includeSr
+                                ? [
+                                      basicDamage(100, 'e-ally-dmg'),
+                                      scorchingRadiationInflict('e-ally-sr'),
+                                      infernoDot('e-ally-dot'),
+                                  ]
+                                : [basicDamage(100, 'e-ally-dmg'), infernoDot('e-ally-dot')],
+                        },
+                    ],
+                },
+            }) as EnemyAttacker;
+
+        const sourceEnemy = (includeAura: boolean): EnemyAttacker =>
+            ({
+                id: 'e-wildfire',
+                stats: {
+                    attack: 0,
+                    crit: 0,
+                    critDamage: WILDFIRE_CRIT_POWER,
+                    defence: 0,
+                    hp: 1_000_000_000,
+                    speed: 100,
+                },
+                chargeCount: 0,
+                startCharged: false,
+                shipSkills: passiveOnly(...(includeAura ? [wildfireTeamAura()] : [])),
+            }) as EnemyAttacker;
+
+        const withMod = infernoTicksByRound(
+            baseEngineInput({
+                numRounds: 3,
+                hp: 1_000_000_000, // huge focus HP so the enemy's hits never destroy it
+                shipSkills: { slots: [{ slot: 'active', abilities: [] }] },
+                enemyAttackers: [sourceEnemy(true), dealerEnemy('e-ally', true)],
+            })
+        );
+        const control = infernoTicksByRound(
+            baseEngineInput({
+                numRounds: 3,
+                hp: 1_000_000_000,
+                shipSkills: { slots: [{ slot: 'active', abilities: [] }] },
+                enemyAttackers: [sourceEnemy(false), dealerEnemy('e-ally', true)],
+            })
+        );
+
+        // Unlike the player-side dummy-enemy fixtures above (where the enemy's tick is a
+        // round-end aggregate step, so a round-1 application already ticks THAT same round),
+        // the FOCUS here is a real positioned actor whose DoT containers tick at ITS OWN
+        // turn-start (the per-victim DoT-tick prologue) — at tied default speed 100 the focus's
+        // turn-start precedes the enemy's application THIS round, so round 1's application isn't
+        // visible until the focus's NEXT turn-start (round 2).
+        expect(control[1]).toBeGreaterThan(0);
+        expect(withMod[1]).toBeCloseTo(control[1] * 1.4, 0);
+        expect(control[2]).toBeGreaterThan(0);
+        expect(withMod[2]).toBeCloseTo(control[2] * 1.4, 0);
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -1931,30 +1931,43 @@ export function runCombat(input: CombatEngineInput): {
         ...(target.corrosionEntries.length > 0 ? ['Corrosion'] : []),
         ...(target.pendingBombs.length > 0 ? ['Bomb'] : []),
     ];
-    // Sub-project I, PR I4b — per-VICTIM, per-TICK resolution of an applier's dotMult. Reads
-    // `ctx.victimGatedDotDamage` (set by runPlayerTurn ONLY when the applier's cast carried an
-    // enemy-status-name-gated dotDamage modifier — Wildfire's Scorching Radiation crit-power
-    // bonus). The fast path (no such modifier — every other ship) returns `ctx.dotMult`
-    // unchanged: byte-identical. When present, re-folds `abilities` against a ctx whose
-    // enemy-status fields are swapped to `victim`'s OWN CURRENT live status (read fresh at
-    // TICK time via `enemyDebuffNamesForTarget`/`selfBuffNamesForOwners` — deliberately NOT a
-    // pre-turn snapshot: a DoT tick is a later, separate event from the cast that applied it,
-    // so there is no anti-causality concern about it seeing that SAME cast's own debuff-
-    // infliction, unlike I2's positional-apply delta). Since the ability was EXCLUDED from the
-    // cast-time `dotMult` bake (see `partitionDotDamageAbilities`), the fresh fold is ADDED
-    // directly — no base-ctx subtraction needed (contrast I2's `perVictimOutgoingDeltaPct`,
-    // which must subtract because its abilities stay baked into the aggregate).
+    // Sub-project I, PR I4b/I4c — per-VICTIM, per-TICK resolution of an applier's dotMult.
+    // Reads `ctx.victimGatedDotDamage` (set by runPlayerTurn ONLY when the applier's cast
+    // carried an enemy-status-name-gated dotDamage modifier — Wildfire's Scorching Radiation
+    // crit-power bonus, either the applier's OWN or one distributed from an ally's "all
+    // allies deal…" aura). The fast path (no such modifier — every other ship) returns
+    // `ctx.dotMult` unchanged: byte-identical. When present, re-folds EACH entry's
+    // `abilities` against a ctx whose enemy-status fields are swapped to `victim`'s OWN
+    // CURRENT live status (read fresh at TICK time via
+    // `enemyDebuffNamesForTarget`/`selfBuffNamesForOwners` — deliberately NOT a pre-turn
+    // snapshot: a DoT tick is a later, separate event from the cast that applied it, so
+    // there is no anti-causality concern about it seeing that SAME cast's own debuff-
+    // infliction, unlike I2's positional-apply delta). I4c: a LIST, not a single entry — the
+    // applier's own entry (if any) keeps its own ctx (selfCritPower = the APPLIER's own crit
+    // power, unchanged from I4b); each distributed ally-aura entry carries the AURA
+    // SOURCE's ctx (selfCritPower = the SOURCE's crit power — the locked rule for Wildfire's
+    // team aura). Each entry's `enemyDebuffNames`/`enemyBuffNames` are independently
+    // re-pointed at `victim` here, so every entry gates on the SAME victim's live status
+    // regardless of whose ctx it originated from. Since the abilities were EXCLUDED from
+    // the cast-time `dotMult` bake (see `partitionDotDamageAbilities`), each fresh fold is
+    // ADDED directly — no base-ctx subtraction needed (contrast I2's
+    // `perVictimOutgoingDeltaPct`, which must subtract because its abilities stay baked
+    // into the aggregate).
     const victimDotMult = (ctx: PlayerRoundCtx, victim: CombatActor): number => {
         const gated = ctx.victimGatedDotDamage;
-        if (!gated || gated.abilities.length === 0) return ctx.dotMult;
-        const victimCtx: ConditionContext = {
-            ...gated.ctx,
-            ...(gated.ctx.enemyDebuffNames !== undefined
-                ? { enemyDebuffNames: enemyDebuffNamesForTarget(victim) }
-                : {}),
-            enemyBuffNames: selfBuffNamesForOwners(statusEngine, [victim.id]),
-        };
-        const bonus = modifierTotalsFromAbilities(gated.abilities, victimCtx).dotDamage;
+        if (!gated || gated.length === 0) return ctx.dotMult;
+        let bonus = 0;
+        for (const entry of gated) {
+            if (entry.abilities.length === 0) continue;
+            const victimCtx: ConditionContext = {
+                ...entry.ctx,
+                ...(entry.ctx.enemyDebuffNames !== undefined
+                    ? { enemyDebuffNames: enemyDebuffNamesForTarget(victim) }
+                    : {}),
+                enemyBuffNames: selfBuffNamesForOwners(statusEngine, [victim.id]),
+            };
+            bonus += modifierTotalsFromAbilities(entry.abilities, victimCtx).dotDamage;
+        }
         return ctx.dotMult + bonus / 100;
     };
     const isStasised = (actorId: string): boolean => ownerDebuffNames(actorId).some(isStasis);
@@ -4343,6 +4356,38 @@ export function runCombat(input: CombatEngineInput): {
                 allyModifierAbilities: sameSideLivingFor(a)
                     .filter((x) => x.id !== a.id)
                     .flatMap((x) => allAlliesModifierAbilitiesById.get(x.id) ?? []),
+                // Sub-project I, PR I4c: per-SOURCE breakdown of ally `all-allies` `dotDamage`-
+                // channel modifier abilities (Wildfire's refit-3 team aura) — needed alongside
+                // `allyModifierAbilities` above because that flat list loses PROVENANCE (which
+                // ally sourced which ability), and the locked game rule requires this bonus to
+                // scale by the AURA SOURCE's own crit power, never the recipient's (unlike
+                // every other all-allies modifier condition, which correctly reads the
+                // recipient's ctx per I3). Filters each ally's all-allies MODIFIER list down to
+                // the `dotDamage` channel BEFORE computing crit power, so `effectiveStatsOf` is
+                // only paid for actual aura sources (every ship without this shape → `.filter`
+                // drops it → `[]`, byte-identical). `sourceCritPower` mirrors the "layers
+                // 1+2+3" shape `modifierCtx.selfCritPower` uses for the ACTING actor (base +
+                // scheduled/timed self-buffs) — the one difference is it omits the acting-
+                // actor-only "active/gated self-ability aura" layer (playerTurn.ts's
+                // `activeAbilityStatuses` component), which Wildfire's kit never uses for its
+                // own crit power (docs/ship-skills.csv: Wildfire's only passives ARE this
+                // dotDamage-scaling ability), so the two are equivalent for this ship.
+                allyDotDamageAuraSources: sameSideLivingFor(a)
+                    .filter((x) => x.id !== a.id)
+                    .map((x) => ({
+                        x,
+                        abilities: (allAlliesModifierAbilitiesById.get(x.id) ?? []).filter(
+                            (ab) =>
+                                ab.config.type === 'modifier' && ab.config.channel === 'dotDamage'
+                        ),
+                    }))
+                    .filter((entry) => entry.abilities.length > 0)
+                    .map((entry) => ({
+                        sourceId: entry.x.id,
+                        sourceCritPower: effectiveStatsOf(statusEngine, selfBuffLookup, entry.x)
+                            .critDamage,
+                        abilities: entry.abilities,
+                    })),
             };
         };
 

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -90,18 +90,23 @@ export interface PlayerRoundCtx {
     effectiveMaxHp: number;
     outgoingHealPct: number;
     incomingHealPct: number;
-    /** Sub-project I, PR I4b — `dotDamage`-channel modifier abilities whose GATE is a
+    /** Sub-project I, PR I4b/I4c — `dotDamage`-channel modifier abilities whose GATE is a
      *  name-specific enemy-status condition (Wildfire's "when an enemy has Scorching
-     *  Radiation… for every N% crit power" bonus), plus the cast-time ctx used to fold them
+     *  Radiation… for every N% crit power" bonus), plus the ctx used to fold each group
      *  (`partitionDotDamageAbilities` — see its jsdoc for the shape check). EXCLUDED from
      *  `dotMult` above, which bakes only the UNCONDITIONAL dotDamage contribution (e.g.
-     *  Decimation set gear). The engine re-folds `abilities` against a per-VICTIM,
-     *  per-TICK ctx (only the enemy-status fields swapped to that victim's own CURRENT live
-     *  status — see `tickDoTs`/`victimDotMult` in engine.ts) so the bonus applies to a tick
-     *  only while the ticking victim currently carries the required status. Undefined/empty
-     *  `abilities` → tick math is `dotMult` alone, byte-identical for every non-Wildfire-
-     *  shaped ship (and for the DPS simulator, which never reads this field). */
-    victimGatedDotDamage?: { abilities: Ability[]; ctx: ConditionContext };
+     *  Decimation set gear). The engine re-folds each entry's `abilities` against a
+     *  per-VICTIM, per-TICK ctx (only the enemy-status fields swapped to that victim's own
+     *  CURRENT live status — see `tickDoTs`/`victimDotMult` in engine.ts) so the bonus
+     *  applies to a tick only while the ticking victim currently carries the required
+     *  status. A LIST (not a single entry) because I4c's refit-3 "all allies deal…" team
+     *  aura contributes ADDITIONAL entries — one per ally aura SOURCE, each carrying that
+     *  SOURCE's own `selfCritPower` (the locked rule: the bonus scales by the aura
+     *  SOURCE's crit power, never the recipient's) — alongside this actor's own entry (if
+     *  any), which keeps using this actor's own ctx unchanged from I4b. Undefined/empty →
+     *  tick math is `dotMult` alone, byte-identical for every non-Wildfire-shaped ship (and
+     *  for the DPS simulator, which never reads this field). */
+    victimGatedDotDamage?: { abilities: Ability[]; ctx: ConditionContext }[];
 }
 
 /** Healing-mode context threaded into player turns (and later the executor). The ENGINE
@@ -455,6 +460,27 @@ export interface PlayerTurnArgs {
      *  perspective, not the source's). Defaults to `[]` — absent/empty is byte-identical to
      *  pre-I3 behavior (no ship's all-allies modifier reaches teammates without this). */
     allyModifierAbilities?: Ability[];
+    /** Sub-project I, PR I4c — per-SOURCE breakdown of `all-allies` `dotDamage`-channel
+     *  modifier abilities, needed IN ADDITION TO `allyModifierAbilities` (which flattens
+     *  every source into one list and so loses provenance). Wildfire's refit-3 aura is the
+     *  one shape (today) where an all-allies modifier's bonus must scale by the SOURCE's
+     *  own live stat (`self-crit-power`) rather than the recipient's — the locked game rule
+     *  for "all allies deal…for every 10% crit power THIS UNIT has" (THIS UNIT = the aura's
+     *  caster, not the ally dealing the tick). Each entry is one living same-side ally
+     *  (excluding this actor): `abilities` is that ally's full all-allies MODIFIER list
+     *  (re-partitioned below via `partitionDotDamageAbilities` to extract just the
+     *  name-gated `dotDamage` ones — everything else already folds correctly via the
+     *  recipient's own ctx through `allyModifierAbilities`, unaffected by this field);
+     *  `sourceCritPower` is that ally's OWN live crit power (base + scheduled/timed self-
+     *  buffs — the same "layers 1+2+3" shape `modifierCtx.selfCritPower` uses for the
+     *  acting actor, computed via `effectiveStatsOf` since the source may not be acting
+     *  this round — see engine.ts's `buildTurnArgs`). Defaults to `[]` — absent/empty is
+     *  byte-identical to pre-I4c behavior. */
+    allyDotDamageAuraSources?: {
+        sourceId: string;
+        sourceCritPower: number;
+        abilities: Ability[];
+    }[];
 }
 
 // ---------------------------------------------------------------------------
@@ -1429,21 +1455,49 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     // does not feed), so ordering is inert here; every ability folds independently in
     // modifierTotalsFromAbilities. Defaults to [] (pre-I3 callers / no ally aura present)
     // → byte-identical.
-    const modifierAbilities = [
+    const selfModifierAbilities = [
         ...(firingSkill?.abilities ?? []),
         ...(passiveSkill?.abilities ?? []),
-        ...(args.allyModifierAbilities ?? []),
     ];
-    // Sub-project I, PR I4b: pull the enemy-status-name-gated dotDamage abilities (Wildfire's
-    // Scorching Radiation crit-power bonus) OUT of the abilities fed to the cast-time fold
-    // below — they must be re-evaluated per VICTIM per TICK against that victim's own live
-    // status (turnCtx.victimGatedDotDamage, resolved in engine.ts's tickDoTs), not baked once
-    // against the primary target. `dotDamageUnconditional` carries every OTHER ability
+    const modifierAbilities = [...selfModifierAbilities, ...(args.allyModifierAbilities ?? [])];
+    // Sub-project I, PR I4b/I4c: pull the enemy-status-name-gated dotDamage abilities
+    // (Wildfire's Scorching Radiation crit-power bonus) OUT of the abilities fed to the
+    // cast-time fold below — they must be re-evaluated per VICTIM per TICK against that
+    // victim's own live status (turnCtx.victimGatedDotDamage, resolved in engine.ts's
+    // tickDoTs), not baked once against the primary target. `dotDamageUnconditional` is
+    // derived from the FULL flat list (self + every ally aura source) so it correctly
+    // excludes name-gated dotDamage from EITHER provenance — carries every OTHER ability
     // unchanged (all channels, plus any non-name-gated dotDamage source e.g. Decimation set
-    // gear) — for every ship without such a modifier this equals `modifierAbilities` and the
+    // gear); for every ship without such a modifier this equals `modifierAbilities` and the
     // fold below is byte-identical to before.
-    const { unconditional: dotDamageUnconditional, conditional: dotDamageConditional } =
+    //
+    // I4c: the CONDITIONAL half is no longer taken from the flat list, because the flat list
+    // loses PROVENANCE (self vs. which ally sourced it) — and the locked game rule requires
+    // Wildfire's team-aura bonus to scale by the SOURCE's crit power, not the recipient's
+    // (`modifierCtx.selfCritPower` below is the RECIPIENT's). Instead: this actor's OWN
+    // conditional dotDamage (unchanged from I4b — ctx = modifierCtx) is partitioned from
+    // `selfModifierAbilities` ALONE, and each ally aura source contributes its OWN entry,
+    // partitioned from JUST that source's abilities, with `selfCritPower` swapped to that
+    // source's own live crit power. No double-apply: a given ability object is folded via
+    // AT MOST one of {dotDamageUnconditional, the self entry, one ally-source entry} — the
+    // flat-list `unconditional` split above already removes every name-gated ability
+    // (self AND ally) from the general fold, and each ally source's abilities are
+    // partitioned in isolation (one source's list can't leak into another's or into self's).
+    const { unconditional: dotDamageUnconditional } =
         partitionDotDamageAbilities(modifierAbilities);
+    const selfDotDamageConditional = partitionDotDamageAbilities(selfModifierAbilities).conditional;
+    const allyDotDamageGated = (args.allyDotDamageAuraSources ?? [])
+        .map((src) => ({
+            abilities: partitionDotDamageAbilities(src.abilities).conditional,
+            ctx: { ...modifierCtx, selfCritPower: src.sourceCritPower },
+        }))
+        .filter((entry) => entry.abilities.length > 0);
+    const victimGatedDotDamage = [
+        ...(selfDotDamageConditional.length > 0
+            ? [{ abilities: selfDotDamageConditional, ctx: modifierCtx }]
+            : []),
+        ...allyDotDamageGated,
+    ];
     // Final four-layer effective-stat fold (layer 1 scheduledTotals + layers 2+3
     // abilitySelfEffects + layer 4 modifierAbilities gated by modifierCtx). The accessor
     // reproduces the prior inline fold byte-for-byte; the turn loop owns gating/side effects.
@@ -2487,12 +2541,11 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         effectiveMaxHp: effectiveHp,
         outgoingHealPct: dmgStats.totals.outgoingHealBuff,
         incomingHealPct: dmgStats.totals.incomingHealBuff,
-        // PR I4b: only set when this cast actually carries a victim-gated dotDamage ability —
-        // undefined for every ship without one (the common case), so tickDoTs' fast path
-        // (`ctx.victimGatedDotDamage` falsy → use `dotMult` unchanged) is byte-identical.
-        ...(dotDamageConditional.length > 0
-            ? { victimGatedDotDamage: { abilities: dotDamageConditional, ctx: modifierCtx } }
-            : {}),
+        // PR I4b/I4c: only set when this cast's own abilities OR a distributed ally aura
+        // actually carry a victim-gated dotDamage ability — undefined for every ship without
+        // one (the common case), so tickDoTs' fast path (`ctx.victimGatedDotDamage` falsy →
+        // use `dotMult` unchanged) is byte-identical.
+        ...(victimGatedDotDamage.length > 0 ? { victimGatedDotDamage } : {}),
     };
 
     // Per-cast attacker-side scalars for the positional apply path (Task 7). Sourced from


### PR DESCRIPTION
## Sub-project I, PR I4c — Wildfire team-wide Inferno aura scaled by source crit power (FINAL)

Third/final part of the Wildfire sub-epic (I4a+I4b merged) and the **last open item of the combat-realism epic**. Spec §5.1/§5.2/§9.

### The aura
Wildfire refit-3: "When an enemy has Scorching Radiation, **all allies** deal 2% additional Inferno damage to that unit for every 10% crit power." **Locked game rule (user):** the "per 10% crit power" scales by **Wildfire's** (the aura source's) crit power, not the dealing ally's.

### The bug this fixes
Because the aura is `target:'all-allies'`, I3 already distributed it into each ally's `modifierAbilities`, and I4b folded it via `victimGatedDotDamage` using the **recipient ally's** `modifierCtx.selfCritPower` — i.e. scaled by the wrong ship's crit power.

### Change
- `victimGatedDotDamage` generalized from a single `{abilities, ctx}` to a **list**. Self's own conditional dotDamage keeps `modifierCtx` (unchanged from I4b); each **ally aura source** contributes its own entry with `ctx = {...modifierCtx, selfCritPower: <source's crit power>}`.
- `engine.ts buildTurnArgs` builds `allyDotDamageAuraSources`: for each living same-side ally (excluding self) with an `all-allies` **dotDamage** modifier, computes the source's crit power via `effectiveStatsOf(...).critDamage` (works for a non-acting source — reads live status-engine state). `victimDotMult` loops the list, re-evaluating each entry's gate per-victim (I4b machinery).
- **No double-apply**: I3's existing `x.id !== a.id` exclusion means a source's own copy folds exactly once (self path, own ctx); the ally-source path only sees OTHER actors. The unconditional dotDamage fold still derives from the full flat list, so non-Wildfire channels are untouched.

### Tests
New `wildfireTeamAuraCritPower.integration.test.ts` (4): low-crit-power ally boosted by **Wildfire's high** crit power (not its own); no boost without Scorching Radiation; single-actor no-double-apply; enemy-side team-symmetry.

### Validation
tsc · lint (0) · full suite (3891) · `audit:skills` (0). Goldens **byte-identical**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPheh4qisgdG9PazKJMkiF
