### PR TITLE
feat(combat): model-completeness SP-G — engine known-limitations (Kinetik/Cinya/Meatshield/Cobalt/FrontLine/Butcher)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -63,6 +63,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Wusheng's charged skill now always strikes with affinity advantage; Isha and Nayra's Affinity Override buffs now force affinity advantage on offense and defense, including their two-ship synergy (each grants the other its extra Override only when both are on the team).",
     'Kinetik and Cinya now correctly apply their per-turn shield / repair at the start of each of their turns (previously modelled as a one-off on cast).',
     'Meatshield now gains its 3 stacks of Protection once at the start of combat, instead of accumulating a stack on every skill use.',
+    'Cobalt\'s start-of-turn "Out. Damage Up II" buff now boosts every one of its turns while at full HP, instead of every other turn.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -62,6 +62,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: AEGIS now grants Defense Up II and cleanses all debuffs from an ally within its Active pattern when that ally's Shield is destroyed, matching its skill text, instead of always granting Defense Up II to the whole team and cleansing itself on every cast.",
     "Combat sim: Wusheng's charged skill now always strikes with affinity advantage; Isha and Nayra's Affinity Override buffs now force affinity advantage on offense and defense, including their two-ship synergy (each grants the other its extra Override only when both are on the team).",
     'Kinetik and Cinya now correctly apply their per-turn shield / repair at the start of each of their turns (previously modelled as a one-off on cast).',
+    'Meatshield now gains its 3 stacks of Protection once at the start of combat, instead of accumulating a stack on every skill use.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -61,6 +61,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Lingshe's charged skill now reduces enemy Bomb timers (hacking-gated), detonating any that reach zero.",
     "Combat sim: AEGIS now grants Defense Up II and cleanses all debuffs from an ally within its Active pattern when that ally's Shield is destroyed, matching its skill text, instead of always granting Defense Up II to the whole team and cleansing itself on every cast.",
     "Combat sim: Wusheng's charged skill now always strikes with affinity advantage; Isha and Nayra's Affinity Override buffs now force affinity advantage on offense and defense, including their two-ship synergy (each grants the other its extra Override only when both are on the team).",
+    'Kinetik and Cinya now correctly apply their per-turn shield / repair at the start of each of their turns (previously modelled as a one-off on cast).',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -65,6 +65,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Meatshield now gains its 3 stacks of Protection once at the start of combat, instead of accumulating a stack on every skill use.',
     'Cobalt\'s start-of-turn "Out. Damage Up II" buff now boosts every one of its turns while at full HP, instead of every other turn.',
     "FrontLine's reactive shield (on an enemy charged skill) now scales off the actual damage it deals — accounting for enemy defense, crits, and affinity — instead of a flat approximation.",
+    'Butcher now correctly gains Marauder Rage II when it inflicts a debuff in team battles (previously the buff only applied in the single-target DPS view).',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -64,6 +64,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Kinetik and Cinya now correctly apply their per-turn shield / repair at the start of each of their turns (previously modelled as a one-off on cast).',
     'Meatshield now gains its 3 stacks of Protection once at the start of combat, instead of accumulating a stack on every skill use.',
     'Cobalt\'s start-of-turn "Out. Damage Up II" buff now boosts every one of its turns while at full HP, instead of every other turn.',
+    "FrontLine's reactive shield (on an enemy charged skill) now scales off the actual damage it deals — accounting for enemy defense, crits, and affinity — instead of a flat approximation.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -4594,9 +4594,10 @@ describe('parseEnemyChargedCastReaction (Curator enemy-charged-cast reaction)', 
         expect(parseEnemyChargedCastReaction(null)).toBeNull();
     });
 
-    // FrontLine R2 (Task 6): reactive damage + shield, once per round. The shield is modelled
-    // as basis:'attack', pct:24 (= round(30 * 80 / 100)) -- see the parser comment for the
-    // derivation (shield kept on the same un-mitigated basis as the 80% reactive damage).
+    // FrontLine R2 (Task 6; magnitude fixed SP-G G3): reactive damage + shield, once per round.
+    // The shield is modelled as basis:'damage-dealt', pct:30 -- the raw clause percentage,
+    // scaled at drain time off the ACTUAL mitigated/crit amount of the 80% reactive damage
+    // (see the parser comment + triggers.ts's reactiveDealtByOwner fallback).
     const FRONTLINE_R2 =
         'When an enemy uses their charged skill, it deals 80% and gains a Shield equal to 30% of the damage dealt, once per round.';
 
@@ -4616,12 +4617,12 @@ describe('parseEnemyChargedCastReaction (Curator enemy-charged-cast reaction)', 
         expect(damage.config).toMatchObject({ type: 'damage', multiplier: 80, hits: 1 });
     });
 
