### PR TITLE
chore(skills): drop stale Curator allowlist entry

### DIFF
--- a/scripts/auditSkills.allowlist.ts
+++ b/scripts/auditSkills.allowlist.ts
@@ -22,11 +22,6 @@ export const ALLOWLIST: AllowEntry[] = [
     // Reactive triggers (on-cleanse / on-kill / on-damaged / enemy-uses-charged / on-resist /
     // on-death) — modelled manually by the user, never auto-derived in single-ship DPS.
     {
-        ship: 'Curator',
-        rules: ['ungated-effect-with-trigger'],
-        reason: 'Reactive: when an enemy uses its Charged skill.',
-    },
-    {
         ship: 'Panon',
         rules: ['instead-replacement'],
         reason: 'Active + charged carry an "If this Unit is Provoked or Taunted, it instead gains <buff> and deals <higher>% damage" full-branch replacement (the only such shape in the corpus). Deferred (PR6b, user decision): a faithful model needs complementary/negated self-conditions AND sim damage-branch selection (the sim reads only the first damage ability) — bespoke infra for one ship. The base branch is already correct in single-ship DPS (self never Provoked/Taunted); only the combat-sim Provoked/Taunted state is imperfect. Revisit as a dedicated design if a second "instead"-branch ship appears.',


### PR DESCRIPTION
Removes the `Curator · ungated-effect-with-trigger` allowlist entry, dead since #231 (the Curator dup-emission fix routed the Block Buff onto `on-enemy-charged-cast`). `npm run audit:skills` had been flagging it as **stale** (no longer suppresses any finding).

After removal: **audit 0 findings, 0 stale warnings**. Curator's `shield-penetration-innate` entry is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)