### PR TITLE
fix(skills): control-twin abilities inherit their debuff twin's trigger and conditions (epic PR2)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -19,6 +19,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Wildfire's refit-3 passive now actually reaches the team — every living ally's Inferno damage against an enemy with Scorching Radiation is boosted by 2% per 10% of Wildfire's own crit power (not the ally's), matching her skill text.",
     'Fixed skill parsing that inflated DPS for Tormenter, Voron, Malvex, and FrontLine — defensive damage-reduction (and shield-scaling) clauses were being counted as extra attacks. Also fixed Amartya, who no longer grants herself a phantom Taunt buff from her "enemy gains Taunt" trigger text, and now correctly inflicts 2 stacks of Exposed (not 1) from her legendary refit passive.',
     'Combat sim: enemy supporters (like Graphite) no longer stop granting buffs and shields for the rest of the battle after the first player ship dies.',
+    "Combat sim: fixed conditional control-effect modeling for Crocus, Nayra, Makoli, Flamel, Guardian, and Meiying. Crocus's and Nayra's conditional Stasis (only landing when the target has 4+ debuffs, or was repaired this round) could reach the sim's reaction machinery unconditionally; Makoli, Flamel, Guardian, and Meiying each had a duplicate, always-firing control entry alongside their real (and already correctly gated) Disable, Stasis, and Provoke effects. Both are fixed — actual gameplay-facing effects are unaffected.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/abilities/__tests__/applyAbilities.test.ts
+++ b/src/utils/abilities/__tests__/applyAbilities.test.ts
@@ -9,6 +9,7 @@ import {
     modifierTotalsFromAbilities,
     gateFiringAbilities,
     extraActionsFromSkill,
+    controlAbilitiesFromSkill,
 } from '../applyAbilities';
 import { Ability, Condition, ModifierChannel, ShipSkills, Skill } from '../../../types/abilities';
 import { ConditionContext } from '../evaluateConditions';
@@ -641,5 +642,66 @@ describe('extraActionsFromSkill', () => {
         expect(extraActionsFromSkill(gatedSkillWith)).toEqual([
             { abilityId: 'xa', oncePerRound: true, endOfRound: false },
         ]);
+    });
+});
+
+// Epic PR2 (control-twin gating parity): controlAbilitiesFromSkill is the engine's ONLY
+// consumer of `type:'control'` abilities (playerTurn.ts emits `control-applied` for each entry
+// it returns). It filters strictly to `trigger === 'on-cast'` — mirroring
+// chargeAbilitiesFromSkill / extraActionsFromSkill above, there is no separate reactive
+// execution path for control abilities. This is the empirical basis for buildShipAbilities'
+// PR2 fix: a control ability whose named debuff/buff twin resolves to a REACTIVE trigger
+// (on-attacked, on-ally-attacked, on-enemy-destroyed, …) would be silently and permanently
+// excluded here if it were still emitted with that trigger — which is why the builder drops
+// those entries outright instead of emitting a dead, unconsumed ability.
+describe('controlAbilitiesFromSkill', () => {
+    const control = (
+        id: string,
+        trigger: Ability['trigger'],
+        conditions: Ability['conditions'] = []
+    ): Ability => ({
+        id,
+        type: 'control',
+        target: 'enemy',
+        trigger,
+        conditions,
+        config: { type: 'control', effect: 'disable' },
+    });
+
+    it('collects on-cast control abilities only — a reactive-trigger control is excluded (would be permanently unconsumed)', () => {
+        const onCast = control('c1', 'on-cast');
+        const reactive = control('c2', 'on-attacked');
+        const skill: Skill = { slot: 'passive', abilities: [onCast, reactive] };
+        expect(controlAbilitiesFromSkill(skill)).toEqual([onCast]);
+    });
+
+    it('returns empty array when no control abilities', () => {
+        const skill: Skill = { slot: 'active', abilities: [damage('a', 100)] };
+        expect(controlAbilitiesFromSkill(skill)).toEqual([]);
+    });
+
+    it('handles undefined skill', () => {
+        expect(controlAbilitiesFromSkill(undefined)).toEqual([]);
+    });
+
+    it('an on-cast control ability carrying an inherited gate condition survives gateFiringAbilities when the condition holds, and is dropped when it does not (proves the control entry is consumed WITH its gate)', () => {
+        const gated = control('c3', 'on-cast', [
+            { subject: 'enemy-debuff', derivable: true, countComparator: 'gte', countThreshold: 4 },
+        ]);
+        const rawSkill: Skill = { slot: 'active', abilities: [gated] };
+        // Condition unmet (0 enemy debuffs) → gateFiringAbilities drops the control ability
+        // before controlAbilitiesFromSkill ever sees it.
+        const { gatedSkill: failing } = gateFiringAbilities(rawSkill, {
+            ...makeConditionContext(),
+            enemyDebuffCount: 0,
+        });
+        expect(controlAbilitiesFromSkill(failing)).toEqual([]);
+        // Condition met (4+ enemy debuffs) → the control ability passes the gate and is
+        // consumed by the cast-path loop exactly as constructed.
+        const { gatedSkill: passing } = gateFiringAbilities(rawSkill, {
+            ...makeConditionContext(),
+            enemyDebuffCount: 4,
+        });
+        expect(controlAbilitiesFromSkill(passing)).toEqual([gated]);
     });
 });

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -3815,6 +3815,198 @@ describe('buildShipAbilities — D-PR13 Disable active-skill: named debuff + add
     });
 });
 
