### PR TITLE
fix(skills): Phase 3 PR-H — NEW on-own-cleanse reactive trigger (Cultivator/Morao/Hayyan)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -38,6 +38,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Hayyan now repairs an ally for 6% of her Max HP whenever a debuff is inflicted on that ally, matching her skill text, instead of the repair never firing.",
     "Combat sim: Ruiner now inflicts Bomb II on any enemy that performs a repair (once per round per enemy), matching her skill text, instead of never firing. Amartya now inflicts a stack of Defense Shred on the specific enemy defender that was just repaired, instead of never firing.",
     "Combat sim: Howler now cleanses a debuff from (and, with her refit, grants a stack of Blast to) the specific ally who just landed a critical hit, matching her skill text, instead of never firing.",
+    "Combat sim: Cultivator now repairs the specific ally whose debuff she just cleansed for 4% of her Max HP, and Hayyan does the same for 4%, matching their skill text instead of never firing. Morao now repairs an extra 5% of her Max HP and gains Defense Up II whenever her own cleanse actually removes a debuff, instead of always firing regardless.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -120,6 +120,14 @@ export type AbilityTrigger =
     // actor other than the owner). The ally counterpart of `on-debuffed`. Does NOT fire for
     // DoTs (dot-applied), matching on-debuffed's debuff-applied-only scoping.
     | 'on-ally-debuffed'
+    // Phase 3 PR-H: fires when THIS unit performs a cleanse that actually removes >= 1 debuff
+    // (rides the existing `cleanse-performed` event, self-scoped on casterId === ownerId).
+    // Cultivator ("when this Unit cleanses a Debuff, it also repairs that ally") is 'ally'-target
+    // — routed to the cleansed ally via eventCtx.cleansedAllyIds; Morao ("upon Cleansing a
+    // Debuff, repairs an additional 5% ... and gains Defense Up II") is 'self'-target — no
+    // capture needed. Distinct from `on-enemy-cleansed` (opposing-scoped) — this is the
+    // OWN-cleanse counterpart, mirroring on-debuffed/on-ally-debuffed's self/ally pairing.
+    | 'on-own-cleanse'
     // D-PR16 Lockdown: fires when THIS unit resists an incoming debuff (rides the existing
     // `debuff-resisted` event, self-scoped on targetId === ownerId). Chains off D-PR15's
     // Block-Debuff auto-resist emission AND normal hacking/affinity resists.
@@ -152,6 +160,8 @@ export const LIVE_TRIGGERS = new Set<AbilityTrigger>([
     'on-ally-debuff-inflicted',
     // Phase 3 PR-E: ally-scoped counterpart of on-debuffed.
     'on-ally-debuffed',
+    // Phase 3 PR-H: self-scoped reaction to THIS unit's own cleanse actually removing a debuff.
+    'on-own-cleanse',
     'on-ally-crit-dot',
     'on-ally-critically-repaired',
     'on-ally-crit',

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -3055,17 +3055,25 @@ describe('parseHealAbilities — unmodeled reactive triggers are NOT emitted', (
         ]);
     });
 
