### PR TITLE
feat(combat): Vindicator on-resist HP-scaled retaliation

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -40,6 +40,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Howler now cleanses a debuff from (and, with her refit, grants a stack of Blast to) the specific ally who just landed a critical hit, matching her skill text, instead of never firing.",
     "Combat sim: Cultivator now repairs the specific ally whose debuff she just cleansed for 4% of her Max HP, and Hayyan does the same for 4%, matching their skill text instead of never firing. Morao now repairs an extra 5% of her Max HP and gains Defense Up II whenever her own cleanse actually removes a debuff, instead of always firing regardless.",
     'Combat sim: Nuqtu now cleanses a debuff from herself (once per round) and gains Terran Bolster III whenever an enemy actually gets buffed, matching her skill text, instead of always firing on her own turn regardless of enemy buffs.',
+    'Combat sim: Vindicator now retaliates when it resists an enemy debuff, dealing damage equal to 30% of its max HP to that enemy.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3354,8 +3354,11 @@ const DocumentationPage: React.FC = () => {
                                     <strong>Panon</strong> reduces all incoming damage — direct and
                                     damage-over-time — while she has Barrier Recharging, and{' '}
                                     <strong>Tormenter&apos;s</strong> reduction (direct and
-                                    damage-over-time) grows the lower her HP falls. More implant and
-                                    gear-set effects will be added in future updates.
+                                    damage-over-time) grows the lower her HP falls.{' '}
+                                    <strong>Vindicator</strong> retaliates when it resists an enemy
+                                    debuff, dealing damage equal to 30% of its own max HP back to
+                                    the ship that attempted it. More implant and gear-set effects
+                                    will be added in future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -412,7 +412,17 @@ export type ModifierChannel =
     | 'incomingDamage';
 
 export type AbilityConfig =
-    | { type: 'damage'; multiplier: number; hits?: number; noCrit?: boolean }
+    | {
+          type: 'damage';
+          multiplier: number;
+          hits?: number;
+          noCrit?: boolean;
+          /** Vindicator on-resist: when set, the REACTIVE damage executor computes the
+           *  pre-mitigation raw from the owner's effective max HP × hpBasisPct (percent) instead
+           *  of attack × multiplier. Reactive-damage path only (applyReactiveDamage); the on-cast
+           *  damage path ignores it. */
+          hpBasisPct?: number;
+      }
     | {
           type: 'counter';
           /** raw percentage of the OWNER's effective attack, e.g. 30/70/100/200. */

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -50,6 +50,7 @@ import {
     parseCounterAbilities,
     parseSelfBuffRemovals,
     parsePreCombatStatGrants,
+    parseOnResistHpDamage,
 } from '../skillTextParser';
 import type { Ship } from '../../types/ship';
 
@@ -4790,5 +4791,35 @@ describe('parseControlInflicts', () => {
 
     it('returns [] for non-control text', () => {
         expect(parseControlInflicts('Deals 300% damage')).toEqual([]);
+    });
+});
+
+describe('parseOnResistHpDamage (Vindicator p2 reactive)', () => {
+    const VINDICATOR_P2 =
+        "This Unit has 20% Shield Penetration. At the start of combat, this Unit gains <unit-skill>Magnetized Shielding</unit-skill>.<br /><br />When this Unit resists a debuff infliction from an enemy, it deals <unit-damage>damage equal to 30%</unit-damage> of this Unit's max HP to that enemy.";
+
+    it('parses the on-resist max-HP damage percentage', () => {
+        expect(parseOnResistHpDamage(VINDICATOR_P2)).toEqual({ pct: 30 });
+    });
+
+    it('returns null for an on-death max-HP proc (Paracelsus p1 — different trigger)', () => {
+        expect(
+            parseOnResistHpDamage(
+                'Upon being killed by direct Damage, this Unit deals <unit-damage>Damage equal to 50%</unit-damage> of its max HP.'
+            )
+        ).toBeNull();
+    });
+
+    it('returns null for an on-cast secondary-damage rider (Chakara active)', () => {
+        expect(
+            parseOnResistHpDamage(
+                'This Unit deals <unit-damage>180% damage</unit-damage> with additional damage equal to <unit-damage>80%</unit-damage> of its Defense.'
+            )
+        ).toBeNull();
+    });
+
+    it('returns null for empty input', () => {
+        expect(parseOnResistHpDamage('')).toBeNull();
+        expect(parseOnResistHpDamage(null)).toBeNull();
     });
 });

--- a/src/utils/abilities/__tests__/vindicatorOnResistDamage.build.test.ts
+++ b/src/utils/abilities/__tests__/vindicatorOnResistDamage.build.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Vindicator on-resist HP-damage — production-routed builder probe. Skill text VERBATIM from
+ * docs/ship-skills.csv (parser source of truth). Drives the REAL buildShipAbilities path.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Ability, Skill } from '../../../types/abilities';
+import { Ship } from '../../../types/ship';
+
+function ship(over: Partial<Ship>): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}, {}, {}], ...over } as Ship;
+}
+function slot(skills: Skill[], name: string): Skill | undefined {
+    return skills.find((s) => s.slot === name);
+}
+function abilitiesFor(over: Partial<Ship>, name: string): Ability[] {
+    return slot(buildShipAbilities(ship(over)).slots, name)?.abilities ?? [];
+}
+
+const VINDICATOR_P2 =
+    "This Unit has 20% Shield Penetration. At the start of combat, this Unit gains <unit-skill>Magnetized Shielding</unit-skill>.<br /><br />When this Unit resists a debuff infliction from an enemy, it deals <unit-damage>damage equal to 30%</unit-damage> of this Unit's max HP to that enemy.";
+
+describe('Vindicator on-resist HP damage — builder', () => {
+    it('emits a damage ability on on-debuff-resisted with hpBasisPct 30', () => {
+        const abilities = abilitiesFor({ firstPassiveSkillText: VINDICATOR_P2 }, 'passive');
+        const proc = abilities.find(
+            (a) => a.type === 'damage' && a.trigger === 'on-debuff-resisted'
+        );
+        expect(proc).toBeDefined();
+        expect(proc!.target).toBe('enemy');
+        expect(proc!.config).toMatchObject({ type: 'damage', hpBasisPct: 30 });
+    });
+});

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -25,6 +25,7 @@ import {
     parseCounterAbilities,
     parseDamageReflection,
     parseSecondaryDamage,
+    parseOnResistHpDamage,
     parseShieldStrip,
     parseConditionalDamage,
     parseEnemyEffectDamageBonus,
@@ -1130,6 +1131,35 @@ function abilitiesFromText(
             },
             pos: secondIdx >= 0 ? secondIdx : firstIdx >= 0 ? firstIdx : MAX_POS,
         });
