### PR TITLE
fix(skills): Phase 3 PR-C — on-ally-crit-dot heal builder (Crocus); Vindicator deferred

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -32,6 +32,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: several defensive passives are now modeled. Nosorog reflects damage back at an attacker that directly hits her as its primary target; Chakara's charged skill now bypasses part of the enemy's Defense; and Anemone, Panon, Wusheng, and Tormenter each take reduced damage under their stated conditions — Anemone and Wusheng take less direct damage (from an enemy afflicted with a damage-over-time effect, and while Stealthed, respectively), while Panon reduces all incoming damage (direct and damage-over-time) while she has Barrier Recharging, and Tormenter's reduction (both direct and damage-over-time) grows as her HP drops.",
     "Combat sim: several \"when hit\" passives now actually trigger on being attacked instead of never firing. Bizon gains XAOC Swiftness on receiving direct damage, Sansi inflicts Inc. Repair Down when hit, and Purifier cleanses a debuff when directly damaged.",
     "Combat sim: several \"on killing an enemy\" passives now actually trigger on a kill instead of never firing. Madax and Rikra repair themselves when an enemy dies, and Obsidian and Valiant gain charges for their Charged Skill on a kill.",
+    "Combat sim: Crocus now repairs herself when another ally lands a critical Damage Over Time hit, matching her skill text, instead of only healing on her own turn.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -400,8 +400,11 @@ describe('buildShipAbilities', () => {
         // ally's OUTGOING crit — if detectDamageReactionTrigger ever reads it as the ally
         // BEING crit-hit, the Task 8 name-only-debuff pass adds a phantom on-ally-attacked
         // Corrosion II debuff card on top of these two.
+        // Phase 3 PR-C: the heal now also rides on-ally-crit-dot (detectAllyCritDotTrigger)
+        // instead of the stale on-cast default — it repairs Crocus reactively, on an ALLY's
+        // crit-DoT infliction, not on Crocus's own cast.
         expect(abilities.map((a) => [a.type, a.trigger])).toEqual([
-            ['heal', 'on-cast'],
+            ['heal', 'on-ally-crit-dot'],
             ['dot', 'on-ally-crit-dot'],
         ]);
     });

--- a/src/utils/abilities/__tests__/reactiveTriggerPromotionTriage.test.ts
+++ b/src/utils/abilities/__tests__/reactiveTriggerPromotionTriage.test.ts
@@ -335,8 +335,6 @@ describe('cluster 7 — ally-crit / cleanse-reactive / DoT-crit / debuff-resiste
         const ab = abilitiesFor({ firstPassiveSkillText: CROCUS_P2 }, 'passive');
         const heal = ab.find((a) => a.type === 'heal');
         expect(heal?.trigger).toBe('on-ally-crit-dot');
-        // GAP: tag-only — self-target heal; on-ally-crit-dot trigger exists (triggers.ts:379) but the
-        // heal builder doesn't derive it.
     });
 
     const VINDICATOR_P3 =
