### PR TITLE
chore(audit): record always-crit + innate shield-pen as data-layer mechanics

### DIFF
--- a/scripts/auditSkills.allowlist.ts
+++ b/scripts/auditSkills.allowlist.ts
@@ -76,6 +76,40 @@ export const ALLOWLIST: AllowEntry[] = [
         reason: '"while this Unit deals…" is simultaneity, not a gate.',
     },
 
+    // ── always-crit: handled at the DATA layer, not the parser ──────────────────
+    // These ships' crit rate is set to 100% by the game-data import, so the "always
+    // critical" clause needs no ability-model flag (a flag would double-count).
+    {
+        ship: 'Asphodel',
+        rules: ['always-crit'],
+        reason: 'Crit rate set to 100% in import data; parser flag would double-count.',
+    },
+    {
+        ship: 'Tormenter',
+        rules: ['always-crit'],
+        reason: 'Crit rate set to 100% in import data; parser flag would double-count.',
+    },
+
+    // ── shield-penetration-innate: handled at the DATA layer, not the parser ─────
+    // "This Unit has X% Shield Penetration" ships already carry shield penetration as a
+    // filled ship stat (import/template data); parsing the clause would double-count.
+    ...[
+        'Crucialis',
+        'Curator',
+        'FrontLine',
+        'Guardian',
+        'Liberator',
+        'Medved',
+        'Provider',
+        'Sustainer',
+        'Vindicator',
+        'Xcellence',
+    ].map((ship) => ({
+        ship,
+        rules: ['shield-penetration-innate'],
+        reason: 'Shield penetration already filled as a ship stat by import/template data.',
+    })),
+
     // Burst-explosion reference — not an accumulate-detonate application.
     {
         ship: 'Valkyrie',

--- a/scripts/auditSkills.ts
+++ b/scripts/auditSkills.ts
@@ -205,6 +205,28 @@ const RULES: Rule[] = [
         handled: (a) => hasType(a, 'dot'),
     },
     {
+        id: 'always-crit',
+        severity: 'medium',
+        // "This Unit's attacks are always critical" (Asphodel) / "always lands critical
+        // hits" (Tormenter). Deliberately NEVER parser-handled: the game-data import sets
+        // these ships' crit rate to 100%, so an ability-model flag would double-count.
+        // The allowlist records the known ships; a NEW ship matching this keyword should
+        // be verified to carry crit 100 in its import/template data, then allowlisted.
+        keyword: (t) => /always\s+(?:lands?\s+)?critical/i.test(t),
+        handled: () => false,
+    },
+    {
+        id: 'shield-penetration-innate',
+        severity: 'medium',
+        // "This Unit has X% Shield Penetration". Deliberately NEVER parser-handled: shield
+        // penetration is already a filled ship stat (import/template data) for every ship
+        // carrying this clause, so parsing it would double-count. The allowlist records the
+        // known ships; a NEW ship matching this keyword should have its stat verified, then
+        // be allowlisted.
+        keyword: (t) => /has\s+\d+(?:\.\d+)?%\s+shield\s+penetration/i.test(t),
+        handled: () => false,
+    },
+    {
         id: 'accumulate-detonate',
         severity: 'high',
         keyword: (t) => /echoing burst/i.test(t),


### PR DESCRIPTION
Two new audit rules — `always-crit` and `shield-penetration-innate` — that are **deliberately never parser-handled**, per the data-layer decision from the skill-model gap epic scoping:

- **Always-crit** ships (Asphodel, Tormenter) have their crit rate set to 100% by the game-data import; an ability-model flag would double-count.
- **Innate shield penetration** ("This Unit has X% Shield Penetration") is already a filled ship stat for every clause-carrying ship; parsing the clause would double-count.

The allowlist records the known ships with the data-layer reason. The new shield-pen rule immediately caught **Xcellence**, which the gap sweep's finders had missed — validating the rule. Any future CSV refresh that adds a ship with either phrasing now surfaces as an audit finding, prompting a verify-the-stat check instead of silently going unmodeled.

`npm run audit:skills`: 147 ships → 0 findings. Full vitest suite green (3891 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPuPgS4wJVpPkudSwLAHjR