### PR TITLE
fix(combat): ally-targeted enemy casters no longer skip turns when the focus player is dead

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -18,6 +18,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Wildfire's bonus Inferno damage against an enemy with Scorching Radiation (scaling with her own crit power, 1% per 10% crit power, 2% with her refit) is now re-checked on every Inferno tick against each affected enemy individually — a target that never had Scorching Radiation (or whose Scorching Radiation has since expired) no longer gets the bonus just because another of her targets currently has it.",
     "Combat sim: Wildfire's refit-3 passive now actually reaches the team — every living ally's Inferno damage against an enemy with Scorching Radiation is boosted by 2% per 10% of Wildfire's own crit power (not the ally's), matching her skill text.",
     'Fixed skill parsing that inflated DPS for Tormenter, Voron, Malvex, and FrontLine — defensive damage-reduction (and shield-scaling) clauses were being counted as extra attacks. Also fixed Amartya, who no longer grants herself a phantom Taunt buff from her "enemy gains Taunt" trigger text, and now correctly inflicts 2 stacks of Exposed (not 1) from her legendary refit passive.',
+    'Combat sim: enemy supporters (like Graphite) no longer stop granting buffs and shields for the rest of the battle after the first player ship dies.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/abilities/applyAbilities.ts
+++ b/src/utils/abilities/applyAbilities.ts
@@ -159,6 +159,35 @@ export function damageInputsFromSkill(skill: Skill | undefined): {
     };
 }
 
+/** Enemy-facing `AbilityTarget` values — anything that resolves against the OPPOSING
+ *  roster. Used by `skillNeedsOpposingVictim` below; kept as its own const so a future
+ *  AbilityTarget addition is an explicit decision here rather than a silent gap. */
+const ENEMY_FACING_TARGETS: ReadonlySet<Ability['target']> = new Set([
+    'enemy',
+    'all-enemies',
+    'enemy-most-buffs',
+    'enemy-highest-attack',
+]);
+
+/**
+ * True when the firing skill contains at least one ability that actually needs a LIVING
+ * opposing victim to resolve against — a `damage` ability (always enemy-facing even when
+ * its `target` field happens to read something else), or any ability whose `target` is
+ * enemy-facing (debuff/dot/purge/control/charge-removal/etc., typically `target: 'enemy'`
+ * or `'all-enemies'`). An ally-targeted support cast (buffs/shields/heals aimed at
+ * `'self'`/`'ally'`/`'all-allies'`/`'adjacent-allies'` only) returns false — it never reads
+ * the bound victim's HP/defence, so it can safely fire even when that victim is dead.
+ *
+ * Consumed by the engine's dead-legacy-victim turn skip (engine.ts, enemy walk): the skip
+ * is narrowed to actors whose firing skill actually needs the dead victim, so an
+ * ally-targeted caster whose positional selection fell back to a dead legacy binding still
+ * runs its turn instead of being permanently silenced for the rest of the battle.
+ */
+export function skillNeedsOpposingVictim(skill: Skill | undefined): boolean {
+    if (!skill) return false;
+    return skill.abilities.some((a) => a.type === 'damage' || ENEMY_FACING_TARGETS.has(a.target));
+}
+
 /** First `additional-damage` ability mapped to a SecondaryDamage, or undefined. */
 export function secondaryFromSkill(skill: Skill | undefined): SecondaryDamage | undefined {
     const additional = skill?.abilities.find((a) => a.type === 'additional-damage');

--- a/src/utils/combat/__tests__/twoTeamBattle.test.ts
+++ b/src/utils/combat/__tests__/twoTeamBattle.test.ts
@@ -1276,3 +1276,245 @@ describe('H1 Task 8 follow-up — simulateBattle end-to-end shield extraction lo
         expect(absorbedRounds.length).toBeGreaterThan(0);
     });
 });