+    }
+
+    // Vindicator p2: "When this Unit resists a debuff infliction from an enemy, it deals damage
+    // equal to X% of this Unit's max HP to that enemy." A standalone HP-scaled REACTIVE damage
+    // proc on the on-debuff-resisted trigger (passive slot only). multiplier:0 — the amount is
+    // carried by hpBasisPct, read by the reactive-damage executor. Routes to the resisted debuff's
+    // inflictor via eventCtx.counterTargetId (set by the on-debuff-resisted listener).
+    if (slot === 'passive') {
+        const onResist = parseOnResistHpDamage(text);
+        if (onResist) {
+            const onResistIdx = text.search(/<unit-damage>/i);
+            out.push({
+                ability: {
+                    id: nextId(),
+                    type: 'damage',
+                    target: 'enemy',
+                    trigger: 'on-debuff-resisted',
+                    conditions: [],
+                    config: {
+                        type: 'damage',
+                        multiplier: 0,
+                        hits: 1,
+                        hpBasisPct: onResist.pct,
+                    },
+                    autoFilled: true,
+                },
+                pos: onResistIdx >= 0 ? onResistIdx : MAX_POS,
+            });
+        }
     }
 
     // PR9(b): standalone "removes X% of the enemy Shield" (APEX/Laika/Malvex) — coordinate

--- a/src/utils/combat/__tests__/onResistSourceCapture.integration.test.ts
+++ b/src/utils/combat/__tests__/onResistSourceCapture.integration.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus } from '../events';
+import { ShipSkills } from '../../../types/abilities';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+// An enemy that casts a timed Def Down at the player carrier each round; hacking 0 → resisted.
+const debuffEnemy = (id: string): EnemyAttacker =>
+    ({
+        id,
+        stats: {
+            attack: 1,
+            crit: 0,
+            critDamage: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 10,
+            hacking: 0,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'enemy-debuff',
+                            type: 'debuff',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: {
+                                type: 'debuff',
+                                buffName: 'Def Down',
+                                parsedEffects: {},
+                                stacks: 1,
+                                isStackable: false,
+                                application: 'inflict',
+                                duration: 1,
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+    }) as EnemyAttacker;
+
+const noopActive: ShipSkills['slots'][number] = {
+    slot: 'active',
+    abilities: [
+        {
+            id: 'noop',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0 },
+        },
+    ],
+};
+
+const BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 1,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [noopActive] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 3,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    speed: 100,
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+describe('debuff-resisted carries the inflictor as sourceId', () => {
+    it('an enemy-inflicted resisted debuff on the player carrier stamps sourceId = the enemy', () => {
+        const bus = createEventBus();
+        const sources: (string | undefined)[] = [];
+        bus.on('debuff-resisted', (e) => {
+            if (e.targetId === 'attacker') sources.push(e.sourceId);
+        });
+        runCombat({ ...BASE({ enemyAttackers: [debuffEnemy('enemy-deb')] }), bus });
+        expect(sources.length).toBeGreaterThan(0);
+        expect(sources.every((s) => s === 'enemy-deb')).toBe(true);
+    });
+});

--- a/src/utils/combat/__tests__/triggers.test.ts
+++ b/src/utils/combat/__tests__/triggers.test.ts
@@ -3825,3 +3825,65 @@ describe('on-deal-damage live trigger', () => {
         expect(reactiveAbilities[0].ability.trigger).toBe('on-deal-damage');
     });
 });