-    it('Cultivator p2: ally-damage clause → ally-target heal with allySubject damageReaction; 4% cleanse clause unchanged', () => {
+    it('Cultivator p2: ally-damage clause → ally-target heal with allySubject damageReaction; 4% cleanse clause carries ownCleanseReaction (Phase 3 PR-H)', () => {
         // Full CSV p2 text (tags stripped; <br /><br /> → '. ' via the plain pipeline).
-        // The 4% cleanse-reaction clause is pinned to its pre-Task-8 shape (on-cast ally
-        // heal, NO damageReaction — "cleanses" is not a damage-reaction shape); the 8%
-        // ally-damaged clause was PR 1-disqualified and now parses with allySubject.
+        // The 4% cleanse-reaction clause now carries `ownCleanseReaction` (Phase 3 PR-H: routes
+        // to the NEW on-own-cleanse trigger — "cleanses" is NOT a damageReaction shape, a
+        // SEPARATE parser-level annotation, see its doc comment); the 8% ally-damaged clause was
+        // PR 1-disqualified and parses with allySubject (unrelated, unaffected by PR-H).
         expect(
             parseHealAbilities(
                 "When this Unit cleanses a Debuff, it also repairs that ally for 4% of this Unit's Max HP. Additionally, when an ally is directly damaged within the active pattern, this Unit repairs that ally for 8% of this Unit's Max HP."
             )
         ).toEqual([
-            { kind: 'heal', pct: 4, basis: 'hp', target: 'ally', explicitTarget: true },
+            {
+                kind: 'heal',
+                pct: 4,
+                basis: 'hp',
+                target: 'ally',
+                explicitTarget: true,
+                ownCleanseReaction: true,
+            },
             {
                 kind: 'heal',
                 pct: 8,

--- a/src/utils/abilities/__tests__/reactiveTriggerPromotionTriage.test.ts
+++ b/src/utils/abilities/__tests__/reactiveTriggerPromotionTriage.test.ts
@@ -304,8 +304,9 @@ describe('cluster 7 — ally-crit / cleanse-reactive / DoT-crit / debuff-resiste
         const ab = abilitiesFor({ firstPassiveSkillText: CULTIVATOR_P2 }, 'passive');
         const heal = ab.find((a) => a.type === 'heal');
         expect(heal?.trigger).not.toBe('on-cast');
-        // GAP: needs-capture (NEW trigger) — "when this Unit cleanses a debuff" has no self-cleanse
-        // reactive trigger; heal targets "that ally" (the cleansed ally) → also needs which-ally capture.
+        // Fixed (Phase 3 PR-H): NEW on-own-cleanse trigger — the heal builder's ownCleanseReaction
+        // annotation routes this repair there, and triggers.ts's on-own-cleanse listener stamps
+        // eventCtx.cleansedAllyIds so the ally-target heal lands on "that ally" (the cleansed one).
     });
 
     const HAYYAN_P3 =
@@ -318,14 +319,31 @@ describe('cluster 7 — ally-crit / cleanse-reactive / DoT-crit / debuff-resiste
         // targetId is the debuffed ally; mirrors self-scoped `on-debuffed`).
     });
 
+    // Hayyan's SIBLING clause (same passive, first sentence — PR-E's on-ally-debuffed fix
+    // deliberately left this one "untouched" per its own commit message, deferring it here):
+    // "When cleansing a Debuff from an Ally, this Unit repairs the ally for 4% of this Unit's
+    // Max HP." Identical shape to Cultivator's own-cleanse repair (ally-target, "the ally" =
+    // the cleansed one) — added as a regression-lock alongside Cultivator/Morao (Phase 3 PR-H),
+    // since the natural on-own-cleanse regex covers all three with no ship-specific carve-out.
+    const HAYYAN_P2_CLEANSE =
+        "When <unit-aid>cleansing a</unit-aid> Debuff from an Ally, this Unit <unit-damage>repairs the ally for 4%</unit-damage> of this Unit's Max HP.";
+    it('Hayyan: repair-on-own-cleanse (sibling clause) rides on-own-cleanse (Phase 3 PR-H)', () => {
+        const ab = abilitiesFor({ firstPassiveSkillText: HAYYAN_P2_CLEANSE }, 'passive');
+        const heal = ab.find((a) => a.type === 'heal');
+        expect(heal?.trigger).toBe('on-own-cleanse');
+        expect(heal?.target).toBe('ally');
+    });
+
     const MORAO_P3 =
         "This Unit <unit-damage>repairs 5%</unit-damage> of its Max HP every turn and, upon <unit-aid>Cleansing a</unit-aid> Debuff, repairs an additional <unit-damage>5%</unit-damage> of its Max HP while gaining <unit-skill>Defense Up II</unit-skill> for 2 turns.";
     it('Morao: repair/buff-on-own-cleanse is reactive, not on-cast', () => {
         const ab = abilitiesFor({ firstPassiveSkillText: MORAO_P3 }, 'passive');
         // Both the extra repair and Defense Up ride "upon cleansing"; today everything is on-cast.
         expect(ab.some((a) => a.trigger !== 'on-cast')).toBe(true);
-        // GAP: needs-capture (NEW trigger on-own-cleanse; self-target so no actor). The "every turn"
-        // repair is a separate recurring-trigger gap, out of this family.
+        // Fixed (Phase 3 PR-H): both the extra repair AND Defense Up II ride the NEW
+        // on-own-cleanse trigger (self-target, no actor capture needed). The "every turn" repair
+        // is a SEPARATE recurring-trigger gap (out of this family) and correctly stays on-cast —
+        // see the dedicated integration test for the precise per-ability assertion.
     });
 
     const CROCUS_P2 =

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -1443,7 +1443,14 @@ function abilitiesFromText(
             ? h.damageReaction.allySubject
                 ? ('on-ally-attacked' as const)
                 : ('on-attacked' as const)
-            : // Epic PR4: Chimei's "At the start of the round, all allies with Stealth repairs
+            : // Phase 3 PR-H: Cultivator ("when this Unit cleanses a Debuff, it also repairs that
+              // ally") / Morao ("upon Cleansing a Debuff, repairs an additional 5%") — the
+              // `ownCleanseReaction` parser annotation (match-position-relative, see its doc
+              // comment for why a position-scoped detector can't disambiguate Morao's two
+              // same-pct repairs) takes the SAME precedence as damageReaction above.
+              h.ownCleanseReaction
+              ? ('on-own-cleanse' as const)
+              : // Epic PR4: Chimei's "At the start of the round, all allies with Stealth repairs
               // 10% of this unit's max HP" parsed on-cast — the SAME phrase already resolves to
               // start-of-round for buff grants (detectReactiveTrigger) and Judge's passive
               // damage (detectStartOfRoundTrigger, added alongside this call). Checked for

--- a/src/utils/combat/__tests__/ownCleanseReactivePromotion.integration.test.ts
+++ b/src/utils/combat/__tests__/ownCleanseReactivePromotion.integration.test.ts
@@ -1,0 +1,721 @@
+/**
+ * Phase 3 PR-H — combat-integration tests for the NEW `on-own-cleanse` reactive trigger:
+ *   - Morao (3rd passive): "This Unit repairs 5% of its Max HP every turn and, upon Cleansing a
+ *     Debuff, repairs an additional 5% of its Max HP while gaining Defense Up II for 2 turns" —
+ *     the "every turn" repair stays on-cast (a separate, out-of-scope recurring-trigger gap); ONLY
+ *     the "upon Cleansing" repair + Defense Up II ride on-own-cleanse. Self-target — no actor
+ *     capture needed.
+ *   - Cultivator (1st passive): "When this Unit cleanses a Debuff, it also repairs that ally for
+ *     4% of this Unit's Max HP" — 'ally'-target, routed to the ACTUALLY-cleansed ally via
+ *     eventCtx.cleansedAllyIds (cleanse-performed.targets), fanning out over every real removal
+ *     (not just the cleanse ability's nominal target set).
+ *
+ * Both owner abilities are extracted through the REAL production path (`buildShipAbilities`) fed
+ * skill text copied verbatim from `docs/ship-skills.csv` (parser source of truth) — never a
+ * hand-built ability array. The cleanse ACTION itself (which drives the reaction) is hand-built,
+ * mirroring `cleanseCastPath.test.ts`/`enemyCleanse.integration.test.ts`'s harness style.
+ *
+ * Non-vacuity: reverting the PR-H src changes (skillTextParser.ts / buildShipAbilities.ts /
+ * triggers.ts / playerTurn.ts / events.ts) turns every "fires"/"routes to" assertion in this file
+ * red (verified manually — see the PR-H report for the revert/restore transcript).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { executeIntent, Intent, IntentExecContext } from '../triggers';
+import { createStatusEngine } from '../statusEngine';
+import type { PlayerActorRuntime, HealingRuntimeCtx } from '../playerTurn';
+import type { CombatActor } from '../state';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
+
+function ship(over: Partial<Ship>): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}, {}, {}], ...over } as Ship;
+}
+
+// A no-op active (0-multiplier hit) so a focus/team actor with no offensive purpose still takes
+// a valid turn each round without ending combat early or erroring.
+const noopActiveSlot = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: 'noop-atk',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0 },
+        },
+    ],
+});
+
+/** Collect every `buff-applied` event from a run (Morao's Defense Up II grant is a BUFF —
+ *  verifiable via the bus, unlike the reactive HEALs; see sumDirectHeal below). */
+function runAndCollectBuffs(input: CombatEngineInput) {
+    const bus = createEventBus();
+    const buffsApplied: Extract<CombatEvent, { type: 'buff-applied' }>[] = [];
+    bus.on('buff-applied', (e) => buffsApplied.push(e));
+    runCombat({ ...input, bus });
+    return { buffsApplied };
+}
+
+/** A reactive heal never re-emits `heal-performed` (deliberate chain guard — triggers.ts: "a
+ *  reactive heal must not re-trigger heal listeners"). It DOES credit the healing-mode per-round
+ *  bookkeeping (`ctx.healing.credit(ownerId, 'directHeal'|'effectiveHeal', raw)`), so verification
+ *  reads `result.healing.rounds[].perActor.get(ownerId)`, mirroring PR-E's Hayyan pattern.
+ *  `directHeal` is credited to the OWNER regardless of WHICH recipient actually received the
+ *  repair; `effectiveHeal` is credited (possibly 0) only when the recipient equals
+ *  `ctx.healing.targetId` — the distinguishing signal used by the Cultivator routing tests below. */
+function sumBucket(
+    result: ReturnType<typeof runCombat>,
+    actorId: string,
+    bucket: 'directHeal' | 'effectiveHeal'
+): number {
+    return (result.healing?.rounds ?? []).reduce(
+        (sum, rd) => sum + (rd.perActor.get(actorId)?.[bucket] ?? 0),
+        0
+    );
+}
+
+// =============================================================================
+// Morao — "This Unit repairs 5% of its Max HP every turn and, upon Cleansing a Debuff, repairs
+// an additional 5% of its Max HP while gaining Defense Up II for 2 turns" (docs/ship-skills.csv,
+// verbatim).
+// =============================================================================
+
+const MORAO_P3 =
+    "This Unit <unit-damage>repairs 5%</unit-damage> of its Max HP every turn and, upon <unit-aid>Cleansing a</unit-aid> Debuff, repairs an additional <unit-damage>5%</unit-damage> of its Max HP while gaining <unit-skill>Defense Up II</unit-skill> for 2 turns.";
+const MORAO_HP = 20_000;
+const MORAO_BASE_PCT = 5; // "every turn" — stays on-cast (out of scope)
+const MORAO_REACTIVE_PCT = 5; // "upon Cleansing a Debuff" — on-own-cleanse
+
+/** Extracts Morao's REAL production passive slot (all 3 abilities, unfiltered — the baseline
+ *  every-turn repair, the reactive repair, and the reactive Defense Up II grant). */
+function moraoPassiveAbilities(): Ability[] {
+    return (
+        buildShipAbilities(ship({ firstPassiveSkillText: MORAO_P3 })).slots.find(
+            (s) => s.slot === 'passive'
+        )?.abilities ?? []
+    );
+}
+
+describe('Morao passive — extracted ability shapes (mutation guard)', () => {
+    it('the "every turn" repair stays on-cast; ONLY the "upon Cleansing" repair + Defense Up II ride on-own-cleanse', () => {
+        const abilities = moraoPassiveAbilities();
+        const heals = abilities.filter((a) => a.type === 'heal');
+        const buffs = abilities.filter((a) => a.type === 'buff');
+        expect(heals).toHaveLength(2);
+        expect(heals.filter((a) => a.trigger === 'on-cast')).toHaveLength(1);
+        expect(heals.filter((a) => a.trigger === 'on-own-cleanse')).toHaveLength(1);
+        expect(buffs).toHaveLength(1);
+        expect(buffs[0].trigger).toBe('on-own-cleanse');
+        expect(buffs[0].target).toBe('self');
+        expect(buffs[0].config.type === 'buff' && buffs[0].config.buffName).toBe('Defense Up II');
+    });
+});
+
+// Focus casts a self-target cleanse each round (mirrors cleanseCastPath.test.ts).
+const selfCleanseActive = (count: number): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: 'self-cleanse',
+            type: 'cleanse',
+            target: 'self',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'cleanse', count },
+        },
+    ],
+});
+
+/** A FASTER enemy whose active applies ONE removable debuff to the heal target (mirrors
+ *  cleanseCastPath.test.ts's debuffEnemy). */
+const debuffEnemy = (id: string): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 1, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1000 },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'enemy-debuff',
+                            type: 'debuff',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: {
+                                type: 'debuff',
+                                buffName: 'Attack Down',
+                                parsedEffects: { attack: -30 },
+                                stacks: 1,
+                                isStackable: false,
+                                application: 'apply',
+                                duration: 5,
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+    }) as EnemyAttacker;
+
+const MORAO_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: {
+        slots: [selfCleanseActive(1), { slot: 'passive', abilities: moraoPassiveAbilities() }],
+    },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: MORAO_HP,
+    speed: 1, // slower than the debuff enemy → the debuff lands before Morao's own cleanse cast
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+describe('Morao (player-side) — self-cleanse drives the reactive repair + Defense Up II', () => {
+    it('a pre-existing debuff removed by its OWN cleanse fires BOTH the baseline and reactive repair (10% total) + Defense Up II', () => {
+        const { buffsApplied } = runAndCollectBuffs(
+            MORAO_BASE({ enemyAttackers: [debuffEnemy('enemy-deb')] })
+        );
+        const result = runCombat(MORAO_BASE({ enemyAttackers: [debuffEnemy('enemy-deb')] }));
+        // Baseline (5%, on-cast, always fires) + reactive (5%, on-own-cleanse) = 10% total.
+        expect(sumBucket(result, 'attacker', 'directHeal')).toBeCloseTo(
+            (MORAO_HP * (MORAO_BASE_PCT + MORAO_REACTIVE_PCT)) / 100,
+            6
+        );
+        const defenseUp = buffsApplied.filter((b) => b.buffName === 'Defense Up II');
+        expect(defenseUp).toHaveLength(1);
+        expect(defenseUp[0].actorId).toBe('attacker');
+    });
+
+    it('NEGATIVE control: no debuff to cleanse → only the baseline 5% fires, no Defense Up II', () => {
+        const { buffsApplied } = runAndCollectBuffs(MORAO_BASE());
+        const result = runCombat(MORAO_BASE());
+        // Only the baseline "every turn" repair (on-cast) fires — the reactive never triggers.
+        expect(sumBucket(result, 'attacker', 'directHeal')).toBeCloseTo(
+            (MORAO_HP * MORAO_BASE_PCT) / 100,
+            6
+        );
+        expect(buffsApplied.filter((b) => b.buffName === 'Defense Up II')).toHaveLength(0);
+    });
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+// Player active: a damage hit PLUS a removable debuff onto the positionally-anchored front enemy
+// (mirrors enemyCleanse.integration.test.ts's damageThenDebuff).
+const damageThenDebuff = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: 'p-basic',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 100 },
+        },
+        {
+            id: 'p-debuff',
+            type: 'debuff',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: {
+                type: 'debuff',
+                buffName: 'Attack Down',
+                parsedEffects: { attack: -30 },
+                stacks: 1,
+                isStackable: false,
+                application: 'apply',
+                duration: 5,
+            },
+        } as unknown as Ability,
+    ],
+});
+
+const enemyAt = (id: string, position: Position, shipSkills: ShipSkills): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 1_000, crit: 0, critDamage: 0, defence: 0, hp: 40_000, speed: 50 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        shipSkills,
+    }) as EnemyAttacker;
+
+describe('Morao (enemy-side) — team symmetry: an enemy Morao self-cleanses and reacts', () => {
+    it('the player-applied debuff, once self-cleansed, fires the reactive repair + Defense Up II on the enemy', () => {
+        const foeSkills: ShipSkills = {
+            slots: [selfCleanseActive(1), { slot: 'passive', abilities: moraoPassiveAbilities() }],
+        };
+        const input: CombatEngineInput = {
+            attack: 10_000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [damageThenDebuff()] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 200, // player acts first, anchoring + debuffing 'foe' before its own turn
+            position: 'M4',
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            healTargetId: 'attacker',
+            enemyAttackers: [enemyAt('foe', 'M4', foeSkills)],
+        };
+        const { buffsApplied } = runAndCollectBuffs(input);
+        const result = runCombat(input);
+        expect(sumBucket(result, 'foe', 'directHeal')).toBeCloseTo(
+            (MORAO_HP * (MORAO_BASE_PCT + MORAO_REACTIVE_PCT)) / 100,
+            6
+        );
+        const defenseUp = buffsApplied.filter((b) => b.buffName === 'Defense Up II');
+        expect(defenseUp).toHaveLength(1);
+        expect(defenseUp[0].actorId).toBe('foe');
+    });
+});
+
+// =============================================================================
+// Cultivator — "When this Unit cleanses a Debuff, it also repairs that ally for 4% of this
+// Unit's Max HP" (docs/ship-skills.csv, verbatim isolated sentence — matches the triage probe).
+// =============================================================================
+
+const CULTIVATOR_P2 =
+    "When this Unit <unit-aid>cleanses a Debuff</unit-aid>, it also <unit-damage>repairs that ally for 4%</unit-damage> of this Unit's Max HP.";
+const CULTIVATOR_HP = 20_000;
+const CULTIVATOR_HEAL_PCT = 4;
+
+/** Extracts Cultivator's ally-repair through the REAL parser/builder (production routing). */
+function cultivatorReactiveHeal(): Ability {
+    const abilities =
+        buildShipAbilities(ship({ firstPassiveSkillText: CULTIVATOR_P2 })).slots.find(
+            (s) => s.slot === 'passive'
+        )?.abilities ?? [];
+    const heal = abilities.find((a) => a.type === 'heal' && a.trigger === 'on-own-cleanse');
+    if (!heal) throw new Error('mutation guard: Cultivator on-own-cleanse repair not found');
+    return heal;
+}
+
+describe('Cultivator repair — extracted ability shape (mutation guard)', () => {
+    it('rides the NEW on-own-cleanse trigger, targeting the ally', () => {
+        const heal = cultivatorReactiveHeal();
+        expect(heal.trigger).toBe('on-own-cleanse');
+        expect(heal.target).toBe('ally');
+    });
+});
+
+// An ALL-ALLIES cleanse (NOT Cultivator's real single-ally shape — a deliberately broader hand-
+// built cast) proves the underlying fan-out is robust: only recipients that ACTUALLY had a debuff
+// removed land in eventCtx.cleansedAllyIds, and the reactive repair follows THOSE ids rather than
+// whatever `healing.targetId`/ownerId default the recipient-resolution would otherwise fall back
+// to (the brief's "Cultivator cleanses 1, but do it robustly").
+const allAlliesCleanseActive = (count: number): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: 'cultivator-cleanse',
+            type: 'cleanse',
+            target: 'all-allies',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'cleanse', count },
+        },
+    ],
+});
+
+/** A FASTER enemy that both damages AND debuffs 'attacker' (so it is BELOW max HP — giving the
+ *  reactive repair real room to register `effectiveHeal` — AND carries a removable debuff). */
+const damageAndDebuffEnemy = (id: string): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 500, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1000 },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'enemy-dmg',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 100 },
+                        },
+                        {
+                            id: 'enemy-debuff',
+                            type: 'debuff',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: {
+                                type: 'debuff',
+                                buffName: 'Attack Down',
+                                parsedEffects: { attack: -30 },
+                                stacks: 1,
+                                isStackable: false,
+                                application: 'apply',
+                                duration: 5,
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+    }) as EnemyAttacker;
+
+const cultivatorTeamActor = (): TeamActor =>
+    ({
+        id: 'cultivator',
+        speed: 10, // slowest — acts after both the enemy AND the other actors
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        walk: {
+            shipSkills: {
+                slots: [
+                    allAlliesCleanseActive(1),
+                    { slot: 'passive', abilities: [cultivatorReactiveHeal()] },
+                ],
+            },
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 100,
+                defence: 0,
+                hp: CULTIVATOR_HP,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    }) as TeamActor;
+
+/** A second ally with NO debuff — included in the all-allies cleanse's target SET but contributes
+ *  zero real removal, so it must never appear in eventCtx.cleansedAllyIds. */
+const allyBTeamActor = (): TeamActor =>
+    ({
+        id: 'ally-b',
+        speed: 30,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        walk: {
+            shipSkills: { slots: [noopActiveSlot()] },
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp: 10_000,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    }) as TeamActor;
+
+const CULTIVATOR_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [noopActiveSlot()] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    speed: 50, // faster than Cultivator's own turn but slower than the enemy
+    teamActors: [cultivatorTeamActor(), allyBTeamActor()],
+    ...overrides,
+});
+
+describe('Cultivator (player-side) — end-to-end: self-cast all-allies cleanse fires the ally repair', () => {
+    // NOTE: in this engine, a non-positional enemy attack always targets `healTargetId` (the
+    // "tank") — so a full-engine run can't decouple "who got debuffed" from "who healTargetId
+    // points at" to prove the reaction follows eventCtx.cleansedAllyIds rather than a
+    // healing.targetId fallback. That precise routing distinction is proven at the unit level
+    // (executeIntent/reactiveRecipients, below); these end-to-end tests confirm the REAL
+    // production wiring fires with the right magnitude and stays silent with nothing to cleanse.
+    it('a pre-existing debuff on the heal target, once cleansed, fires the reaction for 4% of Cultivator Max HP', () => {
+        const result = runCombat(
+            CULTIVATOR_BASE({
+                healTargetId: 'attacker',
+                enemyAttackers: [damageAndDebuffEnemy('enemy-deb')],
+            })
+        );
+        expect(sumBucket(result, 'cultivator', 'directHeal')).toBeCloseTo(
+            (CULTIVATOR_HP * CULTIVATOR_HEAL_PCT) / 100,
+            6
+        );
+        expect(sumBucket(result, 'cultivator', 'effectiveHeal')).toBeGreaterThan(0);
+    });
+
+    it('NEGATIVE control: no debuff anywhere → cleanse removes nothing → the reaction never fires', () => {
+        const result = runCombat(CULTIVATOR_BASE({ healTargetId: 'attacker' }));
+        expect(sumBucket(result, 'cultivator', 'directHeal')).toBe(0);
+    });
+});
+
+// ----------------------------------------------------------------------------------------------
+// Unit-level routing precision (mirrors triggers.test.ts's "damagedAllyId recipient routing"
+// pattern) — proves reactiveRecipients() follows eventCtx.cleansedAllyIds rather than falling
+// back to healing.targetId, with healing.targetId fully decoupled from the cleanse outcome (the
+// full-engine harness above cannot decouple the two — see the note above).
+// ----------------------------------------------------------------------------------------------
+describe("Cultivator's on-own-cleanse ally-target heal — cleansedAllyIds routing (executeIntent unit-level)", () => {
+    const PLAYER_IDS = ['cultivator', 'team1', 'tank'];
+
+    const makeHealIntent = (cleansedAllyIds?: string[]): Intent => ({
+        ownerId: 'cultivator',
+        sourceSlot: 'passive',
+        ability: {
+            id: 'cultivator-ally-repair',
+            type: 'heal',
+            target: 'ally',
+            trigger: 'on-own-cleanse',
+            conditions: [],
+            config: { type: 'heal', pct: 4, basis: 'hp' },
+        },
+        ...(cleansedAllyIds !== undefined ? { eventCtx: { cleansedAllyIds } } : {}),
+    });
+
+    const buildHealCtx = (): {
+        ctx: IntentExecContext;
+        applied: number[];
+        credits: Array<{ actorId: string; bucket: string; amount: number }>;
+    } => {
+        const applied: number[] = [];
+        const credits: Array<{ actorId: string; bucket: string; amount: number }> = [];
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        se.beginRound(1);
+        const healing: HealingRuntimeCtx = {
+            targetId: 'tank',
+            credit: (actorId, bucket, amount) => credits.push({ actorId, bucket, amount }),
+            recipientMaxHp: () => 1000,
+            recipientIncomingHealPct: () => 0,
+            applierMaxHp: () => 1000,
+            applyHealToTarget: (raw) => {
+                applied.push(raw);
+                return { consumed: raw, overheal: 0 };
+            },
+            grantShieldToTarget: () => 0,
+            playerIds: PLAYER_IDS,
+            enemyIds: [],
+            recipientActor: () => undefined,
+        };
+        const ctx: IntentExecContext = {
+            round: 1,
+            enemy: { id: 'enemy-default' } as CombatActor,
+            enemyId: 'enemy-default',
+            statusEngine: se,
+            bus: createEventBus(),
+            corrosionEntries: [],
+            infernoEntries: [],
+            pendingBombs: [],
+            runtimes: new Map([
+                [
+                    'cultivator',
+                    { actor: { id: 'cultivator' }, healModifier: 0, attack: 0, defence: 0, hp: 20_000 } as unknown as PlayerActorRuntime,
+                ],
+            ]),
+            grantAllyCharges: () => {},
+            removeEnemyCharges: () => {},
+            removeChargesFrom: () => {},
+            grantExtraAction: () => {},
+            playerIds: PLAYER_IDS,
+            lastTurnCtxByActor: new Map(),
+            enemyHp: 100000,
+            cumulativeDamage: 0,
+            recordResisted: () => {},
+            healing,
+        };
+        return { ctx, applied, credits };
+    };
+
+    it('a SINGLE cleansedAllyIds entry DIFFERENT from healing.targetId routes there, NOT to the target (no fallback)', () => {
+        const { ctx, applied, credits } = buildHealCtx();
+        executeIntent(makeHealIntent(['team1']), ctx);
+        // 4% of Cultivator's 20,000 HP = 800, credited as directHeal regardless of recipient...
+        expect(credits.filter((c) => c.bucket === 'directHeal')).toEqual([
+            { actorId: 'cultivator', bucket: 'directHeal', amount: 800 },
+        ]);
+        // ...but the pool-consumption path (applyHealToTarget/effectiveHeal) only fires when the
+        // recipient equals healing.targetId ('tank') — 'team1' never triggers it, proving the
+        // routing did NOT fall back to healing.targetId when cleansedAllyIds named someone else.
+        expect(applied).toHaveLength(0);
+        expect(credits.some((c) => c.bucket === 'effectiveHeal')).toBe(false);
+    });
+
+    it('a SINGLE cleansedAllyIds entry EQUAL to healing.targetId consumes the pool (effectiveHeal credited)', () => {
+        const { ctx, applied, credits } = buildHealCtx();
+        executeIntent(makeHealIntent(['tank']), ctx);
+        expect(applied).toEqual([800]);
+        expect(credits).toContainEqual({ actorId: 'cultivator', bucket: 'effectiveHeal', amount: 800 });
+    });
+
+    it('MULTIPLE cleansedAllyIds fan out to EVERY actually-cleansed ally (robustness beyond Cultivator\'s real single-ally shape)', () => {
+        const { ctx, applied, credits } = buildHealCtx();
+        executeIntent(makeHealIntent(['team1', 'tank']), ctx);
+        // Both recipients are credited directHeal (one entry per recipient in the fan-out loop)...
+        expect(credits.filter((c) => c.bucket === 'directHeal')).toHaveLength(2);
+        // ...but only 'tank' (matching healing.targetId) consumes the pool.
+        expect(applied).toEqual([800]);
+        expect(credits.filter((c) => c.bucket === 'effectiveHeal')).toHaveLength(1);
+    });
+
+    it('NO cleansedAllyIds (absent) falls back to the plain healing.targetId (PR1 contract, unchanged for every OTHER ally-target reactive)', () => {
+        const { ctx, applied, credits } = buildHealCtx();
+        executeIntent(makeHealIntent(undefined), ctx);
+        expect(applied).toEqual([800]);
+        expect(credits).toContainEqual({ actorId: 'cultivator', bucket: 'effectiveHeal', amount: 800 });
+    });
+});
+
+describe('Cultivator (enemy-side) — team symmetry: an enemy Cultivator repairs its OWN cleansed ally', () => {
+    it('repairs the OTHER enemy ally the player just debuffed (positional: the non-positional dummy target has no `ally`-selection candidate)', () => {
+        // NOTE: an 'ally'-target cleanse's enemy-caster branch picks via lowestHpEnemyAllyId(),
+        // which iterates `healing.enemyIds` — the EXPLICIT enemyAttackers list only (NOT the
+        // singular non-positional dummy `enemy` target, which the player's non-positional debuff
+        // always lands on regardless of enemyAttackers — verified manually). So a genuine SECOND
+        // EnemyAttacker (not the dummy) is required here, positionally targeted by the player
+        // (mirrors enemyCleanse.integration.test.ts's positional harness).
+        const enemyCultivator: EnemyAttacker = {
+            id: 'enemy-cultivator',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: CULTIVATOR_HP, speed: 10 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active',
+                        abilities: [
+                            {
+                                id: 'enemy-cultivator-cleanse',
+                                type: 'cleanse',
+                                target: 'ally',
+                                trigger: 'on-cast',
+                                conditions: [],
+                                config: { type: 'cleanse', count: 1 },
+                            },
+                        ],
+                    },
+                    { slot: 'passive', abilities: [cultivatorReactiveHeal()] },
+                ],
+            },
+        } as EnemyAttacker;
+
+        // The OTHER enemy ally: positionally anchored at M4/front, no skills of its own (never
+        // acts meaningfully) — only exists to receive the player's debuff and be Cultivator's
+        // sole `ally`-selection candidate (lowestHpEnemyAllyId excludes the caster itself).
+        const enemyAlly = enemyAt('enemy-ally', 'M4', { slots: [] });
+
+        const input: CombatEngineInput = {
+            attack: 10_000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [damageThenDebuff()] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 200, // player acts first — its debuff lands on enemy-ally before enemy-cultivator's turn
+            position: 'M4',
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            healTargetId: 'attacker',
+            enemyAttackers: [enemyAlly, enemyCultivator],
+        };
+
+        const result = runCombat(input);
+        expect(sumBucket(result, 'enemy-cultivator', 'directHeal')).toBeCloseTo(
+            (CULTIVATOR_HP * CULTIVATOR_HEAL_PCT) / 100,
+            6
+        );
+    });
+});

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -156,18 +156,26 @@ export type CombatEvent =
            *  recipient. Always populated by the engine; absent only in hand-crafted test emits. */
           perTarget?: { targetId: string; amount: number }[];
       } & ReactiveStamp)
