### PR TITLE
fix(skills): suppress phantom abilities from reduction clauses and Amartya taunt (epic PR1)

### DIFF
--- a/scripts/auditSkills.allowlist.ts
+++ b/scripts/auditSkills.allowlist.ts
@@ -90,6 +90,18 @@ export const ALLOWLIST: AllowEntry[] = [
         reason: 'Crit rate set to 100% in import data; parser flag would double-count.',
     },
 
+    // ── base-damage: incoming-reduction clause, not an attack (epic PR1) ────────
+    // "gains up to 30% damage reduction as its health decreases" matches the base-damage
+    // keyword regex (contains "N% damage") but is HP-scaled incoming damage reduction, not an
+    // attack — PR1 fixed parseSkillDamage to stop minting a phantom on-cast damage{30} ability
+    // from it. Modeling the actual incoming-reduction mechanic is deferred to epic PR12
+    // (incoming-reduction phrasings: Anemone/Panon/Wusheng/Tormenter).
+    {
+        ship: 'Tormenter',
+        rules: ['base-damage'],
+        reason: 'passive2 "gains up to 30% damage reduction as its health decreases" is HP-scaled incoming damage reduction, not an attack — deferred to epic PR12 (incoming-reduction phrasings).',
+    },
+
     // ── shield-penetration-innate: handled at the DATA layer, not the parser ─────
     // "This Unit has X% Shield Penetration" ships already carry shield penetration as a
     // filled ship stat (import/template data); parsing the clause would double-count.

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -17,6 +17,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Lodolite's charged skill now purges all buffs from the enemy with the most buffs, and her legendary refit strips 100% of that enemy's shield when she does.",
     "Combat sim: Wildfire's bonus Inferno damage against an enemy with Scorching Radiation (scaling with her own crit power, 1% per 10% crit power, 2% with her refit) is now re-checked on every Inferno tick against each affected enemy individually — a target that never had Scorching Radiation (or whose Scorching Radiation has since expired) no longer gets the bonus just because another of her targets currently has it.",
     "Combat sim: Wildfire's refit-3 passive now actually reaches the team — every living ally's Inferno damage against an enemy with Scorching Radiation is boosted by 2% per 10% of Wildfire's own crit power (not the ally's), matching her skill text.",
+    'Fixed skill parsing that inflated DPS for Tormenter, Voron, Malvex, and FrontLine — defensive damage-reduction (and shield-scaling) clauses were being counted as extra attacks. Also fixed Amartya, who no longer grants herself a phantom Taunt buff from her "enemy gains Taunt" trigger text, and now correctly inflicts 2 stacks of Exposed (not 1) from her legendary refit passive.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -101,6 +101,46 @@ describe('parseSkillDamage', () => {
             'Deals <unit-damage>100% damage</unit-damage> plus extra based on <unit-damage>50%</unit-damage> of its HP';
         expect(parseSkillDamage(text)).toBe(100);
     });
