### PR TITLE
feat(combat): model-completeness SP-C + SP-D — 8 skill-model gaps (stat-vs-target + count gates)

### DIFF
--- a/scripts/auditSkills.allowlist.ts
+++ b/scripts/auditSkills.allowlist.ts
@@ -33,12 +33,9 @@ export const ALLOWLIST: AllowEntry[] = [
     },
     // Self-HP / stat-comparison gates — not modelled (sim assumes full HP, no stat comparisons).
     // (Hermes's "If the target has less than N% HP" Cheat-Death gate is now parser-modeled —
-    // Phase 4c PR 3, detectTargetHpGate — so it no longer needs an allowlist entry.)
-    {
-        ship: 'Bayah',
-        rules: ['ungated-effect-with-trigger'],
-        reason: 'Stat comparison gate (Crit Power vs target).',
-    },
+    // Phase 4c PR 3, detectTargetHpGate — so it no longer needs an allowlist entry. Bayah's
+    // Crit-Power-vs-target Stasis gate is now parser-modeled too — SP-C, detectGrantConditions'
+    // stat-vs-target detector — so its entry is likewise removed.)
     // Niche counts / conversions / clause-split false positives.
     {
         ship: 'Belladonna',

--- a/scripts/auditSkills.allowlist.ts
+++ b/scripts/auditSkills.allowlist.ts
@@ -43,11 +43,6 @@ export const ALLOWLIST: AllowEntry[] = [
         reason: 'Crit-power extension now parsed; remaining: named-DoT count (3+ Acidic Decay → Stasis) + Corrosion→Acidic Decay conversion (team mode).',
     },
     {
-        ship: 'Berserker',
-        rules: ['ungated-effect-with-trigger'],
-        reason: 'Multi-target count ("hitting 3+ enemies").',
-    },
-    {
         ship: 'Oleander',
         rules: ['ungated-effect-with-trigger'],
         reason: 'Trigger ("per debuffed enemy") scopes the repair, not the buff.',

--- a/scripts/auditSkills.allowlist.ts
+++ b/scripts/auditSkills.allowlist.ts
@@ -38,11 +38,6 @@ export const ALLOWLIST: AllowEntry[] = [
     // stat-vs-target detector — so its entry is likewise removed.)
     // Niche counts / conversions / clause-split false positives.
     {
-        ship: 'Belladonna',
-        rules: ['ungated-effect-with-trigger'],
-        reason: 'Crit-power extension now parsed; remaining: named-DoT count (3+ Acidic Decay → Stasis) + Corrosion→Acidic Decay conversion (team mode).',
-    },
-    {
         ship: 'Oleander',
         rules: ['ungated-effect-with-trigger'],
         reason: 'Trigger ("per debuffed enemy") scopes the repair, not the buff.',

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -53,6 +53,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Berserker's Marauder Rage passives now only trigger when its attack actually hits 3 or more enemies, instead of always applying.",
     "Combat sim: Tygr's active skill now adds a Charged Skill charge only when it actually damages 2 or more enemies, instead of always granting the charge (including against a single target).",
     "Combat sim: Anemone's charged skill now gains Taunt only when the primary enemy actually has 3 or more Damage over Time effects, instead of always granting it. Belladonna's charged skill now models its \"3 or more Acidic Decay\" Stasis gate too, though it won't actually trigger in combat until the Acidic Decay status itself is added in a future update.",
+    "Combat sim: Snakeroot's passive bonus damage now actually scales with the number of Damage-over-Time effects on the target (30% per stack, up from a flat 120% regardless of stacks), instead of always applying the full amount.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -52,6 +52,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Chakara's active skill now gains a Charged Skill charge only when all damaged enemies have more Speed than her, instead of always granting the charge.",
     "Combat sim: Berserker's Marauder Rage passives now only trigger when its attack actually hits 3 or more enemies, instead of always applying.",
     "Combat sim: Tygr's active skill now adds a Charged Skill charge only when it actually damages 2 or more enemies, instead of always granting the charge (including against a single target).",
+    "Combat sim: Anemone's charged skill now gains Taunt only when the primary enemy actually has 3 or more Damage over Time effects, instead of always granting it. Belladonna's charged skill now models its \"3 or more Acidic Decay\" Stasis gate too, though it won't actually trigger in combat until the Acidic Decay status itself is added in a future update.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -47,6 +47,9 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat sim: Voron now correctly takes 20% less damage from Damage-over-Time effects.',
     "Combat sim: Nosorog's Defense Up II now triggers when it removes a debuff (previously fired on every cast).",
     'Combat sim: Malvex now takes 10% less damage while it has an active shield.',
+    "Combat sim: Bayah's charged skill now inflicts Stasis only when she has more Crit Power than the target, instead of always applying it.",
+    "Combat sim: Cobalt's active skill now deals its extra damage (25% of max HP) only when it has more HP than the enemy, instead of always applying the bonus.",
+    "Combat sim: Chakara's active skill now gains a Charged Skill charge only when all damaged enemies have more Speed than her, instead of always granting the charge.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -50,6 +50,8 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Bayah's charged skill now inflicts Stasis only when she has more Crit Power than the target, instead of always applying it.",
     "Combat sim: Cobalt's active skill now deals its extra damage (25% of max HP) only when it has more HP than the enemy, instead of always applying the bonus.",
     "Combat sim: Chakara's active skill now gains a Charged Skill charge only when all damaged enemies have more Speed than her, instead of always granting the charge.",
+    "Combat sim: Berserker's Marauder Rage passives now only trigger when its attack actually hits 3 or more enemies, instead of always applying.",
+    "Combat sim: Tygr's active skill now adds a Charged Skill charge only when it actually damages 2 or more enemies, instead of always granting the charge (including against a single target).",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -287,7 +287,15 @@ export type ConditionSubject =
     // ConditionContext.selfCritPower (runPlayerTurn's modifierCtx only); defaults to 0
     // elsewhere (no other ConditionContext builder populates it — inert/byte-identical
     // for every ship that doesn't reference this subject). Always derivable:true.
-    | 'self-crit-power';
+    | 'self-crit-power'
+    // Model-completeness SP-C: owner-vs-target stat comparison gate. `Condition.compareStat`
+    // picks the stat (crit power / speed / absolute current HP); `Condition.statComparator`
+    // the direction ('gt' = owner's stat strictly greater than target's, 'lt' = strictly less).
+    // Reads ctx.self{CritPower|Speed|CurrentHp} vs ctx.target{CritPower|Speed|CurrentHp}. DPS
+    // defaults compare the acting ship's stats against the CONFIGURED enemy (unset stat → 0);
+    // the positional engine uses real actor stats (Chakara's aggregate: targetSpeed = MIN speed
+    // among damaged enemies). Always derivable:true.
+    | 'stat-vs-target';
 
 export interface Condition {
     subject: ConditionSubject;
@@ -317,6 +325,11 @@ export interface Condition {
     /** For 'every-n-turns': the residue to match, in [0, period-1] (default 0). E.g.
      *  period 3 + offset 1 → turns 1, 4, 7, …. Out-of-range values never match. */
     offset?: number;
+    /** For 'stat-vs-target': which stat to compare (owner vs target). */
+    compareStat?: 'crit-power' | 'speed' | 'hp';
+    /** For 'stat-vs-target': direction of the OWNER-vs-target comparison.
+     *  'gt' = owner's stat strictly greater; 'lt' = owner's stat strictly less. */
+    statComparator?: 'gt' | 'lt';
 }
 
 /** Gate for a victim-side incoming-effect ability (D-PR3). Evaluated against an

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -302,7 +302,19 @@ export type ConditionSubject =
     // to 1 (the single configured enemy), so a ≥2/≥3 gate is inert (not met) in single-target DPS
     // — the faithful behaviour (Tygr genuinely doesn't add charge against a single target). The
     // positional engine live-derives the real per-cast footprint size. Always derivable:true.
-    | 'enemies-hit-this-cast';
+    | 'enemies-hit-this-cast'
+    // Model-completeness SP-D: COUNT subject — per-target DoT ENTRY count (corrosion + inferno +
+    // bomb entry-array lengths, +acidicDecay once SP-E adds it). Bare (no buffName) = the sum of
+    // ALL DoT entries, regardless of family (Anemone's charged "If the primary enemy has 3 or
+    // more Damage over Time effects" — generic). With `buffName` set = ONE named family only
+    // (Belladonna's charged "If the enemy has 3 or more Acidic Decay" — runtime-inert until SP-E
+    // actually introduces the Acidic Decay DoT family; ConditionContext.enemyDotFamilyCounts
+    // defaults every family to 0 until then, so this gate never fires yet). DoT-ONLY — distinct
+    // from `enemy-debuff`, whose legacy count also folds in landed CONTROL/marker debuffs; this
+    // subject must never be satisfied by e.g. a landed Stasis. Also a SCALING source (Snakeroot's
+    // "for every 4 stacks of damage over time" — reads the raw count, not just a gate). Always
+    // derivable:true.
+    | 'enemy-dot-count';
 
 export interface Condition {
     subject: ConditionSubject;

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -295,7 +295,14 @@ export type ConditionSubject =
     // defaults compare the acting ship's stats against the CONFIGURED enemy (unset stat → 0);
     // the positional engine uses real actor stats (Chakara's aggregate: targetSpeed = MIN speed
     // among damaged enemies). Always derivable:true.
-    | 'stat-vs-target';
+    | 'stat-vs-target'
+    // Model-completeness SP-D: COUNT subject — the number of enemies DAMAGED by THIS cast
+    // (Berserker's "gains Marauder Rage II ... when hitting 3 or more enemies"; Tygr's "if it
+    // damages 2 or more enemies, adds 1 charge"). DPS mode has no multi-target concept → defaults
+    // to 1 (the single configured enemy), so a ≥2/≥3 gate is inert (not met) in single-target DPS
+    // — the faithful behaviour (Tygr genuinely doesn't add charge against a single target). The
+    // positional engine live-derives the real per-cast footprint size. Always derivable:true.
+    | 'enemies-hit-this-cast';
 
 export interface Condition {
     subject: ConditionSubject;

--- a/src/types/calculator.ts
+++ b/src/types/calculator.ts
@@ -9,6 +9,11 @@ export type SecondaryDamageStat = 'defense' | 'hp' | 'shield';
 export interface SecondaryDamage {
     stat: SecondaryDamageStat;
     pct: number; // e.g. 80 for "80% of Defense"
+    /** SP-C — an owner-vs-target stat-comparison gate on THIS secondary-damage rider (Cobalt's
+     *  "If this Unit has more HP than the enemy, it additionally deals damage equal to 25% of
+     *  max HP"). Detected clause-scoped in parseSecondaryDamage (the rider has no buffName to
+     *  drive detectGrantConditions' scoping); undefined when the rider is unconditional. */
+    condition?: Condition;
 }
 
 export type ConditionalCondition =

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -1557,13 +1557,23 @@ describe('parseHpThresholdCondition', () => {
 });
 
 describe('parseChargeGain', () => {
-    it('parses always-true (speed) self gain — Chakara', () => {
+    it('parses the Speed-comparison self gain as a stat-vs-target gate — Chakara', () => {
         const text =
             'This Unit deals <unit-damage>180% damage</unit-damage>. If all damaged enemies have more Speed than this Unit, it <unit-aid>adds 1 charge</unit-aid> to its Charged Skill.';
+        // SP-C: 'always'/derivable is a placeholder (mirrors the Cobalt start-of-turn shape
+        // below) — the real gate rides `conditions`.
         expect(parseChargeGain(text)).toEqual({
             amount: 1,
             condition: 'always',
             derivable: true,
+            conditions: [
+                {
+                    subject: 'stat-vs-target',
+                    derivable: true,
+                    compareStat: 'speed',
+                    statComparator: 'lt',
+                },
+            ],
         });
     });
 

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -1665,13 +1665,24 @@ describe('parseChargeGain', () => {
         });
     });
 
-    it('parses "2 or more enemies" as enemy-adjacent (manual) — Tygr', () => {
+    it('parses "2 or more enemies" as a real enemies-hit-this-cast gate — Tygr', () => {
         const text =
             'If it damages 2 or more enemies, it adds <unit-aid>adds 1 charge</unit-aid> to its Charged Skill.';
+        // SP-D: 'always'/derivable is a placeholder (mirrors the Chakara stat-vs-target shape
+        // above) — the real gate rides `conditions`. Previously fell through to a coarse
+        // 'enemy-adjacent' presence-only proxy that never modeled the actual ≥2 threshold.
         expect(parseChargeGain(text)).toEqual({
             amount: 1,
-            condition: 'enemy-adjacent',
-            derivable: false,
+            condition: 'always',
+            derivable: true,
+            conditions: [
+                {
+                    subject: 'enemies-hit-this-cast',
+                    derivable: true,
+                    countComparator: 'gte',
+                    countThreshold: 2,
+                },
+            ],
         });
     });
 

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -81,8 +81,15 @@ describe('buildShipAbilities', () => {
         const charge = abilityOfType(active!.abilities, 'charge');
         expect(charge).toBeDefined();
         expect(charge!.config).toMatchObject({ type: 'charge', amount: 1 });
-        // Speed condition is classified 'always'/derivable by parseChargeGain.
-        expect(charge!.conditions[0]).toMatchObject({ subject: 'always', derivable: true });
+        // SP-C: "If all damaged enemies have more Speed than this Unit" is now modelled as a
+        // real owner-vs-target stat-comparison gate (previously fell through to the
+        // 'always'/derivable placeholder — see modelCompletenessTriage.test.ts SP-C).
+        expect(charge!.conditions[0]).toMatchObject({
+            subject: 'stat-vs-target',
+            derivable: true,
+            compareStat: 'speed',
+            statComparator: 'lt',
+        });
     });
 
     it('Cobalt passive: start-of-turn self-charge gated by full HP (Phase 3)', () => {

--- a/src/utils/abilities/__tests__/enemiesHitThisCast.test.ts
+++ b/src/utils/abilities/__tests__/enemiesHitThisCast.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { conditionMet } from '../evaluateConditions';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Skill } from '../../../types/abilities';
+import { Ship } from '../../../types/ship';
+import { makeConditionContext } from './conditionContextFixture';
+
+// Local copy of the modelCompletenessTriage.test.ts `abilitiesFor` helper (not imported —
+// importing a sibling *.test.ts file would re-register its describe/it blocks here too).
+function ship(over: Partial<Ship>): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}, {}, {}], ...over } as Ship;
+}
+function slot(skills: Skill[], name: string): Skill | undefined {
+    return skills.find((s) => s.slot === name);
+}
+function abilitiesFor(over: Partial<Ship>, name: string) {
+    return slot(buildShipAbilities(ship(over)).slots, name)?.abilities ?? [];
+}
+
+describe('enemies-hit-this-cast condition', () => {
+    it('gte 3 met only when 3+ enemies hit', () => {
+        const cond = {
+            subject: 'enemies-hit-this-cast' as const,
+            derivable: true,
+            countComparator: 'gte' as const,
+            countThreshold: 3,
+        };
+        expect(conditionMet(cond, makeConditionContext({ enemiesHitThisCast: 3 }))).toBe(true);
+        expect(conditionMet(cond, makeConditionContext({ enemiesHitThisCast: 2 }))).toBe(false);
+    });
+
+    it('defaults to 1 (single-target DPS) → gte 2 not met', () => {
+        const cond = {
+            subject: 'enemies-hit-this-cast' as const,
+            derivable: true,
+            countComparator: 'gte' as const,
+            countThreshold: 2,
+        };
+        expect(conditionMet(cond, makeConditionContext({}))).toBe(false);
+    });
+});
+
+describe('enemies-hit-this-cast — parser output (buildShipAbilities)', () => {
+    // Verbatim from docs/ship-skills.csv (second_passive_skill_text field). NOTE: CSV typo
+    // "3 ore more" preserved verbatim (not "or more").
+    const BERSERKER_P2 =
+        'This Unit gains <unit-skill>Marauder Rage II</unit-skill> for 3 turns when hitting 3 ore more enemies.';
+
+    it('Berserker passive2: Marauder Rage II buff gated on >=3 hits', () => {
+        const abilities = abilitiesFor({ secondPassiveSkillText: BERSERKER_P2 }, 'passive');
+        const rageBuff = abilities.find(
+            (a) => a.config.type === 'buff' && a.config.buffName === 'Marauder Rage II'
+        );
+        expect(
+            rageBuff?.conditions.some(
+                (c) =>
+                    c.subject === 'enemies-hit-this-cast' &&
+                    c.countComparator === 'gte' &&
+                    c.countThreshold === 3
+            )
+        ).toBe(true);
+    });
+
+    // Verbatim from docs/ship-skills.csv (active_skill_text field).
+    const TYGR_ACTIVE =
+        'This Unit deals <unit-damage>180% damage</unit-damage> and inflicts <unit-skill>Security Down II</unit-skill> for 2 turns. If it damages <unit-aid>2 or more enemies, it adds 1 charge</unit-aid> to its Charged Skill.';
+
+    it('Tygr active: self-charge-gain gated on >=2 hits (NOT enemy-adjacent)', () => {
+        const abilities = abilitiesFor({ activeSkillText: TYGR_ACTIVE }, 'active');
+        const chargeGain = abilities.find((a) => a.config.type === 'charge');
+        const tygrChargeCond = chargeGain?.conditions.find((c) => c.subject !== 'always');
+        expect(tygrChargeCond?.subject).toBe('enemies-hit-this-cast');
+        expect(tygrChargeCond?.countThreshold).toBe(2);
+    });
+});

--- a/src/utils/abilities/__tests__/enemyDotCount.test.ts
+++ b/src/utils/abilities/__tests__/enemyDotCount.test.ts
@@ -1,6 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import { conditionMet, evaluateCondition } from '../evaluateConditions';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Skill } from '../../../types/abilities';
+import { Ship } from '../../../types/ship';
 import { makeConditionContext } from './conditionContextFixture';
+
+// Local copy of the modelCompletenessTriage.test.ts `abilitiesFor` helper (not imported —
+// importing a sibling *.test.ts file would re-register its describe/it blocks here too).
+function ship(over: Partial<Ship>): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}, {}, {}], ...over } as Ship;
+}
+function slot(skills: Skill[], name: string): Skill | undefined {
+    return skills.find((s) => s.slot === name);
+}
+function abilitiesFor(over: Partial<Ship>, name: string) {
+    return slot(buildShipAbilities(ship(over)).slots, name)?.abilities ?? [];
+}
 
 // Model-completeness SP-D — `enemy-dot-count` (Anemone's generic "3+ Damage over Time effects"
 // Taunt gate, Belladonna's named "3+ Acidic Decay" Stasis gate, Snakeroot's per-stack scaling).