-    /** A cleanse cast resolved. `casterId` is the cleansing actor; `count` is the
-     *  number of debuffs actually removed (player-side) or the nominal cfg.count
-     *  (enemy-side, event-only path). Asymmetry: player-side performs REAL removal
-     *  and suppresses the event when 0 debuffs were removed; enemy-side fires on
-     *  every qualifying cast regardless of whether a debuff existed (removal is
-     *  deferred — reactors such as Arum/Grif fire on the cast, not the removal).
-     *  The `on-enemy-cleansed` listener filters by `isOpposing(casterId)`. */
+    /** A cleanse cast resolved. `casterId` is the cleansing actor; `count` is the number of
+     *  debuffs ACTUALLY removed. Team-symmetric (the enemy-cleanse-lift, #166-era): BOTH the
+     *  player path and the enemy (event-only) path perform REAL removal via the side-agnostic
+     *  `statusEngine.cleanse` over `recipientsFor`'s side-aware recipients, and the event is
+     *  suppressed on both sides when 0 debuffs were removed. The `on-enemy-cleansed` listener
+     *  filters by `isOpposing(casterId)`; the `on-own-cleanse` listener (Phase 3 PR-H) filters by
+     *  `casterId === ownerId`. */
     | ({
           type: 'cleanse-performed';
           casterId: string;
           count: number;
           round: number;
+          /** Phase 3 PR-H: the recipient ids that ACTUALLY had >= 1 debuff removed (a subset of
+           *  the cleanse ability's targeted recipients — e.g. an `all-allies` cleanse where only
+           *  some allies carried a debuff), in application order. Read by the `on-own-cleanse`
+           *  listener to stamp `eventCtx.cleansedAllyIds`, routing an `ally`-target reactive
+           *  repair (Cultivator's "that ally") to exactly these ids instead of the default heal
+           *  target. Mirrors `heal-performed.targets`/`shield-applied.recipientIds`. Always
+           *  populated by the engine; absent only in hand-crafted test emits. */
+          targets?: string[];
       } & ReactiveStamp)
     /** A purge resolved. `casterId` = the purging actor; `targetId` = the VICTIM whose
      *  buffs were removed (REQUIRED — `on-ally-purged` is victim-scoped, unlike the

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -2407,6 +2407,12 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         // Carried on heal-performed.overheal for an `overheal`-basis reactive shield (Abundant Renewal).
         let overhealSum = 0;
         let cleansePerformedCount = 0;
+        // Phase 3 PR-H: recipient ids that ACTUALLY had >= 1 debuff removed this cast (a subset
+        // of recipientsFor's targeted recipients — e.g. an `all-allies` cleanse where only some
+        // allies carried a debuff). Carried on cleanse-performed.targets for the on-own-cleanse
+        // listener's ally-routing (mirrors healTargets, gated the same way as shieldRecipientIds:
+        // only entries where something actually happened are included).
+        const cleansedRecipientIds: string[] = [];
         // Per-recipient breakdown for heal-performed.perTarget (additive — one entry per recipient).
         const healPerTarget: {
             targetId: string;
@@ -2577,7 +2583,13 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 // metric: the enemy event-only path suppresses it (mirrors E5/#166 credit suppression).
                 let removed = 0;
                 for (const rid of recipientsFor(ability.target)) {
-                    removed += statusEngine.cleanse(rid, cfg.count);
+                    const removedForRid = statusEngine.cleanse(rid, cfg.count);
+                    removed += removedForRid;
+                    // Phase 3 PR-H: only recipients with a REAL removal are on-own-cleanse's
+                    // ally-routing candidates (mirrors shieldRecipientIds' granted>0 gate) — a
+                    // targeted-but-untouched ally (e.g. an all-allies cleanse hitting a debuff-free
+                    // ally) must not appear in cleanse-performed.targets.
+                    if (removedForRid > 0) cleansedRecipientIds.push(rid);
                 }
                 cleansePerformedCount += removed;
                 if (!healEventOnly) healing.credit(actor.id, 'cleanseCount', removed);
@@ -2601,14 +2613,16 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
             });
         }
 
-        // ONE cleanse-performed per cast that cleansed (BOTH modes — the on-enemy-cleansed
-        // listener filters by side, so the player-side emit is inert without an enemy reactor).
+        // ONE cleanse-performed per cast that cleansed (BOTH modes — the on-enemy-cleansed AND
+        // on-own-cleanse listeners filter by side/owner, so an inert emit is harmless without a
+        // matching reactor).
         if (cleansePerformedCount > 0) {
             bus.emit({
                 type: 'cleanse-performed',
                 casterId: actor.id,
                 count: cleansePerformedCount,
                 round: r,
+                targets: cleansedRecipientIds,
             });
         }
     }

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -165,6 +165,13 @@ export interface Intent {
          *  must still resolve, whereas a stale listener firing on some LATER event (e.g. a
          *  dead Curator reacting to an enemy charge rounds after dying) is suppressed. */
         fromOwnDeath?: boolean;