+
+// ===========================================================================
+// Bug repro: dead-legacy-victim binding permanently skips an ally-targeted enemy
+// caster's turn once the FOCUS player (playerTeam[0], engine id 'attacker') dies.
+//
+// Diagnosed chain: an ally-targeted caster's parsed target has side:'ally' →
+// resolvePositionalTarget returns null by design → selectTurnTarget falls back to
+// the enemy side's legacyVictim, which simulateBattle sets to the FOCUS player id
+// (a vestigial binding). Once the focus dies, the enemy walk's
+// `targetDead = tgt.currentHp <= 0` short-circuits the WHOLE turn to cadence-only
+// (no skill fired) — even though this caster (a pure supporter, Graphite-style) never
+// needed an opposing victim in the first place. Positional attackers are unaffected
+// because they re-resolve a LIVING player every turn.
+// ===========================================================================
+
+describe('bug repro: enemy supporter turn skipped after the focus player dies', () => {
+    it('a Graphite-style ally-targeted supporter keeps granting its buff + shield in rounds AFTER the focus dies', () => {
+        const GRAPHITE_ACTIVE_TEXT =
+            'This unit grants <unit-skill>Overclock III</unit-skill> for 2 turns and a ' +
+            '<unit-damage>shield equal to 120%</unit-damage> of its attack.';
+
+        const result = simulateBattle({
+            playerTeam: [
+                // Focus (playerTeam[0] → engine id 'attacker'): fragile, dies to the Killer
+                // in round 2 (60 000 HP, 30 000 dmg/hit → dead after 2 hits).
+                {
+                    ship: makeShip('focus', 'Focus', FRONT),
+                    position: 'M4',
+                    statOverrides: {
+                        attack: 0,
+                        crit: 0,
+                        critDamage: 0,
+                        defensePenetration: 0,
+                        hacking: 200,
+                        defence: 0,
+                        hp: 60_000,
+                        speed: 120,
+                    },
+                },
+                // Survivor: immortal, never dies, keeps the battle running the full 4 rounds
+                // and gives the Killer a living positional target after the focus dies.
+                {
+                    ship: makeShip('survivor', 'Survivor', BACK),
+                    position: 'M3',
+                    statOverrides: {
+                        attack: 0,
+                        crit: 0,
+                        critDamage: 0,
+                        defensePenetration: 0,
+                        hacking: 200,
+                        defence: 0,
+                        hp: 1_000_000_000,
+                        speed: 110,
+                    },
+                },
+            ],
+            enemyTeam: [
+                // Killer: positional attacker (front-target) — kills the focus round 2, then
+                // re-resolves onto the living Survivor. Unaffected by the bug (control case).
+                {
+                    ship: makeShip('killer', 'Killer', FRONT),
+                    position: 'M4',
+                    statOverrides: {
+                        attack: 30_000,
+                        crit: 0,
+                        critDamage: 0,
+                        defensePenetration: 0,
+                        hacking: 200,
+                        defence: 0,
+                        hp: 1_000_000_000,
+                        speed: 130,
+                    },
+                },
+                // Supporter (Graphite-style): ally-targeted (side:'ally' parsed target) → its
+                // positional selection ALWAYS returns null → falls back to the legacy victim
+                // (the focus). Once the focus is dead this is the actor that stops acting.
+                {
+                    ship: makeShip('supporter', 'Supporter', {
+                        activeTarget: 'allies',
+                        activePattern: 'Pattern-Support-Double-Pickaxe-Range-0',
+                        activeSkillText: GRAPHITE_ACTIVE_TEXT,
+                        type: 'Supporter',
+                    }),
+                    position: 'M2',
+                    statOverrides: {
+                        attack: 5_000,
+                        crit: 0,
+                        critDamage: 0,
+                        defensePenetration: 0,
+                        hacking: 200,
+                        defence: 0,
+                        hp: 1_000_000_000,
+                        speed: 90,
+                    },
+                },
+            ],
+            rounds: 4,
+        });
+
+        const FOCUS = 'attacker';
+        const SUPPORTER = 'e:supporter:1';
+
+        const aliveAt = (round: number) =>
+            result.rounds.find((r) => r.round === round)?.ships.find((s) => s.actorId === FOCUS)
+                ?.alive;
+
+        // Sanity check on the repro's premise: the focus is alive round 1, dead from round 2.
+        expect(aliveAt(1)).toBe(true);
+        expect(aliveAt(2)).toBe(false);
+
+        const supporterEntriesAt = (round: number) => {
+            const combatRound = result.combatLog.find((r) => r.round === round);
+            const turn = combatRound?.turns.find((t) => t.actorId === SUPPORTER);
+            return turn?.entries ?? [];
+        };
+
+        // Round 1 (focus alive): the supporter's turn grants Overclock III + a shield —
+        // establishes the skill actually parses/fires as expected while the legacy binding
+        // is still alive.
+        const round1Entries = supporterEntriesAt(1);
+        expect(round1Entries.some((e) => e.kind === 'buff' && e.note === 'Overclock III')).toBe(
+            true
+        );
+        expect(round1Entries.some((e) => e.kind === 'shield')).toBe(true);
+
+        // Round 4 (focus long dead): the supporter must STILL grant the identical effects —
+        // an ally-targeted support cast never needed the dead focus as a victim. This is the
+        // assertion that fails on the buggy engine (the dead-legacy-victim short-circuit empties
+        // the supporter's turn for every round after the focus dies).
+        const round4Entries = supporterEntriesAt(4);
+        expect(round4Entries.some((e) => e.kind === 'buff' && e.note === 'Overclock III')).toBe(
+            true
+        );
+        expect(round4Entries.some((e) => e.kind === 'shield')).toBe(true);
+    });
+
+    it('negative/pin: an enemy ATTACKER (damage skill) bound to the dead legacy victim still skips its turn', () => {
+        // Mirror of the repro above, but the second enemy fires a plain `damage` ability
+        // (target 'enemy' — set by the skill-text parser regardless of the raw targeting
+        // column) while its RAW activeTarget/activePattern columns are ally-shaped, so
+        // resolvePositionalTarget still returns null (side:'ally' → null by design) and
+        // selectTurnTarget falls back to the legacy victim exactly like the supporter.
+        // UNLIKE the supporter, this skill's firing ability DOES need an opposing victim
+        // (type 'damage', target 'enemy') — so the deferred death-fallback-retargeting work
+        // item is explicitly OUT of scope and this actor's turn must keep skipping.
+        const result = simulateBattle({
+            playerTeam: [
+                {
+                    ship: makeShip('focus', 'Focus', FRONT),
+                    position: 'M4',
+                    statOverrides: {
+                        attack: 0,
+                        crit: 0,
+                        critDamage: 0,
+                        defensePenetration: 0,
+                        hacking: 200,
+                        defence: 0,
+                        hp: 60_000,
+                        speed: 120,
+                    },
+                },
+                {
+                    ship: makeShip('survivor', 'Survivor', BACK),
+                    position: 'M3',
+                    statOverrides: {
+                        attack: 0,
+                        crit: 0,
+                        critDamage: 0,
+                        defensePenetration: 0,
+                        hacking: 200,
+                        defence: 0,
+                        hp: 1_000_000_000,
+                        speed: 110,
+                    },
+                },
+            ],
+            enemyTeam: [
+                {
+                    ship: makeShip('killer', 'Killer', FRONT),
+                    position: 'M4',
+                    statOverrides: {
+                        attack: 30_000,
+                        crit: 0,
+                        critDamage: 0,
+                        defensePenetration: 0,
+                        hacking: 200,
+                        defence: 0,
+                        hp: 1_000_000_000,
+                        speed: 130,
+                    },
+                },
+                // A second attacker: ally-shaped raw targeting (activeTarget:'allies') so its
+                // ParsedTarget carries side:'ally' → resolvePositionalTarget always returns
+                // null (same mechanism as the supporter's fallback) — but its firing ability
+                // is a plain `damage` ability (parsed target 'enemy', independent of the raw
+                // targeting column) → the dead-target skip MUST still apply.
+                {
+                    ship: makeShip('deadbound', 'DeadBound', {
+                        activeTarget: 'allies',
+                        activePattern: 'Pattern-Support-Double-Pickaxe-Range-0',
+                        activeSkillText: 'This Unit deals <unit-damage>100% damage</unit-damage>.',
+                    }),
+                    position: 'M2',
+                    statOverrides: {
+                        attack: 9_000,
+                        crit: 0,
+                        critDamage: 0,
+                        defensePenetration: 0,
+                        hacking: 200,
+                        defence: 0,
+                        hp: 1_000_000_000,
+                        speed: 80,
+                    },
+                },
+            ],
+            rounds: 4,
+        });
+
+        const FOCUS = 'attacker';
+        const DEADBOUND = 'e:deadbound:1';
+
+        const aliveAt = (round: number) =>
+            result.rounds.find((r) => r.round === round)?.ships.find((s) => s.actorId === FOCUS)
+                ?.alive;
+        expect(aliveAt(1)).toBe(true);
+        expect(aliveAt(2)).toBe(false);
+
+        // Round 1 (focus alive): the non-positional attacker fires a real attack entry.
+        const round1 = result.combatLog.find((r) => r.round === 1);
+        const round1Turn = round1?.turns.find((t) => t.actorId === DEADBOUND);
+        expect(round1Turn?.entries.some((e) => e.kind === 'attack')).toBe(true);
+
+        // Round 4 (focus long dead, no positional re-target available): the attacker's turn
+        // stays cadence-only — no skill-fired-derived entries at all. This is the PRESERVED
+        // (not fixed) old short-circuit behavior for actors that actually need an opposing
+        // victim.
+        const round4 = result.combatLog.find((r) => r.round === 4);
+        const round4Turn = round4?.turns.find((t) => t.actorId === DEADBOUND);
+        expect(round4Turn).toBeDefined();
+        expect(round4Turn!.entries.length).toBe(0);
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -19,6 +19,7 @@ import {
     selectFiringSkill,
     damageInputsFromSkill,
     modifierTotalsFromAbilities,
+    skillNeedsOpposingVictim,
 } from '../abilities/applyAbilities';
 import { conditionsMet, type ConditionContext } from '../abilities/evaluateConditions';
 import { foldActorBuffTotals, effectiveStatsOf } from './effectiveStats';
@@ -5924,7 +5925,30 @@ export function runCombat(input: CombatEngineInput): {
                             // binding below derives from `tgt` uniformly (defence/maxHp/decline, the
                             // runPlayerTurn `enemy`+containers, and the applyIncomingToTarget intake).
                             const { tgt } = selectTurnTarget(actor);
-                            const targetDead = tgt.currentHp <= 0;
+                            // Narrowed dead-legacy-victim skip: a dead `tgt` only forces the
+                            // cadence-only short-circuit below when the actor's WOULD-BE firing
+                            // skill actually needs a living opposing victim (a `damage` ability,
+                            // or any enemy-facing ability — debuff/dot/purge/control/etc.). An
+                            // ally-targeted support cast (buffs/shields/heals only) never reads
+                            // `tgt`'s HP/defence, so it must still fire even when the legacy
+                            // binding (simulateBattle's vestigial focus-player healTargetId) is
+                            // dead — otherwise every ally-targeted enemy caster permanently stops
+                            // acting the moment the focus player dies (bug repro:
+                            // twoTeamBattle.test.ts "bug repro: enemy supporter turn skipped
+                            // after the focus player dies"). Mirrors runPlayerTurn's OWN action
+                            // selection (preTurn, playerTurn.ts) exactly so the predicate inspects
+                            // the SAME skill that would actually fire.
+                            const enemyWouldFireAction: 'active' | 'charged' =
+                                enemyRuntime.hasChargedSkill && actor.charges >= actor.chargeCount
+                                    ? 'charged'
+                                    : 'active';
+                            const enemyFiringSkillForDeadCheck = selectFiringSkill(
+                                enemyRuntime.castSkills,
+                                enemyWouldFireAction
+                            );
+                            const skipDeadTargetTurn =
+                                tgt.currentHp <= 0 &&
+                                skillNeedsOpposingVictim(enemyFiringSkillForDeadCheck);
                             // This enemy attacker's parsed pattern (Task 9) — REQUIRED for the enemy-site
                             // positional apply (footprint expansion). An enemy with a target but NO pattern
                             // stays on the legacy single-apply path (same `pattern != null` guard as the
@@ -6007,7 +6031,7 @@ export function runCombat(input: CombatEngineInput): {
                                       enemyTurnStasisHitVictims.add(targetId);
                                   }
                                 : undefined;
-                            if (targetDead) {
+                            if (skipDeadTargetTurn) {
                                 // Cadence-only: bank a charge (or fire+reset at cap) without resolving the
                                 // attack. Mirrors runPlayerTurn's preTurn charge step. No skill-fired/
                                 // application events — a dead target is untouched (old short-circuit).


### PR DESCRIPTION
## Summary

User-reported: enemy supporters (e.g. Graphite) stop granting buffs/shields for the rest of a simulator battle once the first player ship dies.

**Root cause:** an ally-targeted caster's positional selection returns null by design (no opposing target to resolve), falling back to the vestigial legacy victim binding — `simulateBattle` sets `healTargetId` to the focus player. The enemy walk's dead-target short-circuit (`engine.ts`) then reduces the caster's whole turn to cadence-only once that focus dies, even though its skill never touches the bound victim.

**Fix:** the skip is narrowed to actors whose would-be firing skill actually needs a living opposing victim — new `skillNeedsOpposingVictim(skill)` (a `damage` ability, or any ability with an enemy-facing `target`). The firing-skill choice mirrors `runPlayerTurn`'s own preTurn action selection exactly. Ally-only support casts now run; attackers bound to a dead victim keep today's skip (death-fallback retargeting remains a separate, deferred work item, pinned by a new negative test).

**Safety of running with a dead-bound victim (investigated):** a support-only cast produces zero damage, so the entire damage/HP/shield mutation + `attacked` emission block is skipped; `enemyHpDecline` is clamped at 0. No spurious events on the corpse.

**Team symmetry:** the mirrored player-side hazard does not exist — the focus/team turn sites have no dead-target skip at all, and the player-side legacy victim is the indestructible DPS dummy.

## Tests
- Red integration test (verified failing on main): a Graphite-style supporter keeps granting its buff + shield in rounds after the focus dies
- Negative/pin: a damage-skill enemy bound to the dead legacy victim still takes the cadence-only skip
- Full suite 302 files / 3914 tests green, zero golden/snapshot churn, lint 0, tsc clean, audit:skills 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPuPgS4wJVpPkudSwLAHjR