+
+    // Epic PR1 (skill-model gap, finding family 1): damage-REDUCTION / conversion clauses were
+    // being read as outgoing attack multipliers because the tag content or nearby text merely
+    // mentions the word "damage" — the heuristic never distinguished incoming reduction from an
+    // outgoing hit. Exact clauses from docs/ship-skills.csv.
+    it('skips "X% damage reduction" (Tormenter p2 — incoming HP-scaled reduction, not an attack)', () => {
+        const text =
+            'This Unit always lands critical hits and gains up to <unit-damage>30% damage</unit-damage> reduction as its health decreases.';
+        expect(parseSkillDamage(text)).toBe(0);
+    });
+
+    it('skips "takes X% less damage from Y" (Voron p2 — DoT-scoped incoming reduction)', () => {
+        const text =
+            'This Unit takes <unit-damage>20% less damage</unit-damage> from <unit-skill>Damage over Time effects</unit-skill>.';
+        expect(parseSkillDamage(text)).toBe(0);
+    });
+
+    it('skips "takes X% less damage" (Malvex p2 — when-Shielded incoming reduction)', () => {
+        const text = 'When Shielded, this Ship takes <unit-damage>10% less damage</unit-damage>.';
+        expect(parseSkillDamage(text)).toBe(0);
+    });
+
+    it('skips "Shield equal to X% of the damage dealt" (FrontLine p2 — shield scaled off damage, not an attack)', () => {
+        const text =
+            'When an enemy uses their Charged skill, it deals <unit-damage>80%</unit-damage> and gains a Shield equal to <unit-damage>30%</unit-damage> of the damage dealt, once per round.';
+        // The real reactive 80% hit is parsed separately by parseEnemyChargedCastReaction (its own
+        // dedicated regex), NOT by this generic scanner — the "80%" tag has no "damage" word within
+        // its own content or the next 20 chars, so parseSkillDamage never reaches it here. This
+        // assertion only guards that the "30%" shield-scaling tag is never mistaken for a base
+        // multiplier (which is what minted the phantom on-cast damage{30} ability pre-fix).
+        expect(parseSkillDamage(text)).toBe(0);
+    });
+
+    it('still parses a genuine damage clause that merely sits near a reduction-family word elsewhere', () => {
+        // Negative companion: Tormenter's OWN active skill still parses its base multiplier —
+        // the reduction guard must not blanket-suppress ordinary "X% damage" tags.
+        const text =
+            'This Unit deals <unit-damage>160% damage</unit-damage> with a guaranteed critical hit and grants <unit-skill>Out. Damage Up I</unit-skill> to itself and all adjacent allies for 1 turn.';
+        expect(parseSkillDamage(text)).toBe(160);
+    });
 });
 
 describe('detectFullyCharged', () => {
@@ -880,6 +920,50 @@ describe('parseSkillEffects', () => {
                 'active'
             )
         ).toEqual([]);
+    });
+
+    // Epic PR1 (skill-model gap, finding family 3): Amartya's "When an enemy defender gains
+    // Taunt, this Unit inflicts N stacks of Exposed on that defender." names Taunt only as the
+    // TRIGGER condition (the enemy is the one gaining it) — the segment loop's verb scan doesn't
+    // check WHO the "gains" verb's subject is, so it minted a phantom self Taunt grant. Exact
+    // clause from docs/ship-skills.csv (Amartya passive2/passive3).
+    it('does not mint a phantom self Taunt grant from an enemy-gains-Taunt trigger clause (Amartya)', () => {
+        const text =
+            'When an enemy defender gains <unit-skill>Taunt</unit-skill>, this Unit inflicts 1 stacks of <unit-skill>Exposed</unit-skill> on that defender.';
+        const result = parseSkillEffects(text, 'passive2');
+        expect(result.find((e) => e.buffName === 'Taunt')).toBeUndefined();
+        expect(result).toEqual([
+            {
+                buffName: 'Exposed',
+                target: 'enemy',
+                duration: 'recurring',
+                stacks: 1,
+                stackTrigger: 'per-round',
+                application: 'inflict',
+                source: 'passive2',
+            },
+        ]);
+    });
+
+    it('still recognizes a genuine self-grant that merely mentions "enemy" earlier in the sentence', () => {
+        // Negative companion: "this Unit" is the true, closer subject of "gains" — the
+        // enemy-subject guard must not blanket-suppress every "gains" that follows an
+        // earlier "enemy" mention in the same sentence.
+        const text =
+            'When an enemy cleanses a Debuff, this Unit gains <unit-skill>Gelecek Contagion I</unit-skill> for 2 turns.';
+        expect(parseSkillEffects(text, 'passive1')).toEqual([
+            { buffName: 'Gelecek Contagion I', target: 'self', duration: 2, source: 'passive1' },
+        ]);
+    });
+
+    it('already extracts the explicit stack count correctly at this layer (Amartya Exposed, R4)', () => {
+        // parseSkillEffects itself is not where the R4 "2 stacks" gets lost — see
+        // skillBuffAutoFill.test.ts for the downstream (toSelectedBuffs) red test that reproduces
+        // the actual bug.
+        const text =
+            'When an enemy defender gains <unit-skill>Taunt</unit-skill>, this Unit inflicts 2 stacks of <unit-skill>Exposed</unit-skill> on that defender.';
+        const result = parseSkillEffects(text, 'passive3');
+        expect(result.find((e) => e.buffName === 'Exposed')?.stacks).toBe(2);
     });
 });
 

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -4076,3 +4076,193 @@ describe('buildShipAbilities — enemy-targeted charge removal (Phase 1 Task 3)'
         });
     });
 });
