### PR TITLE
fix(skills): Phase 3 PR-I — NEW on-enemy-buffed reactive trigger (Nuqtu); final cluster

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -39,6 +39,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Ruiner now inflicts Bomb II on any enemy that performs a repair (once per round per enemy), matching her skill text, instead of never firing. Amartya now inflicts a stack of Defense Shred on the specific enemy defender that was just repaired, instead of never firing.",
     "Combat sim: Howler now cleanses a debuff from (and, with her refit, grants a stack of Blast to) the specific ally who just landed a critical hit, matching her skill text, instead of never firing.",
     "Combat sim: Cultivator now repairs the specific ally whose debuff she just cleansed for 4% of her Max HP, and Hayyan does the same for 4%, matching their skill text instead of never firing. Morao now repairs an extra 5% of her Max HP and gains Defense Up II whenever her own cleanse actually removes a debuff, instead of always firing regardless.",
+    'Combat sim: Nuqtu now cleanses a debuff from herself (once per round) and gains Terran Bolster III whenever an enemy actually gets buffed, matching her skill text, instead of always firing on her own turn regardless of enemy buffs.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -92,6 +92,13 @@ export type AbilityTrigger =
     // repair; Arum/Yarrow/Larkspur/Grif reactions on enemy cleanse. Phase 4c PR 4.
     | 'on-enemy-repaired'
     | 'on-enemy-cleansed'
+    // Phase 3 PR-I: fires when an OPPOSING-side actor receives a timed buff (rides the
+    // existing `buff-applied` event, opposing-scoped on actorId — the buff RECIPIENT).
+    // Nuqtu's self-cleanse + Terran Bolster III grant ("when an enemy gets buffed"),
+    // promoted from a manual, non-derivable `enemy-buff` CONDITION (single-ship DPS has
+    // no enemy casting buffs, so it never fires there) to a live reactive trigger for the
+    // team simulator. Both effects are self-target — no capture needed.
+    | 'on-enemy-buffed'
     // Purge ecosystem C2b: Sefuba self-purge / Salvation ally-purged
     | 'on-enemy-purged'
     | 'on-ally-purged'