+// ── Epic PR2: control-twin gating parity ───────────────────────────────────────────────────
+// A `type:'control'` ability is emitted ADDITIVELY alongside the named debuff/buff twin that
+// actually performs the status (parseControlInflicts is purely additive — see the comment
+// above its call site). Before this PR the control twin was ALWAYS constructed on-cast/[],
+// ignoring whatever trigger/conditions the named twin resolved to. Fix (buildShipAbilities.ts,
+// right before the final per-slot sort): the control twin now inherits the named twin's
+// resolved trigger + conditions —
+//   - twin trigger 'on-cast' (a static gating condition): the control ability's conditions are
+//     overwritten with the twin's conditions (trigger stays 'on-cast', so it is still processed
+//     by the cast-path control-applied loop — gateFiringAbilities now honors the gate).
+//   - twin trigger is REACTIVE (on-attacked / on-ally-attacked / on-enemy-destroyed / …): the
+//     control ability is DROPPED outright. Consumption-side finding: the engine's only
+//     `type:'control'` consumer (controlAbilitiesFromSkill, src/utils/abilities/
+//     applyAbilities.ts) filters strictly to `trigger === 'on-cast'` — mirroring
+//     chargeAbilitiesFromSkill/extraActionsFromSkill, there is no reactive execution path for
+//     control abilities. Inheriting a reactive trigger would leave a permanently-unconsumed
+//     (dead) ability in the model, so it is not emitted at all; the named debuff/buff twin
+//     remains the sole model of the effect.
+describe('buildShipAbilities — control-twin gating parity (epic PR2)', () => {
+    it('Crocus active: control{stasis} inherits the enemy-debuff-gte-4 condition from its Stasis debuff twin (on-cast twin → condition copy)', () => {
+        // docs/ship-skills.csv Crocus active_skill_text (exact clause, routed through the real
+        // active slot): "...If the target has more than 3 Debuffs, it inflicts Stasis for 2
+        // turns."
+        const s = ship({
+            activeSkillText:
+                'This Unit deals <unit-damage>150% Damage</unit-damage> and inflicts <unit-skill>Corrosion II</unit-skill> for 2 turns.<br />If the target has more than 3 Debuffs, it inflicts <unit-skill>Stasis</unit-skill> for 2 turns.',
+        });
+        const active = slot(buildShipAbilities(s).slots, 'active');
+        const debuff = active?.abilities.find(
+            (a) => a.config.type === 'debuff' && a.config.buffName === 'Stasis'
+        );
+        const control = active?.abilities.find(
+            (a) =>
+                a.type === 'control' && a.config.type === 'control' && a.config.effect === 'stasis'
+        );
+        expect(debuff).toBeDefined();
+        expect(debuff!.trigger).toBe('on-cast');
+        expect(debuff!.conditions).toEqual([
+            { subject: 'enemy-debuff', derivable: true, countComparator: 'gte', countThreshold: 4 },
+        ]);
+        // The control twin must inherit the SAME trigger + conditions as its debuff twin.
+        expect(control).toBeDefined();
+        expect(control!.trigger).toBe(debuff!.trigger);
+        expect(control!.conditions).toEqual(debuff!.conditions);
+    });
+
+    it('Nayra active: control{stasis} inherits the target-repaired-this-round condition from its Stasis debuff twin (on-cast twin → condition copy)', () => {
+        // docs/ship-skills.csv Nayra active_skill_text (exact clause, routed through the real
+        // active slot): "...If the target was repaired this round, inflict Stasis for 1 turn."
+        const s = ship({
+            activeSkillText:
+                'This Unit inflicts <unit-skill>Defense Down II</unit-skill> and <unit-skill>Crit Rate Down III</unit-skill> for 2 turns, dealing <unit-damage>170% damage</unit-damage> and additional <unit-damage>damage equal to 30%</unit-damage> of its Defense.<br />If the target was repaired this round, inflict <unit-skill>Stasis</unit-skill> for 1 turn.',
+        });
+        const active = slot(buildShipAbilities(s).slots, 'active');
+        const debuff = active?.abilities.find(
+            (a) => a.config.type === 'debuff' && a.config.buffName === 'Stasis'
+        );
+        const control = active?.abilities.find(
+            (a) =>
+                a.type === 'control' && a.config.type === 'control' && a.config.effect === 'stasis'
+        );
+        expect(debuff).toBeDefined();
+        expect(debuff!.trigger).toBe('on-cast');
+        expect(debuff!.conditions).toEqual([
+            { subject: 'target-repaired-this-round', derivable: true },
+        ]);
+        expect(control).toBeDefined();
+        expect(control!.trigger).toBe(debuff!.trigger);
+        expect(control!.conditions).toEqual(debuff!.conditions);
+    });
+
+    it('Makoli second passive: control{disable} is DROPPED — its Disable debuff twin resolves to a REACTIVE trigger (on-attacked + below-40%-HP), which the cast-path control-applied loop can never consume', () => {
+        // docs/ship-skills.csv Makoli second_passive_skill_text (exact clause, routed through
+        // the real passive slot via refits.length >= 2): "When directly damaged while below 40%
+        // HP, this Unit repairs 20% of its Max HP and inflicts Disable for 1 turn."
+        const s = ship({
+            refits: [{}, {}] as Ship['refits'],
+            secondPassiveSkillText:
+                'When directly damaged while below 40% HP, this Unit <unit-damage>repairs 20%</unit-damage> of its Max HP and inflicts <unit-skill>Disable</unit-skill> for 1 turn.',
+        });
+        const passive = slot(buildShipAbilities(s).slots, 'passive');
+        const debuff = passive?.abilities.find(
+            (a) => a.config.type === 'debuff' && a.config.buffName === 'Disable'
+        );
+        expect(debuff).toBeDefined();
+        expect(debuff!.trigger).toBe('on-attacked');
+        expect(debuff!.conditions).toEqual([
+            {
+                subject: 'hp-threshold',
+                derivable: true,
+                hpComparator: 'below',
+                hpPercent: 40,
+                hpSubject: 'self',
+            },
+        ]);
+        const control = passive?.abilities.find(
+            (a) =>
+                a.type === 'control' && a.config.type === 'control' && a.config.effect === 'disable'
+        );
+        expect(control).toBeUndefined();
+    });
+
+    it('Flamel second passive: control{stasis} is DROPPED — its Stasis debuff twin resolves to the REACTIVE on-attacked trigger', () => {
+        // docs/ship-skills.csv Flamel second_passive_skill_text (exact clause, routed through
+        // the real passive slot via refits.length >= 2): "When directly damaged, this Unit
+        // inflicts Speed Down I for 2 turns and Stasis for 2 turn."
+        const s = ship({
+            refits: [{}, {}] as Ship['refits'],
+            secondPassiveSkillText:
+                'When directly damaged, this Unit inflicts <unit-skill>Speed Down I</unit-skill> for 2 turns and <unit-skill>Stasis</unit-skill> for 2 turn.',
+        });
+        const passive = slot(buildShipAbilities(s).slots, 'passive');
+        const debuff = passive?.abilities.find(
+            (a) => a.config.type === 'debuff' && a.config.buffName === 'Stasis'
+        );
+        expect(debuff).toBeDefined();
+        expect(debuff!.trigger).toBe('on-attacked');
+        const control = passive?.abilities.find(
+            (a) =>
+                a.type === 'control' && a.config.type === 'control' && a.config.effect === 'stasis'
+        );
+        expect(control).toBeUndefined();
+    });
+
+    it('Guardian second passive: control{provoke} is DROPPED — its Provoke debuff twin resolves to the REACTIVE on-ally-attacked trigger', () => {
+        // docs/ship-skills.csv Guardian second_passive_skill_text (exact clause, routed through
+        // the real passive slot via refits.length >= 2): "...When an ally is critically hit by
+        // an enemy, apply Provoke for 1 turn to that enemy."
+        const s = ship({
+            refits: [{}, {}] as Ship['refits'],
+            secondPassiveSkillText:
+                'This Unit has 20% shield penetration. When this Unit is critically hit, it gains <unit-skill>Binderburg Resilience I</unit-skill> for 1 turn.<br /><br />When an ally is critically hit by an enemy, apply <unit-skill>Provoke</unit-skill> for 1 turn to that enemy.',
+        });
+        const passive = slot(buildShipAbilities(s).slots, 'passive');
+        const debuff = passive?.abilities.find(
+            (a) => a.config.type === 'debuff' && a.config.buffName === 'Provoke'
+        );
+        expect(debuff).toBeDefined();
+        expect(debuff!.trigger).toBe('on-ally-attacked');
+        const control = passive?.abilities.find(
+            (a) =>
+                a.type === 'control' && a.config.type === 'control' && a.config.effect === 'provoke'
+        );
+        expect(control).toBeUndefined();
+    });
+
+    it('Meiying first passive: control{stasis} is DROPPED — its Stasis debuff twin resolves to the REACTIVE on-enemy-destroyed trigger', () => {
+        // docs/ship-skills.csv Meiying first_passive_skill_text (exact clause, routed through
+        // the real passive slot): "Upon killing an enemy with a Debuff, this Unit inflicts
+        // Stasis on all adjacent enemies for 1 turn."
+        const s = ship({
+            firstPassiveSkillText:
+                'Upon killing an enemy with a Debuff, this Unit inflicts <unit-skill>Stasis</unit-skill> on all adjacent enemies for 1 turn.',
+        });
+        const passive = slot(buildShipAbilities(s).slots, 'passive');
+        const debuff = passive?.abilities.find(
+            (a) => a.config.type === 'debuff' && a.config.buffName === 'Stasis'
+        );
+        expect(debuff).toBeDefined();
+        expect(debuff!.trigger).toBe('on-enemy-destroyed');
+        const control = passive?.abilities.find(
+            (a) =>
+                a.type === 'control' && a.config.type === 'control' && a.config.effect === 'stasis'
+        );
+        expect(control).toBeUndefined();
+    });
+
+    // Negative companion: a genuinely on-cast, UNCONDITIONAL control skill must stay ungated —
+    // the inheritance logic must not spuriously attach conditions/drop the ability when the
+    // named twin itself has no gate.
+    it('negative: a plain "applies Provoke" active skill keeps its control{provoke} on-cast with EMPTY conditions (no twin gate to inherit)', () => {
+        const s = ship({
+            activeSkillText:
+                'This Unit deals <unit-damage>145% damage</unit-damage> and applies <unit-skill>Provoke</unit-skill> for 1 turn.',
+        });
+        const active = slot(buildShipAbilities(s).slots, 'active');
+        const debuff = active?.abilities.find(
+            (a) => a.config.type === 'debuff' && a.config.buffName === 'Provoke'
+        );
+        const control = active?.abilities.find(
+            (a) =>
+                a.type === 'control' && a.config.type === 'control' && a.config.effect === 'provoke'
+        );
+        expect(debuff).toBeDefined();
+        expect(debuff!.trigger).toBe('on-cast');
+        expect(debuff!.conditions).toEqual([]);
+        expect(control).toBeDefined();
+        expect(control!.trigger).toBe('on-cast');
+        expect(control!.conditions).toEqual([]);
+    });
+});
+
 // ── Phase 1 Task 3: enemy-target charge-removal abilities ─────────────────────────────────
 // parseChargeRemoval (Task 2) is already wired into skillTextParser.ts. This block verifies
 // that buildShipAbilities orchestrates it and emits target:'enemy' charge abilities.

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -16,6 +16,7 @@ import {
     AbilityTrigger,
     ModifierChannel,
     ScalingRule,
+    ControlEffect,
 } from '../../types/abilities';
 import { getShipSkillRows, getSkillRowForSlot } from '../ship/skillRows';
 import {
@@ -2007,6 +2008,61 @@ export function buildShipAbilities(ship: Ship): ShipSkills {
                 autoFilled: true,
             };
             pushToSlot(bySlot, 'passive', [{ ability, pos }]);
+        }
+    }
+
+    // Control-twin gating parity (epic PR2): a `type:'control'` ability is emitted
+    // ADDITIVELY alongside the named debuff/buff that actually performs the status
+    // (parseControlInflicts, above) but is always constructed on-cast/ungated — it does
+    // not see whatever trigger/conditions the named twin resolved to (a reactive trigger
+    // from detectDamageReactionTrigger/detectReactiveTrigger, or a gating condition from
+    // detectGrantConditions/a manual clause gate). Makoli: the Disable DEBUFF correctly
+    // resolves to on-attacked + a below-40%-HP condition, but its control{disable} twin
+    // stayed on-cast/[] — if the engine ever executed it as constructed, Disable's
+    // control-applied event would fire on every cast regardless of the reaction gate.
+    //
+    // The engine's ONLY consumer of `type:'control'` is the on-cast loop in
+    // controlAbilitiesFromSkill (src/utils/abilities/applyAbilities.ts), which filters
+    // strictly to `trigger === 'on-cast'` — mirroring chargeAbilitiesFromSkill /
+    // extraActionsFromSkill, there is no separate reactive-trigger execution path for
+    // control abilities. So the twin's resolved trigger decides which fix applies:
+    //   - twin trigger IS 'on-cast' (Crocus/Nayra: a static gating condition, e.g. an
+    //     enemy-debuff count or "target repaired this round"): inherit the twin's
+    //     conditions onto the control ability. It is STILL processed by the cast-path
+    //     loop, and the shared gateFiringAbilities condition gate (which runs over every
+    //     cast ability uniformly, control included) now suppresses control-applied on the
+    //     same cast where the named status itself would not fire.
+    //   - twin trigger is REACTIVE (Makoli/Flamel/Guardian/Meiying: on-attacked,
+    //     on-ally-attacked, on-enemy-destroyed, …): inheriting that trigger would make the
+    //     control ability permanently unconsumed (no reactive control-applied path
+    //     exists), i.e. a dead, mislabeled entry forever. Drop the control ability outright
+    //     instead — the named debuff/buff twin remains the sole model of the effect, and no
+    //     spurious on-cast control-applied fires.
+    const CONTROL_TWIN_TAG: Record<ControlEffect, string> = {
+        stasis: 'Stasis',
+        provoke: 'Provoke',
+        'concentrate-fire': 'Concentrate Fire',
+        disable: 'Disable',
+        taunt: 'Taunt',
+    };
+    for (const positioned of bySlot.values()) {
+        for (let i = positioned.length - 1; i >= 0; i--) {
+            const ability = positioned[i].ability;
+            if (ability.type !== 'control' || ability.config.type !== 'control') continue;
+            const tag = CONTROL_TWIN_TAG[ability.config.effect];
+            const twinType = ability.config.effect === 'taunt' ? 'buff' : 'debuff';
+            const twin = positioned.find(
+                (p) =>
+                    p.ability !== ability &&
+                    p.ability.config.type === twinType &&
+                    p.ability.config.buffName === tag
+            );
+            if (!twin) continue;
+            if (twin.ability.trigger === 'on-cast') {
+                ability.conditions = twin.ability.conditions;
+            } else {
+                positioned.splice(i, 1);
+            }
         }
     }
 

