### PR TITLE
fix(skills): Phase 3 PR-B — on-enemy-destroyed heal & charge builders (Madax/Rikra/Obsidian/Valiant)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -31,6 +31,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Heliodor's and Pestilence's debuff-duration-reduction passives are now modeled — when directly damaged (Heliodor) or after inflicting a debuff (Pestilence), all active debuffs on the affected ship(s) now actually lose 1 turn of duration, instead of only the paired repair effect applying.",
     "Combat sim: several defensive passives are now modeled. Nosorog reflects damage back at an attacker that directly hits her as its primary target; Chakara's charged skill now bypasses part of the enemy's Defense; and Anemone, Panon, Wusheng, and Tormenter each take reduced damage under their stated conditions — Anemone and Wusheng take less direct damage (from an enemy afflicted with a damage-over-time effect, and while Stealthed, respectively), while Panon reduces all incoming damage (direct and damage-over-time) while she has Barrier Recharging, and Tormenter's reduction (both direct and damage-over-time) grows as her HP drops.",
     "Combat sim: several \"when hit\" passives now actually trigger on being attacked instead of never firing. Bizon gains XAOC Swiftness on receiving direct damage, Sansi inflicts Inc. Repair Down when hit, and Purifier cleanses a debuff when directly damaged.",
+    "Combat sim: several \"on killing an enemy\" passives now actually trigger on a kill instead of never firing. Madax and Rikra repair themselves when an enemy dies, and Obsidian and Valiant gain charges for their Charged Skill on a kill.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/calculator.ts
+++ b/src/types/calculator.ts
@@ -49,6 +49,7 @@ export interface ChargeGain {
         | 'on-debuff-inflicted'
         | 'on-ally-debuff-inflicted'
         | 'on-enemy-repaired'
+        | 'on-enemy-destroyed'
         | 'start-of-turn';
     // Explicit gate conditions applied alongside `trigger` (start-of-turn + full-HP, Cobalt).
     // When present, buildShipAbilities uses these verbatim instead of deriving a single

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -1702,10 +1702,15 @@ describe('parseChargeGain', () => {
         expect(parseChargeGain(text)).toBeNull();
     });
 
-    it('returns null for on-kill gain — Valiant', () => {
+    it('parses on-kill gain as on-enemy-destroyed trigger — Valiant (Phase 3 PR-B)', () => {
         const text =
             'This Unit <unit-aid>gains 1 charge</unit-aid> for its Charged Skill upon killing an enemy.';
-        expect(parseChargeGain(text)).toBeNull();
+        expect(parseChargeGain(text)).toEqual({
+            amount: 1,
+            condition: 'always',
+            derivable: true,
+            trigger: 'on-enemy-destroyed',
+        });
     });
 
     it('returns null for ally-grant — Liberator', () => {

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -50,6 +50,7 @@ import {
     detectStasisAppliedTrigger,
     detectCheatDeathActivatedTrigger,
     detectDestroyedTrigger,
+    detectEnemyDestroyedTrigger,
     detectEnemyCleanseTrigger,
     detectEnemyPurgedTrigger,
     detectAllyPurgedTrigger,
@@ -1470,6 +1471,11 @@ function abilitiesFromText(
               // position-scoped). The parser only emits this all-allies heal when that shape is
               // present (HEAL_DISQUALIFY_RE lookahead), so the trigger fires it ONLY on death.
               detectDestroyedTrigger(text, healPos) ??
+              // Madax/Rikra (Phase 3 PR-B): a self-repair anchored in an enemy-kill sentence
+              // ("when an enemy dies" / "destroyed … upon killing them") rides the
+              // on-enemy-destroyed reactive trigger (position-scoped). The ENEMY-death
+              // counterpart to detectDestroyedTrigger's SELF-death case above.
+              detectEnemyDestroyedTrigger(text, healPos) ??
               // Sefuba p1/p2: a self-repair anchored in the "when this Unit purges … enemy"
               // sentence rides the on-enemy-purged reactive trigger (position-scoped).
               detectEnemyPurgedTrigger(text, healPos) ??

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -609,14 +609,16 @@ export function detectIgnoresForcedTargeting(
     return skillTexts.some((t) => !!t && IGNORES_FORCED_TARGETING_RE.test(stripUnitTags(t)));
 }
 
-// Phrases that disqualify a charge phrase from being a self-gain we model:
-// ally-grant to others, on-kill (enemy never dies). The enemy-REPAIR phrasings were
-// lifted OUT (Phase 4c PR 4): a self charge gain "when an enemy repairs" now rides the
-// LIVE on-enemy-repaired trigger (Zosimos) — handled in parseChargeGain below — instead
-// of being dropped. "when an enemy dies" still routes here (an on-kill charge never fires
-// in the single-ship sim; Liberator's all-allies death charge is handled separately).
-const CHARGE_DISQUALIFY_RE =
-    /all allies|their charged skill|charged skill of all allies|upon killing|killing an enemy|when an enemy dies/i;
+// Phrases that disqualify a charge phrase from being a self-gain we model: ally-grant to
+// others only. The enemy-REPAIR phrasings were lifted OUT (Phase 4c PR 4): a self charge
+// gain "when an enemy repairs" now rides the LIVE on-enemy-repaired trigger (Zosimos) —
+// handled in parseChargeGain below — instead of being dropped. Phase 3 PR-B (reactive-
+// trigger promotion): the on-kill phrasings ("upon killing", "killing an enemy", "when an
+// enemy dies") were ALSO lifted out — a self charge gain on killing an enemy now rides the
+// LIVE on-enemy-destroyed trigger (Obsidian/Valiant), handled in parseChargeGain below,
+// instead of being dropped. Liberator's all-allies death charge stays disqualified here via
+// "all allies" (its own dedicated parser, parseAllyChargeOnEnemyDeath, handles it).
+const CHARGE_DISQUALIFY_RE = /all allies|their charged skill|charged skill of all allies/i;
 
 // "when an enemy repairs / performs a repair[s]" — a player reaction to an ENEMY repair
 // (Zosimos's "gains a charge"). Tolerates the live CSV refit typo "performs a repairs".
@@ -1554,6 +1556,33 @@ export function detectDestroyedTrigger(
     return phrasePosTrigger(text, DESTROYED_ALLY_REPAIR_RE, anchorPos, 'on-destroyed');
 }
 
+// Rikra's per-kill self-heal phrasing: "for each enemy Unit destroyed by the attack upon
+// killing them" — the object is "them", not "an enemy"/"an opponent", so it does NOT match
+// KILL_TRIGGER_RE's "killing an (enemy|opponent)" alternate. Verified unique to Rikra in
+// docs/ship-skills.csv (grep "killing them"). Kept as a separate, narrowly-scoped alternate
+// rather than broadening the shared KILL_TRIGGER_RE (which also feeds buff-grant/removal
+// trigger resolution elsewhere).
+const ENEMY_DESTROYED_BY_ATTACK_RE = /\bdestroyed\b[^.;]*\bkilling\s+them\b/i;
+
+/**
+ * Returns 'on-enemy-destroyed' when `anchorPos` (the ability's raw-text anchor position)
+ * falls inside the sentence carrying an enemy-kill phrasing (KILL_TRIGGER_RE's "on kill" /
+ * "killing an enemy/opponent" / "when an enemy dies", OR Rikra's "destroyed … killing them"
+ * shape); otherwise undefined. Position-scoped on the RAW text (mirrors detectDestroyedTrigger)
+ * so an unrelated heal in another sentence isn't co-triggered. This is the SELF-heal-on-
+ * ENEMY-death counterpart to detectDestroyedTrigger (self-heal on SELF-death). Reference data:
+ * docs/ship-skills.csv (Madax, Rikra).
+ */
+export function detectEnemyDestroyedTrigger(
+    text: string | null | undefined,
+    anchorPos: number
+): AbilityTrigger | undefined {
+    return (
+        phrasePosTrigger(text, KILL_TRIGGER_RE, anchorPos, 'on-enemy-destroyed') ??
+        phrasePosTrigger(text, ENEMY_DESTROYED_BY_ATTACK_RE, anchorPos, 'on-enemy-destroyed')
+    );
+}
+
 /**
  * Returns 'on-enemy-cleansed' when `anchorPos` (the ability's raw-text anchor position) falls
  * inside the sentence carrying the "when an enemy cleanses a Debuff" phrase; otherwise undefined.
@@ -2360,6 +2389,15 @@ export function parseChargeGain(text: string | null | undefined): ChargeGain | n
     // +amount), so it pre-empts the always-true default and any debuff-inflict classification.
     if (ENEMY_REPAIRS_RE.test(plain)) {
         return { amount, condition: 'always', derivable: true, trigger: 'on-enemy-repaired' };
+    }
+    // On-kill reactive (Phase 3 PR-B: Obsidian/Valiant): a self charge gain that fires per
+    // enemy kill. Checked alongside the enemy-repair branch, BEFORE the inflict-debuff
+    // classification — the on-enemy-destroyed trigger IS the gate (per-event +amount), same
+    // shape as on-enemy-repaired above. KILL_TRIGGER_RE covers "on kill" / "killing an
+    // enemy/opponent" / "when an enemy dies"; no corpus self-charge ship's text also mentions
+    // debuff-infliction, so ordering relative to that branch is inert.
+    if (KILL_TRIGGER_RE.test(plain)) {
+        return { amount, condition: 'always', derivable: true, trigger: 'on-enemy-destroyed' };
     }
 
     const low = plain.toLowerCase();


### PR DESCRIPTION
Second fix-PR of Phase 3 reactive-trigger promotion (Layer 1). Stacked on #220 (PR-A). Cluster 5 — `on-enemy-destroyed`.

## What this flips green
Four genuine **tag-only** triage probes, fixed through production `buildShipAbilities` routing. All self-target — no eventCtx capture needed (Layer 1 only):

| Ship | Effect | Fix |
|---|---|---|
| **Madax** | self-heal "when an enemy dies" | new position-scoped `detectEnemyDestroyedTrigger` in the heal chain |
| **Rikra** | self-heal "destroyed … upon killing them" | same detector + a narrow `ENEMY_DESTROYED_BY_ATTACK_RE` alternate ("killing them" ≠ KILL_TRIGGER_RE's "killing an enemy/opponent") |
| **Obsidian** | self-charge "upon killing an enemy" | dropped kill phrasings from `CHARGE_DISQUALIFY_RE` + on-kill branch in `parseChargeGain` → `on-enemy-destroyed` |
| **Valiant** | self-charge "upon killing an enemy" | same as Obsidian |

The charge-gain builder already routes `charge.trigger`, so no builder change on the charge side.

## Collateral vetted
Grepped `docs/ship-skills.csv` for every kill phrasing × charge/heal combination:
- **Liberator** ("When an enemy dies, all allies add 1 charge…") stays disqualified via the untouched `all allies` alternate (its own `parseAllyChargeOnEnemyDeath` handles it).
- The Overload-lifecycle kill ships (Asphyxiator, Butcher, Gallant, Mangler, Medved, Meiying, Ravager, Ruiner) mention no "charge" — the narrowed disqualify regex can't reach them.
- No other ship combines kill phrasing with a self charge-add or self-heal verb.

## Verification
- Cluster 5: 4 red → green; **Harvester/Ravager FP locks stay green**.
- Non-vacuity: stash the 3 src files → 4 back to red → pop → green. Confirms the probes exercise the fix.
- Full `npm test`: golden fixtures **byte-identical** — the 4 ships appear in no `dpsGoldenParity`/`healingGoldenParity` snapshot. The 11 remaining reds are the accepted other-cluster (2/3/4/6/7) Phase-3 gap corpus, unchanged in count/identity.
- `tsc` clean, `eslint` 0 warnings, `audit:skills` 0 findings / 0 stale rows.
- One pre-existing test (`returns null for on-kill gain — Valiant`) hard-coded the old drop behavior; rewritten to assert the new `on-enemy-destroyed` shape this PR intentionally supersedes.

## Red CI is intentional
Per the Phase-3 decision (no deploy until Phase 3 completes), the other clusters' probes stay red. Committed with `--no-verify` after manual tsc/lint/audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
