### PR TITLE
fix(combat): Sentinel reaction-only passives no longer act on its own turn (#2)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -66,6 +66,8 @@ export const UNRELEASED_CHANGES: string[] = [
     'Cobalt\'s start-of-turn "Out. Damage Up II" buff now boosts every one of its turns while at full HP, instead of every other turn.',
     "FrontLine's reactive shield (on an enemy charged skill) now scales off the actual damage it deals — accounting for enemy defense, crits, and affinity — instead of a flat approximation.",
     'Butcher now correctly gains Marauder Rage II when it inflicts a debuff in team battles (previously the buff only applied in the single-target DPS view).',
+    "Combat sim: Sentinel no longer damages or heals on its own turn. Its reaction-only passives now correctly fire when an ally critically hits an enemy — dealing its bonus damage to that enemy and repairing the ally who landed the crit — instead of leaking onto Sentinel's own turn.",
+    'Combat log: reactive damage and reactive repairs now show up in the log, nested under the turn that triggered them. Previously these procs (Sentinel, Grif, FrontLine, Judge, Vindicator, Paracelsus, and other "when …" damage/heal reactions) were applied but never displayed.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -1073,10 +1073,17 @@ function abilitiesFromText(
         // (triggers.ts cfg.type==='damage' branch) and, for start-of-round specifically, the
         // partition machinery removing it from the old passive-payload-hit cast-time fold
         // (playerTurn.ts) both already exist; this ability just needs the correct label.
+        // #2 (Sentinel): a passive damage clause anchored in a "when an ally critically hits an
+        // enemy … deals X% damage to that enemy" sentence rides the on-ally-crit reactive trigger
+        // (the crit-victim enemy is routed via eventCtx.counterTargetId — triggers.ts on-ally-crit
+        // listener). Position-scoped like the round-boundary detectors above, so a co-located
+        // on-cast hit in another sentence is never co-triggered. Corpus: Sentinel alone carries an
+        // ally-crit DAMAGE clause (Hermes = charge, Howler = cleanse — both already wired).
         const damageTrigger: AbilityTrigger =
             detectStartOfRoundTrigger(text, damagePos) ??
             detectEndOfRoundDamageTrigger(text, damagePos) ??
             detectRoundStartContinuationTrigger(text, damagePos) ??
+            detectAllyCritTrigger(text, damagePos) ??
             'on-cast';
         // SP-F F1: emit the BASE branch FIRST (out[0]) so the ungated `.find`-first reads of
         // noCrit/hits below resolve sensibly, and so it stays out[0] for the conditional-scaling
@@ -1720,6 +1727,14 @@ function abilitiesFromText(
                 // calculator consumes start-of-turn self shields/heals; DPS is unaffected.
                 detectEveryTurnTrigger(text, healPos) ??
                 detectCritRepairTrigger(text, healPos) ??
+                // #2 (Sentinel): a repair anchored in a "when an ally critically hits an enemy …
+                // repairs the ally" sentence rides on-ally-crit — the crit-ing ally is routed via
+                // eventCtx.damagedAllyId (triggers.ts on-ally-crit listener; the same lane Howler's
+                // cleanse uses). Distinct from detectCritRepairTrigger above, which matches "when
+                // this Unit critically REPAIRS an ally" (Pallas). Position-scoped; corpus:
+                // Sentinel alone carries an ally-crit HEAL clause (Hermes/Howler self-heal in
+                // active/charge slots, no ally-crit phrase there).
+                detectAllyCritTrigger(text, healPos) ??
                 // Yazid: a repair anchored in the "when Cheat Death activates" sentence rides the
                 // on-cheat-death-activated reactive trigger (self-scoped; position-scoped). Checked
                 // for heals AND shields (the follow-on is a repair, but keep the path symmetric).

--- a/src/utils/calculators/battleSimulator.ts
+++ b/src/utils/calculators/battleSimulator.ts
@@ -207,6 +207,9 @@ export const LOG_EVENT_TYPES = [
     'cleanse-performed',
     'purge-performed',
     'ship-destroyed',
+    // Log-only reactive procs (drain-time damage/heal that emit no ability-performed/heal-performed).
+    'reactive-damage-performed',
+    'reactive-heal-performed',
 ] as const satisfies readonly CombatEvent['type'][];
 
 // Compile-time proof that LOG_EVENT_TYPES ⊇ ASSEMBLED_EVENT_TYPES (bus subscribes to LOG;

--- a/src/utils/combat/__tests__/allyCritReactivePromotion.integration.test.ts
+++ b/src/utils/combat/__tests__/allyCritReactivePromotion.integration.test.ts
@@ -613,12 +613,15 @@ describe('Sentinel (player-side) — reactive heal + damage fire on ally crit, n
         const dmg = reactiveDamage.filter((e) => e.sourceId === 'sentinel');
         expect(dmg.length).toBeGreaterThan(0);
         expect(dmg.every((e) => e.amount > 0 && e.duringTurnOf === 'attacker')).toBe(true);
-        // Reactive HEAL surfaced for the log: caster=sentinel, a recipient present, same stamp.
+        // Reactive HEAL surfaced for the log: caster=sentinel, same stamp, and the repair lands
+        // on the CRIT-ing ally (attacker) — NOT the healTargetId fallback (ally-b). This proves
+        // the damagedAllyId routing via the perTarget recipient, catching the wrong-target trap.
         const heal = reactiveHeals.filter((e) => e.casterId === 'sentinel');
         expect(heal.length).toBeGreaterThan(0);
-        expect(heal.every((e) => e.perTarget.length > 0 && e.duringTurnOf === 'attacker')).toBe(
-            true
-        );
+        expect(heal.every((e) => e.duringTurnOf === 'attacker')).toBe(true);
+        const healRecipients = heal.flatMap((e) => e.perTarget.map((t) => t.targetId));
+        expect(healRecipients).toContain('attacker');
+        expect(healRecipients).not.toContain('ally-b');
     });
 
     it('does NOT heal or deal damage on its own turn when no ally crits (the on-turn leak)', () => {
@@ -699,10 +702,17 @@ describe('Sentinel (enemy-side) — team symmetry: an enemy Sentinel reacts to i
             enemyAttackers: [enemySentinel, enemyCritAlly],
         };
 
-        const { result, credits } = runSentinel(input);
+        const { result, credits, reactiveHeals } = runSentinel(input);
         // The enemy Sentinel's repair fires (directHeal credited) and its reactive damage credits —
         // both keyed to the ENEMY owner, never a player-side actor.
         expect(totalDirectHeal(result, 'enemy-sentinel')).toBeGreaterThan(0);
         expect(credits.some((c) => c.sourceId === 'enemy-sentinel' && c.amount > 0)).toBe(true);
+        // Team symmetry at the recipient level: the reactive repair lands on the crit-ing ENEMY
+        // ally (enemy-critter), never crossing onto a player-side actor.
+        const heal = reactiveHeals.filter((e) => e.casterId === 'enemy-sentinel');
+        expect(heal.length).toBeGreaterThan(0);
+        const healRecipients = heal.flatMap((e) => e.perTarget.map((t) => t.targetId));
+        expect(healRecipients).toContain('enemy-critter');
+        expect(healRecipients).not.toContain('attacker');
     });
 });

