### PR TITLE
fix(skills): Phase 3 PR-E — ally-debuff reactive support (Oleander RoT-to-ally + Hayyan on-ally-debuffed)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -34,6 +34,8 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: several \"on killing an enemy\" passives now actually trigger on a kill instead of never firing. Madax and Rikra repair themselves when an enemy dies, and Obsidian and Valiant gain charges for their Charged Skill on a kill.",
     "Combat sim: Crocus now repairs herself when another ally lands a critical Damage Over Time hit, matching her skill text, instead of only healing on her own turn.",
     "Combat sim: Valkyrie and her lowest-HP ally now repair when her Echoing Burst detonates on an enemy, matching her skill text, instead of the repair never firing.",
+    "Combat sim: Oleander now grants Repair Over Time II to an ally who inflicts a debuff (once per ally each round), matching her skill text, instead of the grant never firing.",
+    "Combat sim: Hayyan now repairs an ally for 6% of her Max HP whenever a debuff is inflicted on that ally, matching her skill text, instead of the repair never firing.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -115,6 +115,11 @@ export type AbilityTrigger =
     // `debuff-applied` event, self-scoped on targetId === ownerId). Does NOT fire for DoTs
     // (separate `dot-applied` event) — matches "when debuffed".
     | 'on-debuffed'
+    // Phase 3 PR-E: fires when a same-side ALLY (not the owner) receives a timed debuff
+    // (rides the existing `debuff-applied` event, ally-scoped on targetId being a same-side
+    // actor other than the owner). The ally counterpart of `on-debuffed`. Does NOT fire for
+    // DoTs (dot-applied), matching on-debuffed's debuff-applied-only scoping.
+    | 'on-ally-debuffed'
     // D-PR16 Lockdown: fires when THIS unit resists an incoming debuff (rides the existing
     // `debuff-resisted` event, self-scoped on targetId === ownerId). Chains off D-PR15's
     // Block-Debuff auto-resist emission AND normal hacking/affinity resists.