-    it('FrontLine shield ability: self target, basis attack, pct 24', () => {
+    it('FrontLine shield ability: self target, basis damage-dealt, pct 30', () => {
         const abilities = parseEnemyChargedCastReaction(FRONTLINE_R2)!;
         const shield = abilities.find((a) => a.type === 'shield')!;
         expect(shield).toBeDefined();
         expect(shield.target).toBe('self');
-        expect(shield.config).toMatchObject({ type: 'shield', basis: 'attack', pct: 24 });
+        expect(shield.config).toMatchObject({ type: 'shield', basis: 'damage-dealt', pct: 30 });
     });
 
     // Cross-ship isolation (Task 5 follow-up): FrontLine text yields NO purge, NO debuff.
@@ -4656,7 +4657,7 @@ describe('parseEnemyChargedCastReaction (Curator enemy-charged-cast reaction)', 
     // — full <unit-damage> tags AND the "Shield equal to 25% of its Max HP at the start of combat"
     // preamble (which must NOT be mistaken for the reaction's shield). Mirrors the Curator real-data
     // test (Task 5): exercises tag stripping + preamble exclusion on the genuine game string.
-    it('FrontLine VERBATIM CSV second-passive text → exactly the damage(80)+shield(attack,24) pair', () => {
+    it('FrontLine VERBATIM CSV second-passive text → exactly the damage(80)+shield(damage-dealt,30) pair', () => {
         const FRONTLINE_R2_VERBATIM =
             'This ship has 20% Shield Penetration.<br />While Shielded, it gains 2500 additional Defense.<br />This Unit gains <unit-damage>Shield equal to 25%</unit-damage> of its Max HP at the start of combat.<br /><br />When an enemy uses their Charged skill, it deals <unit-damage>80%</unit-damage> and gains a Shield equal to <unit-damage>30%</unit-damage> of the damage dealt, once per round.';
         const abilities = parseEnemyChargedCastReaction(FRONTLINE_R2_VERBATIM);
@@ -4670,10 +4671,11 @@ describe('parseEnemyChargedCastReaction (Curator enemy-charged-cast reaction)', 
         expect(damage.config).toMatchObject({ type: 'damage', multiplier: 80, hits: 1 });
 
         const shield = abilities!.find((a) => a.type === 'shield')!;
-        // basis:'attack', pct:24 (= round(30 × 80 / 100)) — the reaction's 30%-of-damage shield,
-        // NOT the 25%-of-Max-HP start-of-combat preamble (which the parser correctly excludes here).
+        // basis:'damage-dealt', pct:30 — the reaction's 30%-of-damage shield, scaled at drain
+        // time off the actual mitigated/crit dealt amount, NOT the 25%-of-Max-HP start-of-combat
+        // preamble (which the parser correctly excludes here).
         expect(shield.target).toBe('self');
-        expect(shield.config).toMatchObject({ type: 'shield', basis: 'attack', pct: 24 });
+        expect(shield.config).toMatchObject({ type: 'shield', basis: 'damage-dealt', pct: 30 });
     });
 });
 

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -2566,7 +2566,7 @@ describe('buildShipAbilities', () => {
             });
         });
 
-        it('FrontLine R4 passive: start-of-combat max-HP shield parses; no damage-dealt/taken shield', () => {
+        it('FrontLine R4 passive: start-of-combat max-HP shield + the on-enemy-charged-cast damage-dealt shield, no duplicate/taken shield', () => {
             const s = ship({
                 thirdPassiveSkillText:
                     'This ship has 20% Shield Penetration.<br />While Shielded, it gains 2500 additional Defense.<br />This Unit gains <unit-damage>Shield equal to 25%</unit-damage> of its Max HP at the start of combat.<br /><br />When an enemy uses their Charged skill, it deals <unit-damage>80%</unit-damage> and gains a Shield equal to <unit-damage>30%</unit-damage> of the damage dealt, once per round.',
@@ -2577,13 +2577,17 @@ describe('buildShipAbilities', () => {
             expect(shields.some((sh) => (sh.config as { basis: string }).basis === 'hp')).toBe(
                 true
             );
-            // No damage-dealt / damage-taken shield is produced from this passive.
+            // SP-G G3: the on-enemy-charged-cast reaction shield is now basis 'damage-dealt' (it
+            // scales off FrontLine's OWN mitigated/crit reactive hit, via reactiveDealtByOwner —
+            // see triggers.ts/engine.ts) — exactly ONE such shield, on the correct trigger.
+            const damageDealtShields = shields.filter(
+                (sh) => (sh.config as { basis: string }).basis === 'damage-dealt'
+            );
+            expect(damageDealtShields).toHaveLength(1);
+            expect(damageDealtShields[0].trigger).toBe('on-enemy-charged-cast');
+            // No damage-taken shield is produced from this passive.
             expect(
-                shields.some((sh) =>
-                    ['damage-dealt', 'damage-taken'].includes(
-                        (sh.config as { basis: string }).basis
-                    )
-                )
+                shields.some((sh) => (sh.config as { basis: string }).basis === 'damage-taken')
             ).toBe(false);
         });
     });

--- a/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
+++ b/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
@@ -756,19 +756,15 @@ describe('SP-G — engine known-limitations', () => {
     const CINYA_P1_SPG =
         'This Unit <unit-damage>repairs 3.5%</unit-damage> of its Max HP every turn.';
 
-    it('Meatshield: "gains 3 stacks of Protection" still rides on-cast — DELIBERATELY UNCHANGED (deferred)', () => {
+    it('Meatshield: "gains 3 stacks of Protection" is a one-time pre-combat grant (SP-G G1b)', () => {
         const abilities = abilitiesFor({ firstPassiveSkillText: MEATSHIELD_P1_SPG }, 'passive');
         const protection = abilities.find(
             (a) => a.config.type === 'buff' && a.config.buffName === 'Protection'
         );
-        // TRUE TODAY: pinned verbatim by
-        // src/utils/abilities/__tests__/roundBoundaryTriggerConsistency.test.ts, describe
-        // ('Meatshield: start-of-combat Protection stacks — DELIBERATELY UNCHANGED (deferred)') —
-        // that test's own name documents this as a CONSCIOUS deferral (the parser's stack-climb
-        // behaviour is keyed off the on-cast shape; relabeling only the trigger without also
-        // reworking the stack accumulation would misrepresent the mechanic). No recurring
-        // per-turn trigger exists today — this is the SP-G mechanic to add.
-        expect(protection?.trigger).toBe('on-cast');
+        // SP-G G1b: a start-of-combat "N stacks" grant no longer climbs per-round — it seeds all
+        // N stacks once at combat start. Pinned end-to-end by roundBoundaryTriggerConsistency.test.ts
+        // ('Meatshield: start-of-combat Protection stacks → one-time pre-combat 3-stack grant').
+        expect(protection?.trigger).toBe('pre-combat');
     });
 
     it('Kinetik: "gains a Shield ... every turn" rides start-of-turn (SP-G G1a)', () => {

--- a/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
+++ b/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
@@ -771,25 +771,19 @@ describe('SP-G — engine known-limitations', () => {
         expect(protection?.trigger).toBe('on-cast');
     });
 
-    it('Kinetik: "gains a Shield ... every turn" still rides on-cast — no recurring trigger exists yet', () => {
+    it('Kinetik: "gains a Shield ... every turn" rides start-of-turn (SP-G G1a)', () => {
         const abilities = abilitiesFor({ firstPassiveSkillText: KINETIK_P1_SPG }, 'passive');
         const shield = abilities.find((a) => a.type === 'shield');
-        // TRUE TODAY: pinned verbatim by
-        // src/utils/abilities/__tests__/roundBoundaryTriggerConsistency.test.ts, describe
-        // ('Kinetik / Cinya: "every turn" (no "at the start of" phrase) — out of PR4 scope,
-        // unaffected'), it('Kinetik: the per-turn shield stays on-cast (no start-of-X phrase to
-        // detect)'). "Every turn" (unlike "at the start of the turn") has no detector at all —
-        // SP-G needs a genuine recurring trigger, not just a relabel.
-        expect(shield?.trigger).toBe('on-cast');
+        // SP-G G1a: detectEveryTurnTrigger routes the trailing "every turn" self-shield to the
+        // start-of-turn LIVE trigger. Pinned end-to-end by roundBoundaryTriggerConsistency.test.ts
+        // ('Kinetik / Cinya: "every turn" self shield/heal ride start-of-turn (SP-G G1a)').
+        expect(shield?.trigger).toBe('start-of-turn');
     });
 
-    it('Cinya: "repairs ... every turn" still rides on-cast — no recurring trigger exists yet', () => {
+    it('Cinya: "repairs ... every turn" rides start-of-turn (SP-G G1a)', () => {
         const abilities = abilitiesFor({ firstPassiveSkillText: CINYA_P1_SPG }, 'passive');
         const heal = abilities.find((a) => a.type === 'heal');
-        // TRUE TODAY: pinned verbatim by the same roundBoundaryTriggerConsistency.test.ts
-        // describe block as Kinetik above, it('Cinya: the per-turn heal stays on-cast (no
-        // start-of-X phrase to detect)'). Same "every turn" gap, distinct ship/ability.
-        expect(heal?.trigger).toBe('on-cast');
+        expect(heal?.trigger).toBe('start-of-turn');
     });
 
     // ── Butcher: positional-path Rage sourceId — NO CORPUS PROBE (see reconciliation doc) ──

--- a/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
+++ b/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
@@ -782,31 +782,28 @@ describe('SP-G — engine known-limitations', () => {
         expect(heal?.trigger).toBe('start-of-turn');
     });
 
-    // ── Butcher: positional-path Rage sourceId — NO CORPUS PROBE (see reconciliation doc) ──
+    // ── Butcher: positional-path Rage — SATISFIED by a positional integration pin (SP-G G4) ──
     // Butcher's "On inflicting a debuff, this Unit gains Marauder Rage II" (second_passive_skill_
-    // text) already has a build-output probe (buildShipAbilities.test.ts, "Butcher p2: remove
-    // Overload on kill + Marauder Rage II on debuff-inflicted") AND an engine-level integration
-    // pin (overloadLifecycle.test.ts, "3. Butcher gains Marauder Rage II when it inflicts a
-    // debuff (on-debuff-inflicted)") — but that integration pin runs ONLY through Channel (A),
-    // `runCombat` (DPS/healing mode), per the file's own docstring. It does NOT exercise the
-    // POSITIONAL two-team path (`simulateBattle`).
+    // text) has a build-output probe (buildShipAbilities.test.ts, "Butcher p2: remove Overload on
+    // kill + Marauder Rage II on debuff-inflicted") AND a Channel-A integration pin
+    // (overloadLifecycle.test.ts, "3. Butcher gains Marauder Rage II when it inflicts a debuff").
+    // SP0 empirically found the reaction did NOT fire on the POSITIONAL two-team `simulateBattle`
+    // path — a team-symmetry gap with no `buildShipAbilities`-observable proxy (the built ability
+    // is byte-identical regardless of which engine channel consumes it).
     //
-    // EMPIRICALLY VERIFIED during this task (throwaway probe, not committed): a Butcher placed in
-    // a real `simulateBattle` two-team battle, casting an active that inflicts Inferno II every
-    // round, DOES emit a `dot-applied` combat-log entry (the debuff infliction lands, sourceId
-    // correctly attributed to the caster) — but NO `buff` combat-log entry for Marauder Rage II
-    // ever appears anywhere across the whole battle. So the on-debuff-inflicted → Marauder Rage II
-    // reaction that works on Channel (A) does NOT fire on the positional path. This is a genuine,
-    // currently-unpinned gap.
+    // SP-G G4 ROOT-CAUSED and FIXED this: "On inflicting a debuff" was double-classified — promoted
+    // to the on-debuff-inflicted TRIGGER (detectReactiveTrigger / APPLYING_DEBUFF_RE) AND, from the
+    // same phrase, given a redundant `enemy-debuff` GATE condition (detectGrantConditions'
+    // appliesDebuffGate). That `derivable:true` condition gates the reactive drain against the
+    // enemy's LIVE debuff store — populated on the aggregate DPS path (shared enemy dummy) but NOT
+    // positionally (DoTs live in per-victim stores) — so it silently blocked Marauder Rage II in
+    // real team battles. The fix (buildShipAbilities.ts) drops the redundant `enemy-debuff`
+    // condition when the trigger is on-debuff-inflicted (the trigger IS the gate — the exact
+    // COLLISION-SCOPE pattern already used for on-enemy-buffed/enemy-buff).
     //
-    // No `buildShipAbilities`-observable proxy exists for this (the built ability object is
-    // byte-identical regardless of which engine channel consumes it — the bug is purely in the
-    // positional path's reactive-listener/event wiring, invisible to a build-output assertion).
-    // No existing integration test exercises this exact failure either (the closest one,
-    // overloadLifecycle.test.ts's Channel-B tests, only covers KILL reactives, not
-    // on-debuff-inflicted) — so, per the task protocol, this is recorded as MISSING in the
-    // reconciliation doc (`docs/model-completeness-triage-2026-07-05.md`) rather than fabricated
-    // a path here. SP-G will need to author a new positional-path integration test for this.
+    // The Butcher SP-G marker is therefore satisfied by the new POSITIONAL-PATH integration pins
+    // (overloadLifecycle.test.ts tests "3b" player-side + "3c" enemy-side team-symmetry) rather
+    // than a corpus `it.fails` flip — there is nothing build-observable to assert here.
 });
 
 describe('confirm-GREEN-only — locked FPs', () => {

--- a/src/utils/abilities/__tests__/reactiveTriggerPromotionTriage.test.ts
+++ b/src/utils/abilities/__tests__/reactiveTriggerPromotionTriage.test.ts
@@ -224,7 +224,7 @@ describe('cluster 5 — on-enemy-destroyed / on-kill', () => {
     });
 
     const MADAX_P2 =
-        "This Unit <unit-damage>repairs itself for 13%</unit-damage> of its Max HP when an enemy dies.";
+        'This Unit <unit-damage>repairs itself for 13%</unit-damage> of its Max HP when an enemy dies.';
     it('Madax: self-heal-on-enemy-death rides on-enemy-destroyed', () => {
         const ab = abilitiesFor({ firstPassiveSkillText: MADAX_P2 }, 'passive');
         const heal = ab.find((a) => a.type === 'heal');
@@ -237,7 +237,9 @@ describe('cluster 5 — on-enemy-destroyed / on-kill', () => {
         'This Unit <unit-aid>adds 2 charges</unit-aid> to its Charged Skill upon killing an enemy.';
     it('Obsidian: charge-on-kill rides on-enemy-destroyed', () => {
         const ab = abilitiesFor({ firstPassiveSkillText: OBSIDIAN_P2 }, 'passive');
-        expect(ab.some((a) => a.type === 'charge' && a.trigger === 'on-enemy-destroyed')).toBe(true);
+        expect(ab.some((a) => a.type === 'charge' && a.trigger === 'on-enemy-destroyed')).toBe(
+            true
+        );
         // GAP: tag-only (detector-recognition) — emits NO ability; the charge builder doesn't
         // detect "upon killing an enemy". Self charge, no actor needed; on-enemy-destroyed exists.
     });
@@ -246,7 +248,9 @@ describe('cluster 5 — on-enemy-destroyed / on-kill', () => {
         'This Unit <unit-aid>gains 1 charge</unit-aid> for its Charged Skill upon killing an enemy.';
     it('Valiant: charge-on-kill rides on-enemy-destroyed', () => {
         const ab = abilitiesFor({ firstPassiveSkillText: VALIANT_P2 }, 'passive');
-        expect(ab.some((a) => a.type === 'charge' && a.trigger === 'on-enemy-destroyed')).toBe(true);
+        expect(ab.some((a) => a.type === 'charge' && a.trigger === 'on-enemy-destroyed')).toBe(
+            true
+        );
         // GAP: tag-only (detector-recognition) — same as Obsidian, emits nothing.
     });
 
@@ -272,7 +276,7 @@ describe('cluster 6 — on-bomb-detonated', () => {
     });
 
     const VALKYRIE_P2 =
-        "When an <unit-aid>Echoing Burst</unit-aid> explodes on an enemy, this Unit and the ally with the lowest current health percentage <unit-damage>repair 5%</unit-damage> of damage dealt.";
+        'When an <unit-aid>Echoing Burst</unit-aid> explodes on an enemy, this Unit and the ally with the lowest current health percentage <unit-damage>repair 5%</unit-damage> of damage dealt.';
     it('Valkyrie: repair on Echoing-Burst detonation rides on-bomb-detonated', () => {
         const ab = abilitiesFor({ firstPassiveSkillText: VALKYRIE_P2 }, 'passive');
         const heal = ab.find((a) => a.type === 'heal');
@@ -338,19 +342,20 @@ describe('cluster 7 — ally-crit / cleanse-reactive / DoT-crit / debuff-resiste
     });
 
     const MORAO_P3 =
-        "This Unit <unit-damage>repairs 5%</unit-damage> of its Max HP every turn and, upon <unit-aid>Cleansing a</unit-aid> Debuff, repairs an additional <unit-damage>5%</unit-damage> of its Max HP while gaining <unit-skill>Defense Up II</unit-skill> for 2 turns.";
+        'This Unit <unit-damage>repairs 5%</unit-damage> of its Max HP every turn and, upon <unit-aid>Cleansing a</unit-aid> Debuff, repairs an additional <unit-damage>5%</unit-damage> of its Max HP while gaining <unit-skill>Defense Up II</unit-skill> for 2 turns.';
     it('Morao: repair/buff-on-own-cleanse is reactive, not on-cast', () => {
         const ab = abilitiesFor({ firstPassiveSkillText: MORAO_P3 }, 'passive');
         // Both the extra repair and Defense Up ride "upon cleansing"; today everything is on-cast.
         expect(ab.some((a) => a.trigger !== 'on-cast')).toBe(true);
         // Fixed (Phase 3 PR-H): both the extra repair AND Defense Up II ride the NEW
         // on-own-cleanse trigger (self-target, no actor capture needed). The "every turn" repair
-        // is a SEPARATE recurring-trigger gap (out of this family) and correctly stays on-cast —
-        // see the dedicated integration test for the precise per-ability assertion.
+        // was a SEPARATE recurring-trigger gap (out of this family); SP-G G1a closed it —
+        // it now rides start-of-turn — see the dedicated integration test for the precise
+        // per-ability assertion.
     });
 
     const CROCUS_P2 =
-        "When another ally inflicts a Damage Over Time (DoT) effect with a critical hit, this Unit <unit-damage>repairs itself for 3%</unit-damage> of its Max HP.";
+        'When another ally inflicts a Damage Over Time (DoT) effect with a critical hit, this Unit <unit-damage>repairs itself for 3%</unit-damage> of its Max HP.';
     it('Crocus: self-repair on ally DoT-crit rides on-ally-crit-dot', () => {
         const ab = abilitiesFor({ firstPassiveSkillText: CROCUS_P2 }, 'passive');
         const heal = ab.find((a) => a.type === 'heal');
@@ -361,7 +366,9 @@ describe('cluster 7 — ally-crit / cleanse-reactive / DoT-crit / debuff-resiste
         "When this Unit resists a debuff infliction from an enemy, it deals <unit-damage>damage equal to 30%</unit-damage> of this Unit's max HP to that enemy.";
     it('Vindicator: reactive damage on debuff-resisted rides on-debuff-resisted', () => {
         const ab = abilitiesFor({ firstPassiveSkillText: VINDICATOR_P3 }, 'passive');
-        expect(ab.some((a) => a.type === 'damage' && a.trigger === 'on-debuff-resisted')).toBe(true);
+        expect(ab.some((a) => a.type === 'damage' && a.trigger === 'on-debuff-resisted')).toBe(
+            true
+        );
         // GAP: DEFERRED (Phase 3 PR-C, 2026-07-04) — two independent infra gaps beyond Layer-1 tag
         // inheritance: (1) no maxHP-scaled damage model — the 'damage' AbilityConfig only carries an
         // attack%-based multiplier (applyReactiveDamage sources ownerStats.attack), so "30% of max HP"

--- a/src/utils/abilities/__tests__/roundBoundaryTriggerConsistency.test.ts
+++ b/src/utils/abilities/__tests__/roundBoundaryTriggerConsistency.test.ts
@@ -320,19 +320,20 @@ describe('Tycho: start-of-combat Cheat Death + Everliving Regeneration I (docs/s
     });
 });
 
-describe('Meatshield: start-of-combat Protection stacks — DELIBERATELY UNCHANGED (deferred)', () => {
-    it('stays on-cast: the parser still climbs stacks per cast, so relabeling only the trigger would misrepresent the mechanic', () => {
+describe('Meatshield: start-of-combat Protection stacks → one-time pre-combat 3-stack grant (SP-G G1b)', () => {
+    it('rides pre-combat and grants 3 stacks in ONE application (no per-cast climb)', () => {
         const abilities = passiveAbilities({
             firstPassiveSkillText:
                 'At the start of combat, this Unit gains 3 stacks of <unit-skill>Protection</unit-skill>.',
         });
         const buff = findBuff(abilities, 'Protection')!;
         expect(buff).toBeDefined();
-        expect(buff.trigger).toBe('on-cast');
-        // Confirms the isAccumulatingBuff guard is actually keyed off this shape.
+        expect(buff.trigger).toBe('pre-combat');
         if (buff.config.type === 'buff') {
+            // One-shot 3-stack grant: still stackable, but NOT a per-round accumulator.
             expect(buff.config.isStackable).toBe(true);
-            expect(buff.config.stackTrigger).toBeDefined();
+            expect(buff.config.stacks).toBe(3);
+            expect(buff.config.stackTrigger).toBeUndefined();
         }
     });
 });

--- a/src/utils/abilities/__tests__/roundBoundaryTriggerConsistency.test.ts
+++ b/src/utils/abilities/__tests__/roundBoundaryTriggerConsistency.test.ts
@@ -337,24 +337,28 @@ describe('Meatshield: start-of-combat Protection stacks — DELIBERATELY UNCHANG
     });
 });
 
-// ─── Out-of-scope suspects verified: NOT "at the start of …" phrasing, correctly untouched ──
-
-describe('Kinetik / Cinya: "every turn" (no "at the start of" phrase) — out of PR4 scope, unaffected', () => {
-    it('Kinetik: the per-turn shield stays on-cast (no start-of-X phrase to detect)', () => {
+// ─── "every turn" → start-of-turn (SP-G G1a) ────────────────────────────────
+describe('Kinetik / Cinya: "every turn" self shield/heal ride start-of-turn (SP-G G1a)', () => {
+    it('Kinetik: the per-turn shield rides start-of-turn', () => {
         const abilities = passiveAbilities({
             firstPassiveSkillText:
                 'This Unit gains a <unit-damage>Shield equal to 4%</unit-damage> of its Max HP every turn.',
         });
         const shield = abilities.find((a) => a.type === 'shield')!;
-        expect(shield.trigger).toBe('on-cast');
+        expect(shield.trigger).toBe('start-of-turn');
+        if (shield.config.type === 'shield') {
+            expect(shield.config.pct).toBe(4);
+            expect(shield.config.basis).toBe('hp');
+        }
     });
 
-    it('Cinya: the per-turn heal stays on-cast (no start-of-X phrase to detect)', () => {
+    it('Cinya: the per-turn heal rides start-of-turn', () => {
         const abilities = passiveAbilities({
             firstPassiveSkillText:
                 'This Unit <unit-damage>repairs 3.5%</unit-damage> of its Max HP every turn.',
         });
         const heal = abilities.find((a) => a.type === 'heal')!;
-        expect(heal.trigger).toBe('on-cast');
+        expect(heal.trigger).toBe('start-of-turn');
+        if (heal.config.type === 'heal') expect(heal.config.pct).toBe(3.5);
     });
 });

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -64,6 +64,7 @@ import {
     detectAllyDebuffedTrigger,
     detectEndOfRoundPurgeTrigger,
     detectStartOfRoundTrigger,
+    detectEveryTurnTrigger,
     detectEndOfRoundDamageTrigger,
     detectRoundStartContinuationTrigger,
     detectKilledByDirectDamageTrigger,
@@ -1712,6 +1713,12 @@ function abilitiesFromText(
                 (h.kind === 'shield' && h.basis === 'hp'
                     ? detectPreCombatShieldTrigger(text, healPos)
                     : undefined) ??
+                // SP-G G1a: a self shield/heal whose anchor falls in an "every turn"/"each turn"
+                // sentence rides the start-of-turn LIVE trigger (Kinetik's per-turn Max-HP shield,
+                // Cinya's per-turn Max-HP repair). Position-scoped; mutually exclusive with the
+                // start-of-round / pre-combat phrases above (different phrasing). The healing
+                // calculator consumes start-of-turn self shields/heals; DPS is unaffected.
+                detectEveryTurnTrigger(text, healPos) ??
                 detectCritRepairTrigger(text, healPos) ??
                 // Yazid: a repair anchored in the "when Cheat Death activates" sentence rides the
                 // on-cheat-death-activated reactive trigger (self-scoped; position-scoped). Checked

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -2675,7 +2675,19 @@ export function buildShipAbilities(ship: Ship): ShipSkills {
                     // manual condition (harmless today since a manual condition with no
                     // manualCount defaults to "met", but leaving it is misleading and the
                     // brief calls it out explicitly).
-                    !(reactiveTrigger === 'on-enemy-buffed' && c.subject === 'enemy-buff')
+                    !(reactiveTrigger === 'on-enemy-buffed' && c.subject === 'enemy-buff') &&
+                    // SP-G G4 (same COLLISION-SCOPE pattern): "On inflicting a debuff, gains X"
+                    // is double-classified — detectReactiveTrigger promotes it to on-debuff-inflicted
+                    // (APPLYING_DEBUFF_RE) AND detectGrantConditions' appliesDebuffGate emits a
+                    // redundant enemy-debuff condition from the SAME phrase. The trigger already
+                    // proves a debuff was inflicted, so drop the enemy-debuff condition. Leaving it
+                    // is not harmless here: enemy-debuff is `derivable:true`, so at reactive drain it
+                    // gates against the enemy's LIVE debuff store. That store is populated on the
+                    // aggregate DPS path (the shared enemy dummy carries the inflicted DoT) but NOT
+                    // on the positional path (DoTs live in per-victim stores), so the stale condition
+                    // silently blocks Butcher's Marauder Rage II in real team battles — a team-symmetry
+                    // violation. (overloadLifecycle.test.ts test 3b pins the positional path.)
+                    !(reactiveTrigger === 'on-debuff-inflicted' && c.subject === 'enemy-debuff')
             );
             // Oleander's "once per ally per round" RoT grant: a DEDICATED cap (not the plain
             // oncePerRound flag) so a different ally inflicting a debuff still procs even if

--- a/src/utils/combat/__tests__/cobaltStartOfTurnCharge.integration.test.ts
+++ b/src/utils/combat/__tests__/cobaltStartOfTurnCharge.integration.test.ts
@@ -378,49 +378,32 @@ describe('Cobalt second passive — charge AND Out. Damage Up II coexist (no cla
     });
 });
 
-// ─── #210 review follow-up: the buff is CONSUMED live (engine level, not just the tag) ───────
+// ─── SP-G G2: the start-of-turn grant now precedes the owner's cast ──────────────────────────
 //
-// The parser-level assertion above proves the TAG; this pins what the ENGINE does with it.
-// Probed behavior (attack 4000, +30% Out. Damage Up II):
-//   old on-cast tag        → [5200, 4000, 4000, …]  boost dies after round 1 (seed-once, 1-turn)
-//   new start-of-turn tag  → [4000, 5200, 4000, 5200, …]  recurring, but ALTERNATING
-//   true in-game behavior  → boosted EVERY turn (grant precedes the act)
-//
-// KNOWN LIMITATION (documented, deliberately pinned): the start-of-turn grant drains AFTER the
-// owner's cast, so each grant boosts the FOLLOWING turn; and a re-grant landing while the buff
-// is still active is swallowed before the post-turn decrement removes it, producing the
-// alternating cadence instead of a steady one. Fixing this means reordering intent drains
-// relative to the cast — an engine-ordering change out of #210's scope. The re-tag is still a
-// strict improvement (recurring vs first-round-only). When the ordering fix lands, the
-// alternation assertions below MUST flip to every-turn — that is the point of pinning them.
-describe('Cobalt Out. Damage Up II — engine consumption (recurring; alternating cadence pinned)', () => {
+// FIXED (SP-G G2): a pre-cast drain of the acting owner's start-of-turn GRANT intents runs
+// between the turn-started emit and the cast, so the Out. Damage Up II buff boosts the SAME turn
+// it is granted — every turn, not every other turn. (The CHARGE half is excluded from this drain
+// and still banks post-cast, so the Part 1/Part 2 charge ledgers are unchanged.)
+describe('Cobalt Out. Damage Up II — engine consumption (recurring, every turn)', () => {
     const runFocusDamage = (withBuff: boolean): number[] => {
         const abilities = resolvePassiveAbilities(COBALT_P2).filter(
             (a) =>
-                a.type !== 'charge' && // charge half exercised by the ledger tests above
+                a.type !== 'charge' &&
                 (withBuff ||
                     !(a.config.type === 'buff' && a.config.buffName === 'Out. Damage Up II'))
         );
         const r = runCombat(
-            buildInput({
-                chargeCount: 0,
-                numRounds: 4,
-                passiveAbilities: abilities,
-            })
+            buildInput({ chargeCount: 0, numRounds: 4, passiveAbilities: abilities })
         );
         return r.rounds.map((round) => round.directDamage);
     };
 
-    it('the buff recurs beyond round 1 (fails under the pre-#210 on-cast/seed-once model)', () => {
+    it('the buff boosts EVERY turn (pre-cast grant ordering)', () => {
         const boosted = runFocusDamage(true);
         const control = runFocusDamage(false);
-        // Rounds 2 and 4 are boosted — under the old on-cast tag EVERY round after the first
-        // was unboosted, so these are the discriminating assertions.
+        expect(boosted[0]).toBeGreaterThan(control[0]);
         expect(boosted[1]).toBeGreaterThan(control[1]);
+        expect(boosted[2]).toBeGreaterThan(control[2]);
         expect(boosted[3]).toBeGreaterThan(control[3]);
-        // Pinned alternation (known limitation above): rounds 1 and 3 are NOT boosted today.
-        // A future drain-ordering fix flips these to boosted — update them consciously.
-        expect(boosted[0]).toBe(control[0]);
-        expect(boosted[2]).toBe(control[2]);
     });
 });

--- a/src/utils/combat/__tests__/enemiesHitGate.integration.test.ts
+++ b/src/utils/combat/__tests__/enemiesHitGate.integration.test.ts
@@ -51,8 +51,8 @@ const BERSERKER_P2 =
     'This Unit gains <unit-skill>Marauder Rage II</unit-skill> for 3 turns when hitting 3 ore more enemies.';
 
 function berserkerShip(): Ship {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ...({} as any),
         refits: [{}, {}, {}, {}],
         secondPassiveSkillText: BERSERKER_P2,

--- a/src/utils/combat/__tests__/enemyChargedCast.integration.test.ts
+++ b/src/utils/combat/__tests__/enemyChargedCast.integration.test.ts
@@ -143,7 +143,7 @@ const reactionAbilitiesFromText = (passiveText: string, refitCount: number): Abi
 // Resolve the three real reaction ability sets ONCE (parse is pure).
 const CURATOR_R0 = reactionAbilitiesFromText(CURATOR_R0_TEXT, 0); // purge 1
 const CURATOR_R4 = reactionAbilitiesFromText(CURATOR_R4_TEXT, 4); // purge 2 + Block Buff(2)
-const FRONTLINE_R2 = reactionAbilitiesFromText(FRONTLINE_R2_TEXT, 2); // damage 80% + shield (attack×24%)
+const FRONTLINE_R2 = reactionAbilitiesFromText(FRONTLINE_R2_TEXT, 2); // damage 80% + shield (30% of dealt damage)
 
 // ─── Enemy fixtures ───────────────────────────────────────────────────────────────────
 type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
@@ -420,31 +420,40 @@ describe('FrontLine damage+shield-on-enemy-charged (engine integration)', () => 
         expect(focusCumulativeDamage(reaction)).toBeGreaterThan(focusCumulativeDamage(control));
     });
 
-    it('the shield magnitude tracks attack (basis attack × 24%): a 2× attack FrontLine yields ~2× shield', () => {
-        // Shield basis 'attack', pct 24 → raw = effectiveAttack × 0.24. Doubling the focus's attack
-        // doubles the credited shield (proportionality, mirroring the amplification/Spearhead tests).
-        const lowAtk = runCombat(
+    it('the shield magnitude tracks the ACTUAL dealt damage (shrinks under enemy defense; basis damage-dealt)', () => {
+        // The reactive shield is 30% of FrontLine's OWN 80% reactive hit, which is defense-mitigated.
+        // A high-defense charging enemy mitigates that hit → a SMALLER shield. The old flat
+        // attack×24% model ignored the victim's defense entirely, so it would grant an EQUAL shield
+        // in both runs — this assertion discriminates the fix from the old approximation.
+        const lowDef = runCombat(
             buildFocusInput({
                 reactionAbilities: FRONTLINE_R2,
                 enemies: [buffingChargedEnemy({ id: 'e1', startCharged: true, chargeCount: 1 })],
                 numRounds: 1,
-                focusAttack: 1000,
             })
         );
-        const highAtk = runCombat(
+        const highDef = runCombat(
             buildFocusInput({
                 reactionAbilities: FRONTLINE_R2,
-                enemies: [buffingChargedEnemy({ id: 'e1', startCharged: true, chargeCount: 1 })],
+                enemies: [
+                    {
+                        ...buffingChargedEnemy({ id: 'e1', startCharged: true, chargeCount: 1 }),
+                        stats: {
+                            attack: 1000,
+                            crit: 0,
+                            critDamage: 0,
+                            speed: 40,
+                            defence: 100000,
+                        },
+                    },
+                ],
                 numRounds: 1,
-                focusAttack: 2000,
             })
         );
-        const sLow = totalShield(lowAtk);
-        const sHigh = totalShield(highAtk);
-        expect(sLow).toBeGreaterThan(0);
-        // ~2× (allow a small tolerance for any non-attack folding); strictly larger and near double.
-        expect(sHigh).toBeGreaterThan(sLow * 1.8);
-        expect(sHigh).toBeLessThan(sLow * 2.2);
+        expect(totalShield(lowDef)).toBeGreaterThan(0);
+        expect(totalShield(highDef)).toBeGreaterThan(0);
+        // Dealt-amount basis: mitigation shrinks the shield. (Old attack-basis model → equal.)
+        expect(totalShield(highDef)).toBeLessThan(totalShield(lowDef));
     });
 });
 

--- a/src/utils/combat/__tests__/overloadLifecycle.test.ts
+++ b/src/utils/combat/__tests__/overloadLifecycle.test.ts
@@ -336,6 +336,54 @@ describe('Overload lifecycle — engine fixtures', () => {
         expect(namesNoDebuff.some((round) => round.includes('Overload'))).toBe(true);
     });
 
+    it('3b. Butcher gains Marauder Rage II on debuff-inflict on the POSITIONAL path (simulateBattle, team-symmetric)', () => {
+        // Channel (B): the SP-G G4 gap. Channel-A test 3 proves this fires under runCombat; here we
+        // pin it under the positional two-team simulateBattle path, where SP0 found it silently
+        // never fired. Butcher inflicts Inferno II every round on an indestructible wall (no kill),
+        // so the ONLY source of Marauder Rage II is the on-debuff-inflicted reaction.
+        const butcher = ship('Butcher', {
+            activeSkillText:
+                'This Unit deals <unit-damage>160% damage</unit-damage> and inflicts <unit-skill>Inferno II</unit-skill> for 3 turns.',
+            firstPassiveSkillText: 'placeholder (R0 — superseded by the refit-active R2 passive)',
+            secondPassiveSkillText: BUTCHER_P2,
+            refits: [{}, {}] as Ship['refits'],
+        });
+        const r = simulateBattle({
+            playerTeam: [place(butcher, 'M4', 100, 1e12)],
+            enemyTeam: [place(dummy('wall', 'Defender'), 'M3', 1, 1e12)],
+            rounds: 4,
+        });
+        const mr = buffActorRounds(r, 'Marauder Rage II');
+        expect(mr.actors.has('attacker')).toBe(true);
+    });
+
+    it('3c. team symmetry — an ENEMY-side Butcher inflicting a debuff ALSO gains Marauder Rage II positionally', () => {
+        // Mirror of 3b with the Butcher on the ENEMY team. The G4 fix is parse-time (side-agnostic),
+        // so the reaction must fire identically on either side (feedback_engine_team_symmetry). A
+        // player-side indestructible wall is the debuff victim (no kill confound); the enemy Butcher
+        // inflicts Inferno II every round → its ONLY source of Marauder Rage II is on-debuff-inflicted.
+        const enemyButcher = ship('EnemyButcher', {
+            activeSkillText:
+                'This Unit deals <unit-damage>160% damage</unit-damage> and inflicts <unit-skill>Inferno II</unit-skill> for 3 turns.',
+            firstPassiveSkillText: 'placeholder (R0 — superseded by the refit-active R2 passive)',
+            secondPassiveSkillText: BUTCHER_P2,
+            refits: [{}, {}] as Ship['refits'],
+        });
+        const r = simulateBattle({
+            playerTeam: [place(dummy('wall', 'Defender'), 'M3', 1, 1e12)],
+            enemyTeam: [place(enemyButcher, 'M4', 100, 1e12)],
+            rounds: 4,
+        });
+        const mr = buffActorRounds(r, 'Marauder Rage II');
+        const enemyId = r.roster.find((x) => x.side === 'enemy')!.actorId;
+        // The grant landed — and ONLY on the enemy Butcher's own actor id (team-agnostic self-grant;
+        // it never leaks to the player side).
+        expect(mr.actors.has(enemyId)).toBe(true);
+        for (const a of mr.actors) {
+            expect(r.roster.find((x) => x.actorId === a)?.side).toBe('enemy');
+        }
+    });
+
     // ── 4. Ruiner on-enemy-repaired (gain Overload) ──────────────────────────
     it('4. Ruiner gains Overload when an enemy performs a repair (on-enemy-repaired)', () => {
         // Channel (A) healing mode: an enemy attacker that casts an all-allies repair each round.

--- a/src/utils/combat/__tests__/ownCleanseReactivePromotion.integration.test.ts
+++ b/src/utils/combat/__tests__/ownCleanseReactivePromotion.integration.test.ts
@@ -2,9 +2,10 @@
  * Phase 3 PR-H — combat-integration tests for the NEW `on-own-cleanse` reactive trigger:
  *   - Morao (3rd passive): "This Unit repairs 5% of its Max HP every turn and, upon Cleansing a
  *     Debuff, repairs an additional 5% of its Max HP while gaining Defense Up II for 2 turns" —
- *     the "every turn" repair stays on-cast (a separate, out-of-scope recurring-trigger gap); ONLY
- *     the "upon Cleansing" repair + Defense Up II ride on-own-cleanse. Self-target — no actor
- *     capture needed.
+ *     the "every turn" repair now rides start-of-turn (SP-G G1a, 2026-07-09: detectEveryTurnTrigger
+ *     closed the "every turn" recurring-trigger gap this file's own comments used to call
+ *     out-of-scope); the "upon Cleansing" repair + Defense Up II ride on-own-cleanse. Self-target —
+ *     no actor capture needed.
  *   - Cultivator (1st passive): "When this Unit cleanses a Debuff, it also repairs that ally for
  *     4% of this Unit's Max HP" — 'ally'-target, routed to the ACTUALLY-cleansed ally via
  *     eventCtx.cleansedAllyIds (cleanse-performed.targets), fanning out over every real removal
@@ -91,9 +92,9 @@ function sumBucket(
 // =============================================================================
 
 const MORAO_P3 =
-    "This Unit <unit-damage>repairs 5%</unit-damage> of its Max HP every turn and, upon <unit-aid>Cleansing a</unit-aid> Debuff, repairs an additional <unit-damage>5%</unit-damage> of its Max HP while gaining <unit-skill>Defense Up II</unit-skill> for 2 turns.";
+    'This Unit <unit-damage>repairs 5%</unit-damage> of its Max HP every turn and, upon <unit-aid>Cleansing a</unit-aid> Debuff, repairs an additional <unit-damage>5%</unit-damage> of its Max HP while gaining <unit-skill>Defense Up II</unit-skill> for 2 turns.';
 const MORAO_HP = 20_000;
-const MORAO_BASE_PCT = 5; // "every turn" — stays on-cast (out of scope)
+const MORAO_BASE_PCT = 5; // "every turn" — start-of-turn (SP-G G1a)
 const MORAO_REACTIVE_PCT = 5; // "upon Cleansing a Debuff" — on-own-cleanse
 
 /** Extracts Morao's REAL production passive slot (all 3 abilities, unfiltered — the baseline
@@ -107,12 +108,12 @@ function moraoPassiveAbilities(): Ability[] {
 }
 
 describe('Morao passive — extracted ability shapes (mutation guard)', () => {
-    it('the "every turn" repair stays on-cast; ONLY the "upon Cleansing" repair + Defense Up II ride on-own-cleanse', () => {
+    it('the "every turn" repair rides start-of-turn (SP-G G1a); the "upon Cleansing" repair + Defense Up II ride on-own-cleanse', () => {
         const abilities = moraoPassiveAbilities();
         const heals = abilities.filter((a) => a.type === 'heal');
         const buffs = abilities.filter((a) => a.type === 'buff');
         expect(heals).toHaveLength(2);
-        expect(heals.filter((a) => a.trigger === 'on-cast')).toHaveLength(1);
+        expect(heals.filter((a) => a.trigger === 'start-of-turn')).toHaveLength(1);
         expect(heals.filter((a) => a.trigger === 'on-own-cleanse')).toHaveLength(1);
         expect(buffs).toHaveLength(1);
         expect(buffs[0].trigger).toBe('on-own-cleanse');
@@ -205,7 +206,7 @@ describe('Morao (player-side) — self-cleanse drives the reactive repair + Defe
             MORAO_BASE({ enemyAttackers: [debuffEnemy('enemy-deb')] })
         );
         const result = runCombat(MORAO_BASE({ enemyAttackers: [debuffEnemy('enemy-deb')] }));
-        // Baseline (5%, on-cast, always fires) + reactive (5%, on-own-cleanse) = 10% total.
+        // Baseline (5%, start-of-turn — SP-G G1a, always fires) + reactive (5%, on-own-cleanse) = 10% total.
         expect(sumBucket(result, 'attacker', 'directHeal')).toBeCloseTo(
             (MORAO_HP * (MORAO_BASE_PCT + MORAO_REACTIVE_PCT)) / 100,
             6
@@ -218,7 +219,7 @@ describe('Morao (player-side) — self-cleanse drives the reactive repair + Defe
     it('NEGATIVE control: no debuff to cleanse → only the baseline 5% fires, no Defense Up II', () => {
         const { buffsApplied } = runAndCollectBuffs(MORAO_BASE());
         const result = runCombat(MORAO_BASE());
-        // Only the baseline "every turn" repair (on-cast) fires — the reactive never triggers.
+        // Only the baseline "every turn" repair (start-of-turn) fires — the reactive never triggers.
         expect(sumBucket(result, 'attacker', 'directHeal')).toBeCloseTo(
             (MORAO_HP * MORAO_BASE_PCT) / 100,
             6
@@ -266,10 +267,14 @@ const damageThenDebuff = (): ShipSkills['slots'][number] => ({
     ],
 });
 
+// Deliberately independent of MORAO_HP (20_000, the 'attacker'-side fixture above) — enemyAt is a
+// shared generic enemy-attacker factory (also used by the Cultivator team-symmetry test below),
+// so its HP is its own fixture value. FOE_HP names it for the self-heal-basis math below.
+const FOE_HP = 40_000;
 const enemyAt = (id: string, position: Position, shipSkills: ShipSkills): EnemyAttacker =>
     ({
         id,
-        stats: { attack: 1_000, crit: 0, critDamage: 0, defence: 0, hp: 40_000, speed: 50 },
+        stats: { attack: 1_000, crit: 0, critDamage: 0, defence: 0, hp: FOE_HP, speed: 50 },
         chargeCount: 0,
         startCharged: false,
         position,
@@ -313,8 +318,13 @@ describe('Morao (enemy-side) — team symmetry: an enemy Morao self-cleanses and
         };
         const { buffsApplied } = runAndCollectBuffs(input);
         const result = runCombat(input);
+        // SP-G G1a: the "every turn" repair now rides start-of-turn, so — team-symmetrically with
+        // the 'attacker'-side test above — BOTH self-heals fire on the enemy actor too (previously
+        // only the on-own-cleanse repair fired here; the base repair was dormant on the enemy side
+        // since 'on-cast' never applied to a walked enemy attacker). The basis is 'foe's OWN HP
+        // (FOE_HP, enemyAt's fixture value), not the player-fixture's MORAO_HP.
         expect(sumBucket(result, 'foe', 'directHeal')).toBeCloseTo(
-            (MORAO_HP * (MORAO_BASE_PCT + MORAO_REACTIVE_PCT)) / 100,
+            (FOE_HP * (MORAO_BASE_PCT + MORAO_REACTIVE_PCT)) / 100,
             6
         );
         const defenseUp = buffsApplied.filter((b) => b.buffName === 'Defense Up II');
@@ -589,7 +599,13 @@ describe("Cultivator's on-own-cleanse ally-target heal — cleansedAllyIds routi
             runtimes: new Map([
                 [
                     'cultivator',
-                    { actor: { id: 'cultivator' }, healModifier: 0, attack: 0, defence: 0, hp: 20_000 } as unknown as PlayerActorRuntime,
+                    {
+                        actor: { id: 'cultivator' },
+                        healModifier: 0,
+                        attack: 0,
+                        defence: 0,
+                        hp: 20_000,
+                    } as unknown as PlayerActorRuntime,
                 ],
             ]),
             grantAllyCharges: () => {},
@@ -624,10 +640,14 @@ describe("Cultivator's on-own-cleanse ally-target heal — cleansedAllyIds routi
         const { ctx, applied, credits } = buildHealCtx();
         executeIntent(makeHealIntent(['tank']), ctx);
         expect(applied).toEqual([800]);
-        expect(credits).toContainEqual({ actorId: 'cultivator', bucket: 'effectiveHeal', amount: 800 });
+        expect(credits).toContainEqual({
+            actorId: 'cultivator',
+            bucket: 'effectiveHeal',
+            amount: 800,
+        });
     });
 
-    it('MULTIPLE cleansedAllyIds fan out to EVERY actually-cleansed ally (robustness beyond Cultivator\'s real single-ally shape)', () => {
+    it("MULTIPLE cleansedAllyIds fan out to EVERY actually-cleansed ally (robustness beyond Cultivator's real single-ally shape)", () => {
         const { ctx, applied, credits } = buildHealCtx();
         executeIntent(makeHealIntent(['team1', 'tank']), ctx);
         // Both recipients are credited directHeal (one entry per recipient in the fan-out loop)...
@@ -641,7 +661,11 @@ describe("Cultivator's on-own-cleanse ally-target heal — cleansedAllyIds routi
         const { ctx, applied, credits } = buildHealCtx();
         executeIntent(makeHealIntent(undefined), ctx);
         expect(applied).toEqual([800]);
-        expect(credits).toContainEqual({ actorId: 'cultivator', bucket: 'effectiveHeal', amount: 800 });
+        expect(credits).toContainEqual({
+            actorId: 'cultivator',
+            bucket: 'effectiveHeal',
+            amount: 800,
+        });
     });
 });
 

--- a/src/utils/combat/__tests__/statusEngine.test.ts
+++ b/src/utils/combat/__tests__/statusEngine.test.ts
@@ -1404,6 +1404,72 @@ describe('per-target debuff stores (Task 1)', () => {
             expect(active[0].payload.buffName).toBe('WeakenAura');
         });
 
+        // SP-G G1b: a start-of-combat "N stacks" grant (Meatshield's Protection) is a
+        // stackable, non-accumulating buff — the parser leaves stackTrigger undefined so it
+        // rides the AURA branch (not accumulating) once seeded via buildShipAbilities' pre-combat
+        // relabel. Before this fix, the aura branch's `active` object never carried a `stacks`
+        // field at all (only the accumulating/persistent branches did), so a stackable one-shot
+        // grant's reported stack count silently vanished even though its STATIC payload.stacks
+        // was correct all along. Team-symmetric by construction: activeAbilityStatuses is the
+        // SAME function for both 'self' and 'enemy' — reading either aura list runs the
+        // identical stacks-inclusion branch below.
+        it("activeAbilityStatuses reports a stackable aura's payload.stacks on `active` — both sides (SP-G G1b)", () => {
+            const selfAura: RegisteredAbilityStatus = {
+                kind: 'aura',
+                side: 'self',
+                sourceSlot: 'passive',
+                conditions: [],
+                payload: {
+                    buffName: 'Protection',
+                    stacks: 3,
+                    parsedEffects: {},
+                    isStackable: true,
+                },
+            };
+            const enemyAura: RegisteredAbilityStatus = {
+                kind: 'aura',
+                side: 'enemy',
+                sourceSlot: 'passive',
+                conditions: [],
+                payload: {
+                    buffName: 'Protection',
+                    stacks: 3,
+                    parsedEffects: {},
+                    isStackable: true,
+                },
+            };
+            const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+            eng.registerAbilityStatuses([selfAura]);
+            eng.registerAbilityStatuses([enemyAura]);
+            eng.beginRound(1);
+
+            const self = eng.activeAbilityStatuses('self', () => baseCtx);
+            expect(self).toHaveLength(1);
+            expect(self[0].active.stacks).toBe(3);
+
+            const enemy = eng.activeAbilityStatuses('enemy', () => baseCtx);
+            expect(enemy).toHaveLength(1);
+            expect(enemy[0].active.stacks).toBe(3);
+        });
+
+        it('activeAbilityStatuses does NOT report stacks for a non-stackable aura (structural stacks:1 default stays hidden)', () => {
+            const aura: RegisteredAbilityStatus = {
+                kind: 'aura',
+                side: 'self',
+                sourceSlot: 'passive',
+                conditions: [],
+                // isStackable omitted (false-ish) — every buff/debuff payload carries a `stacks`
+                // field (non-stackable ones default to 1), but that's not a count worth reporting.
+                payload: { buffName: 'Focus', stacks: 1, parsedEffects: { crit: 15 } },
+            };
+            const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+            eng.registerAbilityStatuses([aura]);
+            eng.beginRound(1);
+            const active = eng.activeAbilityStatuses('self', () => baseCtx);
+            expect(active).toHaveLength(1);
+            expect(active[0].active.stacks).toBeUndefined();
+        });
+
         it('decrementEnemy decrements timed ability status on default target', () => {
             const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
             const status = timedEnemyStatus('Def Down', 2);

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -237,6 +237,11 @@ function registerActorAbilityStatuses(
                 stacks: cfg.stacks,
                 parsedEffects: cfg.parsedEffects,
                 ...(cfg.type === 'debuff' ? { application: cfg.application } : {}),
+                // SP-G G1b: threads the config's isStackable flag through so the aura branch of
+                // activeAbilityStatuses can tell a genuinely-stackable one-shot grant (Meatshield's
+                // Protection) apart from the structural stacks:1 default every non-stackable buff
+                // carries — only the former should surface a reported stack count.
+                ...(cfg.isStackable ? { isStackable: true } : {}),
             };
             // `as const` keeps the literal types (side, sourceSlot) so the spread into
             // a union variant below doesn't widen them — runtime object is unchanged.

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3124,6 +3124,11 @@ export function runCombat(input: CombatEngineInput): {
         // reactive heals fired by that emit correctly count toward THIS round (C2b-3).
         repairedThisRound.clear();
         hitThisRound.clear();
+        // SP-G G3 (CodeRabbit): reset the reactive dealt-amount slot each round so a
+        // basis:'damage-dealt' shield can never read a stale value from a previous round if its
+        // paired reactive-damage proc is gated out (differing procChance/oncePerRound/condition)
+        // and applyReactiveDamage never runs — the fallback read then correctly resolves to 0.
+        reactiveDealtByOwner.clear();
         // Reset per round so a start-of-round reactive drain (round 2+) stamps duringTurnOf
         // as turn-less (undefined) rather than the previous round's last acting actor.
         actingActorId = undefined;

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -4111,7 +4111,13 @@ export function runCombat(input: CombatEngineInput): {
             );
             // Guard: swallows zero/negative procs (defensive — a 0-attack or 0-multiplier proc
             // credits nothing), matching the pre-fix zero-damage guard.
-            if (raw <= 0) return;
+            if (raw <= 0) {
+                // SP-G G3: a non-positive reactive hit still resets the owner's dealt-amount slot,
+                // so a paired basis:'damage-dealt' shield (FrontLine) reads 0 for THIS proc rather
+                // than a stale prior-round value.
+                reactiveDealtByOwner.set(ownerId, 0);
+                return;
+            }
             reactiveDealtByOwner.set(ownerId, raw);
             creditDamage(ownerId, 'direct', raw);
         };
@@ -5407,6 +5413,8 @@ export function runCombat(input: CombatEngineInput): {
         // drainQueue's isTurnBlocked filter — a stunned owner's grant is dropped, matching every
         // other reactive.
         const drainStartOfTurnGrants = (ownerId: string): void => {
+            // The spliced batch (p/e) is drained in isolation; any follow-up intents a grant
+            // chain-enqueues land on the global queues and drain at the normal post-cast point.
             const isGrant = (i: Intent): boolean =>
                 i.ownerId === ownerId &&
                 i.ability.trigger === 'start-of-turn' &&

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2466,6 +2466,13 @@ export function runCombat(input: CombatEngineInput): {
     // skips the roll entirely) — no gate is ever created for them, so they can never crit by
     // construction, independent of the RNG stream.
     const reactiveDamageCritGates = new Map<string, RateGate>();
+    // SP-G G3: the last reactive-damage `raw` each owner dealt, so a sibling reactive shield
+    // enqueued on the SAME trigger (FrontLine's "Shield equal to 30% of the damage dealt")
+    // can scale off the ACTUAL mitigated/crit amount rather than a flat attack approximation.
+    // Written by applyReactiveDamage (below), read by the reactive-shield executor via the
+    // exec ctx. Damage intent drains before the shield intent (enqueue order), so the value is
+    // fresh when the shield reads it.
+    const reactiveDealtByOwner = new Map<string, number>();
 
     // ═══════════════════════════════════════════════════════════════════════════════════════
     // Reactive extra-action timing analysis (Phase 4b Task 10). Two death paths land an
@@ -4105,6 +4112,7 @@ export function runCombat(input: CombatEngineInput): {
             // Guard: swallows zero/negative procs (defensive — a 0-attack or 0-multiplier proc
             // credits nothing), matching the pre-fix zero-damage guard.
             if (raw <= 0) return;
+            reactiveDealtByOwner.set(ownerId, raw);
             creditDamage(ownerId, 'direct', raw);
         };
 
@@ -5180,6 +5188,7 @@ export function runCombat(input: CombatEngineInput): {
                         // undefined → assume-met fallback (byte-identical).
                         nameByActorId: nameByActorId.size > 0 ? nameByActorId : undefined,
                         lastTurnCtxByActor,
+                        reactiveDealtByOwner,
                         enemyType,
                         enemyHp,
                         // Drain-time HP% includes this round's damage SO FAR (the round

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -5337,23 +5337,25 @@ export function runCombat(input: CombatEngineInput): {
 
         // Player drain — binds the player queue + player-side ctx. Behaviourally identical to
         // the pre-refactor drainIntents (same runtimes/playerIds/lowest-speed/grantAllyCharges).
-        const drainIntents = (): void =>
-            drainQueue(intentQueue, {
-                runtimes: runtimesById,
-                recipientIds: playerIds,
-                isLowestSpeedAllyFor: (ownerId) => bySide('player').lowestSpeedIds().has(ownerId),
-                grantAllyCharges: bySide('player').grantAllyCharges,
-                removeEnemyCharges: bySide('player').removeEnemyCharges,
-                removeChargesFrom: bySide('player').removeChargesFrom,
-                selfHpPctFor: bySide('player').selfHpPctFor,
-                enemyWithMostBuffs: () => mostBuffsAmong(enemyAttackerActors),
-                enemyWithHighestAttack: () => highestAttackInRoster(enemyAttackerActors),
-                firstActivatorId,
-                lastStandingId: soleSurvivorOf(allPlayerActors),
-                oncePerRoundConsumed,
-                adjacentAllyIdsFor: bySide('player').adjacentAllyIdsFor,
-                footprintAllyIdsFor: bySide('player').footprintAllyIdsFor,
-            });
+        // Hoisted into a named factory (SP-G G2) so the new pre-cast start-of-turn grant drain
+        // can reuse the exact same ctx shape as the full drain.
+        const playerDrainCtx = (): ReactiveSideCtx => ({
+            runtimes: runtimesById,
+            recipientIds: playerIds,
+            isLowestSpeedAllyFor: (ownerId) => bySide('player').lowestSpeedIds().has(ownerId),
+            grantAllyCharges: bySide('player').grantAllyCharges,
+            removeEnemyCharges: bySide('player').removeEnemyCharges,
+            removeChargesFrom: bySide('player').removeChargesFrom,
+            selfHpPctFor: bySide('player').selfHpPctFor,
+            enemyWithMostBuffs: () => mostBuffsAmong(enemyAttackerActors),
+            enemyWithHighestAttack: () => highestAttackInRoster(enemyAttackerActors),
+            firstActivatorId,
+            lastStandingId: soleSurvivorOf(allPlayerActors),
+            oncePerRoundConsumed,
+            adjacentAllyIdsFor: bySide('player').adjacentAllyIdsFor,
+            footprintAllyIdsFor: bySide('player').footprintAllyIdsFor,
+        });
+        const drainIntents = (): void => drainQueue(intentQueue, playerDrainCtx());
 
         // Enemy drain (enemy-team PR1) — binds the SEPARATE enemy queue + enemy-side ctx.
         // recipientIds is the enemy-attacker ids (PR1 exercises self-target only; this
@@ -5362,27 +5364,56 @@ export function runCombat(input: CombatEngineInput): {
         // ally-charge grant now bumps the enemy attackers' charges, not the player team.
         // Skips entirely when the enemy queue is empty (DPS / no enemy reactives) so the
         // player path is untouched.
+        // Use the enemy executor's own runtime map (NOT runtimesById, which drives
+        // leech scan / seeding / credit and must stay player-only). This reuses the
+        // existing enemyPlayerRuntimeByActorId — same source, key, and values.
+        // Hoisted into a named factory (SP-G G2) alongside playerDrainCtx above.
+        const enemyDrainCtx = (): ReactiveSideCtx => ({
+            runtimes: enemyPlayerRuntimeByActorId,
+            recipientIds: enemyAttackerActorIds,
+            isLowestSpeedAllyFor: (ownerId) => bySide('enemy').lowestSpeedIds().has(ownerId),
+            grantAllyCharges: bySide('enemy').grantAllyCharges,
+            removeEnemyCharges: bySide('enemy').removeEnemyCharges,
+            removeChargesFrom: bySide('enemy').removeChargesFrom,
+            selfHpPctFor: bySide('enemy').selfHpPctFor,
+            enemyWithMostBuffs: () => mostBuffsAmong(allPlayerActors),
+            enemyWithHighestAttack: () => highestAttackInRoster(allPlayerActors),
+            firstActivatorId,
+            lastStandingId: soleSurvivorOf(enemyAttackerActors),
+            oncePerRoundConsumed,
+            adjacentAllyIdsFor: bySide('enemy').adjacentAllyIdsFor,
+            footprintAllyIdsFor: bySide('enemy').footprintAllyIdsFor,
+        });
         const drainEnemyIntents = (): void => {
             if (enemyIntentQueue.length === 0) return;
-            // Use the enemy executor's own runtime map (NOT runtimesById, which drives
-            // leech scan / seeding / credit and must stay player-only). This reuses the
-            // existing enemyPlayerRuntimeByActorId — same source, key, and values.
-            drainQueue(enemyIntentQueue, {
-                runtimes: enemyPlayerRuntimeByActorId,
-                recipientIds: enemyAttackerActorIds,
-                isLowestSpeedAllyFor: (ownerId) => bySide('enemy').lowestSpeedIds().has(ownerId),
-                grantAllyCharges: bySide('enemy').grantAllyCharges,
-                removeEnemyCharges: bySide('enemy').removeEnemyCharges,
-                removeChargesFrom: bySide('enemy').removeChargesFrom,
-                selfHpPctFor: bySide('enemy').selfHpPctFor,
-                enemyWithMostBuffs: () => mostBuffsAmong(allPlayerActors),
-                enemyWithHighestAttack: () => highestAttackInRoster(allPlayerActors),
-                firstActivatorId,
-                lastStandingId: soleSurvivorOf(enemyAttackerActors),
-                oncePerRoundConsumed,
-                adjacentAllyIdsFor: bySide('enemy').adjacentAllyIdsFor,
-                footprintAllyIdsFor: bySide('enemy').footprintAllyIdsFor,
-            });
+            drainQueue(enemyIntentQueue, enemyDrainCtx());
+        };
+
+        // SP-G G2: start-of-turn GRANTS (buffs/shields/heals) must apply BEFORE the acting owner
+        // casts, so a self-buff boosts the same turn it is granted (matching the game). Scoped to
+        // the acting owner only. CHARGE intents are EXCLUDED — they keep their post-cast drain
+        // (see drainIntents()/drainEnemyIntents() calls in the turn loop below), on which the
+        // Cobalt charge ledger depends. Team-symmetric: drains both side queues, so a ship on
+        // either side gets the same pre-cast ordering. Turn-block suppression is inherited from
+        // drainQueue's isTurnBlocked filter — a stunned owner's grant is dropped, matching every
+        // other reactive.
+        const drainStartOfTurnGrants = (ownerId: string): void => {
+            const isGrant = (i: Intent): boolean =>
+                i.ownerId === ownerId &&
+                i.ability.trigger === 'start-of-turn' &&
+                i.ability.type !== 'charge';
+            const take = (queue: Intent[]): Intent[] => {
+                const ready: Intent[] = [];
+                for (let i = 0; i < queue.length; ) {
+                    if (isGrant(queue[i])) ready.push(queue.splice(i, 1)[0]);
+                    else i++;
+                }
+                return ready;
+            };
+            const p = take(intentQueue);
+            if (p.length) drainQueue(p, playerDrainCtx());
+            const e = take(enemyIntentQueue);
+            if (e.length) drainQueue(e, enemyDrainCtx());
         };
 
         // Path-B flush (Task 10): grants buffered from a PRIOR round's post-round enemy death
@@ -5554,6 +5585,10 @@ export function runCombat(input: CombatEngineInput): {
                 // uses a ≥2-turn block spanning a proc turn.
                 // The dummy-sink enemy is also bumped here; harmless (no every-n-turns ability on it).
                 actor.turnsTaken += 1;
+
+                // SP-G G2: apply this actor's start-of-turn GRANTS before it acts (see
+                // drainStartOfTurnGrants). Runs for every acting actor on both sides.
+                drainStartOfTurnGrants(actor.id);
 
                 // Task 11b: tick the HEAL TARGET's own enemy-applied DoTs at ITS turn-start
                 // (mirroring the dummy enemy's DoT-tick timing — DoTs tick at the afflicted ship's

--- a/src/utils/combat/statusEngine.ts
+++ b/src/utils/combat/statusEngine.ts
@@ -45,6 +45,12 @@ export interface AbilityStatusPayload {
     stacks: number;
     parsedEffects: ParsedBuffEffects;
     application?: 'inflict' | 'apply';
+    /** SP-G G1b: mirrors the ability config's `isStackable` flag. `stacks` is populated on
+     *  EVERY buff/debuff payload (even non-stackable ones default to 1) — this flag lets a
+     *  consumer (the aura branch of activeAbilityStatuses) distinguish "genuinely stackable,
+     *  report the count" from "stacks:1 is just the structural default, no count to report".
+     *  Absent/false preserves prior behaviour byte-for-byte. */
+    isStackable?: boolean;
 }
 
 interface AbilityStatusBase {
@@ -1389,7 +1395,21 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
             if (!conditionsMet(a.conditions, resolveCtx(a.casterId ?? 'attacker'))) continue;
             out.push({
                 payload: a.payload,
-                active: { buffName: a.payload.buffName, turnsRemaining: 'recurring' },
+                active: {
+                    buffName: a.payload.buffName,
+                    turnsRemaining: 'recurring',
+                    // SP-G G1b: a one-time "N stacks" grant (Meatshield's Protection) rides the
+                    // aura branch once its per-round stackTrigger cadence is suppressed (a stackable,
+                    // non-accumulating buff — see skillTextParser's startOfCombatOneShot carve-out).
+                    // Without this, the aura's reported stack count silently dropped (undefined),
+                    // even though the STATIC payload.stacks carried the configured count all along.
+                    // Gated on isStackable (not just `stacks !== undefined`) because EVERY buff/debuff
+                    // payload carries a `stacks` field — non-stackable buffs default it to 1, which is
+                    // a structural placeholder, not a meaningful count to surface here.
+                    ...(a.payload.isStackable && a.payload.stacks !== undefined
+                        ? { stacks: a.payload.stacks }
+                        : {}),
+                },
                 casterId: a.casterId,
             });
         }

--- a/src/utils/combat/statusEngine.ts
+++ b/src/utils/combat/statusEngine.ts
@@ -1446,6 +1446,9 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
         // enemyTargetId). The `ownerId` param is ignored for enemy-side; `enemyTargetId`
         // is ignored for self-side — matching the pre-Task-1 behavior where enemy maps were
         // singular and ownerId was never consulted for them.
+        // NOTE: like the aura branch, this finite-duration branch does not surface `active.stacks`.
+        // No corpus ship pairs a stackable status with a finite duration today; if one appears,
+        // apply the same isStackable-gated stacks spread used in the aura branch above.
         const map = side === 'self' ? selfMaps.get(ownerId) : enemyMaps.get(enemyTargetId);
         const out: ActiveAbilityStatus[] = [];
         if (map) {

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -973,6 +973,10 @@ export interface IntentExecContext {
     /** Per-actor last-turn ctx (effectiveAttack/affinityMult for bombs). Undefined for an
      *  owner that has not acted this run (faster enemy, round 1) → bomb follow-ups skip. */
     lastTurnCtxByActor: Map<string, PlayerRoundCtx>;
+    /** SP-G G3: last reactive-damage amount each owner dealt this drain cycle. A reactive shield
+     *  on the same trigger with basis 'damage-dealt' but no eventCtx.triggerDamage (on-enemy-
+     *  charged-cast stamps only counterTargetId) falls back to this owner-keyed amount. */
+    reactiveDealtByOwner?: Map<string, number>;
     enemyType?: EnemyBaseClass;
     enemyHp: number;
     /** Damage dealt to the enemy so far (drives the drain-time enemyHpPct). */
@@ -2286,7 +2290,15 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                       // the damage TAKEN (the on-attacked hit's e.damage) for damage-taken. Falls
                       // back to 0 when no triggering damage is present (non-crit path or missing
                       // context) — a damage-scaled reactive with no damage context grants nothing.
-                      (intent.eventCtx?.triggerDamage ?? 0)
+                      (intent.eventCtx?.triggerDamage ??
+                      // SP-G G3: on-enemy-charged-cast doesn't stamp triggerDamage; a
+                      // damage-dealt shield falls back to the sibling reactive-damage proc's
+                      // actual dealt amount (stamped in applyReactiveDamage). damage-dealt
+                      // ONLY — damage-taken has no sibling-proc dealt amount to fall back to.
+                      (cfg.basis === 'damage-dealt'
+                          ? ctx.reactiveDealtByOwner?.get(intent.ownerId)
+                          : undefined) ??
+                      0)
                     : cfg.basis === 'overheal'
                       ? // Reactive overheal (Abundant Renewal on-own-repair-to-ally): scale off the
                         // clipped over-repair captured in eventCtx.overhealAmount by the listener.

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -2841,20 +2841,11 @@ export function parseEnemyChargedCastReaction(text: string | null | undefined): 
                 oncePerRound,
                 autoFilled: true,
             });
-            // Shield basis derivation: the text says "30% of the damage dealt", referring to
-            // FrontLine's OWN 80% reactive damage. The reactive-shield executor's
-            // basis:'damage-dealt' reads eventCtx.triggerDamage, which on THIS trigger is the
-            // ENEMY's charged-cast damage (wrong). So the shield is modeled as basis:'attack'
-            // with pct = shieldPct * damagePct / 100 = 30*80/100 = 24 — an UN-mitigated
-            // approximation of "the damage dealt". Kept exact (no round) so a fractional
-            // source percentage isn't silently truncated.
-            //
-            // KNOWN DIVERGENCE (#211): since epic PR4b the reactive DAMAGE half is
-            // defense-mitigated and crit-eligible, so this flat-attack shield no longer shares
-            // the damage's basis — vs a high-defense enemy the shield over-grants relative to
-            // the true dealt amount (and under-grants on a crit). Tying the shield to the
-            // ACTUAL applyReactiveDamage result needs new eventCtx plumbing (thread the dealt
-            // amount into the reactive-shield executor for this trigger) — deferred.
+            // SP-G G3: the shield is "30% of the damage dealt" — FrontLine's OWN 80% reactive
+            // hit, which applyReactiveDamage computes defense-mitigated and crit-eligible. The
+            // reactive-damage intent drains before this shield intent (enqueue order) and stamps
+            // its dealt amount into reactiveDealtByOwner; basis:'damage-dealt' reads it via the
+            // exec ctx (see triggers.ts). pct is the raw clause percentage (30) — no attack fold.
             out.push({
                 id: '',
                 type: 'shield',
@@ -2863,8 +2854,8 @@ export function parseEnemyChargedCastReaction(text: string | null | undefined): 
                 conditions: [],
                 config: {
                     type: 'shield',
-                    basis: 'attack',
-                    pct: (shieldPct * damagePct) / 100,
+                    basis: 'damage-dealt',
+                    pct: shieldPct,
                 },
                 oncePerRound,
                 autoFilled: true,

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -4669,8 +4669,13 @@ export function parseSkillEffects(
 
         // Detect accumulating buffs: stacks gained per trigger with a recurring duration.
         // passive sources → per-round; active/charge → per-active/per-charge.
+        // SP-G G1b EXCEPTION: a start-of-combat "N stacks" grant (Meatshield) is a ONE-TIME
+        // grant, not a per-turn accumulator — leave stackTrigger undefined so buildShipAbilities'
+        // isAccumulatingBuff gate is false and the pre-combat relabel fires. The N-stack count and
+        // the persistent 'recurring' duration are preserved (seeded once at combat start).
         let stackTrigger: StackTrigger | undefined;
-        if (stacks !== undefined && duration === 'recurring') {
+        const startOfCombatOneShot = START_OF_COMBAT_GRANT_RE.test(prevText);
+        if (stacks !== undefined && duration === 'recurring' && !startOfCombatOneShot) {
             if (source === 'passive1' || source === 'passive2' || source === 'passive3') {
                 stackTrigger = 'per-round';
             } else if (source === 'active') {

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1202,6 +1202,10 @@ function matchesActiveSelfCrit(text: string): boolean {
 }
 const START_OF_ROUND_RE =
     /at the start of (?:the|each|every) round|starts? (?:the|each|every) round/i;
+// "every turn" / "each turn" — a per-own-turn recurring self-grant. Distinct from
+// START_OF_TURN_CHARGE_RE ("at the start of the turn"): the trailing-phrase form Kinetik's
+// per-turn shield and Cinya's per-turn heal use (docs/ship-skills.csv). SP-G G1a.
+const EVERY_TURN_RE = /\b(?:each|every)\s+turn\b/i;
 // "starts (each|every|the) round with <buff>" — a start-of-round self-grant whose governing
 // phrase uses no application verb (Chakara's R2 passive; unique in the corpus). findVerb treats
 // it as a self-receive ('gains') so the buff segments extract.
@@ -2068,6 +2072,24 @@ export function detectStartOfRoundTrigger(
     anchorPos: number
 ): AbilityTrigger | undefined {
     return phrasePosTrigger(text, START_OF_ROUND_RE, anchorPos, 'start-of-round');
+}
+
+/**
+ * SP-G G1a: returns 'start-of-turn' when `anchorPos` (a shield/heal ability's raw-text anchor)
+ * falls in a sentence carrying "every turn"/"each turn". Position-scoped (mirrors
+ * phrasePosTrigger's sentence-scoping) so an unrelated heal/shield in another sentence is never
+ * co-triggered. Reference data: docs/ship-skills.csv (Kinetik shield, Cinya heal).
+ */
+export function detectEveryTurnTrigger(
+    text: string,
+    anchorPos: number
+): 'start-of-turn' | undefined {
+    // phrasePosTrigger's return type is the broader AbilityTrigger (it's shared by every
+    // detectX helper); passed the literal 'start-of-turn' trigger, it can only ever come back
+    // as that literal or undefined, so the narrowing cast here is safe.
+    return phrasePosTrigger(text, EVERY_TURN_RE, anchorPos, 'start-of-turn') as
+        | 'start-of-turn'
+        | undefined;
 }
 
 /**


### PR DESCRIPTION
## Model-Completeness SP-G — Engine Known-Limitations (final epic step)

Closes the last six engine-only known-limitation markers of the model-completeness epic — four independent mechanisms across six ships, each verified through a production routing/runtime path. **This completes the model-completeness epic** (SP0 #230 · SP-A/B #233 · SP-C/D #235 · SP-E #236 · SP-F #237 · SP-G here).

### What changed

- **G1a — Kinetik / Cinya** ("every turn" self shield/heal): new `EVERY_TURN_RE` phrase detector routes per-turn self shield/heal to the existing `start-of-turn` trigger instead of falling through to `on-cast`. The generic detector also correctly fixed Morao/Redeemer/Nemesis.
- **G1b — Meatshield** ("at the start of combat, 3 stacks of Protection"): re-modelled from an `on-cast` per-cast-climbing buff to a **one-time `pre-combat` 3-stack grant**. Also fixed a latent engine gap — the aura branch of `statusEngine` never reported `active.stacks` (now gated on `isStackable`).
- **G2 — Cobalt** (start-of-turn grant ordering): start-of-turn **grant** intents now drain **before** the acting owner casts, so a self-buff boosts the same turn it is granted (was every-other-turn). Charge intents are excluded from the pre-cast drain, so the Cobalt charge ledger is unchanged. Team-symmetric via the single shared turn loop.
- **G3 — FrontLine** (reactive shield magnitude): the shield now scales off the **actual dealt damage** (defense-mitigated, crit-eligible, affinity-aware) instead of a flat `attack × 24%`. `applyReactiveDamage` stamps its dealt amount into an owner-keyed map that the sibling `basis:'damage-dealt'` shield reads.
- **G4 — Butcher** (positional on-debuff-inflicted): fixed a team-symmetry violation where Marauder Rage II fired on the DPS path but never in team battles. Root cause: "On inflicting a debuff" was double-classified — promoted to the `on-debuff-inflicted` trigger **and** given a redundant `enemy-debuff` gate that reads the enemy's live debuff store (populated on the shared-dummy DPS path, empty per-victim positionally). The fix drops that redundant gate (mirrors the accepted `on-enemy-buffed`/`enemy-buff` precedent).

Plus an incidental `chore` commit fixing a **pre-existing** misplaced `eslint-disable` directive in `enemiesHitGate.integration.test.ts` (was flagged unused by `--report-unused-disable-directives`, blocking the lint gate).

### Verification

- Full suite **4363/4363** green (whole-`npm test` golden audit; no `vitest -u`).
- `tsc --noEmit` clean · `npm run lint` (`--max-warnings 0`) clean · `audit:skills` **147 ships → 0 findings / 0 stale**.
- All three engine mechanisms (G2/G3/G4) are team-symmetric (G4 tested both sides; G2/G3 symmetric by shared-closure construction). New maps are provably inert for unaffected ships → goldens byte-identical.
- Subagent-driven: 5 sequential tasks, per-task Opus review + a whole-branch Opus review ("Ready to merge: Yes", no Critical/Important).

### Out of scope (unchanged deferrals)
SP-F Protection-as-damage-transfer + Meatshield "maintain 3 stacks" sibling; data-layer/harness allowlist FPs (innate shield-pen, always-crit). Retained allowlist entries: FrontLine `shield-penetration-innate`, Meatshield `transform-incoming-to-dot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