@@ -344,8 +342,12 @@ describe('cluster 7 — ally-crit / cleanse-reactive / DoT-crit / debuff-resiste
     it('Vindicator: reactive damage on debuff-resisted rides on-debuff-resisted', () => {
         const ab = abilitiesFor({ firstPassiveSkillText: VINDICATOR_P3 }, 'passive');
         expect(ab.some((a) => a.type === 'damage' && a.trigger === 'on-debuff-resisted')).toBe(true);
-        // GAP: tag-only — emits NO ability; the damage builder has no reaction path (only round-boundary).
-        // on-debuff-resisted trigger exists in the union. Damage targets "that enemy" (the resisted attacker).
+        // GAP: DEFERRED (Phase 3 PR-C, 2026-07-04) — two independent infra gaps beyond Layer-1 tag
+        // inheritance: (1) no maxHP-scaled damage model — the 'damage' AbilityConfig only carries an
+        // attack%-based multiplier (applyReactiveDamage sources ownerStats.attack), so "30% of max HP"
+        // cannot be emitted faithfully; (2) no-capturable-actor — the debuff-resisted event carries only
+        // targetId (the resister), no source/attacker id, so "that enemy" cannot be resolved. Spec-locked
+        // out-of-scope (no-capturable-actor → candidate future work). Probe intentionally left RED.
     });
 
     const AMARTYA_P2 =

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -45,6 +45,7 @@ import {
     parseCritPowerExtend,
     parseDebuffDurationReduction,
     parseAllyCritDot,
+    detectAllyCritDotTrigger,
     detectCritRepairTrigger,
     detectDebuffInflictedTrigger,
     detectStasisAppliedTrigger,
@@ -1476,6 +1477,10 @@ function abilitiesFromText(
               // on-enemy-destroyed reactive trigger (position-scoped). The ENEMY-death
               // counterpart to detectDestroyedTrigger's SELF-death case above.
               detectEnemyDestroyedTrigger(text, healPos) ??
+              // Crocus (Phase 3 PR-C): a self-repair anchored in the "when another ally
+              // inflicts a Damage Over Time (DoT) effect with a critical hit" sentence rides
+              // the on-ally-crit-dot reactive trigger (self-target heal; position-scoped).
+              detectAllyCritDotTrigger(text, healPos) ??
               // Sefuba p1/p2: a self-repair anchored in the "when this Unit purges … enemy"
               // sentence rides the on-enemy-purged reactive trigger (position-scoped).
               detectEnemyPurgedTrigger(text, healPos) ??

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1325,6 +1325,22 @@ export function parseAllyCritDot(text: string | null | undefined): boolean {
     return !!text && ALLY_CRIT_DOT_RE.test(stripUnitTags(text));
 }
 
+/**
+ * Returns 'on-ally-crit-dot' when `anchorPos` (the ability's raw-text anchor position) falls
+ * inside the sentence carrying the "when (an/another) ally inflicts a DoT effect with a
+ * critical hit" phrase; otherwise undefined. Position-scoped on the RAW text (mirrors
+ * detectCritRepairTrigger). This is the HEAL-builder counterpart to parseAllyCritDot's
+ * DoT-infliction reading of the same phrase (Crocus p1: self-repair; Crocus p3/refit-passive
+ * additionally chains a DoT infliction on the same trigger, handled separately in
+ * buildShipAbilities' dot-effects branch). Reference data: docs/ship-skills.csv (Crocus).
+ */
+export function detectAllyCritDotTrigger(
+    text: string | null | undefined,
+    anchorPos: number
+): AbilityTrigger | undefined {
+    return phrasePosTrigger(text, ALLY_CRIT_DOT_RE, anchorPos, 'on-ally-crit-dot');
+}
+
 // Pallas's TWO ally-crit reactive phrasings (live triggers; see types/abilities.ts):
 //  - "when this unit critically repairs an ally / allies" → on-ally-critically-repaired (the
 //    OWNER's own crit-repair fires it; stamped onto heal/shield/cleanse abilities in that


### PR DESCRIPTION
## Phase 3 reactive-trigger promotion — PR-C

Stacked on #221 (PR-B). Part of the epic; **CI is intentionally red** for the duration of Phase 3 (the other clusters' triage probes stay red until their fix-PRs land — user pre-approved, no deploy until Phase 3 completes).

### Shipped: Crocus (Layer-1 tag inheritance)
Crocus's self-repair passive — *"When another ally inflicts a Damage Over Time (DoT) effect with a critical hit, this Unit repairs itself for 3% of its Max HP"* — now rides the **`on-ally-crit-dot`** reactive trigger instead of defaulting to `on-cast`.

- Added `detectAllyCritDotTrigger` (position-scoped wrapper around the pre-existing `ALLY_CRIT_DOT_RE`, mirroring `detectCritRepairTrigger`) in `skillTextParser.ts`.
- Wired it into the heal builder's `??` trigger-resolution chain in `buildShipAbilities.ts` (right after PR-B's `detectEnemyDestroyedTrigger`).
- Self-target heal → no actor capture needed (pure Layer-1).
- Updated a pre-existing `buildShipAbilities.test.ts` pin that had baked in the buggy `on-cast` heal trigger; the paired DoT ability already rode `on-ally-crit-dot`.
- Triage probe flipped RED→GREEN; non-vacuity bracket confirmed (revert wiring → probe red again).

### Deferred: Vindicator (spec-locked out-of-scope)
*"When this Unit resists a debuff infliction from an enemy, it deals damage equal to 30% of this Unit's max HP to that enemy."* — **not** a contained Layer-1 fix. Two independent infra gaps:
1. **No maxHP-scaled damage model** — the `damage` `AbilityConfig` carries only an attack%-based multiplier (`applyReactiveDamage`/`victimHitDamage` source `ownerStats.attack`); "30% of max HP" cannot be emitted faithfully.
2. **`no-capturable-actor`** — the `debuff-resisted` event carries only `targetId` (the resister), no source/attacker id, so "that enemy" (the resisted attacker) can't be resolved.

Both match the epic spec's locked "Out of scope" (`no-capturable-actor` → candidate future work). Probe left intentionally RED with a `// GAP: DEFERRED` note. No allowlist row (audit already reports 0 findings; a bare row would be stale).

### Gates
- `tsc --noEmit` clean; `npm run lint` clean; `npm run audit:skills` → 0 findings, 147 ships.
- Full suite: only the accepted Phase-3 triage reds fail (other clusters); Crocus green; no unintended golden churn (`buildShipAbilities.test.ts` was the only collateral pin, and it's a correct behavior update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)