### PR TITLE
fix(skills): Phase 3 PR-F — on-enemy-repaired reactive debuffs (Ruiner Bomb + Amartya Defense Shred)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -36,6 +36,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Valkyrie and her lowest-HP ally now repair when her Echoing Burst detonates on an enemy, matching her skill text, instead of the repair never firing.",
     "Combat sim: Oleander now grants Repair Over Time II to an ally who inflicts a debuff (once per ally each round), matching her skill text, instead of the grant never firing.",
     "Combat sim: Hayyan now repairs an ally for 6% of her Max HP whenever a debuff is inflicted on that ally, matching her skill text, instead of the repair never firing.",
+    "Combat sim: Ruiner now inflicts Bomb II on any enemy that performs a repair (once per round per enemy), matching her skill text, instead of never firing. Amartya now inflicts a stack of Defense Shred on the specific enemy defender that was just repaired, instead of never firing.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -707,6 +707,20 @@ export interface Ability {
      *  Gated executor-side via IntentExecContext.oncePerRoundConsumed, keyed with the
      *  ally id (distinct from the plain `oncePerRound` flag above). Absent → no cap. */
     oncePerRoundPerAlly?: boolean;
+    /** Phase 3 PR-F: this reactive applies at most once per round PER ENEMY (keyed on
+     *  (owner, ability, eventCtx.repairerId)), rather than once per round overall. Ruiner's
+     *  "once per round per enemy" Bomb-on-repair: a DIFFERENT enemy repairing still procs
+     *  even if one enemy already consumed the cap this round. Gated executor-side via
+     *  IntentExecContext.oncePerRoundConsumed (mirrors oncePerRoundPerAlly above, keyed with
+     *  the repairer id instead of an ally id). Absent → no cap. */
+    oncePerRoundPerEnemy?: boolean;
+    /** Phase 3 PR-F: an on-enemy-repaired debuff lands on the REPAIRED RECIPIENT(S)
+     *  (eventCtx.repairedEnemyIds — "that defender", Amartya's Defense Shred) instead of the
+     *  default single counterTargetId/ctx.enemy.id route every other debuff applier uses
+     *  (including Ruiner's REPAIRER-targeted Bomb sharing the same trigger + event). A
+     *  multi-recipient heal fans the debuff out to EVERY repaired recipient. Absent → the
+     *  normal single-target route. */
+    repairedRecipientTargeted?: boolean;
     /** D-PR14 Bulwark: an on-ally-attacked reactive fires only when the DAMAGED ally is
      *  adjacent to this owner (board neighbours; non-positional → any living same-side ally).
      *  Filtered in the listener via registerReactiveListeners' adjacentAllyIdsFor. Absent →

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -65,6 +65,8 @@ import {
     detectKilledByDirectDamageTrigger,
     detectMostBuffsTarget,
     detectRepairedThisRoundCondition,
+    detectEnemyRepairedTrigger,
+    ONCE_PER_ROUND_PER_ENEMY_RE,
     PURGE_MORE_RE,
     parseControlInflicts,
     detectAllyCritTrigger,
@@ -2315,7 +2317,11 @@ export function buildShipAbilities(ship: Ship): ShipSkills {
             // Oleander's "once per ally per round" RoT grant: a DEDICATED cap (not the plain
             // oncePerRound flag) so a different ally inflicting a debuff still procs even if
             // another ally already consumed the cap this round.
-            if (reactiveTrigger === 'on-ally-debuff-inflicted' && rowText && ONCE_PER_ALLY_PER_ROUND_RE.test(rowText)) {
+            if (
+                reactiveTrigger === 'on-ally-debuff-inflicted' &&
+                rowText &&
+                ONCE_PER_ALLY_PER_ROUND_RE.test(rowText)
+            ) {
                 ability.oncePerRoundPerAlly = true;
             }
         } else if (
@@ -2404,6 +2410,24 @@ export function buildShipAbilities(ship: Ship): ShipSkills {
                         },
                     ];
                 }
+            } else if (target === 'enemy' && rowText && pos >= 0) {
+                // Phase 3 PR-F: Amartya's "when an enemy defender is directly repaired, …
+                // inflicts 1 stack of Defense Shred on that defender" — NOT a damage reaction
+                // (detectDamageReactionTrigger above returns undefined), so it falls through
+                // here. Enemy-target-only: Ruiner's SAME-family "on any enemy performing a
+                // repair" phrasing never reaches this branch because it names a DoT (Bomb),
+                // which mergeBuff never sees (isDoTBuffName excludes it — handled separately by
+                // the passive DoT-reaction loop below).
+                const enemyRepairedReaction = detectEnemyRepairedTrigger(rowText, pos);
+                if (enemyRepairedReaction) {
+                    ability.trigger = enemyRepairedReaction.trigger;
+                    // "That defender" = the REPAIRED RECIPIENT, not the repairer — route via
+                    // eventCtx.repairedEnemyIds (fans out over every healed enemy) instead of
+                    // the default single counterTargetId route.
+                    if (enemyRepairedReaction.recipientTargeted) {
+                        ability.repairedRecipientTargeted = true;
+                    }
+                }
             }
         }
         // Epic PR4 (start-of-combat one-time grant family): a still-on-cast, NON-STACKING buff
@@ -2460,9 +2484,16 @@ export function buildShipAbilities(ship: Ship): ShipSkills {
             const pos = passiveRowText.indexOf(eff.buffName);
             const reaction =
                 pos >= 0 ? detectDamageReactionTrigger(passiveRowText, pos) : undefined;
-            if (!reaction) continue;
+            // Phase 3 PR-F: Ruiner's "This Unit inflicts Bomb II … on any enemy performing a
+            // repair, once per round per enemy" is the SAME name-only-DEBUFF shape as the
+            // Warden/Shepherd damage-reaction case above, but the reaction is an on-enemy-repaired
+            // one instead of on-attacked — checked only when the damage-reaction detector found
+            // nothing, so the two phrasing families stay mutually exclusive.
+            const enemyRepairedReaction =
+                !reaction && pos >= 0 ? detectEnemyRepairedTrigger(passiveRowText, pos) : undefined;
+            if (!reaction && !enemyRepairedReaction) continue;
             const dotReactionConditions: Condition[] =
-                reaction.hpBelowPct !== undefined
+                reaction?.hpBelowPct !== undefined
                     ? [
                           {
                               subject: 'hp-threshold',
@@ -2477,8 +2508,15 @@ export function buildShipAbilities(ship: Ship): ShipSkills {
                 id: nextId(),
                 type: 'debuff',
                 target: 'enemy',
-                trigger: reaction.trigger,
-                ...(reaction.critFilter ? { triggerCritFilter: reaction.critFilter } : {}),
+                trigger: reaction?.trigger ?? enemyRepairedReaction!.trigger,
+                ...(reaction?.critFilter ? { triggerCritFilter: reaction.critFilter } : {}),
+                // "once per round per enemy" (Ruiner) — a DIFFERENT repairing enemy still procs.
+                // Tested against the whole passive row rather than a sentence scope: the phrase
+                // is corpus-unique to Ruiner (docs/ship-skills.csv), so there is no cross-talk
+                // risk from a broader match.
+                ...(enemyRepairedReaction && ONCE_PER_ROUND_PER_ENEMY_RE.test(passiveRowText)
+                    ? { oncePerRoundPerEnemy: true }
+                    : {}),
                 conditions: dotReactionConditions,
                 config: {
                     type: 'debuff',

--- a/src/utils/combat/__tests__/onEnemyRepairedReactivePromotion.integration.test.ts
+++ b/src/utils/combat/__tests__/onEnemyRepairedReactivePromotion.integration.test.ts
@@ -1,0 +1,495 @@
+/**
+ * Phase 3 PR-F — combat-integration tests for the `on-enemy-repaired` recipient + Ruiner
+ * promotions:
+ *   - Ruiner (1st passive): "This Unit inflicts Bomb II for 2 turns on any enemy performing a
+ *     repair, once per round per enemy" — on-enemy-repaired, REPAIRER-routed via
+ *     eventCtx.counterTargetId (fed by repairerId), capped once per round PER ENEMY
+ *     (oncePerRoundPerEnemy).
+ *   - Amartya (1st passive): "When an enemy defender is directly repaired, this Unit inflicts
+ *     1 stack of Defense Shred on that defender" — on-enemy-repaired, RECIPIENT-routed via
+ *     eventCtx.repairedEnemyIds (repairedRecipientTargeted), with NO per-round cap.
+ *
+ * Both owner abilities are extracted through the REAL production path (`buildShipAbilities`)
+ * fed verbatim skill text copied from `docs/ship-skills.csv` (parser source of truth) — never a
+ * hand-built ability array. The surrounding cast (enemies/allies that merely need to perform a
+ * repair to generate the triggering event) are minimal hand-built actors, following
+ * `allyDebuffReactivePromotion.integration.test.ts`'s harness style.
+ *
+ * Non-vacuity: reverting the PR-F src changes (skillTextParser.ts / buildShipAbilities.ts /
+ * triggers.ts) turns every "fires"/"routes" assertion in this file red (verified manually — see
+ * the PR-F report for the exact revert/restore transcript).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { Ability, ShipSkills } from '../../../types/abilities';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
+
+function ship(over: Partial<Ship>): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}, {}, {}], ...over } as Ship;
+}
+
+// A no-op active (0-multiplier hit) so a focus/team actor with no offensive purpose still takes
+// a valid turn each round without ending combat early or erroring.
+const noopActiveSlot = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: 'noop-atk',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0 },
+        },
+    ],
+});
+
+/** Collect every `debuff-applied` event from a run — the discrete infliction event, one per
+ *  landed application, carrying the exact `targetId` the executor routed to. */
+function runAndCollectDebuffs(input: CombatEngineInput) {
+    const bus = createEventBus();
+    const debuffsApplied: Extract<CombatEvent, { type: 'debuff-applied' }>[] = [];
+    bus.on('debuff-applied', (e) => debuffsApplied.push(e));
+    runCombat({ ...input, bus });
+    return { debuffsApplied };
+}
+
+// A plain self-heal (10% of own max HP, unconditional — heals even at full HP since the engine
+// pushes every recipient onto `healTargets` regardless of actual consumption) — the minimal
+// "this actor performs a repair" trigger for on-enemy-repaired.
+const selfHeal = (id: string): Ability => ({
+    id,
+    type: 'heal',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'heal', pct: 10, basis: 'target-hp' },
+});
+
+// A heal targeting a SINGLE other same-side actor ('ally' target) — for an enemy caster this
+// resolves to the lowest-HP OTHER living enemy ally (never the caster); for a player caster this
+// resolves to CombatEngineInput.healTargetId. Used to prove Amartya's Defense Shred lands on the
+// RECIPIENT, distinct from the caster.
+const healAlly = (id: string): Ability => ({
+    id,
+    type: 'heal',
+    target: 'ally',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'heal', pct: 10, basis: 'target-hp' },
+});
+
+// An AoE heal ('all-allies' target) — a SINGLE cast that repairs EVERY same-side actor, emitting
+// ONE heal-performed event whose `targets` lists all recipients. Used to exercise the
+// repairedEnemyIds.length > 1 fan-out (one repair event → Defense Shred on each repaired
+// recipient). NOTE: 'all-allies' includes the caster itself (there is no caster-excluding
+// multi-recipient heal target — 'ally' is single, 'adjacent-allies' isn't resolved by the heal
+// path), so the caster is legitimately one of the repaired recipients and receives Defense Shred
+// too. The discriminating assertion is that the OTHER (non-caster) recipients each receive it from
+// the one event — under a hypothetical repairer-only routing ONLY the caster would.
+const healAllAllies = (id: string): Ability => ({
+    id,
+    type: 'heal',
+    target: 'all-allies',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'heal', pct: 10, basis: 'target-hp' },
+});
+
+// Liberator-style once-per-round self extra-action (verified game rule: re-inserts the actor at
+// its speed position; the fastest remaining actor acts again immediately). Used to make the SAME
+// actor perform two repairs within a single round — the only way this per-turn engine produces
+// two `heal-performed` events from one caster in one round.
+const extraAction = (id: string): Ability => ({
+    id,
+    type: 'extra-action',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'extra-action', oncePerRound: true },
+});
+
+// =============================================================================
+// Ruiner — "This Unit inflicts Bomb II for 2 turns on any enemy performing a repair, once per
+// round per enemy" (docs/ship-skills.csv, verbatim).
+// =============================================================================
+
+const RUINER_P2 =
+    'This Unit inflicts <unit-skill>Bomb II</unit-skill> for 2 turns on any enemy performing a <unit-aid>repair</unit-aid>, once per round per enemy.';
+
+/** Extracts Ruiner's Bomb-on-enemy-repair debuff through the REAL parser/builder. */
+function ruinerBombAbility(): Ability {
+    const abilities =
+        buildShipAbilities(ship({ firstPassiveSkillText: RUINER_P2 })).slots.find(
+            (s) => s.slot === 'passive'
+        )?.abilities ?? [];
+    const bomb = abilities.find(
+        (a) => a.type === 'debuff' && a.config.type === 'debuff' && a.config.buffName === 'Bomb II'
+    );
+    if (!bomb) throw new Error('mutation guard: Ruiner Bomb-on-enemy-repair debuff not found');
+    return bomb;
+}
+
+// Sanity-check the extracted ability BEFORE using it as engine input — a mutation guard so a
+// regression in the parser/builder wiring fails loudly here rather than silently no-op'ing the
+// engine tests below.
+describe('Ruiner Bomb — extracted ability shape (mutation guard)', () => {
+    it('rides on-enemy-repaired, enemy-targeted, with the once-per-round-per-enemy cap flag set', () => {
+        const bomb = ruinerBombAbility();
+        expect(bomb.trigger).toBe('on-enemy-repaired');
+        expect(bomb.target).toBe('enemy');
+        expect(bomb.oncePerRoundPerEnemy).toBe(true);
+        // NOT recipient-targeted — Ruiner routes to the REPAIRER, Amartya's flag stays unset here.
+        expect(bomb.repairedRecipientTargeted).toBeUndefined();
+    });
+});
+
+describe('Ruiner (player-side) — Bomb routes to the REPAIRER, capped once per round PER ENEMY', () => {
+    const ruinerFocusSkills = (): ShipSkills => ({
+        slots: [noopActiveSlot(), { slot: 'passive', abilities: [ruinerBombAbility()] }],
+    });
+
+    // enemy-x: fastest, self-heals AND grants itself one extra action → repairs TWICE this round.
+    const enemyX = (): EnemyAttacker =>
+        ({
+            id: 'enemy-x',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000, speed: 1000 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: {
+                slots: [
+                    { slot: 'active', abilities: [selfHeal('x-heal')] },
+                    { slot: 'passive', abilities: [extraAction('x-extra')] },
+                ],
+            },
+        }) as EnemyAttacker;
+
+    // enemy-y: no extra action → repairs ONCE this round. A DIFFERENT repairer from enemy-x.
+    const enemyY = (): EnemyAttacker =>
+        ({
+            id: 'enemy-y',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000, speed: 500 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: { slots: [{ slot: 'active', abilities: [selfHeal('y-heal')] }] },
+        }) as EnemyAttacker;
+
+    const BASE = (): CombatEngineInput => ({
+        attack: 0,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: ruinerFocusSkills(),
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 1,
+        healTargetId: 'attacker',
+        enemyAttackers: [enemyX(), enemyY()],
+    });
+
+    it('enemy-x repairs TWICE this round but receives Bomb II only ONCE (per-enemy cap); enemy-y (a DIFFERENT enemy) still gets its own Bomb II', () => {
+        const { debuffsApplied } = runAndCollectDebuffs(BASE());
+        const bombs = debuffsApplied.filter((d) => d.buffName === 'Bomb II');
+        // Routing proof: the Bomb lands on the ACTUAL repairer id, not a shared default target —
+        // if routing were broken (falling back to the singular default enemy store) neither
+        // enemy-x nor enemy-y would appear here at all.
+        expect(bombs.filter((b) => b.targetId === 'enemy-x')).toHaveLength(1);
+        expect(bombs.filter((b) => b.targetId === 'enemy-y')).toHaveLength(1);
+        expect(bombs).toHaveLength(2);
+    });
+});
+
+describe('Ruiner (enemy-side) — team symmetry: an enemy Ruiner reacts to a PLAYER repair', () => {
+    it('Bomb lands on the repairing PLAYER actor (attacker), not a default target', () => {
+        const enemyRuiner: EnemyAttacker = {
+            id: 'enemy-ruiner',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 10 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: { slots: [{ slot: 'passive', abilities: [ruinerBombAbility()] }] },
+        } as EnemyAttacker;
+
+        const input: CombatEngineInput = {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [{ slot: 'active', abilities: [selfHeal('atk-heal')] }] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 200, // player acts first — its self-repair wakes the enemy reactive same round
+            healTargetId: 'attacker',
+            enemyAttackers: [enemyRuiner],
+        };
+
+        const { debuffsApplied } = runAndCollectDebuffs(input);
+        const bombs = debuffsApplied.filter((d) => d.buffName === 'Bomb II');
+        expect(bombs).toHaveLength(1);
+        expect(bombs[0].targetId).toBe('attacker');
+    });
+});
+
+// =============================================================================
+// Amartya — "When an enemy defender is directly repaired, this Unit inflicts 1 stack of
+// Defense Shred on that defender" (docs/ship-skills.csv, verbatim).
+// =============================================================================
+
+const AMARTYA_P2 =
+    'When an enemy defender is directly repaired, this Unit inflicts 1 stack of <unit-skill>Defense Shred</unit-skill> on that defender.';
+
+/** Extracts Amartya's recipient-targeted Defense Shred through the REAL parser/builder. */
+function amartyaDefenseShredAbility(): Ability {
+    const abilities =
+        buildShipAbilities(ship({ firstPassiveSkillText: AMARTYA_P2 })).slots.find(
+            (s) => s.slot === 'passive'
+        )?.abilities ?? [];
+    const shred = abilities.find((a) => a.type === 'debuff');
+    if (!shred) throw new Error('mutation guard: Amartya Defense Shred not found');
+    return shred;
+}
+
+describe('Amartya Defense Shred — extracted ability shape (mutation guard)', () => {
+    it('rides on-enemy-repaired, enemy-targeted, RECIPIENT-routed, with NO per-round cap', () => {
+        const shred = amartyaDefenseShredAbility();
+        expect(shred.trigger).toBe('on-enemy-repaired');
+        expect(shred.target).toBe('enemy');
+        expect(shred.repairedRecipientTargeted).toBe(true);
+        // No frequency cap — "on that defender" fires every qualifying repair.
+        expect(shred.oncePerRoundPerEnemy).toBeUndefined();
+        expect(shred.oncePerRound).toBeUndefined();
+    });
+});
+
+describe('Amartya (player-side) — Defense Shred lands on the REPAIRED RECIPIENT, not the healer; no cap', () => {
+    const amartyaFocusSkills = (): ShipSkills => ({
+        slots: [noopActiveSlot(), { slot: 'passive', abilities: [amartyaDefenseShredAbility()] }],
+    });
+
+    // enemy-healer heals enemy-defender (its only OTHER living enemy ally) each of its turns.
+    // `twice` grants it an extra action so it repairs enemy-defender TWICE in one round —
+    // proving Amartya carries NO per-round cap (unlike Ruiner).
+    const enemyHealer = (twice: boolean): EnemyAttacker =>
+        ({
+            id: 'enemy-healer',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000, speed: 1000 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: {
+                slots: twice
+                    ? [
+                          { slot: 'active', abilities: [healAlly('heal-ally')] },
+                          { slot: 'passive', abilities: [extraAction('healer-extra')] },
+                      ]
+                    : [{ slot: 'active', abilities: [healAlly('heal-ally')] }],
+            },
+        }) as EnemyAttacker;
+
+    const enemyDefender = (): EnemyAttacker =>
+        ({
+            id: 'enemy-defender',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000, speed: 500 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: { slots: [] } as ShipSkills,
+        }) as EnemyAttacker;
+
+    const BASE = (twice: boolean): CombatEngineInput => ({
+        attack: 0,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: amartyaFocusSkills(),
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 1,
+        healTargetId: 'attacker',
+        enemyAttackers: [enemyHealer(twice), enemyDefender()],
+    });
+
+    it('lands on enemy-defender (the repaired recipient), NEVER on enemy-healer', () => {
+        const { debuffsApplied } = runAndCollectDebuffs(BASE(false));
+        const shred = debuffsApplied.filter((d) => d.buffName === 'Defense Shred');
+        expect(shred).toHaveLength(1);
+        expect(shred[0].targetId).toBe('enemy-defender');
+        expect(shred.some((d) => d.targetId === 'enemy-healer')).toBe(false);
+    });
+
+    it('NO per-round cap: two repairs of the SAME recipient in one round produce TWO Defense Shred applications', () => {
+        const { debuffsApplied } = runAndCollectDebuffs(BASE(true));
+        const shred = debuffsApplied.filter(
+            (d) => d.buffName === 'Defense Shred' && d.targetId === 'enemy-defender'
+        );
+        expect(shred).toHaveLength(2);
+    });
+
+    it('multi-recipient fan-out: a SINGLE AoE heal repairing 2+ defenders inflicts Defense Shred on EACH repaired defender from that one event', () => {
+        // One all-allies heal cast → ONE heal-performed event with targets
+        // [enemy-aoe-healer, enemy-def-1, enemy-def-2]. The repairedEnemyIds fan-out must land
+        // Defense Shred on each repaired recipient — this is the core new Layer-2 behavior
+        // (a single repair EVENT distributing "on that defender" across every recipient), as
+        // opposed to the separate-events case above (which uses two distinct heal-performed
+        // events via an extra action).
+        const aoeHealer: EnemyAttacker = {
+            id: 'enemy-aoe-healer',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000, speed: 1000 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: { slots: [{ slot: 'active', abilities: [healAllAllies('aoe-heal')] }] },
+        } as EnemyAttacker;
+        const def1: EnemyAttacker = {
+            id: 'enemy-def-1',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000, speed: 500 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: { slots: [] } as ShipSkills,
+        } as EnemyAttacker;
+        const def2: EnemyAttacker = {
+            id: 'enemy-def-2',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000, speed: 400 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: { slots: [] } as ShipSkills,
+        } as EnemyAttacker;
+
+        // Tap heal-performed too, to PROVE the fan-out came from a SINGLE cast (not several).
+        const bus = createEventBus();
+        const debuffsApplied: Extract<CombatEvent, { type: 'debuff-applied' }>[] = [];
+        const healsPerformed: Extract<CombatEvent, { type: 'heal-performed' }>[] = [];
+        bus.on('debuff-applied', (e) => debuffsApplied.push(e));
+        bus.on('heal-performed', (e) => healsPerformed.push(e));
+        runCombat({ ...BASE(false), enemyAttackers: [aoeHealer, def1, def2], bus });
+
+        // Exactly ONE repair event this round (the single AoE cast), carrying all three recipients.
+        expect(healsPerformed).toHaveLength(1);
+        expect(new Set(healsPerformed[0].targets)).toEqual(
+            new Set(['enemy-aoe-healer', 'enemy-def-1', 'enemy-def-2'])
+        );
+
+        const shred = debuffsApplied.filter((d) => d.buffName === 'Defense Shred');
+        // Fan-out proof: BOTH non-caster defenders receive Defense Shred from the one event
+        // (repairer-only routing would touch neither — it would target just the caster).
+        expect(shred.filter((d) => d.targetId === 'enemy-def-1')).toHaveLength(1);
+        expect(shred.filter((d) => d.targetId === 'enemy-def-2')).toHaveLength(1);
+        // The caster self-repaired (all-allies includes self) → it too is a repaired defender and
+        // correctly receives one. Total = one per repaired recipient in the single event.
+        expect(shred.filter((d) => d.targetId === 'enemy-aoe-healer')).toHaveLength(1);
+        expect(shred).toHaveLength(3);
+    });
+});
+
+describe('Amartya (enemy-side) — team symmetry: an enemy Amartya reacts to a PLAYER repair-to-ally', () => {
+    it('Defense Shred lands on the REPAIRED player ally (teamActor), not the healer (attacker)', () => {
+        const enemyAmartya: EnemyAttacker = {
+            id: 'enemy-amartya',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 10 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: { slots: [{ slot: 'passive', abilities: [amartyaDefenseShredAbility()] }] },
+        } as EnemyAttacker;
+
+        const recipientAlly: TeamActor = {
+            id: 'ally-recipient',
+            speed: 50,
+            chargeCount: 0,
+            startCharged: false,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            walk: {
+                shipSkills: { slots: [noopActiveSlot()] },
+                stats: {
+                    attack: 0,
+                    crit: 0,
+                    critDamage: 0,
+                    defensePenetration: 0,
+                    hacking: 0,
+                    defence: 0,
+                    hp: 20_000,
+                },
+                selfDotModifier: 0,
+                defensePenetrationBuff: 0,
+                affinityDamageModifier: 0,
+                affinityCritCap: 100,
+                affinityCritPenalty: 0,
+                hasChargedSkill: false,
+            },
+        } as TeamActor;
+
+        const input: CombatEngineInput = {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [{ slot: 'active', abilities: [healAlly('heal-ally')] }] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 200, // player acts first — its repair-to-ally wakes the enemy reactive same round
+            healTargetId: 'ally-recipient',
+            teamActors: [recipientAlly],
+            enemyAttackers: [enemyAmartya],
+        };
+
+        const { debuffsApplied } = runAndCollectDebuffs(input);
+        const shred = debuffsApplied.filter((d) => d.buffName === 'Defense Shred');
+        expect(shred).toHaveLength(1);
+        expect(shred[0].targetId).toBe('ally-recipient');
+        expect(shred.some((d) => d.targetId === 'attacker')).toBe(false);
+    });
+});

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -101,7 +101,8 @@ export interface Intent {
     /** Event context captured by the listener at enqueue time (per-event intents).
      *  `counterTargetId`: the attacking enemy's actor id for "on that enemy"
      *  counter-inflictions (Warden, Guardian's ally-Provoke) — the executor's debuff
-     *  branch routes the application to THIS enemy's per-target store.
+     *  branch routes the application to THIS enemy's per-target store. Phase 3 PR-F:
+     *  on-enemy-repaired also stamps this with the REPAIRER's id (Ruiner's Bomb).
      *  `damagedAllyId`: the DAMAGED ally's actor id (on-ally-attacked) — the heal and
      *  buff branches route an 'ally'-target payload to exactly this recipient
      *  (Cultivator's repair, Refine/Graphite's grants) instead of the default. Generic
@@ -139,8 +140,15 @@ export interface Intent {
         repairedAllyIds?: string[];
         /** The repairing actor's id (heal-performed.casterId), captured by the on-enemy-repaired
          *  listener. Used by the charge branch as the per-source key for an `everyNthEvent` gate
-         *  AND as the single-target for "decrease THAT enemy's charge" (Zosimos). */
+         *  AND as the single-target for "decrease THAT enemy's charge" (Zosimos). Phase 3 PR-F:
+         *  ALSO used to key the debuff branch's oncePerRoundPerEnemy cap (Ruiner). */
         repairerId?: string;
+        /** Phase 3 PR-F: the recipients of an on-enemy-repaired heal-performed event
+         *  (heal-performed.targets — every healed enemy, unfiltered). Read by a
+         *  `repairedRecipientTargeted` debuff (Amartya's "on that defender" Defense Shred),
+         *  which fans out to EACH of these instead of routing to the repairer. Mirrors
+         *  repairedAllyIds/shieldRecipientIds but for the OPPOSING side. */
+        repairedEnemyIds?: string[];
         /** The clipped overheal (heal-performed.overheal) carried from an own-repair-to-ally
          *  event, read by an `overheal`-basis reactive shield to scale off the over-repaired
          *  amount rather than the owner's max HP (Abundant Renewal). */
@@ -250,7 +258,9 @@ export function partitionReactiveAbilities(shipSkills: ShipSkills): {
  *    (any opposing-side actor — for players: dummy wall + walked enemy attackers;
  *    for enemy owners: any player actor).
  *  - on-enemy-repaired → heal-performed where isOpposing(casterId)
- *    (any opposing-side actor's repair cast). One enqueue per cast.
+ *    (any opposing-side actor's repair cast). One enqueue per cast. Stamps repairerId (the
+ *    caster) AND repairedEnemyIds (e.targets, unfiltered) — Ruiner's Bomb routes to the
+ *    former (counterTargetId), Amartya's Defense Shred fans out over the latter.
  *  - on-enemy-cleansed → cleanse-performed where isOpposing(casterId)
  *    (any opposing-side actor's cleanse cast). One enqueue per cast.
  *  - on-hp-threshold-crossed → hp-changed where targetId === ownerId and the event is a
@@ -374,14 +384,20 @@ export function registerReactiveListeners(args: {
                         // (own inflictions go to on-debuff-inflicted) AND every opposing actor
                         // (an opposing actor is never an ally).
                         if (isSameSideAlly(e.sourceId, ownerId))
-                            enqueue({ ...intent, eventCtx: { ...intent.eventCtx, damagedAllyId: e.sourceId } });
+                            enqueue({
+                                ...intent,
+                                eventCtx: { ...intent.eventCtx, damagedAllyId: e.sourceId },
+                            });
                     });
                     bus.on('dot-applied', (e) => {
                         // Team DoT applications now emit dot-applied with the team sourceId
                         // (Task 4 seam, live since Task 6) — an ally DoT infliction triggers
                         // this listener exactly as an ally debuff does.
                         if (isSameSideAlly(e.sourceId, ownerId))
-                            enqueue({ ...intent, eventCtx: { ...intent.eventCtx, damagedAllyId: e.sourceId } });
+                            enqueue({
+                                ...intent,
+                                eventCtx: { ...intent.eventCtx, damagedAllyId: e.sourceId },
+                            });
                     });
                     break;
                 case 'on-ally-crit-dot':
@@ -536,7 +552,10 @@ export function registerReactiveListeners(args: {
                         // via damagedAllyId. Excludes the owner (that is on-debuffed) and DoTs (dot-applied),
                         // matching on-debuffed's debuff-applied-only scoping.
                         if (isSameSideAlly(e.targetId, ownerId))
-                            enqueue({ ...intent, eventCtx: { ...intent.eventCtx, damagedAllyId: e.targetId } });
+                            enqueue({
+                                ...intent,
+                                eventCtx: { ...intent.eventCtx, damagedAllyId: e.targetId },
+                            });
                     });
                     break;
                 case 'on-debuff-resisted':
@@ -642,10 +661,20 @@ export function registerReactiveListeners(args: {
                         // Opposing-scoped. Capture the repairer id so the charge branch can (a)
                         // count repairs per source for an everyNthEvent gate and (b) target THAT
                         // enemy. Harmless for Zosimos's self-gain intent (it ignores repairerId).
+                        // Phase 3 PR-F: ALSO stamp counterTargetId = the repairer (Ruiner's Bomb
+                        // routes here like every other "on that enemy" counter-infliction — the
+                        // debuff branch's existing `counterTargetId ?? ctx.enemy.id` fallback picks
+                        // this up for free) and repairedEnemyIds = e.targets (Amartya's "that
+                        // defender" Defense Shred fans out to every healed enemy instead).
                         if (isOpposing(e.casterId))
                             enqueue({
                                 ...intent,
-                                eventCtx: { ...intent.eventCtx, repairerId: e.casterId },
+                                eventCtx: {
+                                    ...intent.eventCtx,
+                                    repairerId: e.casterId,
+                                    counterTargetId: e.casterId,
+                                    repairedEnemyIds: e.targets,
+                                },
                             });
                     });
                     break;
@@ -1745,6 +1774,17 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
         // a future ability combines them, move this mark below the target-resolution guard so a
         // no-living-target round doesn't burn the charge.
         if (intent.ability.oncePerRound) ctx.oncePerRoundConsumed?.add(onceKey);
+        // Phase 3 PR-F: "once per round per enemy" cap (Ruiner's Bomb-on-repair). A DEDICATED
+        // flag — not the plain oncePerRound gate above, which caps once per round OVERALL — so a
+        // DIFFERENT enemy repairing still procs even if one enemy already consumed the cap this
+        // round. Keyed on (owner, ability, repairerId), mirroring the buff branch's
+        // oncePerRoundPerAlly. Consumed BEFORE the procChance gate above already ran (Ruiner's
+        // Bomb has no procChance today; see oncePerRoundPerAlly's NOTE for the ordering caveat).
+        if (intent.ability.oncePerRoundPerEnemy) {
+            const key = `${intent.ownerId}:${intent.ability.id}:${intent.eventCtx?.repairerId ?? ''}`;
+            if (ctx.oncePerRoundConsumed?.has(key)) return;
+            ctx.oncePerRoundConsumed?.add(key);
+        }
 
         const status: Extract<RegisteredAbilityStatus, { kind: 'timed' }> = {
             payload: payloadFromConfig(cfg),
@@ -1777,46 +1817,69 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
         // No living highest-attack enemy → no-op (don't fall back to the default enemy).
         if (intent.ability.target === 'enemy-highest-attack' && counterTargetId === undefined)
             return;
-        // Block Debuff fold (D-PR15 Task 5): a target carrying Block Debuff auto-resists every
-        // incoming timed debuff. Gate immunity into the landing condition so the EXISTING resist
-        // `else` handles it (no duplicated resist code). `&&` short-circuits when not immune →
-        // byte-identical to the original `landsTimedEnemyApplication`-only condition.
-        const debuffTargetId = counterTargetId ?? ctx.enemy.id;
-        const blockedByImmunity = targetCarriesBlockDebuff(ctx.statusEngine, debuffTargetId);
-        // Draw the OWNER's landing gate (its hacking-vs-security / affinity disadvantage),
-        // NOT a global one — a team ship's debuff lands at ITS landing chance.
-        // Task A: re-resolve an 'apply' debuff's landing vs the ACTUAL target's affinity (not the
-        // applier's precomputed-vs-representative static flag). affinityOf is absent in unit-test
-        // ctxs → undefined target affinity → static fallback (byte-identical for single-opponent).
-        if (
-            !blockedByImmunity &&
-            owner.landsTimedEnemyApplication(cfg.application, ctx.affinityOf?.(debuffTargetId))
-        ) {
-            ctx.statusEngine.applyTimedAbilityStatus(ctx.round, status, undefined, counterTargetId);
-            // Discrete infliction event — sourceId = the owner so the application is chainable.
-            ctx.bus.emit({
-                type: 'debuff-applied',
-                sourceId: intent.ownerId,
-                targetId: counterTargetId ?? ctx.enemy.id,
-                round: ctx.round,
-                buffName: cfg.buffName,
-            });
-        } else {
-            // A persistent-stacking name (would have landed as a never-expiring stack)
-            // surfaces its resisted display row as 'permanent', not its turn count.
-            const turnsRemaining: ActiveBuff['turnsRemaining'] = PERSISTENT_STACKING_BUFFS.has(
-                cfg.buffName
-            )
-                ? 'permanent'
-                : status.duration;
-            ctx.recordResisted({ buffName: cfg.buffName, turnsRemaining });
-            ctx.bus.emit({
-                type: 'debuff-resisted',
-                // debuff-resisted feeds the round display only — no per-target counter routing needed.
-                targetId: ctx.enemy.id,
-                round: ctx.round,
-                buffName: cfg.buffName,
-            });
+        // Phase 3 PR-F: Amartya's recipient-targeted repair reaction fans the debuff out to
+        // EVERY repaired enemy from the triggering heal-performed event ("that defender"
+        // distributes across a multi-target heal) — mirrors the buff branch's repairedAllyIds
+        // fan-out, but for enemy-side recipients. Distinct from Ruiner's REPAIRER-targeted Bomb
+        // (same on-enemy-repaired trigger, same event), which stays on the singular
+        // counterTargetId route below (an empty list falls back to it defensively).
+        const applicationTargetIds: (string | undefined)[] =
+            intent.ability.repairedRecipientTargeted && intent.eventCtx?.repairedEnemyIds?.length
+                ? intent.eventCtx.repairedEnemyIds
+                : [counterTargetId];
+        for (const applicationTargetId of applicationTargetIds) {
+            // Block Debuff fold (D-PR15 Task 5): a target carrying Block Debuff auto-resists
+            // every incoming timed debuff. Gate immunity into the landing condition so the
+            // EXISTING resist `else` handles it (no duplicated resist code). `&&`
+            // short-circuits when not immune → byte-identical to the original
+            // `landsTimedEnemyApplication`-only condition.
+            const debuffTargetId = applicationTargetId ?? ctx.enemy.id;
+            const blockedByImmunity = targetCarriesBlockDebuff(ctx.statusEngine, debuffTargetId);
+            // Draw the OWNER's landing gate (its hacking-vs-security / affinity disadvantage),
+            // NOT a global one — a team ship's debuff lands at ITS landing chance. One draw PER
+            // TARGET (per-victim landing, matching the established per-victim precedent) — for
+            // every pre-existing single-target caller applicationTargetIds has exactly one
+            // element, so this is still exactly one draw, byte-identical to before the loop.
+            // Task A: re-resolve an 'apply' debuff's landing vs the ACTUAL target's affinity (not
+            // the applier's precomputed-vs-representative static flag). affinityOf is absent in
+            // unit-test ctxs → undefined target affinity → static fallback (byte-identical for
+            // single-opponent).
+            if (
+                !blockedByImmunity &&
+                owner.landsTimedEnemyApplication(cfg.application, ctx.affinityOf?.(debuffTargetId))
+            ) {
+                ctx.statusEngine.applyTimedAbilityStatus(
+                    ctx.round,
+                    status,
+                    undefined,
+                    applicationTargetId
+                );
+                // Discrete infliction event — sourceId = the owner so the application is chainable.
+                ctx.bus.emit({
+                    type: 'debuff-applied',
+                    sourceId: intent.ownerId,
+                    targetId: debuffTargetId,
+                    round: ctx.round,
+                    buffName: cfg.buffName,
+                });
+            } else {
+                // A persistent-stacking name (would have landed as a never-expiring stack)
+                // surfaces its resisted display row as 'permanent', not its turn count.
+                const turnsRemaining: ActiveBuff['turnsRemaining'] = PERSISTENT_STACKING_BUFFS.has(
+                    cfg.buffName
+                )
+                    ? 'permanent'
+                    : status.duration;
+                ctx.recordResisted({ buffName: cfg.buffName, turnsRemaining });
+                ctx.bus.emit({
+                    type: 'debuff-resisted',
+                    // debuff-resisted feeds the round display only — no per-target counter
+                    // routing needed (unchanged even for the recipient-targeted fan-out above).
+                    targetId: ctx.enemy.id,
+                    round: ctx.round,
+                    buffName: cfg.buffName,
+                });
+            }
         }
         return;
     }

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -2061,6 +2061,52 @@ export function detectDamageReactionTrigger(
     return undefined;
 }
 
+// Phase 3 PR-F: two DISTINCT "enemy repair" reaction phrasings that both ride the LIVE
+// on-enemy-repaired trigger but route to DIFFERENT actors:
+//  - Ruiner's Bomb infliction ("on any enemy performing a repair") has NO leading "when" (so
+//    ENEMY_REPAIRS_RE in detectReactiveTrigger — which requires "when a[n] enemy … repairs" —
+//    does not match it) and lands on the REPAIRER (eventCtx.repairerId), like every other
+//    "on that enemy" counter-infliction.
+//  - Amartya's Defense Shred ("when an enemy defender is directly repaired … on that
+//    defender") uses the past-participle "repaired" (ENEMY_REPAIRS_RE's `repairs?\b` does not
+//    match "repaired") and lands on the REPAIRED RECIPIENT ("that defender"), NOT the healer —
+//    flagged `recipientTargeted` so the caller routes via eventCtx.repairedEnemyIds instead.
+// Corpus-verified unique phrasings (docs/ship-skills.csv): grep for "performing a repair" and
+// "defender is directly repaired" each return exactly one ship.
+const ENEMY_PERFORMING_REPAIR_RE = /\bon\s+any\s+enemy\s+performing\s+an?\s+repairs?\b/i;
+const ENEMY_DEFENDER_DIRECTLY_REPAIRED_RE =
+    /\bwhen\s+an?\s+enemy\s+defender\s+is\s+directly\s+repaired\b/i;
+
+/**
+ * Sentence-scoped (mirrors detectDamageReactionTrigger/detectHpCrossingTrigger) detector for
+ * the two "enemy repair" reaction phrasings above. Returns undefined outside their sentence.
+ * Reference data: docs/ship-skills.csv (Ruiner, Amartya).
+ */
+export function detectEnemyRepairedTrigger(
+    text: string,
+    pos: number
+): { trigger: 'on-enemy-repaired'; recipientTargeted?: boolean } | undefined {
+    const sentence = rawSentenceAround(text, pos);
+    if (sentence === undefined) return undefined;
+    // Ruiner's "repair" is itself <unit-aid>-tagged ("performing a <unit-aid>repair</unit-aid>"),
+    // which the RAW phrase regex below does not span — strip tags before testing (position
+    // alignment is not needed here, only the boolean match, so this is safe unlike
+    // phrasePosTrigger's raw-text scoping).
+    const stripped = stripUnitTags(sentence);
+    if (ENEMY_DEFENDER_DIRECTLY_REPAIRED_RE.test(stripped)) {
+        return { trigger: 'on-enemy-repaired', recipientTargeted: true };
+    }
+    if (ENEMY_PERFORMING_REPAIR_RE.test(stripped)) {
+        return { trigger: 'on-enemy-repaired' };
+    }
+    return undefined;
+}
+
+// Once-per-round-per-ENEMY cap on a reactive debuff (Ruiner's Bomb: "once per round per
+// enemy") — distinct from the plain "once per round" cap (which caps once per round OVERALL).
+// Exported: buildShipAbilities.ts's passive DoT-reaction loop tests it directly.
+export const ONCE_PER_ROUND_PER_ENEMY_RE = /\bonce per round per enemy\b/i;
+
 // Phase 4c PR 3 (Task 6): "when HP drops/falls below N%" buff-grant reactives
 // (Tycho/Shelter/Los/Kafa/Redeemer). The (drops|falls) VERB is what distinguishes a
 // threshold-CROSSING reactive from the static "while/if below N% HP" gates handled


### PR DESCRIPTION
## Phase 3 PR-F — `on-enemy-repaired` reactive debuffs (Ruiner + Amartya)

Part of the reactive-trigger-promotion epic (family C, Layer-2 cluster). Stacked on **PR-E** (`phase3/pr-e-ally-debuff-inflicted`) — both touch the repair-event capture in `triggers.ts`, so the DAG serializes E→F. Merge PR-E first.

### What was broken
Two family-C ships whose reactive debuff defaulted to `on-cast` (never fired in the sim):

- **Ruiner** — *"inflicts Bomb II for 2 turns on any enemy performing a repair, once per round per enemy."* Emitted **no** ability at all: the "performing a repair" phrasing was unrecognized (it's a name-only DoT card that `mergeBuff` never sees).
- **Amartya** — *"When an enemy defender is directly repaired, this Unit inflicts 1 stack of Defense Shred on that defender."* Resolved as a plain `on-cast` debuff — the past-participle "repaired" didn't match the existing verb-form regex, and there was no way to target *the healed recipient*.

### The fix
- **Parser** (`skillTextParser.ts`): new sentence-scoped `detectEnemyRepairedTrigger` recognizes both phrasings → the live `on-enemy-repaired` trigger. Amartya's variant is flagged `recipientTargeted` ("that defender" = the healed unit, not the healer). Corpus-verified: each phrase matches exactly one ship.
- **Builder** (`buildShipAbilities.ts`): wires the detector into (a) the passive DoT-reaction loop (Ruiner's Bomb) and (b) `mergeBuff`'s reaction else-branch (Amartya's Defense Shred).
- **Engine** (`triggers.ts`): the `on-enemy-repaired` listener now also stamps `counterTargetId` (repairer routing, reused for Ruiner's Bomb) and a new **`repairedEnemyIds`** capture (`heal-performed.targets`, for Amartya's recipient fan-out — the Layer-2 addition, mirroring the `repairedAllyIds` precedent). The debuff executor loops over the target list: single `counterTargetId` by default, or fans out over every repaired recipient when `repairedRecipientTargeted`. New **`oncePerRoundPerEnemy`** cap keyed on `repairerId` (Ruiner's per-enemy limit; mirrors PR-E's `oncePerRoundPerAlly`).

Team-symmetric by construction (works identically on either side). Confirmed `heal-performed` fires only on genuine heal casts, never RoT/regen ticks, so *"directly repaired"* needs no extra gating.

### Verification
- Both triage probes (Ruiner, Amartya) flip **green**; new `onEnemyRepairedReactivePromotion.integration.test.ts` — **8 tests** (per-enemy cap, single-event multi-recipient fan-out, team symmetry both sides for each ship), driven through the real `buildShipAbilities` + engine path. Non-vacuity confirmed (reverting src reds all 10 assertions).
- Full suite: only the **5 pre-existing out-of-scope** triage failures remain (Nuqtu/Howler/Cultivator/Morao/Vindicator — future PR-G/H/I gaps); **no golden churn**, no other ship moved.
- `lint` / `tsc --noEmit` / `audit:skills` (0 findings) all clean.
- Adversarial review cleared all risk areas (counterTargetId overload, fan-out `status` aliasing, unfiltered recipient capture, cap ordering, parser scoping, Ruiner's untouched Overload clauses, the RoT-tick claim) — no blockers.

**Red CI is expected for the duration of Phase 3** (user decision: no deploy until the phase completes). Committed with `--no-verify` after lint+tsc pass, per the PR0 procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dp1hGz5xU95ZwDtmWSnvT