--- a/src/utils/combat/__tests__/controlClassificationEmission.integration.test.ts
+++ b/src/utils/combat/__tests__/controlClassificationEmission.integration.test.ts
@@ -266,3 +266,81 @@ describe('control-classification emission — resist ownership (Task 4)', () => 
         );
     });
 });
+
+// Epic PR2 (control-twin gating parity): buildShipAbilities now copies a control ability's
+// named-twin CONDITIONS onto the control ability itself when the twin stays on-cast (Crocus
+// "if the target has more than 3 Debuffs" / Nayra "if the target was repaired this round" —
+// both static per-cast gates, not reactive triggers). This proves the FULL engine — not just
+// the applyAbilities plumbing in isolation — actually honors that inherited condition on the
+// cast path: `runCombat` builds the real per-cast ConditionContext, gateFiringAbilities filters
+// the skill's abilities against it (control included, uniformly with every other ability type),
+// and controlAbilitiesFromSkill only ever sees what survives the gate.
+describe('control-classification emission — inherited condition gate is honored end-to-end (epic PR2)', () => {
+    it('a Crocus-style control{stasis} gated on "enemy has 4+ debuffs" does NOT emit control-applied when the target has fewer debuffs', () => {
+        const { bus, events } = tap();
+        const gatedControl = controlAb('stasis');
+        gatedControl.conditions = [
+            { subject: 'enemy-debuff', derivable: true, countComparator: 'gte', countThreshold: 4 },
+        ];
+        // Focus actor (the control's target) carries NO standing debuffs → the gate fails.
+        run({ slots: [] }, bus, attackerWith(namedControlDebuff('Stasis'), gatedControl));
+
+        expect(events.some((e) => e.type === 'control-applied' && e.effect === 'stasis')).toBe(
+            false
+        );
+    });
+
+    // Positive counterpart, driven via a self-buff gate (easy to stand up deterministically): the
+    // attacker carries its OWN standing recurring self-buff (a passive-style aura registered at
+    // combat setup, same mechanism as the Block-Debuff fixture above but on the CASTER instead of
+    // the target — so it is live in the caster's own ConditionContext before its first cast, and
+    // is entirely independent of the target-immunity suppression exercised by the Block-Debuff
+    // tests). This proves the SAME gate mechanism DOES let control-applied through once its
+    // inherited condition holds.
+    it('a control{stasis} gated on the caster holding its own standing self-buff DOES emit control-applied once that self-buff is present', () => {
+        const { bus, events } = tap();
+        const gatedControl = controlAb('stasis');
+        gatedControl.conditions = [
+            { subject: 'self-buff', derivable: true, buffName: 'Overload', anyOf: true },
+        ];
+        const attackerWithOwnAura: EnemyAttacker = {
+            id: 'e1',
+            stats: { attack: 1000, crit: 0, critDamage: 0, speed: 10 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active',
+                        abilities: [
+                            enemyAb({
+                                type: 'damage',
+                                config: { type: 'damage', multiplier: 100 },
+                            }),
+                            enemyAb({
+                                type: 'buff',
+                                target: 'self',
+                                config: {
+                                    type: 'buff',
+                                    buffName: 'Overload',
+                                    stacks: 1,
+                                    isStackable: false,
+                                    duration: 'recurring',
+                                    parsedEffects: {},
+                                },
+                            }),
+                            namedControlDebuff('Stasis'),
+                            gatedControl,
+                        ],
+                    },
+                ],
+            } as ShipSkills,
+        } as EnemyAttacker;
+
+        run({ slots: [] }, bus, attackerWithOwnAura);
+
+        expect(events.some((e) => e.type === 'control-applied' && e.effect === 'stasis')).toBe(
+            true
+        );
+    });
+});


