### PR TITLE
feat(combat): model-completeness SP-A + SP-B — 5 skill-model gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ video/
 
 # husky internals (generated; symlinked in worktrees)
 .husky/_
+
+# local editor/backup artifacts (never commit)
+.env.bak
+.cursor/

--- a/docs/superpowers/plans/2026-07-06-model-completeness-sp-ab.md
+++ b/docs/superpowers/plans/2026-07-06-model-completeness-sp-ab.md
@@ -1,0 +1,541 @@
+# Model-completeness SP-A + SP-B Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the 5 real-gap `it.fails` probes owned by SP-A (Malvex, Voron-reduction) and SP-B (Paracelsus, Ravager, Nosorog) in `modelCompletenessTriage.test.ts`, faithfully — zero real-gap allowlist deferrals for these ships.
+
+**Architecture:** Each gap is an independent change on the skill-parse → `buildShipAbilities` → combat-engine pipeline. Two need new engine consumption (Malvex's `self-shielded` incoming-condition, Ravager's inflictor-side reactive trigger); the rest are parser/build-branch additions reusing live infrastructure. Acceptance per gap = flip its `it.fails` → `it`. New reactive triggers additionally get a team-symmetry integration test (a ship acts identically on either side).
+
+**Tech Stack:** TypeScript, Vitest. Skill text parsed in `src/utils/skillTextParser.ts` and `src/utils/abilities/buildShipAbilities.ts`; abilities typed in `src/types/abilities.ts`; combat engine in `src/utils/combat/`.
+
+## Global Constraints
+
+- **Parser truth = `docs/ship-skills.csv`**, verbatim. All probe text constants in `modelCompletenessTriage.test.ts` are already copied byte-identical; do NOT alter them.
+- **Each PR flips exactly its own probe(s)** `it.fails` → `it`; no other triage probe changes state.
+- **The full test suite must stay green** at the end of each task (`npm test`). The husky pre-commit hook runs `vitest --run`.
+- **Percentage stats are integers** (crit: 70 not 0.70) — not directly relevant here but holds for any buff fixtures.
+- **Team symmetry:** any new reactive trigger must fire identically whether the ship is player-side or enemy-side (engine-team-symmetry rule).
+- **`.env` must exist in the worktree** before running the full suite (gitignored; ~14 `.tsx` tests fail to collect without it) — `cp` it from the main repo if working in a fresh worktree.
+- The four PRs are mutually independent (different ships, different seams) and MAY be executed in parallel worktrees. Ordering below (trivial → Paracelsus → Ravager → Malvex) is by ascending invasiveness, not dependency.
+
+---
+
+## Task 1 (PR-trivial): Voron DoT reduction + Nosorog cleanse-verb widen
+
+Two parser-only widenings, grouped into one PR (both trivial, no engine change).
+
+**Files:**
+- Modify: `src/utils/abilities/buildShipAbilities.ts` — `parseIncomingDamageReductionPhrasings` (function at `:728-786`); add a Voron branch.
+- Modify: `src/utils/skillTextParser.ts:1068-1069` — widen `OWN_CLEANSE_TRIGGER_RE` (Nosorog).
+- Test: `src/utils/abilities/__tests__/modelCompletenessTriage.test.ts` — flip the Voron probe (`:76-95`) and the Nosorog probe (`:191-205`).
+- Modify: `scripts/auditSkills.allowlist.ts` — remove the Voron `incoming-damage-reduction` entry (`:139-143`) and the Nosorog `ungated-effect-with-trigger` entry (`:39-43`). KEEP the Nosorog `damage-reflection` entry (`:123-127`, harness FP).
+- Modify: `src/constants/changelog.ts` — `UNRELEASED_CHANGES`.
+
+**Interfaces:**
+- Consumes: `ParsedIncomingDamageReduction` (`buildShipAbilities.ts:700-706`), `detectReactiveTrigger` (`skillTextParser.ts:1122`).
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Flip both probes to failing**
+
+In `modelCompletenessTriage.test.ts`, change the Voron probe (`:76`) from `it.fails(` to `it(` and the Nosorog probe (`:191`) from `it.fails(` to `it(`. Leave both assertion bodies unchanged (they already assert the faithful final shape).
+
+- [ ] **Step 2: Run to verify both fail**
+
+Run: `npx vitest run src/utils/abilities/__tests__/modelCompletenessTriage.test.ts -t "Voron|Nosorog"`
+Expected: 2 FAIL — Voron: `expected false to be true` (no incoming-reduction built); Nosorog: `expected undefined to be 'on-own-cleanse'` (buff rides on-cast). (The SP-E Voron transform probe stays `it.fails` and green — do not touch it.)
+
+- [ ] **Step 3: Add the Voron parser branch**
+
+In `buildShipAbilities.ts`, inside `parseIncomingDamageReductionPhrasings`, after the `tormenterM` block (`:783`) and before `return out;` (`:785`):
+
+```ts
+    // Voron: "This Unit takes N% less damage from Damage over Time effects" — a flat
+    // reduction against the unit's OWN incoming DoT ticks. scope:'dot' + condition:'always'
+    // are both existing type-valid values (Tormenter uses the same pair via hpScaling).
+    const voronM =
+        /takes\s+(\d+(?:\.\d+)?)%\s+less\s+damage\s+from\s+damage\s+over\s+time\s+effects/i.exec(
+            plain
+        );
+    if (voronM) {
+        out.push({
+            scopes: ['dot'],
+            condition: 'always',
+            pct: parseFloat(voronM[1]),
+            matchIndex: voronM.index,
+        });
+    }
+```
+
+- [ ] **Step 4: Widen `OWN_CLEANSE_TRIGGER_RE` for Nosorog**
+
+In `skillTextParser.ts:1068-1069`, replace the regex with one that also matches "removes a Debuff" (scoped to that exact phrase — NOT bare "removes", which also strips shields/buffs):
+
+```ts
+const OWN_CLEANSE_TRIGGER_RE =
+    /\b(?:when\s+this\s+unit\s+cleanses\s+a\s+debuff|(?:when|upon)\s+cleansing\s+a\s+debuff|when\s+this\s+unit\s+removes\s+a\s+debuff)\b/i;
+```
+
+Also append to the doc comment above it (`:1058-1067`) a note that Nosorog's "removes a Debuff" phrasing is now covered.
+
+- [ ] **Step 5: Run to verify both pass**
+
+Run: `npx vitest run src/utils/abilities/__tests__/modelCompletenessTriage.test.ts -t "Voron|Nosorog"`
+Expected: 2 PASS (the Voron reduction row and the Nosorog row). The Voron SP-E transform probe still `it.fails`-green.
+
+- [ ] **Step 6: Remove the two allowlist entries and confirm audit clean**
+
+Delete the Voron `incoming-damage-reduction` object (`scripts/auditSkills.allowlist.ts:139-143`) and the Nosorog `ungated-effect-with-trigger` object (`:39-43`). Do NOT touch the Nosorog `damage-reflection` object (`:123-127`).
+
+Run: `npm run audit:skills`
+Expected: 0 findings. (If Nosorog or Voron re-flags, restore only the re-flagging entry and note why in the PR — but per triage both should clear.)
+
+- [ ] **Step 7: Add changelog entry**
+
+In `src/constants/changelog.ts`, add to `UNRELEASED_CHANGES`:
+- "Voron now correctly takes 20% less damage from Damage-over-Time effects."
+- "Nosorog's Defense Up II now triggers when it removes a debuff (previously fired on every cast)."
+
+- [ ] **Step 8: Full suite + lint**
+
+Run: `npm test && npm run lint`
+Expected: all green, 0 warnings.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/utils/abilities/buildShipAbilities.ts src/utils/skillTextParser.ts \
+        src/utils/abilities/__tests__/modelCompletenessTriage.test.ts \
+        scripts/auditSkills.allowlist.ts src/constants/changelog.ts
+git commit -m "fix(skills): Voron DoT reduction + Nosorog removes-debuff cleanse trigger"
+```
+
+---
+
+## Task 2 (PR-B1): Paracelsus on-destroyed retaliation + ally-buff
+
+Compose the existing `on-destroyed` trigger with the existing `hpBasisPct` config, and route both halves of the clause.
+
+**Files:**
+- Modify: `src/utils/skillTextParser.ts` — widen `KILLED_BY_DIRECT_RE` (`:1920`); add a `parseKilledByDirectHpDamage` parser (mirror `parseOnResistHpDamage` at `:378-386`); add a `KILLED_BY_DIRECT_RE` rule to `detectReactiveTrigger` (`:1122-1168`) so the ally-buff routes onto `on-destroyed`.
+- Modify: `src/utils/abilities/buildShipAbilities.ts` — add a build block (mirror the Vindicator on-resist block at `:1136-1163`) emitting the retaliation damage on `on-destroyed`; import the new parser (`:28` import group).
+- Test: `modelCompletenessTriage.test.ts` — flip Paracelsus probe (`:103-121`), add a 2nd assertion for the ally-buff.
+- Test (integration): `src/utils/combat/__tests__/paracelsusOnDestroyed.integration.test.ts` (create).
+- Modify: `scripts/auditSkills.allowlist.ts` — remove Paracelsus `ungated-effect-with-trigger` (`:34-38`).
+- Modify: `src/constants/changelog.ts`.
+
+**Interfaces:**
+- Consumes: `phrasePosTrigger` / `detectKilledByDirectDamageTrigger` pattern (`skillTextParser.ts:1928-1933`); the `on-destroyed` live trigger (`abilities.ts:82`, `:179`) — already bound in the reactive registry.
+- Produces: `parseKilledByDirectHpDamage(text: string | null | undefined): { pct: number } | null`.
+
+- [ ] **Step 1: Flip + extend the probe**
+
+In `modelCompletenessTriage.test.ts`, change the Paracelsus probe (`:103`) from `it.fails(` to `it(`. Keep the existing assertion (retaliation) and add a second assertion for the ally-buff below it:
+
+```ts
+            // Retaliation: on-destroyed HP-scaled damage.
+            expect(
+                abilities.some(
+                    (a) =>
+                        a.trigger === 'on-destroyed' &&
+                        a.config.type === 'damage' &&
+                        a.config.hpBasisPct != null
+                )
+            ).toBe(true);
+            // Ally-buff half: Everliving Regeneration II must also fire on-destroyed
+            // (was wrongly on-cast). Fixed together per the epic's faithfulness goal.
+            const regen = abilities.find(
+                (a) => a.config.type === 'buff' && a.config.buffName === 'Everliving Regeneration II'
+            );
+            expect(regen?.trigger).toBe('on-destroyed');
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/utils/abilities/__tests__/modelCompletenessTriage.test.ts -t "Paracelsus"`
+Expected: FAIL on the first assertion (`expected false to be true` — no retaliation ability built).
+
+- [ ] **Step 3: Widen `KILLED_BY_DIRECT_RE`**
+
+In `skillTextParser.ts:1920`, widen to also match "upon being killed by direct damage":
+
+```ts
+const KILLED_BY_DIRECT_RE = /\b(?:when|upon\s+being)\s+killed\s+by\s+direct\b[^.;]*\bdamage\b/i;
+```
+
+(Faust's "when killed by direct Damage" still matches — the alternation only adds a case.)
+
+- [ ] **Step 4: Add the retaliation-damage parser**
+
+In `skillTextParser.ts`, after `parseOnResistHpDamage` (`:386`), add:
+
+```ts
+/**
+ * "Upon being killed by direct Damage, this Unit deals Damage equal to N% of its max HP"
+ * — Paracelsus on-destroyed HP-scaled retaliation. Mirrors parseOnResistHpDamage; the amount
+ * rides hpBasisPct (multiplier:0), executed by the reactive-damage executor on on-destroyed.
+ */
+export function parseKilledByDirectHpDamage(text: string | null | undefined): { pct: number } | null {
+    if (!text) return null;
+    const re =
+        /(?:when|upon\s+being)\s+killed\s+by\s+direct\s+damage\b[^.]*?<unit-damage>(?:damage\s+equal\s+to\s+)?(\d+(?:\.\d+)?)%[^<]*<\/unit-damage>\s*of\s+(?:its|this\s+unit'?s)\s+max\s+hp/i;
+    const m = re.exec(text);
+    if (!m) return null;
+    const pct = parseFloat(m[1]);
+    return isNaN(pct) ? null : { pct };
+}
+```
+
+- [ ] **Step 5: Route the ally-buff onto on-destroyed**
+
+In `skillTextParser.ts`, inside `detectReactiveTrigger`, add a rule BEFORE `return undefined;` (`:1168`). Place it after the `APPLYING_DEBUFF_RE` line (`:1167`):
+
+```ts
+    // Paracelsus: "Upon being killed by direct Damage … grants allies <buff>" — the named-buff
+    // half of an on-destroyed clause. Mirrors Faust's detectKilledByDirectDamageTrigger (which
+    // routes the purge half); here the buffName-scoped clause carries the same phrase.
+    if (KILLED_BY_DIRECT_RE.test(clause)) return 'on-destroyed';
+```
+
+- [ ] **Step 6: Build the retaliation ability**
+
+In `buildShipAbilities.ts`, import `parseKilledByDirectHpDamage` in the `skillTextParser` import group (near `:28`). Then, immediately after the Vindicator on-resist block (`:1163`, still inside `if (slot === 'passive') {`), add:
+
+```ts
+        // Paracelsus p2: "Upon being killed by direct Damage, this Unit deals Damage equal to
+        // N% of its max HP." on-destroyed HP-scaled retaliation — composes the existing
+        // on-destroyed trigger with hpBasisPct (multiplier:0), same executor shape as Vindicator.
+        const onKilled = parseKilledByDirectHpDamage(text);
+        if (onKilled) {
+            const onKilledIdx = text.search(/<unit-damage>/i);
+            out.push({
+                ability: {
+                    id: nextId(),
+                    type: 'damage',
+                    target: 'enemy',
+                    trigger: 'on-destroyed',
+                    conditions: [],
+                    config: {
+                        type: 'damage',
+                        multiplier: 0,
+                        hits: 1,
+                        hpBasisPct: onKilled.pct,
+                    },
+                    autoFilled: true,
+                },
+                pos: onKilledIdx >= 0 ? onKilledIdx : MAX_POS,
+            });
+        }
+```
+
+- [ ] **Step 7: Run to verify the probe passes**
+
+Run: `npx vitest run src/utils/abilities/__tests__/modelCompletenessTriage.test.ts -t "Paracelsus"`
+Expected: PASS (both assertions — retaliation builds on-destroyed, Everliving Regen II routes on-destroyed). Also confirm Faust still green: `-t "Faust"` → PASS.
+
+- [ ] **Step 8: Write the team-symmetry integration test**
+
+Create `src/utils/combat/__tests__/paracelsusOnDestroyed.integration.test.ts`. Mirror an existing positional two-team integration test (template: `src/utils/combat/__tests__/enemyChargedCast.integration.test.ts` for `simulateBattle` setup). Assert: when a Paracelsus is killed by direct damage, (a) an enemy takes HP-scaled retaliation damage, and (b) allies receive Everliving Regeneration II — and that BOTH hold whether Paracelsus is on the player side OR the enemy side (two `simulateBattle` runs, sides swapped). If the on-destroyed executor does not run `type:'damage'` abilities, wire it in the reactive-damage executor (surface this in the PR description) — the executor already handles Vindicator's on-debuff-resisted HP-scaled damage, so the same path should apply.
+
+- [ ] **Step 9: Run the integration test**
+
+Run: `npx vitest run src/utils/combat/__tests__/paracelsusOnDestroyed.integration.test.ts`
+Expected: PASS both sides.
+
+- [ ] **Step 10: Remove allowlist entry + audit**
+
+Delete the Paracelsus `ungated-effect-with-trigger` object (`scripts/auditSkills.allowlist.ts:34-38`).
+Run: `npm run audit:skills`
+Expected: 0 findings.
+
+- [ ] **Step 11: Changelog**
+
+Add to `UNRELEASED_CHANGES`: "Paracelsus now retaliates for 50% of its max HP and grants allies Everliving Regeneration II when killed by direct damage (previously the regen buff fired on every cast and the retaliation was missing)."
+
+- [ ] **Step 12: Full suite + lint + commit**
+
+Run: `npm test && npm run lint`
+Expected: green, 0 warnings.
+
+```bash
+git add src/utils/skillTextParser.ts src/utils/abilities/buildShipAbilities.ts \
+        src/utils/abilities/__tests__/modelCompletenessTriage.test.ts \
+        src/utils/combat/__tests__/paracelsusOnDestroyed.integration.test.ts \
+        scripts/auditSkills.allowlist.ts src/constants/changelog.ts
+git commit -m "feat(combat): Paracelsus on-destroyed retaliation + ally-buff routing"
+```
+
+---
+
+## Task 3 (PR-B2): Ravager inflictor-side `on-own-debuff-resisted` trigger
+
+New trigger literal + reactive-listener case + parser rule. No new event emission — the existing `debuff-resisted` bus event already carries the inflictor as `sourceId`.
+
+**Files:**
+- Modify: `src/types/abilities.ts` — add `'on-own-debuff-resisted'` to the `AbilityTrigger` union (`:62-150`) and to `LIVE_TRIGGERS` (`:160-205`).
+- Modify: `src/utils/combat/triggers.ts` — add a `case 'on-own-debuff-resisted':` in the `registerReactiveListeners` switch (`:329+`), mirroring the `on-debuff-resisted` case (`:587-608`) but filtering `sourceId`.
+- Modify: `src/utils/skillTextParser.ts` — add a `DEBUFF_RESISTED_RE` const + a rule in `detectReactiveTrigger` (`:1122-1168`).
+- Test: `modelCompletenessTriage.test.ts` — flip Ravager probe (`:171-185`), strengthen the assertion.
+- Test (integration): `src/utils/combat/__tests__/ravagerResistReaction.integration.test.ts` (create).
+- Modify: `scripts/auditSkills.allowlist.ts` — remove Ravager `ungated-effect-with-trigger` (`:24-28`).
+- Modify: `src/constants/changelog.ts`.
+
+**Interfaces:**
+- Consumes: the `debuff-resisted` bus event (`events.ts:98-106`, `{sourceId?, targetId, round, buffName}` — `sourceId`=inflictor, `targetId`=resister); the `on-debuff-resisted` listener template (`triggers.ts:587-608`); `detectReactiveTrigger` buff-name routing (`buildShipAbilities.ts:2324`).
+- Produces: the `'on-own-debuff-resisted'` trigger literal (consumed only within this task).
+
+- [ ] **Step 1: Flip + strengthen the probe**
+
+In `modelCompletenessTriage.test.ts`, change the Ravager probe (`:171`) from `it.fails(` to `it(` and strengthen the assertion (`:183`) from `.not.toBe('on-cast')` to the exact trigger:
+
+```ts
+            expect(effect?.trigger).toBe('on-own-debuff-resisted');
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/utils/abilities/__tests__/modelCompletenessTriage.test.ts -t "Ravager"`
+Expected: FAIL (`expected 'on-cast' to be 'on-own-debuff-resisted'`).
+
+- [ ] **Step 3: Add the trigger literal**
+
+In `src/types/abilities.ts`, add to the `AbilityTrigger` union (`:62-150`), directly after the `'on-debuff-resisted'` line (`:141`):
+
+```ts
+    // Fires when a debuff THIS unit inflicted is RESISTED by its target (inflictor-scoped on
+    // sourceId === ownerId). Mirror of on-debuff-resisted (resister-scoped). Ravager's Hacking
+    // Module Overdrive grant.
+    | 'on-own-debuff-resisted'
+```
+
+And add `'on-own-debuff-resisted'` to the `LIVE_TRIGGERS` set (`:160-205`), next to `'on-debuff-resisted'` (`:200`).
+
+- [ ] **Step 4: Add the reactive-listener case**
+
+In `src/utils/combat/triggers.ts`, in the `registerReactiveListeners` switch (`:329+`), add a case immediately after the `on-debuff-resisted` case (`:587-608`), mirroring it but filtering the INFLICTOR side and routing back to the resister:
+
+```ts
+                case 'on-own-debuff-resisted':
+                    bus.on('debuff-resisted', (e) => {
+                        if (e.sourceId !== ownerId) return; // inflictor-scoped (the mirror)
+                        enqueue(
+                            e.targetId !== undefined
+                                ? {
+                                      ...intent,
+                                      eventCtx: { ...intent.eventCtx, counterTargetId: e.targetId },
+                                  }
+                                : intent
+                        );
+                    });
+                    break;
+```
+
+- [ ] **Step 5: Add the parser rule**
+
+In `skillTextParser.ts`, near the other reactive-trigger regexes (after `APPLYING_DEBUFF_RE` at `:1088`), add:
+
+```ts
+// "If its debuff is resisted" — Ravager's INFLICTOR-side reaction (the debuff THIS unit
+// inflicted got resisted). Distinct from the resister-side "when this Unit resists a debuff"
+// (parseOnResistHpDamage). Corpus-verified: Ravager is the only "its debuff is resisted" row.
+const OWN_DEBUFF_RESISTED_RE = /\bits\s+debuff\s+is\s+resisted\b/i;
+```
+
+Then add a rule in `detectReactiveTrigger`, before `return undefined;` (`:1168`):
+
+```ts
+    // Ravager: "If its debuff is resisted, it gains <buff>" — inflictor-side reaction.
+    if (OWN_DEBUFF_RESISTED_RE.test(clause)) return 'on-own-debuff-resisted';
+```
+
+- [ ] **Step 6: Run to verify the probe passes**
+
+Run: `npx vitest run src/utils/abilities/__tests__/modelCompletenessTriage.test.ts -t "Ravager"`
+Expected: PASS (Hacking Module Overdrive routes onto `on-own-debuff-resisted`).
+
+- [ ] **Step 7: Team-symmetry integration test**
+
+Create `src/utils/combat/__tests__/ravagerResistReaction.integration.test.ts`. In a positional two-team `simulateBattle` (template: `enemyChargedCast.integration.test.ts`), give an enemy high debuff-resistance so Ravager's inflicted debuff is resisted, and assert a `buff` combat-log entry for "Hacking Module Overdrive" appears for Ravager. Assert it fires whether Ravager is player-side OR enemy-side (two runs, sides swapped). This also proves the listener case is reached (an unwired trigger would partition as reactive but never fire — see triggers.ts:184).
+
+- [ ] **Step 8: Run the integration test**
+
+Run: `npx vitest run src/utils/combat/__tests__/ravagerResistReaction.integration.test.ts`
+Expected: PASS both sides.
+
+- [ ] **Step 9: Remove allowlist entry + audit**
+
+Delete the Ravager `ungated-effect-with-trigger` object (`scripts/auditSkills.allowlist.ts:24-28`).
+Run: `npm run audit:skills`
+Expected: 0 findings.
+
+- [ ] **Step 10: Changelog**
+
+Add to `UNRELEASED_CHANGES`: "Ravager now gains Hacking Module Overdrive when a debuff it inflicts is resisted (previously the buff was granted on every cast)."
+
+- [ ] **Step 11: Full suite + lint + commit**
+
+Run: `npm test && npm run lint`
+Expected: green, 0 warnings.
+
+```bash
+git add src/types/abilities.ts src/utils/combat/triggers.ts src/utils/skillTextParser.ts \
+        src/utils/abilities/__tests__/modelCompletenessTriage.test.ts \
+        src/utils/combat/__tests__/ravagerResistReaction.integration.test.ts \
+        scripts/auditSkills.allowlist.ts src/constants/changelog.ts
+git commit -m "feat(combat): Ravager on-own-debuff-resisted inflictor-side trigger"
+```
+
+---
+
+## Task 4 (PR-A): Malvex `self-shielded` incoming-reduction
+
+New `IncomingCondition` literal with full engine consumption. This is the most invasive task — the per-hit condition is context-driven, so every `IncomingHitContext` build site must populate the new field (the TypeScript compiler enforces this since the field is required).
+
+**Files:**
+- Modify: `src/types/abilities.ts` — add `'self-shielded'` to `IncomingCondition` (`:319-337`); add `victimHasShield: boolean` to `IncomingHitContext` (`:340-361`).
+- Modify: `src/utils/combat/incomingEffects.ts:4-25` — add the `case 'self-shielded'` to `conditionMet`.
+- Modify: `src/utils/combat/engine.ts` — add a `hasShield(actorId)` helper (mirror `hasBarrierRecharging` at `:2743-2744`); populate `victimHasShield` at every ctx build site (`:3196-3199`, `:3553-3556`, `:4145-4148`, `:4536` block, `:5298-5300`, `:5373-5375`, `:6318-6320`, `:6330-6332`).
+- Modify: `src/utils/abilities/buildShipAbilities.ts` — add a Malvex branch in `parseIncomingDamageReductionPhrasings` (`:728-786`).
+- Test: `modelCompletenessTriage.test.ts` — flip Malvex probe (`:55-69`), strengthen the assertion.
+- Test (integration): `src/utils/combat/__tests__/malvexShieldedReduction.integration.test.ts` (create).
+- Modify: `scripts/auditSkills.allowlist.ts` — remove Malvex `incoming-damage-reduction` (`:135-138`).
+- Modify: `src/constants/changelog.ts`.
+
+**Interfaces:**
+- Consumes: `conditionMet(cond, ctx)` (`incomingEffects.ts:4-25`); `CombatActor.shieldPool` (`state.ts:119`, live absorption pool — "has shield" = `> 0`; do NOT use `ActorHealing.shield` at `state.ts:29`); `hasBarrierRecharging` helper precedent (`engine.ts:2743-2744`); `ParsedIncomingDamageReduction` (`buildShipAbilities.ts:700-706`).
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Flip + strengthen the probe**
+
+In `modelCompletenessTriage.test.ts`, change the Malvex probe (`:55`) from `it.fails(` to `it(` and strengthen the assertion (`:63-67`) to check the condition, not just the type:
+
+```ts
+            expect(
+                abilities.some(
+                    (a) =>
+                        a.type === 'incoming-reduction' &&
+                        a.config.type === 'incoming-reduction' &&
+                        a.config.condition === 'self-shielded'
+                )
+            ).toBe(true);
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/utils/abilities/__tests__/modelCompletenessTriage.test.ts -t "Malvex"`
+Expected: FAIL (`expected false to be true` — no incoming-reduction built for the "When Shielded" clause).
+
+- [ ] **Step 3: Add the `self-shielded` literal + context field**
+
+In `src/types/abilities.ts`, add `'self-shielded'` to the `IncomingCondition` union (`:319-337`), after `'self-barrier-recharging'`. Then add a required field to `IncomingHitContext` (`:340-361`), mirroring `victimHasBarrierRecharging` (`:353-355`):
+
+```ts
+    /** Victim currently holds an active shield pool (shieldPool > 0) — gates self-shielded. */
+    victimHasShield: boolean;
+```
+
+- [ ] **Step 4: Add the evaluator case**
+
+In `src/utils/combat/incomingEffects.ts`, in the `conditionMet` switch (`:4-25`), add next to the `'self-barrier-recharging'` case:
+
+```ts
+        case 'self-shielded':
+            return ctx.victimHasShield;
+```
+
+- [ ] **Step 5: Run typecheck to enumerate the ctx build sites**
+
+Run: `npx tsc --noEmit`
+Expected: FAIL — one "Property 'victimHasShield' is missing" error per `IncomingHitContext` literal in `engine.ts`. This is the authoritative checklist for Step 6.
+
+- [ ] **Step 6: Add the helper + populate every ctx site**
+
+In `engine.ts`, add near `hasBarrierRecharging` (`:2743-2744`):
+
+```ts
+    const hasShield = (actorId: string): boolean =>
+        (allActorsById.get(actorId)?.shieldPool ?? 0) > 0;
+```
+
+Then at each ctx build site the compiler flagged (`:3196-3199`, `:3553-3556`, `:4145-4148`, the `:4536` block, `:5298-5300`, `:5373-5375`, `:6318-6320`, `:6330-6332`), add the field next to the existing `victimHasBarrierRecharging: hasBarrierRecharging(<victimId>)`, using the SAME victim id argument:
+
+```ts
+        victimHasShield: hasShield(<victimId>),
+```
+
+(At the reflected/counter site `:3553-3556` the victim is the original attacker — use whatever id that block passes to `hasBarrierRecharging`, keeping them identical.)
+
+Re-run `npx tsc --noEmit` until 0 errors.
+
+- [ ] **Step 7: Add the Malvex parser branch**
+
+In `buildShipAbilities.ts`, inside `parseIncomingDamageReductionPhrasings`, after the Voron branch from Task 1 (or after `tormenterM` if Task 1 not yet merged) and before `return out;`:
+
+```ts
+    // Malvex: "When Shielded, this Ship takes N% less damage" — a self-shield-gated flat
+    // reduction. New self-shielded IncomingCondition (evaluated per-hit against the victim's
+    // live shieldPool). Anchored on "when shielded" so it never matches Voron's DoT phrasing
+    // or a bare "takes N% less damage".
+    const malvexM =
+        /when\s+shielded,?\s+this\s+(?:ship|unit)\s+takes\s+(\d+(?:\.\d+)?)%\s+less\s+damage/i.exec(
+            plain
+        );
+    if (malvexM) {
+        out.push({
+            scopes: ['direct'],
+            condition: 'self-shielded',
+            pct: parseFloat(malvexM[1]),
+            matchIndex: malvexM.index,
+        });
+    }
+```
+
+- [ ] **Step 8: Run to verify the probe passes**
+
+Run: `npx vitest run src/utils/abilities/__tests__/modelCompletenessTriage.test.ts -t "Malvex"`
+Expected: PASS (incoming-reduction with `condition: 'self-shielded'` builds).
+
+- [ ] **Step 9: Team-symmetry integration test**
+
+Create `src/utils/combat/__tests__/malvexShieldedReduction.integration.test.ts`. In a positional two-team `simulateBattle`, give Malvex a shield and assert an incoming hit is reduced by 10% WHILE shielded and NOT reduced once the shield is gone — and that this holds whether Malvex is player-side OR enemy-side (confirms `conditionMet` is context-driven, not side-gated). Template: any existing `incomingEffects`/reduction integration test, or `enemyChargedCast.integration.test.ts` for the two-team harness.
+
+- [ ] **Step 10: Run the integration test**
+
+Run: `npx vitest run src/utils/combat/__tests__/malvexShieldedReduction.integration.test.ts`
+Expected: PASS both sides.
+
+- [ ] **Step 11: Remove allowlist entry + audit**
+
+Delete the Malvex `incoming-damage-reduction` object (`scripts/auditSkills.allowlist.ts:135-138`).
+Run: `npm run audit:skills`
+Expected: 0 findings.
+
+- [ ] **Step 12: Changelog**
+
+Add to `UNRELEASED_CHANGES`: "Malvex now takes 10% less damage while it has an active shield."
+
+- [ ] **Step 13: Full suite + lint + commit**
+
+Run: `npm test && npm run lint`
+Expected: green, 0 warnings.
+
+```bash
+git add src/types/abilities.ts src/utils/combat/incomingEffects.ts src/utils/combat/engine.ts \
+        src/utils/abilities/buildShipAbilities.ts \
+        src/utils/abilities/__tests__/modelCompletenessTriage.test.ts \
+        src/utils/combat/__tests__/malvexShieldedReduction.integration.test.ts \
+        scripts/auditSkills.allowlist.ts src/constants/changelog.ts
+git commit -m "feat(combat): Malvex self-shielded incoming damage reduction"
+```
+
+---
+
+## Cleanup on epic completion (after all 4 PRs merge)
+
+- Confirm `npm run audit:skills` is at 0 findings with all five entries removed (Ravager, Paracelsus, Nosorog-`ungated`, Malvex, Voron). The Nosorog `damage-reflection` (harness FP) entry stays.
+- Update `project_model_completeness_epic.md` memory: SP-A + SP-B ✅ MERGED; next = C ∥ D.
+
+## Self-review notes
+
+- **Spec coverage:** all 5 gaps have a task (Malvex T4, Voron T1, Paracelsus T2, Ravager T3, Nosorog T1); allowlist removal + changelog per task; team-symmetry integration tests for the 3 engine-touching gaps (Malvex, Paracelsus, Ravager); Voron/Nosorog need none (no engine change).
+- **Type consistency:** `parseKilledByDirectHpDamage` return `{pct}` matches its consumer in T2 Step 6; `victimHasShield` field name is identical across T4 Steps 3/4/6; `'self-shielded'` / `'on-own-debuff-resisted'` literals are spelled identically at every use.
+- **Voron↔Task-ordering:** Task 1's Voron branch and Task 4's Malvex branch both edit `parseIncomingDamageReductionPhrasings`; if run in parallel worktrees they touch adjacent lines — trivial merge, but the second-merged PR should re-run `npm test` after rebase.

--- a/docs/superpowers/specs/2026-07-06-model-completeness-sp-ab-design.md
+++ b/docs/superpowers/specs/2026-07-06-model-completeness-sp-ab-design.md
@@ -1,0 +1,194 @@
+# Model-completeness epic — SP-A + SP-B (combined) design
+
+**Date:** 2026-07-06
+**Epic:** model-completeness (roadmap `docs/superpowers/specs/2026-07-05-model-completeness-epic-roadmap.md`)
+**Input:** SP0 triage reconciliation `docs/model-completeness-triage-2026-07-05.md`
+**Predecessor:** SP0 triage merged (#230); Curator dup-emission bug fixed (#231)
+
+## Goal
+
+Close the 5 real-gap `it.fails` probes owned by SP-A and SP-B, faithfully — zero real-gap
+allowlist deferrals for these ships. SP-A and SP-B are independent infra (`A ∥ B` in the DAG);
+combined here into one spec / plan / merge-loop because both are small.
+
+**Acceptance per gap:** flip its `it.fails` → `it` in
+`src/utils/abilities/__tests__/modelCompletenessTriage.test.ts`. Two probes are tier-1 (type-only
+today) and get their assertions *strengthened* as their new literal lands (Malvex condition,
+Ravager exact trigger).
+
+## Scope decisions (locked with the user)
+
+1. **Combined spec** covering SP-A (Malvex, Voron-reduction) + SP-B (Paracelsus, Ravager, Nosorog).
+   Ships as separate PRs, one brainstorm/spec/plan/merge-loop.
+2. **Voron-reduction built now** (not deferred to SP-E). It is type-valid and applies to *any*
+   DoT Voron takes; SP-E's damage→DoT transform layers on top later.
+3. **Paracelsus — fix both halves.** Route BOTH the 50%-max-HP retaliation AND the Everliving
+   Regeneration II ally-buff onto `on-destroyed`. Both are wrong (on-cast) today.
+4. **PR decomposition:** 4 PRs. Group the two trivial parser widenings (Voron + Nosorog); Malvex,
+   Paracelsus, Ravager each atomic.
+
+## Out of scope
+
+- Voron's damage→DoT *transform* (SP-E, Task 6). This spec builds only Voron's DoT reduction.
+- Belladonna, and all SP-C/D/E/F/G ships.
+- Curator duplicate-emission (already fixed, #231).
+- Any allowlist row not tied to these 5 ships.
+
+---
+
+## The five gaps
+
+### SP-A — incoming-reduction gaps
+
+Both feed the detector `parseIncomingDamageReductionPhrasings`
+(`src/utils/skillTextParser.ts:728–786`), whose output the build loop at
+`src/utils/abilities/buildShipAbilities.ts:2099–2124` turns into `incoming-reduction` abilities
+(`target:'self'`, `trigger:'on-cast'`). The `incoming-reduction` config variant lives at
+`src/types/abilities.ts:595–613` (`scope:'direct'|'dot'`, `condition: IncomingCondition`, `pct`,
+`critFamily`, optional `hpScaling`).
+
+#### A1 — Malvex (NEW primitive) — PR-A
+
+**Clause (passive2):** "When Shielded, this Ship takes 10% less damage."
+
+Today: no incoming-reduction ability builds for this clause at all (only the separate "gains
+Shield = 15% of damage taken" ability). `IncomingCondition` has no self-shield member.
+
+**Changes:**
+1. **Type** — add `'self-shielded'` to the `IncomingCondition` union (`abilities.ts:319–337`).
+   Fits existing naming (`self-stealth`, `self-stasis`, `self-barrier-recharging`).
+2. **Parser** — new branch in `parseIncomingDamageReductionPhrasings` matching "When Shielded"
+   → emit `{scopes:['direct'], condition:'self-shielded', pct:10}`.
+3. **Engine consumption** — extend the per-hit `IncomingCondition` evaluator so `self-shielded`
+   applies the reduction only when the victim currently holds an active shield (`shield > 0`).
+   (Locate the evaluator that reads `config.condition` during damage resolution and add the case.)
+4. **Test** — strengthen the tier-1 probe (currently `a.type === 'incoming-reduction'`) to also
+   assert `a.config.condition === 'self-shielded'`, then flip `it.fails` → `it`.
+
+Team-symmetry: incoming-reduction is victim-side per-hit; verify it protects Malvex on either team
+(check the evaluator is not player-side-gated).
+
+#### A2 — Voron reduction (trivial, type-valid) — PR-trivial (with Nosorog)
+
+**Clause (passive2):** "…takes 20% less damage from Damage over Time effects."
+
+Today: the whole passive slot builds no abilities for this clause.
+
+**Changes:**
+1. **Parser** — new branch in `parseIncomingDamageReductionPhrasings` matching "less damage from
+   Damage over Time effects" → emit `{scopes:['dot'], condition:'always', pct:20}`.
+2. **Engine** — none. `scope:'dot' + condition:'always'` is the live Tormenter path
+   (`skillTextParser.ts:771–783` builds the same shape via `hpScaling`; the engine already
+   consumes dot-scoped always-reductions).
+3. **Test** — probe already asserts `scope==='dot' && condition==='always'`; flips automatically.
+
+### SP-B — reactive-trigger gaps
+
+#### B1 — Paracelsus (composes 2 precedents) — PR-B1
+
+**Clause (passive2):** "Upon being killed by direct Damage, this Unit deals Damage equal to 50%
+of its max HP and grants allies Everliving Regeneration II for 4 turns."
+
+Today: only the Everliving Regen buff builds, and it wrongly rides `on-cast`; the retaliation
+builds nothing. `hpBasisPct` and `on-destroyed` come from *different* precedents — this is the
+first ship to combine them:
+- `on-destroyed` trigger literal: `abilities.ts:82` (union) + `:179` (LIVE_TRIGGERS). Text→
+  `on-destroyed` routing precedents: `detectKilledByDirectDamageTrigger` (Faust,
+  `skillTextParser.ts:1918–1933`, regex `KILLED_BY_DIRECT_RE` at `:1920`) and
+  `detectDestroyedAllyRepairTrigger` (Salvation, `:1693–1702`).
+- `hpBasisPct` config field: `abilities.ts:424` (in the `type:'damage'` variant). Build precedent:
+  Vindicator p2 at `buildShipAbilities.ts:1136–1163` (`type:'damage'`, `multiplier:0`, `hits:1`,
+  `hpBasisPct`) — but that rides `on-debuff-resisted`, not `on-destroyed`.
+
+**Changes:**
+1. **Parser** — widen `KILLED_BY_DIRECT_RE` (`:1920`) to also match "**upon being** killed by
+   direct damage" (today only "when killed…"). Re-verify Faust still matches after widening.
+2. **Build (retaliation)** — emit a `type:'damage'`, `multiplier:0`, `hits:1`, `hpBasisPct:50`,
+   `trigger:'on-destroyed'`, `target:'enemy'` ability (Vindicator's shape + on-destroyed trigger).
+3. **Build (ally-buff)** — route the "grants allies Everliving Regeneration II 4t" buff onto
+   `on-destroyed` (currently on-cast). `target:'all-allies'`.
+4. **Team-symmetry** — verify both fire when Paracelsus dies on the enemy side.
+5. **Test** — flip `it.fails` → `it` (existing assertion checks `on-destroyed` + damage +
+   `hpBasisPct != null`); add a 2nd assertion that the Everliving Regen buff's
+   `trigger === 'on-destroyed'`.
+
+#### B2 — Ravager (NEW inflictor-side trigger) — PR-B2
+
+**Clause (passive2):** "…If its debuff is resisted, it gains Hacking Module Overdrive for 1 turn."
+
+Today: the grant rides `on-cast`. Only the resister-side `on-debuff-resisted` exists
+(`abilities.ts:141` union, `:200` LIVE_TRIGGERS; "fires when THIS unit resists an incoming
+debuff, self-scoped on targetId === ownerId"). Ravager needs the **inflictor** side — the debuff
+*this* unit inflicted got resisted by the target.
+
+**Changes:**
+1. **Type** — add `'on-own-debuff-resisted'` to the `AbilityTrigger` union (`abilities.ts:62–150`)
+   AND `LIVE_TRIGGERS` (`:160–205`). Doc it as the inflictor-side mirror of `on-debuff-resisted`.
+2. **Parser** — new inflictor-side detector matching "if its debuff is resisted" → route the
+   "gains Hacking Module Overdrive" grant onto `on-own-debuff-resisted`.
+3. **Engine** — emit this trigger to the *inflictor* at the debuff-resist resolution point (mirror
+   of the resister-side `on-debuff-resisted` emission). Team-symmetric — fires whichever side
+   Ravager is on.
+4. **Test** — strengthen the proxy assertion from `.not.toBe('on-cast')` to
+   `=== 'on-own-debuff-resisted'`, then flip `it.fails` → `it`.
+
+#### B3 — Nosorog (trivial regex widen) — PR-trivial (with Voron)
+
+**Clause (passive2):** "…Additionally, when this Unit removes a Debuff, it gains Defense Up II
+for 1 turn."
+
+Today: the grant rides `on-cast`. `OWN_CLEANSE_TRIGGER_RE` (`skillTextParser.ts:1068–1069`) only
+matches the verbs "cleanses"/"cleansing"; "removes a Debuff" is a different verb, so it never
+routes to `on-own-cleanse`.
+
+**Changes:**
+1. **Parser** — widen `OWN_CLEANSE_TRIGGER_RE` to also match "**removes a Debuff**", scoped to
+   that exact phrase (NOT bare "removes", which also strips shields/buffs — the purge parsers at
+   `:3404–3418` deliberately exclude other verbs; keep them excluded).
+2. **Engine** — none. Routing at `:1155` already returns `on-own-cleanse` (Phase-3 PR-H trigger,
+   `abilities.ts:137` / `:171`), which the engine already consumes.
+3. **Test** — probe already asserts `trigger === 'on-own-cleanse'`; flips automatically.
+
+---
+
+## PR decomposition (4 PRs, `A ∥ B`)
+
+| PR | Ships | Kind | Engine work? |
+|----|-------|------|--------------|
+| PR-A | Malvex | NEW `IncomingCondition` literal + parser branch | Yes (`self-shielded` evaluator) |
+| PR-trivial | Voron + Nosorog | Two parser-branch/regex widenings | No |
+| PR-B1 | Paracelsus | Compose `on-destroyed` + `hpBasisPct`, route both halves | No (existing on-destroyed emission) |
+| PR-B2 | Ravager | NEW `on-own-debuff-resisted` trigger + detector | Yes (inflictor-side emission) |
+
+All four are mutually independent (different ships, different seams) and can be worked in parallel.
+
+## Test strategy
+
+- Each PR flips exactly its own probe(s) `it.fails` → `it`; no other triage probe changes.
+- Tier-1 strengthenings land in the same PR as their literal (Malvex `self-shielded`, Ravager
+  `on-own-debuff-resisted`).
+- Per-PR gate: full suite minus the triage file must stay green, then the triage file's flipped
+  probe passes (per the merge-loop lessons in `project_skill_model_gap_sweep`).
+- New reactive triggers (Paracelsus `on-destroyed`, Ravager `on-own-debuff-resisted`) get a
+  team-symmetry assertion — the ship behaves identically on either side (engine-team-symmetry rule).
+
+## Cleanup on completion
+
+- **Allowlist:** remove Malvex, Voron, Paracelsus, Ravager, Nosorog rows from
+  `scripts/auditSkills.allowlist.ts`; add/update audit rules as each PR lands so `audit:skills`
+  stays at 0 findings.
+- **Changelog:** add `UNRELEASED_CHANGES` entries in `src/constants/changelog.ts` for the
+  user-facing fidelity fixes (Malvex shield mitigation, Voron DoT resistance, Paracelsus death
+  retaliation, Ravager resist-reaction, Nosorog cleanse-reaction).
+- **Docs:** no `DocumentationPage.tsx` change (internal combat-model fidelity, not a new UI feature).
+
+## Risks / watch-items
+
+- **Malvex engine evaluator** is the only non-trivial engine change — confirm the per-hit
+  `IncomingCondition` check is team-agnostic before wiring `self-shielded`.
+- **`KILLED_BY_DIRECT_RE` widening** must not regress Faust (its on-destroyed purge rides the same
+  regex) — assert Faust still routes to `on-destroyed` after the change.
+- **Nosorog "removes" scoping** — must stay narrow ("removes a Debuff") so it doesn't capture
+  shield/buff-strip phrasings.
+- **Ravager inflictor-side emission** — ensure the resist event reaches the inflictor without
+  double-firing the existing resister-side reaction.

--- a/scripts/auditSkills.allowlist.ts
+++ b/scripts/auditSkills.allowlist.ts
@@ -22,24 +22,9 @@ export const ALLOWLIST: AllowEntry[] = [
     // Reactive triggers (on-cleanse / on-kill / on-damaged / enemy-uses-charged / on-resist /
     // on-death) — modelled manually by the user, never auto-derived in single-ship DPS.
     {
-        ship: 'Ravager',
-        rules: ['ungated-effect-with-trigger'],
-        reason: 'Reactive: when its debuff is resisted.',
-    },
-    {
         ship: 'Curator',
         rules: ['ungated-effect-with-trigger'],
         reason: 'Reactive: when an enemy uses its Charged skill.',
-    },
-    {
-        ship: 'Paracelsus',
-        rules: ['ungated-effect-with-trigger'],
-        reason: 'Reactive: on being killed.',
-    },
-    {
-        ship: 'Nosorog',
-        rules: ['ungated-effect-with-trigger'],
-        reason: 'Reactive: when this Unit removes a debuff.',
     },
     {
         ship: 'Panon',
@@ -124,22 +109,6 @@ export const ALLOWLIST: AllowEntry[] = [
         ship: 'Nosorog',
         rules: ['damage-reflection'],
         reason: "Passive-gated (buildShipAbilities checks slot === 'passive'); the audit harness's abilitiesFor always re-parses text as the ACTIVE slot, so the reflect ability never builds under audit even though production (real Ship with secondPassiveSkillText/thirdPassiveSkillText) handles it correctly — a harness scoping false flag, not a missing gate.",
-    },
-
-    // ── epic PR12(C): incoming-damage-reduction rule — additional un-wired phrasings ──
-    // The new rule's keyword is intentionally broad (catches the whole "takes/reduces …
-    // damage" corpus family, not just the four PR12(C) target ships) so future additions to
-    // this family surface automatically. It also caught two phrasings OUTSIDE PR12(C)'s scope
-    // (Anemone/Panon/Wusheng/Tormenter) — deferred, not fixed here.
-    {
-        ship: 'Malvex',
-        rules: ['incoming-damage-reduction'],
-        reason: 'passive2 "When Shielded, this Ship takes 10% less damage" — a self-shielded-gated incoming reduction, a DIFFERENT condition from all four epic PR12(C) target ships. Out of scope for PR12; revisit as a follow-up (would need a new self-shield IncomingCondition, distinct from the existing self-shield ConditionSubject used elsewhere for the standing-modifier fold).',
-    },
-    {
-        ship: 'Voron',
-        rules: ['incoming-damage-reduction'],
-        reason: 'passive2 "This Unit transforms the damage into a Damage over Time effect… takes 20% less damage from Damage over Time effects" — a reduction against the unit\'s OWN incoming DoT ticks (dot-scope, self-referential condition), a DIFFERENT shape from all four epic PR12(C) target ships and coupled to the (also unmodeled) damage-to-DoT transform clause. Out of scope for PR12; revisit as a follow-up.',
     },
 
     // ── shield-penetration-innate: handled at the DATA layer, not the parser ─────

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -42,6 +42,11 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat sim: Nuqtu now cleanses a debuff from herself (once per round) and gains Terran Bolster III whenever an enemy actually gets buffed, matching her skill text, instead of always firing on her own turn regardless of enemy buffs.',
     'Combat sim: Vindicator now retaliates when it resists an enemy debuff, dealing damage equal to 30% of its max HP to that enemy.',
     'Combat sim: Curator now inflicts Block Buff only when an enemy uses its Charged skill (its intended reaction), instead of also inflicting it on every one of its own turns — a duplicate application has been removed.',
+    'Combat sim: Paracelsus now retaliates for 50% of its max HP and grants allies Everliving Regeneration II when killed by direct damage (previously the regen buff fired on every cast and the retaliation was missing).',
+    'Combat sim: Ravager now gains Hacking Module Overdrive when a debuff it inflicts is resisted (previously the buff was granted on every cast).',
+    'Combat sim: Voron now correctly takes 20% less damage from Damage-over-Time effects.',
+    "Combat sim: Nosorog's Defense Up II now triggers when it removes a debuff (previously fired on every cast).",
+    'Combat sim: Malvex now takes 10% less damage while it has an active shield.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -139,6 +139,10 @@ export type AbilityTrigger =
     // `debuff-resisted` event, self-scoped on targetId === ownerId). Chains off D-PR15's
     // Block-Debuff auto-resist emission AND normal hacking/affinity resists.
     | 'on-debuff-resisted'
+    // Fires when a debuff THIS unit inflicted is RESISTED by its target (inflictor-scoped on
+    // sourceId === ownerId). Mirror of on-debuff-resisted (resister-scoped). Ravager's Hacking
+    // Module Overdrive grant.
+    | 'on-own-debuff-resisted'
     // Fired once per shield-application CAST. Reaction is keyed on the granter (acting actor)
     // and targets the shield recipient set — used by Resonating Fury to grant Crit Power Up 3
     // to everyone the carrier just shielded.
@@ -198,6 +202,8 @@ export const LIVE_TRIGGERS = new Set<AbilityTrigger>([
     'on-debuffed',
     // D-PR16 Lockdown: self-scoped reaction to RESISTING an incoming debuff.
     'on-debuff-resisted',
+    // PR-B2: inflictor-scoped mirror — reaction to a debuff THIS unit inflicted being resisted.
+    'on-own-debuff-resisted',
     // Warpstrike: owner dealt direct damage on its turn.
     'on-deal-damage',
     // Resonating Fury: granter-scoped reaction fired once per shield-application cast.
@@ -332,6 +338,10 @@ export type IncomingCondition =
     // (Panon — "reduces all incoming damage by 20% when affected by Barrier Recharging").
     // A literal named-status check, mirroring the self-stealth/self-stasis precedent.
     | 'self-barrier-recharging'
+    // Model-completeness epic (SP-A): the VICTIM currently holds an active shield pool
+    // (Malvex — "When Shielded, this Ship takes 10% less damage"). Context-driven, not
+    // side-gated — evaluated per-hit against the victim's live shieldPool.
+    | 'self-shielded'
     // Epic PR12 (C): unconditional — used with `hpScaling` (Tormenter's HP-proportional
     // reduction, which carries no trigger/status gate, only continuous HP scaling).
     | 'always';
@@ -353,6 +363,8 @@ export interface IncomingHitContext {
     /** Epic PR12 (C): true when the VICTIM currently carries its own "Barrier Recharging"
      *  self-status (Panon). Live-derived by the engine; defaults false. */
     victimHasBarrierRecharging: boolean;
+    /** Victim currently holds an active shield pool (shieldPool > 0) — gates self-shielded. */
+    victimHasShield: boolean;
     /** Epic PR12 (C): the VICTIM's own live HP% (0..100) at hit time, for HP-proportional
      *  incoming-reduction scaling (Tormenter's `hpScaling`). Live-derived by the engine;
      *  defaults 100 (full HP) where unused/inapplicable — inert unless an ability's config

--- a/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
+++ b/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
@@ -52,47 +52,39 @@ describe('SP-A — incoming-reduction condition gates', () => {
     const MALVEX_P2 =
         'When Shielded, this Ship takes <unit-damage>10% less damage</unit-damage>. When directly damaged as a primary target, this Unit gains <unit-damage>Shield equal to 15%</unit-damage> of the Damage dealt to them.';
 
-    it.fails(
-        'Malvex: "When Shielded, takes 10% less damage" builds a shield-gated incoming-reduction',
-        () => {
-            const abilities = abilitiesFor({ secondPassiveSkillText: MALVEX_P2 }, 'passive');
-            // GAP: SP-A — today NO incoming-reduction ability is emitted at all for this clause
-            // (only the "gains Shield equal to 15% of damage taken" ability builds); the parser's
-            // incoming-damage-reduction phrasings (Anemone/Panon/Wusheng/Tormenter) don't cover
-            // "When Shielded". Needs a new self-shield IncomingCondition literal + parser branch.
-            expect(
-                abilities.some(
-                    (a) => a.type === 'incoming-reduction' /* && shielded condition present */
-                )
-            ).toBe(true);
-        }
-    );
+    it('Malvex: "When Shielded, takes 10% less damage" builds a shield-gated incoming-reduction', () => {
+        const abilities = abilitiesFor({ secondPassiveSkillText: MALVEX_P2 }, 'passive');
+        expect(
+            abilities.some(
+                (a) =>
+                    a.type === 'incoming-reduction' &&
+                    a.config.type === 'incoming-reduction' &&
+                    a.config.condition === 'self-shielded'
+            )
+        ).toBe(true);
+    });
 
     // Verbatim from docs/ship-skills.csv (second_passive_skill_text field). NOTE: split A+E —
     // this probe owns only the reduction half; the "transforms the damage into a Damage over
     // Time effect" transform is SP-E (Task 6). Text shared with the SP-E probe (VORON_PASSIVE2).
     const VORON_P2 = VORON_PASSIVE2;
 
-    it.fails(
-        'Voron: "takes 20% less damage from Damage over Time effects" builds a DoT-scoped incoming-reduction',
-        () => {
-            const abilities = abilitiesFor({ secondPassiveSkillText: VORON_P2 }, 'passive');
-            // GAP: SP-A — today the whole passive slot builds NO abilities at all (neither the
-            // transform nor the reduction); the incoming-damage-reduction phrasings don't cover
-            // "from Damage over Time effects". `scope: 'dot'` + `condition: 'always'` are both
-            // EXISTING, type-valid values (used elsewhere, e.g. Tormenter) — this is the faithful
-            // final shape, not a proxy.
-            expect(
-                abilities.some(
-                    (a) =>
-                        a.type === 'incoming-reduction' &&
-                        a.config.type === 'incoming-reduction' &&
-                        a.config.scope === 'dot' &&
-                        a.config.condition === 'always'
-                )
-            ).toBe(true);
-        }
-    );
+    it('Voron: "takes 20% less damage from Damage over Time effects" builds a DoT-scoped incoming-reduction', () => {
+        const abilities = abilitiesFor({ secondPassiveSkillText: VORON_P2 }, 'passive');
+        // CLOSED (SP-A): the parser now emits a DoT-scoped incoming-reduction for the "N% less
+        // damage from Damage over Time effects" phrasing. `scope: 'dot'` + `condition: 'always'`
+        // are EXISTING, type-valid values (used elsewhere, e.g. Tormenter) — the faithful final
+        // shape, not a proxy. (The SP-E "transforms the damage into a DoT" half is a separate probe.)
+        expect(
+            abilities.some(
+                (a) =>
+                    a.type === 'incoming-reduction' &&
+                    a.config.type === 'incoming-reduction' &&
+                    a.config.scope === 'dot' &&
+                    a.config.condition === 'always'
+            )
+        ).toBe(true);
+    });
 });
 
 describe('SP-B — new reactive trigger families', () => {
@@ -100,25 +92,24 @@ describe('SP-B — new reactive trigger families', () => {
     const PARACELSUS_P2 =
         'Upon being killed by direct Damage, this Unit deals <unit-damage>Damage equal to 50%</unit-damage> of its max HP and grants allies <unit-skill>Everliving Regeneration II</unit-skill> for 4 turns.';
 
-    it.fails(
-        'Paracelsus: "Upon being killed by direct Damage, deals damage equal to 50% of its max HP" builds an on-destroyed HP-scaled retaliation',
-        () => {
-            const abilities = abilitiesFor({ secondPassiveSkillText: PARACELSUS_P2 }, 'passive');
-            // GAP: SP-B — today NO ability at all is emitted for the retaliation clause (only the
-            // "grants allies Everliving Regeneration II" buff builds, and it incorrectly rides
-            // on-cast instead of on-destroyed too). `on-destroyed` is an EXISTING live trigger and
-            // `hpBasisPct` is an EXISTING type-valid AbilityConfig['damage'] field (Vindicator
-            // precedent, PR #229) — this is the faithful final shape, not a proxy.
-            expect(
-                abilities.some(
-                    (a) =>
-                        a.trigger === 'on-destroyed' &&
-                        a.config.type === 'damage' &&
-                        a.config.hpBasisPct != null
-                )
-            ).toBe(true);
-        }
-    );
+    it('Paracelsus: "Upon being killed by direct Damage, deals damage equal to 50% of its max HP" builds an on-destroyed HP-scaled retaliation', () => {
+        const abilities = abilitiesFor({ secondPassiveSkillText: PARACELSUS_P2 }, 'passive');
+        // Retaliation: on-destroyed HP-scaled damage.
+        expect(
+            abilities.some(
+                (a) =>
+                    a.trigger === 'on-destroyed' &&
+                    a.config.type === 'damage' &&
+                    a.config.hpBasisPct != null
+            )
+        ).toBe(true);
+        // Ally-buff half: Everliving Regeneration II must also fire on-destroyed
+        // (was wrongly on-cast). Fixed together per the epic's faithfulness goal.
+        const regen = abilities.find(
+            (a) => a.config.type === 'buff' && a.config.buffName === 'Everliving Regeneration II'
+        );
+        expect(regen?.trigger).toBe('on-destroyed');
+    });
 
     // Verbatim from docs/ship-skills.csv (second_passive_skill_text field).
     const FAUST_P2 =
@@ -168,41 +159,32 @@ describe('SP-B — new reactive trigger families', () => {
     const RAVAGER_P2 =
         'This Unit ignores 10% of Defense. It gains 1 stack of <unit-skill>Overload</unit-skill> every turn. Upon killing an enemy, it loses <unit-skill>Overload</unit-skill> and gains <unit-skill>Marauder Rage III</unit-skill> for 3 turns. If its debuff is resisted, it gains <unit-skill>Hacking Module Overdrive</unit-skill> for 1 turn.';
 
-    it.fails(
-        'Ravager: "If its debuff is resisted, gains Hacking Module Overdrive" is an unmodelled INFLICTOR-side reaction',
-        () => {
-            const abilities = abilitiesFor({ secondPassiveSkillText: RAVAGER_P2 }, 'passive');
-            const effect = abilities.find(
-                (a) => a.config.type === 'buff' && a.config.buffName === 'Hacking Module Overdrive'
-            );
-            // GAP: SP-B — only the RESISTER-scoped `on-debuff-resisted` trigger exists (self-scoped
-            // on the unit that resisted, D-PR16 Lockdown); the INFLICTOR-side "when the debuff THIS
-            // unit inflicted gets resisted" trigger does not exist yet. Today the grant rides plain
-            // on-cast (ungated). Proxy per the decision rule: `on-cast` is the only literal a
-            // faithful new inflictor-side trigger could never collide with here.
-            expect(effect?.trigger).not.toBe('on-cast');
-        }
-    );
+    it('Ravager: "If its debuff is resisted, gains Hacking Module Overdrive" rides the INFLICTOR-side reaction', () => {
+        const abilities = abilitiesFor({ secondPassiveSkillText: RAVAGER_P2 }, 'passive');
+        const effect = abilities.find(
+            (a) => a.config.type === 'buff' && a.config.buffName === 'Hacking Module Overdrive'
+        );
+        // PR-B2: the INFLICTOR-side "when the debuff THIS unit inflicted gets resisted" trigger
+        // is now modelled as `on-own-debuff-resisted` — mirror of the RESISTER-scoped
+        // `on-debuff-resisted` (D-PR16 Lockdown).
+        expect(effect?.trigger).toBe('on-own-debuff-resisted');
+    });
 
     // Verbatim from docs/ship-skills.csv (second_passive_skill_text field).
     const NOSOROG_P2 =
         'This Unit reflects 40% of the Damage taken back to the enemy when directly damaged as a primary target. Additionally, when this Unit removes a Debuff, it gains <unit-skill>Defense Up II</unit-skill> for 1 turn.';
 
-    it.fails(
-        'Nosorog: "when this Unit removes a Debuff, gains Defense Up II" does not ride on-own-cleanse',
-        () => {
-            const abilities = abilitiesFor({ secondPassiveSkillText: NOSOROG_P2 }, 'passive');
-            const effect = abilities.find(
-                (a) => a.config.type === 'buff' && a.config.buffName === 'Defense Up II'
-            );
-            // GAP: SP-B — VERIFIED (not the assumed FP): `on-own-cleanse` (Phase 3 PR-H) exists but
-            // its trigger detector (OWN_CLEANSE_TRIGGER_RE) only matches the verbs
-            // "cleanses"/"cleansing", not Nosorog's "removes a Debuff" phrasing — so this grant
-            // rides plain on-cast today. Needs the detector's verb alternation widened (or a
-            // parallel phrasing) to cover "removes a Debuff".
-            expect(effect?.trigger).toBe('on-own-cleanse');
-        }
-    );
+    it('Nosorog: "when this Unit removes a Debuff, gains Defense Up II" now rides on-own-cleanse', () => {
+        const abilities = abilitiesFor({ secondPassiveSkillText: NOSOROG_P2 }, 'passive');
+        const effect = abilities.find(
+            (a) => a.config.type === 'buff' && a.config.buffName === 'Defense Up II'
+        );
+        // CLOSED (SP-B): `on-own-cleanse` (Phase 3 PR-H) existed but its detector
+        // (OWN_CLEANSE_TRIGGER_RE) only matched "cleanses"/"cleansing", not Nosorog's "removes a
+        // Debuff" phrasing. The detector's verb alternation is now widened to cover "removes a
+        // Debuff", so this grant rides on-own-cleanse instead of plain on-cast.
+        expect(effect?.trigger).toBe('on-own-cleanse');
+    });
 });
 
 describe('SP-C — stat-comparison gates', () => {

--- a/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
+++ b/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
@@ -94,13 +94,14 @@ describe('SP-B — new reactive trigger families', () => {
 
     it('Paracelsus: "Upon being killed by direct Damage, deals damage equal to 50% of its max HP" builds an on-destroyed HP-scaled retaliation', () => {
         const abilities = abilitiesFor({ secondPassiveSkillText: PARACELSUS_P2 }, 'passive');
-        // Retaliation: on-destroyed HP-scaled damage.
+        // Retaliation: on-destroyed HP-scaled damage. Assert the exact basis (skill text says
+        // "Damage equal to 50% of its max HP") so a wrong-scaling regression is caught.
         expect(
             abilities.some(
                 (a) =>
                     a.trigger === 'on-destroyed' &&
                     a.config.type === 'damage' &&
-                    a.config.hpBasisPct != null
+                    a.config.hpBasisPct === 50
             )
         ).toBe(true);
         // Ally-buff half: Everliving Regeneration II must also fire on-destroyed

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -26,6 +26,7 @@ import {
     parseDamageReflection,
     parseSecondaryDamage,
     parseOnResistHpDamage,
+    parseKilledByDirectHpDamage,
     parseShieldStrip,
     parseConditionalDamage,
     parseEnemyEffectDamageBonus,
@@ -782,6 +783,39 @@ function parseIncomingDamageReductionPhrasings(text: string): ParsedIncomingDama
         });
     }
 
+    // Voron: "This Unit takes N% less damage from Damage over Time effects" — a flat
+    // reduction against the unit's OWN incoming DoT ticks. scope:'dot' + condition:'always'
+    // are both existing type-valid values (Tormenter uses the same pair via hpScaling).
+    const voronM =
+        /takes\s+(\d+(?:\.\d+)?)%\s+less\s+damage\s+from\s+damage\s+over\s+time\s+effects/i.exec(
+            plain
+        );
+    if (voronM) {
+        out.push({
+            scopes: ['dot'],
+            condition: 'always',
+            pct: parseFloat(voronM[1]),
+            matchIndex: voronM.index,
+        });
+    }
+
+    // Malvex: "When Shielded, this Ship takes N% less damage" — a self-shield-gated flat
+    // reduction. New self-shielded IncomingCondition (evaluated per-hit against the victim's
+    // live shieldPool). Anchored on "when shielded" so it never matches Voron's DoT phrasing
+    // or a bare "takes N% less damage".
+    const malvexM =
+        /when\s+shielded,?\s+this\s+(?:ship|unit)\s+takes\s+(\d+(?:\.\d+)?)%\s+less\s+damage/i.exec(
+            plain
+        );
+    if (malvexM) {
+        out.push({
+            scopes: ['direct'],
+            condition: 'self-shielded',
+            pct: parseFloat(malvexM[1]),
+            matchIndex: malvexM.index,
+        });
+    }
+
     return out;
 }
 
@@ -1158,6 +1192,31 @@ function abilitiesFromText(
                     autoFilled: true,
                 },
                 pos: onResistIdx >= 0 ? onResistIdx : MAX_POS,
+            });
+        }
+
+        // Paracelsus p2: "Upon being killed by direct Damage, this Unit deals Damage equal to
+        // N% of its max HP." on-destroyed HP-scaled retaliation — composes the existing
+        // on-destroyed trigger with hpBasisPct (multiplier:0), same executor shape as Vindicator.
+        const onKilled = parseKilledByDirectHpDamage(text);
+        if (onKilled) {
+            const onKilledIdx = text.search(/<unit-damage>/i);
+            out.push({
+                ability: {
+                    id: nextId(),
+                    type: 'damage',
+                    target: 'enemy',
+                    trigger: 'on-destroyed',
+                    conditions: [],
+                    config: {
+                        type: 'damage',
+                        multiplier: 0,
+                        hits: 1,
+                        hpBasisPct: onKilled.pct,
+                    },
+                    autoFilled: true,
+                },
+                pos: onKilledIdx >= 0 ? onKilledIdx : MAX_POS,
             });
         }
     }

--- a/src/utils/combat/__tests__/incomingEffects.test.ts
+++ b/src/utils/combat/__tests__/incomingEffects.test.ts
@@ -10,6 +10,7 @@ const ctx = (over: Partial<IncomingHitContext> = {}): IncomingHitContext => ({
     hitIndexThisRound: 1,
     attackerHasDot: false,
     victimHasBarrierRecharging: false,
+    victimHasShield: false,
     selfHpPct: 100,
     ...over,
 });

--- a/src/utils/combat/__tests__/malvexShieldedReduction.integration.test.ts
+++ b/src/utils/combat/__tests__/malvexShieldedReduction.integration.test.ts
@@ -1,0 +1,264 @@
+/**
+ * malvexShieldedReduction.integration.test.ts — Malvex `self-shielded` incoming-reduction
+ * (model-completeness epic, SP-A / Task 4-PR-A).
+ *
+ * Malvex ("When Shielded, this Ship takes 10% less damage") is the first ship to exercise the
+ * NEW context-driven `self-shielded` IncomingCondition: the reduction is gated on the VICTIM's
+ * own live shield pool (CombatActor.shieldPool > 0), evaluated per-hit by `conditionMet`
+ * (incomingEffects.ts) — NOT on which side the ship sits on. Team-symmetry: the SAME ability
+ * config must produce the SAME reduction whether Malvex is a PLAYER team victim (enemy→player
+ * positional path) or an ENEMY victim (player→enemy positional path).
+ *
+ * The ability is injected directly (not parsed from CSV text) to isolate the engine-plumbing
+ * fix under test from Malvex's OTHER passive clause (a reactive "gains Shield equal to 15% of
+ * the Damage dealt to them" ability, unrelated to this task). The parser wiring itself (that the
+ * real Malvex skill text builds an `incoming-reduction` ability with `condition: 'self-shielded'`)
+ * is covered by the SP-A triage probe in modelCompletenessTriage.test.ts.
+ *
+ * MEASUREMENT: reads the `attacked` event's `damage` field (the per-attack landed hit AFTER any
+ * incoming-reduction fold but BEFORE the shield-first drain split) rather than a death-bracket —
+ * Malvex's shield pool is a REAL absorption pool (state.ts's `shieldPool`), so any non-zero
+ * starting shield also absorbs part of the landed hit before it reaches HP. Reading `damage`
+ * directly observes the reduction in isolation from that (legitimate, separate) absorption math.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import { emptyPreFightModifiers } from '../preFight/types';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
+
+// Malvex's "When Shielded, this Ship takes 10% less damage" clause, injected directly (see
+// file header for why this isn't parsed from the verbatim CSV text here).
+const malvexReduction: Ability = {
+    id: 'malvex-self-shielded',
+    type: 'incoming-reduction',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: {
+        type: 'incoming-reduction',
+        scope: 'direct',
+        condition: 'self-shielded',
+        pct: 10,
+        critFamily: false,
+    },
+};
+const malvexPassive: ShipSkills['slots'][number] = {
+    slot: 'passive',
+    abilities: [malvexReduction],
+};
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+// A no-op damage active (multiplier 0) so a bystander actor still "casts" each round.
+const noopActive: ShipSkills['slots'][number] = {
+    slot: 'active',
+    abilities: [
+        {
+            id: 'noop-dmg',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0 },
+        },
+    ],
+};
+
+// A plain single-hit basic attack (multiplier 100% = 1x attack, defence 0 → flat landed damage).
+const basicAttack: ShipSkills['slots'][number] = {
+    slot: 'active',
+    abilities: [
+        {
+            id: 'basic',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 100 },
+        },
+    ],
+};
+
+/** Landed `attacked.damage` values credited to `victimId` across the run. */
+const landedDamagesFor = (input: CombatEngineInput, victimId: string): number[] => {
+    const bus = createEventBus();
+    const landed: number[] = [];
+    bus.on('attacked', (e: Extract<CombatEvent, { type: 'attacked' }>) => {
+        if (e.targetId === victimId && e.damage !== undefined) landed.push(e.damage);
+    });
+    runCombat({ ...input, bus });
+    return landed;
+};
+
+// ───────────────────────────────────────────────────────────────────────────
+// PLAYER-side Malvex: a positioned player TEAM victim hit by a positioned ENEMY attacker
+// (enemy→player positional path, mirroring incomingReductionEngine.test.ts).
+// ───────────────────────────────────────────────────────────────────────────
+
+/** A positioned PLAYER Malvex carrying the injected incoming-reduction passive, with a starting
+ *  shield pool of `shieldPctOfHp`% of its max HP (0 = no shield). HP is huge so it never dies —
+ *  this test reads the landed-hit signal directly, not a death bracket. */
+const playerMalvex = (id: string, position: Position, shieldPctOfHp: number): TeamActor => ({
+    id,
+    speed: 1000, // acts before the enemy — irrelevant here (the shield exists from creation).
+    chargeCount: 0,
+    startCharged: false,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    position,
+    preFight: { ...emptyPreFightModifiers(), startingShieldPctOfHp: shieldPctOfHp },
+    walk: {
+        shipSkills: { slots: [noopActive, malvexPassive] },
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            hacking: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+        },
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        hasChargedSkill: false,
+    },
+});
+
+/** A positioned ENEMY attacker: attack 5000 × 100% × 1 hit vs defence 0 → 5000 firing-hit. */
+const offensiveEnemy = (
+    id: string,
+    position: Position,
+    selection: ParsedTarget['selection']
+): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 5000, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget(selection),
+        pattern: basePattern(),
+        shipSkills: { slots: [{ slot: 'active', abilities: basicAttack.abilities }] },
+    }) as EnemyAttacker;
+
+const BASE_PLAYER_SIDE = (overrides: Partial<CombatEngineInput>): CombatEngineInput => ({
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [noopActive] }, // DPS-mode focus is an inert bystander here.
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+describe('Malvex self-shielded incoming-reduction — PLAYER side (enemy→player positional path)', () => {
+    const run = (shieldPctOfHp: number): CombatEngineInput =>
+        BASE_PLAYER_SIDE({
+            teamActors: [playerMalvex('malvex', 'M4', shieldPctOfHp)],
+            enemyAttackers: [offensiveEnemy('enemy-1', 'M1', 'front')],
+        });
+
+    it('WHILE shielded — the landed hit is reduced by 10% (5000 → 4500)', () => {
+        const landed = landedDamagesFor(run(50), 'malvex');
+        expect(landed).toEqual([4500]);
+    });
+
+    it('control: with NO shield — the landed hit is the FULL, unreduced 5000', () => {
+        const landed = landedDamagesFor(run(0), 'malvex');
+        expect(landed).toEqual([5000]);
+    });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// ENEMY-side Malvex: a positioned ENEMY victim hit by the PLAYER focus attacker
+// (player→enemy positional path, mirroring enemySideAttacked.integration.test.ts).
+// ───────────────────────────────────────────────────────────────────────────
+
+/** A positioned ENEMY Malvex carrying the injected incoming-reduction passive, with a starting
+ *  shield pool of `shieldPctOfHp`% of its max HP (0 = no shield). Attack 0 — pure victim, huge
+ *  HP so it never dies. */
+const enemyMalvex = (id: string, shieldPctOfHp: number): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position: 'M4',
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        shipSkills: { slots: [malvexPassive] },
+        preFight: { ...emptyPreFightModifiers(), startingShieldPctOfHp: shieldPctOfHp },
+    }) as EnemyAttacker;
+
+const BASE_ENEMY_SIDE = (overrides: Partial<CombatEngineInput>): CombatEngineInput => ({
+    attack: 5_000, // player focus attack → the hit landing on the enemy Malvex.
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [basicAttack] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000, // immortal player attacker — never dies, irrelevant to this test.
+    speed: 200,
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    ...overrides,
+});
+
+describe('Malvex self-shielded incoming-reduction — ENEMY side (player→enemy positional path)', () => {
+    const run = (shieldPctOfHp: number): CombatEngineInput =>
+        BASE_ENEMY_SIDE({ enemyAttackers: [enemyMalvex('malvex', shieldPctOfHp)] });
+
+    it('WHILE shielded — the landed hit is reduced by 10% (5000 → 4500)', () => {
+        const landed = landedDamagesFor(run(50), 'malvex');
+        expect(landed).toEqual([4500]);
+    });
+
+    it('control: with NO shield — the landed hit is the FULL, unreduced 5000', () => {
+        const landed = landedDamagesFor(run(0), 'malvex');
+        expect(landed).toEqual([5000]);
+    });
+});

--- a/src/utils/combat/__tests__/paracelsusOnDestroyed.integration.test.ts
+++ b/src/utils/combat/__tests__/paracelsusOnDestroyed.integration.test.ts
@@ -1,0 +1,380 @@
+/**
+ * PR-B1: Paracelsus's "Upon being killed by direct Damage" clause routes BOTH halves onto the
+ * existing on-destroyed trigger:
+ *   (a) a 50%-max-HP retaliation (`type: 'damage'`, `hpBasisPct`) against the killer, and
+ *   (b) an ally-wide Everliving Regeneration II grant (`type: 'buff'`, `target: 'all-allies'`) —
+ *       previously wired onto on-cast; PR-B1 moves it onto on-destroyed too.
+ *
+ * Model-completeness triage locked the ability SHAPE (modelCompletenessTriage.test.ts, SP-B).
+ * These are the ENGINE-level integration tests proving the shapes actually EXECUTE:
+ *   - the retaliation credits real (mitigated) damage against the actor that landed the killing
+ *     DIRECT blow (the same credit-only reactive-damage executor Vindicator's on-resist proc
+ *     uses — see vindicatorOnResistDamage.integration.test.ts for the precedent: this executor
+ *     never mutates a victim's live HP, it credits the owner's round damage-dealt bucket),
+ *   - the buff lands on every LIVING ally,
+ *   - and BOTH hold identically whether Paracelsus is a PLAYER-side team actor or an
+ *     ENEMY-side attacker (team symmetry) — mirroring the Battlecry/Last Wish on-destroyed
+ *     precedents (equipmentAbilities.integration.test.ts) for the positional two-team harness.
+ *
+ * Each scenario carries a gate-flip CONTROL (Paracelsus's passive replaced by a plain basic
+ * attack) proving the observed retaliation credit + buff are caused by the real parsed
+ * ability, not some baseline artefact.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import { ShipSkills } from '../../../types/abilities';
+import type { Ship } from '../../../types/ship';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+// Verbatim from docs/ship-skills.csv (second_passive_skill_text field) — same constant as the
+// SP-B triage probe (modelCompletenessTriage.test.ts). Do not alter.
+const PARACELSUS_P2 =
+    'Upon being killed by direct Damage, this Unit deals <unit-damage>Damage equal to 50%</unit-damage> of its max HP and grants allies <unit-skill>Everliving Regeneration II</unit-skill> for 4 turns.';
+
+/** Minimal Ship stub — mirrors modelCompletenessTriage.test.ts's `ship()` helper. */
+function makeShip(over: Partial<Ship>): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}, {}, {}], ...over } as Ship;
+}
+
+/** Single-hit, harmless (multiplier 0) basic attack — keeps the round cadence without
+ *  contributing any of its own credited damage (isolates the retaliation credit). */
+const basicAttackSlot = (): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        {
+            id: 'basic-atk',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-cast',
+            conditions: [],
+            config: { type: 'damage', multiplier: 0 },
+        },
+    ],
+});
+
+/** Builds Paracelsus's REAL production passive slot from the verbatim text (buildShipAbilities —
+ *  the same path simulateBattle feeds the engine), paired with a no-op active. */
+function buildParacelsusSlots(): ShipSkills['slots'] {
+    const built = buildShipAbilities(makeShip({ secondPassiveSkillText: PARACELSUS_P2 }));
+    const passive = built.slots.find((s) => s.slot === 'passive');
+    if (!passive) throw new Error('no passive slot built from Paracelsus text');
+    return [basicAttackSlot(), passive];
+}
+
+/** Control slots: no Paracelsus passive at all — proves the main run's credit/buff are caused
+ *  by the real parsed ability, not some baseline artefact. */
+const controlSlots = (): ShipSkills['slots'] => [basicAttackSlot()];
+
+const PARA_HP = 10_000;
+const EXPECTED_RETALIATION = PARA_HP * 0.5; // hpBasisPct 50, defence 0 → exact (no mitigation/crit)
+const REGEN_BUFF = 'Everliving Regeneration II';
+const REGEN_DURATION = 4;
+
+const parsedTargetFront = (): ParsedTarget => ({ raw: 'front', side: 'enemy', selection: 'front' });
+// Line-Range-1: origin (front-most) full damage + one covered cell (half damage).
+const lineRange1 = (): ParsedPattern => ({
+    raw: 'line-range-1',
+    shape: 'line',
+    range: 1,
+    modifiers: {},
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════════
+// Scenario A — Paracelsus is a PLAYER-side team actor.
+// ═══════════════════════════════════════════════════════════════════════════════════
+//
+// Board: surviving focus 'attacker' at M3 (covered, huge HP, receives the buff); team actor
+// 'paracelsus' at M4 (origin, tiny HP, one-shot); enemy 'killer' at M1 firing a lethal
+// Line-Range-1 hit at `front`. The killer is fast (acts first); paracelsus/attacker are slow
+// (playerActorAt's template speed 1), so the kill lands round 1.
+
+function playerActorAt(
+    id: string,
+    position: Position,
+    slots: ShipSkills['slots'],
+    hp: number
+): TeamActorEngineInput {
+    return {
+        id,
+        speed: 1,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        target: parsedTargetFront(),
+        pattern: lineRange1(),
+        walk: {
+            shipSkills: { slots },
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+            healModifier: 0,
+        },
+    };
+}
+
+/** An enemy attacker firing a REAL damaging (100%) Line-Range-1 hit at `front` — the killer. */
+function offensiveEnemyAt(id: string, position: Position, attack: number): EnemyAttacker {
+    return {
+        id,
+        stats: { attack, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1_000 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTargetFront(),
+        pattern: lineRange1(),
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'killer-hit',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 100, hits: 1 },
+                        },
+                    ],
+                },
+            ],
+        } as ShipSkills,
+    } as EnemyAttacker;
+}
+
+const FOCUS_HP = 1_000_000_000;
+
+const playerScenarioInput = (paracelsusSlots: ShipSkills['slots']): CombatEngineInput => ({
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [basicAttackSlot()] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: FOCUS_HP,
+    healModifier: 0,
+    healTargetId: 'attacker',
+    position: 'M3', // focus is the COVERED survivor
+    target: parsedTargetFront(),
+    pattern: lineRange1(),
+    teamActors: [playerActorAt('paracelsus', 'M4', paracelsusSlots, PARA_HP)],
+    enemyAttackers: [offensiveEnemyAt('killer', 'M1', 1_000_000_000)],
+});
+
+/** Runs a scenario input, collecting ship-destroyed/buff-applied events + credited direct
+ *  damage per source id. */
+function runScenario(input: CombatEngineInput) {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    bus.on('ship-destroyed', (e) => events.push(e as CombatEvent));
+    bus.on('buff-applied', (e) => events.push(e as CombatEvent));
+    const creditedDirect = new Map<string, number>();
+    runCombat({
+        ...input,
+        bus,
+        __testTapCreditDamage: (id, channel, amount) => {
+            if (channel === 'direct')
+                creditedDirect.set(id, (creditedDirect.get(id) ?? 0) + amount);
+        },
+    });
+    return { events, creditedDirect };
+}
+
+describe('Paracelsus on-destroyed retaliation + ally-buff — player side', () => {
+    it('Paracelsus killed by direct damage: retaliation credits ~50% of its max HP; allies get Everliving Regeneration II', () => {
+        const { events, creditedDirect } = runScenario(playerScenarioInput(buildParacelsusSlots()));
+
+        // Sanity: Paracelsus actually died to a DIRECT hit.
+        const destroyed = events.filter(
+            (e) => e.type === 'ship-destroyed' && e.actorId === 'paracelsus'
+        );
+        expect(destroyed.length).toBeGreaterThanOrEqual(1);
+        expect(destroyed.some((e) => e.type === 'ship-destroyed' && e.byDirectDamage)).toBe(true);
+
+        // (a) Retaliation: the dying Paracelsus's death credits ~50% of its own max HP as
+        // 'direct' damage (defence 0, crit 0, same-affinity → no mitigation/bonus, so the raw
+        // credited amount equals the basis exactly — mirrors the Vindicator on-resist pin).
+        expect(creditedDirect.get('paracelsus') ?? 0).toBeCloseTo(EXPECTED_RETALIATION, 0);
+
+        // (b) Ally-buff: the surviving ally 'attacker' receives Everliving Regeneration II
+        // for its full 4-turn duration.
+        const regen = events.filter(
+            (e) =>
+                e.type === 'buff-applied' && e.buffName === REGEN_BUFF && e.actorId === 'attacker'
+        );
+        expect(regen.length).toBeGreaterThanOrEqual(1);
+        expect(regen.some((e) => e.type === 'buff-applied' && e.duration === REGEN_DURATION)).toBe(
+            true
+        );
+    });
+
+    it('CONTROL — Paracelsus with no passive: dying credits nothing and grants no buff', () => {
+        const { events, creditedDirect } = runScenario(playerScenarioInput(controlSlots()));
+
+        const destroyed = events.filter(
+            (e) => e.type === 'ship-destroyed' && e.actorId === 'paracelsus'
+        );
+        expect(destroyed.length).toBeGreaterThanOrEqual(1); // still dies (same lethal hit)
+
+        expect(creditedDirect.get('paracelsus') ?? 0).toBe(0);
+        expect(
+            events.filter((e) => e.type === 'buff-applied' && e.buffName === REGEN_BUFF)
+        ).toHaveLength(0);
+    });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════════
+// Scenario B — Paracelsus is an ENEMY-side attacker (team symmetry mirror of Scenario A).
+// ═══════════════════════════════════════════════════════════════════════════════════
+//
+// Board: player 'attacker' at M1 (fast, deals the lethal Line-Range-1 hit at `front`);
+// enemy 'paracelsus-e' at M4 (origin, tiny HP, one-shot, carries the same real Paracelsus
+// passive); enemy 'enemy-ally' at M2 (outside the AoE footprint — untouched, survives,
+// receives the buff). This exercises the SEPARATE enemy-side reactive registration
+// (registerReactiveListeners' second call in engine.ts) end-to-end.
+
+function enemyActorAt(
+    id: string,
+    position: Position,
+    slots: ShipSkills['slots'],
+    hp: number,
+    speed = 10
+): EnemyAttacker {
+    return {
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp, speed },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        shipSkills: { slots },
+    } as EnemyAttacker;
+}
+
+const enemyScenarioInput = (paracelsusSlots: ShipSkills['slots']): CombatEngineInput => ({
+    attack: 1_000_000_000, // dwarfs PARA_HP → guaranteed one-shot direct hit on paracelsus-e
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [basicAttackSlot()] }, // placeholder; replaced below with a REAL attack
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    speed: 100, // fast — the player acts first each round
+    healTargetId: 'attacker',
+    position: 'M1',
+    target: parsedTargetFront(),
+    pattern: lineRange1(),
+    enemyAttackers: [
+        enemyActorAt('paracelsus-e', 'M4', paracelsusSlots, PARA_HP),
+        enemyActorAt('enemy-ally', 'M2', [basicAttackSlot()], 1_000_000_000),
+    ],
+});
+
+// The player's own basic attack must actually deal damage (100% multiplier) to land the
+// lethal hit — overrides the placeholder harmless slot above.
+const playerLethalAttackSlots: ShipSkills['slots'] = [
+    {
+        slot: 'active',
+        abilities: [
+            {
+                id: 'player-hit',
+                type: 'damage',
+                target: 'enemy',
+                trigger: 'on-cast',
+                conditions: [],
+                config: { type: 'damage', multiplier: 100, hits: 1 },
+            },
+        ],
+    },
+];
+
+describe('Paracelsus on-destroyed retaliation + ally-buff — enemy side (team symmetry)', () => {
+    it('An enemy Paracelsus killed by direct damage: retaliation credits ~50% of its max HP against the killer; enemy allies get Everliving Regeneration II', () => {
+        const { events, creditedDirect } = runScenario({
+            ...enemyScenarioInput(buildParacelsusSlots()),
+            shipSkills: { slots: playerLethalAttackSlots },
+        });
+
+        const destroyed = events.filter(
+            (e) => e.type === 'ship-destroyed' && e.actorId === 'paracelsus-e'
+        );
+        expect(destroyed.length).toBeGreaterThanOrEqual(1);
+        expect(destroyed.some((e) => e.type === 'ship-destroyed' && e.byDirectDamage)).toBe(true);
+
+        // (a) Retaliation: credited against the dying enemy Paracelsus's own bucket, routed at
+        // the player 'attacker' (the killer) — same magnitude as the player-side scenario.
+        expect(creditedDirect.get('paracelsus-e') ?? 0).toBeCloseTo(EXPECTED_RETALIATION, 0);
+
+        // (b) Ally-buff: the surviving enemy ally receives Everliving Regeneration II.
+        const regen = events.filter(
+            (e) =>
+                e.type === 'buff-applied' && e.buffName === REGEN_BUFF && e.actorId === 'enemy-ally'
+        );
+        expect(regen.length).toBeGreaterThanOrEqual(1);
+        expect(regen.some((e) => e.type === 'buff-applied' && e.duration === REGEN_DURATION)).toBe(
+            true
+        );
+    });
+
+    it('CONTROL — enemy Paracelsus with no passive: dying credits nothing and grants no buff', () => {
+        const { events, creditedDirect } = runScenario({
+            ...enemyScenarioInput(controlSlots()),
+            shipSkills: { slots: playerLethalAttackSlots },
+        });
+
+        const destroyed = events.filter(
+            (e) => e.type === 'ship-destroyed' && e.actorId === 'paracelsus-e'
+        );
+        expect(destroyed.length).toBeGreaterThanOrEqual(1);
+
+        expect(creditedDirect.get('paracelsus-e') ?? 0).toBe(0);
+        expect(
+            events.filter((e) => e.type === 'buff-applied' && e.buffName === REGEN_BUFF)
+        ).toHaveLength(0);
+    });
+});

--- a/src/utils/combat/__tests__/ravagerResistReaction.integration.test.ts
+++ b/src/utils/combat/__tests__/ravagerResistReaction.integration.test.ts
@@ -1,0 +1,185 @@
+/**
+ * PR-B2 — Ravager's `on-own-debuff-resisted` inflictor-side reaction (ENGINE integration).
+ *
+ * Ravager's second passive (verbatim from docs/ship-skills.csv): "...If its debuff is
+ * resisted, it gains <unit-skill>Hacking Module Overdrive</unit-skill> for 1 turn." This is
+ * the INFLICTOR-scoped mirror of the RESISTER-scoped `on-debuff-resisted` (D-PR16 Lockdown /
+ * Vindicator's on-resist HP retaliation): it fires on Ravager itself when a debuff RAVAGER
+ * inflicted is resisted by its target, not when Ravager resists an incoming debuff.
+ *
+ * Driven through the REAL pipeline: `simulateBattle` (placement-based two-team battle) →
+ * `buildShipAbilities` parses the verbatim passive text into an `on-own-debuff-resisted`
+ * reactive ability → the engine's reactive listener (triggers.ts) enqueues the Hacking Module
+ * Overdrive grant when the `debuff-resisted` event's `sourceId` is Ravager. Asserted via the
+ * combat log's `buff` entries (kind:'buff', note: buffName) — proves the full parse → build →
+ * engine → log path, not just the listener plumbing in isolation.
+ *
+ * Deterministic resist: Ravager's hacking is forced to 0 while the target's security defaults
+ * to 100 (resolveStats' `security ?? 100`) — the live hacking-vs-security landing chance
+ * clamps to 0, so Ravager's inflicted debuff is resisted on every cast, no RNG pin needed.
+ *
+ * Team symmetry (the epic's binding constraint): the SAME passive text, run twice — once with
+ * Ravager on the PLAYER team, once with Ravager on the ENEMY team — must both grant Hacking
+ * Module Overdrive. `on-own-debuff-resisted`'s listener filters `e.sourceId === ownerId`
+ * (triggers.ts), which is side-agnostic by construction, so this is a genuine regression guard
+ * against an accidental side-scoped filter creeping in later.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateBattle, BattlePlacement } from '../../calculators/battleSimulator';
+import type { Ship } from '../../../types/ship';
+import type { Position } from '../../../types/encounters';
+import { flattenCombatLog } from '../log/__testutils__/flattenCombatLog';
+
+// Verbatim from docs/ship-skills.csv (second_passive_skill_text field). Do NOT alter this text.
+const RAVAGER_P2 =
+    'This Unit ignores 10% of Defense. It gains 1 stack of <unit-skill>Overload</unit-skill> every turn. Upon killing an enemy, it loses <unit-skill>Overload</unit-skill> and gains <unit-skill>Marauder Rage III</unit-skill> for 3 turns. If its debuff is resisted, it gains <unit-skill>Hacking Module Overdrive</unit-skill> for 1 turn.';
+
+const HACKING_MODULE_OVERDRIVE = 'Hacking Module Overdrive';
+
+/** Ravager: a real corpus-phrased "inflicts <unit-skill>X</unit-skill> for N turns" active
+ *  (parses to an enemy-targeted timed debuff, skillTextParser.test.ts:381-394) + the verbatim
+ *  RAVAGER_P2 passive on the R2 (2-refit) slot, so buildShipAbilities produces the REAL
+ *  on-own-debuff-resisted reactive ability from production parsing — not a hand-written proxy. */
+const makeRavager = (id: string): Ship => ({
+    id,
+    name: 'Ravager',
+    rarity: 'legendary',
+    faction: 'TERRAN_COMBINE',
+    type: 'Attacker',
+    baseStats: {
+        hp: 0,
+        attack: 0,
+        defence: 0,
+        hacking: 200,
+        security: 100,
+        crit: 0,
+        critDamage: 0,
+        speed: 100,
+    },
+    equipment: {},
+    implants: {},
+    // 2 refits → getShipSkillRows selects secondPassiveSkillText (skillRows.ts).
+    refits: Array.from({ length: 2 }, () => ({})) as unknown as Ship['refits'],
+    affinity: 'antimatter',
+    activeSkillText: 'This Unit inflicts <unit-skill>Defense Down II</unit-skill> for 2 turns.',
+    chargeSkillCharge: 0,
+    activeTarget: 'front',
+    activePattern: 'Pattern-Base',
+    secondPassiveSkillText: RAVAGER_P2,
+});
+
+/** A harmless target with a trivial damage active — just needs to be alive so Ravager's
+ *  debuff has somewhere to land (and miss). Its default security (100) vs Ravager's forced
+ *  hacking 0 guarantees a 0% landing chance. */
+const makeTarget = (id: string): Ship => ({
+    id,
+    name: 'Target',
+    rarity: 'legendary',
+    faction: 'AURELIAN_SOVEREIGNTY',
+    type: 'Defender',
+    baseStats: {
+        hp: 0,
+        attack: 0,
+        defence: 0,
+        hacking: 200,
+        security: 100,
+        crit: 0,
+        critDamage: 0,
+        speed: 50,
+    },
+    equipment: {},
+    implants: {},
+    refits: [],
+    affinity: 'antimatter',
+    activeSkillText: 'This Unit deals <unit-damage>10% damage</unit-damage>.',
+    chargeSkillCharge: 0,
+    activeTarget: 'front',
+    activePattern: 'Pattern-Base',
+});
+
+const ravagerPlacement = (ship: Ship, position: Position): BattlePlacement => ({
+    ship,
+    position,
+    statOverrides: {
+        attack: 100,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        // Forced to 0: vs the target's default security 100, the live landing chance
+        // clamp((0-100)/100, 0, 1) = 0 → every inflicted debuff is resisted, deterministically.
+        hacking: 0,
+        defence: 0,
+        hp: 1_000_000,
+        security: 100,
+        speed: 100,
+    },
+});
+
+const targetPlacement = (ship: Ship, position: Position): BattlePlacement => ({
+    ship,
+    position,
+    statOverrides: {
+        attack: 1,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        hacking: 200,
+        defence: 0,
+        hp: 1_000_000,
+        security: 100,
+        speed: 50,
+    },
+});
+
+/** Every `buff` combat-log entry for `buffName` attributed to `actorId`, across all rounds. */
+const buffEntriesFor = (
+    result: ReturnType<typeof simulateBattle>,
+    actorId: string,
+    buffName: string
+) =>
+    flattenCombatLog(result).filter(
+        (e) => e.kind === 'buff' && e.actorId === actorId && e.note === buffName
+    );
+
+describe('Ravager on-own-debuff-resisted (engine integration)', () => {
+    it('PLAYER-side Ravager: a resisted inflicted debuff grants itself Hacking Module Overdrive', () => {
+        const result = simulateBattle({
+            playerTeam: [ravagerPlacement(makeRavager('ravager'), 'M4')],
+            enemyTeam: [targetPlacement(makeTarget('target'), 'M4')],
+            rounds: 2,
+        });
+
+        // Ravager is playerTeam[0] → the engine's reserved focus id 'attacker'.
+        const grants = buffEntriesFor(result, 'attacker', HACKING_MODULE_OVERDRIVE);
+        expect(grants.length).toBeGreaterThan(0);
+    });
+
+    it('ENEMY-side Ravager: the SAME reaction fires when Ravager is on the enemy team (team symmetry)', () => {
+        const result = simulateBattle({
+            playerTeam: [targetPlacement(makeTarget('target'), 'M4')],
+            enemyTeam: [ravagerPlacement(makeRavager('ravager'), 'M4')],
+            rounds: 2,
+        });
+
+        // Ravager is enemyTeam[0] → minted id `e:ravager:0` (battleSimulator.ts id scheme).
+        const grants = buffEntriesFor(result, 'e:ravager:0', HACKING_MODULE_OVERDRIVE);
+        expect(grants.length).toBeGreaterThan(0);
+    });
+
+    it('control: WITHOUT the resist-inflicting kit, no Hacking Module Overdrive is ever granted', () => {
+        // Same Ravager passive, but its active never fires a debuff (bare 0-damage attack) —
+        // no debuff-resisted event ever occurs, so the reaction never enqueues. Non-vacuity
+        // guard: proves the grant above is caused by the resist, not an unconditional on-cast.
+        const bareRavager: Ship = {
+            ...makeRavager('ravager'),
+            activeSkillText: 'This Unit deals <unit-damage>0% damage</unit-damage>.',
+        };
+        const result = simulateBattle({
+            playerTeam: [ravagerPlacement(bareRavager, 'M4')],
+            enemyTeam: [targetPlacement(makeTarget('target'), 'M4')],
+            rounds: 2,
+        });
+        const grants = buffEntriesFor(result, 'attacker', HACKING_MODULE_OVERDRIVE);
+        expect(grants.length).toBe(0);
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2742,6 +2742,11 @@ export function runCombat(input: CombatEngineInput): {
     // literal name.
     const hasBarrierRecharging = (actorId: string): boolean =>
         selfBuffNamesForOwners(statusEngine, [actorId]).includes('Barrier Recharging');
+    // Model-completeness epic (SP-A): does the given actor currently hold an active shield
+    // pool? (Malvex — "When Shielded, this Ship takes 10% less damage.") Reads the live
+    // absorption pool directly off the CombatActor, mirroring hasBarrierRecharging.
+    const hasShield = (actorId: string): boolean =>
+        (allActorsById.get(actorId)?.shieldPool ?? 0) > 0;
     // Epic PR12 (C): the given actor's own live HP% (0..100) at this instant, for
     // Tormenter's HP-proportional incoming-reduction scaling. Defaults 100 for an unresolvable
     // actor/zero max HP (inert — no reduction).
@@ -3196,6 +3201,7 @@ export function runCombat(input: CombatEngineInput): {
                             hitIndexThisRound: idx,
                             attackerHasDot: attackerHasDot(cause?.killerId ?? ''),
                             victimHasBarrierRecharging: hasBarrierRecharging(victim.id),
+                            victimHasShield: hasShield(victim.id),
                             selfHpPct: selfHpPctOf(victim.id),
                         },
                         (abilityId, chance) => {
@@ -3553,6 +3559,7 @@ export function runCombat(input: CombatEngineInput): {
                                 // scope) and its "victim" is `attacker` (receiving the bounce-back).
                                 attackerHasDot: attackerHasDot(victim.id),
                                 victimHasBarrierRecharging: hasBarrierRecharging(attacker.id),
+                                victimHasShield: hasShield(attacker.id),
                                 selfHpPct: selfHpPctOf(attacker.id),
                             }
                         );
@@ -3792,11 +3799,18 @@ export function runCombat(input: CombatEngineInput): {
             multiplier: number,
             hits: number,
             noCrit: boolean,
-            hpBasisPct?: number
+            hpBasisPct?: number,
+            allowDeadOwner?: boolean
         ): void => {
             const owner = allActorsById.get(ownerId);
             const victim = allActorsById.get(victimId);
-            if (!owner || owner.destroyedRound !== undefined) return;
+            // allowDeadOwner (PR-B1, Paracelsus): an on-destroyed retaliation is BORN of the
+            // owner's own death — the owner is already stamped destroyedRound by the time this
+            // drains (recordDestroyed runs before the ship-destroyed emit that enqueues this
+            // intent), so the plain "owner must be alive" gate would always no-op it. Mirrors the
+            // fromOwnDeath exemption the dead-owner drain gate already grants in triggers.ts
+            // (executeIntent) for Martyrdom's killer-Disable / Salvation's heal.
+            if (!owner || (owner.destroyedRound !== undefined && !allowDeadOwner)) return;
             // A missing/already-destroyed victim has no defense to mitigate against — skip
             // rather than crediting an un-mitigated number. BEHAVIOR CHANGE vs the pre-#211
             // formula (which never referenced a victim and credited unconditionally): for the
@@ -4145,6 +4159,7 @@ export function runCombat(input: CombatEngineInput): {
                         hitIndexThisRound: 0, // unused by reduction (only block reads it)
                         attackerHasDot: attackerHasDot(args.actingId),
                         victimHasBarrierRecharging: hasBarrierRecharging(victim.id),
+                        victimHasShield: hasShield(victim.id),
                         selfHpPct: selfHpPctOf(victim.id),
                     });
                     if (!didCrit) return equip;
@@ -5297,6 +5312,7 @@ export function runCombat(input: CombatEngineInput): {
                                     // never matters (scope-filtered before conditionMet reads it).
                                     attackerHasDot: false,
                                     victimHasBarrierRecharging: hasBarrierRecharging(healTarget.id),
+                                    victimHasShield: hasShield(healTarget.id),
                                     selfHpPct: selfHpPctOf(healTarget.id),
                                 }),
                             // PR I4b: the tank is the ticking victim.
@@ -5372,6 +5388,7 @@ export function runCombat(input: CombatEngineInput): {
                                         // on a DoT tick; harmless (scope:'direct'-only condition).
                                         attackerHasDot: false,
                                         victimHasBarrierRecharging: hasBarrierRecharging(actor.id),
+                                        victimHasShield: hasShield(actor.id),
                                         selfHpPct: selfHpPctOf(actor.id),
                                     }),
                                 // PR I4b: this actor IS the ticking victim.
@@ -6317,6 +6334,7 @@ export function runCombat(input: CombatEngineInput): {
                                           hitIndexThisRound: 0,
                                           attackerHasDot: attackerHasDot(actor.id),
                                           victimHasBarrierRecharging: hasBarrierRecharging(tgt.id),
+                                          victimHasShield: hasShield(tgt.id),
                                           selfHpPct: selfHpPctOf(tgt.id),
                                       })
                                     : 0;
@@ -6329,6 +6347,7 @@ export function runCombat(input: CombatEngineInput): {
                                           hitIndexThisRound: 0,
                                           attackerHasDot: attackerHasDot(actor.id),
                                           victimHasBarrierRecharging: hasBarrierRecharging(tgt.id),
+                                          victimHasShield: hasShield(tgt.id),
                                           selfHpPct: selfHpPctOf(tgt.id),
                                       })
                                     : 0;

--- a/src/utils/combat/incomingEffects.ts
+++ b/src/utils/combat/incomingEffects.ts
@@ -19,6 +19,8 @@ function conditionMet(cond: IncomingCondition, ctx: IncomingHitContext): boolean
             return ctx.attackerHasDot;
         case 'self-barrier-recharging':
             return ctx.victimHasBarrierRecharging;
+        case 'self-shielded':
+            return ctx.victimHasShield;
         case 'always':
             return true;
     }

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -606,6 +606,24 @@ export function registerReactiveListeners(args: {
                         );
                     });
                     break;
+                case 'on-own-debuff-resisted':
+                    bus.on('debuff-resisted', (e) => {
+                        // Inflictor-scoped mirror of on-debuff-resisted above: fires when a debuff
+                        // THIS unit inflicted (e.sourceId === ownerId) is resisted by its target.
+                        // Route the resister (e.targetId) as counterTargetId so a reaction could
+                        // target them; Ravager's Hacking Module Overdrive grant is self-target and
+                        // ignores this, but future inflictor-side reactions may need it.
+                        if (e.sourceId !== ownerId) return; // inflictor-scoped (the mirror)
+                        enqueue(
+                            e.targetId !== undefined
+                                ? {
+                                      ...intent,
+                                      eventCtx: { ...intent.eventCtx, counterTargetId: e.targetId },
+                                  }
+                                : intent
+                        );
+                    });
+                    break;
                 case 'on-ally-attacked':
                     bus.on('attacked', (e) => {
                         // Ally-scoped: fires when ANY OTHER same-side actor is hit — per HIT
@@ -650,17 +668,20 @@ export function registerReactiveListeners(args: {
                 case 'on-destroyed':
                     bus.on('ship-destroyed', (e) => {
                         // Self-scoped: THIS owner was destroyed (mirrors on-crit's own-id scoping).
-                        // Killer-targeted reactions (Faust's PURGE, Martyrdom's DEBUFF) fire only when
-                        // killed by DIRECT damage and route to the killer (counterTargetId = e.killerId).
-                        // Salvation's self-destruct HEAL (and any other on-destroyed reaction) fires on ANY
+                        // Killer-targeted reactions (Faust's PURGE, Martyrdom's DEBUFF, Paracelsus's
+                        // HP-scaled retaliation DAMAGE — PR-B1) fire only when killed by DIRECT damage
+                        // and route to the killer (counterTargetId = e.killerId). Salvation's
+                        // self-destruct HEAL (and any other on-destroyed reaction) fires on ANY
                         // death, unchanged.
                         if (e.actorId !== ownerId) return;
                         // fromOwnDeath: marks this as the owner's OWN death reaction so the
                         // dead-owner drain gate (executeIntent) lets it through even though the
-                        // owner is now destroyed (Martyrdom's killer-Disable, Salvation's heal).
+                        // owner is now destroyed (Martyrdom's killer-Disable, Salvation's heal,
+                        // Paracelsus's retaliation).
                         if (
                             ra.ability.config.type === 'purge' ||
-                            ra.ability.config.type === 'debuff'
+                            ra.ability.config.type === 'debuff' ||
+                            ra.ability.config.type === 'damage'
                         ) {
                             if (!e.byDirectDamage) return;
                             enqueue({
@@ -963,7 +984,9 @@ export interface IntentExecContext {
      *  entirely. Mirrors `applyCounterAttack`'s mitigated/crit walk but credits the owner's round
      *  damage-dealt bucket (creditDamage) instead of applying real HP damage — this executor
      *  never mutated a specific victim's HP (was credit-only pre-fix). Absent → the damage
-     *  branch is inert (unit fixtures / DPS mode w/o delegate). */
+     *  branch is inert (unit fixtures / DPS mode w/o delegate). `allowDeadOwner` (PR-B1,
+     *  Paracelsus) lets an on-destroyed retaliation fire even though its owner is already
+     *  stamped destroyedRound — the reaction is BORN of that same death. */
     applyReactiveDamage?: (
         ownerId: string,
         victimId: string,
@@ -971,7 +994,8 @@ export interface IntentExecContext {
         multiplier: number,
         hits: number,
         noCrit: boolean,
-        hpBasisPct?: number
+        hpBasisPct?: number,
+        allowDeadOwner?: boolean
     ) => void;
     /** G PR1: apply a full mitigated/crit counter walk from `ownerId` to `attackerId`.
      *  `abilityId` keys the dedicated counter crit-gate. Reuses the engine's no-event
@@ -2293,7 +2317,12 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                 cfg.multiplier, // inert on this path — the engine reads hpBasisPct, not multiplier, when set
                 cfg.hits ?? 1,
                 cfg.noCrit ?? false,
-                cfg.hpBasisPct
+                cfg.hpBasisPct,
+                // PR-B1 (Paracelsus): an on-destroyed retaliation's owner is already dead by the
+                // time this drains — fromOwnDeath (stamped by the on-destroyed listener) lets the
+                // executor's owner-alive gate stand aside for this one reaction, same exemption the
+                // dead-owner drain gate above already grants.
+                intent.eventCtx?.fromOwnDeath === true
             );
             return;
         }

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -385,6 +385,23 @@ export function parseOnResistHpDamage(text: string | null | undefined): { pct: n
     return isNaN(pct) ? null : { pct };
 }
 
+/**
+ * "Upon being killed by direct Damage, this Unit deals Damage equal to N% of its max HP"
+ * — Paracelsus on-destroyed HP-scaled retaliation. Mirrors parseOnResistHpDamage; the amount
+ * rides hpBasisPct (multiplier:0), executed by the reactive-damage executor on on-destroyed.
+ */
+export function parseKilledByDirectHpDamage(
+    text: string | null | undefined
+): { pct: number } | null {
+    if (!text) return null;
+    const re =
+        /(?:when|upon\s+being)\s+killed\s+by\s+direct\s+damage\b[^.]*?<unit-damage>(?:damage\s+equal\s+to\s+)?(\d+(?:\.\d+)?)%[^<]*<\/unit-damage>\s*of\s+(?:its|this\s+unit'?s)\s+max\s+hp/i;
+    const m = re.exec(text);
+    if (!m) return null;
+    const pct = parseFloat(m[1]);
+    return isNaN(pct) ? null : { pct };
+}
+
 // Matches "X% ... for each <phrase>" where no other % sits between the number and
 // "for each". Global so we can skip repair/heal contexts and unknown phrases.
 const CONDITIONAL_RE = /(\d+(?:\.\d+)?)\s*%[^%]*?for each\s+([^.,;<]+)/gi;
@@ -1064,9 +1081,10 @@ const ENEMY_CLEANSE_RE = /\bwhen\s+an?\s+enemy\b[^.]*?\bcleanses?\b[^.]*?\bdebuf
 // Larkspur/Pestilence/Yarrow, verb form "cleanses" with subject "an enemy", never matched by this
 // "this unit"/subjectless-gerund phrasing — see ENEMY_CLEANSE_RE above, checked first). Corpus-
 // verified (docs/ship-skills.csv, grep "cleanses? a\b"/"cleansing a"): ONLY Cultivator, Hayyan,
-// Morao match; every enemy-subject/numeral-cleanse row above does not.
+// Morao match; every enemy-subject/numeral-cleanse row above does not. Task 1 (2026-07-06):
+// Nosorog's "when this Unit removes a Debuff" phrasing is now also covered.
 const OWN_CLEANSE_TRIGGER_RE =
-    /\b(?:when\s+this\s+unit\s+cleanses\s+a\s+debuff|(?:when|upon)\s+cleansing\s+a\s+debuff)\b/i;
+    /\b(?:when\s+this\s+unit\s+cleanses\s+a\s+debuff|(?:when|upon)\s+cleansing\s+a\s+debuff|when\s+this\s+unit\s+removes\s+a\s+debuff)\b/i;
 // Phase 3 PR-I: "when an enemy gets/is/becomes buffed" — Nuqtu's self-cleanse + Terran Bolster
 // III grant. Promoted from a manual, non-derivable `enemy-buff` CONDITION (detectGrantConditions
 // rule 4b below, which the single-ship DPS sim still consumes as a manual toggle — no enemy casts
@@ -1086,6 +1104,10 @@ const KILL_TRIGGER_RE =
     /\bon\s+(?:a\s+)?kill\b|killing\s+an\s+(?:enemy|opponent)|when\s+an\s+enemy\s+dies/i;
 // "On inflicting a debuff" / "upon applying a debuff" → on-debuff-inflicted (Butcher Marauder Rage II).
 const APPLYING_DEBUFF_RE = /\b(?:upon|on|after|when)\s+(?:inflicting|applying)\s+(?:a\s+)?debuff/i;
+// "If its debuff is resisted" — Ravager's INFLICTOR-side reaction (the debuff THIS unit
+// inflicted got resisted). Distinct from the resister-side "when this Unit resists a debuff"
+// (parseOnResistHpDamage). Corpus-verified: Ravager is the only "its debuff is resisted" row.
+const OWN_DEBUFF_RESISTED_RE = /\bits\s+debuff\s+is\s+resisted\b/i;
 
 /**
  * Detects a reactive AbilityTrigger for the buff/debuff/DoT named `buffName`, scoped to the
@@ -1115,6 +1137,8 @@ const APPLYING_DEBUFF_RE = /\b(?:upon|on|after|when)\s+(?:inflicting|applying)\s
  *    (Overload lifecycle, Task 4: Mangler/Ravager/Asphyxiator/Butcher).
  *  - "on inflicting a debuff" / "upon applying a debuff" → 'on-debuff-inflicted'
  *    (Overload lifecycle, Task 4: Butcher Marauder Rage II).
+ *  - "if its debuff is resisted" → 'on-own-debuff-resisted' (PR-B2: Ravager's Hacking Module
+ *    Overdrive grant; inflictor-scoped mirror of the resister-side on-debuff-resisted).
  *
  * Other reactive phrasings (when-attacked, ally-crit, …) are NOT derivable this phase and stay
  * undefined (manual modelling). Reference data: docs/ship-skills.csv.
@@ -1165,6 +1189,12 @@ export function detectReactiveTrigger(
     if (ENEMY_REPAIRS_RE.test(clause)) return 'on-enemy-repaired';
     if (KILL_TRIGGER_RE.test(clause)) return 'on-enemy-destroyed';
     if (APPLYING_DEBUFF_RE.test(clause)) return 'on-debuff-inflicted';
+    // Paracelsus: "Upon being killed by direct Damage … grants allies <buff>" — the named-buff
+    // half of an on-destroyed clause. Mirrors Faust's detectKilledByDirectDamageTrigger (which
+    // routes the purge half); here the buffName-scoped clause carries the same phrase.
+    if (KILLED_BY_DIRECT_RE.test(clause)) return 'on-destroyed';
+    // Ravager: "If its debuff is resisted, it gains <buff>" — inflictor-side reaction.
+    if (OWN_DEBUFF_RESISTED_RE.test(clause)) return 'on-own-debuff-resisted';
     return undefined;
 }
 
@@ -1916,8 +1946,10 @@ export function detectRoundStartContinuationTrigger(
 }
 
 // "… when killed by direct Damage" — Faust on-destroyed purge (killer-targeted, direct-only).
-// Crosses tags; "direct" guards against a future DoT-kill phrasing.
-const KILLED_BY_DIRECT_RE = /\bwhen\s+killed\s+by\s+direct\b[^.;]*\bdamage\b/i;
+// Crosses tags; "direct" guards against a future DoT-kill phrasing. Widened (PR-B1) to also
+// match "upon being killed by direct Damage" (Paracelsus's retaliation + ally-buff clause) —
+// the alternation only ADDS a case, so Faust's "when killed by direct Damage" still matches.
+const KILLED_BY_DIRECT_RE = /\b(?:when|upon\s+being)\s+killed\s+by\s+direct\b[^.;]*\bdamage\b/i;
 
 /**
  * Returns 'on-destroyed' when `anchorPos` falls inside the sentence carrying the
@@ -3218,10 +3250,7 @@ export function parseHealAbilities(text: string | null | undefined): ParsedHealA
             let ownCleanseReaction: true | undefined;
             if (!leechBasis && !damageReaction) {
                 const cleanseTriggerMatch = OWN_CLEANSE_TRIGGER_RE.exec(sentence);
-                if (
-                    cleanseTriggerMatch &&
-                    m.index - sentenceStart > cleanseTriggerMatch.index
-                ) {
+                if (cleanseTriggerMatch && m.index - sentenceStart > cleanseTriggerMatch.index) {
                     ownCleanseReaction = true;
                 }
             }


### PR DESCRIPTION
## Summary

Closes the 5 real-gap `it.fails` probes owned by **SP-A** and **SP-B** of the model-completeness epic — each faithfully modeled and flipped to a passing `it`. Delivered as one squashed PR (the four sub-tasks touch the same 3–4 files, so separate PRs would conflict with each other).

| Ship | SP | Change |
|------|----|--------|
| **Malvex** | A | New `self-shielded` `IncomingCondition` + required `victimHasShield` ctx field (7 engine sites) — 10% less damage while it holds a shield |
| **Voron** | A | DoT-scoped incoming-reduction (`scope:'dot'`, `condition:'always'`) — 20% less DoT damage |
| **Paracelsus** | B | `on-destroyed` HP-scaled retaliation (50% max HP) + Everliving Regeneration II ally-buff routed to `on-destroyed` |
| **Ravager** | B | New `on-own-debuff-resisted` inflictor-side reactive trigger — Hacking Module Overdrive on resisted-inflict |
| **Nosorog** | B | Widened `OWN_CLEANSE_TRIGGER_RE` to match "removes a Debuff" → Defense Up II rides `on-own-cleanse` |

## Notable

- **Latent engine bug fixed (Paracelsus):** the `on-destroyed` damage executor never ran for `type:'damage'` reactions — `counterTargetId` routing didn't include `'damage'`, and `applyReactiveDamage`'s owner-alive gate no-oped because `recordDestroyed` stamps `destroyedRound` before the event emits. Added a `fromOwnDeath`-gated `allowDeadOwner` bypass, narrowly scoped to on-own-death HP-basis retaliations (mirrors the existing dead-owner drain-gate exemption; Vindicator on-resist / counters / Faust provably unaffected).
- **Team-symmetry** integration tests (player + enemy side) with non-vacuity controls for all three engine-touching gaps.
- Allowlist: removed the 5 corresponding entries (kept Nosorog's `damage-reflection` harness FP).

## Verification

- Full suite green: **327 files / 4250 tests**
- `tsc --noEmit` clean, `npm run lint` 0 warnings, `npm run audit:skills` 0 findings
- Each task individually reviewed (spec + quality); final whole-branch review (Opus): ready to merge

## Out of scope

Pre-existing stale allowlist entry `Curator · ungated-effect-with-trigger` (dead since #231) — trivial separate cleanup.

Spec: `docs/superpowers/specs/2026-07-06-model-completeness-sp-ab-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)