### PR TITLE
fix(skills): Phase 3 PR-G — on-ally-crit which-ally routing (Howler cleanse + Blast to the crit-er)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -37,6 +37,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Oleander now grants Repair Over Time II to an ally who inflicts a debuff (once per ally each round), matching her skill text, instead of the grant never firing.",
     "Combat sim: Hayyan now repairs an ally for 6% of her Max HP whenever a debuff is inflicted on that ally, matching her skill text, instead of the repair never firing.",
     "Combat sim: Ruiner now inflicts Bomb II on any enemy that performs a repair (once per round per enemy), matching her skill text, instead of never firing. Amartya now inflicts a stack of Defense Shred on the specific enemy defender that was just repaired, instead of never firing.",
+    "Combat sim: Howler now cleanses a debuff from (and, with her refit, grants a stack of Blast to) the specific ally who just landed a critical hit, matching her skill text, instead of never firing.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/abilities/__tests__/reactiveTriggerPromotionTriage.test.ts
+++ b/src/utils/abilities/__tests__/reactiveTriggerPromotionTriage.test.ts
@@ -293,8 +293,9 @@ describe('cluster 7 — ally-crit / cleanse-reactive / DoT-crit / debuff-resiste
         const ab = abilitiesFor({ firstPassiveSkillText: HOWLER_P2 }, 'passive');
         const cleanse = ab.find((a) => a.type === 'cleanse');
         expect(cleanse?.trigger).toBe('on-ally-crit');
-        // GAP: needs-capture — cleanse target is "that ally" (the crit-er); on-ally-crit (triggers.ts:441)
-        // captures no actor. Cleanse builder only derives on-ally-critically-repaired. Needs which-ally capture.
+        // Fixed (Phase 3 PR-G): the on-ally-crit listener now stamps damagedAllyId = the crit-ing
+        // ally (triggers.ts), and the cleanse builder derives on-ally-crit via detectAllyCritTrigger
+        // — the cleanse lands on "that ally" (the crit-er), not a fallback.
     });
 
     const CULTIVATOR_P2 =

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -1605,6 +1605,9 @@ function abilitiesFromText(
         const cleansePos = text.search(/cleanse/i);
         // Pallas: "when this unit critically repairs an ally, it cleanses 1 debuff from itself" —
         // the cleanse rides the on-ally-critically-repaired reactive trigger (position-scoped).
+        // Howler (Phase 3 PR-G): "cleanses 1 debuff from an ally when that ally crits an enemy" —
+        // rides on-ally-crit instead (a DIFFERENT ally does the critting, not the owner) — routed
+        // to the crit-er via eventCtx.damagedAllyId (triggers.ts on-ally-crit listener).
         // Purifier (Phase 3 PR-A): a PASSIVE-slot "cleanses N debuff when directly damaged" cleanse
         // rides on-attacked — the cleanse builder previously derived ONLY the crit-repair reaction,
         // so a direct-damage cleanse fell through to on-cast. Gated to passive (an active/charged
@@ -1613,6 +1616,7 @@ function abilitiesFromText(
         // cleanses sit in active/charged slots or a different sentence; Cultivator's is on-own-cleanse).
         const reactiveTrigger =
             detectCritRepairTrigger(text, cleansePos) ??
+            detectAllyCritTrigger(text, cleansePos) ??
             (slot === 'passive' &&
             detectDamageReactionTrigger(text, cleansePos)?.trigger === 'on-attacked'
                 ? ('on-attacked' as const)

--- a/src/utils/combat/__tests__/allyCritReactivePromotion.integration.test.ts
+++ b/src/utils/combat/__tests__/allyCritReactivePromotion.integration.test.ts
@@ -1,0 +1,444 @@
+/**
+ * Phase 3 PR-G — combat-integration tests for Howler's on-ally-crit cleanse + Blast grant.
+ *
+ * Howler (2nd/refit passive, docs/ship-skills.csv verbatim): "This Unit cleanses 1 debuff from
+ * an ally and grants them 1 stack of Blast when that ally crits an enemy." — the cleanse AND the
+ * Blast grant both ride the on-ally-crit reactive trigger, routed to the CRIT-ING ally via
+ * eventCtx.damagedAllyId (the same routing lane on-ally-debuffed/on-ally-purged already use).
+ *
+ * Both owner abilities are extracted through the REAL production path (`buildShipAbilities`) fed
+ * verbatim skill text from `docs/ship-skills.csv` — never a hand-built ability array.
+ *
+ * Non-vacuity: reverting the PR-G src changes (skillTextParser.ts's broadened ALLY_CRIT_HIT_RE,
+ * buildShipAbilities.ts's cleanse builder detectAllyCritTrigger wiring, and triggers.ts's
+ * damagedAllyId stamp on the on-ally-crit listener) turns every "fires"/"lands on the crit-er"
+ * assertion in this file red (verified manually — see the PR-G report for the revert/restore
+ * transcript).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { StatusEngine } from '../statusEngine';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+function ship(over: Partial<Ship>): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}], ...over } as Ship;
+}
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const allPattern = (): ParsedPattern => ({ raw: 'all', shape: 'all', range: 'all', modifiers: {} });
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+const hit = (): Ability => ({
+    id: 'hit',
+    type: 'damage',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'damage', multiplier: 100 },
+});
+
+// =============================================================================
+// Howler — "This Unit cleanses 1 debuff from an ally and grants them 1 stack of Blast when
+// that ally crits an enemy." (docs/ship-skills.csv, verbatim refit-active 2nd passive).
+// =============================================================================
+
+const HOWLER_P2 =
+    'This Unit <unit-aid>cleanses 1</unit-aid> debuff from an ally when that ally crits an enemy.';
+const HOWLER_P3_REFIT =
+    'This Unit <unit-aid>cleanses 1</unit-aid> debuff from an ally and grants them 1 stack of <unit-skill>Blast</unit-skill> when that ally crits an enemy.';
+
+/** Extracts Howler's ally-crit reactive abilities through the REAL parser/builder. */
+function howlerAllyCritAbilities(): Ability[] {
+    return (
+        buildShipAbilities(
+            ship({ firstPassiveSkillText: HOWLER_P2, secondPassiveSkillText: HOWLER_P3_REFIT })
+        ).slots.find((s) => s.slot === 'passive')?.abilities ?? []
+    );
+}
+
+function howlerCleanse(): Ability {
+    const c = howlerAllyCritAbilities().find((a) => a.type === 'cleanse');
+    if (!c) throw new Error('mutation guard: Howler on-ally-crit cleanse not found');
+    return c;
+}
+
+function howlerBlastGrant(): Ability {
+    const b = howlerAllyCritAbilities().find((a) => a.type === 'buff');
+    if (!b) throw new Error('mutation guard: Howler on-ally-crit Blast grant not found');
+    return b;
+}
+
+describe('Howler ally-crit abilities — extracted shape (mutation guard)', () => {
+    it('cleanse rides on-ally-crit, targeting the ally', () => {
+        const c = howlerCleanse();
+        expect(c.trigger).toBe('on-ally-crit');
+        expect(c.target).toBe('ally');
+        expect(c.config).toMatchObject({ type: 'cleanse', count: 1 });
+    });
+
+    it('Blast grant rides on-ally-crit, targeting the ally', () => {
+        const b = howlerBlastGrant();
+        expect(b.trigger).toBe('on-ally-crit');
+        expect(b.target).toBe('ally');
+        expect(b.config).toMatchObject({ type: 'buff', buffName: 'Blast' });
+    });
+});
+
+// =============================================================================
+// Engine integration — a positional 3-actor same-side roster (a crit-ing ally, a non-critting
+// ally, and Howler itself) all take an AoE debuff from an opposing all-enemies debuffer. Only the
+// CRIT-ING ally's debuff should be cleansed and only it should receive Blast — proven against a
+// DELIBERATELY WRONG fallback (healTargetId points at the non-critting ally) so a false-positive
+// "it just landed on the heal-target fallback" can't slip through.
+// =============================================================================
+
+const noopActive = (): Ability => ({
+    id: 'noop',
+    type: 'damage',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'damage', multiplier: 0 },
+});
+
+const howlerObserver = (position: Position): TeamActorEngineInput =>
+    ({
+        id: 'howler',
+        speed: 1, // acts last — the crit + debuffs must already have happened
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        walk: {
+            shipSkills: {
+                slots: [
+                    { slot: 'active', abilities: [noopActive()] },
+                    { slot: 'passive', abilities: [howlerCleanse(), howlerBlastGrant()] },
+                ],
+            },
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp: 20_000,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    }) as TeamActorEngineInput;
+
+/** A same-side ally that crits (or not) an enemy on its own turn. */
+const critAlly = (id: string, position: Position, critPct: number): TeamActorEngineInput =>
+    ({
+        id,
+        speed: 300,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        walk: {
+            shipSkills: { slots: [{ slot: 'active', abilities: [hit()] }] },
+            stats: {
+                attack: 1000,
+                crit: critPct,
+                critDamage: 100,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp: 20_000,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    }) as TeamActorEngineInput;
+
+/** An opposing AoE debuffer: an 'all-enemies'-target Def Down that lands on EVERY same-side
+ *  actor on the other team (the focus + every positioned team actor). */
+const debuffAoE = (id: string, position: Position): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 1, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1000 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget('front'),
+        pattern: allPattern(),
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'aoe-debuff',
+                            type: 'debuff',
+                            target: 'all-enemies',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: {
+                                type: 'debuff',
+                                buffName: 'Def Down',
+                                parsedEffects: {},
+                                stacks: 1,
+                                isStackable: false,
+                                application: 'apply',
+                                duration: 5,
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+    }) as EnemyAttacker;
+
+function runAndCollect(input: CombatEngineInput) {
+    const bus = createEventBus();
+    const debuffsApplied: Extract<CombatEvent, { type: 'debuff-applied' }>[] = [];
+    const buffsApplied: Extract<CombatEvent, { type: 'buff-applied' }>[] = [];
+    bus.on('debuff-applied', (e) => debuffsApplied.push(e));
+    bus.on('buff-applied', (e) => buffsApplied.push(e));
+    let engine: StatusEngine | undefined;
+    const result = runCombat({
+        ...input,
+        bus,
+        __testTapStatusEngine: (e) => {
+            engine = e;
+        },
+    });
+    return { result, debuffsApplied, buffsApplied, engine: engine! };
+}
+
+describe('Howler (player-side) — cleanse + Blast land on the crit-ing ally, not the heal-target fallback', () => {
+    // 'attacker' (the crit-100 focus) crits; 'ally-b' (crit 0) never crits. healTargetId is
+    // DELIBERATELY 'ally-b' — if the cleanse/buff ever fell back to the heal target instead of
+    // reading eventCtx.damagedAllyId, this setup would catch it landing on the WRONG actor.
+    const BASE = (): CombatEngineInput => ({
+        attack: 1000,
+        crit: 100,
+        critDamage: 100,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: { slots: [{ slot: 'active', abilities: [hit()] }] },
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 500,
+        healTargetId: 'ally-b', // deliberately the NON-critting ally (the fallback trap)
+        position: 'M1',
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        teamActors: [howlerObserver('M3'), critAlly('ally-b', 'M2', 0)],
+        enemyAttackers: [debuffAoE('enemy-deb', 'M4')],
+    });
+
+    it('the crit-ing ally (attacker) is cleansed; the non-critting ally (ally-b, the fallback) keeps its debuff', () => {
+        const { engine } = runAndCollect(BASE());
+        expect(
+            engine.timedAbilityStatuses('enemy', undefined, 'attacker').map((s) => s.active.buffName)
+        ).toEqual([]);
+        expect(
+            engine.timedAbilityStatuses('enemy', undefined, 'ally-b').map((s) => s.active.buffName)
+        ).toEqual(['Def Down']);
+    });
+
+    it('Blast lands ONLY on the crit-ing ally (attacker), never on ally-b or Howler itself', () => {
+        const { buffsApplied } = runAndCollect(BASE());
+        const blast = buffsApplied.filter((b) => b.buffName === 'Blast');
+        expect(blast).toHaveLength(1);
+        expect(blast[0].actorId).toBe('attacker');
+    });
+
+    it('no ally crits (crit 0 everywhere) → the cleanse never fires', () => {
+        const noCritInput: CombatEngineInput = {
+            ...BASE(),
+            crit: 0,
+            teamActors: [howlerObserver('M3'), critAlly('ally-b', 'M2', 0)],
+        };
+        const { result, buffsApplied } = runAndCollect(noCritInput);
+        expect(
+            (result.healing?.rounds ?? []).reduce(
+                (sum, rd) => sum + (rd.perActor.get('howler')?.cleanseCount ?? 0),
+                0
+            )
+        ).toBe(0);
+        expect(buffsApplied.some((b) => b.buffName === 'Blast')).toBe(false);
+    });
+});
+
+describe('Howler (enemy-side) — team symmetry: an enemy Howler reacts to its OWN crit-ing ally', () => {
+    it('cleanses the crit-ing ENEMY ally and grants it Blast, never touching a player-side actor', () => {
+        const enemyHowler: EnemyAttacker = {
+            id: 'enemy-howler',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1 },
+            chargeCount: 0,
+            startCharged: false,
+            position: 'M3',
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            shipSkills: {
+                slots: [
+                    { slot: 'active', abilities: [noopActive()] },
+                    { slot: 'passive', abilities: [howlerCleanse(), howlerBlastGrant()] },
+                ],
+            },
+        } as EnemyAttacker;
+
+        const enemyCritAlly: EnemyAttacker = {
+            id: 'enemy-critter',
+            stats: {
+                attack: 1000,
+                crit: 100,
+                critDamage: 100,
+                defence: 0,
+                hp: 1_000_000_000,
+                speed: 300,
+            },
+            chargeCount: 0,
+            startCharged: false,
+            position: 'M2',
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            shipSkills: { slots: [{ slot: 'active', abilities: [hit()] }] },
+        } as EnemyAttacker;
+
+        // A player-side AoE debuffer whose 'all-enemies' target reaches every enemy-side actor
+        // (the mirror of debuffAoE above, cast from the other direction).
+        const playerDebuffSkills: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'aoe-debuff',
+                            type: 'debuff',
+                            target: 'all-enemies',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: {
+                                type: 'debuff',
+                                buffName: 'Def Down',
+                                parsedEffects: {},
+                                stacks: 1,
+                                isStackable: false,
+                                application: 'apply',
+                                duration: 5,
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const playerAlly: TeamActorEngineInput = {
+            id: 'player-ally',
+            speed: 1,
+            chargeCount: 0,
+            startCharged: false,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            position: 'M2',
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            walk: {
+                shipSkills: { slots: [{ slot: 'active', abilities: [noopActive()] }] },
+                stats: {
+                    attack: 0,
+                    crit: 0,
+                    critDamage: 0,
+                    defensePenetration: 0,
+                    hacking: 0,
+                    defence: 0,
+                    hp: 20_000,
+                },
+                selfDotModifier: 0,
+                defensePenetrationBuff: 0,
+                affinityDamageModifier: 0,
+                affinityCritCap: 100,
+                affinityCritPenalty: 0,
+                hasChargedSkill: false,
+            },
+        } as TeamActorEngineInput;
+
+        const input: CombatEngineInput = {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: playerDebuffSkills,
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 1000, // the player debuffs first, waking the enemy reactives the same round
+            healTargetId: 'attacker',
+            position: 'M1',
+            target: parsedTarget('front'),
+            pattern: allPattern(),
+            teamActors: [playerAlly],
+            enemyAttackers: [enemyHowler, enemyCritAlly],
+        };
+
+        const { engine, buffsApplied } = runAndCollect(input);
+        // The crit-ing enemy ally is cleansed …
+        expect(
+            engine
+                .timedAbilityStatuses('enemy', undefined, 'enemy-critter')
+                .map((s) => s.active.buffName)
+        ).toEqual([]);
+        // … and receives Blast — EXACTLY one grant, and it is NOT the player-side ally: an enemy
+        // Howler's reaction never crosses the side boundary onto a player-side actor.
+        const blast = buffsApplied.filter((b) => b.buffName === 'Blast');
+        expect(blast).toHaveLength(1);
+        expect(blast[0].actorId).toBe('enemy-critter');
+    });
+});

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -470,7 +470,17 @@ export function registerReactiveListeners(args: {
                         // walked enemy now emits ability-performed.
                         if (!isSameSideAlly(e.actorId, ownerId)) return;
                         const n = e.critHits ?? (e.didCrit ? 1 : 0);
-                        for (let i = 0; i < n; i++) enqueue(intent);
+                        // Stamp the crit-ing ally via damagedAllyId (Phase 3 PR-G, Howler) so an
+                        // 'ally'-target reactive (cleanse/buff) lands on THAT ally, mirroring the
+                        // on-ally-debuffed/on-ally-purged siblings. Zero-collateral for existing
+                        // on-ally-crit riders (Hermes's charge + Everliving Regeneration buff are
+                        // both 'self'-target, which never reads damagedAllyId — see
+                        // reactiveRecipients/the buff branch's recipient resolution).
+                        for (let i = 0; i < n; i++)
+                            enqueue({
+                                ...intent,
+                                eventCtx: { ...intent.eventCtx, damagedAllyId: e.actorId },
+                            });
                     });
                     break;
                 case 'start-of-round':

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1395,7 +1395,10 @@ export function detectBombDetonatedTrigger(
 // carrying the phrase. So an unrelated heal/charge in a DIFFERENT sentence is never mis-triggered,
 // even when it shares the anchor keyword. Reference data: docs/ship-skills.csv.
 const CRIT_REPAIR_RE = /when this unit critically repairs (?:an ally|allies)/i;
-const ALLY_CRIT_HIT_RE = /when an ally critically hits/i;
+// "when an ally critically hits" (Hermes/Sentinel) and "when that ally crits" (Howler) are the
+// same reactive trigger under two phrasings — verified zero-collateral: across all 147 ships in
+// docs/ship-skills.csv, "ally crit(ically hits/s)" appears ONLY on these three ships.
+const ALLY_CRIT_HIT_RE = /when (?:an|that) ally (?:critically hits|crits)/i;
 
 /**
  * Returns 'on-ally-critically-repaired' when `anchorPos` (the ability's raw-text anchor position)


### PR DESCRIPTION
## Phase 3 reactive-trigger promotion — PR-G (L2)

Stacked on #225 (PR-F). Part of the reactive-trigger-promotion epic; **red CI is accepted for the duration of Phase 3** (no deploy until the phase completes) — the only failing tests are the not-yet-fixed out-of-scope triage probes.

### What
**Howler**: "cleanses 1 debuff from an ally [and, on refit, grants them 1 stack of Blast] when that ally crits an enemy." The cleanse (and Blast) now ride the existing `on-ally-crit` trigger and land on the **specific ally who crit**, instead of never firing.

### How (narrow L2 — trigger already existed, only the actor stamp + builder wiring were missing)
- `triggers.ts` — the `on-ally-crit` listener now stamps `eventCtx.damagedAllyId = e.actorId` (the crit-ing ally), mirroring the `on-ally-debuffed`/`on-ally-purged` siblings. `reactiveRecipients` already routes an `'ally'`-target reactive to `damagedAllyId`, so no executor change.
- `buildShipAbilities.ts` — added `detectAllyCritTrigger` to the cleanse builder's reactive-trigger chain.
- `skillTextParser.ts` — broadened `ALLY_CRIT_HIT_RE` to also match Howler's "when that ally crits an enemy" (grep-verified: "ally crit*" appears only on Hermes/Howler/Sentinel across all 147 ships; the Blast buff-half is wired for free via the shared regex in `detectReactiveTrigger`).

### Collision check (PR-E Provider-lesson)
The other `on-ally-crit` riders are byte-identical: Hermes's charge + Everliving Regen buff are both `target:'self'` (never read `damagedAllyId`); Pallas rides `on-ally-critically-repaired` (different trigger); Sentinel's heal is `on-cast` (the heal builder never wired the ally-crit chain — a pre-existing, out-of-scope gap noted for the backlog). Golden-parity suites 76/76 unchanged.

### Verification
- Howler triage probe flipped green; new `allyCritReactivePromotion.integration.test.ts` (6 tests: lands-on-crit-er not fallback, Blast-to-crit-er, no-crit→no-fire, enemy-side team symmetry). Non-vacuity confirmed (7 tests go red on src revert).
- Full suite 4047/4051 (the 4 failures = accepted-red out-of-scope probes Nuqtu/Cultivator/Morao/Vindicator). tsc/lint clean; `audit:skills` 0 findings, no allowlist rows.
- Adversarial review: APPROVE, no findings (claims independently re-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dp1hGz5xU95ZwDtmWSnvT