+
+describe('on-debuff-resisted listener — source routing', () => {
+    const onResistDamage = (): ReactiveAbility => ({
+        sourceSlot: 'passive',
+        ability: ab({
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-debuff-resisted',
+            config: { type: 'damage', multiplier: 0, hits: 1, hpBasisPct: 30 },
+        }),
+    });
+
+    function emitResist(sourceId: string | undefined): Intent[] {
+        const bus = createEventBus();
+        const intents: Intent[] = [];
+        registerReactiveListeners({
+            bus,
+            perOwner: [{ ownerId: 'vindi', reactiveAbilities: [onResistDamage()] }],
+            enqueue: (i) => intents.push(i),
+            isOpposing: (id) => id === 'enemy1' || id === 'enemy2',
+        });
+        bus.emit({
+            type: 'debuff-resisted',
+            sourceId,
+            targetId: 'vindi',
+            round: 1,
+            buffName: 'Def Down',
+        });
+        return intents;
+    }
+
+    it('routes the inflictor as counterTargetId when the resist carries a source', () => {
+        const intents = emitResist('enemy1');
+        expect(intents).toHaveLength(1);
+        expect(intents[0].eventCtx?.counterTargetId).toBe('enemy1');
+    });
+
+    it('enqueues without counterTargetId when the resist has no source', () => {
+        const intents = emitResist(undefined);
+        expect(intents).toHaveLength(1);
+        expect(intents[0].eventCtx?.counterTargetId).toBeUndefined();
+    });
+
+    it('does not fire for a resist on a different unit', () => {
+        const bus = createEventBus();
+        const intents: Intent[] = [];
+        registerReactiveListeners({
+            bus,
+            perOwner: [{ ownerId: 'vindi', reactiveAbilities: [onResistDamage()] }],
+            enqueue: (i) => intents.push(i),
+            isOpposing: (id) => id === 'enemy1',
+        });
+        bus.emit({
+            type: 'debuff-resisted',
+            sourceId: 'enemy1',
+            targetId: 'someoneElse',
+            round: 1,
+            buffName: 'Def Down',
+        });
+        expect(intents).toHaveLength(0);
+    });
+});

--- a/src/utils/combat/__tests__/triggers.test.ts
+++ b/src/utils/combat/__tests__/triggers.test.ts
@@ -3887,3 +3887,95 @@ describe('on-debuff-resisted listener — source routing', () => {
         expect(intents).toHaveLength(0);
     });
 });