### PR DESCRIPTION
## Summary

PR2 of the skill-model gap epic (Phase 1, spec: `docs/superpowers/specs/2026-07-03-skill-model-gap-epic-design.md`). Follows #205.

`type:'control'` abilities (Stasis/Provoke/Taunt/Concentrate Fire/Disable classification entries) are emitted additively alongside the named debuff/buff that performs the status, but were always constructed `on-cast`/ungated — ignoring the trigger and conditions the named twin resolved to.

### Consumption-side finding (determined the fix shape)
The engine's only consumer of `type:'control'` is `controlAbilitiesFromSkill` (`applyAbilities.ts`), which filters strictly to `trigger === 'on-cast'` — there is no reactive execution path for control abilities. So:

- **Twin is on-cast with a static gate** (Crocus: ≥4 enemy debuffs; Nayra: target-repaired-this-round) → the control ability **inherits the twin's conditions**; the shared `gateFiringAbilities` pass now suppresses `control-applied` on exactly the casts where the named status wouldn't fire.
- **Twin is reactive** (Makoli on-attacked+HP<40, Flamel on-attacked, Guardian on-ally-attacked, Meiying on-enemy-destroyed) → inheriting the trigger would leave a permanently-unconsumed dead entry, so the control twin is **not emitted at all**; the named debuff/buff remains the sole model (this is the spec's "don't emit the ungated twin" branch).

### Verification
All 6 ships red-confirmed pre-change (exact CSV clause text through the real production slot routing), independently re-verified by running the new tests against the pre-change builder: 6 failures. New `applyAbilities` tests pin the on-cast filter + gate consumption; two full `runCombat` integration tests prove a gated control does/doesn't emit `control-applied` by condition state.

## Validation
- Full vitest: 302 files / 3925 tests green (+13 new), zero golden/snapshot churn
- `npm run lint` 0 warnings, `tsc --noEmit` clean, `npm run audit:skills` 0 findings (no allowlist changes)
- Changelog entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPuPgS4wJVpPkudSwLAHjR