@@ -176,6 +183,8 @@ export const LIVE_TRIGGERS = new Set<AbilityTrigger>([
     'on-hp-threshold-crossed',
     'on-enemy-repaired',
     'on-enemy-cleansed',
+    // Phase 3 PR-I: opposing-scoped reaction to an enemy actor receiving a timed buff.
+    'on-enemy-buffed',
     // Purge ecosystem C2b: Sefuba self-purge / Salvation ally-purged
     'on-enemy-purged',
     'on-ally-purged',

--- a/src/utils/abilities/__tests__/reactiveTriggerPromotionTriage.test.ts
+++ b/src/utils/abilities/__tests__/reactiveTriggerPromotionTriage.test.ts
@@ -195,11 +195,14 @@ describe('cluster 4 — on-enemy-buffed (Nuqtu)', () => {
         const ab = abilitiesFor({ firstPassiveSkillText: NUQTU_P2 }, 'passive');
         const cleanse = ab.find((a) => a.type === 'cleanse');
         expect(cleanse?.trigger).not.toBe('on-cast');
-        // GAP: needs-capture (NEW event) — the sweep filed Nuqtu under on-enemy-cleansed, but the
-        // real clause is "when an enemy gets buffed". No on-enemy-buffed trigger exists in the
-        // AbilityTrigger union, and there is no buff-applied CombatEvent (only debuff-applied). Fix
-        // needs a new event + trigger. Both the cleanse and the Terran-Bolster buff (self-target,
-        // once-per-round) hang off it.
+        // FIXED (Phase 3 PR-I): the sweep's original GAP comment claimed no buff-applied
+        // CombatEvent existed — that was factually wrong; buff-applied already existed and
+        // already fired for enemy-side actors (events.ts, playerTurn.ts, engine.ts, triggers.ts).
+        // Only a NEW `on-enemy-buffed` trigger + listener (triggers.ts, subscribing to
+        // buff-applied, isOpposing-gated) was needed, plus promoting the "enemy gets/is buffed"
+        // clause (skillTextParser.ts, previously a manual `enemy-buff` CONDITION) to a live
+        // trigger. Both the cleanse (once-per-round, self-scoped Ability.oncePerRound) and the
+        // Terran Bolster III buff grant now ride on-enemy-buffed.
     });
 });
 

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -70,6 +70,8 @@ import {
     PURGE_MORE_RE,
     parseControlInflicts,
     detectAllyCritTrigger,
+    detectEnemyBuffedTrigger,
+    detectCleanseOncePerRound,
     parseNoCrit,
     parseDoesntBreakStasis,
     parseChargeLossImmune,
@@ -1621,14 +1623,19 @@ function abilitiesFromText(
         // cleanse is on-cast) and position-scoped, so only a passive cleanse whose own sentence
         // carries the reaction phrase flips (corpus: Purifier alone — Makoli/Nosorog/Nyxen's
         // cleanses sit in active/charged slots or a different sentence; Cultivator's is on-own-cleanse).
+        // Nuqtu (Phase 3 PR-I): "Cleanses 1 debuff from itself (once per round) ... when an enemy
+        // gets buffed" rides on-enemy-buffed (position-scoped; opposing-scoped trigger).
         const reactiveTrigger =
             detectCritRepairTrigger(text, cleansePos) ??
             detectAllyCritTrigger(text, cleansePos) ??
+            detectEnemyBuffedTrigger(text, cleansePos) ??
             (slot === 'passive' &&
             detectDamageReactionTrigger(text, cleansePos)?.trigger === 'on-attacked'
                 ? ('on-attacked' as const)
                 : undefined);
         const cleanseTarget = flipBareSupportTarget(c.target, c.explicitTarget, slot, mult > 0);
+        // Nuqtu's "(once per round)" cap — the plain self-scoped Ability.oncePerRound flag.
+        const cleanseOncePerRound = detectCleanseOncePerRound(text, cleansePos);
         out.push({
             ability: {
                 id: nextId(),
@@ -1641,6 +1648,7 @@ function abilitiesFromText(
                     count: c.count,
                     ...(c.debuffType ? { debuffType: c.debuffType } : {}),
                 },
+                ...(cleanseOncePerRound ? { oncePerRound: true } : {}),
                 autoFilled: true,
             },
             pos: cleansePos >= 0 ? cleansePos : MAX_POS,
@@ -2324,7 +2332,18 @@ export function buildShipAbilities(ship: Ship): ShipSkills {
         }
         if (reactiveTrigger) {
             ability.trigger = reactiveTrigger;
-            ability.conditions = ability.conditions.filter((c) => c.subject !== 'self-crit');
+            ability.conditions = ability.conditions.filter(
+                (c) =>
+                    c.subject !== 'self-crit' &&
+                    // Phase 3 PR-I (COLLISION-SCOPE / "PR-E Provider lesson"): drop the now-
+                    // redundant manual enemy-buff condition once the clause is promoted to the
+                    // on-enemy-buffed trigger — the trigger IS the gate. Without this, Nuqtu's
+                    // Terran Bolster III would carry BOTH the reactive trigger AND the stale
+                    // manual condition (harmless today since a manual condition with no
+                    // manualCount defaults to "met", but leaving it is misleading and the
+                    // brief calls it out explicitly).
+                    !(reactiveTrigger === 'on-enemy-buffed' && c.subject === 'enemy-buff')
+            );
             // Oleander's "once per ally per round" RoT grant: a DEDICATED cap (not the plain
             // oncePerRound flag) so a different ally inflicting a debuff still procs even if
             // another ally already consumed the cap this round.

--- a/src/utils/combat/__tests__/enemyBuffedReactivePromotion.integration.test.ts
+++ b/src/utils/combat/__tests__/enemyBuffedReactivePromotion.integration.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Phase 3 PR-I — combat-integration tests for the NEW `on-enemy-buffed` reactive trigger:
+ *   - Nuqtu (1st passive): "This Unit Cleanses 1 debuff from itself (once per round) and gains
+ *     Terran Bolster III for 1 turn when an enemy gets buffed" (docs/ship-skills.csv, verbatim).
+ *     Both effects are SELF-target — no actor capture needed. The cleanse is capped at once per
+ *     round (Ability.oncePerRound); the Terran Bolster III grant carries no cap.
+ *
+ *   The clause was previously modeled as an ON-CAST ability gated by a manual, non-derivable
+ *   `enemy-buff` CONDITION (the single-ship DPS sim has no enemy casting buffs, so it never fired
+ *   there — the user could only toggle it manually). It is now a LIVE reactive trigger for the
+ *   team simulator: `buff-applied` (which already existed and already fired for enemy-side
+ *   actors — see events.ts / playerTurn.ts / engine.ts / triggers.ts) drives a NEW
+ *   `on-enemy-buffed` listener (isOpposing-gated), and the "when an enemy gets buffed" clause is
+ *   promoted from the manual condition to the trigger (skillTextParser.ts).
+ *
+ * Nuqtu's ability is extracted through the REAL production path (`buildShipAbilities`) fed skill
+ * text copied verbatim from `docs/ship-skills.csv` (parser source of truth) — never a hand-built
+ * ability array. The surrounding cast (an enemy that self-buffs to generate the triggering event,
+ * an enemy that debuffs Nuqtu so its cleanse has something real to remove) are minimal hand-built
+ * actors, following `onEnemyRepairedReactivePromotion.integration.test.ts`'s harness style.
+ *
+ * Non-vacuity: reverting the PR-I src changes (skillTextParser.ts / buildShipAbilities.ts /
+ * triggers.ts / types/abilities.ts) turns every "fires"/"routes" assertion in this file red
+ * (verified manually — see the PR-I report for the exact revert/restore transcript).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { Ability, ShipSkills } from '../../../types/abilities';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
+
+function ship(over: Partial<Ship>): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}, {}, {}], ...over } as Ship;
+}
+
+// A no-op active (0-multiplier hit) so a focus/team actor with no offensive purpose still takes
+// a valid turn each round without ending combat early or erroring.
+const noopActiveSlot = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: 'noop-atk',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0 },
+        },
+    ],
+});
+
+/** Collect every `buff-applied` event from a run. `actorId` is the buff RECIPIENT (events.ts). */
+function runAndCollectBuffs(input: CombatEngineInput) {
+    const bus = createEventBus();
+    const buffsApplied: Extract<CombatEvent, { type: 'buff-applied' }>[] = [];
+    bus.on('buff-applied', (e) => buffsApplied.push(e));
+    const result = runCombat({ ...input, bus });
+    return { buffsApplied, result };
+}
+
+function cleanseCountFor(result: ReturnType<typeof runCombat>, actorId: string): number {
+    return (result.healing?.rounds ?? []).reduce(
+        (sum, rd) => sum + (rd.perActor.get(actorId)?.cleanseCount ?? 0),
+        0
+    );
+}
+
+// A self-buff-on-cast ability — the minimal "this actor gets buffed" trigger for
+// on-enemy-buffed. Any actor (enemy or player/ally) carrying this on its active slot emits
+// `buff-applied` keyed on ITS OWN id when it acts (playerTurn.ts's per-recipient emission
+// covers both sides identically).
+const selfBuffOnCast = (id: string, buffName: string): Ability => ({
+    id,
+    type: 'buff',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: {
+        type: 'buff',
+        buffName,
+        parsedEffects: {},
+        stacks: 1,
+        isStackable: false,
+        duration: 1,
+    },
+});
+
+// A single-hit debuff-on-cast ability (target 'enemy' from the CASTER's perspective) — used to
+// seed a real, removable debuff on Nuqtu before its cleanse reactive fires. Mirrors
+// ownCleanseReactivePromotion.integration.test.ts's debuffEnemy fixture.
+const debuffOnCast = (id: string, buffName: string): Ability => ({
+    id,
+    type: 'debuff',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: {
+        type: 'debuff',
+        buffName,
+        parsedEffects: { attack: -30 },
+        stacks: 1,
+        isStackable: false,
+        application: 'apply',
+        duration: 5,
+    },
+});
+
+// =============================================================================
+// Nuqtu — "This Unit Cleanses 1 debuff from itself (once per round) and gains Terran Bolster III
+// for 1 turn when an enemy gets buffed" (docs/ship-skills.csv, verbatim — base passive).
+// =============================================================================
+
+const NUQTU_P1 =
+    'This Unit <unit-aid>Cleanses 1</unit-aid> debuff from itself (once per round) and gains <unit-skill>Terran Bolster III</unit-skill> for 1 turn when an enemy gets buffed.';
+
+/** Extracts Nuqtu's REAL production passive slot (the self-cleanse + Terran Bolster III grant). */
+function nuqtuPassiveAbilities(): Ability[] {
+    return (
+        buildShipAbilities(ship({ firstPassiveSkillText: NUQTU_P1 })).slots.find(
+            (s) => s.slot === 'passive'
+        )?.abilities ?? []
+    );
+}
+
+function nuqtuCleanse(): Ability {
+    const cleanse = nuqtuPassiveAbilities().find((a) => a.type === 'cleanse');
+    if (!cleanse) throw new Error('mutation guard: Nuqtu self-cleanse not found');
+    return cleanse;
+}
+
+function nuqtuBolsterGrant(): Ability {
+    const grant = nuqtuPassiveAbilities().find(
+        (a) => a.type === 'buff' && a.config.type === 'buff' && a.config.buffName === 'Terran Bolster III'
+    );
+    if (!grant) throw new Error('mutation guard: Nuqtu Terran Bolster III grant not found');
+    return grant;
+}
+
+// Sanity-check the extracted abilities BEFORE using them as engine input — a mutation guard so a
+// regression in the parser/builder wiring fails loudly here rather than silently no-op'ing the
+// engine tests below.
+describe('Nuqtu self-cleanse + Terran Bolster III — extracted ability shape (mutation guard)', () => {
+    it('both ride on-enemy-buffed, self-target; only the cleanse carries the once-per-round cap', () => {
+        const cleanse = nuqtuCleanse();
+        const grant = nuqtuBolsterGrant();
+        expect(cleanse.trigger).toBe('on-enemy-buffed');
+        expect(cleanse.target).toBe('self');
+        expect(cleanse.oncePerRound).toBe(true);
+        expect(grant.trigger).toBe('on-enemy-buffed');
+        expect(grant.target).toBe('self');
+        expect(grant.oncePerRound).toBeUndefined();
+        // COLLISION-SCOPE: the promoted grant must NOT also carry the now-redundant manual
+        // enemy-buff condition (double-gating would silently suppress the reactive).
+        expect(grant.conditions.some((c) => c.subject === 'enemy-buff')).toBe(false);
+    });
+});
+
+describe('Nuqtu (player-side) — an opposing buff wakes the self-cleanse + Terran Bolster III grant', () => {
+    const nuqtuFocusSkills = (): ShipSkills => ({
+        slots: [noopActiveSlot(), { slot: 'passive', abilities: nuqtuPassiveAbilities() }],
+    });
+
+    // Faster than the buffing enemy: lands a real, removable debuff on Nuqtu BEFORE the
+    // self-buff reactive fires this same round.
+    const debuffEnemy = (id: string): EnemyAttacker =>
+        ({
+            id,
+            stats: { attack: 1, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1000 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: { slots: [{ slot: 'active', abilities: [debuffOnCast('deb', 'Attack Down')] }] },
+        }) as EnemyAttacker;
+
+    const buffEnemy = (id: string, speed: number, buffName = 'Damage Up I'): EnemyAttacker =>
+        ({
+            id,
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: { slots: [{ slot: 'active', abilities: [selfBuffOnCast('buf', buffName)] }] },
+        }) as EnemyAttacker;
+
+    const BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+        attack: 0,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: nuqtuFocusSkills(),
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 1, // Nuqtu acts last — irrelevant to the reactive, which fires off the ENEMIES' turns
+        healTargetId: 'attacker',
+        ...overrides,
+    });
+
+    it('an enemy self-buffing removes Nuqtu\'s pre-existing debuff and grants it Terran Bolster III', () => {
+        const { buffsApplied, result } = runAndCollectBuffs(
+            BASE({ enemyAttackers: [debuffEnemy('enemy-deb'), buffEnemy('enemy-buf', 900)] })
+        );
+        expect(cleanseCountFor(result, 'attacker')).toBe(1);
+        const bolster = buffsApplied.filter(
+            (b) => b.buffName === 'Terran Bolster III' && b.actorId === 'attacker'
+        );
+        expect(bolster).toHaveLength(1);
+    });
+
+    it('once-per-round cap: TWO opposing self-buffs in one round cleanse only ONCE, but grant Terran Bolster III TWICE', () => {
+        const debuffEnemyB = (id: string): EnemyAttacker =>
+            ({
+                id,
+                stats: {
+                    attack: 1,
+                    crit: 0,
+                    critDamage: 0,
+                    defence: 0,
+                    hp: 1_000_000_000,
+                    speed: 950,
+                },
+                chargeCount: 0,
+                startCharged: false,
+                shipSkills: {
+                    slots: [{ slot: 'active', abilities: [debuffOnCast('deb-b', 'Defense Down')] }],
+                },
+            }) as EnemyAttacker;
+
+        const { buffsApplied, result } = runAndCollectBuffs(
+            BASE({
+                enemyAttackers: [
+                    debuffEnemy('enemy-deb-a'), // speed 1000: seeds 'Attack Down'
+                    debuffEnemyB('enemy-deb-b'), // speed 950: seeds 'Defense Down' (2nd removable debuff)
+                    buffEnemy('enemy-buf-1', 900), // 1st on-enemy-buffed firing
+                    buffEnemy('enemy-buf-2', 800), // 2nd on-enemy-buffed firing, same round
+                ],
+            })
+        );
+        // Two debuffs existed, but the once-per-round cap on the CLEANSE lets only the FIRST
+        // opposing buff consume it — the second firing is gated out before touching the store.
+        expect(cleanseCountFor(result, 'attacker')).toBe(1);
+        // The buff GRANT carries no cap — it fires on every qualifying opposing buff this round.
+        const bolster = buffsApplied.filter(
+            (b) => b.buffName === 'Terran Bolster III' && b.actorId === 'attacker'
+        );
+        expect(bolster).toHaveLength(2);
+    });
+
+    it('a same-side ALLY buffing itself does NOT wake the reactive (opposing-scoped)', () => {
+        const allyBuff = (): TeamActor =>
+            ({
+                id: 'ally-buffer',
+                speed: 950,
+                chargeCount: 0,
+                startCharged: false,
+                selfBuffs: [],
+                enemyDebuffs: [],
+                walk: {
+                    shipSkills: {
+                        slots: [{ slot: 'active', abilities: [selfBuffOnCast('ally-buf', 'Damage Up I')] }],
+                    },
+                    stats: {
+                        attack: 0,
+                        crit: 0,
+                        critDamage: 0,
+                        defensePenetration: 0,
+                        hacking: 0,
+                        defence: 0,
+                        hp: 20_000,
+                    },
+                    selfDotModifier: 0,
+                    defensePenetrationBuff: 0,
+                    affinityDamageModifier: 0,
+                    affinityCritCap: 100,
+                    affinityCritPenalty: 0,
+                    hasChargedSkill: false,
+                },
+            }) as TeamActor;
+
+        const { buffsApplied, result } = runAndCollectBuffs(
+            BASE({ teamActors: [allyBuff()], enemyAttackers: [debuffEnemy('enemy-deb')] })
+        );
+        expect(cleanseCountFor(result, 'attacker')).toBe(0);
+        expect(
+            buffsApplied.some((b) => b.buffName === 'Terran Bolster III' && b.actorId === 'attacker')
+        ).toBe(false);
+    });
+
+    it('NEGATIVE control: no opposing buff this round → neither the cleanse nor the grant fires', () => {
+        const passiveEnemy: EnemyAttacker = {
+            id: 'enemy-passive',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 500 },
+            chargeCount: 0,
+            startCharged: false,
+            shipSkills: { slots: [] } as ShipSkills,
+        } as EnemyAttacker;
+
+        const { buffsApplied, result } = runAndCollectBuffs(
+            BASE({ enemyAttackers: [debuffEnemy('enemy-deb'), passiveEnemy] })
+        );
+        // The debuff still lands (proving the store isn't empty for unrelated reasons), but with
+        // no opposing buff this round the cleanse never fires.
+        expect(cleanseCountFor(result, 'attacker')).toBe(0);
+        expect(
+            buffsApplied.some((b) => b.buffName === 'Terran Bolster III' && b.actorId === 'attacker')
+        ).toBe(false);
+    });
+});
+
+describe('Nuqtu (enemy-side) — team symmetry: an enemy Nuqtu reacts to a PLAYER self-buff', () => {
+    it('a player self-buffing wakes the enemy Nuqtu\'s self-cleanse + Terran Bolster III grant', () => {
+        const enemyDebuffsAttacker = (id: string): EnemyAttacker =>
+            ({
+                id,
+                stats: { attack: 1, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 5 },
+                chargeCount: 0,
+                startCharged: false,
+                shipSkills: { slots: [] } as ShipSkills,
+            }) as EnemyAttacker;
+
+        const enemyNuqtu: EnemyAttacker = {
+            id: 'enemy-nuqtu',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 10 },
+            chargeCount: 0,
+            startCharged: false,
+            // Give the enemy Nuqtu a standing debuff to cleanse by pre-seeding via a slower ally
+            // is unnecessary here — the player's OWN self-buff below is the ONLY event under
+            // test; the cleanse still fires (gated by the trigger, not by debuff presence — a
+            // cleanse with nothing to remove is a no-op remove, not a skipped reactive).
+            shipSkills: { slots: [{ slot: 'passive', abilities: nuqtuPassiveAbilities() }] },
+        };
+
+        const input: CombatEngineInput = {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            // The player (attacker) self-buffs on cast — the triggering event for the enemy Nuqtu.
+            shipSkills: { slots: [{ slot: 'active', abilities: [selfBuffOnCast('atk-buf', 'Damage Up I')] }] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 200, // player acts first — its self-buff wakes the enemy Nuqtu the same round
+            healTargetId: 'attacker',
+            enemyAttackers: [enemyDebuffsAttacker('enemy-filler'), enemyNuqtu],
+        };
+
+        const { buffsApplied } = runAndCollectBuffs(input);
+        const bolster = buffsApplied.filter(
+            (b) => b.buffName === 'Terran Bolster III' && b.actorId === 'enemy-nuqtu'
+        );
+        expect(bolster).toHaveLength(1);
+    });
+});