+
+// ----------------------------------------------------------------------
+// Task 4: the `cfg.type === 'damage'` executor branch for an hpBasisPct-flagged
+// ability (Vindicator on-resist). Requires a routed source (never falls back to
+// ctx.enemy), dedups per (owner, ability, source) via oncePerRoundConsumed, and
+// passes hpBasisPct through to ctx.applyReactiveDamage as the 7th arg.
+// ----------------------------------------------------------------------
+describe('on-debuff-resisted damage branch (hpBasisPct)', () => {
+    type Call = { owner: string; victim: string; mult: number; hpPct?: number };
+    // Minimal PlayerActorRuntime — executeIntent requires an owner runtime entry
+    // (dead-owner gate reads owner.actor.destroyedRound); nothing else is read on
+    // this branch.
+    const vindiRuntime = (): PlayerActorRuntime =>
+        ({ actor: { id: 'vindi' } as CombatActor }) as unknown as PlayerActorRuntime;
+    const makeCtx = (over: Partial<IntentExecContext> = {}) => {
+        const calls: Call[] = [];
+        const ctx = {
+            round: 1,
+            enemy: { id: 'dummy' } as CombatActor,
+            enemyId: 'dummy',
+            statusEngine: createStatusEngine({ selfBuffs: [], enemyDebuffs: [] }),
+            bus: createEventBus(),
+            corrosionEntries: [],
+            infernoEntries: [],
+            pendingBombs: [],
+            runtimes: new Map([['vindi', vindiRuntime()]]),
+            grantAllyCharges: () => {},
+            removeEnemyCharges: () => {},
+            removeChargesFrom: () => {},
+            grantExtraAction: () => {},
+            playerIds: ['vindi'],
+            lastTurnCtxByActor: new Map(),
+            enemyHp: 100000,
+            cumulativeDamage: 0,
+            recordResisted: () => {},
+            oncePerRoundConsumed: new Set<string>(),
+            applyReactiveDamage: (
+                owner: string,
+                victim: string,
+                _id: string,
+                mult: number,
+                _hits: number,
+                _noCrit: boolean,
+                hpPct?: number
+            ) => calls.push({ owner, victim, mult, hpPct }),
+            ...over,
+        } as unknown as IntentExecContext;
+        return { ctx, calls };
+    };
+    const intent = (counterTargetId?: string): Intent => ({
+        ownerId: 'vindi',
+        sourceSlot: 'passive',
+        ability: {
+            id: 'vindi-onresist',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-debuff-resisted',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0, hits: 1, hpBasisPct: 30 },
+        },
+        ...(counterTargetId ? { eventCtx: { counterTargetId } } : {}),
+    });
+
+    it('passes hpBasisPct through to applyReactiveDamage, targeting the routed source', () => {
+        const { ctx, calls } = makeCtx();
+        executeIntent(intent('enemy1'), ctx);
+        expect(calls).toHaveLength(1);
+        expect(calls[0]).toMatchObject({ owner: 'vindi', victim: 'enemy1', hpPct: 30 });
+    });
+
+    it('no-ops when no source is routed (never falls back to ctx.enemy)', () => {
+        const { ctx, calls } = makeCtx();
+        executeIntent(intent(undefined), ctx);
+        expect(calls).toHaveLength(0);
+    });
+
+    it('dedups multiple resists from the SAME source in one round to one proc', () => {
+        const shared = new Set<string>();
+        const { ctx, calls } = makeCtx({ oncePerRoundConsumed: shared });
+        executeIntent(intent('enemy1'), ctx);
+        executeIntent(intent('enemy1'), ctx);
+        expect(calls).toHaveLength(1);
+    });
+
+    it('fires once per DISTINCT source in the same round', () => {
+        const shared = new Set<string>();
+        const { ctx, calls } = makeCtx({ oncePerRoundConsumed: shared });
+        executeIntent(intent('enemy1'), ctx);
+        executeIntent(intent('enemy2'), ctx);
+        expect(calls).toHaveLength(2);
+    });
+});