+        /** Phase 3 PR-H: the recipient ids ACTUALLY cleansed by the owner's OWN cleanse-performed
+         *  event (cleanse-performed.targets — a subset of the cleanse's targeted recipients,
+         *  only those with a real removal). The `on-own-cleanse` listener stamps this so an
+         *  `ally`-target reactive repair (Cultivator's "that ally") fans out to exactly these ids
+         *  via `reactiveRecipients`, instead of the default heal target. Mirrors
+         *  repairedAllyIds/shieldRecipientIds. A `self`-target reaction (Morao) ignores it. */
+        cleansedAllyIds?: string[];
     };
 }
 
@@ -263,6 +270,11 @@ export function partitionReactiveAbilities(shipSkills: ShipSkills): {
  *    former (counterTargetId), Amartya's Defense Shred fans out over the latter.
  *  - on-enemy-cleansed → cleanse-performed where isOpposing(casterId)
  *    (any opposing-side actor's cleanse cast). One enqueue per cast.
+ *  - on-own-cleanse → cleanse-performed where casterId === ownerId (Phase 3 PR-H: Cultivator's
+ *    ally-repair, Morao's self-repair + Defense Up II). Self-scoped — the OWN-cleanse counterpart
+ *    of on-enemy-cleansed. Stamps eventCtx.cleansedAllyIds = e.targets (the actually-cleansed
+ *    recipients) so an 'ally'-target reaction fans out to exactly those ids (reactiveRecipients);
+ *    a 'self'-target reaction ignores it. One enqueue per qualifying (>= 1 real removal) cast.
  *  - on-hp-threshold-crossed → hp-changed where targetId === ownerId and the event is a
  *    DOWNWARD crossing of N (oldPct >= N > newPct), N read from the ability's self
  *    hp-threshold condition (trigger CONFIG — executeIntent scrubs it from the drain-time
@@ -694,6 +706,22 @@ export function registerReactiveListeners(args: {
                         // call: enemy side. For the enemy call: player side.
                         // One enqueue per cast.
                         if (isOpposing(e.casterId)) enqueue(intent);
+                    });
+                    break;
+                case 'on-own-cleanse':
+                    bus.on('cleanse-performed', (e) => {
+                        // Self-scoped: THIS owner performed the cleanse (Cultivator/Morao). Stamp
+                        // cleansedAllyIds = e.targets (the actually-cleansed recipient ids,
+                        // unfiltered) so an 'ally'-target repair (Cultivator's "that ally") fans
+                        // out to exactly those recipients via reactiveRecipients; a 'self'-target
+                        // repair/buff (Morao) routes to the owner regardless and ignores it. One
+                        // enqueue per qualifying cast (cleanse-performed is already suppressed
+                        // when 0 debuffs were removed on both sides — see events.ts).
+                        if (e.casterId === ownerId)
+                            enqueue({
+                                ...intent,
+                                eventCtx: { ...intent.eventCtx, cleansedAllyIds: e.targets },
+                            });
                     });
                     break;
                 case 'on-enemy-purged':
@@ -1350,9 +1378,10 @@ function payloadFromConfig(cfg: {
 
 /**
  * Resolve the recipient id list for a reactive heal/cleanse/purge intent.
- * 'ally'-target: prefers eventCtx.damagedAllyId (the ally that was hit), falls
- * back to fallbackTargetId (the heal target). 'all-allies': fans out to every
- * same-side id (ctx.playerIds). Anything else (self, enemy, …): the owner only.
+ * 'ally'-target: prefers eventCtx.cleansedAllyIds (Phase 3 PR-H: fans out over EVERY actually-
+ * cleansed ally — Cultivator's "that ally"), then eventCtx.damagedAllyId (the ally that was hit),
+ * falling back to fallbackTargetId (the heal target). 'all-allies': fans out to every same-side
+ * id (ctx.playerIds). Anything else (self, enemy, …): the owner only.
  */
 export function reactiveRecipients(
     intent: Intent,
@@ -1361,7 +1390,9 @@ export function reactiveRecipients(
 ): string[] {
     const base =
         intent.ability.target === 'ally'
-            ? [intent.eventCtx?.damagedAllyId ?? fallbackTargetId]
+            ? intent.eventCtx?.cleansedAllyIds?.length
+                ? intent.eventCtx.cleansedAllyIds
+                : [intent.eventCtx?.damagedAllyId ?? fallbackTargetId]
             : intent.ability.target === 'all-allies'
               ? ctx.playerIds
               : intent.ability.target === 'adjacent-allies'

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1039,6 +1039,18 @@ const BOMB_DETONATE_RE = /(?:detonates? a bomb|bomb explodes|explodes on (?:an|t
 // Arum's Out. Damage Down debuff, Yarrow/Larkspur's Gelecek Contagion buff. Routes the
 // buff/debuff grant onto the LIVE on-enemy-cleansed trigger. Reference data: docs/ship-skills.csv.
 const ENEMY_CLEANSE_RE = /\bwhen\s+an?\s+enemy\b[^.]*?\bcleanses?\b[^.]*?\bdebuff/i;
+// Phase 3 PR-H: "when this Unit cleanses a Debuff" (Cultivator) / "(when|upon) cleansing a
+// Debuff" (Morao, Hayyan) — the reactive TRIGGER verb ("this unit"/implicit-self
+// cleanses/CLEANSING), not a cleanse EFFECT riding a DIFFERENT reaction (Hermes'
+// on-ally-critically-repaired "it Cleanses 1 debuff from itself" — numeral form, no "a") nor a
+// plain cleanse ACTION on an active/charged cast (Nyxen/Makoli/Nosorog/Nuqtu's "Cleanses 1/2/all"
+// numeral forms) nor an ENEMY-subject reaction ("when an enemy cleanses a Debuff" — Arum/Grif/
+// Larkspur/Pestilence/Yarrow, verb form "cleanses" with subject "an enemy", never matched by this
+// "this unit"/subjectless-gerund phrasing — see ENEMY_CLEANSE_RE above, checked first). Corpus-
+// verified (docs/ship-skills.csv, grep "cleanses? a\b"/"cleansing a"): ONLY Cultivator, Hayyan,
+// Morao match; every enemy-subject/numeral-cleanse row above does not.
+const OWN_CLEANSE_TRIGGER_RE =
+    /\b(?:when\s+this\s+unit\s+cleanses\s+a\s+debuff|(?:when|upon)\s+cleansing\s+a\s+debuff)\b/i;
 // Overload lifecycle (Task 4) — kill/apply-debuff reactive phrasings for buff grants/removals.
 // Kept SEPARATE from the shared ENEMY_DEATH_PHRASING_RE used by parseExtraAction (do NOT broaden
 // that one). "on kill" (Mangler/Butcher), "upon killing an enemy/opponent" (Mangler/Ravager/
@@ -1070,6 +1082,8 @@ const APPLYING_DEBUFF_RE = /\b(?:upon|on|after|when)\s+(?:inflicting|applying)\s
  *    detectEnemyCleanseTrigger (sentence-scoped) since it has no buffName to key on.
  *  - "when an enemy performs a repair" → 'on-enemy-repaired' (Overload lifecycle, Task 4).
  *    Checked BEFORE the kill rule so Ruiner's comma-joined grant resolves correctly.
+ *  - "when this Unit cleanses a Debuff" / "upon Cleansing a Debuff" → 'on-own-cleanse'
+ *    (Phase 3 PR-H: Morao's Defense Up II grant).
  *  - "on kill" / "upon killing an enemy" / "when an enemy dies" → 'on-enemy-destroyed'
  *    (Overload lifecycle, Task 4: Mangler/Ravager/Asphyxiator/Butcher).
  *  - "on inflicting a debuff" / "upon applying a debuff" → 'on-debuff-inflicted'
@@ -1107,6 +1121,11 @@ export function detectReactiveTrigger(
     // for the named buff/debuff grant in its clause (Arum Out. Damage Down I, Yarrow/Larkspur
     // Gelecek Contagion, Arum-refit all-allies Gelecek Contagion II).
     if (ENEMY_CLEANSE_RE.test(clause)) return 'on-enemy-cleansed';
+    // Phase 3 PR-H: "when this Unit cleanses a Debuff" / "upon Cleansing a Debuff" — Morao's
+    // Defense Up II grant. Clause-scoped by buffName (resolveBuffClause) so no anchor-position
+    // ambiguity — a buff name is unique per grant, unlike the heal-side same-pct collision (see
+    // ParsedHealAbility.ownCleanseReaction in parseHealAbilities for that case).
+    if (OWN_CLEANSE_TRIGGER_RE.test(clause)) return 'on-own-cleanse';
     // Overload lifecycle (Task 4). REPAIR is checked BEFORE KILL: Ruiner's Overload grant and its
     // kill-removal share one comma-joined sentence ("gains Overload when an enemy performs a repair,
     // upon killing an enemy, this Unit removes Overload") — the grant must resolve to
@@ -2797,6 +2816,18 @@ export interface ParsedHealAbility {
          *  Add the channel if such a ship ever appears. */
         allySubject?: boolean;
     };
+    /** Phase 3 PR-H: this specific repair match is the reactive component of an own-cleanse
+     *  sentence ("when this Unit cleanses a Debuff, it ALSO repairs that ally" / "…every turn
+     *  and, upon Cleansing a Debuff, repairs an ADDITIONAL 5%…"). buildShipAbilities maps it to
+     *  trigger 'on-own-cleanse'. A PARSER-level (match-position-relative) annotation rather than
+     *  a position-scoped detector call in buildShipAbilities — Morao's sentence carries TWO
+     *  same-pct repair matches ("repairs 5% … every turn" AND "repairs an additional 5%
+     *  … upon Cleansing"), and buildShipAbilities' shared healTagPos anchor (keyed only on pct)
+     *  collapses both onto the FIRST occurrence, so a sentence-scoped phrasePosTrigger detector
+     *  would incorrectly promote the "every turn" heal too. Set only when THIS match's own
+     *  position (m.index, known precisely here) falls AFTER the cleanse-trigger phrase within the
+     *  sentence — mirrors the instead-on-crit split's inInstead position comparison. */
+    ownCleanseReaction?: true;
     /** PR6b: per-count repair scaling — the repair grows by `perUnit`% per matched `condition`
      *  count (Oleander "additional 8.5% repair for each debuffed enemy" → base kept + perUnit
      *  bonus; Meatshield "repairs 1.5% … for each debuff on itself" → pure per-count, `pct` is
@@ -3113,6 +3144,22 @@ export function parseHealAbilities(text: string | null | undefined): ParsedHealA
                     };
                 }
             }
+            // Phase 3 PR-H: own-cleanse reactive annotation (Cultivator/Morao). Gated the same as
+            // damageReaction (no leech, no damage-reaction) — no corpus row combines an own-cleanse
+            // repair with either. Position-relative (not sentence-only) — see
+            // ParsedHealAbility.ownCleanseReaction's doc comment for why Morao needs this instead
+            // of a plain position-scoped detector: only the match whose OWN position (m.index)
+            // falls AFTER the cleanse-trigger phrase's own position is the reactive one.
+            let ownCleanseReaction: true | undefined;
+            if (!leechBasis && !damageReaction) {
+                const cleanseTriggerMatch = OWN_CLEANSE_TRIGGER_RE.exec(sentence);
+                if (
+                    cleanseTriggerMatch &&
+                    m.index - sentenceStart > cleanseTriggerMatch.index
+                ) {
+                    ownCleanseReaction = true;
+                }
+            }
             const rawBasis = leechBasis ?? resolveHealBasis(basisScope);
             // Damage-taken procs always shield/heal the damaged unit ITSELF — "them" in
             // "Damage dealt to them" refers back to this Unit, so the \bthem\b ally rule
@@ -3152,6 +3199,7 @@ export function parseHealAbilities(text: string | null | undefined): ParsedHealA
                 ...(leechScope ? { leechScope } : {}),
                 ...(requiresHpDamage ? { requiresHpDamage } : {}),
                 ...(damageReaction ? { damageReaction } : {}),
+                ...(ownCleanseReaction ? { ownCleanseReaction } : {}),
                 ...(countScaling
                     ? {
                           scaling: {
@@ -3201,6 +3249,7 @@ export function parseHealAbilities(text: string | null | undefined): ParsedHealA
                             // continuation with the instead-on-crit split, so the inherited
                             // critFilter is always absent today).
                             ...(damageReaction ? { damageReaction } : {}),
+                            ...(ownCleanseReaction ? { ownCleanseReaction } : {}),
                         });
                     }
                 }


### PR DESCRIPTION
## Phase 3 reactive-trigger promotion — PR-H (L2, NEW trigger)

Stacked on #226 (PR-G). Red CI is accepted for the duration of Phase 3 (no deploy until the phase completes) — after this PR the only failing tests are the two remaining out-of-scope probes (Nuqtu — fixed by PR-I; Vindicator — deferred).

### What
A brand-new reactive trigger **`on-own-cleanse`** — effects that fire "when this unit cleanses a debuff":
- **Cultivator** — repairs the specific ally that was cleansed (4% of Cultivator's Max HP).
- **Morao** — repairs itself an extra 5% + grants itself Defense Up II, on its own cleanse.
- **Hayyan** — repairs the cleansed ally 4% (sibling clause PR-E explicitly deferred to "PR-H"; the trigger-phrase regex matches exactly these three ships with no ship-specific carve-out).

### How
- `types/abilities.ts` — new `'on-own-cleanse'` in `AbilityTrigger` + `LIVE_TRIGGERS`.
- `events.ts` / `playerTurn.ts` — `cleanse-performed` gains `targets?: string[]` (recipients that actually had a debuff removed, `> 0` gated, mirroring `heal-performed.targets`).
- `triggers.ts` — new `on-own-cleanse` listener (`cleanse-performed`, `casterId === ownerId`) stamps `eventCtx.cleansedAllyIds`; `reactiveRecipients` fans an `'ally'`-target reactive out over the cleansed allies (falls back to the existing `damagedAllyId` chain when absent — non-breaking for every other consumer).
- `skillTextParser.ts` — `OWN_CLEANSE_TRIGGER_RE`; a parser-level `ownCleanseReaction` annotation using each match's own `m.index` (a plain position detector would mis-promote Morao's "repairs 5% every turn" heal, which shares a tag anchor with the reactive 5% repair — the annotation disambiguates by match position relative to the trigger phrase).

### Verification
- Cultivator + Morao triage probes green (+ a Hayyan regression-lock probe); new `ownCleanseReactivePromotion.integration.test.ts` (12 tests: self/ally routing, fan-out, negative controls, enemy-side team symmetry). Non-vacuity confirmed.
- Full suite 4062/4064 (the 2 failures = out-of-scope Nuqtu + Vindicator). tsc/lint clean; `audit:skills` 0 findings, no allowlist rows. One `skillTextParser.test.ts` golden hand-updated to the intended `ownCleanseReaction: true` field — the only golden that moved; all DPS/healing parity snapshots byte-identical.
- Adversarial review: APPROVE, no findings (all gates + regex scope + non-vacuity + parser logic independently re-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dp1hGz5xU95ZwDtmWSnvT