+
+// Epic PR1 (skill-model gap, finding family 1): damage-reduction / shield-scaled-off-damage
+// clauses were being minted as phantom on-cast attacks because parseSkillDamage's "does this
+// tag mention 'damage'?" heuristic can't distinguish an outgoing hit from an incoming-reduction
+// or shield-scaling clause. All texts below are exact CSV clauses (docs/ship-skills.csv),
+// assigned to their REAL slot fields (matching how buildShipAbilities is actually invoked in
+// production via getShipSkillRows) — not the audit script's "treat every slot as active"
+// simplification.
+describe('buildShipAbilities — PR1 phantom-ability suppression (reduction/conversion clauses)', () => {
+    it('Tormenter passive2 (R2): no phantom damage ability from "30% damage reduction"', () => {
+        const s = ship({
+            refits: [{}, {}] as never,
+            firstPassiveSkillText: 'This Unit always lands critical hits.',
+            secondPassiveSkillText:
+                'This Unit always lands critical hits and gains up to <unit-damage>30% damage</unit-damage> reduction as its health decreases.',
+        });
+        const { slots } = buildShipAbilities(s);
+        const passive = slot(slots, 'passive');
+        expect(passive?.abilities.some((a) => a.type === 'damage') ?? false).toBe(false);
+    });
+
+    it('Tormenter active still parses its real 160% base damage (negative companion)', () => {
+        const s = ship({
+            activeSkillText:
+                'This Unit deals <unit-damage>160% damage</unit-damage> with a guaranteed critical hit and grants <unit-skill>Out. Damage Up I</unit-skill> to itself and all adjacent allies for 1 turn.',
+        });
+        const { slots } = buildShipAbilities(s);
+        const active = slot(slots, 'active')!;
+        expect(abilityOfType(active.abilities, 'damage')).toMatchObject({
+            config: { type: 'damage', multiplier: 160 },
+        });
+    });
+
+    it('Voron passive2 (R2): no phantom damage ability from "takes 20% less damage from DoTs"', () => {
+        const s = ship({
+            refits: [{}, {}] as never,
+            firstPassiveSkillText:
+                'When directly damaged, this Unit transforms the damage into a <unit-skill>Damage over Time effect</unit-skill> effect lasting for 3 turns.',
+            secondPassiveSkillText:
+                'When directly damaged, this Unit transforms the damage into a <unit-skill>Damage over Time effect</unit-skill> lasting for 3 turns.<br /><br />This Unit takes <unit-damage>20% less damage</unit-damage> from <unit-skill>Damage over Time effects</unit-skill>.',
+        });
+        const { slots } = buildShipAbilities(s);
+        const passive = slot(slots, 'passive');
+        expect(passive?.abilities.some((a) => a.type === 'damage') ?? false).toBe(false);
+    });
+
+    it('Malvex passive2 (R2): no phantom damage ability from "takes 10% less damage"', () => {
+        const s = ship({
+            refits: [{}, {}] as never,
+            firstPassiveSkillText:
+                'When directly damaged as a primary target, this Unit gains <unit-damage>Shield equal to 15%</unit-damage> of the Damage dealt to them.',
+            secondPassiveSkillText:
+                'When Shielded, this Ship takes <unit-damage>10% less damage</unit-damage>. When directly damaged as a primary target, this Unit gains <unit-damage>Shield equal to 15%</unit-damage> of the Damage dealt to them.',
+        });
+        const { slots } = buildShipAbilities(s);
+        const passive = slot(slots, 'passive');
+        expect(passive?.abilities.some((a) => a.type === 'damage') ?? false).toBe(false);
+        // The (separately-tracked, out-of-scope) on-attacked shield-gain clause is untouched.
+        expect(passive?.abilities.some((a) => a.type === 'shield')).toBe(true);
+    });
+
+    it('FrontLine passive2 (R2): phantom on-cast damage(30) from the shield clause is gone, real on-enemy-charged-cast damage(80) survives', () => {
+        const s = ship({
+            refits: [{}, {}] as never,
+            firstPassiveSkillText:
+                'This ship has 20% Shield Penetration.<br />While Shielded, it gains 2500 additional Defense.<br />This Unit gains <unit-damage>Shield equal to 25%</unit-damage> of its Max HP at the start of combat.',
+            secondPassiveSkillText:
+                'This ship has 20% Shield Penetration.<br />While Shielded, it gains 2500 additional Defense.<br />This Unit gains <unit-damage>Shield equal to 25%</unit-damage> of its Max HP at the start of combat.<br /><br />When an enemy uses their Charged skill, it deals <unit-damage>80%</unit-damage> and gains a Shield equal to <unit-damage>30%</unit-damage> of the damage dealt, once per round.',
+        });
+        const { slots } = buildShipAbilities(s);
+        const passive = slot(slots, 'passive')!;
+        const damageAbilities = passive.abilities.filter((a) => a.type === 'damage');
+        // Exactly one damage ability — the real on-enemy-charged-cast reactive hit — no phantom
+        // on-cast multiplier-30 sibling.
+        expect(damageAbilities).toHaveLength(1);
+        expect(damageAbilities[0]).toMatchObject({
+            trigger: 'on-enemy-charged-cast',
+            config: { type: 'damage', multiplier: 80 },
+        });
+        expect(damageAbilities.some((a) => a.trigger === 'on-cast')).toBe(false);
+    });
+});
+
+// Epic PR1 (skill-model gap, finding family 2): the sweep report's "trigger-phrase DoT
+// re-application" claim for Wisteria/Valerian/Lingshe/Belladonna was reproduced by the sweep's
+// OWN methodology (docs/skill-model-gap-sweep-2026-07-03.md: "each slot parsed in isolation as
+// the active slot"), which routes passive text through buildDoTAutoFill's active/charge-only DoT
+// auto-fill. Under REAL usage — text assigned to its correct slot field, exactly how
+// buildShipAbilities is invoked via getShipSkillRows in production — buildDoTAutoFill never sees
+// passive text, so the phantom DoT does not reproduce for any of the four ships. These tests were
+// RED-checked (asserted the phantom absent) BEFORE any parser change and already passed —
+// confirmed FALSE POSITIVE; no parser change was made for this family. Kept as regression guards.
+describe('buildShipAbilities — PR1 finding family 2 (confirmed FALSE POSITIVE under real usage)', () => {
+    it('Wisteria passive1 (R0): no phantom Corrosion dot from the "after applying Corrosion" trigger phrase', () => {
+        const s = ship({
+            refits: [] as never,
+            firstPassiveSkillText:
+                'This Unit, after applying <unit-skill>Corrosion</unit-skill> with a Critical hit, inflicts <unit-skill>Inferno II</unit-skill> for 2 turns.',
+        });
+        const { slots } = buildShipAbilities(s);
+        const passive = slot(slots, 'passive');
+        expect(passive?.abilities.some((a) => a.type === 'dot') ?? false).toBe(false);
+    });
+
+    it('Valerian passive2 (R2): no phantom Corrosion dot from "After inflicting Corrosion with a Critical hit"', () => {
+        const s = ship({
+            refits: [{}, {}] as never,
+            firstPassiveSkillText:
+                'This Unit <unit-damage>repairs 15%</unit-damage> of Damage dealt to the enemy, including inflcted Damage over Time effects.',
+            secondPassiveSkillText:
+                'This Unit <unit-damage>repairs 15%</unit-damage> of damage dealt to an enemy, including damage from damage over time effects. After inflicting <unit-skill>Corrosion</unit-skill> with a Critical hit, the duration of the newly applied <unit-skill>Corrosion</unit-skill> is extended by 1 turn, with the extension chance equal to the Critical Power.',
+        });
+        const { slots } = buildShipAbilities(s);
+        const passive = slot(slots, 'passive')!;
+        expect(passive.abilities.some((a) => a.type === 'dot')).toBe(false);
+        // The real extend-dot ability (self-crit gated) is still there, unaffected.
+        expect(passive.abilities.some((a) => a.type === 'extend-dot')).toBe(true);
+    });
+
+    it('Lingshe passive1 (R0): no phantom Bomb dot from "When this Unit inflicts a Bomb"', () => {
+        const s = ship({
+            refits: [] as never,
+            firstPassiveSkillText:
+                'When this Unit inflicts a <unit-skill>Bomb</unit-skill> it gains <unit-skill>Stealth</unit-skill> for 1 turn.',
+        });
+        const { slots } = buildShipAbilities(s);
+        const passive = slot(slots, 'passive');
+        expect(passive?.abilities.some((a) => a.type === 'dot') ?? false).toBe(false);
+    });
+
+    it('Belladonna passive1 (R0): no phantom Corrosion dot from "When an ally inflicts Corrosion"', () => {
+        const s = ship({
+            refits: [] as never,
+            firstPassiveSkillText:
+                'When an ally inflicts <unit-skill>Corrosion</unit-skill>, this Unit has a chance to convert the <unit-skill>Corrosion</unit-skill> into <unit-skill>Acidic Decay</unit-skill> of the same level, with the chance scaling at 1% per 10 Hacking.',
+        });
+        const { slots } = buildShipAbilities(s);
+        const passive = slot(slots, 'passive');
+        expect(passive?.abilities.some((a) => a.type === 'dot') ?? false).toBe(false);
+    });
+});
+
+// Epic PR1 (skill-model gap, finding family 3): Amartya's "When an enemy defender gains Taunt,
+// this Unit inflicts N stacks of Exposed" minted a phantom self Taunt grant (the trigger clause's
+// buff misread as a self-application) and force-collapsed the explicit "2 stacks" count to 1.
+describe('buildShipAbilities — PR1 Amartya phantom Taunt + Exposed stack count', () => {
+    it('passive2 (R2): no self Taunt buff ability; Exposed debuff carries 1 stack', () => {
+        const s = ship({
+            refits: [{}, {}] as never,
+            firstPassiveSkillText:
+                'When an enemy defender is directly repaired, this Unit inflicts 1 stack of <unit-skill>Defense Shred</unit-skill> on that defender.',
+            secondPassiveSkillText:
+                'When an enemy defender is directly repaired, this Unit inflicts 1 stack of <unit-skill>Defense Shred</unit-skill> on that defender.<br /><br />When an enemy defender gains <unit-skill>Taunt</unit-skill>, this Unit inflicts 1 stacks of <unit-skill>Exposed</unit-skill> on that defender.',
+        });
+        const { slots } = buildShipAbilities(s);
+        const passive = slot(slots, 'passive')!;
+        const taunt = passive.abilities.find(
+            (a) => a.type === 'buff' && (a.config as { buffName?: string }).buffName === 'Taunt'
+        );
+        expect(taunt).toBeUndefined();
+        const exposed = passive.abilities.find(
+            (a) => a.type === 'debuff' && (a.config as { buffName?: string }).buffName === 'Exposed'
+        );
+        expect(exposed).toBeDefined();
+        expect((exposed!.config as { stacks?: number }).stacks).toBe(1);
+    });
+
+    it('passive3 (R4): Exposed debuff carries the explicit 2-stack count', () => {
+        const s = ship({
+            refits: [{}, {}, {}, {}] as never,
+            firstPassiveSkillText:
+                'When an enemy defender is directly repaired, this Unit inflicts 1 stack of <unit-skill>Defense Shred</unit-skill> on that defender.',
+            secondPassiveSkillText:
+                'When an enemy defender is directly repaired, this Unit inflicts 1 stack of <unit-skill>Defense Shred</unit-skill> on that defender.<br /><br />When an enemy defender gains <unit-skill>Taunt</unit-skill>, this Unit inflicts 1 stacks of <unit-skill>Exposed</unit-skill> on that defender.',
+            thirdPassiveSkillText:
+                'When an enemy defender is directly repaired, this Unit inflicts 2 stack of <unit-skill>Defense Shred</unit-skill> on that defender.<br /><br />When an enemy defender gains <unit-skill>Taunt</unit-skill>, this Unit inflicts 2 stacks of <unit-skill>Exposed</unit-skill> on that defender.',
+        });
+        const { slots } = buildShipAbilities(s);
+        const passive = slot(slots, 'passive')!;
+        const taunt = passive.abilities.find(
+            (a) => a.type === 'buff' && (a.config as { buffName?: string }).buffName === 'Taunt'
+        );
+        expect(taunt).toBeUndefined();
+        const exposed = passive.abilities.find(
+            (a) => a.type === 'debuff' && (a.config as { buffName?: string }).buffName === 'Exposed'
+        );
+        expect(exposed).toBeDefined();
+        expect((exposed!.config as { stacks?: number }).stacks).toBe(2);
+    });
+});