@@ -47,6 +63,51 @@ describe('enemy-dot-count condition', () => {
                     enemyDotCount: 5,
                     enemyDotFamilyCounts: { 'Acidic Decay': 3 },
                 })
+            )
+        ).toBe(true);
+    });
+});
+
+describe('enemy-dot-count parsing (countGateCondition DoT branch)', () => {
+    // Verbatim from docs/ship-skills.csv (charge_skill_text field) — same constant used by the
+    // SP-D Anemone triage probe.
+    const ANEMONE_CHARGE =
+        'This Unit deals <unit-damage>200% damage</unit-damage> and inflicts <unit-skill>Corrosion III</unit-skill> for 2 turns. If the primary enemy has 3 or more Damage over Time effects, this Unit gains <unit-skill>Taunt</unit-skill> for 1 turn.';
+
+    it('Anemone charged: Taunt gated on generic DoT count >=3 (drops the spurious self-buff Taunt artifact)', () => {
+        const abilities = abilitiesFor(
+            { chargeSkillText: ANEMONE_CHARGE, chargeSkillCharge: 3 },
+            'charged'
+        );
+        const taunt = abilities.find(
+            (a) => a.config.type === 'control' && a.config.effect === 'taunt'
+        );
+        expect(
+            taunt?.conditions.some(
+                (c) => c.subject === 'enemy-dot-count' && c.countThreshold === 3 && !c.buffName
+            )
+        ).toBe(true);
+    });
+
+    // Verbatim from docs/ship-skills.csv (charge_skill_text field) — same constant used by the
+    // SP-D Belladonna triage probe.
+    const BELLADONNA_CHARGE =
+        'This Unit deals <unit-damage>180% damage</unit-damage> and inflicts <unit-skill>Corrosion II</unit-skill> for 2 turns.<br />If the enemy has 3 or more <unit-skill>Acidic Decay</unit-skill>, inflict <unit-skill>Stasis</unit-skill> for 1 turn.';
+
+    it('Belladonna charged: Stasis gated on Acidic Decay count >=3', () => {
+        const abilities = abilitiesFor(
+            { chargeSkillText: BELLADONNA_CHARGE, chargeSkillCharge: 3 },
+            'charged'
+        );
+        const bellaStasis = abilities.find(
+            (a) => a.config.type === 'control' && a.config.effect === 'stasis'
+        );
+        expect(
+            bellaStasis?.conditions.some(
+                (c) =>
+                    c.subject === 'enemy-dot-count' &&
+                    c.buffName === 'Acidic Decay' &&
+                    c.countThreshold === 3
             )
         ).toBe(true);
     });

--- a/src/utils/abilities/__tests__/enemyDotCount.test.ts
+++ b/src/utils/abilities/__tests__/enemyDotCount.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { conditionMet, evaluateCondition } from '../evaluateConditions';
+import { makeConditionContext } from './conditionContextFixture';
+
+// Model-completeness SP-D — `enemy-dot-count` (Anemone's generic "3+ Damage over Time effects"
+// Taunt gate, Belladonna's named "3+ Acidic Decay" Stasis gate, Snakeroot's per-stack scaling).
+describe('enemy-dot-count condition', () => {
+    it('bare enemy-dot-count = sum of DoT entries (Anemone), gate gte 3', () => {
+        const cond = {
+            subject: 'enemy-dot-count' as const,
+            derivable: true,
+            countComparator: 'gte' as const,
+            countThreshold: 3,
+        };
+        expect(conditionMet(cond, makeConditionContext({ enemyDotCount: 3 }))).toBe(true);
+        expect(conditionMet(cond, makeConditionContext({ enemyDotCount: 2 }))).toBe(false);
+    });
+
+    it('named family filter is 0 until the family exists (Belladonna Acidic Decay inert)', () => {
+        const cond = {
+            subject: 'enemy-dot-count' as const,
+            derivable: true,
+            buffName: 'Acidic Decay',
+            countComparator: 'gte' as const,
+            countThreshold: 3,
+        };
+        expect(conditionMet(cond, makeConditionContext({ enemyDotCount: 5 }))).toBe(false); // no Acidic Decay family yet
+    });
+
+    it('as a scaling source, returns the raw DoT entry count (Snakeroot)', () => {
+        const cond = { subject: 'enemy-dot-count' as const, derivable: true };
+        expect(evaluateCondition(cond, makeConditionContext({ enemyDotCount: 8 }))).toBe(8);
+    });
+
+    it('named family filter reads enemyDotFamilyCounts when populated (post-SP-E)', () => {
+        const cond = {
+            subject: 'enemy-dot-count' as const,
+            derivable: true,
+            buffName: 'Acidic Decay',
+            countComparator: 'gte' as const,
+            countThreshold: 3,
+        };
+        expect(
+            conditionMet(
+                cond,
+                makeConditionContext({
+                    enemyDotCount: 5,
+                    enemyDotFamilyCounts: { 'Acidic Decay': 3 },
+                })
+            )
+        ).toBe(true);
+    });
+});

--- a/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
+++ b/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
@@ -299,54 +299,50 @@ describe('SP-D — count-based gates', () => {
     const BELLADONNA_CHARGE =
         'This Unit deals <unit-damage>180% damage</unit-damage> and inflicts <unit-skill>Corrosion II</unit-skill> for 2 turns.<br />If the enemy has 3 or more <unit-skill>Acidic Decay</unit-skill>, inflict <unit-skill>Stasis</unit-skill> for 1 turn.';
 
-    it.fails(
-        'Belladonna: "If the enemy has 3 or more Acidic Decay, inflict Stasis" is not gated on a named-DoT-stack-count threshold',
-        () => {
-            const abilities = abilitiesFor(
-                { chargeSkillText: BELLADONNA_CHARGE, chargeSkillCharge: 3 },
-                'charged'
-            );
-            const stasis = abilities.find(
-                (a) => a.config.type === 'control' && a.config.effect === 'stasis'
-            );
-            // GAP: SP-D — no named-DoT-stack-count ConditionSubject exists (verified:
-            // countGateCondition in skillTextParser.ts only recognises the literal words
-            // "buffs?"/"debuffs?" in its count-threshold regexes — "Acidic Decay" never matches,
-            // so this clause reaches no count-gate classifier at all). Today the Stasis inflict
-            // builds fully ungated (conditions: []). Proxy: conditions.length, 0 now, must be
-            // >0 once SP-D models the "3+ Acidic Decay stacks on target" gate.
-            expect(stasis?.conditions.length).toBeGreaterThan(0);
-        }
-    );
+    it('Belladonna: "If the enemy has 3 or more Acidic Decay, inflict Stasis" is gated on a named-DoT-stack-count threshold', () => {
+        const abilities = abilitiesFor(
+            { chargeSkillText: BELLADONNA_CHARGE, chargeSkillCharge: 3 },
+            'charged'
+        );
+        const stasis = abilities.find(
+            (a) => a.config.type === 'control' && a.config.effect === 'stasis'
+        );
+        // CLOSED (SP-D): countGateCondition now recognises "N or more Acidic Decay" and emits a
+        // real enemy-dot-count condition carrying the family name — the Stasis inflict is gated
+        // on the ACTUAL 3+ Acidic Decay threshold. Runtime-inert until SP-E introduces the Acidic
+        // Decay DoT family (enemyDotFamilyCounts defaults every family to 0 until then).
+        expect(
+            stasis?.conditions.some(
+                (c) =>
+                    c.subject === 'enemy-dot-count' &&
+                    c.buffName === 'Acidic Decay' &&
+                    c.countThreshold === 3
+            )
+        ).toBe(true);
+    });
 
     // Verbatim from docs/ship-skills.csv (charge_skill_text field).
     const ANEMONE_CHARGE =
         'This Unit deals <unit-damage>200% damage</unit-damage> and inflicts <unit-skill>Corrosion III</unit-skill> for 2 turns. If the primary enemy has 3 or more Damage over Time effects, this Unit gains <unit-skill>Taunt</unit-skill> for 1 turn.';
 
-    it.fails(
-        'Anemone: "If the primary enemy has 3 or more Damage over Time effects, gains Taunt" is not gated on a DoT-stack-count threshold',
-        () => {
-            const abilities = abilitiesFor(
-                { chargeSkillText: ANEMONE_CHARGE, chargeSkillCharge: 3 },
-                'charged'
-            );
-            const taunt = abilities.find(
-                (a) => a.config.type === 'control' && a.config.effect === 'taunt'
-            );
-            // GAP: SP-D — dry-run curiosity, NOT a clean ungated-array case: this ability already
-            // carries ONE condition, `{ subject: 'self-buff', buffName: 'Taunt', derivable: true }`
-            // — but that is a SPURIOUS artifact of an unrelated detector (skillTextParser.ts's
-            // Taunt/Provoke self-status rule matches the bare word "Taunt" anywhere in the
-            // sentence, including in the granted-effect verb "gains Taunt", not just in an actual
-            // "if this Unit is Taunted" gate). It has nothing to do with the "3+ Damage over Time
-            // effects on the primary enemy" count clause, which no ConditionSubject models today
-            // (verified against the full ConditionSubject union). Proxy: a condition whose subject
-            // is something OTHER than that spurious 'self-buff' entry — false now (only the
-            // spurious one is present), true once SP-D adds the real DoT-count gate (regardless
-            // of whether the spurious entry is also cleaned up).
-            expect(taunt?.conditions.some((c) => c.subject !== 'self-buff')).toBe(true);
-        }
-    );
+    it('Anemone: "If the primary enemy has 3 or more Damage over Time effects, gains Taunt" is gated on a DoT-stack-count threshold', () => {
+        const abilities = abilitiesFor(
+            { chargeSkillText: ANEMONE_CHARGE, chargeSkillCharge: 3 },
+            'charged'
+        );
+        const taunt = abilities.find(
+            (a) => a.config.type === 'control' && a.config.effect === 'taunt'
+        );
+        // CLOSED (SP-D): countGateCondition now recognises "N or more Damage over Time effects"
+        // and emits a real enemy-dot-count condition (no buffName — generic, sums all DoT
+        // families) BEFORE detectGrantConditions' Taunt/Provoke self-status rule ever runs, so
+        // the previously-spurious `{subject:'self-buff', buffName:'Taunt'}` artifact (matched
+        // from the bare word "Taunt" in the granted-effect verb "gains Taunt") no longer appears
+        // at all — countGateCondition returns early with the real gate instead.
+        expect(
+            taunt?.conditions.some((c) => c.subject === 'enemy-dot-count' && c.countThreshold === 3)
+        ).toBe(true);
+    });
 
     // Verbatim from docs/ship-skills.csv (second_passive_skill_text field).
     const SNAKEROOT_P2 =

--- a/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
+++ b/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
@@ -260,51 +260,38 @@ describe('SP-D — count-based gates', () => {
     const BERSERKER_P2 =
         'This Unit gains <unit-skill>Marauder Rage II</unit-skill> for 3 turns when hitting 3 ore more enemies.';
 
-    it.fails(
-        'Berserker: "gains Marauder Rage II when hitting 3 ore more enemies" is not gated on a hit-count threshold',
-        () => {
-            const abilities = abilitiesFor({ secondPassiveSkillText: BERSERKER_P2 }, 'passive');
-            const rageBuff = abilities.find(
-                (a) => a.config.type === 'buff' && a.config.buffName === 'Marauder Rage II'
-            );
-            // GAP: SP-D — no hit-count ConditionSubject exists (verified: ConditionSubject in
-            // src/types/abilities.ts has no "N enemies hit this cast" literal). Today the
-            // Marauder Rage II grant builds fully ungated (conditions: []). Proxy per the
-            // decision rule: conditions.length, 0 now, must be >0 once SP-D models the
-            // "hitting 3+ enemies" gate.
-            expect(rageBuff?.conditions.length).toBeGreaterThan(0);
-        }
-    );
+    it('Berserker: "gains Marauder Rage II when hitting 3 ore more enemies" is gated on a hit-count threshold', () => {
+        const abilities = abilitiesFor({ secondPassiveSkillText: BERSERKER_P2 }, 'passive');
+        const rageBuff = abilities.find(
+            (a) => a.config.type === 'buff' && a.config.buffName === 'Marauder Rage II'
+        );
+        // CLOSED (SP-D): detectGrantConditions now detects the hit-count clause (matching both
+        // "or" and the CSV's "ore" typo) and carries it as a real enemies-hit-this-cast/gte
+        // condition on the buff grant.
+        expect(
+            rageBuff?.conditions.some(
+                (c) =>
+                    c.subject === 'enemies-hit-this-cast' &&
+                    c.countComparator === 'gte' &&
+                    c.countThreshold === 3
+            )
+        ).toBe(true);
+    });
 
     // Verbatim from docs/ship-skills.csv (active_skill_text field).
     const TYGR_ACTIVE =
         'This Unit deals <unit-damage>180% damage</unit-damage> and inflicts <unit-skill>Security Down II</unit-skill> for 2 turns. If it damages 2 or more enemies, it adds <unit-aid>adds 1 charge</unit-aid> to its Charged Skill.';
 
-    it.fails(
-        'Tygr: "If it damages 2 or more enemies, adds 1 charge" is not gated on an actual ≥2 hit-count threshold',
-        () => {
-            const abilities = abilitiesFor({ activeSkillText: TYGR_ACTIVE }, 'active');
-            const chargeGain = abilities.find((a) => a.config.type === 'charge');
-            // GAP: SP-D — dry-run curiosity, NOT a clean FP: classifyChargeCondition
-            // (skillTextParser.ts, matching literal "damages 2") already attaches a non-default
-            // `enemy-adjacent` condition here, reusing the splash-adjacency count as a coarse
-            // presence-only proxy for "hit multiple enemies" — so the naive "a non-'always'
-            // subject is present" proxy (the one used for Chakara/Cobalt in SP-C) is ALREADY
-            // TRUE today and would be a trivially-true trap if used here. Neither call site that
-            // emits 'enemy-adjacent' (skillTextParser.ts) ever sets countComparator/countThreshold
-            // — so today ANY adjacent enemy satisfies the gate (presence, count>0), not the
-            // clause's actual "2 or more". Proxy: countThreshold on the condition, undefined now,
-            // must be set once SP-D models the real ≥N hit-count threshold.
-            // ASSUMPTION: `.find()` takes the first non-'always' condition — valid only if SP-D
-            // augments this existing single condition in place (sets countThreshold on it) rather
-            // than appending a second condition object. The charge-condition slot is single-
-            // condition today (in-place augmentation is the natural extension), so risk is low,
-            // but an append-a-second-condition fix would leave this `.find()` still pointing at
-            // the untouched original and the proxy would never flip.
-            const cond = chargeGain?.conditions.find((c) => c.subject !== 'always');
-            expect(cond?.countThreshold).toBeDefined();
-        }
-    );
+    it('Tygr: "If it damages 2 or more enemies, adds 1 charge" is gated on an actual ≥2 hit-count threshold', () => {
+        const abilities = abilitiesFor({ activeSkillText: TYGR_ACTIVE }, 'active');
+        const chargeGain = abilities.find((a) => a.config.type === 'charge');
+        // CLOSED (SP-D): parseChargeGain now routes this clause through hitCountConditionFromClause
+        // + the `conditions` escape hatch (the same mechanism Chakara's SP-C stat-vs-target gate
+        // uses) — a real enemies-hit-this-cast/gte/2 condition, replacing the old coarse
+        // 'enemy-adjacent' presence-only proxy that never modeled the actual ≥N threshold.
+        const cond = chargeGain?.conditions.find((c) => c.subject !== 'always');
+        expect(cond?.subject === 'enemies-hit-this-cast' && cond?.countThreshold === 2).toBe(true);
+    });
 
     // Verbatim from docs/ship-skills.csv (charge_skill_text field). NOTE: Belladonna also
     // appears in SP-E (Task 6) for its passive "convert Corrosion into Acidic Decay" clause —

--- a/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
+++ b/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
@@ -348,28 +348,16 @@ describe('SP-D — count-based gates', () => {
     const SNAKEROOT_P2 =
         'This Unit deals <unit-damage>120% damage</unit-damage> for every 4 stacks of damage over time inflicted on to a single enemy.';
 
-    it.fails(
-        'Snakeroot: "deals 120% damage for every 4 stacks of damage over time" is not gated/scaled on a DoT-stack count',
+    it(
+        'Snakeroot: "deals 120% damage for every 4 stacks of damage over time" is gated/scaled ' +
+            'on the enemy-dot-count entry count (SP-D, PR-D3 — closed)',
         () => {
             const abilities = abilitiesFor({ secondPassiveSkillText: SNAKEROOT_P2 }, 'passive');
-            // GAP: SP-D — this is a per-stack SCALING gate, not a binary threshold: `scaling`
-            // (ScalingRule: `{ conditionIndex, perUnit, cap? }`, a top-level Ability field) is
-            // the EXISTING type-valid mechanism for this shape (used by the self-crit-power/
-            // enemy-stealth-count/conditional-damage scaling sources). It requires BOTH a
-            // DoT-stack-count Condition (which does not exist — same gap as Belladonna/Anemone)
-            // AND a `scaling` rule referencing it. Today the sole ability this clause builds is
-            // flat: `type: 'damage'`, `config.multiplier: 120`, no `scaling` field at all
-            // (verified via dry-run dump of buildShipAbilities' output for this text — one
-            // ability, no scaling). NOT matched on `multiplier === 120`: the faithful fix may
-            // either (a) attach conditions+scaling directly to this same `type: 'damage'`
-            // ability — the parseConditionalDamage precedent (buildShipAbilities.ts ~L1186) — or
-            // (b) reshape the clause into a `type: 'modifier'` ability with a 0 base value and
-            // `scaling.perUnit` carrying the 120 (the "X% (more) damage for each <thing>"
-            // convention, buildShipAbilities.ts ~L403-420); either shape keeps `scaling` as a
-            // top-level Ability field, so the proxy below is flip-valid under both. Proxy:
-            // any damage/modifier/additional-damage-typed ability with `.scaling` defined —
-            // false now (no ability here has `.scaling`), true once SP-D models the "per 4 DoT
-            // stacks on target" scaling gate regardless of which of the two shapes it lands on.
+            // CLOSED: SP-D — attaches conditions+scaling directly to the same `type: 'damage'`
+            // ability (the parseConditionalDamage precedent, buildShipAbilities.ts), zeroing the
+            // base multiplier since the whole 120% IS the per-4-entries rate (0 entries → 0%
+            // damage) — see src/utils/abilities/__tests__/snakerootScaling.test.ts for the full
+            // build-output coverage (base-zeroing + perUnit=30 percentage-points-per-entry).
             const scaled = abilities.find(
                 (a) =>
                     (a.config.type === 'damage' ||
@@ -377,7 +365,10 @@ describe('SP-D — count-based gates', () => {
                         a.config.type === 'additional-damage') &&
                     a.scaling !== undefined
             );
-            expect(scaled).toBeDefined();
+            expect(scaled?.scaling).toBeDefined();
+            expect(scaled!.conditions[scaled!.scaling!.conditionIndex].subject).toBe(
+                'enemy-dot-count'
+            );
         }
     );
 });

--- a/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
+++ b/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
@@ -193,46 +193,39 @@ describe('SP-C — stat-comparison gates', () => {
     const BAYAH_CHARGE =
         'This Unit deals <unit-damage>150% damage</unit-damage> plus an additional amount equal to <unit-damage>30%</unit-damage> of its Defense and inflicts <unit-skill>Crit Rate Down II</unit-skill> for 2 turns. If this Unit has more Crit Power than the target, it inflicts <unit-skill>Stasis</unit-skill> for 1 turn.';
 
-    it.fails(
-        'Bayah: "If this Unit has more Crit Power than the target, inflicts Stasis" is not gated on a Crit Power comparison',
-        () => {
-            const abilities = abilitiesFor(
-                { chargeSkillText: BAYAH_CHARGE, chargeSkillCharge: 2 },
-                'charged'
-            );
-            const stasis = abilities.find(
-                (a) => a.config.type === 'control' && a.config.effect === 'stasis'
-            );
-            // GAP: SP-C — no owner-vs-target stat-comparison ConditionSubject exists yet (verified:
-            // `ConditionSubject` in src/types/abilities.ts has no "self stat greater than target
-            // stat" literal; the nearest analogues, `OutgoingCondition['amplify-vs-higher-attack']`
-            // and `HealAmpCondition['target-hp-below-self']`, are narrow single-purpose comparisons
-            // wired only to the Giant Slayer implant / heal-amp seam, not a general gate usable
-            // here). Today the Stasis inflict builds fully ungated (conditions: []). Proxy per the
-            // decision rule: conditions.length, which is 0 now and must be >0 once SP-C models the
-            // Crit-Power-vs-target gate.
-            expect(stasis?.conditions.length).toBeGreaterThan(0);
-        }
-    );
+    it('Bayah: "If this Unit has more Crit Power than the target, inflicts Stasis" is gated on a Crit Power comparison', () => {
+        const abilities = abilitiesFor(
+            { chargeSkillText: BAYAH_CHARGE, chargeSkillCharge: 2 },
+            'charged'
+        );
+        const stasis = abilities.find(
+            (a) => a.config.type === 'control' && a.config.effect === 'stasis'
+        );
+        // CLOSED (SP-C): the Stasis inflict now carries a real owner-vs-target
+        // stat-vs-target/crit-power/gt condition (detectGrantConditions' new SP-C detector).
+        expect(
+            stasis?.conditions.some(
+                (c) => c.subject === 'stat-vs-target' && c.compareStat === 'crit-power'
+            )
+        ).toBe(true);
+    });
 
     // Verbatim from docs/ship-skills.csv (active_skill_text field).
     const CHAKARA_ACTIVE =
         'This Unit deals <unit-damage>180% damage</unit-damage> with additional damage equal to <unit-damage>80%</unit-damage> of its Defense. If all damaged enemies have more Speed than this Unit, it <unit-aid>adds 1 charge</unit-aid> to its Charged Skill.';
 
-    it.fails(
-        'Chakara: "If all damaged enemies have more Speed than this Unit, adds 1 charge" is not gated on a Speed comparison',
-        () => {
-            const abilities = abilitiesFor({ activeSkillText: CHAKARA_ACTIVE }, 'active');
-            const chargeGain = abilities.find((a) => a.config.type === 'charge');
-            // GAP: SP-C — same missing-comparison-subject gap as Bayah, distinct proxy: this charge
-            // grant already carries a condition, but it's the default unconditional annotation
-            // (subject: 'always', derivable: true) applied to every auto-filled ability, NOT the
-            // "enemies have more Speed than this Unit" comparison from the clause. Proxy: assert a
-            // NON-'always' condition subject is present, false now (only 'always' present), true
-            // once SP-C adds the real Speed-comparison subject.
-            expect(chargeGain?.conditions.some((c) => c.subject !== 'always')).toBe(true);
-        }
-    );
+    it('Chakara: "If all damaged enemies have more Speed than this Unit, adds 1 charge" is gated on a Speed comparison', () => {
+        const abilities = abilitiesFor({ activeSkillText: CHAKARA_ACTIVE }, 'active');
+        const chargeGain = abilities.find((a) => a.config.type === 'charge');
+        // CLOSED (SP-C): parseChargeGain now detects the Speed-comparison clause and carries it
+        // via the existing `conditions` escape hatch (the same mechanism Cobalt's start-of-turn
+        // full-HP gate uses), instead of falling through to the 'always' placeholder.
+        expect(
+            chargeGain?.conditions.some(
+                (c) => c.subject === 'stat-vs-target' && c.compareStat === 'speed'
+            )
+        ).toBe(true);
+    });
 
     // Verbatim from docs/ship-skills.csv (active_skill_text field). NOTE: Cobalt also appears in
     // SP-G (Task 8) for its passive "adds 1 charge ... at the start of the turn if it is at full
@@ -241,24 +234,24 @@ describe('SP-C — stat-comparison gates', () => {
     const COBALT_ACTIVE =
         "This Unit purges <unit-aid>1 buff</unit-aid> from the enemy and deals <unit-damage>200% damage</unit-damage>. If this Unit has more HP than the enemy, it additionally deals <unit-damage>damage equal to 25%</unit-damage> of this Unit's max HP.";
 
-    it.fails(
-        'Cobalt: "If this Unit has more HP than the enemy, deals additional damage equal to 25% of max HP" is not gated on an HP comparison',
-        () => {
-            const abilities = abilitiesFor({ activeSkillText: COBALT_ACTIVE }, 'active');
-            const bonusDamage = abilities.find(
-                (a) =>
-                    a.config.type === 'additional-damage' &&
-                    a.config.stat === 'hp' &&
-                    a.config.pct === 25
-            );
-            // GAP: SP-C — same missing-comparison-subject gap as Bayah/Chakara. Today the 25%-max-HP
-            // additional-damage ability builds fully ungated (conditions: []). Proxy: conditions.length,
-            // 0 now, must be >0 once SP-C models the owner-HP-vs-target-HP gate. Distinct from the
-            // SP-G start-of-turn full-HP self-check on this same ship's passives (a self-only
-            // threshold, not an owner-vs-target comparison) — no overlap in mechanism.
-            expect(bonusDamage?.conditions.length).toBeGreaterThan(0);
-        }
-    );
+    it('Cobalt: "If this Unit has more HP than the enemy, deals additional damage equal to 25% of max HP" is gated on an HP comparison', () => {
+        const abilities = abilitiesFor({ activeSkillText: COBALT_ACTIVE }, 'active');
+        const bonusDamage = abilities.find(
+            (a) =>
+                a.config.type === 'additional-damage' &&
+                a.config.stat === 'hp' &&
+                a.config.pct === 25
+        );
+        // CLOSED (SP-C): parseSecondaryDamage now detects the owner-vs-target HP comparison
+        // clause preceding this rider and carries it as a real condition. Distinct from the
+        // SP-G start-of-turn full-HP self-check on this same ship's passives (a self-only
+        // threshold, not an owner-vs-target comparison) — no overlap in mechanism.
+        expect(
+            bonusDamage?.conditions.some(
+                (c) => c.subject === 'stat-vs-target' && c.compareStat === 'hp'
+            )
+        ).toBe(true);
+    });
 });
 
 describe('SP-D — count-based gates', () => {

--- a/src/utils/abilities/__tests__/snakerootScaling.test.ts
+++ b/src/utils/abilities/__tests__/snakerootScaling.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { Ability, Skill } from '../../../types/abilities';
+
+function ship(over: Partial<Ship>): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}, {}, {}], ...over } as Ship;
+}
+
+function slot(skills: Skill[], name: string): Skill | undefined {
+    return skills.find((s) => s.slot === name);
+}
+
+function abilityOfType(abilities: Ability[], type: string): Ability | undefined {
+    return abilities.find((a) => a.type === type);
+}
+
+// Verbatim from docs/ship-skills.csv (second_passive_skill_text) — Snakeroot p2. The refit-2
+// text; with the default 4-refit fixture this is the refit-active passive row.
+const SNAKEROOT_P2 =
+    'This Unit deals <unit-damage>120% damage</unit-damage> for every 4 stacks of damage over time inflicted on to a single enemy.';
+
+// Verbatim from docs/ship-skills.csv (first_passive_skill_text) — Snakeroot p1 (the R0
+// innate, same clause shape with a different rate — 100% per 7 stacks).
+const SNAKEROOT_P1 =
+    'This Unit deals <unit-damage>100% damage</unit-damage> for every 7 stacks of damage over time inflicted on to a single enemy.';
+
+describe('Snakeroot per-DoT-entry damage scaling (model-completeness SP-D, PR-D3)', () => {
+    it('"120% damage for every 4 stacks of DoT" → scaling on enemy-dot-count, base zeroed', () => {
+        const s = ship({ secondPassiveSkillText: SNAKEROOT_P2 });
+        const abilities = slot(buildShipAbilities(s).slots, 'passive')!.abilities;
+        const dmg = abilityOfType(abilities, 'damage')!;
+
+        // The whole 120% IS the per-4-entries rate — with 0 tracked DoT entries the ability
+        // deals 0% damage, so the base <unit-damage> multiplier must be zeroed, not kept flat.
+        expect(dmg.config).toMatchObject({ type: 'damage', multiplier: 0 });
+        expect(dmg.scaling).toBeDefined();
+        expect(dmg.conditions[dmg.scaling!.conditionIndex]).toMatchObject({
+            subject: 'enemy-dot-count',
+            derivable: true,
+        });
+        // No countComparator/countThreshold on the scaling-source condition — bare, so
+        // evaluateCondition returns the RAW DoT-entry count (Task 3 precedent), not a 0/1 gate.
+        expect(dmg.conditions[dmg.scaling!.conditionIndex].countComparator).toBeUndefined();
+
+        // 120% per 4 entries = 30 percentage points per entry. `enemy-dot-count` resolves to
+        // the raw INTEGER entry count (0, 1, 2, …) — the same percentage-point convention as
+        // the existing integer-count scaling precedents (Selenite's enemy-stealth-count
+        // perUnit=10, Crucialis's self-crit perUnit=75), NOT the 0..1-fraction convention
+        // reserved for the 0..100-scaled enemy-hp-pct/enemy-hp-missing-pct sources (Akula:
+        // perUnit = value/100). scaledBonus folds `count * perUnit` additively into the
+        // multiplier as percentage points (playerTurn.ts: `(effectiveMultiplier +
+        // conditionalBonusPct) / 100`), so at 4 entries this must total 120, not 1.2.
+        expect(dmg.scaling!.perUnit).toBeCloseTo(30);
+        expect(dmg.scaling!.cap).toBeUndefined();
+    });
+
+    it('sibling first-passive phrasing (100% per 7 stacks) scales identically, different rate', () => {
+        const s = ship({ firstPassiveSkillText: SNAKEROOT_P1, refits: [] });
+        const abilities = slot(buildShipAbilities(s).slots, 'passive')!.abilities;
+        const dmg = abilityOfType(abilities, 'damage')!;
+
+        expect(dmg.config).toMatchObject({ type: 'damage', multiplier: 0 });
+        expect(dmg.conditions[dmg.scaling!.conditionIndex]).toMatchObject({
+            subject: 'enemy-dot-count',
+            derivable: true,
+        });
+        expect(dmg.scaling!.perUnit).toBeCloseTo(100 / 7);
+    });
+});

--- a/src/utils/abilities/__tests__/statVsTarget.test.ts
+++ b/src/utils/abilities/__tests__/statVsTarget.test.ts
@@ -1,6 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import { conditionMet } from '../evaluateConditions';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Skill } from '../../../types/abilities';
+import { Ship } from '../../../types/ship';
 import { makeConditionContext } from './conditionContextFixture';
+
+// Local copy of the modelCompletenessTriage.test.ts `abilitiesFor` helper (not imported —
+// importing a sibling *.test.ts file would re-register its describe/it blocks here too).
+function ship(over: Partial<Ship>): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}, {}, {}], ...over } as Ship;
+}
+function slot(skills: Skill[], name: string): Skill | undefined {
+    return skills.find((s) => s.slot === name);
+}
+function abilitiesFor(over: Partial<Ship>, name: string) {
+    return slot(buildShipAbilities(ship(over)).slots, name)?.abilities ?? [];
+}
 
 describe('stat-vs-target condition', () => {
     it('crit-power gt: met when self crit power exceeds target', () => {
@@ -59,5 +75,71 @@ describe('stat-vs-target condition', () => {
             statComparator: 'gt' as const,
         };
         expect(conditionMet(cond, makeConditionContext({ selfCritPower: 150 }))).toBe(true);
+    });
+});
+
+describe('parser via buildShipAbilities', () => {
+    // Verbatim from docs/ship-skills.csv (charge_skill_text field) — same constant used by the
+    // SP-C Bayah triage probe in modelCompletenessTriage.test.ts.
+    const BAYAH_CHARGE =
+        'This Unit deals <unit-damage>150% damage</unit-damage> plus an additional amount equal to <unit-damage>30%</unit-damage> of its Defense and inflicts <unit-skill>Crit Rate Down II</unit-skill> for 2 turns. If this Unit has more Crit Power than the target, it inflicts <unit-skill>Stasis</unit-skill> for 1 turn.';
+
+    it('Bayah charged: Stasis inflict gated on crit-power gt', () => {
+        const abilities = abilitiesFor(
+            { chargeSkillText: BAYAH_CHARGE, chargeSkillCharge: 2 },
+            'charged'
+        );
+        const stasis = abilities.find(
+            (a) => a.config.type === 'control' && a.config.effect === 'stasis'
+        );
+        expect(
+            stasis?.conditions.some(
+                (c) =>
+                    c.subject === 'stat-vs-target' &&
+                    c.compareStat === 'crit-power' &&
+                    c.statComparator === 'gt'
+            )
+        ).toBe(true);
+    });
+
+    // Verbatim from docs/ship-skills.csv (active_skill_text field) — same constant used by the
+    // SP-C Cobalt triage probe.
+    const COBALT_ACTIVE =
+        "This Unit purges <unit-aid>1 buff</unit-aid> from the enemy and deals <unit-damage>200% damage</unit-damage>. If this Unit has more HP than the enemy, it additionally deals <unit-damage>damage equal to 25%</unit-damage> of this Unit's max HP.";
+
+    it('Cobalt active: 25%-max-HP additional-damage gated on hp gt', () => {
+        const abilities = abilitiesFor({ activeSkillText: COBALT_ACTIVE }, 'active');
+        const bonusDamage = abilities.find(
+            (a) =>
+                a.config.type === 'additional-damage' &&
+                a.config.stat === 'hp' &&
+                a.config.pct === 25
+        );
+        expect(
+            bonusDamage?.conditions.some(
+                (c) =>
+                    c.subject === 'stat-vs-target' &&
+                    c.compareStat === 'hp' &&
+                    c.statComparator === 'gt'
+            )
+        ).toBe(true);
+    });
+
+    // Verbatim from docs/ship-skills.csv (active_skill_text field) — same constant used by the
+    // SP-C Chakara triage probe.
+    const CHAKARA_ACTIVE =
+        'This Unit deals <unit-damage>180% damage</unit-damage> with additional damage equal to <unit-damage>80%</unit-damage> of its Defense. If all damaged enemies have more Speed than this Unit, it <unit-aid>adds 1 charge</unit-aid> to its Charged Skill.';
+
+    it('Chakara active: self-charge-gain gated on speed lt', () => {
+        const abilities = abilitiesFor({ activeSkillText: CHAKARA_ACTIVE }, 'active');
+        const chargeGain = abilities.find((a) => a.config.type === 'charge');
+        expect(
+            chargeGain?.conditions.some(
+                (c) =>
+                    c.subject === 'stat-vs-target' &&
+                    c.compareStat === 'speed' &&
+                    c.statComparator === 'lt'
+            )
+        ).toBe(true);
     });
 });

--- a/src/utils/abilities/__tests__/statVsTarget.test.ts
+++ b/src/utils/abilities/__tests__/statVsTarget.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { conditionMet } from '../evaluateConditions';
+import { makeConditionContext } from './conditionContextFixture';
+
+describe('stat-vs-target condition', () => {
+    it('crit-power gt: met when self crit power exceeds target', () => {
+        const cond = {
+            subject: 'stat-vs-target' as const,
+            derivable: true,
+            compareStat: 'crit-power' as const,
+            statComparator: 'gt' as const,
+        };
+        expect(
+            conditionMet(cond, makeConditionContext({ selfCritPower: 150, targetCritPower: 100 }))
+        ).toBe(true);
+        expect(
+            conditionMet(cond, makeConditionContext({ selfCritPower: 100, targetCritPower: 150 }))
+        ).toBe(false);
+    });
+    it('speed lt: met when self speed is below target (Chakara)', () => {
+        const cond = {
+            subject: 'stat-vs-target' as const,
+            derivable: true,
+            compareStat: 'speed' as const,
+            statComparator: 'lt' as const,
+        };
+        expect(conditionMet(cond, makeConditionContext({ selfSpeed: 40, targetSpeed: 60 }))).toBe(
+            true
+        );
+        expect(conditionMet(cond, makeConditionContext({ selfSpeed: 60, targetSpeed: 40 }))).toBe(
+            false
+        );
+    });
+    it('hp gt: uses ABSOLUTE current HP, not percentage (Cobalt)', () => {
+        const cond = {
+            subject: 'stat-vs-target' as const,
+            derivable: true,
+            compareStat: 'hp' as const,
+            statComparator: 'gt' as const,
+        };
+        expect(
+            conditionMet(
+                cond,
+                makeConditionContext({ selfCurrentHp: 50000, targetCurrentHp: 18000 })
+            )
+        ).toBe(true);
+        expect(
+            conditionMet(
+                cond,
+                makeConditionContext({ selfCurrentHp: 10000, targetCurrentHp: 18000 })
+            )
+        ).toBe(false);
+    });
+    it('unset target stat defaults to 0 (crit power: no enemy field → gate met)', () => {
+        const cond = {
+            subject: 'stat-vs-target' as const,
+            derivable: true,
+            compareStat: 'crit-power' as const,
+            statComparator: 'gt' as const,
+        };
+        expect(conditionMet(cond, makeConditionContext({ selfCritPower: 150 }))).toBe(true);
+    });
+});

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -30,6 +30,7 @@ import {
     parseShieldStrip,
     parseConditionalDamage,
     parseEnemyEffectDamageBonus,
+    parseDotEntryDamageScaling,
     parseConditionalStasisApplied,
     parseChargeGain,
     parseAllyChargeOnEnemyDeath,
@@ -1290,6 +1291,32 @@ function abilitiesFromText(
                 perUnit: enemyBonus.pct,
                 cap: enemyBonus.pct,
             };
+        }
+    }
+
+    // SP-D (Task 4/PR-D3): "deals X% damage for every N stacks of damage over time inflicted
+    // on[to] a single enemy" (Snakeroot p1/p2) — an OPEN-ENDED per-DoT-entry SCALING multiplier.
+    // Unlike the enemy-effect BONUS above (a flat, capped add-on to a standing base), the WHOLE
+    // X% here IS the per-N-entries rate, so the base multiplier this row's <unit-damage> tag
+    // parsed into `mult` must be zeroed and replaced entirely by the scaling bonus (0 tracked
+    // DoT entries → 0% damage). Attaches a bare `enemy-dot-count` condition (Task 3) as the
+    // scaling source — bare so `evaluateCondition` returns the raw entry count, not a
+    // threshold-gated 0/1 (see docs/model-completeness-triage… SP-D). Only when no scaling was
+    // attached above (mirrors the other conditional-scaling attach points' precedence).
+    if (
+        out[0]?.ability.type === 'damage' &&
+        out[0].ability.config.type === 'damage' &&
+        !out[0].ability.scaling
+    ) {
+        const dotScaling = parseDotEntryDamageScaling(text);
+        if (dotScaling) {
+            const idx = out[0].ability.conditions.length;
+            out[0].ability.conditions = [
+                ...out[0].ability.conditions,
+                { subject: 'enemy-dot-count', derivable: true },
+            ];
+            out[0].ability.config.multiplier = 0;
+            out[0].ability.scaling = { conditionIndex: idx, perUnit: dotScaling.perUnit };
         }
     }
 

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -1159,7 +1159,10 @@ function abilitiesFromText(
                 type: 'additional-damage',
                 target: 'enemy',
                 trigger: 'on-cast',
-                conditions: [],
+                // SP-C: Cobalt's "If this Unit has more HP than the enemy, it additionally
+                // deals …" owner-vs-target gate, detected clause-scoped by parseSecondaryDamage
+                // (sec.condition). Unconditional riders (the common case) get [].
+                conditions: sec.condition ? [sec.condition] : [],
                 config: { type: 'additional-damage', stat: sec.stat, pct: sec.pct },
                 autoFilled: true,
             },

--- a/src/utils/abilities/evaluateConditions.ts
+++ b/src/utils/abilities/evaluateConditions.ts
@@ -89,6 +89,18 @@ export interface ConditionContext {
      *  enemies" gates). Default 1 (DPS single-target mode — a ≥2/≥3 gate is inert, the faithful
      *  behaviour). Live-derived by the positional engine from the firing actor's footprint. */
     enemiesHitThisCast?: number;
+    /** SP-D — per-target DoT-ONLY entry subtotal (corrosion + inferno + bomb entry-array
+     *  lengths, +acidicDecay once SP-E adds it). Distinct from `enemyDebuffCount`, which also
+     *  folds in landed CONTROL/marker debuffs — `enemy-dot-count` must never be satisfied by a
+     *  non-DoT debuff (e.g. Stasis). Default 0 (DPS-safe / no DoTs). Derived by buildRoundContext
+     *  from the SAME corrosionEntryCount/infernoEntryCount/bombCount already threaded through the
+     *  funnel for `enemyDebuffCount` — no new engine seam required. */
+    enemyDotCount?: number;
+    /** SP-D — optional per-family DoT entry count lookup, for `enemy-dot-count` conditions that
+     *  carry a `buffName` (Belladonna's "3+ Acidic Decay"). Absent/missing family → 0 (the
+     *  Acidic Decay DoT family does not exist until SP-E introduces it, so Belladonna's gate is
+     *  runtime-inert today by design, not a bug). */
+    enemyDotFamilyCounts?: Record<string, number>;
 }
 
 /** Resolve one condition to a count (>= 0). 0 means "not met". */
@@ -137,6 +149,9 @@ export function evaluateCondition(cond: Condition, ctx: ConditionContext): numbe
             return ctx.selfCritPower ?? 0;
         case 'enemies-hit-this-cast':
             return ctx.enemiesHitThisCast ?? 1;
+        case 'enemy-dot-count':
+            if (cond.buffName) return ctx.enemyDotFamilyCounts?.[cond.buffName] ?? 0;
+            return ctx.enemyDotCount ?? 0;
         case 'stat-vs-target': {
             const self =
                 cond.compareStat === 'crit-power'

--- a/src/utils/abilities/evaluateConditions.ts
+++ b/src/utils/abilities/evaluateConditions.ts
@@ -85,6 +85,10 @@ export interface ConditionContext {
     selfCurrentHp?: number;
     /** SP-C — target's ABSOLUTE current HP (not %). Default 0. DPS: configured enemyHp. */
     targetCurrentHp?: number;
+    /** SP-D — the number of enemies DAMAGED by THIS cast (Berserker/Tygr's "hitting N or more
+     *  enemies" gates). Default 1 (DPS single-target mode — a ≥2/≥3 gate is inert, the faithful
+     *  behaviour). Live-derived by the positional engine from the firing actor's footprint. */
+    enemiesHitThisCast?: number;
 }
 
 /** Resolve one condition to a count (>= 0). 0 means "not met". */
@@ -131,6 +135,8 @@ export function evaluateCondition(cond: Condition, ctx: ConditionContext): numbe
             return ctx.stealthedEnemyCount ?? 0;
         case 'self-crit-power':
             return ctx.selfCritPower ?? 0;
+        case 'enemies-hit-this-cast':
+            return ctx.enemiesHitThisCast ?? 1;
         case 'stat-vs-target': {
             const self =
                 cond.compareStat === 'crit-power'

--- a/src/utils/abilities/evaluateConditions.ts
+++ b/src/utils/abilities/evaluateConditions.ts
@@ -72,6 +72,19 @@ export interface ConditionContext {
      *  critDamage itself). Defaults to 0 everywhere else (DPS-safe: no other ConditionContext
      *  builder populates it, so it's inert for every ship besides Wildfire). */
     selfCritPower?: number;
+    /** SP-C — the acting unit's target's effective crit power. Default 0 (no enemy crit-power
+     *  config in DPS → an owner with any crit power out-competes it). Live-derived in the engine. */
+    targetCritPower?: number;
+    /** SP-C — the acting unit's own Speed. Default 0. Live-derived (ship stat / real actor). */
+    selfSpeed?: number;
+    /** SP-C — comparison target Speed. DPS: configured enemySpeed. Positional: MIN Speed among
+     *  damaged enemies (Chakara "all damaged enemies have more Speed"). Default 0. */
+    targetSpeed?: number;
+    /** SP-C — the acting unit's ABSOLUTE current HP (not %). Default 0. DPS: ship max HP
+     *  (full-HP assumption). Live-derived in the engine. */
+    selfCurrentHp?: number;
+    /** SP-C — target's ABSOLUTE current HP (not %). Default 0. DPS: configured enemyHp. */
+    targetCurrentHp?: number;
 }
 
 /** Resolve one condition to a count (>= 0). 0 means "not met". */
@@ -118,6 +131,21 @@ export function evaluateCondition(cond: Condition, ctx: ConditionContext): numbe
             return ctx.stealthedEnemyCount ?? 0;
         case 'self-crit-power':
             return ctx.selfCritPower ?? 0;
+        case 'stat-vs-target': {
+            const self =
+                cond.compareStat === 'crit-power'
+                    ? (ctx.selfCritPower ?? 0)
+                    : cond.compareStat === 'speed'
+                      ? (ctx.selfSpeed ?? 0)
+                      : (ctx.selfCurrentHp ?? 0);
+            const target =
+                cond.compareStat === 'crit-power'
+                    ? (ctx.targetCritPower ?? 0)
+                    : cond.compareStat === 'speed'
+                      ? (ctx.targetSpeed ?? 0)
+                      : (ctx.targetCurrentHp ?? 0);
+            return (cond.statComparator === 'lt' ? self < target : self > target) ? 1 : 0;
+        }
         case 'hp-threshold':
             return evalHpThreshold(cond, ctx) ? 1 : 0;
         // HP-percentage counts: the enemy's current/missing HP% (0..100). Used as

--- a/src/utils/abilities/roundContext.ts
+++ b/src/utils/abilities/roundContext.ts
@@ -77,6 +77,10 @@ export function buildRoundContext(state: {
      *  empty/whiffed footprint — and is NOT re-defaulted here). See
      *  ConditionContext.enemiesHitThisCast. */
     enemiesHitThisCast?: number;
+    /** SP-D — optional per-family DoT entry count lookup (Belladonna's named "3+ Acidic Decay"
+     *  gate). Default undefined (no family tracking today — every family reads 0 via
+     *  ConditionContext.enemyDotFamilyCounts' own fallback). See ConditionContext.enemyDotFamilyCounts. */
+    enemyDotFamilyCounts?: Record<string, number>;
 }): ConditionContext {
     return {
         selfBuffNames: state.selfBuffNames,
@@ -111,6 +115,13 @@ export function buildRoundContext(state: {
         selfCurrentHp: state.selfCurrentHp ?? 0,
         targetCurrentHp: state.targetCurrentHp ?? 0,
         enemiesHitThisCast: state.enemiesHitThisCast ?? 1,
+        // SP-D — DoT-ONLY subtotal, derived from the SAME entry counts already folded into
+        // enemyDebuffCount above. Deliberately excludes landedEnemyDebuffCount (control/marker
+        // debuffs) — that is the whole DoT-ONLY point of this subject vs `enemy-debuff`.
+        enemyDotCount: state.corrosionEntryCount + state.infernoEntryCount + state.bombCount,
+        ...(state.enemyDotFamilyCounts !== undefined
+            ? { enemyDotFamilyCounts: state.enemyDotFamilyCounts }
+            : {}),
         ...(state.roundCrit !== undefined ? { roundCrit: state.roundCrit } : {}),
         // Sentinel spread (sub-project I, PR I1): only set the key when the caller passed a
         // real array — an explicit `undefined` value would collapse to the same runtime

--- a/src/utils/abilities/roundContext.ts
+++ b/src/utils/abilities/roundContext.ts
@@ -62,6 +62,16 @@ export function buildRoundContext(state: {
      *  power known to this caller — DPS-safe / inert for every ship besides Wildfire). Only
      *  runPlayerTurn's modifierCtx passes a real value. See ConditionContext.selfCritPower. */
     selfCritPower?: number;
+    /** SP-C — target's crit power. Default 0 (no enemy crit-power config). */
+    targetCritPower?: number;
+    /** SP-C — owner Speed. Default 0. */
+    selfSpeed?: number;
+    /** SP-C — comparison target Speed (DPS: enemySpeed; engine: min damaged-enemy speed). Default 0. */
+    targetSpeed?: number;
+    /** SP-C — owner absolute current HP. Default 0 (DPS callers pass ship max HP). */
+    selfCurrentHp?: number;
+    /** SP-C — target absolute current HP (DPS: enemyHp). Default 0. */
+    targetCurrentHp?: number;
 }): ConditionContext {
     return {
         selfBuffNames: state.selfBuffNames,
@@ -90,6 +100,11 @@ export function buildRoundContext(state: {
         turnsTaken: state.turnsTaken ?? 0,
         stealthedEnemyCount: state.stealthedEnemyCount ?? 0,
         selfCritPower: state.selfCritPower ?? 0,
+        targetCritPower: state.targetCritPower ?? 0,
+        selfSpeed: state.selfSpeed ?? 0,
+        targetSpeed: state.targetSpeed ?? 0,
+        selfCurrentHp: state.selfCurrentHp ?? 0,
+        targetCurrentHp: state.targetCurrentHp ?? 0,
         ...(state.roundCrit !== undefined ? { roundCrit: state.roundCrit } : {}),
         // Sentinel spread (sub-project I, PR I1): only set the key when the caller passed a
         // real array — an explicit `undefined` value would collapse to the same runtime

--- a/src/utils/abilities/roundContext.ts
+++ b/src/utils/abilities/roundContext.ts
@@ -72,6 +72,11 @@ export function buildRoundContext(state: {
     selfCurrentHp?: number;
     /** SP-C — target absolute current HP (DPS: enemyHp). Default 0. */
     targetCurrentHp?: number;
+    /** SP-D — number of enemies damaged by this cast. Default 1 (DPS single-target mode).
+     *  Positional callers pass the real per-cast footprint size (0 is a real value — an
+     *  empty/whiffed footprint — and is NOT re-defaulted here). See
+     *  ConditionContext.enemiesHitThisCast. */
+    enemiesHitThisCast?: number;
 }): ConditionContext {
     return {
         selfBuffNames: state.selfBuffNames,
@@ -105,6 +110,7 @@ export function buildRoundContext(state: {
         targetSpeed: state.targetSpeed ?? 0,
         selfCurrentHp: state.selfCurrentHp ?? 0,
         targetCurrentHp: state.targetCurrentHp ?? 0,
+        enemiesHitThisCast: state.enemiesHitThisCast ?? 1,
         ...(state.roundCrit !== undefined ? { roundCrit: state.roundCrit } : {}),
         // Sentinel spread (sub-project I, PR I1): only set the key when the caller passed a
         // real array — an explicit `undefined` value would collapse to the same runtime

--- a/src/utils/combat/__tests__/abilityStatusGating.test.ts
+++ b/src/utils/combat/__tests__/abilityStatusGating.test.ts
@@ -94,3 +94,34 @@ describe('liveGateConditions — not-hit-this-round (D-PR8)', () => {
         expect(out[0].subject).toBe('not-hit-this-round');
     });
 });
+
+describe('liveGateConditions — enemy-dot-count (SP-D)', () => {
+    // Guards the LIVE_SUBJECTS membership: if this subject is ever dropped from LIVE_SUBJECTS,
+    // Anemone's Taunt (a timed self-buff) and Belladonna's Stasis (a timed enemy debuff) would
+    // both neutralize to 'always' and fire/land unconditionally, ignoring the "3+ DoT effects"
+    // gate entirely.
+    it('keeps a derivable enemy-dot-count condition (does NOT neutralize to always)', () => {
+        const conds: Condition[] = [
+            {
+                subject: 'enemy-dot-count',
+                derivable: true,
+                countComparator: 'gte',
+                countThreshold: 3,
+            },
+        ];
+        expect(liveGateConditions(conds)).toEqual(conds);
+    });
+
+    it('keeps a derivable named-family enemy-dot-count condition (Belladonna Acidic Decay)', () => {
+        const conds: Condition[] = [
+            {
+                subject: 'enemy-dot-count',
+                derivable: true,
+                buffName: 'Acidic Decay',
+                countComparator: 'gte',
+                countThreshold: 3,
+            },
+        ];
+        expect(liveGateConditions(conds)).toEqual(conds);
+    });
+});

--- a/src/utils/combat/__tests__/enemiesHitGate.integration.test.ts
+++ b/src/utils/combat/__tests__/enemiesHitGate.integration.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect } from 'vitest';
+import { runCombat, type CombatEngineInput, type TeamActorEngineInput } from '../engine';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import type { Ability, ShipSkills } from '../../../types/abilities';
+import type { Ship } from '../../../types/ship';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { StatusEngine } from '../statusEngine';
+
+// ---------------------------------------------------------------------------
+// SP-D — Berserker's Marauder Rage II passive ("gains Marauder Rage II for 3 turns when
+// hitting 3 ore more enemies") gated live on the ACTUAL per-cast footprint size.
+//
+// Harness mirrors aoePurge.test.ts's positional two-team battle-sim (healTargetId set unlocks
+// the enemy roster; the focus needs position + parsed target so selectTurnTarget resolves a
+// REAL enemy as the anchor). Berserker's REAL production-parsed passive-2 ability (from the
+// verbatim docs/ship-skills.csv text) supplies the gated buff-grant under test; the damage
+// ability is a hand-crafted splash hit (Berserker's own "125% damage" active text carries no
+// pattern info of its own — pattern/position are encounter-level, not skill-text-derived).
+//
+// Distinct seam from Tygr's charge gate (playerTurn.ts's on-cast `ctx`): a passive-sourced
+// TIMED self-buff can only be seeded once at combat start (seedPassiveTimedStatuses, before any
+// cast has fired) unless promoted to a REACTIVE trigger — detectReactiveTrigger now routes this
+// clause to `on-deal-damage`, so the buff re-evaluates at drain time (buildDrainContext) against
+// the LIVE per-cast footprint recorded by engine.ts's enemiesHitThisCastByActor.
+// ---------------------------------------------------------------------------
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `ehg${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+
+const allPattern = (): ParsedPattern => ({ raw: 'all', shape: 'all', range: 'all', modifiers: {} });
+
+const hit = (): Ability =>
+    ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 100 } });
+
+// Verbatim from docs/ship-skills.csv (second_passive_skill_text field). NOTE: CSV typo
+// "3 ore more" preserved verbatim (not "or more") — same constant used by the SP-D
+// modelCompletenessTriage probe / enemiesHitThisCast.test.ts parser block.
+const BERSERKER_P2 =
+    'This Unit gains <unit-skill>Marauder Rage II</unit-skill> for 3 turns when hitting 3 ore more enemies.';
+
+function berserkerShip(): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return {
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        secondPassiveSkillText: BERSERKER_P2,
+    } as Ship;
+}
+
+/** Berserker's REAL production-parsed passive-2 abilities (the gated Marauder Rage II grant,
+ *  carrying the enemies-hit-this-cast/gte/3 condition + the on-deal-damage reactive trigger). */
+const berserkerPassiveAbilities = (): Ability[] => {
+    const built = buildShipAbilities(berserkerShip());
+    const passive = built.slots.find((s) => s.slot === 'passive');
+    if (!passive) throw new Error('no passive slot built from Berserker text');
+    return passive.abilities;
+};
+
+const berserkerShipSkills = (): ShipSkills =>
+    ({
+        slots: [
+            { slot: 'active', abilities: [hit()] },
+            { slot: 'passive', abilities: berserkerPassiveAbilities() },
+        ],
+    }) as ShipSkills;
+
+/** A harmless dummy enemy: no active abilities of its own (never acts meaningfully), huge HP
+ *  (never dies to the focus's splash hit), positioned so it counts toward the footprint. */
+const dummyVictim = (id: string, position: Position) => ({
+    id,
+    stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1 },
+    chargeCount: 0,
+    startCharged: false,
+    position,
+    shipSkills: { slots: [{ slot: 'active' as const, abilities: [] }] },
+});
+
+const focusBase = (enemyPositions: Position[]): CombatEngineInput => ({
+    attack: 1000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: berserkerShipSkills(),
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedTarget('front'),
+    pattern: allPattern(),
+    enemyAttackers: enemyPositions.map((p, i) => dummyVictim(`dummy-${i}`, p)),
+});
+
+const rageGranted = (enemyPositions: Position[], ownerId: string): boolean => {
+    idc = 0;
+    let engine: StatusEngine | undefined;
+    runCombat({
+        ...focusBase(enemyPositions),
+        __testTapStatusEngine: (e) => {
+            engine = e;
+        },
+    });
+    return engine!
+        .timedAbilityStatuses('self', ownerId)
+        .some((b) => b.active.buffName === 'Marauder Rage II');
+};
+
+describe('SP-D: enemies-hit-this-cast live gate — Berserker Marauder Rage II (player side)', () => {
+    it('splash hits 3 enemies → Marauder Rage II IS granted', () => {
+        expect(rageGranted(['M4', 'M3', 'M2'], 'attacker')).toBe(true);
+    });
+
+    it('splash hits only 2 enemies → Marauder Rage II is NOT granted', () => {
+        expect(rageGranted(['M4', 'M3'], 'attacker')).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Team-symmetry: the SAME gate fires when Berserker is the ENEMY attacker, splashing the
+// PLAYER team. Mirrors aoePurge.test.ts's "E3 Test B" side-symmetric harness — the focus is a
+// passive HP sink (healTargetId unlocks the enemy roster); positioned player actors (focus +
+// walked team) stand in as the enemy's footprint victims.
+// ---------------------------------------------------------------------------
+const sinkSkills = (): ShipSkills => ({ slots: [{ slot: 'active', abilities: [] }] });
+
+const berserkerEnemy = (id: string): NonNullable<CombatEngineInput['enemyAttackers']>[number] => ({
+    id,
+    stats: { attack: 1000, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 200 },
+    chargeCount: 0,
+    startCharged: false,
+    position: 'M4' as Position,
+    target: parsedTarget('front'),
+    pattern: allPattern(),
+    shipSkills: berserkerShipSkills(),
+});
+
+const playerTeamActorAt = (id: string, position: Position): TeamActorEngineInput => ({
+    id,
+    speed: 1,
+    chargeCount: 0,
+    startCharged: false,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    position,
+    target: parsedTarget('front'),
+    pattern: allPattern(),
+    walk: {
+        shipSkills: sinkSkills(),
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            hacking: 200,
+            defence: 0,
+            hp: 1_000_000_000,
+        },
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        hasChargedSkill: false,
+    },
+});
+
+const enemyRageGranted = (playerPositions: Position[]): boolean => {
+    idc = 0;
+    let engine: StatusEngine | undefined;
+    runCombat({
+        attack: 0,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: sinkSkills(),
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        healTargetId: 'attacker',
+        position: playerPositions[0],
+        target: parsedTarget('front'),
+        pattern: allPattern(),
+        teamActors: playerPositions
+            .slice(1)
+            .map((p, i) => playerTeamActorAt(`player-team-${i}`, p)),
+        enemyAttackers: [berserkerEnemy('enemy-front')],
+        __testTapStatusEngine: (e) => {
+            engine = e;
+        },
+    });
+    return engine!
+        .timedAbilityStatuses('self', 'enemy-front')
+        .some((b) => b.active.buffName === 'Marauder Rage II');
+};
+
+describe('SP-D: enemies-hit-this-cast live gate — Berserker Marauder Rage II (enemy side, team-symmetric)', () => {
+    it('an ENEMY Berserker splashing 3 positioned players IS granted Marauder Rage II', () => {
+        expect(enemyRageGranted(['M4', 'M3', 'M2'])).toBe(true);
+    });
+
+    it('an ENEMY Berserker splashing only 2 positioned players is NOT granted Marauder Rage II', () => {
+        expect(enemyRageGranted(['M4', 'M3'])).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tygr's self-charge-gain ("If it damages 2 or more enemies, it adds 1 charge to its Charged
+// Skill") — the OTHER seam (playerTurn.ts's on-cast `ctx`, gating a `type:'charge'` payload
+// ability via gateFiringAbilities, distinct from Berserker's reactive-drain seam above). DPS
+// mode has no multi-target concept → the gate defaults to 1 hit → not met (Tygr genuinely
+// doesn't add charge against a single target); a positional splash hitting 2+ enemies meets it.
+// ---------------------------------------------------------------------------
+const TYGR_ACTIVE =
+    'This Unit deals <unit-damage>180% damage</unit-damage> and inflicts <unit-skill>Security Down II</unit-skill> for 2 turns. If it damages 2 or more enemies, it adds <unit-aid>adds 1 charge</unit-aid> to its Charged Skill.';
+
+function tygrShip(): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}, {}, {}], activeSkillText: TYGR_ACTIVE } as Ship;
+}
+
+const tygrActiveAbilities = (): Ability[] => {
+    const built = buildShipAbilities(tygrShip());
+    const active = built.slots.find((s) => s.slot === 'active');
+    if (!active) throw new Error('no active slot built from Tygr text');
+    return active.abilities;
+};
+
+const tygrShipSkills = (): ShipSkills =>
+    ({ slots: [{ slot: 'active', abilities: tygrActiveAbilities() }] }) as ShipSkills;
+
+const tygrChargesAfterRound1 = (enemyPositions?: Position[]): number => {
+    const result = runCombat({
+        attack: 1000,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 5, // high cap: the +1 gain never reaches the charged-skill threshold
+        shipSkills: tygrShipSkills(),
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        // Charge accumulation is gated on hasChargedSkill (playerTurn.ts) — true here so the
+        // +1 self-charge-gain ability can actually bank toward chargeCount without the ACTUAL
+        // charged skill ever firing (5 is never reached by a single +1 gain).
+        hasChargedSkill: true,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        ...(enemyPositions
+            ? {
+                  healTargetId: 'attacker',
+                  position: 'M4' as Position,
+                  target: parsedTarget('front'),
+                  pattern: allPattern(),
+                  enemyAttackers: enemyPositions.map((p, i) => dummyVictim(`dummy-${i}`, p)),
+              }
+            : {}),
+    });
+    return result.rounds[0].charges;
+};
+
+// `hasChargedSkill: true` (required to unlock charge accumulation at all — see
+// tygrChargesAfterRound1) ALSO unlocks the baseline +1-per-active-turn cadence
+// (advanceChargeCadence, state.ts) — independent of any ability. So every scenario below
+// carries that +1 baseline; a MET enemies-hit-this-cast gate adds a further +1 on top
+// (Tygr's ability-driven gain), observable as the delta between the met/not-met cases.
+const BASELINE_CADENCE = 1;
+
+describe('SP-D: enemies-hit-this-cast live gate — Tygr self-charge-gain', () => {
+    it('single-target DPS mode: the gate defaults to 1 hit → NOT met, no ability charge gained', () => {
+        expect(tygrChargesAfterRound1()).toBe(BASELINE_CADENCE);
+    });
+
+    it('positional splash hitting 2 enemies: the gate IS met, ability charge gained on top', () => {
+        expect(tygrChargesAfterRound1(['M4', 'M3'])).toBe(BASELINE_CADENCE + 1);
+    });
+
+    it('positional splash hitting only 1 enemy: the gate is NOT met, no ability charge gained', () => {
+        expect(tygrChargesAfterRound1(['M4'])).toBe(BASELINE_CADENCE);
+    });
+});

--- a/src/utils/combat/__tests__/enemyDotCountGate.integration.test.ts
+++ b/src/utils/combat/__tests__/enemyDotCountGate.integration.test.ts
@@ -1,0 +1,252 @@
+/**
+ * SP-D engine population — Anemone's charged-skill Taunt gate ("If the primary enemy has 3
+ * or more Damage over Time effects, this Unit gains Taunt for 1 turn"), live-derived from the
+ * actual per-target DoT entry counts (corrosion + inferno + bomb).
+ *
+ * Uses Anemone's REAL production-parsed charged-slot abilities (built via `buildShipAbilities`
+ * on her verbatim charge_skill_text from docs/ship-skills.csv) so the `enemy-dot-count` condition
+ * under test is the production parser output, not a hand-written stand-in. The active slot is a
+ * hand-crafted set of DoT-inflicting abilities (Anemone's own kit only inflicts Corrosion —
+ * getting a THIRD, distinct DoT family onto the target organically would require other ships)
+ * used to seed the target's pre-existing DoT entries in round 1, so round 2's charged cast reads
+ * a real (not simulated) count via preDebuffGateCtx/postDebuffGateCtx — the SAME funnel Task 1
+ * proved for Bayah's crit-power-gated Stasis.
+ *
+ * chargeCount is set to the CAP (1): round 1 (bank 0 < cap 1) fires the active seed abilities and
+ * banks the unconditional +1 cadence; round 2 (bank 1 >= cap 1) fires the charged skill, whose
+ * gate reads the round-1 DoT entries (2-turn duration — still present) BEFORE this cast's own new
+ * Corrosion III application.
+ *
+ * Team-symmetry: the SAME gate must fire whether Anemone is the focus PLAYER attacker or an
+ * ENEMY attacker splashing a player-side target — no player/enemy branch in the implementation.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, type CombatEngineInput } from '../engine';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import type { Ability, ShipSkills } from '../../../types/abilities';
+import type { Ship } from '../../../types/ship';
+import type { StatusEngine } from '../statusEngine';
+
+// Verbatim from docs/ship-skills.csv (charge_skill_text field) — same constant used by the
+// SP-D Anemone triage probe / enemyDotCount.test.ts parser block.
+const ANEMONE_CHARGE =
+    'This Unit deals <unit-damage>200% damage</unit-damage> and inflicts <unit-skill>Corrosion III</unit-skill> for 2 turns. If the primary enemy has 3 or more Damage over Time effects, this Unit gains <unit-skill>Taunt</unit-skill> for 1 turn.';
+
+function anemoneShip(): Ship {
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        chargeSkillText: ANEMONE_CHARGE,
+        chargeSkillCharge: 3,
+    } as Ship;
+}
+
+/** Anemone's REAL production-parsed charged-slot abilities (damage + auto-filled Corrosion III +
+ *  the gated Taunt self-buff carrying the enemy-dot-count/gte/3 condition under test). */
+const anemoneChargedAbilities = (): Ability[] => {
+    const built = buildShipAbilities(anemoneShip());
+    const charged = built.slots.find((s) => s.slot === 'charged');
+    if (!charged) throw new Error('no charged slot built from Anemone text');
+    return charged.abilities;
+};
+
+type SeedDotType = 'corrosion' | 'inferno' | 'bomb';
+
+let idc = 0;
+/** Hand-crafted DoT-seeding ability (active slot): NOT Anemone's real active skill text — just
+ *  scaffolding to land a pre-existing DoT entry of the given family on the target in round 1. */
+const seedDot = (dotType: SeedDotType): Ability => ({
+    id: `seed-${dotType}-${++idc}`,
+    type: 'dot',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'dot', dotType, tier: 15, stacks: 1, duration: 2 },
+});
+
+const anemoneShipSkills = (seedDots: SeedDotType[]): ShipSkills =>
+    ({
+        slots: [
+            { slot: 'active', abilities: seedDots.map(seedDot) },
+            { slot: 'charged', abilities: anemoneChargedAbilities() },
+        ],
+    }) as ShipSkills;
+
+describe('enemy-dot-count engine gate — Anemone charged-skill Taunt (player side)', () => {
+    const tauntGranted = (seedDots: SeedDotType[]): boolean => {
+        idc = 0;
+        let engine: StatusEngine | undefined;
+        runCombat({
+            attack: 1000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 1, // cap: round 1's baseline +1 cadence reaches it → round 2 casts charged
+            shipSkills: anemoneShipSkills(seedDots),
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 2,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: true,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 100,
+            __testTapStatusEngine: (e) => {
+                engine = e;
+            },
+        });
+        return engine!
+            .timedAbilityStatuses('self', 'attacker')
+            .some((b) => b.active.buffName === 'Taunt');
+    };
+
+    it('target carries 3 pre-existing DoT entries (corrosion+inferno+bomb) → Taunt IS granted', () => {
+        expect(tauntGranted(['corrosion', 'inferno', 'bomb'])).toBe(true);
+    });
+
+    it('target carries only 2 pre-existing DoT entries → Taunt is NOT granted', () => {
+        expect(tauntGranted(['corrosion', 'inferno'])).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Team-symmetry: the SAME gate fires when Anemone is the ENEMY attacker, seeding DoTs onto and
+// then casting her charged skill against the player-side focus. Mirrors
+// statVsTargetGate.integration.test.ts's Cobalt enemy-side harness — the focus is a passive HP
+// sink (healTargetId unlocks the enemy roster) so the enemy's DoT-seeding + charged cast targets
+// a REAL CombatActor.
+// ---------------------------------------------------------------------------
+describe('enemy-dot-count engine gate — Anemone charged-skill Taunt (enemy side, team-symmetric)', () => {
+    const enemyTauntGranted = (seedDots: SeedDotType[]): boolean => {
+        idc = 0;
+        let engine: StatusEngine | undefined;
+        runCombat({
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [{ slot: 'active', abilities: [] }] } as ShipSkills,
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 2,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 1,
+            healTargetId: 'attacker',
+            enemyAttackers: [
+                {
+                    id: 'e1',
+                    stats: {
+                        attack: 1000,
+                        crit: 0,
+                        critDamage: 0,
+                        speed: 200,
+                        hp: 1_000_000_000,
+                        defence: 0,
+                    },
+                    chargeCount: 1,
+                    startCharged: false,
+                    shipSkills: anemoneShipSkills(seedDots),
+                },
+            ],
+            __testTapStatusEngine: (e) => {
+                engine = e;
+            },
+        } as CombatEngineInput);
+        return engine!
+            .timedAbilityStatuses('self', 'e1')
+            .some((b) => b.active.buffName === 'Taunt');
+    };
+
+    it('an ENEMY Anemone whose target carries 3 pre-existing DoT entries IS granted Taunt', () => {
+        expect(enemyTauntGranted(['corrosion', 'inferno', 'bomb'])).toBe(true);
+    });
+
+    it('an ENEMY Anemone whose target carries only 2 pre-existing DoT entries is NOT granted Taunt', () => {
+        expect(enemyTauntGranted(['corrosion', 'inferno'])).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Belladonna's named-family gate stays RUNTIME-INERT until SP-E introduces the Acidic Decay DoT
+// family: enemyDotFamilyCounts['Acidic Decay'] is always 0 today, so the Stasis inflict never
+// lands even when the generic DoT count (corrosion+inferno+bomb) is high. Build-output coverage
+// (the condition is actually EMITTED) lives in enemyDotCount.test.ts / modelCompletenessTriage.
+// ---------------------------------------------------------------------------
+const BELLADONNA_CHARGE =
+    'This Unit deals <unit-damage>180% damage</unit-damage> and inflicts <unit-skill>Corrosion II</unit-skill> for 2 turns.<br />If the enemy has 3 or more <unit-skill>Acidic Decay</unit-skill>, inflict <unit-skill>Stasis</unit-skill> for 1 turn.';
+
+function belladonnaShip(): Ship {
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        chargeSkillText: BELLADONNA_CHARGE,
+        chargeSkillCharge: 3,
+    } as Ship;
+}
+
+const belladonnaChargedAbilities = (): Ability[] => {
+    const built = buildShipAbilities(belladonnaShip());
+    const charged = built.slots.find((s) => s.slot === 'charged');
+    if (!charged) throw new Error('no charged slot built from Belladonna text');
+    return charged.abilities;
+};
+
+const belladonnaShipSkills = (seedDots: SeedDotType[]): ShipSkills =>
+    ({
+        slots: [
+            { slot: 'active', abilities: seedDots.map(seedDot) },
+            { slot: 'charged', abilities: belladonnaChargedAbilities() },
+        ],
+    }) as ShipSkills;
+
+describe('enemy-dot-count engine gate — Belladonna charged-skill Stasis (runtime-inert until SP-E)', () => {
+    it('even with 3 pre-existing generic DoT entries, Stasis does NOT land (Acidic Decay family count is 0 today)', () => {
+        idc = 0;
+        const result = runCombat({
+            attack: 1000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 1,
+            shipSkills: belladonnaShipSkills(['corrosion', 'inferno', 'bomb']),
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 2,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: true,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 100,
+        });
+        const round2Names = result.rounds[1].activeEnemyDebuffs.map((d) => d.buffName);
+        // SP-E enables this once the Acidic Decay DoT family actually exists.
+        expect(round2Names).not.toContain('Stasis');
+    });
+});

--- a/src/utils/combat/__tests__/statVsTargetGate.integration.test.ts
+++ b/src/utils/combat/__tests__/statVsTargetGate.integration.test.ts
@@ -1,0 +1,236 @@
+/**
+ * SP-C engine population — Cobalt's owner-vs-target HP-comparison gate ("If this Unit has
+ * more HP than the enemy, it additionally deals damage equal to 25% of its max HP").
+ *
+ * Uses the REAL parsed abilities (via `buildShipAbilities` on Cobalt's verbatim active-skill
+ * text from docs/ship-skills.csv) so the `stat-vs-target`/hp/gt condition under test is the
+ * production parser output, not a hand-written stand-in.
+ *
+ * Team-symmetry: the SAME gate must fire whether Cobalt is the focus PLAYER attacker (its
+ * `stat-vs-target` condition gates via `runPlayerTurn`'s per-cast `ctx`, fed by the DPS-mode
+ * `hp`/`enemyHp` top-level inputs) or an ENEMY attacker (the same condition gates via the
+ * SAME code path, fed by `buildTurnArgs`'s live `actor`/`enemy` CombatActor pairing — no
+ * player/enemy branch in the implementation).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, type CombatEngineInput } from '../engine';
+import { createEventBus } from '../events';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import type { Ability, ShipSkills } from '../../../types/abilities';
+import type { Ship } from '../../../types/ship';
+
+// Verbatim from docs/ship-skills.csv (active_skill_text field) — same constant used by the
+// SP-C Cobalt triage probe / statVsTarget.test.ts parser block.
+const COBALT_ACTIVE =
+    "This Unit purges <unit-aid>1 buff</unit-aid> from the enemy and deals <unit-damage>200% damage</unit-damage>. If this Unit has more HP than the enemy, it additionally deals <unit-damage>damage equal to 25%</unit-damage> of this Unit's max HP.";
+
+function cobaltShip(): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}, {}, {}], activeSkillText: COBALT_ACTIVE } as Ship;
+}
+
+/** Cobalt's REAL production-parsed active-slot abilities (damage + purge + the gated
+ *  additional-damage rider carrying the stat-vs-target/hp/gt condition under test). */
+const cobaltActiveAbilities = (): Ability[] => {
+    const built = buildShipAbilities(cobaltShip());
+    const active = built.slots.find((s) => s.slot === 'active');
+    if (!active) throw new Error('no active slot built from Cobalt text');
+    return active.abilities;
+};
+
+const cobaltShipSkills = (): ShipSkills =>
+    ({ slots: [{ slot: 'active', abilities: cobaltActiveAbilities() }] }) as ShipSkills;
+
+describe('stat-vs-target engine gate — Cobalt HP-vs-target bonus damage', () => {
+    it('player-side Cobalt: the 25%-max-HP bonus lands when its own maxHp exceeds the (dummy) enemy maxHp', () => {
+        const makeInput = (hp: number, enemyHp: number): CombatEngineInput => ({
+            attack: 1000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: cobaltShipSkills(),
+            enemyDefense: 0,
+            enemyHp,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp,
+            speed: 100,
+        });
+
+        // Base hit: 200% of 1000 attack vs 0 defence = 2000 direct damage (no crit, no defence
+        // reduction). The 25%-of-50000-maxHp bonus (12500) is far larger — a clean signal.
+        const advantaged = runCombat(makeInput(50000, 18000));
+        const disadvantaged = runCombat(makeInput(10000, 18000));
+        expect(advantaged.rounds[0].directDamage).toBeGreaterThan(10_000);
+        expect(disadvantaged.rounds[0].directDamage).toBeLessThan(3_000);
+    });
+
+    it('enemy-side Cobalt: the SAME gate fires when Cobalt is the ENEMY attacker (team-symmetry)', () => {
+        // The focus PLAYER is the passive heal-target sink (huge HP, no offense of its own beyond
+        // a token basic attack) so runCombat unlocks the enemy roster (healTargetId requirement)
+        // and the enemy attacker's turn targets it as a REAL CombatActor (real currentHp/stats.hp).
+        const basicAttack: ShipSkills = {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'p-a',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 10 },
+                        },
+                    ],
+                },
+            ],
+        } as ShipSkills;
+
+        const makeInput = (cobaltHp: number, playerHp: number): CombatEngineInput => ({
+            attack: 1000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: basicAttack,
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000, // the DPS-dummy the player's own basic attack pokes; irrelevant
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: playerHp,
+            speed: 200, // focus acts first so it has a last-turn ctx before the enemy's cast
+            healTargetId: 'attacker',
+            enemyAttackers: [
+                {
+                    id: 'e1',
+                    stats: {
+                        attack: 1000,
+                        crit: 0,
+                        critDamage: 0,
+                        speed: 40,
+                        hp: cobaltHp,
+                        defence: 0,
+                    },
+                    chargeCount: 0,
+                    startCharged: false,
+                    shipSkills: cobaltShipSkills(),
+                },
+            ],
+        });
+
+        const events = (input: CombatEngineInput) => {
+            const collected: number[] = [];
+            const bus = createEventBus();
+            bus.on('ability-performed', (e) => {
+                if (
+                    e.type === 'ability-performed' &&
+                    e.actorId === 'e1' &&
+                    e.abilityType === 'damage'
+                ) {
+                    collected.push(e.damage ?? 0);
+                }
+            });
+            runCombat({ ...input, bus });
+            return collected;
+        };
+
+        const advantaged = events(makeInput(50000, 18000));
+        const disadvantaged = events(makeInput(10000, 18000));
+        expect(advantaged[0]).toBeGreaterThan(10_000);
+        expect(disadvantaged[0]).toBeLessThan(3_000);
+    });
+});
+
+// Verbatim from docs/ship-skills.csv (charge_skill_text field) — same constant used by the
+// SP-C Bayah triage probe / statVsTarget.test.ts parser block.
+const BAYAH_CHARGE =
+    'This Unit deals <unit-damage>150% damage</unit-damage> plus an additional amount equal to <unit-damage>30%</unit-damage> of its Defense and inflicts <unit-skill>Crit Rate Down II</unit-skill> for 2 turns. If this Unit has more Crit Power than the target, it inflicts <unit-skill>Stasis</unit-skill> for 1 turn.';
+
+function bayahShip(): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return {
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        chargeSkillText: BAYAH_CHARGE,
+        chargeSkillCharge: 2,
+    } as Ship;
+}
+
+const bayahChargedAbilities = (): Ability[] => {
+    const built = buildShipAbilities(bayahShip());
+    const charged = built.slots.find((s) => s.slot === 'charged');
+    if (!charged) throw new Error('no charged slot built from Bayah text');
+    return charged.abilities;
+};
+
+const bayahShipSkills = (): ShipSkills =>
+    ({ slots: [{ slot: 'charged', abilities: bayahChargedAbilities() }] }) as ShipSkills;
+
+describe('stat-vs-target engine gate — Bayah crit-power-vs-target Stasis inflict', () => {
+    it('the ACTUAL Stasis timed-debuff application (not just the control-applied reaction) is gated on crit power', () => {
+        // Distinct seam from Cobalt's additional-damage gate: Bayah's Stasis is BOTH a
+        // `type:'control'` ability (gates via runPlayerTurn's payload `ctx`, driving the
+        // `control-applied` reaction event) AND a named timed ENEMY DEBUFF (gates via the
+        // EARLIER `preDebuffGateCtx`, which actually lands/removes the status). Reading
+        // RoundData.activeEnemyDebuffs (the reliable per-round landed-debuff source used
+        // elsewhere in this suite) proves the real effect landed, not just the event.
+        const makeInput = (critDamage: number): CombatEngineInput => ({
+            attack: 1000,
+            crit: 0,
+            critDamage,
+            defensePenetration: 0,
+            chargeCount: 2,
+            shipSkills: bayahShipSkills(),
+            enemyDefense: 0,
+            enemyHp: 1_000_000,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: true,
+            startCharged: true,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 10_000,
+            speed: 100,
+        });
+
+        // The DPS-dummy enemy always has critDamage 0 (no enemy crit-power config) — any
+        // positive self critDamage exceeds it.
+        const advantaged = runCombat(makeInput(200));
+        const advantagedNames = advantaged.rounds[0].activeEnemyDebuffs.map((d) => d.buffName);
+        expect(advantagedNames).toContain('Stasis');
+
+        // Gate-flip control: self critDamage 0 vs the dummy's hardcoded 0 → NOT strictly
+        // greater → Stasis absent (Crit Rate Down II, the unconditional co-debuff, still lands).
+        const disadvantaged = runCombat(makeInput(0));
+        const disadvantagedNames = disadvantaged.rounds[0].activeEnemyDebuffs.map(
+            (d) => d.buffName
+        );
+        expect(disadvantagedNames).not.toContain('Stasis');
+        expect(disadvantagedNames).toContain('Crit Rate Down II');
+    });
+});

--- a/src/utils/combat/__tests__/statVsTargetGate.integration.test.ts
+++ b/src/utils/combat/__tests__/statVsTargetGate.integration.test.ts
@@ -234,3 +234,66 @@ describe('stat-vs-target engine gate — Bayah crit-power-vs-target Stasis infli
         expect(disadvantagedNames).toContain('Crit Rate Down II');
     });
 });
+
+// Verbatim from docs/ship-skills.csv (active_skill_text field) — same constant used by the
+// SP-C Chakara triage probe / statVsTarget.test.ts parser block.
+const CHAKARA_ACTIVE =
+    'This Unit deals <unit-damage>180% damage</unit-damage> with additional damage equal to <unit-damage>80%</unit-damage> of its Defense. If all damaged enemies have more Speed than this Unit, it <unit-aid>adds 1 charge</unit-aid> to its Charged Skill.';
+
+function chakaraShip(): Ship {
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        activeSkillText: CHAKARA_ACTIVE,
+    } as Ship;
+}
+
+const chakaraActiveAbilities = (): Ability[] => {
+    const built = buildShipAbilities(chakaraShip());
+    const active = built.slots.find((s) => s.slot === 'active');
+    if (!active) throw new Error('no active slot built from Chakara text');
+    return active.abilities;
+};
+
+const chakaraShipSkills = (): ShipSkills =>
+    ({ slots: [{ slot: 'active', abilities: chakaraActiveAbilities() }] }) as ShipSkills;
+
+describe('stat-vs-target engine gate — Chakara speed-vs-target charge gain', () => {
+    it('the charge gain lands only when the (dummy) enemy is faster than Chakara', () => {
+        // chargeCount kept high so the ship never actually reaches its charged skill (stays on
+        // 'active' every round) — isolating the charge-count delta as the only observable signal.
+        const makeInput = (speed: number, enemySpeed: number): CombatEngineInput => ({
+            attack: 1000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 5,
+            shipSkills: chakaraShipSkills(),
+            enemyDefense: 0,
+            enemyHp: 1_000_000,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: true,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 10_000,
+            speed,
+            enemySpeed,
+        });
+
+        // Both runs bank the engine's unconditional per-turn charge (advanceChargeCadence) —
+        // Chakara's ability grant is an ADDITIONAL +1 on top of that baseline, only when the
+        // gate is met. Slower than the enemy (enemy has MORE Speed) → gate met → baseline + 1.
+        const advantaged = runCombat(makeInput(40, 60));
+        // Chakara faster than the enemy → gate NOT met → baseline only.
+        const disadvantaged = runCombat(makeInput(60, 40));
+        expect(advantaged.rounds[0].charges).toBe(disadvantaged.rounds[0].charges + 1);
+    });
+});

--- a/src/utils/combat/__tests__/statVsTargetGate.integration.test.ts
+++ b/src/utils/combat/__tests__/statVsTargetGate.integration.test.ts
@@ -167,8 +167,8 @@ const BAYAH_CHARGE =
     'This Unit deals <unit-damage>150% damage</unit-damage> plus an additional amount equal to <unit-damage>30%</unit-damage> of its Defense and inflicts <unit-skill>Crit Rate Down II</unit-skill> for 2 turns. If this Unit has more Crit Power than the target, it inflicts <unit-skill>Stasis</unit-skill> for 1 turn.';
 
 function bayahShip(): Ship {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ...({} as any),
         refits: [{}, {}, {}, {}],
         chargeSkillText: BAYAH_CHARGE,

--- a/src/utils/combat/abilityStatusGating.ts
+++ b/src/utils/combat/abilityStatusGating.ts
@@ -32,6 +32,13 @@ const LIVE_SUBJECTS: ReadonlySet<ConditionSubject> = new Set([
     // by the engine drain context's turnsTakenFor delegate). Evaluated literally so the modulo
     // period gate fires only when turnsTaken % period === offset.
     'every-n-turns',
+    // SP-C: owner-vs-target stat comparison is live-derivable from the acting actor's own
+    // stats vs its target's (ConditionContext.self{CritPower|Speed|CurrentHp}/target{...},
+    // populated by playerTurn.ts's preDebuffGateCtx/postDebuffGateCtx/ctx). Needed here for
+    // Bayah's crit-power-gated Stasis INFLICT — a named timed enemy debuff, gated at
+    // application via this liveGateConditions rewrite, not just the payload `ctx` that drives
+    // the `type:'control'` ability's `control-applied` reaction event.
+    'stat-vs-target',
 ]);
 
 /**

--- a/src/utils/combat/abilityStatusGating.ts
+++ b/src/utils/combat/abilityStatusGating.ts
@@ -47,6 +47,15 @@ const LIVE_SUBJECTS: ReadonlySet<ConditionSubject> = new Set([
     // trigger (a passive-sourced timed self-buff can otherwise only be seeded once at combat
     // start, before any cast has happened — see seedPassiveTimedStatuses).
     'enemies-hit-this-cast',
+    // SP-D: per-target DoT-only entry count is live-derivable — buildRoundContext derives
+    // ConditionContext.enemyDotCount from the SAME corrosionEntryCount/infernoEntryCount/
+    // bombCount already threaded through preDebuffGateCtx/postDebuffGateCtx (populated at cast
+    // time by playerTurn.ts's ctx builders, and at reactive drain time by
+    // buildDrainContext/buildActorConditionContext). Needed here for Anemone's Taunt (a timed
+    // SELF-buff gated on "3+ Damage over Time effects on the primary enemy") and Belladonna's
+    // Stasis (a timed ENEMY debuff gated on "3+ Acidic Decay") — without this, both conditions
+    // would be neutralized to 'always' and grant/inflict unconditionally.
+    'enemy-dot-count',
 ]);
 
 /**

--- a/src/utils/combat/abilityStatusGating.ts
+++ b/src/utils/combat/abilityStatusGating.ts
@@ -39,6 +39,14 @@ const LIVE_SUBJECTS: ReadonlySet<ConditionSubject> = new Set([
     // application via this liveGateConditions rewrite, not just the payload `ctx` that drives
     // the `type:'control'` ability's `control-applied` reaction event.
     'stat-vs-target',
+    // SP-D: number of enemies damaged by this cast is live-derivable — the positional engine
+    // knows the firing actor's per-cast footprint size (ConditionContext.enemiesHitThisCast,
+    // populated at reactive drain time by buildDrainContext/buildActorConditionContext, and at
+    // cast time by playerTurn.ts's ctx builders). Needed here for Berserker's Marauder Rage I/II
+    // — a timed self-buff gated on "hitting 3+ enemies", drained via the on-deal-damage reactive
+    // trigger (a passive-sourced timed self-buff can otherwise only be seeded once at combat
+    // start, before any cast has happened — see seedPassiveTimedStatuses).
+    'enemies-hit-this-cast',
 ]);
 
 /**

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -1848,6 +1848,17 @@ export function runCombat(input: CombatEngineInput): {
     // The focus actor's ctx feeds the row exactly as the old single `lastAttackerCtx` did. An
     // entry whose applier has not yet acted this run (faster-enemy round 1) has no ctx → skip.
     const lastTurnCtxByActor = new Map<string, PlayerRoundCtx>();
+    // SP-D: per-actor count of enemies DAMAGED by that actor's most recent cast this round,
+    // for the `enemies-hit-this-cast` gate at REACTIVE drain time (Berserker's Marauder Rage,
+    // drained via the on-deal-damage trigger — a passive-sourced timed self-buff can otherwise
+    // only be seeded once at combat start, before any cast has fired). Sourced from the SAME
+    // `aoeVictimIds` footprint buildTurnArgs already computes for the AoE-purge fan-out (E3) —
+    // the actor's own splash pattern from its resolved anchor position against the LIVE
+    // opposing roster, known BEFORE runPlayerTurn returns (unlike the actual HP application,
+    // which drivePositionalApply performs AFTER). Set at each of the three turn-firing call
+    // sites (focus/team/enemy), mirroring lastTurnCtxByActor's per-turn update. Absent id (no
+    // cast yet) → the enemiesHitThisCastFor delegate below defaults to 1.
+    const enemiesHitThisCastByActor = new Map<string, number>();
 
     // --- Healing mode (healing calc) ---
     // Resolve the heal target up front (throw on an unknown id — the switch must name a
@@ -4963,6 +4974,13 @@ export function runCombat(input: CombatEngineInput): {
                         // every-n-turns). allActorsById covers both sides in a single combat-wide
                         // map — no per-side sideCtx field needed (mirrors wasHitThisRoundFor).
                         turnsTakenFor: (ownerId) => allActorsById.get(ownerId)?.turnsTaken ?? 0,
+                        // SP-D: live per-actor count of enemies damaged by that actor's most
+                        // recent cast this round (Berserker's Marauder Rage, drained via
+                        // on-deal-damage). Combat-wide map — no per-side sideCtx field needed
+                        // (mirrors turnsTakenFor/wasHitThisRoundFor). Absent id → default 1
+                        // (buildDrainContext).
+                        enemiesHitThisCastFor: (ownerId) =>
+                            enemiesHitThisCastByActor.get(ownerId) ?? 1,
                         // D-PR11: live adjacent-allies resolver (Fortifying Shroud). Sourced
                         // per-side from sideCtx; positional neighbours, else all same-side allies.
                         adjacentAllyIdsFor: sideCtx.adjacentAllyIdsFor,
@@ -5507,8 +5525,9 @@ export function runCombat(input: CombatEngineInput): {
                             // not retroactively satisfy its own per-victim outgoing gate.
                             const preTurnVictimStatus =
                                 snapshotPreTurnVictimStatus(enemyAttackerActors);
+                            const focusTurnArgs = buildTurnArgs(actor, tgt);
                             const turn = runPlayerTurn({
-                                ...buildTurnArgs(actor, tgt),
+                                ...focusTurnArgs,
                                 deferAbilityPerformedToEngine: willApplyPositionally,
                                 onHitBreakStasis: tgtWasStasised
                                     ? (targetId: string) => {
@@ -5739,6 +5758,13 @@ export function runCombat(input: CombatEngineInput): {
 
                             // Record this actor's round-scoped ctx for the enemy's DoT-tick attribution.
                             lastTurnCtxByActor.set(actor.id, turn.turnCtx);
+                            // SP-D: record this cast's footprint size (aoeVictimIds — undefined in
+                            // DPS/non-positional mode → default 1) for the enemies-hit-this-cast
+                            // drain-time gate.
+                            enemiesHitThisCastByActor.set(
+                                actor.id,
+                                focusTurnArgs.aoeVictimIds?.length ?? 1
+                            );
 
                             // Extra-action grants from this turn bump the attacker's pending-action
                             // count, so selectNextBySpeed re-picks it at its live speed-rank (full extra
@@ -5831,8 +5857,9 @@ export function runCombat(input: CombatEngineInput): {
                             // Sub-project I, PR I2: pre-turn snapshot (mirrors the focus site).
                             const teamPreTurnVictimStatus =
                                 snapshotPreTurnVictimStatus(enemyAttackerActors);
+                            const teamTurnArgs = buildTurnArgs(actor, tgt);
                             const teamTurn = runPlayerTurn({
-                                ...buildTurnArgs(actor, tgt),
+                                ...teamTurnArgs,
                                 deferAbilityPerformedToEngine: teamWillApplyPositionally,
                                 onHitBreakStasis: teamTgtWasStasised
                                     ? (targetId: string) => {
@@ -6034,6 +6061,11 @@ export function runCombat(input: CombatEngineInput): {
                             // Record this team actor's ctx for the enemy's per-entry DoT-tick attribution
                             // (its inferno entries tick with ITS effectiveAttack/dotMult/affinityMult).
                             lastTurnCtxByActor.set(actor.id, teamTurn.turnCtx);
+                            // SP-D: record this cast's footprint size (mirrors the focus site).
+                            enemiesHitThisCastByActor.set(
+                                actor.id,
+                                teamTurnArgs.aoeVictimIds?.length ?? 1
+                            );
 
                             // Heal-target buffs: a walked team actor that IS the heal target surfaces its
                             // own comprehensive activeSelfBuffs (incl. recurring Cheat Death/Everliving Regen).
@@ -6369,8 +6401,9 @@ export function runCombat(input: CombatEngineInput): {
                                 // opposing roster is the PLAYER team — allPlayerActors).
                                 enemyPreTurnVictimStatus =
                                     snapshotPreTurnVictimStatus(allPlayerActors);
+                                const enemyTurnArgs = buildTurnArgs(actor, tgt);
                                 const enemyTurn = runPlayerTurn({
-                                    ...buildTurnArgs(actor, tgt),
+                                    ...enemyTurnArgs,
                                     deferAbilityPerformedToEngine: enemyWillApplyPositionally,
                                     onHitBreakStasis: enemyBreakHook,
                                     incomingReductionNonCritPct,
@@ -6427,6 +6460,11 @@ export function runCombat(input: CombatEngineInput): {
                                 // Record the enemy actor's round-scoped ctx (parity with player/team branches;
                                 // its own future DoT entries would tick with this ctx).
                                 lastTurnCtxByActor.set(actor.id, enemyTurn.turnCtx);
+                                // SP-D: record this cast's footprint size (mirrors the focus/team sites).
+                                enemiesHitThisCastByActor.set(
+                                    actor.id,
+                                    enemyTurnArgs.aoeVictimIds?.length ?? 1
+                                );
                                 // Surface this enemy attacker's effects for the UI's round overview (Task 10a):
                                 // its own active self-buffs and the debuffs it landed on the heal target,
                                 // ATTRIBUTED to this enemy's actor id. NAMES ONLY for display — never folded

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1192,6 +1192,21 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         enemyDebuffNames: enemyDebuffNamesArg,
         selfDebuffNames: selfDebuffNamesArg,
         turnsTaken: actor.turnsTaken,
+        // SP-C: owner-vs-target stat comparison. REQUIRED here (not just at the payload
+        // hard-gate `ctx` further down) — this is the gate for TIMED ENEMY DEBUFF application
+        // (the `conditionsMet(status.conditions, preDebuffGateCtx)` check just below), which is
+        // how Bayah's crit-power-gated Stasis INFLICT actually lands (the `type:'control'`
+        // ability gated by the later `ctx` only drives the `control-applied` reaction event, not
+        // the debuff status itself). Same live actor/enemy sourcing as `ctx` (team-symmetric,
+        // DPS-safe); selfCritPower is a layer-1-only estimate here (critDamageForGates hasn't
+        // folded layers 2+3 yet at this point in the turn) — matching this ctx's existing
+        // effectiveCritRate, which is the same partial-fold convention.
+        selfSpeed: actor.stats.speed,
+        selfCurrentHp: actor.currentHp,
+        selfCritPower: critDamage + critDamageForGates,
+        targetSpeed: enemy.stats.speed,
+        targetCurrentHp: enemy.currentHp,
+        targetCritPower: enemy.stats.critDamage,
     });
 
     // §4.5 Direct-damage Stasis break (B3 Task 2). Fires AFTER scheduled debuffs (sourceFired)
@@ -1649,6 +1664,28 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         // (on-cast/active/charged) evaluate against the real N — symmetric with the reactive
         // (end-of-turn) drain path, which already reads it via the turnsTakenFor delegate.
         turnsTaken: actor.turnsTaken,
+        // SP-C: owner-vs-target stat comparison (Bayah/Cobalt/Chakara), gating THIS cast's
+        // payload abilities via gateFiringAbilities below. Sourced directly from the live
+        // `actor`/`enemy` CombatActor pair — the SAME pairing every call site (focus/team/
+        // enemy-walk) passes via buildTurnArgs's `runtime`/`enemy` — so this is team-symmetric
+        // with zero player/enemy branching, and DPS-safe: the single-ship DPS dummy `enemy` is
+        // itself a real CombatActor (stats.critDamage hardcoded 0 — no enemy crit-power config;
+        // stats.speed/stats.hp/currentHp from the configured enemySpeed/enemyHp inputs), so no
+        // special-casing is needed for that mode either.
+        selfSpeed: actor.stats.speed,
+        selfCurrentHp: actor.currentHp,
+        // Mirrors modifierCtx's existing selfCritPower estimate (layers 1+2+3, pre-modifier) —
+        // both this ctx and modifierCtx sit AFTER critDamageForGates' final += (line ~1431), so
+        // the value is identical and stable here.
+        selfCritPower: critDamage + critDamageForGates,
+        // Cobalt/Bayah are single-target casts, so the primary `enemy` IS "the target". Chakara's
+        // charge gate ("all damaged enemies have more Speed") is also single-target in the
+        // corpus today — the MIN-across-damaged-enemies aggregate the game text describes
+        // degenerates to this one target's speed. A future multi-target stat-vs-target ship
+        // would need real per-victim aggregation; out of scope here (no corpus ship needs it).
+        targetSpeed: enemy.stats.speed,
+        targetCurrentHp: enemy.currentHp,
+        targetCritPower: enemy.stats.critDamage,
     });
 
     // Hard gate: payload abilities whose conditions fail contribute nothing this

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1686,6 +1686,14 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         targetSpeed: enemy.stats.speed,
         targetCurrentHp: enemy.currentHp,
         targetCritPower: enemy.stats.critDamage,
+        // SP-D: enemies-hit-this-cast, gating Tygr's self-charge-gain (a `type:'charge'` on-cast
+        // ability evaluated via gateFiringAbilities below, NOT a timed self-buff — so it needs
+        // THIS ctx, distinct from Berserker's Marauder Rage which drains via the on-deal-damage
+        // reactive path instead). aoeVictimIds is the actor's own splash-pattern footprint
+        // (already computed pre-turn by buildTurnArgs for the AoE-purge fan-out, E3) — undefined
+        // in DPS/non-positional mode → default 1 (single-target DPS, the faithful "Tygr doesn't
+        // add charge against one target" behaviour).
+        enemiesHitThisCast: aoeVictimIds?.length,
     });
 
     // Hard gate: payload abilities whose conditions fail contribute nothing this

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -977,6 +977,12 @@ export interface IntentExecContext {
     /** The owner's current own-turn counter (CombatActor.turnsTaken). Engine-populated;
      *  absent in DPS mode → defaults 0 (every-n-turns inert). */
     turnsTakenFor?: (ownerId: string) => number;
+    /** SP-D: number of enemies damaged by `ownerId`'s most recent cast this round, feeding the
+     *  `enemies-hit-this-cast` gate at drain time (Berserker's Marauder Rage, drained via the
+     *  on-deal-damage reactive trigger). Engine-populated from the per-turn footprint size;
+     *  absent → buildDrainContext defaults to 1 (no cast yet / DPS mode — a >=2/>=3 gate is
+     *  inert, byte-identical). */
+    enemiesHitThisCastFor?: (ownerId: string) => number;
     /** PR4b: apply a full mitigated/crit-eligible reactive damage hit from `ownerId` against
      *  `victimId` (Judge/Chakara/Incinerator/Rhodium start-of-round/end-of-round, Grif's
      *  on-enemy-cleansed, FrontLine's on-enemy-charged-cast). `abilityId` keys the dedicated
@@ -1102,6 +1108,12 @@ export function buildActorConditionContext(
         /** Owner's own-turn counter (CombatActor.turnsTaken). Default 0 (DPS-assumption).
          *  Populated by buildDrainContext (Phase 0 Task 4). */
         turnsTaken?: number;
+        /** SP-D: number of enemies damaged by the owner's most recent cast this round. Default 1
+         *  (no cast yet / DPS mode). Populated by buildDrainContext from the engine's per-actor
+         *  enemiesHitThisCastFor delegate — REQUIRED for a passive-sourced timed self-buff gated
+         *  on this subject (Berserker's Marauder Rage) to actually re-evaluate on-cast instead of
+         *  only at the one-time combat-start seed (see seedPassiveTimedStatuses). */
+        enemiesHitThisCast?: number;
     }
 ) {
     const snap = statusEngine.snapshot(ownerId);
@@ -1132,6 +1144,7 @@ export function buildActorConditionContext(
         firstActivator: shared.firstActivator,
         lastStanding: shared.lastStanding,
         turnsTaken: shared.turnsTaken,
+        enemiesHitThisCast: shared.enemiesHitThisCast,
     });
 }
 
@@ -1186,6 +1199,10 @@ function buildDrainContext(ctx: IntentExecContext, ownerId: string) {
         // paths read 0 and stay byte-identical (the evaluator's t<=0 guard blocks ALL
         // periods at turn 0, so every-n-turns is never met).
         turnsTaken: ctx.turnsTakenFor?.(ownerId) ?? 0,
+        // SP-D: live enemies-hit-this-cast gate (Berserker's Marauder Rage). Default 1 → DPS /
+        // no-delegate paths keep the single-target assumption (a >=2/>=3 gate stays inert) and
+        // stay byte-identical.
+        enemiesHitThisCast: ctx.enemiesHitThisCastFor?.(ownerId) ?? 1,
     });
 }
 

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -601,6 +601,33 @@ export function parseEnemyEffectDamageBonus(
     return null;
 }
 
+// "deals X% damage for every N stacks/entries of damage over time inflicted on[to] a single
+// enemy" (Snakeroot p1/p2: "100% damage for every 7 stacks…" / "120% damage for every 4
+// stacks…") — an OPEN-ENDED per-DoT-entry SCALING multiplier, distinct from
+// parseConditionalDamage's "for each" additive-bonus shape (CONDITIONAL_RE only matches
+// "for each", never "for every" — no collision). Here the WHOLE X% IS the per-N-entries rate:
+// with 0 tracked DoT entries on the target the ability deals 0% damage, so the base multiplier
+// the caller parsed from the same <unit-damage> tag must be zeroed and replaced by a `scaling`
+// rule against the (Task 3) `enemy-dot-count` condition, perUnit = X / N (matches the
+// enemy-stealth-count/self-crit-power precedent: bare `enemy-dot-count` resolves to the raw
+// integer DoT-entry count, so perUnit is expressed in full percentage points per entry, NOT a
+// 0..1 fraction — that fractional form is reserved for the 0..100-scaled enemy-hp-pct/
+// enemy-hp-missing-pct scaling sources).
+const DOT_ENTRY_SCALING_RE =
+    /(\d+(?:\.\d+)?)%\s*damage\s+for every\s+(\d+)\s+stacks?\s+of\s+damage over time\s+inflicted\s+on\s*to?\s+a\s+single\s+enemy/i;
+
+export function parseDotEntryDamageScaling(
+    text: string | null | undefined
+): { perUnit: number } | null {
+    if (!text) return null;
+    const m = DOT_ENTRY_SCALING_RE.exec(stripUnitTags(text));
+    if (!m) return null;
+    const pct = parseFloat(m[1]);
+    const n = parseInt(m[2], 10);
+    if (!n) return null;
+    return { perUnit: pct / n };
+}
+
 // "if/when [this unit|it is] critical[ly hits], … additional[ly] … N% damage" — extra damage
 // dealt on a crit. Covers Crucialis active ("if critical, additionally deals 75%") and its
 // charged "deals and additional" typo phrasing ("when it is critical, deals and additional 190%").

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1218,6 +1218,13 @@ export function detectReactiveTrigger(
     // here, but the ally subject makes this an ally-scoped trigger, not a self-crit.
     if (ALLY_CRIT_HIT_RE.test(clause)) return 'on-ally-crit';
     if (matchesActiveSelfCrit(clause)) return 'on-crit';
+    // SP-D (Berserker): "gains <Buff> for N turns when hitting 3 ore more enemies" is a
+    // reaction to THIS UNIT's own damage-dealing action (same family as the self-crit rule
+    // above), not a combat-start-only fact — route it through on-deal-damage so the drain-time
+    // enemies-hit-this-cast gate (still carried in `conditions`, untouched here) re-evaluates on
+    // every damage-dealing cast instead of being seeded once at combat start (which can never
+    // observe a real hit count before any turn has fired).
+    if (hitCountConditionFromClause(clause.toLowerCase())) return 'on-deal-damage';
     if (START_OF_ROUND_RE.test(clause)) return 'start-of-round';
     // Epic PR4: "at the start of (the|its|each|every) turn" — Cobalt's Out. Damage Up II buff
     // shares its governing trailing phrase with its sibling charge ability (already

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -766,6 +766,27 @@ const capType = (s: string): EnemyBaseClass =>
  */
 function countGateCondition(clause: string): Condition | null {
     const low = clause.toLowerCase();
+
+    // SP-D: DoT-stack-count gates. Generic "N or more Damage over Time effects" (Anemone) and
+    // named families "N or more Acidic Decay" (Belladonna). Emit enemy-dot-count; carry the
+    // family name as buffName when a specific DoT is named. Checked FIRST (before the buffs?/
+    // debuffs? matches below) so DoT phrasings never fall through to the generic buff/debuff
+    // classifier (which doesn't recognise "Damage over Time effects"/"Acidic Decay" as a kind)
+    // or further down to the Taunt/Provoke self-status detector (rule 5 in detectGrantConditions,
+    // which would otherwise match the bare word "Taunt" in "gains Taunt" and emit a spurious
+    // self-buff condition instead of the real DoT-count gate).
+    let dotMatch: RegExpMatchArray | null;
+    if ((dotMatch = low.match(/(\d+)\s+or\s+more\s+(damage over time effects?|acidic decay)/))) {
+        const dotFamily = /acidic decay/.test(dotMatch[2]) ? 'Acidic Decay' : undefined;
+        return {
+            subject: 'enemy-dot-count',
+            derivable: true,
+            countComparator: 'gte',
+            countThreshold: parseInt(dotMatch[1], 10),
+            ...(dotFamily ? { buffName: dotFamily } : {}),
+        };
+    }
+
     let comparator: 'gte' | 'lte' | 'eq' | null = null;
     let threshold = 0;
     let kind: string | null = null;

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -730,12 +730,10 @@ function classifyChargeCondition(
         p.includes('number of buffs')
     )
         return { condition: 'enemy-buff', derivable: false };
-    if (
-        p.includes('2 or more enemies') ||
-        p.includes('two or more enemies') ||
-        p.includes('damages 2')
-    )
-        return { condition: 'enemy-adjacent', derivable: false };
+    // NOTE: "N or more enemies" / "damages N" hit-count phrasings (Tygr) are handled upstream
+    // in parseChargeGain via hitCountConditionFromClause + the `conditions` escape hatch (SP-D)
+    // — they used to fall through to a coarse 'enemy-adjacent' presence proxy here, which never
+    // modeled the actual ≥N threshold; that branch was removed rather than left dead/misleading.
     // speed / full-HP / lowest-speed and anything else → always-true under sim assumptions
     return { condition: 'always', derivable: true };
 }
@@ -917,6 +915,22 @@ function statVsTargetConditionFromClause(low: string): Condition | null {
     return null;
 }
 
+// SP-D: "hitting N or more enemies" / "damages N or more enemies" — a real hit-count gate on
+// THIS cast (Berserker's passive Marauder Rage grants; Tygr's self-charge-gain). Shared by
+// `detectGrantConditions` (buff clauses) and `parseChargeGain` (Tygr's charge-gain, via the same
+// `conditions` escape hatch statVsTargetConditionFromClause uses for Chakara) — CSV note:
+// Berserker's text has a typo "N ore more" — the `or?e?` group matches both "or" and "ore".
+function hitCountConditionFromClause(low: string): Condition | null {
+    const m = low.match(/(?:hitting|damages?|damaging)\s+(\d+)\s+or?e?\s+more\s+enemies/);
+    if (!m) return null;
+    return {
+        subject: 'enemies-hit-this-cast',
+        derivable: true,
+        countComparator: 'gte',
+        countThreshold: parseInt(m[1], 10),
+    };
+}
+
 export function detectGrantConditions(
     skillText: string | null | undefined,
     buffName: string
@@ -1012,6 +1026,11 @@ export function detectGrantConditions(
     // to drive this function's clause-scoping, so it calls the extracted helper directly).
     const statVsTarget = statVsTargetConditionFromClause(low);
     if (statVsTarget) return [statVsTarget];
+
+    // SP-D: hit-count gate (Berserker's "gains Marauder Rage ... when hitting 3 or more
+    // enemies"). Shared with parseChargeGain below (Tygr's charge-gain analog).
+    const hitCount = hitCountConditionFromClause(low);
+    if (hitCount) return [hitCount];
 
     // 3. buff/debuff count threshold ("more than 3 Debuffs", "no debuffs")
     const countGate = countGateCondition(clause);
@@ -2731,6 +2750,16 @@ export function parseChargeGain(text: string | null | undefined): ChargeGain | n
     const statVsTarget = statVsTargetConditionFromClause(low);
     if (statVsTarget) {
         return { amount, condition: 'always', derivable: true, conditions: [statVsTarget] };
+    }
+
+    // SP-D (Tygr): "If it damages 2 or more enemies, it adds 1 charge to its Charged Skill" —
+    // a real hit-count gate on THIS cast's self-charge-gain. Same `conditions` escape hatch as
+    // the Chakara branch above. Previously fell through to classifyChargeCondition's
+    // 'enemy-adjacent' branch (a coarse presence-only proxy that never modeled the actual ≥N
+    // threshold — removed there since this is now the sole route for that phrasing).
+    const hitCount = hitCountConditionFromClause(low);
+    if (hitCount) {
+        return { amount, condition: 'always', derivable: true, conditions: [hitCount] };
     }
 
     const { condition, derivable, requiredEnemyType } = classifyChargeCondition(plain);

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -366,7 +366,12 @@ export function parseSecondaryDamage(text: string | null | undefined): Secondary
         : statRaw.includes('shield')
           ? 'shield'
           : 'defense';
-    return { stat, pct };
+    // SP-C: a leading "If this Unit has more HP/Crit Power than the target/enemy, it
+    // additionally deals …" gate on THIS rider (Cobalt). sentencePrefix is exactly the clause
+    // text preceding the secondary-damage tag within the same sentence, so this is naturally
+    // scoped to the rider's own gate and can't pick up an unrelated earlier-sentence comparison.
+    const condition = statVsTargetConditionFromClause(sentencePrefix);
+    return { stat, pct, ...(condition ? { condition } : {}) };
 }
 
 /**
@@ -878,6 +883,40 @@ function resolveBuffClause(skillText: string, buffName: string): string {
     return clauseMasked.split(ABBR_MARK).join(' ');
 }
 
+/**
+ * SP-C: owner-vs-target stat comparison gate, matched against an already-lowercased clause/
+ * sentence. "If this Unit has more Crit Power/HP than the target/enemy" (owner greater → gt);
+ * "If all damaged enemies have more Speed than this Unit" (owner slower → speed lt). Shared by
+ * `detectGrantConditions` (buff/debuff clauses, scoped via resolveBuffClause) and
+ * `parseSecondaryDamage` (Cobalt's nameless 25%-max-HP additional-damage rider, which has no
+ * buffName to drive that clause-scoping — it scopes to the SENTENCE preceding the secondary-
+ * damage match instead). Returns null when no comparison phrasing is present.
+ */
+function statVsTargetConditionFromClause(low: string): Condition | null {
+    if (/this unit has more crit power than the (?:target|enemy)/i.test(low))
+        return {
+            subject: 'stat-vs-target',
+            derivable: true,
+            compareStat: 'crit-power',
+            statComparator: 'gt',
+        };
+    if (/this unit has more hp than the (?:target|enemy)/i.test(low))
+        return {
+            subject: 'stat-vs-target',
+            derivable: true,
+            compareStat: 'hp',
+            statComparator: 'gt',
+        };
+    if (/(?:all\s+)?(?:damaged\s+)?enemies have more speed than this unit/i.test(low))
+        return {
+            subject: 'stat-vs-target',
+            derivable: true,
+            compareStat: 'speed',
+            statComparator: 'lt',
+        };
+    return null;
+}
+
 export function detectGrantConditions(
     skillText: string | null | undefined,
     buffName: string
@@ -967,6 +1006,12 @@ export function detectGrantConditions(
     if (/\blowest\s+speed\s+among\s+(?:all\s+)?allies\b/i.test(low)) {
         return [{ subject: 'lowest-speed-ally', derivable: true }];
     }
+
+    // SP-C: owner-vs-target stat comparison (Bayah's Crit-Power-gated Stasis inflict). Shared
+    // with parseSecondaryDamage below (Cobalt's nameless additional-damage rider has no buffName
+    // to drive this function's clause-scoping, so it calls the extracted helper directly).
+    const statVsTarget = statVsTargetConditionFromClause(low);
+    if (statVsTarget) return [statVsTarget];
 
     // 3. buff/debuff count threshold ("more than 3 Debuffs", "no debuffs")
     const countGate = countGateCondition(clause);
@@ -2675,6 +2720,17 @@ export function parseChargeGain(text: string | null | undefined): ChargeGain | n
                 },
             ],
         };
+    }
+
+    // SP-C (Chakara): "If all damaged enemies have more Speed than this Unit, it adds 1 charge
+    // to its Charged Skill" — an owner-vs-target stat-comparison gate on a self-charge-gain.
+    // Same `conditions` escape hatch as the Cobalt start-of-turn branch above (condition:'always'
+    // is a placeholder; the real gate rides `conditions`) — this avoids widening
+    // `ConditionalCondition` (a closed union with no general stat-comparison member) for a gate
+    // that already has a dedicated, richer `Condition` representation.
+    const statVsTarget = statVsTargetConditionFromClause(low);
+    if (statVsTarget) {
+        return { amount, condition: 'always', derivable: true, conditions: [statVsTarget] };
     }
 
     const { condition, derivable, requiredEnemyType } = classifyChargeCondition(plain);


### PR DESCRIPTION
Closes the 8 real-gap skill-model probes owned by SP-C and SP-D of the model-completeness epic. Two new condition primitives on the combat model's `ConditionSubject` seam; each ship's `it.fails` probe in `modelCompletenessTriage.test.ts` flips to `it` with a strengthened literal assertion.

## SP-C — owner-vs-target stat comparison (`stat-vs-target`)

One parameterized `ConditionSubject` (`compareStat: 'crit-power'|'speed'|'hp'` + `statComparator: 'gt'|'lt'`):
- **Bayah** — inflicts Stasis only when it has more Crit Power than the target.
- **Cobalt** — 25%-max-HP bonus damage only when it has more (absolute) HP than the enemy.
- **Chakara** — gains charge only when slower than the damaged enemy (min-speed aggregate; single-target in DPS).

New DPS-inert `ConditionContext` fields (`targetCritPower`/`selfSpeed`/`targetSpeed`/`selfCurrentHp`/`targetCurrentHp`), enemy-config-driven in DPS (unset Crit Power → 0), real actor stats + team-symmetric in the positional engine.

## SP-D — count gates

- **`enemies-hit-this-cast`** — Berserker gains Marauder Rage II on hitting 3+ enemies; Tygr gains charge on damaging 2+ (replaces a coarse adjacency proxy). Berserker's passive is promoted to the existing `on-deal-damage` reactive trigger (passive buffs seed once at combat start). DPS default 1 → inert single-target (faithful).
- **`enemy-dot-count`** — per-target DoT *entry* count (DoT-only, excludes control debuffs). Anemone gains Taunt on 3+ DoT effects; Belladonna inflicts Stasis on 3+ Acidic Decay (build-emitted, runtime-inert until SP-E introduces the Acidic Decay family).
- **Snakeroot** — per-DoT-entry damage `ScalingRule` (+30% per DoT entry = 120% per 4).

## Invariants

- **Byte-identical DPS:** all new `ConditionContext` fields optional + DPS-safe-defaulted; read only by the new evaluators. No golden drift.
- **Team-symmetry:** every engine-derived gate fires identically on either side (dedicated enemy-side integration tests).
- Full suite green (334 files / 4287 tests), lint + tsc clean, `audit:skills` 0 findings / 0 stale. Allowlist rows for Bayah/Belladonna/Berserker removed; changelog updated.

Each task passed an independent spec+quality review and a final whole-branch review (all clean, no Critical/Important).

🤖 Generated with [Claude Code](https://claude.com/claude-code)