--- a/src/utils/combat/__tests__/allyCritReactivePromotion.integration.test.ts
+++ b/src/utils/combat/__tests__/allyCritReactivePromotion.integration.test.ts
@@ -273,7 +273,9 @@ describe('Howler (player-side) — cleanse + Blast land on the crit-ing ally, no
     it('the crit-ing ally (attacker) is cleansed; the non-critting ally (ally-b, the fallback) keeps its debuff', () => {
         const { engine } = runAndCollect(BASE());
         expect(
-            engine.timedAbilityStatuses('enemy', undefined, 'attacker').map((s) => s.active.buffName)
+            engine
+                .timedAbilityStatuses('enemy', undefined, 'attacker')
+                .map((s) => s.active.buffName)
         ).toEqual([]);
         expect(
             engine.timedAbilityStatuses('enemy', undefined, 'ally-b').map((s) => s.active.buffName)
@@ -440,5 +442,267 @@ describe('Howler (enemy-side) — team symmetry: an enemy Howler reacts to its O
         const blast = buffsApplied.filter((b) => b.buffName === 'Blast');
         expect(blast).toHaveLength(1);
         expect(blast[0].actorId).toBe('enemy-critter');
+    });
+});
+
+// =============================================================================
+// Sentinel (#2 reaction-only-on-turn fix) — a reaction-only unit whose passive damage AND heal
+// fire ONLY "when an ally critically hits an enemy". Both must ride on-ally-crit: the damage
+// lands on the CRIT-VICTIM enemy ("that enemy"), the heal on the CRIT-ING ally ("the ally").
+// On Sentinel's OWN turn nothing should fire (the reported leak was an on-turn heal).
+//
+//   R0 (unrefit):   "…this Unit deals 40% damage to that enemy. This attack cannot crit."
+//   R2 (refit-active): "…repairs the ally for 5% of Max HP AND deals 60% damage to that enemy…"
+// (docs/ship-skills.csv, verbatim.)
+// =============================================================================
+
+const SENTINEL_R0 =
+    'When an ally critically hits an enemy, this Unit deals <unit-damage>40% damage</unit-damage> to that enemy.<br />This attack cannot critically hit.';
+const SENTINEL_R2 =
+    "When an ally critically hits an enemy, this Unit <unit-damage>repairs the ally for 5%</unit-damage> of this Unit's Max HP and deals <unit-damage>60% damage</unit-damage> to that enemy.<br />This attack cannot critically hit.";
+
+/** Sentinel's refit-resolved passive abilities through the REAL parser/builder. */
+function sentinelPassiveAbilities(refits: number): Ability[] {
+    return (
+        buildShipAbilities(
+            ship({
+                refits: Array.from({ length: refits }, () => ({})) as Ship['refits'],
+                firstPassiveSkillText: SENTINEL_R0,
+                secondPassiveSkillText: SENTINEL_R2,
+            })
+        ).slots.find((s) => s.slot === 'passive')?.abilities ?? []
+    );
+}
+
+describe('Sentinel ally-crit abilities — extracted shape (mutation guard)', () => {
+    it('R0 passive damage rides on-ally-crit, targeting the enemy, cannot crit', () => {
+        const dmg = sentinelPassiveAbilities(0).find((a) => a.type === 'damage');
+        if (!dmg) throw new Error('mutation guard: Sentinel R0 on-ally-crit damage not found');
+        expect(dmg.trigger).toBe('on-ally-crit');
+        expect(dmg.target).toBe('enemy');
+        expect(dmg.config).toMatchObject({ type: 'damage', multiplier: 40, noCrit: true });
+    });
+
+    it('R2 passive heal rides on-ally-crit, targeting the ally', () => {
+        const heal = sentinelPassiveAbilities(2).find((a) => a.type === 'heal');
+        if (!heal) throw new Error('mutation guard: Sentinel R2 on-ally-crit heal not found');
+        expect(heal.trigger).toBe('on-ally-crit');
+        expect(heal.target).toBe('ally');
+        expect(heal.config).toMatchObject({ type: 'heal', pct: 5 });
+    });
+
+    it('R2 passive damage rides on-ally-crit, targeting the enemy, cannot crit', () => {
+        const dmg = sentinelPassiveAbilities(2).find((a) => a.type === 'damage');
+        if (!dmg) throw new Error('mutation guard: Sentinel R2 on-ally-crit damage not found');
+        expect(dmg.trigger).toBe('on-ally-crit');
+        expect(dmg.target).toBe('enemy');
+        expect(dmg.config).toMatchObject({ type: 'damage', multiplier: 60, noCrit: true });
+    });
+});
+
+/** A Sentinel observer (team actor): R2 passive (heal + damage), real attack/HP so its reactive
+ *  damage credits and its 5%-Max-HP repair is non-zero. Acts LAST so ally crits precede it. */
+const sentinelObserver = (position: Position): TeamActorEngineInput =>
+    ({
+        id: 'sentinel',
+        speed: 1,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        walk: {
+            shipSkills: {
+                slots: [
+                    { slot: 'active', abilities: [noopActive()] },
+                    { slot: 'passive', abilities: sentinelPassiveAbilities(2) },
+                ],
+            },
+            stats: {
+                attack: 1000,
+                crit: 0,
+                critDamage: 100,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp: 20_000,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    }) as TeamActorEngineInput;
+
+function runSentinel(input: CombatEngineInput) {
+    const bus = createEventBus();
+    const credits: { sourceId: string; amount: number }[] = [];
+    const reactiveDamage: Extract<CombatEvent, { type: 'reactive-damage-performed' }>[] = [];
+    const reactiveHeals: Extract<CombatEvent, { type: 'reactive-heal-performed' }>[] = [];
+    bus.on('reactive-damage-performed', (e) => reactiveDamage.push(e));
+    bus.on('reactive-heal-performed', (e) => reactiveHeals.push(e));
+    const result = runCombat({
+        ...input,
+        bus,
+        __testTapCreditDamage: (sourceId, _channel, amount) => credits.push({ sourceId, amount }),
+    });
+    return { result, credits, reactiveDamage, reactiveHeals };
+}
+
+/** Total reactive repair the healing accounting credited to `ownerId` across all rounds. A
+ *  reactive heal credits `directHeal` to its OWNER (it emits no heal-performed — chain guard),
+ *  so this is the observable for "Sentinel's on-ally-crit repair fired". */
+const totalDirectHeal = (result: ReturnType<typeof runCombat>, ownerId: string): number =>
+    (result.healing?.rounds ?? []).reduce(
+        (sum, rd) => sum + (rd.perActor.get(ownerId)?.directHeal ?? 0),
+        0
+    );
+
+describe('Sentinel (player-side) — reactive heal + damage fire on ally crit, never on its own turn', () => {
+    // Focus 'attacker' (crit 100) crits every hit; 'ally-b' (crit 0) never crits. healTargetId is
+    // DELIBERATELY 'ally-b' (the fallback trap) — if the heal ever fell back to the on-cast heal
+    // target instead of the crit-ing ally, this catches it landing on the WRONG actor.
+    const BASE = (): CombatEngineInput => ({
+        attack: 1000,
+        crit: 100,
+        critDamage: 100,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: { slots: [{ slot: 'active', abilities: [hit()] }] },
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 500,
+        healTargetId: 'ally-b', // deliberately the NON-critting ally (the fallback trap)
+        position: 'M1',
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        teamActors: [sentinelObserver('M3'), critAlly('ally-b', 'M2', 0)],
+        enemyAttackers: [debuffAoE('enemy-x', 'M4')],
+    });
+
+    it('fires its repair reactively when an ally crits (directHeal credited to Sentinel)', () => {
+        const { result } = runSentinel(BASE());
+        expect(totalDirectHeal(result, 'sentinel')).toBeGreaterThan(0);
+    });
+
+    it('deals reactive damage (credited to Sentinel) when an ally crits', () => {
+        const { credits } = runSentinel(BASE());
+        expect(credits.some((c) => c.sourceId === 'sentinel' && c.amount > 0)).toBe(true);
+    });
+
+    it('emits log-only reactive damage + heal events, stamped to the crit-ing ally turn', () => {
+        const { reactiveDamage, reactiveHeals } = runSentinel(BASE());
+        // Reactive DAMAGE surfaced for the log: owner=sentinel, amount>0, nested under the
+        // crit-ing ally's turn (duringTurnOf === 'attacker'). NEVER re-emits ability-performed.
+        const dmg = reactiveDamage.filter((e) => e.sourceId === 'sentinel');
+        expect(dmg.length).toBeGreaterThan(0);
+        expect(dmg.every((e) => e.amount > 0 && e.duringTurnOf === 'attacker')).toBe(true);
+        // Reactive HEAL surfaced for the log: caster=sentinel, a recipient present, same stamp.
+        const heal = reactiveHeals.filter((e) => e.casterId === 'sentinel');
+        expect(heal.length).toBeGreaterThan(0);
+        expect(heal.every((e) => e.perTarget.length > 0 && e.duringTurnOf === 'attacker')).toBe(
+            true
+        );
+    });
+
+    it('does NOT heal or deal damage on its own turn when no ally crits (the on-turn leak)', () => {
+        const noCrit: CombatEngineInput = {
+            ...BASE(),
+            crit: 0,
+            teamActors: [sentinelObserver('M3'), critAlly('ally-b', 'M2', 0)],
+        };
+        const { result, credits } = runSentinel(noCrit);
+        expect(totalDirectHeal(result, 'sentinel')).toBe(0);
+        expect(credits.some((c) => c.sourceId === 'sentinel' && c.amount > 0)).toBe(false);
+    });
+});
+
+describe('Sentinel (enemy-side) — team symmetry: an enemy Sentinel reacts to its OWN crit-ing ally', () => {
+    it('heals the crit-ing ENEMY ally and credits reactive damage, never touching a player actor', () => {
+        const enemySentinel: EnemyAttacker = {
+            id: 'enemy-sentinel',
+            stats: { attack: 1000, crit: 0, critDamage: 100, defence: 0, hp: 20_000, speed: 1 },
+            chargeCount: 0,
+            startCharged: false,
+            position: 'M3',
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            shipSkills: {
+                slots: [
+                    { slot: 'active', abilities: [noopActive()] },
+                    { slot: 'passive', abilities: sentinelPassiveAbilities(2) },
+                ],
+            },
+        } as EnemyAttacker;
+
+        const enemyCritAlly: EnemyAttacker = {
+            id: 'enemy-critter',
+            stats: {
+                attack: 1000,
+                crit: 100,
+                critDamage: 100,
+                defence: 0,
+                hp: 1_000_000_000,
+                speed: 300,
+            },
+            chargeCount: 0,
+            startCharged: false,
+            position: 'M2',
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            shipSkills: { slots: [{ slot: 'active', abilities: [hit()] }] },
+        } as EnemyAttacker;
+
+        const input: CombatEngineInput = {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [{ slot: 'active', abilities: [noopActive()] }] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            speed: 1000,
+            healTargetId: 'attacker',
+            position: 'M1',
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            teamActors: [],
+            enemyAttackers: [enemySentinel, enemyCritAlly],
+        };
+
+        const { result, credits } = runSentinel(input);
+        // The enemy Sentinel's repair fires (directHeal credited) and its reactive damage credits —
+        // both keyed to the ENEMY owner, never a player-side actor.
+        expect(totalDirectHeal(result, 'enemy-sentinel')).toBeGreaterThan(0);
+        expect(credits.some((c) => c.sourceId === 'enemy-sentinel' && c.amount > 0)).toBe(true);
     });
 });

--- a/src/utils/combat/__tests__/enemyActions.test.ts
+++ b/src/utils/combat/__tests__/enemyActions.test.ts
@@ -202,8 +202,9 @@ describe('PR4b: damage reactive executor branch — applyReactiveDamage wiring',
     it('routes to ctx.enemy.id when no eventCtx counterTargetId is present (Judge/Chakara/Incinerator/Rhodium shape)', () => {
         const calls: Call[] = [];
         const ctx = makeExecCtx({
-            applyReactiveDamage: (ownerId, victimId, abilityId, multiplier, hits, noCrit) =>
-                calls.push({ ownerId, victimId, abilityId, multiplier, hits, noCrit }),
+            applyReactiveDamage: (ownerId, victimId, abilityId, multiplier, hits, noCrit) => {
+                calls.push({ ownerId, victimId, abilityId, multiplier, hits, noCrit });
+            },
         });
 
         executeIntent(makeDamageIntent('grif', { multiplier: 75, noCrit: true }), ctx);
@@ -223,8 +224,9 @@ describe('PR4b: damage reactive executor branch — applyReactiveDamage wiring',
     it('routes to eventCtx.counterTargetId when present (FrontLine on-enemy-charged-cast shape)', () => {
         const calls: Call[] = [];
         const ctx = makeExecCtx({
-            applyReactiveDamage: (ownerId, victimId, abilityId, multiplier, hits, noCrit) =>
-                calls.push({ ownerId, victimId, abilityId, multiplier, hits, noCrit }),
+            applyReactiveDamage: (ownerId, victimId, abilityId, multiplier, hits, noCrit) => {
+                calls.push({ ownerId, victimId, abilityId, multiplier, hits, noCrit });
+            },
         });
 
         executeIntent(
@@ -247,8 +249,9 @@ describe('PR4b: damage reactive executor branch — applyReactiveDamage wiring',
     it('defaults noCrit to false and hits to 1 when the config omits them', () => {
         const calls: Call[] = [];
         const ctx = makeExecCtx({
-            applyReactiveDamage: (ownerId, victimId, abilityId, multiplier, hits, noCrit) =>
-                calls.push({ ownerId, victimId, abilityId, multiplier, hits, noCrit }),
+            applyReactiveDamage: (ownerId, victimId, abilityId, multiplier, hits, noCrit) => {
+                calls.push({ ownerId, victimId, abilityId, multiplier, hits, noCrit });
+            },
         });
 
         executeIntent(makeDamageIntent('grif', { multiplier: 60 }), ctx);

--- a/src/utils/combat/__tests__/sentinelReactionLog.integration.test.ts
+++ b/src/utils/combat/__tests__/sentinelReactionLog.integration.test.ts
@@ -1,0 +1,136 @@
+/**
+ * #2 (reaction-only-on-turn) end-to-end log visibility, through the REAL sim path
+ * (planPlacement -> simulateBattle -> buildCombatLog).
+ *
+ * Sentinel's refit-active passive (docs/ship-skills.csv, verbatim): "When an ally critically hits
+ * an enemy, this Unit repairs the ally for 5% of this Unit's Max HP and deals 60% damage to that
+ * enemy." Both ride on-ally-crit. Drain-time reactive damage/heal emit no ability/heal event
+ * (chain guard), so they surface via the LOG-ONLY reactive-damage-performed / reactive-heal-performed
+ * events, nested under the crit-ing ally's turn — never on Sentinel's own turn.
+ *
+ * Non-vacuity: without the parser/trigger fix the reactions never fire; without the log-only
+ * emits they fire but stay invisible — both make the "surfaces in the log" assertions red.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateBattle, BattlePlacement } from '../../calculators/battleSimulator';
+import { flattenCombatLog } from '../log/__testutils__/flattenCombatLog';
+import type { Ship } from '../../../types/ship';
+import type { GearPiece } from '../../../types/gear';
+
+const SENTINEL_R2 =
+    "When an ally critically hits an enemy, this Unit <unit-damage>repairs the ally for 5%</unit-damage> of this Unit's Max HP and deals <unit-damage>60% damage</unit-damage> to that enemy.<br />This attack cannot critically hit.";
+
+const makeShip = (id: string, name: string, over: Partial<Ship> = {}): Ship => ({
+    id,
+    name,
+    rarity: 'legendary',
+    faction: 'TERRAN_COMBINE',
+    type: 'Attacker',
+    baseStats: {
+        hp: 0,
+        attack: 0,
+        defence: 0,
+        hacking: 0,
+        security: 0,
+        crit: 0,
+        critDamage: 0,
+        speed: 100,
+    },
+    equipment: {},
+    implants: {},
+    refits: [],
+    affinity: 'antimatter',
+    activeSkillText: 'This Unit deals <unit-damage>100% damage</unit-damage>.',
+    chargeSkillCharge: 0,
+    activeTarget: 'front',
+    activePattern: 'Pattern-Base',
+    ...over,
+});
+
+const placement = (
+    ship: Ship,
+    position: BattlePlacement['position'],
+    over: Partial<NonNullable<BattlePlacement['statOverrides']>>
+): BattlePlacement => ({
+    ship,
+    position,
+    statOverrides: {
+        attack: 1000,
+        crit: 0,
+        critDamage: 100,
+        defensePenetration: 0,
+        hacking: 0,
+        defence: 0,
+        hp: 20_000,
+        speed: 100,
+        ...over,
+    },
+});
+
+const noGear = (): GearPiece | undefined => undefined;
+
+describe('Sentinel reactions surface in the combat log (real sim path)', () => {
+    // Sentinel: buff-only active (no on-turn damage), R2 refit passive, acts LAST. A fast ally
+    // crits the enemy → Sentinel reacts. Enemy is an indestructible punching bag.
+    const build = () => {
+        const sentinel = makeShip('sentinel', 'Sentinel', {
+            activeSkillText: 'This Unit grants <unit-skill>Attack Up III</unit-skill> for 1 turn.',
+            secondPassiveSkillText: SENTINEL_R2,
+            refits: [{}, {}] as Ship['refits'],
+        });
+        const critAlly = makeShip('critter', 'Critter');
+        const enemy = makeShip('dummy', 'Dummy');
+
+        const result = simulateBattle(
+            {
+                playerTeam: [
+                    placement(sentinel, 'M3', { attack: 1000, crit: 0, hp: 20_000, speed: 1 }),
+                    placement(critAlly, 'M2', { attack: 1000, crit: 100, hp: 20_000, speed: 300 }),
+                ],
+                enemyTeam: [
+                    placement(enemy, 'M4', { attack: 1, crit: 0, hp: 1_000_000_000, speed: 1000 }),
+                ],
+                rounds: 1,
+            },
+            noGear
+        );
+        const sentinelId = result.roster.find((r) => r.name === 'Sentinel')?.actorId;
+        expect(sentinelId).toBeDefined();
+        return { result, sentinelId: sentinelId! };
+    };
+
+    it("Sentinel's reactive damage appears in the log as an attack entry", () => {
+        const { result, sentinelId } = build();
+        const sentinelAttacks = flattenCombatLog(result).filter(
+            (e) => e.kind === 'attack' && e.actorId === sentinelId
+        );
+        expect(sentinelAttacks.length).toBeGreaterThan(0);
+        expect(sentinelAttacks.some((e) => e.targets.some((t) => (t.amount ?? 0) > 0))).toBe(true);
+    });
+
+    it("Sentinel's reactive repair appears in the log as a heal entry", () => {
+        const { result, sentinelId } = build();
+        const sentinelHeals = flattenCombatLog(result).filter(
+            (e) => e.kind === 'heal' && e.actorId === sentinelId
+        );
+        expect(sentinelHeals.length).toBeGreaterThan(0);
+    });
+
+    it('Sentinel does NO damage or heal on its OWN turn (reactions nest under the ally, not its turn)', () => {
+        const { result, sentinelId } = build();
+        const sentinelTurns = result.combatLog
+            .flatMap((r) => r.turns)
+            .filter((t) => t.actorId === sentinelId);
+        expect(sentinelTurns.length).toBeGreaterThan(0);
+        const ownTurnEntries = sentinelTurns.flatMap((t) => t.entries);
+        // No repair on its own turn — this is the fixed leak. (A buff-only turn still opens an
+        // empty 0-damage attack ROW — a separate pre-existing cosmetic issue — so we assert no
+        // attack lands actual DAMAGE rather than no attack entry at all.)
+        expect(ownTurnEntries.some((e) => e.kind === 'heal')).toBe(false);
+        expect(
+            ownTurnEntries.some(
+                (e) => e.kind === 'attack' && e.targets.some((t) => (t.amount ?? 0) > 0)
+            )
+        ).toBe(false);
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -4044,7 +4044,7 @@ export function runCombat(input: CombatEngineInput): {
             noCrit: boolean,
             hpBasisPct?: number,
             allowDeadOwner?: boolean
-        ): void => {
+        ): { dealt: number; didCrit: boolean } | void => {
             const owner = allActorsById.get(ownerId);
             const victim = allActorsById.get(victimId);
             // allowDeadOwner (PR-B1, Paracelsus): an on-destroyed retaliation is BORN of the
@@ -4125,6 +4125,7 @@ export function runCombat(input: CombatEngineInput): {
             }
             reactiveDealtByOwner.set(ownerId, raw);
             creditDamage(ownerId, 'direct', raw);
+            return { dealt: raw, didCrit };
         };
 
         // §4.5 STASIS direct-damage break (B3 Task 2). Fires via the `onHitBreakStasis` hook

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -164,6 +164,31 @@ export type CombatEvent =
            *  recipient. Always populated by the engine; absent only in hand-crafted test emits. */
           perTarget?: { targetId: string; amount: number }[];
       } & ReactiveStamp)
+    /** LOG-ONLY: a drain-time REACTIVE damage proc resolved (applyReactiveDamage → creditDamage).
+     *  A reactive damage credits its total but emits NO `ability-performed` (chain guard — an
+     *  ability-performed would re-trigger on-crit/on-attacked/on-ally-crit listeners and loop).
+     *  This event exists SOLELY so buildCombatLog can surface the proc: NO combat listener
+     *  subscribes to it, so it can never chain. `sourceId` = the reacting owner; `targetId` = the
+     *  victim; `amount` = the mitigated/credited damage; `didCrit` when the proc crit. */
+    | ({
+          type: 'reactive-damage-performed';
+          sourceId: string;
+          targetId: string;
+          round: number;
+          amount: number;
+          didCrit?: boolean;
+      } & ReactiveStamp)
+    /** LOG-ONLY: a drain-time REACTIVE heal resolved (executeIntent heal branch). A reactive heal
+     *  credits `directHeal` but emits NO `heal-performed` (chain guard — it must not re-trigger
+     *  on-repair listeners). This event exists SOLELY for buildCombatLog: NO combat listener
+     *  subscribes to it. `casterId` = the reacting owner; `perTarget` = per-recipient raw repair. */
+    | ({
+          type: 'reactive-heal-performed';
+          casterId: string;
+          round: number;
+          amount: number;
+          perTarget: { targetId: string; amount: number }[];
+      } & ReactiveStamp)
     /** A cleanse cast resolved. `casterId` is the cleansing actor; `count` is the number of
      *  debuffs ACTUALLY removed. Team-symmetric (the enemy-cleanse-lift, #166-era): BOTH the
      *  player path and the enemy (event-only) path perform REAL removal via the side-agnostic

--- a/src/utils/combat/log/__tests__/buildCombatLog.test.ts
+++ b/src/utils/combat/log/__tests__/buildCombatLog.test.ts
@@ -1659,4 +1659,101 @@ describe('buildCombatLog', () => {
         expect(entry.actorId).toBe('B');
         expect(entry.targets).toEqual([]);
     });
+
+    // ─── Log-only reactive damage / heal (drain-time procs that emit no ability/heal event) ───
+    it('reactive-damage-performed nests under the trigger turn as an attack entry', () => {
+        // A crits B on A's turn; a reaction (stamped duringTurnOf:'A') deals damage to B. The
+        // reactive-damage-performed carries its own target — no follow-up `attacked` event.
+        const events: CombatEvent[] = [
+            ev({ type: 'round-started', round: 1 }),
+            ev({ type: 'turn-started', actorId: 'A', round: 1 }),
+            ev({
+                type: 'ability-performed',
+                actorId: 'A',
+                targetId: 'B',
+                round: 1,
+                abilityType: 'damage',
+                damage: 1000,
+                didHit: true,
+            }),
+            ev({
+                type: 'attacked',
+                attackerId: 'A',
+                targetId: 'B',
+                round: 1,
+                damage: 1000,
+                isPrimaryTarget: true,
+            }),
+            ev({
+                type: 'reactive-damage-performed',
+                sourceId: 'A',
+                targetId: 'B',
+                round: 1,
+                amount: 600,
+                didCrit: false,
+                reactive: true,
+                duringTurnOf: 'A',
+                triggerActorId: 'A',
+            }),
+            ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
+            ev({ type: 'round-ended', round: 1 }),
+        ];
+        const log = buildCombatLog(events, roster, initialCharge);
+        const turn = log[0].turns[0];
+        // Only ONE top-level entry: A's attack. The reactive damage nests under it.
+        expect(turn.entries).toHaveLength(1);
+        const attack = turn.entries[0];
+        expect(attack.reactions).toHaveLength(1);
+        const reaction = attack.reactions[0];
+        expect(reaction.kind).toBe('attack');
+        expect(reaction.actorId).toBe('A');
+        expect(reaction.targets).toEqual([
+            expect.objectContaining({ targetId: 'B', amount: 600, didHit: true }),
+        ]);
+    });
+
+    it('reactive-heal-performed nests under the trigger turn as a heal entry', () => {
+        const events: CombatEvent[] = [
+            ev({ type: 'round-started', round: 1 }),
+            ev({ type: 'turn-started', actorId: 'A', round: 1 }),
+            ev({
+                type: 'ability-performed',
+                actorId: 'A',
+                targetId: 'B',
+                round: 1,
+                abilityType: 'damage',
+                damage: 1000,
+                didHit: true,
+            }),
+            ev({
+                type: 'attacked',
+                attackerId: 'A',
+                targetId: 'B',
+                round: 1,
+                damage: 1000,
+                isPrimaryTarget: true,
+            }),
+            ev({
+                type: 'reactive-heal-performed',
+                casterId: 'B',
+                round: 1,
+                amount: 1152,
+                perTarget: [{ targetId: 'A', amount: 1152 }],
+                reactive: true,
+                duringTurnOf: 'A',
+                triggerActorId: 'A',
+            }),
+            ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
+            ev({ type: 'round-ended', round: 1 }),
+        ];
+        const log = buildCombatLog(events, roster, initialCharge);
+        const attack = log[0].turns[0].entries[0];
+        expect(attack.reactions).toHaveLength(1);
+        const reaction = attack.reactions[0];
+        expect(reaction.kind).toBe('heal');
+        expect(reaction.actorId).toBe('B');
+        expect(reaction.targets).toEqual([
+            expect.objectContaining({ targetId: 'A', amount: 1152 }),
+        ]);
+    });
 });

--- a/src/utils/combat/log/buildCombatLog.ts
+++ b/src/utils/combat/log/buildCombatLog.ts
@@ -415,6 +415,33 @@ const handlers: Partial<{ [K in CombatEventType]: Handler<K> }> = {
         ctx.attachEntry(entry);
     },
 
+    // Log-only reactive procs (drain-time damage/heal that emit no ability-performed/heal-performed
+    // — chain guard). Self-contained: the event carries its own target(s), so no follow-up
+    // `attacked` event fills them in. Both nest under the trigger turn via `currentStamp`.
+    'reactive-damage-performed': (e, ctx) => {
+        if (!ctx.currentTurn && !ctx.currentRound) return;
+        const target: CombatLogTarget = { targetId: e.targetId, amount: e.amount, didHit: true };
+        if (e.didCrit) target.didCrit = true;
+        const entry: CombatLogEntry = {
+            kind: 'attack',
+            actorId: e.sourceId,
+            targets: [target],
+            reactions: [],
+        };
+        ctx.attachEntry(entry);
+    },
+
+    'reactive-heal-performed': (e, ctx) => {
+        if (!ctx.currentTurn && !ctx.currentRound) return;
+        const entry: CombatLogEntry = {
+            kind: 'heal',
+            actorId: e.casterId,
+            targets: e.perTarget.map((pt) => ({ targetId: pt.targetId, amount: pt.amount })),
+            reactions: [],
+        };
+        ctx.attachEntry(entry);
+    },
+
     'debuff-applied': (e, ctx) => {
         if (!ctx.currentTurn && !ctx.currentRound) return;
         const entry: CombatLogEntry = {

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -513,15 +513,21 @@ export function registerReactiveListeners(args: {
                         if (!isSameSideAlly(e.actorId, ownerId)) return;
                         const n = e.critHits ?? (e.didCrit ? 1 : 0);
                         // Stamp the crit-ing ally via damagedAllyId (Phase 3 PR-G, Howler) so an
-                        // 'ally'-target reactive (cleanse/buff) lands on THAT ally, mirroring the
-                        // on-ally-debuffed/on-ally-purged siblings. Zero-collateral for existing
-                        // on-ally-crit riders (Hermes's charge + Everliving Regeneration buff are
-                        // both 'self'-target, which never reads damagedAllyId — see
-                        // reactiveRecipients/the buff branch's recipient resolution).
+                        // 'ally'-target reactive (cleanse/buff/heal — Sentinel's repair) lands on
+                        // THAT ally, mirroring the on-ally-debuffed/on-ally-purged siblings. ALSO
+                        // stamp the crit-VICTIM enemy via counterTargetId (#2, Sentinel) so an
+                        // 'enemy'-target reactive damage hits "that enemy" (the one the ally crit)
+                        // rather than the ctx.enemy fallback. Zero-collateral for the pre-existing
+                        // riders (Hermes's charge + Everliving Regeneration buff are 'self'-target;
+                        // Howler's cleanse is 'ally'-target — none read counterTargetId).
                         for (let i = 0; i < n; i++)
                             enqueue({
                                 ...intent,
-                                eventCtx: { ...intent.eventCtx, damagedAllyId: e.actorId },
+                                eventCtx: {
+                                    ...intent.eventCtx,
+                                    damagedAllyId: e.actorId,
+                                    counterTargetId: e.targetId,
+                                },
                             });
                     });
                     break;
@@ -1055,7 +1061,10 @@ export interface IntentExecContext {
         noCrit: boolean,
         hpBasisPct?: number,
         allowDeadOwner?: boolean
-    ) => void;
+        // Returns the mitigated/credited amount + crit flag so the caller can surface the proc in
+        // the combat log (reactive-damage-performed); void/0 when the proc was guarded (dead
+        // victim, non-positive) or the delegate is absent (unit fixtures).
+    ) => { dealt: number; didCrit: boolean } | void;
     /** G PR1: apply a full mitigated/crit counter walk from `ownerId` to `attackerId`.
      *  `abilityId` keys the dedicated counter crit-gate. Reuses the engine's no-event
      *  apply path (no attacked event → no re-counter). */
@@ -1656,6 +1665,8 @@ type StampedEventType =
     | 'charge-changed'
     | 'heal-performed'
     | 'shield-applied'
+    | 'reactive-damage-performed'
+    | 'reactive-heal-performed'
     | 'buff-applied'
     | 'buff-expired'
     | 'debuff-applied'
@@ -1689,6 +1700,12 @@ const REACTIVE_STAMPED_EVENT_TYPES: ReadonlySet<CombatEventType> = new Set<Stamp
     // it under the triggering turn instead. On-turn charge emissions use the captured outer bus
     // (unstamped) → unchanged.
     'charge-changed',
+    // #2 log visibility: drain-time reactive damage/heal procs emit these LOG-ONLY events so the
+    // combat log can surface them (they deliberately emit no ability-performed/heal-performed —
+    // chain guard). Emitted through ctx.bus during a reactive intent → stamped duringTurnOf so
+    // they nest under the triggering turn. No combat listener subscribes → they never chain.
+    'reactive-damage-performed',
+    'reactive-heal-performed',
 ]);
 
 /** Wrap a bus so every reactive-capable event emitted through it is branded with
@@ -1722,6 +1739,28 @@ function makeReactiveStampingBus(bus: CombatEventBus, duringTurnOf?: string): Co
             bus.emit(stamped);
         },
     };
+}
+
+/** Emit the LOG-ONLY `reactive-damage-performed` event for a proc that actually dealt damage.
+ *  `ctx.bus` is the reactive stamping wrapper (when present) → the event is branded `duringTurnOf`
+ *  so the combat log nests it under the triggering turn. NO combat listener subscribes to this
+ *  type, so it can never chain. Inert when the proc was guarded (void / dealt <= 0) or no bus is
+ *  wired (unit fixtures). */
+function emitReactiveDamageLog(
+    ctx: IntentExecContext,
+    ownerId: string,
+    victimId: string,
+    outcome: { dealt: number; didCrit: boolean } | void
+): void {
+    if (!ctx.bus || !outcome || outcome.dealt <= 0) return;
+    ctx.bus.emit({
+        type: 'reactive-damage-performed',
+        sourceId: ownerId,
+        targetId: victimId,
+        round: ctx.round,
+        amount: outcome.dealt,
+        didCrit: outcome.didCrit,
+    });
 }
 
 export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
@@ -2320,6 +2359,10 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
         const shieldRecipientIds: string[] = [];
         let shieldGrantedSum = 0;
         const shieldPerTarget: { targetId: string; amount: number }[] = [];
+        // #2 log visibility: accumulate the reactive HEAL's per-recipient raw repair so we can emit
+        // ONE log-only reactive-heal-performed after the loop (the executor emits no heal-performed).
+        const healPerTarget: { targetId: string; amount: number }[] = [];
+        let healSum = 0;
         for (const rid of recipients) {
             // Skip DEAD recipients from the gross credit (Phase 4b KNOWN LIMITATION 5):
             // an `all-allies` ON-DESTROYED heal (Salvation) fires when its OWN caster is
@@ -2351,6 +2394,8 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                 raw *= 1 + (healing.recipientIncomingHealAmpPct?.(rid) ?? 0) / 100;
             if (cfg.type === 'heal') {
                 ctx.healing.credit(intent.ownerId, 'directHeal', raw);
+                healPerTarget.push({ targetId: rid, amount: raw });
+                healSum += raw;
                 if (rid === ctx.healing.targetId) {
                     const { consumed, overheal } = ctx.healing.applyHealToTarget(raw);
                     ctx.healing.credit(intent.ownerId, 'effectiveHeal', consumed);
@@ -2388,6 +2433,19 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                 round: ctx.round,
                 amount: shieldGrantedSum,
                 perTarget: shieldPerTarget,
+            });
+        }
+        // #2 log visibility: a reactive HEAL emits the LOG-ONLY reactive-heal-performed (NOT
+        // heal-performed — that would re-trigger on-repair listeners). No combat listener
+        // subscribes to this type, so it can't chain; buildCombatLog surfaces it, stamped
+        // duringTurnOf via ctx.bus so it nests under the triggering turn.
+        if (cfg.type === 'heal' && healPerTarget.length > 0 && ctx.bus) {
+            ctx.bus.emit({
+                type: 'reactive-heal-performed',
+                casterId: intent.ownerId,
+                round: ctx.round,
+                amount: healSum,
+                perTarget: healPerTarget,
             });
         }
         return;
@@ -2503,7 +2561,7 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
             const onceKey = `${intent.ownerId}:${intent.ability.id}:${sourceId}`;
             if (ctx.oncePerRoundConsumed?.has(onceKey)) return;
             ctx.oncePerRoundConsumed?.add(onceKey);
-            ctx.applyReactiveDamage?.(
+            const hpOutcome = ctx.applyReactiveDamage?.(
                 intent.ownerId,
                 sourceId,
                 intent.ability.id,
@@ -2517,6 +2575,7 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                 // dead-owner drain gate above already grants.
                 intent.eventCtx?.fromOwnDeath === true
             );
+            emitReactiveDamageLog(ctx, intent.ownerId, sourceId, hpOutcome);
             return;
         }
         if (!passesOncePerRoundGate(intent, ctx)) return;
@@ -2538,7 +2597,7 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
         // the cast path (e.g. 75 for "75% damage"); `hits` folds into the mitigation call the
         // same way applyCounterAttack folds a counter's hit count. Emits NO event → no chain.
         const targetId = intent.eventCtx?.counterTargetId ?? ctx.enemy.id;
-        ctx.applyReactiveDamage?.(
+        const outcome = ctx.applyReactiveDamage?.(
             intent.ownerId,
             targetId,
             intent.ability.id,
@@ -2546,6 +2605,7 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
             cfg.hits ?? 1,
             cfg.noCrit ?? false
         );
+        emitReactiveDamageLog(ctx, intent.ownerId, targetId, outcome);
         return;
     }
 


### PR DESCRIPTION
## Summary

Combat-sim finding **#2** (reaction-only units act as if they have an on-turn attack). Sentinel's active only grants buffs; its passives deal damage / repair an ally **only** "when an ally critically hits an enemy." The engine was running those reactions on Sentinel's own turn (the reported `Sentinel heals → Judge` leak) and never firing them on ally crits.

### Root cause
Sentinel's passive damage (40%/60%) and heal (5%) were parsed with `trigger: 'on-cast'` instead of `'on-ally-crit'`. `detectAllyCritTrigger` was wired into the cleanse and charge builders but **missing from the damage- and heal-trigger chains** in `buildShipAbilities`. Since `on-cast` isn't a live trigger, `partitionReactiveAbilities` left both abilities in the on-cast passive slot → the heal leaked onto the own-turn heal path, and the damage never fired reactively.

### Fix (correctness)
- **`buildShipAbilities`**: add position-scoped `detectAllyCritTrigger` to the damage and heal trigger chains. Blast radius = **Sentinel only** (Hermes = charge, Howler = cleanse — already wired; their self-heals sit in active/charge slots without the ally-crit phrase, so the position-scoped detector can't touch them).
- **`triggers` `on-ally-crit` listener**: also stamp `counterTargetId = e.targetId` (the crit-victim enemy) so the `enemy`-target reactive damage hits "that enemy." The heal already routes to the crit-ing ally via the existing `damagedAllyId` stamp.

Team-symmetric via `isSameSideAlly` — an enemy Sentinel reacts to its own crit-ing ally.

### Fix (log visibility, folded in)
Drain-time reactive damage (`applyReactiveDamage` → `creditDamage`) and reactive heals emit **no** `ability-performed`/`heal-performed` by design (chain guard — those would re-trigger `on-crit`/`on-attacked`/`on-repair` listeners). Since the combat log is built purely from events, these procs were applied-but-invisible.

Added two **log-only** event types — `reactive-damage-performed`, `reactive-heal-performed` — that:
- no combat listener subscribes to (so they can't chain);
- are emitted through the reactive stamping bus, so they carry `duringTurnOf` and **nest under the triggering turn**;
- are consumed only by `buildCombatLog` → rendered as normal `attack`/`heal` entries.

This also surfaces Grif / FrontLine / Judge / Vindicator / Paracelsus reactions that were previously invisible.

## Testing
- New parser mutation-guards + player/enemy-side integration in `allyCritReactivePromotion.integration.test.ts`.
- `buildCombatLog` unit tests for the two new event types (nesting).
- New end-to-end `sentinelReactionLog.integration.test.ts` drives the **real** `simulateBattle → buildCombatLog` path: Sentinel's reactive damage + heal appear in the log nested under the crit-ing ally's turn, and Sentinel does no damage/heal on its own turn.
- Full suite **4376 green**, `tsc` + `lint` clean, `audit:skills` **0 findings**. DPS/healing goldens unchanged (they read totals, not the log).

## Out of scope (residual)
- Counterattacks (Stalwart/Centurion) and reflects (Nosorog) use a separate `applyCounterAttack` path and still emit no log event.
- The pre-existing cosmetic empty 0-damage attack row on pure-support turns remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)