--- a/src/utils/combat/__tests__/vindicatorOnResistDamage.integration.test.ts
+++ b/src/utils/combat/__tests__/vindicatorOnResistDamage.integration.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+const debuffEnemy = (id: string, debuffs = 1): EnemyAttacker =>
+    ({
+        id,
+        stats: {
+            attack: 1,
+            crit: 0,
+            critDamage: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 10,
+            hacking: 0,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: Array.from({ length: debuffs }, (_, i) => ({
+                        id: `enemy-debuff-${i}`,
+                        type: 'debuff' as const,
+                        target: 'enemy' as const,
+                        trigger: 'on-cast' as const,
+                        conditions: [],
+                        config: {
+                            type: 'debuff' as const,
+                            buffName: `Def Down ${i}`,
+                            parsedEffects: {},
+                            stacks: 1,
+                            isStackable: false,
+                            application: 'inflict' as const,
+                            duration: 1,
+                        },
+                    })),
+                },
+            ],
+        },
+    }) as EnemyAttacker;
+
+// Vindicator's on-resist HP proc, injected directly (the builder path is covered by Task 2).
+const onResistPassive = (pct = 30): ShipSkills['slots'][number] => ({
+    slot: 'passive',
+    abilities: [
+        {
+            id: 'vindi-onresist',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-debuff-resisted',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0, hits: 1, hpBasisPct: pct },
+        },
+    ],
+});
+
+const noopActive: ShipSkills['slots'][number] = {
+    slot: 'active',
+    abilities: [
+        {
+            id: 'noop',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0 },
+        },
+    ],
+};
+
+const CARRIER_HP = 1_000_000;
+const BASE = (
+    slots: ShipSkills['slots'],
+    overrides: Partial<CombatEngineInput> = {}
+): CombatEngineInput => ({
+    attack: 1,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: CARRIER_HP,
+    speed: 100,
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+// Sums direct-channel creditDamage attributed to `sourceId` across the run.
+const creditedDirectFor = (sourceId: string, input: CombatEngineInput): number => {
+    let total = 0;
+    runCombat({
+        ...input,
+        __testTapCreditDamage: (id, channel, amount) => {
+            if (id === sourceId && channel === 'direct') total += amount;
+        },
+    });
+    return total;
+};
+
+describe('Vindicator on-resist HP damage — engine integration', () => {
+    it('deals ~30% of the carrier max HP to the resisted enemy (defence-0, mitigation ~none)', () => {
+        const credited = creditedDirectFor(
+            'attacker',
+            BASE([noopActive, onResistPassive(30)], {
+                enemyAttackers: [debuffEnemy('enemy-deb', 1)],
+            })
+        );
+        expect(credited).toBeCloseTo(CARRIER_HP * 0.3, 0);
+    });
+
+    it('is mitigated by the victim defence', () => {
+        const lowDef = creditedDirectFor(
+            'attacker',
+            BASE([noopActive, onResistPassive(30)], {
+                enemyAttackers: [debuffEnemy('enemy-deb', 1)],
+            })
+        );
+        const highDefEnemy = debuffEnemy('enemy-deb', 1);
+        (highDefEnemy.stats as { defence: number }).defence = 50_000;
+        const highDef = creditedDirectFor(
+            'attacker',
+            BASE([noopActive, onResistPassive(30)], { enemyAttackers: [highDefEnemy] })
+        );
+        expect(highDef).toBeGreaterThan(0);
+        expect(highDef).toBeLessThan(lowDef);
+    });
+
+    it('procs once when two debuffs from ONE cast are both resisted', () => {
+        const credited = creditedDirectFor(
+            'attacker',
+            BASE([noopActive, onResistPassive(30)], {
+                enemyAttackers: [debuffEnemy('enemy-deb', 2)],
+            })
+        );
+        expect(credited).toBeCloseTo(CARRIER_HP * 0.3, 0); // one proc, not two
+    });
+
+    it('procs once per DISTINCT enemy resisting in the same round', () => {
+        const credited = creditedDirectFor(
+            'attacker',
+            BASE([noopActive, onResistPassive(30)], {
+                enemyAttackers: [debuffEnemy('enemy-a', 1), debuffEnemy('enemy-b', 1)],
+            })
+        );
+        expect(credited).toBeCloseTo(CARRIER_HP * 0.6, 0); // two procs
+    });
+
+    it('control: no on-resist passive → no credit', () => {
+        const credited = creditedDirectFor(
+            'attacker',
+            BASE([noopActive], { enemyAttackers: [debuffEnemy('enemy-deb', 1)] })
+        );
+        expect(credited).toBe(0);
+    });
+});
+
+// Team symmetry: an ENEMY-owned Vindicator resisting a PLAYER debuff procs identically.
+//
+// NOTE on targeting: a NON-positional player cast always resolves against the fixed 'enemy'
+// DPS dummy (engine.ts's `legacyVictim` for the player side), never against a specific
+// `enemyAttackers[]` entry — so a plain `target: 'enemy'` debuff can never land ON the
+// enemy-owned Vindicator. To route the player's debuff at the actual enemyAttacker, both the
+// caster and the target enemy need a board `position` (the recipe `enemySideAttacked.integration
+// .test.ts` uses for its positional two-team battle): `position`/`target`/`pattern` on the
+// CombatEngineInput make the player's cast resolve via `resolvePositionalTarget` over
+// `enemyAttackerActors`, landing on 'enemy-vindi' instead of the dummy.
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+describe('Vindicator on-resist HP damage — team symmetry (enemy-owned)', () => {
+    it('an enemy carrier deals ~30% of ITS max HP to the resisting player when it resists a player debuff', () => {
+        const ENEMY_HP = 2_000_000;
+        // Player casts a timed debuff at the (positionally-targeted) enemy carrier; the player's
+        // hacking 0 vs the carrier's default security 100 → landing chance clamps to 0 → the
+        // debuff is RESISTED every time (deterministic, no RNG pin needed).
+        const input: CombatEngineInput = {
+            attack: 1,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active',
+                        abilities: [
+                            {
+                                id: 'player-debuff',
+                                type: 'debuff',
+                                target: 'enemy',
+                                trigger: 'on-cast',
+                                conditions: [],
+                                config: {
+                                    type: 'debuff',
+                                    buffName: 'Def Down',
+                                    parsedEffects: {},
+                                    stacks: 1,
+                                    isStackable: false,
+                                    application: 'inflict',
+                                    duration: 1,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+            enemyDefense: 0,
+            enemyHp: ENEMY_HP,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 100,
+            healTargetId: 'attacker',
+            hacking: 0,
+            position: 'M4' as Position,
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            enemyAttackers: [
+                {
+                    id: 'enemy-vindi',
+                    stats: {
+                        attack: 1,
+                        crit: 0,
+                        critDamage: 0,
+                        defence: 0,
+                        hp: ENEMY_HP,
+                        speed: 10,
+                    },
+                    chargeCount: 0,
+                    startCharged: false,
+                    position: 'M4' as Position,
+                    shipSkills: { slots: [noopActive, onResistPassive(30)] },
+                } as EnemyAttacker,
+            ],
+        };
+        const credited = creditedDirectFor('enemy-vindi', input);
+        expect(credited).toBeGreaterThan(0);
+        expect(credited).toBeCloseTo(ENEMY_HP * 0.3, 0);
+    });
+});

--- a/src/utils/combat/debuffImmunity.ts
+++ b/src/utils/combat/debuffImmunity.ts
@@ -43,9 +43,10 @@ export const controlEffectLabel = (effect: ControlEffect): string => CONTROL_EFF
  *  normal DoT landing-roll failures stay silent (byte-identical). */
 export function emitBlockDebuffResist(
     bus: CombatEventBus,
+    sourceId: string,
     targetId: string,
     round: number,
     buffName: string
 ): void {
-    bus.emit({ type: 'debuff-resisted', targetId, round, buffName });
+    bus.emit({ type: 'debuff-resisted', sourceId, targetId, round, buffName });
 }

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3791,7 +3791,8 @@ export function runCombat(input: CombatEngineInput): {
             abilityId: string,
             multiplier: number,
             hits: number,
-            noCrit: boolean
+            noCrit: boolean,
+            hpBasisPct?: number
         ): void => {
             const owner = allActorsById.get(ownerId);
             const victim = allActorsById.get(victimId);
@@ -3826,12 +3827,18 @@ export function runCombat(input: CombatEngineInput): {
                     ownerStats.crit / 100
                 );
 
+            // Vindicator on-resist: raw = owner effective max HP × hpBasisPct% (mitigated below the
+            // same as any direct hit — defence + affinity + crit). Otherwise attack × multiplier.
+            const basisStat =
+                hpBasisPct !== undefined ? recipientMaxHp(ownerId) : ownerStats.attack;
+            const basisPct = hpBasisPct !== undefined ? hpBasisPct : multiplier;
+
             const raw = victimHitDamage(
                 {
-                    effectiveAttack: ownerStats.attack,
+                    effectiveAttack: basisStat,
                     // Fold hit count into the multiplier and pass hits:1 (mirrors
                     // applyCounterAttack) — models the reactive proc as ONE consolidated hit.
-                    multiplierPct: multiplier * hits,
+                    multiplierPct: basisPct * hits,
                     secondaryStatValue: 0,
                     hits: 1,
                     effectiveCritDamage: ownerStats.critDamage,

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -97,6 +97,9 @@ export type CombatEvent =
       } & ReactiveStamp)
     | ({
           type: 'debuff-resisted';
+          /** The inflicting actor (Vindicator on-resist retaliation routes here). Optional: a
+           *  display-only resist path may omit it; a source-requiring reaction no-ops when absent. */
+          sourceId?: string;
           targetId: string;
           round: number;
           buffName: string;

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -946,7 +946,13 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     const hasDamageAbility = damageAbility !== undefined;
 
     const emitDebuffResisted = (buffName: string, victimId: string = enemy.id) =>
-        bus.emit({ type: 'debuff-resisted', targetId: victimId, round: r, buffName });
+        bus.emit({
+            type: 'debuff-resisted',
+            sourceId: actor.id,
+            targetId: victimId,
+            round: r,
+            buffName,
+        });
     // emitDebuffApplied: discrete-infliction-only (Phase 3 retiming). `sourceId` is the
     // actor that inflicted the debuff. NOT called for recurring/aura per-round re-applications
     // or for every round a standing timed status is active — only at the infliction site.
@@ -1972,7 +1978,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
             // NOTE: a blocked `bomb` DoT emits the resist event but has NO `resistedDots`
             // row — the engine's resistedDots derivation filters to corrosion/inferno only
             // (bombs are display-only elsewhere too). Event-yes/surface-no is intentional.
-            emitBlockDebuffResist(bus, enemy.id, r, dotResistLabel(dot.type, dot.tier));
+            emitBlockDebuffResist(bus, actor.id, enemy.id, r, dotResistLabel(dot.type, dot.tier));
         }
     } else {
         // DoTs gate at application: draw the shared per-round roll only when there are

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -2290,7 +2290,7 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                 intent.ownerId,
                 sourceId,
                 intent.ability.id,
-                cfg.multiplier,
+                cfg.multiplier, // inert on this path — the engine reads hpBasisPct, not multiplier, when set
                 cfg.hits ?? 1,
                 cfg.noCrit ?? false,
                 cfg.hpBasisPct

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -970,7 +970,8 @@ export interface IntentExecContext {
         abilityId: string,
         multiplier: number,
         hits: number,
-        noCrit: boolean
+        noCrit: boolean,
+        hpBasisPct?: number
     ) => void;
     /** G PR1: apply a full mitigated/crit counter walk from `ownerId` to `attackerId`.
      *  `abilityId` keys the dedicated counter crit-gate. Reuses the engine's no-event
@@ -2273,6 +2274,29 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
 
     if (cfg.type === 'damage') {
         if (!passesProcChanceGate(intent, ctx)) return;
+        // HP-basis reactive (Vindicator on-resist): REQUIRES a routed inflictor (counterTargetId)
+        // — no fallback to ctx.enemy (you cannot retaliate against no-one). Frequency: one proc per
+        // triggering enemy action, keyed (owner, ability, round, source) so multiple debuffs
+        // resisted from ONE cast collapse to a single proc while two DIFFERENT enemies each proc.
+        // (oncePerRoundConsumed is the per-round set; a 3-part key never collides with the 2-part
+        // keys passesOncePerRoundGate uses.)
+        if (cfg.hpBasisPct !== undefined) {
+            const sourceId = intent.eventCtx?.counterTargetId;
+            if (sourceId === undefined) return;
+            const onceKey = `${intent.ownerId}:${intent.ability.id}:${sourceId}`;
+            if (ctx.oncePerRoundConsumed?.has(onceKey)) return;
+            ctx.oncePerRoundConsumed?.add(onceKey);
+            ctx.applyReactiveDamage?.(
+                intent.ownerId,
+                sourceId,
+                intent.ability.id,
+                cfg.multiplier,
+                cfg.hits ?? 1,
+                cfg.noCrit ?? false,
+                cfg.hpBasisPct
+            );
+            return;
+        }
         if (!passesOncePerRoundGate(intent, ctx)) return;
         // PR4b: reactive direct-damage proc (Grif's on-enemy-cleansed 75% no-crit, FrontLine's
         // on-enemy-charged-cast 80%, and epic PR4's re-tagged Judge/Chakara/Incinerator/Rhodium

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -588,9 +588,22 @@ export function registerReactiveListeners(args: {
                     bus.on('debuff-resisted', (e) => {
                         // Self-scoped on the RESISTER. `debuff-resisted` carries targetId = the
                         // unit that resisted (either side: cast-side, reactive-side, and the
-                        // D-PR15 Block-Debuff auto-resist all emit it). all-allies recipient
-                        // routing happens in the buff executor.
-                        if (e.targetId === ownerId) enqueue(intent);
+                        // D-PR15 Block-Debuff auto-resist all emit it). Route the inflictor
+                        // (e.sourceId) as counterTargetId so a damage reaction (Vindicator's
+                        // on-resist HP proc) retaliates against THAT enemy. When the resist carries
+                        // no source, enqueue the bare intent — buff consumers (Lockdown) are
+                        // source-agnostic and still fire; a source-requiring damage reaction no-ops
+                        // downstream (triggers.ts damage branch). all-allies recipient routing
+                        // happens in the buff executor.
+                        if (e.targetId !== ownerId) return;
+                        enqueue(
+                            e.sourceId !== undefined
+                                ? {
+                                      ...intent,
+                                      eventCtx: { ...intent.eventCtx, counterTargetId: e.sourceId },
+                                  }
+                                : intent
+                        );
                     });
                     break;
                 case 'on-ally-attacked':
@@ -1928,6 +1941,9 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                 ctx.recordResisted({ buffName: cfg.buffName, turnsRemaining });
                 ctx.bus.emit({
                     type: 'debuff-resisted',
+                    // sourceId = the inflictor (PR-J) so an on-debuff-resisted reaction (Vindicator)
+                    // can route retaliation back at it; the round display ignores it.
+                    sourceId: intent.ownerId,
                     // debuff-resisted feeds the round display only — no per-target counter
                     // routing needed (unchanged even for the recipient-targeted fan-out above).
                     targetId: ctx.enemy.id,
@@ -1948,6 +1964,7 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
         if (targetCarriesBlockDebuff(ctx.statusEngine, ctx.enemy.id)) {
             emitBlockDebuffResist(
                 ctx.bus,
+                intent.ownerId,
                 ctx.enemy.id,
                 ctx.round,
                 dotResistLabel(cfg.dotType, cfg.tier)

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -369,6 +369,22 @@ export function parseSecondaryDamage(text: string | null | undefined): Secondary
     return { stat, pct };
 }
 
+/**
+ * Vindicator p2 reactive proc: "When this Unit resists a debuff infliction from an enemy, it deals
+ * <unit-damage>damage equal to X%</unit-damage> of this Unit's max HP to that enemy." Standalone
+ * HP-scaled REACTIVE damage — NOT an on-cast rider (parseSecondaryDamage deliberately parks the
+ * "resists … debuff" clause at its sentence guard). Returns { pct } or null.
+ */
+export function parseOnResistHpDamage(text: string | null | undefined): { pct: number } | null {
+    if (!text) return null;
+    const re =
+        /when\s+this\s+unit\s+resists\s+a\s+debuff\b[^.]*?<unit-damage>(?:damage\s+equal\s+to\s+)?(\d+(?:\.\d+)?)%[^<]*<\/unit-damage>\s*of\s+(?:its|this\s+unit'?s)\s+max\s+hp/i;
+    const m = re.exec(text);
+    if (!m) return null;
+    const pct = parseFloat(m[1]);
+    return isNaN(pct) ? null : { pct };
+}
+
 // Matches "X% ... for each <phrase>" where no other % sits between the number and
 // "for each". Global so we can skip repair/heal contexts and unknown phrases.
 const CONDITIONAL_RE = /(\d+(?:\.\d+)?)\s*%[^%]*?for each\s+([^.,;<]+)/gi;


### PR DESCRIPTION
## Vindicator on-resist HP-scaled retaliation

Implements Vindicator's third passive as a real reactive combat proc:

> When this Unit resists a debuff infliction from an enemy, it deals damage equal to 30% of this Unit's max HP to that enemy.

This was the **last remaining red probe** in the Phase 3 reactive-trigger triage, spec-locked as *no-capturable-actor*.

### Re-triage: it was a mis-bucket
The triage assumed `debuff-resisted` carries no source. But the inflictor **is in scope at every emit site** (`actor.id` in playerTurn ×2, `intent.ownerId` in triggers ×2, closure-captured source in statusEngine) — it just wasn't on the event. So this is a **needs-capture** case (same pattern as `debuff-applied` + `counterTargetId`), not an impossibility. The genuinely-new piece is **HP-scaled standalone damage**, which the `damage` config didn't model.

### The 5 layers
1. **Parser** — `parseOnResistHpDamage` recognizes the on-resist max-HP clause (previously parked at the `parseSecondaryDamage` guard).
2. **Config** — NEW optional `hpBasisPct?` on the `damage` ability config (generic, reusable — Paracelsus's on-death 50%-max-HP proc is the trivial next consumer, still deferred as an out-of-scope trigger family).
3. **Builder** — emits `{ type:'damage', multiplier:0, hits:1, hpBasisPct:30 }` on `on-debuff-resisted`.
4. **Event capture** — adds optional `sourceId?` to `debuff-resisted`, routed to `eventCtx.counterTargetId` in the listener. Existing consumers (Lockdown) unaffected — bare-intent fallback when source is absent.
5. **Executor** — `applyReactiveDamage` HP-basis path: `recipientMaxHp(owner) × hpBasisPct` through the **same** defence + affinity mitigation and crit gate as any direct hit. The damage branch **requires** a routed source (no-op if absent — no `ctx.enemy` fallback) and dedups **one proc per (owner, ability, round, source)** — multiple debuffs resisted from one cast collapse to one proc; two different enemies each proc.

### Verification
- **Goldens byte-identical:** full suite **317 files / 4126 tests** green, no `vitest -u`.
- **Audit:** `Audited 147 ships → 0 findings`, no stale allowlist entries.
- **Team-symmetric:** an enemy-owned Vindicator is proven to credit 30% of *its* max HP to the resisting player.
- **Damage model** matches the game rule (mitigated, crit-eligible — no "cannot critically hit" clause).
- **Combat-sim only:** the proc needs an enemy inflicting a debuff *on* Vindicator, which never happens in DPS mode → DPS numbers unchanged.
- TDD throughout; per-task reviews + a final whole-branch review (opus) = **Ready to merge**.

### Merge notes for the reviewer
- **Base branch:** this branches off `main` (not the Phase 3 stack #219–#228), since the fix is self-contained and `main` is the epic's integration target. It's an independent PR to `main`; the `phase3/pr0-triage` Vindicator RED probe flips green once both land on `main`. Minor rebase overlap possible with PR-C (#222) in `buildShipAbilities.ts` / `triggers.ts` (different regions).
- **Deferred (final review = acceptable, do NOT harden here):** Vindicator's reactive ability lands at `out[0]` (no base damage), exposed to the generic on-cast enrichment blocks keyed on `out[0].type==='damage'`. Verified **zero current impact** (no Vindicator clause matches any). Hardening (`out[0].trigger==='on-cast'` guards) touches shared corpus code and would risk the byte-identical-goldens constraint — latent only for a hypothetical future on-resist+conditional ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