@@ -145,6 +150,8 @@ export const LIVE_TRIGGERS = new Set<AbilityTrigger>([
     'on-crit',
     'on-debuff-inflicted',
     'on-ally-debuff-inflicted',
+    // Phase 3 PR-E: ally-scoped counterpart of on-debuffed.
+    'on-ally-debuffed',
     'on-ally-crit-dot',
     'on-ally-critically-repaired',
     'on-ally-crit',
@@ -693,6 +700,13 @@ export interface Ability {
      *  AbilityConfig variants — this is the top-level Ability flag (read via
      *  `intent.ability.oncePerRound`), honoring the spec's "no AbilityConfig change". */
     oncePerRound?: boolean;
+    /** Phase 3 PR-E: this reactive applies at most once per round PER ALLY (keyed on
+     *  (owner, ability, eventCtx.damagedAllyId)), rather than once per round overall.
+     *  Oleander's "once per ally per round" RoT grant: a different ally inflicting a
+     *  debuff still procs even if another ally already consumed the cap this round.
+     *  Gated executor-side via IntentExecContext.oncePerRoundConsumed, keyed with the
+     *  ally id (distinct from the plain `oncePerRound` flag above). Absent → no cap. */
+    oncePerRoundPerAlly?: boolean;
     /** D-PR14 Bulwark: an on-ally-attacked reactive fires only when the DAMAGED ally is
      *  adjacent to this owner (board neighbours; non-positional → any living same-side ally).
      *  Filtered in the listener via registerReactiveListeners' adjacentAllyIdsFor. Absent →

--- a/src/utils/abilities/__tests__/reactiveTriggerPromotionTriage.test.ts
+++ b/src/utils/abilities/__tests__/reactiveTriggerPromotionTriage.test.ts
@@ -309,11 +309,12 @@ describe('cluster 7 — ally-crit / cleanse-reactive / DoT-crit / debuff-resiste
 
     const HAYYAN_P3 =
         "When a debuff is inflicted on an ally, this Unit <unit-damage>repairs the ally for 6%</unit-damage> of this Unit's Max HP.";
-    it('Hayyan: repair-on-ally-debuffed rides on-ally-debuff-inflicted', () => {
+    it('Hayyan: repair-on-ally-debuffed rides on-ally-debuffed', () => {
         const ab = abilitiesFor({ firstPassiveSkillText: HAYYAN_P3 }, 'passive');
         const heal = ab.find((a) => a.type === 'heal');
-        expect(heal?.trigger).toBe('on-ally-debuff-inflicted');
-        // GAP: needs-capture — same which-ally gap as Oleander (heal targets "the ally").
+        expect(heal?.trigger).toBe('on-ally-debuffed');
+        // GAP: needs-capture — NEW `on-ally-debuffed` trigger (victim-scoped `debuff-applied`,
+        // targetId is the debuffed ally; mirrors self-scoped `on-debuffed`).
     });
 
     const MORAO_P3 =

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -35,6 +35,7 @@ import {
     parseExtraAction,
     detectGrantConditions,
     detectReactiveTrigger,
+    detectAllyInflictsGrantTrigger,
     detectPreCombatBuffTrigger,
     detectPreCombatShieldTrigger,
     detectDamageReactionTrigger,
@@ -56,6 +57,7 @@ import {
     detectEnemyCleanseTrigger,
     detectEnemyPurgedTrigger,
     detectAllyPurgedTrigger,
+    detectAllyDebuffedTrigger,
     detectEndOfRoundPurgeTrigger,
     detectStartOfRoundTrigger,
     detectEndOfRoundDamageTrigger,
@@ -73,6 +75,7 @@ import {
     parseSelfBuffRemovals,
     parseEnemyChargedCastReaction,
     REMOVE_CHARGE_RE,
+    ONCE_PER_ALLY_PER_ROUND_RE,
     parseAllyInflictsDebuff,
     parseDetonateDoT,
     parseAccumulateDetonate,
@@ -1494,6 +1497,11 @@ function abilitiesFromText(
               // Salvation p3: a repair anchored in the "when a buff is purged from an ally"
               // sentence rides the on-ally-purged reactive trigger (position-scoped).
               detectAllyPurgedTrigger(text, healPos) ??
+              // Hayyan p2: a repair anchored in the "when a debuff is inflicted on an ally"
+              // sentence rides the on-ally-debuffed reactive trigger (victim-scoped; position-
+              // scoped). Position-scoping keeps Hayyan's sibling on-own-cleanse repair (a
+              // different sentence) untouched.
+              detectAllyDebuffedTrigger(text, healPos) ??
               (h.kind === 'shield'
                   ? (detectDebuffInflictedTrigger(text, healPos) ??
                     // Defiant: a SHIELD anchored in the "when applying Stasis" clause rides the
@@ -2289,9 +2297,27 @@ export function buildShipAbilities(ship: Ship): ShipSkills {
         if (reactiveTrigger === undefined && rowText && pos >= 0) {
             reactiveTrigger = detectRoundStartContinuationTrigger(rowText, pos);
         }
+        // Oleander: an ally-target buff granted "when an ally inflicts a debuff" rides
+        // on-ally-debuff-inflicted, routed to the inflicting ally via eventCtx.damagedAllyId. Gated on
+        // target==='ally' + type 'buff' so Provider's enemy-target Crit Rate Down II counter-debuff in the
+        // same phrasing family stays on-cast (a deferred deep one-off).
+        if (
+            reactiveTrigger === undefined &&
+            target === 'ally' &&
+            ability.config.type === 'buff' &&
+            rowText
+        ) {
+            reactiveTrigger = detectAllyInflictsGrantTrigger(rowText, buff.buffName);
+        }
         if (reactiveTrigger) {
             ability.trigger = reactiveTrigger;
             ability.conditions = ability.conditions.filter((c) => c.subject !== 'self-crit');
+            // Oleander's "once per ally per round" RoT grant: a DEDICATED cap (not the plain
+            // oncePerRound flag) so a different ally inflicting a debuff still procs even if
+            // another ally already consumed the cap this round.
+            if (reactiveTrigger === 'on-ally-debuff-inflicted' && rowText && ONCE_PER_ALLY_PER_ROUND_RE.test(rowText)) {
+                ability.oncePerRoundPerAlly = true;
+            }
         } else if (
             // Phase 4c PR 3 (Task 7): "when HP drops/falls below N%" buff-grant reactives
             // (Tycho/Shelter/Los/Kafa/Redeemer) ride the LIVE on-hp-threshold-crossed trigger.

--- a/src/utils/combat/__tests__/allyDebuffReactivePromotion.integration.test.ts
+++ b/src/utils/combat/__tests__/allyDebuffReactivePromotion.integration.test.ts
@@ -1,0 +1,504 @@
+/**
+ * Phase 3 PR-E — combat-integration tests for the ally-debuff reactive promotions:
+ *   - Oleander (2nd passive): "When an ally inflicts a debuff ... once per ally per round,
+ *     grants Repair Over Time II to that Ally" — on-ally-debuff-inflicted, source-scoped,
+ *     routed to the inflicting ally via eventCtx.damagedAllyId, capped once per ally per round.
+ *   - Hayyan (2nd passive, 2nd sentence): "When a debuff is inflicted on an ally, this Unit
+ *     repairs the ally for 6% of this Unit's Max HP" — NEW on-ally-debuffed trigger,
+ *     victim-scoped, routed to the debuffed ally via eventCtx.damagedAllyId.
+ *
+ * Both owner abilities are extracted through the REAL production path (`buildShipAbilities`)
+ * fed verbatim skill text copied from `docs/ship-skills.csv` (parser source of truth) — never a
+ * hand-built ability array. The surrounding cast (allies/enemies that merely need to inflict a
+ * debuff/DoT to generate the triggering event) are minimal hand-built actors, following the
+ * `enemySideAttacked.integration.test.ts` harness style.
+ *
+ * Non-vacuity: reverting the Task 2/3/4 src changes (skillTextParser.ts / buildShipAbilities.ts /
+ * triggers.ts) turns every "fires" assertion in this file red (verified manually; see the PR-E
+ * report for the exact revert/restore transcript).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { Ability, ShipSkills } from '../../../types/abilities';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
+
+function ship(over: Partial<Ship>): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}, {}, {}], ...over } as Ship;
+}
+
+// A no-op active (0-multiplier hit) so a focus/team actor with no offensive purpose still takes
+// a valid turn each round without ending combat early or erroring.
+const noopActiveSlot = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: 'noop-atk',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0 },
+        },
+    ],
+});
+
+/** Collect every `buff-applied` event from a run (Oleander's RoT grant is a BUFF — verifiable
+ *  via the bus, unlike a reactive HEAL; see sumDirectHeal below for why Hayyan's repair needs a
+ *  different verification path). */
+function runAndCollectBuffs(input: CombatEngineInput) {
+    const bus = createEventBus();
+    const buffsApplied: Extract<CombatEvent, { type: 'buff-applied' }>[] = [];
+    bus.on('buff-applied', (e) => buffsApplied.push(e));
+    runCombat({ ...input, bus });
+    return { buffsApplied };
+}
+
+// =============================================================================
+// Oleander — "When an ally inflicts a debuff ... once per ally per round, grants Repair Over
+// Time II to that Ally" (docs/ship-skills.csv, verbatim).
+// =============================================================================
+
+const OLEANDER_P3 =
+    "When an ally inflicts a debuff, this Unit <unit-aid>adds 1 charge</unit-aid> to it's Charged Skill and then, once per ally per round, grants <unit-skill>Repair Over Time II</unit-skill> to that Ally for 2 turns.";
+
+/** Extracts Oleander's RoT-to-ally grant through the REAL parser/builder (production routing). */
+function oleanderRotGrant(): Ability {
+    const abilities =
+        buildShipAbilities(ship({ firstPassiveSkillText: OLEANDER_P3 })).slots.find(
+            (s) => s.slot === 'passive'
+        )?.abilities ?? [];
+    const rot = abilities.find((a) => a.type === 'buff' && a.target === 'ally');
+    if (!rot) throw new Error('mutation guard: Oleander RoT-to-ally grant not found');
+    return rot;
+}
+
+// Sanity-check the extracted ability BEFORE using it as engine input — a mutation guard so a
+// regression in Tasks 2/3 fails loudly here rather than silently no-op'ing the engine tests below.
+describe('Oleander RoT grant — extracted ability shape (mutation guard)', () => {
+    it('rides on-ally-debuff-inflicted with the per-ally-per-round cap flag set', () => {
+        const rot = oleanderRotGrant();
+        expect(rot.trigger).toBe('on-ally-debuff-inflicted');
+        expect(rot.target).toBe('ally');
+        expect(rot.oncePerRoundPerAlly).toBe(true);
+    });
+});
+
+const debuffAbility = (buffName: string): Ability => ({
+    id: `deb-${buffName}`,
+    type: 'debuff',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: {
+        type: 'debuff',
+        buffName,
+        parsedEffects: {},
+        stacks: 1,
+        isStackable: false,
+        application: 'apply', // always lands — isolates the reactive-routing behavior under test
+        duration: 5,
+    },
+});
+
+describe('Oleander (player-side) — RoT routes to the inflicting ally, capped once per ally per round', () => {
+    const oleanderFocusSkills = (): ShipSkills => ({
+        slots: [noopActiveSlot(), { slot: 'passive', abilities: [oleanderRotGrant()] }],
+    });
+
+    const allyA = (): TeamActor =>
+        ({
+            id: 'ally-a',
+            speed: 130,
+            chargeCount: 0,
+            startCharged: false,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            walk: {
+                // TWO debuffs in ONE cast → two debuff-applied events from the SAME ally in the
+                // SAME round, proving the per-ally cap (not a plain once-per-round-overall cap).
+                shipSkills: {
+                    slots: [
+                        {
+                            slot: 'active',
+                            abilities: [debuffAbility('Def Down'), debuffAbility('Hacking Down')],
+                        },
+                    ],
+                },
+                stats: {
+                    attack: 100,
+                    crit: 0,
+                    critDamage: 0,
+                    defensePenetration: 0,
+                    hacking: 100,
+                    defence: 0,
+                    hp: 10_000,
+                },
+                selfDotModifier: 0,
+                defensePenetrationBuff: 0,
+                affinityDamageModifier: 0,
+                affinityCritCap: 100,
+                affinityCritPenalty: 0,
+                hasChargedSkill: false,
+            },
+        }) as TeamActor;
+
+    const allyB = (): TeamActor =>
+        ({
+            id: 'ally-b',
+            speed: 120,
+            chargeCount: 0,
+            startCharged: false,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            walk: {
+                shipSkills: { slots: [{ slot: 'active', abilities: [debuffAbility('Speed Down')] }] },
+                stats: {
+                    attack: 100,
+                    crit: 0,
+                    critDamage: 0,
+                    defensePenetration: 0,
+                    hacking: 100,
+                    defence: 0,
+                    hp: 10_000,
+                },
+                selfDotModifier: 0,
+                defensePenetrationBuff: 0,
+                affinityDamageModifier: 0,
+                affinityCritCap: 100,
+                affinityCritPenalty: 0,
+                hasChargedSkill: false,
+            },
+        }) as TeamActor;
+
+    const BASE = (): CombatEngineInput => ({
+        attack: 100,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: oleanderFocusSkills(),
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 100,
+        teamActors: [allyA(), allyB()],
+    });
+
+    it('grants RoT to ally-a ONCE (despite 2 inflictions) and to ally-b ONCE; never to the owner', () => {
+        const { buffsApplied } = runAndCollectBuffs(BASE());
+        const rot = buffsApplied.filter((b) => b.buffName === 'Repair Over Time II');
+
+        // Per-ally cap: ally-a inflicted twice this round but only received ONE grant.
+        expect(rot.filter((b) => b.actorId === 'ally-a')).toHaveLength(1);
+        // A DIFFERENT ally still procs — the cap is per-ally, not once-per-round-overall.
+        expect(rot.filter((b) => b.actorId === 'ally-b')).toHaveLength(1);
+        // The owner (Oleander/'attacker') never inflicted a debuff itself → never receives it.
+        expect(rot.some((b) => b.actorId === 'attacker')).toBe(false);
+        // Exactly 2 grants total this round.
+        expect(rot).toHaveLength(2);
+    });
+});
+
+describe('Oleander (enemy-side) — team symmetry: an enemy Oleander reacts to its OWN ally', () => {
+    it('grants the RoT to the inflicting ENEMY ally, not to itself', () => {
+        const enemyOleander: EnemyAttacker = {
+            id: 'enemy-oleander',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 10 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: { slots: [{ slot: 'passive', abilities: [oleanderRotGrant()] }] },
+        } as EnemyAttacker;
+
+        const enemyAllyDebuffer: EnemyAttacker = {
+            id: 'enemy-ally',
+            stats: { attack: 100, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 200 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: { slots: [{ slot: 'active', abilities: [debuffAbility('Def Down')] }] },
+        } as EnemyAttacker;
+
+        const input: CombatEngineInput = {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [noopActiveSlot()] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 1,
+            healTargetId: 'attacker',
+            enemyAttackers: [enemyAllyDebuffer, enemyOleander],
+        };
+
+        const { buffsApplied } = runAndCollectBuffs(input);
+        const rot = buffsApplied.filter((b) => b.buffName === 'Repair Over Time II');
+        expect(rot).toHaveLength(1);
+        expect(rot[0].actorId).toBe('enemy-ally');
+    });
+});
+
+// =============================================================================
+// Hayyan — "When a debuff is inflicted on an ally, this Unit repairs the ally for 6% of this
+// Unit's Max HP" (docs/ship-skills.csv, verbatim isolated sentence — matches the triage probe).
+// =============================================================================
+
+const HAYYAN_P3 =
+    "When a debuff is inflicted on an ally, this Unit <unit-damage>repairs the ally for 6%</unit-damage> of this Unit's Max HP.";
+
+/** Extracts Hayyan's ally-debuffed repair through the REAL parser/builder (production routing). */
+function hayyanAllyDebuffedHeal(): Ability {
+    const abilities =
+        buildShipAbilities(ship({ firstPassiveSkillText: HAYYAN_P3 })).slots.find(
+            (s) => s.slot === 'passive'
+        )?.abilities ?? [];
+    const heal = abilities.find((a) => a.type === 'heal' && a.trigger === 'on-ally-debuffed');
+    if (!heal) throw new Error('mutation guard: Hayyan on-ally-debuffed repair not found');
+    return heal;
+}
+
+const HAYYAN_HP = 20_000;
+const HAYYAN_HEAL_PCT = 6;
+
+describe('Hayyan RoT-repair — extracted ability shape (mutation guard)', () => {
+    it('rides the NEW on-ally-debuffed trigger, targeting the ally', () => {
+        const heal = hayyanAllyDebuffedHeal();
+        expect(heal.trigger).toBe('on-ally-debuffed');
+        expect(heal.target).toBe('ally');
+    });
+});
+
+/** An enemy that lands a timed (non-DoT) debuff on the player focus every round. */
+const debuffEnemy = (id: string): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 1, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1000 },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'enemy-debuff',
+                            type: 'debuff',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: {
+                                type: 'debuff',
+                                buffName: 'Def Down',
+                                parsedEffects: {},
+                                stacks: 1,
+                                isStackable: false,
+                                application: 'apply',
+                                duration: 1,
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+    }) as EnemyAttacker;
+
+/** An enemy that lands a DoT (not a timed debuff) on the player focus every round. */
+const dotEnemy = (id: string): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 1, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1000 },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'enemy-dot',
+                            type: 'dot',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'dot', dotType: 'corrosion', tier: 5, stacks: 1, duration: 3 },
+                        },
+                    ],
+                },
+            ],
+        },
+    }) as EnemyAttacker;
+
+const hayyanTeamActor = (): TeamActor =>
+    ({
+        id: 'hayyan',
+        speed: 80,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        walk: {
+            shipSkills: { slots: [{ slot: 'passive', abilities: [hayyanAllyDebuffedHeal()] }] },
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp: HAYYAN_HP,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    }) as TeamActor;
+
+const HAYYAN_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [noopActiveSlot()] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    speed: 1, // slower than the enemy → the enemy's debuff/DoT lands before the focus acts
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+// A reactive heal never re-emits `heal-performed` (deliberate chain guard — triggers.ts ~2019:
+// "a reactive heal must not re-trigger heal listeners"). It DOES credit the healing-mode
+// per-round bookkeeping (`ctx.healing.credit(ownerId, 'directHeal', raw)`), so verification reads
+// `result.healing.rounds[].perActor.get(ownerId).directHeal`, mirroring purgeReactiveIntegration's
+// Salvation/Sefuba pattern.
+function sumDirectHeal(result: ReturnType<typeof runCombat>, actorId: string): number {
+    return (result.healing?.rounds ?? []).reduce(
+        (sum, rd) => sum + (rd.perActor.get(actorId)?.directHeal ?? 0),
+        0
+    );
+}
+
+describe('Hayyan (player-side) — repairs ONLY the debuffed ally, not itself, not on a DoT', () => {
+    it('an enemy debuff on the ally (focus) is repaired by Hayyan (team actor) for 6% of Hayyan Max HP', () => {
+        const result = runCombat(
+            HAYYAN_BASE({ teamActors: [hayyanTeamActor()], enemyAttackers: [debuffEnemy('enemy-deb')] })
+        );
+        // numRounds:1 → exactly one qualifying debuff-applied event → one 6%-of-max-HP grant.
+        expect(sumDirectHeal(result, 'hayyan')).toBeCloseTo((HAYYAN_HP * HAYYAN_HEAL_PCT) / 100, 6);
+    });
+
+    it('a debuff landing on Hayyan ITSELF (self, not an ally) does NOT fire on-ally-debuffed', () => {
+        // Hayyan IS the focus here (ownerId === 'attacker'); the enemy debuffs 'attacker' → the
+        // targetId equals the OWNER's own id → isSameSideAlly excludes it (that is on-debuffed's
+        // job, not on-ally-debuffed's).
+        const selfHayyanSkills: ShipSkills = {
+            slots: [noopActiveSlot(), { slot: 'passive', abilities: [hayyanAllyDebuffedHeal()] }],
+        };
+        const result = runCombat(
+            HAYYAN_BASE({ shipSkills: selfHayyanSkills, enemyAttackers: [debuffEnemy('enemy-deb')] })
+        );
+        expect(sumDirectHeal(result, 'attacker')).toBe(0);
+    });
+
+    it('a DoT (not a timed debuff) landing on the ally does NOT fire on-ally-debuffed', () => {
+        const result = runCombat(
+            HAYYAN_BASE({ teamActors: [hayyanTeamActor()], enemyAttackers: [dotEnemy('enemy-dot')] })
+        );
+        expect(sumDirectHeal(result, 'hayyan')).toBe(0);
+    });
+});
+
+describe('Hayyan (enemy-side) — team symmetry: an enemy Hayyan repairs its OWN debuffed ally', () => {
+    it('repairs the ally the PLAYER just debuffed (the shared enemy-side dummy actor), scaled off its OWN max HP', () => {
+        // The player's non-positional debuff always lands on the singular dummy `enemy` actor
+        // (id 'enemy') — the engine's own doc comment (CombatEngineInput.enemyAttackers) names it
+        // "the player-offense target". That dummy IS enemy-side (isEnemySide checks
+        // `actorId === enemy.id`), so it is a same-side ALLY to enemy-hayyan — exactly the
+        // ally-scoping this trigger exists to prove, without needing extra positional plumbing.
+        const enemyHayyan: EnemyAttacker = {
+            id: 'enemy-hayyan',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: HAYYAN_HP, speed: 10 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: { slots: [{ slot: 'passive', abilities: [hayyanAllyDebuffedHeal()] }] },
+        } as EnemyAttacker;
+
+        const playerDebuffSkills: ShipSkills = {
+            slots: [{ slot: 'active', abilities: [debuffAbility('Def Down')] }],
+        };
+
+        const input: CombatEngineInput = {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: playerDebuffSkills,
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 200, // player acts first — its debuff wakes the enemy reactive same round
+            healTargetId: 'attacker',
+            enemyAttackers: [enemyHayyan],
+        };
+
+        const result = runCombat(input);
+        expect(sumDirectHeal(result, 'enemy-hayyan')).toBeCloseTo((HAYYAN_HP * HAYYAN_HEAL_PCT) / 100, 6);
+    });
+});

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -104,7 +104,10 @@ export interface Intent {
      *  branch routes the application to THIS enemy's per-target store.
      *  `damagedAllyId`: the DAMAGED ally's actor id (on-ally-attacked) — the heal and
      *  buff branches route an 'ally'-target payload to exactly this recipient
-     *  (Cultivator's repair, Refine/Graphite's grants) instead of the default.
+     *  (Cultivator's repair, Refine/Graphite's grants) instead of the default. Generic
+     *  "route reactive ally-support here" field: also carries the inflicting/victim ally
+     *  for debuff-event reactions (Oleander's on-ally-debuff-inflicted RoT grant routes to
+     *  the inflicting ally; Hayyan's on-ally-debuffed repair routes to the debuffed ally).
      *  `fromPurgeEvent`: depth-1 purge chain guard — a purge triggered by a
      *  purge-performed event does not re-emit purge-performed, preventing infinite chains. */
     eventCtx?: {
@@ -207,6 +210,9 @@ export function partitionReactiveAbilities(shipSkills: ShipSkills): {
  *    ally (not opposing, not the owner itself). For the PLAYER registration this is any OTHER
  *    PLAYER's infliction; for the ENEMY registration this is any other enemy actor's infliction.
  *    The dot-applied subscription is now LIVE (the team dot-applied seam exists since Task 4).
+ *  - on-ally-debuffed → debuff-applied where the TARGET is a same-side ally (not opposing, not
+ *    the owner itself) — the ally counterpart of on-debuffed (Hayyan). Does NOT subscribe to
+ *    dot-applied, matching on-debuffed's scoping.
  *  - on-ally-crit-dot → dot-applied with viaCrit from any same-side ally (opposing sources
  *    excluded, own casts excluded)
  *  - on-ally-critically-repaired → the OWNER's OWN heal-performed (casterId === ownerId) with
@@ -367,13 +373,15 @@ export function registerReactiveListeners(args: {
                         // Ally = any OTHER same-side actor's infliction. Exclude this owner
                         // (own inflictions go to on-debuff-inflicted) AND every opposing actor
                         // (an opposing actor is never an ally).
-                        if (isSameSideAlly(e.sourceId, ownerId)) enqueue(intent);
+                        if (isSameSideAlly(e.sourceId, ownerId))
+                            enqueue({ ...intent, eventCtx: { ...intent.eventCtx, damagedAllyId: e.sourceId } });
                     });
                     bus.on('dot-applied', (e) => {
                         // Team DoT applications now emit dot-applied with the team sourceId
                         // (Task 4 seam, live since Task 6) — an ally DoT infliction triggers
                         // this listener exactly as an ally debuff does.
-                        if (isSameSideAlly(e.sourceId, ownerId)) enqueue(intent);
+                        if (isSameSideAlly(e.sourceId, ownerId))
+                            enqueue({ ...intent, eventCtx: { ...intent.eventCtx, damagedAllyId: e.sourceId } });
                     });
                     break;
                 case 'on-ally-crit-dot':
@@ -519,6 +527,16 @@ export function registerReactiveListeners(args: {
                         // on-attacked's targetId === ownerId scoping. DoTs use dot-applied (not
                         // this event) → Firewall does not fire on DoT application, by design.
                         if (e.targetId === ownerId) enqueue(intent);
+                    });
+                    break;
+                case 'on-ally-debuffed':
+                    bus.on('debuff-applied', (e) => {
+                        // Victim-scoped: a timed debuff landed on MY ally (Hayyan). The ally counterpart of
+                        // on-debuffed (which is targetId === ownerId). Route the reactive repair to that ally
+                        // via damagedAllyId. Excludes the owner (that is on-debuffed) and DoTs (dot-applied),
+                        // matching on-debuffed's debuff-applied-only scoping.
+                        if (isSameSideAlly(e.targetId, ownerId))
+                            enqueue({ ...intent, eventCtx: { ...intent.eventCtx, damagedAllyId: e.targetId } });
                     });
                     break;
                 case 'on-debuff-resisted':
@@ -1579,6 +1597,19 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
             const key = `${intent.ownerId}:${intent.ability.id}`;
             if (ctx.oncePerCombatFired?.has(key)) return;
             ctx.oncePerCombatFired?.add(key);
+        }
+        // Phase 3 PR-E: "once per ally per round" cap (Oleander's RoT-to-ally grant). A DEDICATED
+        // flag — not the plain oncePerRound gate above, which has no gate in THIS branch today
+        // (adding one there would newly cap every other reactive buff and drift goldens). Keyed
+        // on (owner, ability, damagedAllyId) so a DIFFERENT ally still procs this round.
+        // NOTE: consumes the cap BEFORE the procChance gate below. Inert today (Oleander's grant
+        // has no procChance), but if a future oncePerRoundPerAlly ability ALSO carries a
+        // procChance, move this below passesProcChanceGate so a failed proc does not burn the cap
+        // (matching the plain oncePerRound "mark only on a successful proc" contract).
+        if (intent.ability.oncePerRoundPerAlly) {
+            const key = `${intent.ownerId}:${intent.ability.id}:${intent.eventCtx?.damagedAllyId ?? ''}`;
+            if (ctx.oncePerRoundConsumed?.has(key)) return;
+            ctx.oncePerRoundConsumed?.add(key);
         }
         // D-PR8: procChance gate for reactive buff grants (Ambush 5-16%, Alacrity 12-20%).
         // De-Morgan pass-through — true when procChance is undefined/≤0/≥1, so every existing

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -649,6 +649,11 @@ const EVERY_SECOND_REPAIR_RE = /every second repair/i;
 // A team-dependent trigger: manual (non-derivable) since the single-ship sim has no allies.
 const ALLY_INFLICTS_DEBUFF_RE = /\ball(?:y|ies)\b[^.]*\b(?:appl|inflict)\w*\s+a\s+debuff\b/i;
 
+// Oleander's "once per ally per round" cap on the RoT-to-ally grant — distinct from the plain
+// "once per round" cap (ECC_ONCE_PER_ROUND_RE) which caps once per round OVERALL, not per ally.
+// Exported: buildShipAbilities.ts's mergeBuff path tests it directly against the buff's clause.
+export const ONCE_PER_ALLY_PER_ROUND_RE = /\bonce per ally per round\b/i;
+
 // Cobalt: "adds N charge ... at the start of the turn if it is at full HP" — a periodic
 // self-charge gated on full HP. The two halves are detected together so the start-of-turn
 // trigger and the hp-threshold gate ride as a pair. Epic PR4: ALSO reused (unmodified regex)
@@ -1111,6 +1116,22 @@ export function detectReactiveTrigger(
     if (KILL_TRIGGER_RE.test(clause)) return 'on-enemy-destroyed';
     if (APPLYING_DEBUFF_RE.test(clause)) return 'on-debuff-inflicted';
     return undefined;
+}
+
+/** Oleander: an ALLY-target buff granted in a "when an ally inflicts a debuff" clause rides
+ *  on-ally-debuff-inflicted (routed to the inflicting ally via eventCtx.damagedAllyId). Scoped to
+ *  the buff's OWN clause (resolveBuffClause). Distinct from detectReactiveTrigger because that
+ *  function is target-blind: the caller gates this on target==='ally' so an enemy-target counter-
+ *  debuff in the same "ally inflicts a debuff" phrasing family (Provider's Crit Rate Down II)
+ *  stays on-cast. */
+export function detectAllyInflictsGrantTrigger(
+    text: string | null | undefined,
+    buffName: string
+): AbilityTrigger | undefined {
+    if (!text || !buffName) return undefined;
+    return ALLY_INFLICTS_DEBUFF_RE.test(resolveBuffClause(text, buffName))
+        ? 'on-ally-debuff-inflicted'
+        : undefined;
 }
 
 // Epic PR4 (start-of-combat one-time grant family): "At the start of combat, this Unit gains
@@ -1678,6 +1699,24 @@ export function detectAllyPurgedTrigger(
     anchorPos: number
 ): AbilityTrigger | undefined {
     return phrasePosTrigger(text, ALLY_PURGED_RE, anchorPos, 'on-ally-purged');
+}
+
+// "When a debuff is inflicted on an ally" — Hayyan p2's second sentence (victim-scoped repair).
+// Corpus-verified: grep docs/ship-skills.csv for "debuff is inflicted on an ally" = Hayyan only.
+const ALLY_DEBUFFED_RE = /\bdebuff\s+is\s+inflicted\s+on\s+an\s+ally\b/i;
+
+/**
+ * Returns 'on-ally-debuffed' when `anchorPos` falls inside the sentence carrying the
+ * "when a debuff is inflicted on an ally" phrase (Hayyan p2); otherwise undefined.
+ * Position-scoped on the RAW text (mirrors detectAllyPurgedTrigger) so Hayyan's SIBLING
+ * "when cleansing a debuff from an ally" repair (a different sentence, PR-H) is untouched.
+ * Reference data: docs/ship-skills.csv (Hayyan).
+ */
+export function detectAllyDebuffedTrigger(
+    text: string | null | undefined,
+    anchorPos: number
+): AbilityTrigger | undefined {
+    return phrasePosTrigger(text, ALLY_DEBUFFED_RE, anchorPos, 'on-ally-debuffed');
 }
 
 // "at the end of the round, … purges …" — Rhodium end-of-round purge. Position-scoped.


### PR DESCRIPTION
## Phase 3 PR-E — reactive-trigger promotion (first L2, `debuff-applied` ally capture)

Stacked on #223 (`phase3/pr-d-bomb-detonated-heal`). Part of the reactive-trigger-promotion epic; **red CI is accepted for the phase** (no deploy until Phase 3 completes) — the remaining triage reds are the intentional later-cluster gaps inherited from the stack.

Promotes two reactive support effects from `on-cast` to their real triggers, routing each to the correct ally.

### Oleander — `on-ally-debuff-inflicted` (source-scoped) + per-ally cap
"When an ally inflicts a debuff … grants **Repair Over Time II to that Ally**, once per ally per round." The RoT buff now rides `on-ally-debuff-inflicted` and routes to the **inflicting** ally (`debuff-applied.sourceId`) via `eventCtx.damagedAllyId`, with a dedicated per-(owner, ability, ally) round cap (`oncePerRoundPerAlly`). The charge half already rode the trigger.

### Hayyan — NEW `on-ally-debuffed` trigger (victim-scoped)
"When a debuff is inflicted **on an ally** … repairs the ally 6%." **Triage correction:** the DAG lumped this with Oleander, but its ally is the debuff **victim**, not the inflicter — it needs a new `on-ally-debuffed` trigger (the ally counterpart of self-scoped `on-debuffed`, `debuff-applied.targetId`, excludes owner and DoTs). Routes via `damagedAllyId`. Hayyan's sibling on-own-cleanse repair is position-scoped out and stays `on-cast` for a later PR.

### Notes / safety
- Reuses the generic `eventCtx.damagedAllyId` routing (established by `on-ally-purged`) — no new eventCtx field, no reader changes.
- **Provider collision fixed:** the promotion is gated at the mergeBuff caller on `target === 'ally' && type 'buff'` (via a new `detectAllyInflictsGrantTrigger`), so Provider's enemy-target Crit Rate Down II counter-debuff in the same phrasing family stays `on-cast`.
- Team-symmetric by construction (`isSameSideAlly` + shared `debuff-applied` bus); enemy-side behavior asserted.
- Both triage probes flipped green; 8 new integration tests (per-ally cap, self/DoT exclusion, team symmetry) with an independent non-vacuity bracket.
- Full suite: only the 7 pre-existing later-cluster triage reds remain; **goldens byte-identical** beyond Oleander/Hayyan. `audit:skills` 0 findings / 0 stale. Changelog entries added.

Adversarial review: APPROVE-WITH-NITS (both nits applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dp1hGz5xU95ZwDtmWSnvT