--- a/src/utils/combat/__tests__/enemyBuffedReactivePromotion.integration.test.ts
+++ b/src/utils/combat/__tests__/enemyBuffedReactivePromotion.integration.test.ts
@@ -160,6 +160,60 @@ describe('Nuqtu self-cleanse + Terran Bolster III — extracted ability shape (m
     });
 });
 
+// =============================================================================
+// Nuqtu — REFIT (2nd) passive: "This Unit Cleanses 1 debuff from itself (once per round) and
+// gains Terran Bolster III for 1 turn, and gains 1 stack of Core Charge I when an enemy gets
+// buffed" (docs/ship-skills.csv, verbatim — refit-active passive). Per this project's convention
+// only the refit-active passive applies in-game — getShipSkillRows resolves refitCount >= 2 to
+// `secondPassiveSkillText` (src/utils/ship/skillRows.ts) — so THIS is the passive a real,
+// refitted Nuqtu actually runs. It adds a THIRD clause over the base passive above: a Core
+// Charge I stack grant, sharing the same "when an enemy gets buffed" trigger clause.
+// =============================================================================
+
+const NUQTU_P2_REFIT =
+    'This Unit <unit-aid>Cleanses 1</unit-aid> debuff from itself (once per round) and gains <unit-skill>Terran Bolster III</unit-skill> for 1 turn, and gains 1 stack of <unit-skill>Core Charge I</unit-skill> when an enemy gets buffed.';
+
+/**
+ * Extracts Nuqtu's REAL production REFIT passive slot. `ship()` defaults to 4 refits, so with
+ * only `secondPassiveSkillText` set (no thirdPassiveSkillText), getShipSkillRows's refitCount >= 2
+ * branch resolves this text as the active passive row — exactly what a refitted Nuqtu runs.
+ */
+function nuqtuRefitPassiveAbilities(): Ability[] {
+    return (
+        buildShipAbilities(ship({ secondPassiveSkillText: NUQTU_P2_REFIT })).slots.find(
+            (s) => s.slot === 'passive'
+        )?.abilities ?? []
+    );
+}
+
+describe('Nuqtu REFIT passive — self-cleanse + Terran Bolster III + Core Charge I stack — extracted ability shape (mutation guard)', () => {
+    it('all THREE effects ride on-enemy-buffed, self-target; only the cleanse carries the once-per-round cap', () => {
+        const abilities = nuqtuRefitPassiveAbilities();
+        const cleanse = abilities.find((a) => a.type === 'cleanse');
+        const bolster = abilities.find(
+            (a) =>
+                a.type === 'buff' && a.config.type === 'buff' && a.config.buffName === 'Terran Bolster III'
+        );
+        const coreCharge = abilities.find(
+            (a) => a.type === 'buff' && a.config.type === 'buff' && a.config.buffName === 'Core Charge I'
+        );
+        if (!cleanse) throw new Error('mutation guard: Nuqtu refit self-cleanse not found');
+        if (!bolster) throw new Error('mutation guard: Nuqtu refit Terran Bolster III grant not found');
+        if (!coreCharge) throw new Error('mutation guard: Nuqtu refit Core Charge I stack grant not found');
+
+        for (const ability of [cleanse, bolster, coreCharge]) {
+            expect(ability.trigger).toBe('on-enemy-buffed');
+            expect(ability.target).toBe('self');
+            // COLLISION-SCOPE: none of the three promoted effects may carry the now-redundant
+            // manual enemy-buff condition (double-gating would silently suppress the reactive).
+            expect(ability.conditions.some((c) => c.subject === 'enemy-buff')).toBe(false);
+        }
+        expect(cleanse.oncePerRound).toBe(true);
+        expect(bolster.oncePerRound).toBeUndefined();
+        expect(coreCharge.oncePerRound).toBeUndefined();
+    });
+});
+
 describe('Nuqtu (player-side) — an opposing buff wakes the self-cleanse + Terran Bolster III grant', () => {
     const nuqtuFocusSkills = (): ShipSkills => ({
         slots: [noopActiveSlot(), { slot: 'passive', abilities: nuqtuPassiveAbilities() }],

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -275,6 +275,10 @@ export function partitionReactiveAbilities(shipSkills: ShipSkills): {
  *    of on-enemy-cleansed. Stamps eventCtx.cleansedAllyIds = e.targets (the actually-cleansed
  *    recipients) so an 'ally'-target reaction fans out to exactly those ids (reactiveRecipients);
  *    a 'self'-target reaction ignores it. One enqueue per qualifying (>= 1 real removal) cast.
+ *  - on-enemy-buffed → buff-applied where isOpposing(actorId) (Phase 3 PR-I: Nuqtu's
+ *    self-cleanse + Terran Bolster III grant, "when an enemy gets buffed"). actorId is the
+ *    buff RECIPIENT (events.ts), so this fires once per opposing-side buff application. Both
+ *    effects are self-target — no eventCtx capture needed.
  *  - on-hp-threshold-crossed → hp-changed where targetId === ownerId and the event is a
  *    DOWNWARD crossing of N (oldPct >= N > newPct), N read from the ability's self
  *    hp-threshold condition (trigger CONFIG — executeIntent scrubs it from the drain-time
@@ -706,6 +710,16 @@ export function registerReactiveListeners(args: {
                         // call: enemy side. For the enemy call: player side.
                         // One enqueue per cast.
                         if (isOpposing(e.casterId)) enqueue(intent);
+                    });
+                    break;
+                case 'on-enemy-buffed':
+                    bus.on('buff-applied', (e) => {
+                        // Opposing-scoped: any opposing-side actor RECEIVING a timed buff
+                        // (e.actorId is the recipient — events.ts). For the player call: an
+                        // enemy attacker gaining a self-buff. For the enemy call: a player actor
+                        // gaining one. Nuqtu's self-cleanse + Terran Bolster III are both
+                        // self-target — no eventCtx capture needed. One enqueue per application.
+                        if (isOpposing(e.actorId)) enqueue(intent);
                     });
                     break;
                 case 'on-own-cleanse':
@@ -2173,6 +2187,11 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
         // gate tick the healing-on pass does not, desynchronizing the proc stream across sims.
         if (!ctx.healing) return; // healing mode off → not-simulated follow-up
         if (!passesProcChanceGate(intent, ctx)) return;
+        // Phase 3 PR-I: "(once per round)" cap (Nuqtu's self-cleanse). Mirrors the heal/shield
+        // branch's ordering (procChance, THEN oncePerRound) — this branch previously had NO
+        // oncePerRound consult at all (no shipped cleanse set the flag pre-PR-I), so this is
+        // additive: every other cleanse ability leaves `oncePerRound` unset and passes through.
+        if (!passesOncePerRoundGate(intent, ctx)) return;
         // ctx.playerIds is the SAME-SIDE ally id order (sideCtx.recipientIds) — side-correct for
         // both player and enemy reactive drains. ctx.statusEngine is the live store. Mirrors the
         // reactive heal branch's recipient resolution: an 'ally'-target cleanse prefers the

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1051,6 +1051,17 @@ const ENEMY_CLEANSE_RE = /\bwhen\s+an?\s+enemy\b[^.]*?\bcleanses?\b[^.]*?\bdebuf
 // Morao match; every enemy-subject/numeral-cleanse row above does not.
 const OWN_CLEANSE_TRIGGER_RE =
     /\b(?:when\s+this\s+unit\s+cleanses\s+a\s+debuff|(?:when|upon)\s+cleansing\s+a\s+debuff)\b/i;
+// Phase 3 PR-I: "when an enemy gets/is/becomes buffed" — Nuqtu's self-cleanse + Terran Bolster
+// III grant. Promoted from a manual, non-derivable `enemy-buff` CONDITION (detectGrantConditions
+// rule 4b below, which the single-ship DPS sim still consumes as a manual toggle — no enemy casts
+// buffs there) to a LIVE reactive trigger for the team simulator. Requires a leading "when" (mirrors
+// ENEMY_DEBUFFED_RE's sibling regex below) to disambiguate from an unrelated later "enemy buffed"
+// mention in a longer sentence. Corpus-verified (docs/ship-skills.csv, grep this exact phrase
+// family): ONLY Nuqtu's two passives (base + refit) match — no collateral on any other ship's
+// "for each buff on the enemy" per-count scaling (Nuqtu's own active/charged text) or any other
+// enemy-buff condition consumer (Amartya/Panon Taunt-style gates use a different phrasing).
+const ENEMY_BUFFED_RE =
+    /\bwhen\b[^.]*?\benem(?:y|ies)\b[^.]*?\b(?:gets?|is|are|becomes?)\s+buffed\b/i;
 // Overload lifecycle (Task 4) — kill/apply-debuff reactive phrasings for buff grants/removals.
 // Kept SEPARATE from the shared ENEMY_DEATH_PHRASING_RE used by parseExtraAction (do NOT broaden
 // that one). "on kill" (Mangler/Butcher), "upon killing an enemy/opponent" (Mangler/Ravager/
@@ -1126,6 +1137,10 @@ export function detectReactiveTrigger(
     // ambiguity — a buff name is unique per grant, unlike the heal-side same-pct collision (see
     // ParsedHealAbility.ownCleanseReaction in parseHealAbilities for that case).
     if (OWN_CLEANSE_TRIGGER_RE.test(clause)) return 'on-own-cleanse';
+    // Phase 3 PR-I: "when an enemy gets buffed" → on-enemy-buffed (Nuqtu's Terran Bolster III
+    // grant). See ENEMY_BUFFED_RE's doc comment for the corpus-verification that only Nuqtu's
+    // clauses match.
+    if (ENEMY_BUFFED_RE.test(clause)) return 'on-enemy-buffed';
     // Overload lifecycle (Task 4). REPAIR is checked BEFORE KILL: Ruiner's Overload grant and its
     // kill-removal share one comma-joined sentence ("gains Overload when an enemy performs a repair,
     // upon killing an enemy, this Unit removes Overload") — the grant must resolve to
@@ -1442,6 +1457,40 @@ export function detectAllyCritTrigger(
     anchorPos: number
 ): AbilityTrigger | undefined {
     return phrasePosTrigger(text, ALLY_CRIT_HIT_RE, anchorPos, 'on-ally-crit');
+}
+
+/**
+ * Returns 'on-enemy-buffed' when `anchorPos` falls inside the sentence carrying the "when an
+ * enemy gets buffed" phrase; otherwise undefined. Position-scoped on the RAW text (mirrors
+ * detectCritRepairTrigger) — used by the CLEANSE builder, which has no buff name to resolve a
+ * clause on (unlike the buff-grant path, which reuses ENEMY_BUFFED_RE directly inside
+ * detectReactiveTrigger). Reference data: docs/ship-skills.csv (Nuqtu only).
+ */
+export function detectEnemyBuffedTrigger(
+    text: string | null | undefined,
+    anchorPos: number
+): AbilityTrigger | undefined {
+    return phrasePosTrigger(text, ENEMY_BUFFED_RE, anchorPos, 'on-enemy-buffed');
+}
+
+// Nuqtu's self-cleanse "(once per round)" cap — the plain self-scoped Ability.oncePerRound flag
+// (no per-ally/per-enemy dimension; this is a self-target effect). Position-scoped to the
+// cleanse's OWN sentence so an unrelated "once per round" phrase elsewhere in the same passive
+// row could never leak onto this cleanse. Reference data: docs/ship-skills.csv — grep-verified
+// the parenthesized "(once per round)" phrasing appears ONLY on Nuqtu's two passives.
+const CLEANSE_ONCE_PER_ROUND_RE = /\(once per round\)/i;
+
+/**
+ * Returns true when `anchorPos` falls inside the sentence carrying the "(once per round)"
+ * phrase; otherwise false. Position-scoped on the RAW text (mirrors detectEnemyBuffedTrigger).
+ */
+export function detectCleanseOncePerRound(
+    text: string | null | undefined,
+    anchorPos: number
+): boolean {
+    if (!text) return false;
+    const sentence = rawSentenceAround(text, anchorPos);
+    return sentence !== undefined && CLEANSE_ONCE_PER_ROUND_RE.test(sentence);
 }
 
 // "when an enemy gets/is/becomes debuffed" — a reactive own-infliction trigger (APEX's


### PR DESCRIPTION
## Phase 3 reactive-trigger promotion — PR-I (L2, NEW trigger) — FINAL cluster

Stacked on #227 (PR-H). This is the last fix-PR of the Phase-3 reactive-trigger-promotion epic. After it, the **only** remaining red triage probe is Vindicator (spec-locked `no-capturable-actor` deferral — needs a maxHP-scaled-damage model that doesn't exist yet). Red CI remains accepted until the whole stack lands (no deploy until then).

### What
A new reactive trigger **`on-enemy-buffed`** for **Nuqtu**: "when an enemy gets buffed", Nuqtu cleanses 1 debuff from herself (once per round) + gains Terran Bolster III [+ a Core Charge I stack on her refit-active passive]. All effects are self-target.

Previously this was modeled as an on-cast ability gated by a manual `enemy-buff` condition — and manual non-derivable conditions default to "met", so it actually fired on **every one of Nuqtu's own turns regardless of any enemy buff**. Now it fires only when an enemy is genuinely buffed.

### How (no new event needed — `buff-applied` already exists and already fires enemy-side)
- `types/abilities.ts` — new `'on-enemy-buffed'` in `AbilityTrigger` + `LIVE_TRIGGERS`.
- `triggers.ts` — new `on-enemy-buffed` listener (`buff-applied`, `isOpposing(e.actorId)`-gated, self-target); and the cleanse `'remove'` executor branch gains its first-ever `oncePerRound` consult (inert for every existing cleanse — grep confirms no shipped cleanse sets the flag).
- `skillTextParser.ts` — `ENEMY_BUFFED_RE` (promotes the "when an enemy gets buffed" phrasing from a manual condition to the trigger; grep-verified to match only Nuqtu), a position-scoped `detectEnemyBuffedTrigger` for the cleanse builder, and `detectCleanseOncePerRound` for the "(once per round)" cap ("(once per round)" occurs only on Nuqtu across all 147 ships).
- `buildShipAbilities.ts` — wires both, and drops the leftover `enemy-buff` condition on the promoted grant to avoid double-gating (the PR-E Provider lesson; no target-gate needed here since Nuqtu's grant is self-target).

### Verification
- Nuqtu triage probe green; new `enemyBuffedReactivePromotion.integration.test.ts` (7 tests: base + refit-passive shape guards, positive/negative controls, once-per-round cap, same-side-ally exclusion, enemy-side team symmetry). Non-vacuity confirmed (probe + 4 discriminating tests flip red on src revert).
- Full suite 4069/4070 (sole failure = deferred Vindicator). tsc/lint clean; `audit:skills` 0 findings, no allowlist rows. DPS 23/23 + healing 53/53 parity byte-identical; zero snapshot churn.
- Adversarial review: APPROVE-WITH-NITS (both LOW; the substantive one — untested refit passive — fixed by the added refit-passive test). All gates, regex scope, and non-vaciuity independently re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Dp1hGz5xU95ZwDtmWSnvT