--- a/src/utils/calculators/__tests__/skillBuffAutoFill.test.ts
+++ b/src/utils/calculators/__tests__/skillBuffAutoFill.test.ts
@@ -105,6 +105,38 @@ describe('buildSkillBuffAutoFill', () => {
         const count = result.selfBuffs.filter((b) => b.buffName === 'Attack Up III').length;
         expect(count).toBe(1);
     });
+
+    // Epic PR1 (skill-model gap, finding family 3b): Exposed isn't in the BUFFS "stackable" set
+    // (it's a binary status, not an accumulating one), so toSelectedBuffs's
+    // `stacks: stackTrigger ? (effect.stacks ?? 1) : 1` forced every Exposed grant to 1 stack
+    // regardless of what the text actually said. Amartya's R4 passive explicitly inflicts "2
+    // stacks of Exposed" — the parsed count must survive even though Exposed never accumulates
+    // across separate triggers. Exact clause from docs/ship-skills.csv (Amartya passive3).
+    it('preserves an explicit multi-stack count on a non-mechanically-stackable debuff (Amartya Exposed, R4)', () => {
+        const ship = {
+            thirdPassiveSkillText:
+                'When an enemy defender gains <unit-skill>Taunt</unit-skill>, this Unit inflicts 2 stacks of <unit-skill>Exposed</unit-skill> on that defender.',
+            refits: [{}, {}, {}, {}],
+        } as unknown as Ship;
+        const result = buildSkillBuffAutoFill(ship);
+        const exposed = result.enemyDebuffs.find((b) => b.buffName === 'Exposed');
+        expect(exposed).toBeDefined();
+        expect(exposed?.isStackable).toBe(false);
+        expect(exposed?.stacks).toBe(2);
+    });
+
+    it('still forces a single stack when the text states only 1 (Amartya Exposed, R0/R2)', () => {
+        // Negative companion: the R0/R2 clause says "1 stacks of Exposed" — must stay 1, not be
+        // inflated by the R4 fix.
+        const ship = {
+            secondPassiveSkillText:
+                'When an enemy defender gains <unit-skill>Taunt</unit-skill>, this Unit inflicts 1 stacks of <unit-skill>Exposed</unit-skill> on that defender.',
+            refits: [{}, {}],
+        } as unknown as Ship;
+        const result = buildSkillBuffAutoFill(ship);
+        const exposed = result.enemyDebuffs.find((b) => b.buffName === 'Exposed');
+        expect(exposed?.stacks).toBe(1);
+    });
 });
 
 describe('mergeAutoFill', () => {

--- a/src/utils/calculators/skillBuffAutoFill.ts
+++ b/src/utils/calculators/skillBuffAutoFill.ts
@@ -73,8 +73,13 @@ function toSelectedBuffs(
             // must NOT share an id. Manually-added picker entries still use the bare buff name.
             id: `${buff.name}-${effect.source}-${effect.target}`,
             buffName: buff.name,
-            // For accumulating buffs, stacks = rate per trigger; otherwise always 1.
-            stacks: stackTrigger ? (effect.stacks ?? 1) : 1,
+            // For accumulating buffs, stacks = rate per trigger. Otherwise, use whatever count
+            // the text explicitly stated for THIS single application (e.g. Amartya's "2 stacks of
+            // Exposed" — Exposed isn't mechanically "stackable" across triggers, but the count of
+            // a single infliction is still real data the parser must not discard). Epic PR1
+            // (skill-model gap, finding family 3b): previously hard-forced to 1 whenever
+            // stackTrigger was absent, silently dropping any parsed count > 1.
+            stacks: effect.stacks ?? 1,
             parsedEffects,
             isStackable: stackInfo.stackable,
             maxStacks: stackInfo.maxStacks,

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -156,12 +156,29 @@ export function extractSkillNames(skillText: string | null | undefined): string[
     return [...new Set(matches)]; // Remove duplicates
 }
 
+// Epic PR1 (skill-model gap, finding family 1): a <unit-damage> tag whose CONTENT says "X% less
+// damage" is an INCOMING-damage reduction (Voron "takes 20% less damage from DoTs", Malvex "takes
+// 10% less damage"), never an outgoing attack multiplier.
+const LESS_DAMAGE_RE = /\bless\s+damage\b/i;
+// A tag reading "X% damage" immediately followed by " reduction …" (Tormenter "gains up to 30%
+// damage reduction as its health decreases") is the same incoming-reduction family — the
+// "reduction" noun sits just outside the tag, in the next ~15 chars.
+const DAMAGE_REDUCTION_FOLLOWING_RE = /^\s*reduction\b/i;
+// A bare percentage tag ("<unit-damage>30%</unit-damage>") preceded by "Shield equal to " is a
+// shield-scaling clause ("gains a Shield equal to 30% of the damage dealt", FrontLine) — the
+// nearby word "damage" describes what the SHIELD scales off of, not an attack the tag itself
+// represents.
+const SHIELD_EQUAL_TO_LEAD_IN_RE = /shield\s+equal\s+to\s*$/i;
+
 /**
  * Returns the first <unit-damage>X% ...</unit-damage> value in skill text.
  * Skips values where the 20 characters after the tag start with " of its" or " of this"
  * (stat-based damage like "30% of its DEF" or "10% of this Unit's max HP" —
  * must be added manually as a buff).
  * Secondary damage tags (conditional/situational bonuses) are ignored.
+ * Also skips incoming-damage-reduction clauses ("X% less damage", "X% damage reduction") and
+ * shield-scaled-off-damage clauses ("Shield equal to X% of the damage dealt") — neither is an
+ * outgoing attack, even though both sit near the word "damage" (PR1 phantom-ability suppression).
  * Returns an integer percentage (e.g. 190 for "190% damage"), or 0 if none found.
  */
 export function parseSkillDamage(text: string): number {
@@ -177,6 +194,14 @@ export function parseSkillDamage(text: string): number {
         // "X% more (direct) damage" is a passive output MODIFIER, not a base skill
         // multiplier — skip it (parseModifier handles it). e.g. Thresh's passive.
         if (/\bmore\b/i.test(match[1])) continue;
+        // Incoming-damage reduction, either "X% less damage" inside the tag or "X% damage"
+        // immediately followed by "reduction" outside it — not an outgoing attack.
+        if (LESS_DAMAGE_RE.test(match[1])) continue;
+        if (DAMAGE_REDUCTION_FOLLOWING_RE.test(following)) continue;
+        // "Shield equal to X%" lead-in immediately before the tag — a shield scaled off damage
+        // dealt, not the damage itself.
+        const preceding = text.slice(Math.max(0, match.index - 30), match.index);
+        if (SHIELD_EQUAL_TO_LEAD_IN_RE.test(preceding)) continue;
         // <unit-damage> is also used for non-damage numbers (e.g. "7.5% defense
         // penetration", "repairs 20%"). Only treat it as a base multiplier when the
         // tag content or the following text actually mentions damage.
@@ -3038,6 +3063,46 @@ function findSharedDuration(
     return null;
 }
 
+// Words that pin a self-grant verb's subject to the caster once encountered while scanning
+// backward from the verb — "this Unit gains X" / "it gains X" / "they gain X" (team subjects).
+// Reaching one of these BEFORE an "enemy"/"enemies" word means the verb is a genuine self-grant.
+const SELF_SUBJECT_STOP_WORDS = new Set(['this', 'unit', 'it', 'itself', 'they', 'their', 'ally']);
+// Bound the backward subject scan to a short window — the known shape ("an enemy defender
+// gains") is 1-2 words — so an unrelated, distant "enemy" earlier in a long sentence can never
+// mis-flag an unrelated verb (mirrors the ~20-char window used by the analogous Taunt-only guard
+// in CONTROL_INFLICTS).
+const ENEMY_SUBJECT_SCAN_WINDOW = 6;
+
+/**
+ * True when the application verb at `words[verbIndex]` (a SELF_VERB, e.g. "gains"/"grants") has
+ * "enemy"/"enemies" as its nearer grammatical subject rather than the caster — i.e. the verb sits
+ * inside a trigger/condition clause ("When an enemy defender gains Taunt, …") rather than
+ * describing something THIS Unit receives. Scans backward a short, bounded window and stops as
+ * soon as it hits a caster/team subject word (SELF_SUBJECT_STOP_WORDS), a clause-boundary
+ * keyword, OR any other application/skip verb — crossing a PRIOR verb's territory means an
+ * "enemy" beyond it belongs to a different clause (Ravager: "upon killing an enemy, loses
+ * Overload and gains Marauder Rage III" — "enemy" is killing's object, in an earlier clause than
+ * this "gains"; the intervening "loses" stops the scan before reaching it). No lookbehind (iOS
+ * Safari 15).
+ */
+function hasEnemySubject(words: string[], verbIndex: number): boolean {
+    const limit = Math.max(0, verbIndex - ENEMY_SUBJECT_SCAN_WINDOW);
+    for (let j = verbIndex - 1; j >= limit; j--) {
+        const w = words[j];
+        if (w === 'enemy' || w === 'enemies') return true;
+        if (SELF_SUBJECT_STOP_WORDS.has(w)) return false;
+        if (w === 'when' || w === 'after' || w === 'if' || w === 'while' || w === 'upon')
+            return false;
+        if (APPLICATION_VERBS.has(w) || SKIP_VERBS.has(w)) return false;
+        // "… to that enemy AND gains …" / "loses Overload AND gains …" (Stalwart, Ravager) is a
+        // COMPOUND predicate — "and" carries the subject over from an earlier, unrelated clause
+        // (an elided "it"/"this Unit"), so an "enemy" beyond "and" is never this verb's subject.
+        // The genuine bug shape ("an enemy defender gains X") never has "and" in between.
+        if (w === 'and') return false;
+    }
+    return false;
+}
+
 /**
  * Scans backward through preceding text segments to find the nearest application verb,
  * stopping at sentence boundaries (. ; <br>) or MAX_SCAN_CHARS.
@@ -3077,6 +3142,13 @@ function findVerb(segments: SkillTextSegment[], tagIndex: number): string | null
             // "newly applied X" is adjectival (referencing an existing effect being
             // extended), not an application — keep scanning for a real verb instead.
             if (words[i - 1] === ADJECTIVAL_MARKER) continue;
+            // Epic PR1 (skill-model gap, finding family 3): "when an enemy [defender] gains
+            // <BuffName>, this Unit inflicts …" names the buff only as the TRIGGER condition —
+            // the grammatical subject of "gains" is the ENEMY, not this Unit. Without this
+            // check a self-grant verb (gains/grants) minted a phantom self-buff regardless of
+            // subject (Amartya: "gains Taunt" read as This-Unit-gains-Taunt). Keep scanning past
+            // it for an earlier governing verb (or none) instead of returning it.
+            if (SELF_VERBS.has(words[i]) && hasEnemySubject(words, i)) continue;
             return words[i];
         }
         if (SKIP_VERBS.has(words[i])) return null;


### PR DESCRIPTION
## Summary

PR1 of the skill-model gap epic (Phase 1, spec: `docs/superpowers/specs/2026-07-03-skill-model-gap-epic-design.md`). Suppresses phantom abilities the parser minted from non-effect clauses — the largest DPS-inflation fix in the epic.

### Finding family 1 — reduction/shield clauses parsed as attacks (FIXED)
`parseSkillDamage` now skips:
- `"X% less damage"` inside a `<unit-damage>` tag (Voron "takes 20% less damage from DoTs", Malvex "takes 10% less damage") — incoming reduction, not an attack
- `"X% damage"` immediately followed by `reduction` (Tormenter "gains up to 30% damage reduction as its health decreases")
- a bare-percentage tag preceded by `"Shield equal to "` (FrontLine "gains a Shield equal to 30% of the damage dealt")

Corpus-grep verified these patterns are unique to exactly these ships. FrontLine keeps its real on-enemy-charged-cast `damage{80}`.

### Finding family 2 — trigger-phrase phantom DoTs (CONFIRMED FALSE POSITIVE, no fix)
The sweep's "phantom Corrosion + Inferno tier 30" for Wisteria/Valerian/Lingshe/Belladonna reproduced only under the sweep's parse-every-slot-as-active methodology. In production, `buildDoTAutoFill` filters to active/charge sources, so passive text never reaches the DoT auto-fill — red tests through the real slot routing passed pre-change. Kept as regression guards. (The genuine "inflicts Inferno II after crit-Corrosion" mechanic parses to nothing — a reactive-trigger coverage gap already deferred to epic Phase 3.)

### Finding family 3 — Amartya (FIXED, both sub-findings)
- "When an enemy defender gains Taunt, …" minted a phantom **self** Taunt grant — `findVerb` now checks the verb's grammatical subject (`hasEnemySubject`, bounded 6-word backward scan with self-subject/clause-keyword/verb/"and" stops; all 4 corpus `enemy…gains` shapes verified safe)
- "2 stacks of Exposed" collapsed to 1 — `toSelectedBuffs` no longer forces `stacks: 1` for non-accumulating buffs (Exposed is the only non-stackable multi-count buff in the corpus)

## Verification protocol
Red-test-first per epic spec: families 1 and 3 confirmed RED pre-change (independently re-verified by running the new tests against the old parser: 12 failures); family 2's red test passed pre-change → stop-and-report FP per protocol.

## Validation
- Full vitest: 302 files / 3912 tests green, **zero golden/snapshot churn**
- `npm run lint` 0 warnings, `tsc --noEmit` clean
- `npm run audit:skills` 0 findings (one new allowlist row: Tormenter `base-damage`, reduction clause deferred to epic PR12 incoming-reduction phrasings)
- Changelog entry added to `UNRELEASED_CHANGES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPuPgS4wJVpPkudSwLAHjR