### PR TITLE
fix(combat): Hermes charge, Stasis reduce-on-hit, DoT debuff display, Voron HP

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -68,6 +68,10 @@ export const UNRELEASED_CHANGES: string[] = [
     'Butcher now correctly gains Marauder Rage II when it inflicts a debuff in team battles (previously the buff only applied in the single-target DPS view).',
     "Combat sim: Sentinel no longer damages or heals on its own turn. Its reaction-only passives now correctly fire when an ally critically hits an enemy — dealing its bonus damage to that enemy and repairing the ally who landed the crit — instead of leaking onto Sentinel's own turn.",
     'Combat log: reactive damage and reactive repairs now show up in the log, nested under the turn that triggered them. Previously these procs (Sentinel, Grif, FrontLine, Judge, Vindicator, Paracelsus, and other "when …" damage/heal reactions) were applied but never displayed.',
+    'Combat sim: Hermes now gains 1 charge per ally attack that lands a critical hit, instead of one charge per critical hit — a multi-hit or multi-target attack that crits several times now grants a single charge, matching the skill text.',
+    'Combat sim: direct damage to a ship in Stasis now reduces its remaining Stasis by one turn instead of removing Stasis entirely — the target wakes up sooner with each hit rather than immediately.',
+    "Combat sim: Damage-over-Time effects (Corrosion, Inferno, Bomb, and transform DoTs) now show up in a ship's active debuff list in the battle playback, alongside its other debuffs.",
+    'Combat sim: fixed the HP shown for Voron (and Orel) after a hit is converted into a Damage-over-Time effect — the battle playback no longer double-counts the converted hit, so the HP bar reflects the real remaining HP.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3165,7 +3165,10 @@ const DocumentationPage: React.FC = () => {
                                     </li>
                                     <li>
                                         Pin a ship to open a per-round detail card with its full
-                                        breakdown for that round
+                                        breakdown for that round, including its active buffs and
+                                        debuffs — Damage over Time effects (Corrosion, Inferno,
+                                        Bomb, and converted-damage DoTs) are listed among the
+                                        debuffs
                                     </li>
                                     <li>
                                         The event log lists every turn-by-turn action, reaction, and

--- a/src/utils/calculators/__tests__/battleAssemble.test.ts
+++ b/src/utils/calculators/__tests__/battleAssemble.test.ts
@@ -302,6 +302,58 @@ describe('assembleBattleResult — buff tracking', () => {
         // debuff persists (no expiry event)
         expect(find(result, 2, 'enemy-front').activeDebuffs).toContain('Defense Shred');
     });
+
+    it('folds dot-applied into the victim activeDebuffs (DoTs shown as debuffs)', () => {
+        const events: CombatEvent[] = [
+            {
+                type: 'dot-applied',
+                sourceId: 'attacker',
+                targetId: 'enemy-front',
+                round: 1,
+                dotType: 'corrosion',
+                stacks: 3,
+            },
+        ];
+        const result = assembleBattleResult({
+            events,
+            perRoundPerTarget: {},
+            roster: roster(),
+            numRounds: 2,
+        });
+        // The DoT surfaces in the victim's debuff list with a readable, stack-independent label…
+        expect(find(result, 1, 'enemy-front').activeDebuffs).toContain('Corrosion');
+        // …and persists to later rounds (infliction-only, mirroring debuff-applied).
+        expect(find(result, 2, 'enemy-front').activeDebuffs).toContain('Corrosion');
+    });
+
+    it('labels each DoT family in activeDebuffs, generic as "Damage over Time"', () => {
+        const events: CombatEvent[] = [
+            {
+                type: 'dot-applied',
+                sourceId: 'attacker',
+                targetId: 'enemy-front',
+                round: 1,
+                dotType: 'inferno',
+                stacks: 1,
+            },
+            {
+                type: 'dot-applied',
+                sourceId: 'attacker',
+                targetId: 'enemy-back',
+                round: 1,
+                dotType: 'generic',
+                stacks: 1,
+            },
+        ];
+        const result = assembleBattleResult({
+            events,
+            perRoundPerTarget: {},
+            roster: roster(),
+            numRounds: 1,
+        });
+        expect(find(result, 1, 'enemy-front').activeDebuffs).toContain('Inferno');
+        expect(find(result, 1, 'enemy-back').activeDebuffs).toContain('Damage over Time');
+    });
 });
 
 describe('assembleBattleResult — hierarchical combatLog (buildCombatLog)', () => {

--- a/src/utils/calculators/__tests__/battleAssemble.test.ts
+++ b/src/utils/calculators/__tests__/battleAssemble.test.ts
@@ -344,6 +344,14 @@ describe('assembleBattleResult — buff tracking', () => {
                 dotType: 'generic',
                 stacks: 1,
             },
+            {
+                type: 'dot-applied',
+                sourceId: 'enemy-front',
+                targetId: 'player-team',
+                round: 1,
+                dotType: 'bomb',
+                stacks: 1,
+            },
         ];
         const result = assembleBattleResult({
             events,
@@ -353,6 +361,7 @@ describe('assembleBattleResult — buff tracking', () => {
         });
         expect(find(result, 1, 'enemy-front').activeDebuffs).toContain('Inferno');
         expect(find(result, 1, 'enemy-back').activeDebuffs).toContain('Damage over Time');
+        expect(find(result, 1, 'player-team').activeDebuffs).toContain('Bomb');
     });
 });
 

--- a/src/utils/calculators/battleSimulator.ts
+++ b/src/utils/calculators/battleSimulator.ts
@@ -37,7 +37,7 @@
 import type { CombatEvent } from '../combat/events';
 import type { Position } from '../../types/encounters';
 import type { Ship, AffinityName } from '../../types/ship';
-import type { CombatStatBlock } from '../../types/calculator';
+import type { CombatStatBlock, DoTType } from '../../types/calculator';
 import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../combat/engine';
 import { createEventBus } from '../combat/events';
 import { buildShipAbilities } from '../abilities/buildShipAbilities';
@@ -63,6 +63,17 @@ import { detectFullyCharged } from '../skillTextParser';
 import { getShipSkillRows } from '../ship/skillRows';
 import type { ShipTypeName } from '../../constants/shipTypes';
 import { computeAffinityModifiers } from './affinityUtils';
+
+/** A stack-independent debuff-badge label for a DoT family, so DoTs surface in a ship's
+ *  `activeDebuffs` list like any other debuff. Stack-independent on purpose: `activeDebuffs`
+ *  is a de-duplicating set, so a per-application "×N" suffix would proliferate a new chip on
+ *  every re-application. (The chronological combat log keeps the "dotType ×stacks" detail.) */
+const DOT_DEBUFF_LABELS: Record<DoTType, string> = {
+    corrosion: 'Corrosion',
+    inferno: 'Inferno',
+    bomb: 'Bomb',
+    generic: 'Damage over Time',
+};
 
 export interface ShipRoundState {
     actorId: string;
@@ -303,6 +314,10 @@ export function assembleBattleResult(args: {
                 activeBuffs.get(e.actorId)?.delete(e.buffName);
             } else if (e.type === 'debuff-applied') {
                 ensure(activeDebuffs, e.targetId).add(e.buffName);
+            } else if (e.type === 'dot-applied') {
+                // DoTs are debuffs too — surface them in the victim's debuff list (infliction-only,
+                // like debuff-applied). Labeled by family so re-applications collapse to one chip.
+                ensure(activeDebuffs, e.targetId).add(DOT_DEBUFF_LABELS[e.dotType]);
             }
         }
 

--- a/src/utils/combat/__tests__/healing.test.ts
+++ b/src/utils/combat/__tests__/healing.test.ts
@@ -1515,16 +1515,17 @@ describe('healing — Task 9: reactive listeners (on-ally-critically-repaired / 
         expect(enqueued).toHaveLength(1);
     });
 
-    it('on-ally-crit: an ally crit enqueues once per critting hit; own/enemy/no-crit do not', () => {
+    it('on-ally-crit (non-charge rider): an ally crit enqueues once per critting hit; own/enemy/no-crit do not', () => {
         const handBus = makeHandBus();
         const enqueued: Intent[] = [];
+        // A NON-charge rider (Sentinel-style reactive damage) — these fire once per critting hit.
         const ability: Ability = {
-            id: 'ally-crit-charge',
-            type: 'charge',
-            target: 'self',
+            id: 'ally-crit-damage',
+            type: 'damage',
+            target: 'enemy',
             trigger: 'on-ally-crit',
             conditions: [],
-            config: { type: 'charge', amount: 1 },
+            config: { type: 'damage', multiplier: 40, noCrit: true },
         };
         const ra: ReactiveAbility = { ability, sourceSlot: 'passive' };
         registerReactiveListeners({
@@ -1559,6 +1560,51 @@ describe('healing — Task 9: reactive listeners (on-ally-critically-repaired / 
         // Another player's cast with didCrit binary only (no critHits field) → 1 enqueue.
         handBus.emit({ ...base, type: 'ability-performed', actorId: 'other', didCrit: true });
         expect(enqueued).toHaveLength(3);
+    });
+
+    it('on-ally-crit (charge rider): charge gain is once PER ATTACK that crits, not per critting hit', () => {
+        const handBus = makeHandBus();
+        const enqueued: Intent[] = [];
+        // A CHARGE rider (Hermes: "gains 1 charge" per ally-crit event) — one enqueue per attack
+        // that crits, regardless of how many hits/victims crit.
+        const ability: Ability = {
+            id: 'ally-crit-charge',
+            type: 'charge',
+            target: 'self',
+            trigger: 'on-ally-crit',
+            conditions: [],
+            config: { type: 'charge', amount: 1 },
+        };
+        const ra: ReactiveAbility = { ability, sourceSlot: 'passive' };
+        registerReactiveListeners({
+            bus: handBus,
+            perOwner: [{ ownerId: 'attacker', reactiveAbilities: [ra] }],
+            enqueue: (intent) => enqueued.push(intent),
+            isOpposing: (id) => id === 'enemy',
+        });
+        const base = {
+            round: 1,
+            didCrit: true,
+            targetId: 'enemy',
+            abilityType: 'damage' as const,
+        };
+
+        // An ally's cast with 2 critting hits → ONE enqueue (per attack, not per hit).
+        handBus.emit({ type: 'ability-performed', actorId: 'other', critHits: 2, ...base });
+        expect(enqueued).toHaveLength(1);
+
+        // Own / enemy casts → excluded → 0 additional.
+        handBus.emit({ type: 'ability-performed', actorId: 'attacker', critHits: 2, ...base });
+        handBus.emit({ type: 'ability-performed', actorId: 'enemy', critHits: 2, ...base });
+        expect(enqueued).toHaveLength(1);
+
+        // An ally's non-critting cast → 0 additional.
+        handBus.emit({ ...base, type: 'ability-performed', actorId: 'other', didCrit: false });
+        expect(enqueued).toHaveLength(1);
+
+        // Another ally attack that crits → +1 (one per ATTACK).
+        handBus.emit({ type: 'ability-performed', actorId: 'other', critHits: 3, ...base });
+        expect(enqueued).toHaveLength(2);
     });
 
     it('on-debuff-inflicted shield (APEX): own infliction enqueues; ally/enemy infliction does not', () => {
@@ -2045,7 +2091,7 @@ describe('healing — Task 9: reactive trigger integration', () => {
         expect(focusHeal(result, 'cleanseCount')).toBe(0);
     });
 
-    it('on-ally-crit: a walked ally crit multi-hits (2) each round → focus banks 2 charges per ally cast', () => {
+    it('on-ally-crit: a walked ally crit multi-hits (2) each round → focus banks 1 charge per ally cast (per attack that crits, not per hit)', () => {
         idCounter = 0;
         const result = runCombat(
             BASE({
@@ -2078,9 +2124,10 @@ describe('healing — Task 9: reactive trigger integration', () => {
                 },
             })
         );
-        // The ally's active crit-hits twice → 2 critting hits → 2 reactive charge intents → the
-        // focus banks 2 charges. Surfaced via the round's charge accounting.
-        expect(result.rounds[0].charges).toBe(2);
+        // The ally's active crit-hits twice, but charge gain is once PER ATTACK that crits (Hermes:
+        // "gains 1 charge" per ally-crit event) — so the focus banks exactly 1 charge, not one per
+        // critting hit. Surfaced via the round's charge accounting.
+        expect(result.rounds[0].charges).toBe(1);
     });
 });
 

--- a/src/utils/combat/__tests__/hermesAllyCritCharge.integration.test.ts
+++ b/src/utils/combat/__tests__/hermesAllyCritCharge.integration.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Hermes on-ally-crit charge gain — "per attack that crits", not "per crit".
+ *
+ * Hermes (docs/ship-skills.csv, first passive, verbatim): "When an ally critically hits an
+ * enemy, this Unit gains 1 charge to its Charged Skill." The intended rule is ONE charge per
+ * ally ATTACK that lands a crit — a single AoE (or multi-hit) attack that crits several victims
+ * must grant exactly 1 charge, not one per critting (hit, victim) pair.
+ *
+ * The ability is extracted through the REAL production path (buildShipAbilities on verbatim CSV
+ * skill text), never a hand-built ability.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { Ability } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+function ship(over: Partial<Ship>): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}], ...over } as Ship;
+}
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+const HERMES_P1 =
+    'When an ally critically hits an enemy, this Unit <unit-aid>gains 1 charge</unit-aid> to its Charged Skill.';
+
+/** Hermes' on-ally-crit charge ability through the REAL parser/builder. */
+function hermesChargeAbility(): Ability {
+    const abilities =
+        buildShipAbilities(ship({ firstPassiveSkillText: HERMES_P1 })).slots.find(
+            (s) => s.slot === 'passive'
+        )?.abilities ?? [];
+    const charge = abilities.find((a) => a.type === 'charge');
+    if (!charge) throw new Error('mutation guard: Hermes on-ally-crit charge not found');
+    return charge;
+}
+
+describe('Hermes charge ability — extracted shape (mutation guard)', () => {
+    it('rides on-ally-crit, self-targeted, +1 charge', () => {
+        const c = hermesChargeAbility();
+        expect(c.trigger).toBe('on-ally-crit');
+        expect(c.target).toBe('self');
+        expect(c.config).toMatchObject({ type: 'charge', amount: 1 });
+    });
+});
+
+/** A dummy enemy target: fat HP, does nothing meaningful. */
+const dummyEnemy = (id: string, position: Position): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'noop',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 0 },
+                        },
+                    ],
+                },
+            ],
+        },
+    }) as EnemyAttacker;
+
+/** Hermes observer (team actor): its ONLY ability is the on-ally-crit charge passive. It has a
+ *  chargeCount headroom of 6 and acts last (speed 1) so the ally crit precedes it. */
+const hermesObserver = (position: Position): TeamActorEngineInput =>
+    ({
+        id: 'hermes',
+        speed: 1,
+        chargeCount: 6,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        walk: {
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active',
+                        abilities: [
+                            {
+                                id: 'noop',
+                                type: 'damage',
+                                target: 'enemy',
+                                trigger: 'on-cast',
+                                conditions: [],
+                                config: { type: 'damage', multiplier: 0 },
+                            },
+                        ],
+                    },
+                    { slot: 'passive', abilities: [hermesChargeAbility()] },
+                ],
+            },
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp: 20_000,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    }) as TeamActorEngineInput;
+
+/** The main focus is an ally that lands a 3-hit crit (all hits crit -> critPairs === 3) on a
+ *  single enemy. Hermes, its ally, should gain exactly ONE charge from that single attack. */
+function runHermes() {
+    const input: CombatEngineInput = {
+        attack: 1000,
+        crit: 100, // every hit crits
+        critDamage: 100,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'multi-hit',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 100, hits: 3 },
+                        },
+                    ],
+                },
+            ],
+        },
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 500, // acts before Hermes
+        healTargetId: 'hermes',
+        position: 'M1',
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        teamActors: [hermesObserver('M3')],
+        enemyAttackers: [dummyEnemy('enemy-a', 'M4')],
+    };
+
+    const bus = createEventBus();
+    const chargeGains: Extract<CombatEvent, { type: 'charge-changed' }>[] = [];
+    bus.on('charge-changed', (e) => {
+        if (e.actorId === 'hermes' && e.reason === 'manip') chargeGains.push(e);
+    });
+    runCombat({ ...input, bus });
+    return { chargeGains };
+}
+
+describe('Hermes on-ally-crit charge — one charge per attack that crits, not per crit', () => {
+    it('a single 3-hit attack that crits grants Hermes exactly one charge', () => {
+        const { chargeGains } = runHermes();
+        // Pre-fix: 3 (one per critting hit). Post-fix: 1 (one per attack that crits).
+        const totalGained = chargeGains.reduce((s, e) => s + (e.newCharge - e.oldCharge), 0);
+        expect(totalGained).toBe(1);
+    });
+});

--- a/src/utils/combat/__tests__/perFootprintStasisBreak.integration.test.ts
+++ b/src/utils/combat/__tests__/perFootprintStasisBreak.integration.test.ts
@@ -8,21 +8,23 @@
  * This task adds a covered-victim Stasis-break at all THREE positional cast-sites (focus,
  * walked-team, enemy). For every hit footprint victim that was stasised at hit time (and only when
  * the attacker does NOT have doesntBreakStasis), a DEFERRED break is recorded via stasisBreakPending
- * — the same deferral the anchor uses — so the victim's own skip branch removes the Stasis and it
- * acts on its NEXT scheduled turn. Covered victims have NO same-turn re-apply vector (the turn's
- * debuffs only ever target the anchor), so their break fires UNCONDITIONALLY (no re-apply guard).
+ * — the same deferral the anchor uses — so the victim's own skip branch reduces the Stasis and it
+ * eventually resumes acting. Covered victims have NO same-turn re-apply vector (the turn's debuffs
+ * only ever target the anchor), so their break fires UNCONDITIONALLY (no re-apply guard).
  *
  * Harness mirrors perVictimAttacked.integration.test.ts (positioned actors, Line-Range-1 AoE) +
  * stasis.test.ts (Stasis applied once by fast stasis-bots that are then killed; break observed via
  * the victim acting again — emitting ability-performed — on a round it would otherwise still skip).
  *
- * OBSERVATION MODEL. A stasised actor skips its turn (no ability-performed). We seed Stasis(20) on
+ * OBSERVATION MODEL. A stasised actor skips its turn (no ability-performed). We seed Stasis(4) on
  * two victims in round 1 via two fast stasis-bots, then kill those bots that same round (a culler)
- * so the Stasis is NEVER re-applied. Stasis(20) ≫ numRounds:4 → absent a break a victim NEVER acts.
- * A player/enemy AoE breaker (WITHOUT doesntBreakStasis) hits BOTH the anchor and the covered victim
- * every round. The anchor break already worked (it acts from round 2). The NEW behaviour: the COVERED
- * victim also breaks and acts (FAILS pre-change — it never acted). The break is DEFERRED (consumed at
- * the victim's own next skip), so a broken victim acts from round 2 onward.
+ * so the Stasis is NEVER re-applied. A direct hit REDUCES Stasis by one turn (not a full removal),
+ * so a victim HIT every round loses 2 turns/round (deferred break −1 + natural Post-Turn −1) and
+ * clears by the end of round 2 → acts from round 3; a victim NOT hit loses only −1/round and still
+ * has Stasis left at the end of the 4-round run → never acts. A player/enemy AoE breaker (WITHOUT
+ * doesntBreakStasis) hits BOTH the anchor and the covered victim every round. The anchor break
+ * already worked (it acts from round 3). The NEW behaviour: the COVERED victim also breaks and acts
+ * (FAILS pre-change — it never acted).
  *
  * GRID. Positions are the T/M/B × col-1..4 board. Targeting scans by ROW (the acting actor's row
  * first, then descend, wrapping bottom→top), then column within the first occupied row. We isolate
@@ -118,7 +120,12 @@ const firedRounds = (
     actorId: string
 ): number[] => performed.filter((e) => e.actorId === actorId).map((e) => e.round);
 
-const STASIS_LONG = 20; // ≫ numRounds → no natural expiry inside the run; only a break can free it
+// Stasis(4) + numRounds:4 is the reduce-by-one observation window. A footprint victim HIT every
+// round loses 2 turns/round (the deferred break's −1 plus the natural Post-Turn −1), so it clears
+// by the end of round 2 and acts from round 3. A victim NOT hit loses only the natural −1/round, so
+// Stasis(4) still has 1 turn left at the end of round 4 → it never acts inside the run. That gap is
+// what distinguishes a footprint-covered (hit) victim from an uncovered (unhit) one.
+const STASIS_LONG = 4;
 const ROUNDS = 4;
 
 // ---------------------------------------------------------------------------------------------

--- a/src/utils/combat/__tests__/removeTimedEnemyStatus.test.ts
+++ b/src/utils/combat/__tests__/removeTimedEnemyStatus.test.ts
@@ -57,3 +57,46 @@ describe('removeTimedEnemyStatus — targeted enemy status removal', () => {
         expect(after.map((s) => s.payload.buffName)).toContain('Defense Down');
     });
 });
+
+describe('reduceTimedEnemyStatus — shave one turn (direct-damage Stasis break)', () => {
+    const stasisNames = (se: ReturnType<typeof createStatusEngine>) =>
+        se.timedAbilityStatuses('enemy', undefined, 'victim-1').map((s) => s.payload.buffName);
+
+    it('reduces the named status by one turn, deleting it only when it reaches 0', () => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        se.beginRound(1);
+        se.applyTimedAbilityStatus(1, timedEnemyStatus('Stasis', 2), undefined, 'victim-1');
+
+        // Stasis(2): one reduce leaves it at 1 turn (still present)…
+        se.reduceTimedEnemyStatus('victim-1', 'Stasis');
+        expect(stasisNames(se)).toContain('Stasis');
+
+        // …a second reduce takes it to 0 → deleted.
+        se.reduceTimedEnemyStatus('victim-1', 'Stasis');
+        expect(stasisNames(se)).not.toContain('Stasis');
+    });
+
+    it('reduces ONLY the named family, preserving co-applied debuffs on the same victim', () => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        se.beginRound(1);
+        se.applyTimedAbilityStatus(1, timedEnemyStatus('Stasis', 1), undefined, 'victim-1');
+        se.applyTimedAbilityStatus(1, timedEnemyStatus('Defense Down', 3), undefined, 'victim-1');
+
+        // A single reduce clears the 1-turn Stasis but leaves Defense Down untouched.
+        se.reduceTimedEnemyStatus('victim-1', 'Stasis');
+        const after = se
+            .timedAbilityStatuses('enemy', undefined, 'victim-1')
+            .map((s) => s.payload.buffName);
+        expect(after).not.toContain('Stasis');
+        expect(after).toContain('Defense Down');
+    });
+
+    it('is a safe no-op for an unknown targetId or unknown buffName', () => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        se.beginRound(1);
+        se.applyTimedAbilityStatus(1, timedEnemyStatus('Defense Down', 2), undefined, 'victim-1');
+        expect(() => se.reduceTimedEnemyStatus('nonexistent', 'Stasis')).not.toThrow();
+        expect(() => se.reduceTimedEnemyStatus('victim-1', 'Nonexistent')).not.toThrow();
+        expect(stasisNames(se)).toContain('Defense Down');
+    });
+});

--- a/src/utils/combat/__tests__/stasis.test.ts
+++ b/src/utils/combat/__tests__/stasis.test.ts
@@ -1320,7 +1320,7 @@ describe('B3 Task 1 — reactive suppression: (d) non-stasised focus — on-atta
 
 describe('B3 Task 2 — direct-damage break', () => {
     // (i) A direct firing hit breaks Stasis
-    it('(i) direct hit breaks Stasis: victim acts on next scheduled turn instead of skipping the full duration', () => {
+    it('(i) direct hit reduces Stasis by one turn (not full removal): victim resumes one round later than a full break would give', () => {
         idc = 0;
         /**
          * Setup:
@@ -1333,18 +1333,15 @@ describe('B3 Task 2 — direct-damage break', () => {
          *   - breaker-enemy (speed=150): basicAttack targeting 'front' (the focus).
          *     Acts between killer and focus.
          *
-         * Without break: Stasis(3) skips rounds 1, 2, 3 → focus fires round 4.
-         * With break: in round 2 the breaker lands a direct hit → Stasis removed →
-         *   focus IS stasised in round 1 (applied round 1, decremented post-round1→2 remaining),
-         *   focus IS skipped in round 1. After breaker hits in round 2, Stasis is removed.
-         *   Focus acts in round 2 itself (after break) or round 3.
+         * A direct hit REDUCES the Stasis turn count by one instead of clearing it, so:
+         *   R1: Stasis(3) applied; breaker hits → break decrement 3→2, then Post-Turn 2→1.
+         *   R2: breaker hits → break decrement 1→0 (expired); focus still skipped this round.
+         *   R3: focus is free → fires.
+         * Compared to an untouched Stasis(3) (skips R1/R2/R3, fires R4), the every-round breaking
+         * hits shave it to a round-3 resume — one round later than the OLD full-removal rule (which
+         * cleared Stasis on the first hit and resumed in round 2).
          *
-         * We use numRounds:4. Assert focus fires in round 3 OR earlier (not only round 4+).
-         * Concretely: focus should fire in round 2 or 3 (break happened in round 2 before focus turn
-         * if breaker speed > focus speed, but break fires DURING apply, not before turn-gate check
-         * for the current round). Let's simplify: assert focus fired BEFORE round 4.
-         *
-         * Use __testTapIsStasised to also check Stasis is gone after round 2's apply.
+         * numRounds:4. Use __testTapIsStasised to confirm Stasis is gone by the end of the run.
          */
         let capturedIsStasised: ((actorId: string) => boolean) | undefined;
         const { events } = run({
@@ -1434,14 +1431,13 @@ describe('B3 Task 2 — direct-damage break', () => {
         expect(focusFiredRounds).not.toContain(1);
 
         // Turn order: stasis-bot(300) → killer(200) → breaker-enemy(150) → focus(100).
-        // Round 1: stasis-bot applies Stasis(3), killer kills stasis-bot, breaker hits stasised
-        // focus → break marked. Focus skip branch: consumes break → Stasis removed (but skip runs).
-        // Round 2: focus NOT stasised → fires in EXACTLY round 2 (not 3 or 4).
-        // Pinned to round 2 — "≤3" would pass under a one-round-late regression.
+        // Reduce-by-one (see the trace above): resumes round 3. Full removal would resume round 2;
+        // an untouched Stasis(3) would resume round 4. Pinned to round 3 — a loose "≤2" would pass
+        // under a full-removal regression, "≥4" under a no-break regression.
         const firstFiredRound = focusFiredRounds.length > 0 ? Math.min(...focusFiredRounds) : 999;
-        expect(firstFiredRound).toBe(2);
+        expect(firstFiredRound).toBe(3);
 
-        // Post-run: Stasis should be gone (broken in round 2).
+        // Post-run: Stasis should be gone (reduced to 0 by round 2, freed from round 3).
         expect(capturedIsStasised).toBeDefined();
         expect(capturedIsStasised!('attacker')).toBe(false);
     });
@@ -1681,7 +1677,8 @@ describe('B3 Task 2 — direct-damage break', () => {
          * numRounds=4.
          *
          * Without break: focus fires round 4 (after 3 skips).
-         * With break: focus fires in round 2 or 3.
+         * With reduce-by-one (breaker hits every round): R1 3→break2→post1; R2 1→break0 expired;
+         * focus fires round 3.
          */
         const { events } = run({
             attack: 0,
@@ -1763,12 +1760,11 @@ describe('B3 Task 2 — direct-damage break', () => {
 
         // Focus was stasised in round 1
         expect(focusFiredRounds).not.toContain(1);
-        // The breaker (a DIFFERENT attacker from the original applier) breaks Stasis in round 2.
+        // The breaker (a DIFFERENT attacker from the original applier) reduces Stasis each round.
         // Turn order: stasis-bot(300) → killer(200) → breaker-enemy(150) → focus(100).
-        // Round 1: break marked in focus's skip. Round 2: focus fires.
-        // Pinned to exactly round 2 — "≤3" would pass under a one-round-late regression.
+        // Reduce-by-one → focus fires round 3 (full removal would give round 2; no break, round 4).
         const firstFiredRound = focusFiredRounds.length > 0 ? Math.min(...focusFiredRounds) : 999;
-        expect(firstFiredRound).toBe(2);
+        expect(firstFiredRound).toBe(3);
     });
 
     // (v) break regardless of minimal damage
@@ -1862,11 +1858,10 @@ describe('B3 Task 2 — direct-damage break', () => {
         // Stasis applied in round 1 (speed 300 > 200 > 100).
         expect(focusFiredRounds).not.toContain(1);
         // Turn order: stasis-bot(300) → killer(200) → tiny-attacker(150) → focus(100).
-        // Round 1: tiny-attacker hits stasised focus → break marked in focus's skip.
-        // Round 2: focus NOT stasised → fires in EXACTLY round 2.
-        // Pinned to round 2 — "≤3" would pass under a one-round-late regression.
+        // The minimal-damage hit still reduces Stasis each round (reduce-by-one): R1 3→break2→post1;
+        // R2 1→break0 expired; focus fires round 3. Any direct hit reduces Stasis regardless of damage.
         const firstFiredRound = focusFiredRounds.length > 0 ? Math.min(...focusFiredRounds) : 999;
-        expect(firstFiredRound).toBe(2);
+        expect(firstFiredRound).toBe(3);
 
         // Confirm attack was minimal but still connected (non-vacuous: the attacked event fired)
         const attacked = events.filter(
@@ -2080,17 +2075,15 @@ describe('B3 Task 2 — direct-damage break', () => {
         // Focus was stasised in round 1 (stasis-bot applied Stasis before focus acted).
         expect(focusFiredRounds).not.toContain(1);
 
-        // The breaking hit (round 1, breaker-enemy speed=150 > focus speed=100) marks a break
-        // on the focus's skip. Focus skip consumes the break → Stasis removed.
-        // Round 2: focus NOT stasised → fires in EXACTLY round 2.
-        // Pinned to round 2 — a loose "≤3" would pass under a one-round-late regression.
+        // The Barrier-absorbed hits (breaker-enemy speed=150 > focus speed=100) still reduce Stasis
+        // each round (reduce-by-one): R1 3→break2→post1; R2 1→break0 expired; focus fires round 3.
         const firstFiredRound = focusFiredRounds.length > 0 ? Math.min(...focusFiredRounds) : 999;
-        expect(firstFiredRound).toBe(2);
+        expect(firstFiredRound).toBe(3);
 
         // NON-VACUITY: without a breaking hit, Stasis(3) would keep focus locked in rounds 1–3
-        // and fire only in round 4. The focus fires in round 2 here — 2 rounds earlier than the
+        // and fire only in round 4. The focus fires in round 3 here — one round earlier than the
         // no-break baseline. This early fire is only possible if the Barrier-absorbed direct hit
-        // still broke Stasis despite delivering 0 HP loss (spec §3 case).
+        // still reduced Stasis despite delivering 0 HP loss (spec §3 case).
     });
 
     // (vii) REGRESSION: same attacker applies Stasis(5) then fires pure-damage hits → breaks
@@ -2102,8 +2095,8 @@ describe('B3 Task 2 — direct-damage break', () => {
          * Setup (healing mode):
          *   - focus ('attacker', speed=50, attack=0): stands as a victim; carries basicAttack.
          *   - std-enemy ('std-enemy', speed=300, hp=12000, chargeCount=1, startCharged=false):
-         *     active skill = stasisInflictAttack(5); charged skill = basicAttack (pure damage).
-         *     Round 1: NOT charged → fires active (stasisInflictAttack(5)) → Stasis(5) on focus.
+         *     active skill = stasisInflictAttack(3); charged skill = basicAttack (pure damage).
+         *     Round 1: NOT charged → fires active (stasisInflictAttack(3)) → Stasis(3) on focus.
          *     Round 2: charges >= chargeCount → fires charged (basicAttack) → pure damage, NO Stasis.
          *     casterId of the Stasis entry = 'std-enemy'.
          *     In the old code (casterId-identity bug): breakingAttackerId = 'std-enemy',
@@ -2123,12 +2116,14 @@ describe('B3 Task 2 — direct-damage break', () => {
          * Round 2:
          *   std-enemy fires charged (basicAttack) → pure hit on stasised focus → break marked.
          *   killer fires → std-enemy takes 10000 damage → killed (2000 − 10000 < 0).
-         *   focus: STASISED → skip → consumes break → Stasis removed.
+         *   focus: STASISED → skip → consumes break → Stasis reduced (2→1 here, then Post-Turn 1→0
+         *     → expired).
          * Round 3:
          *   std-enemy dead. killer fires. focus NOT stasised → acts.
          *
          * Assert: focus fires in round 3 (no earlier, because rounds 1-2 stasised/skip).
-         * No-break baseline: Stasis(5) would keep focus stasised through round 5 (5 skips before expiry).
+         * No-break baseline: without the round-2 break, Stasis(3) keeps focus stasised through
+         * round 3 (3 skips) and fires only in round 4 — so a round-3 fire proves the break fired.
          */
         const { events } = run({
             attack: 0,
@@ -2178,7 +2173,7 @@ describe('B3 Task 2 — direct-damage break', () => {
                     pattern: basePattern(),
                     shipSkills: {
                         slots: [
-                            // Active slot: stasisInflictAttack(5) — fires in round 1
+                            // Active slot: stasisInflictAttack(3) — fires in round 1
                             {
                                 slot: 'active',
                                 abilities: [
@@ -2194,7 +2189,7 @@ describe('B3 Task 2 — direct-damage break', () => {
                                             type: 'debuff',
                                             buffName: 'Stasis',
                                             application: 'inflict',
-                                            duration: 5,
+                                            duration: 3,
                                             stacks: 1,
                                             isStackable: false,
                                             parsedEffects: {},
@@ -2368,12 +2363,13 @@ describe("B3 Task 3 — Akula don't-break", () => {
         }
     });
 
-    it('(control) same fixture WITHOUT doesntBreakStasis → Stasis IS broken, focus fires round 2', () => {
+    it('(control) same fixture WITHOUT doesntBreakStasis → Stasis IS reduced, focus fires round 3', () => {
         idc = 0;
         /**
          * Identical to the activation test above EXCEPT doesntBreakStasis is NOT set on
-         * akula-enemy. Without the flag the breaker behaves like any other attacker and
-         * breaks Stasis on the first direct hit (round 1 skip → focus fires round 2).
+         * akula-enemy. Without the flag the breaker behaves like any other attacker and reduces
+         * Stasis each round (reduce-by-one): R1 3→break2→post1; R2 1→break0 expired; focus fires
+         * round 3 (vs round 4 when the flag suppresses every break).
          */
         const { events } = run({
             attack: 0,
@@ -2455,9 +2451,9 @@ describe("B3 Task 3 — Akula don't-break", () => {
             .filter((e) => e.actorId === 'attacker')
             .map((e) => e.round);
 
-        // Without the flag: normal-enemy breaks Stasis → focus fires in round 2 (not 4).
+        // Without the flag: normal-enemy reduces Stasis each round → focus fires in round 3 (not 4).
         expect(focusFiredRounds).not.toContain(1); // still stasised round 1 (break pending)
         const firstFiredRound = focusFiredRounds.length > 0 ? Math.min(...focusFiredRounds) : 999;
-        expect(firstFiredRound).toBe(2); // break frees focus → fires round 2
+        expect(firstFiredRound).toBe(3); // reduce-by-one frees focus → fires round 3
     });
 });

--- a/src/utils/combat/__tests__/transformIncomingToDot.test.ts
+++ b/src/utils/combat/__tests__/transformIncomingToDot.test.ts
@@ -260,12 +260,13 @@ describe('Voron replaces a direct hit with a generic DoT (D/turns per tick, SP-A
         expect(totalHpLost).toBeCloseTo(totalTickDamage, 6);
     });
 
-    it('records ZERO net incoming HP in the sim intake bucket for the transform round (battle-sim HP fix)', () => {
-        // The positional battle sim derives each ship's HP% from `perActorIncoming`
-        // (incoming − shieldAbsorbed − barrierAbsorbed), NOT hp-changed. A transformed direct hit
-        // must net to zero there — the hit is DEFERRED into a DoT, not lost as HP this turn.
-        // Round 1: Voron (speed 1000) ticks BEFORE the attacker, so no DoT ticks yet — the only
-        // intake this round is the transformed direct hit, which must net to 0 (pre-fix: 5000).
+    it('the transform round shows ZERO HP loss in the battle-sim HP derivation (not the raw 5000)', () => {
+        // The positional battle sim derives each ship's per-round HP loss exactly as below:
+        // the per-victim `perActorIncoming` bucket (incoming − shield − barrier) when present,
+        // else the raw `perTargetDamage` fallback (see battleSimulator.assembleBattleResult). A
+        // transformed direct hit must net to 0 on BOTH channels — the hit is DEFERRED into a DoT,
+        // not lost as HP this turn. Round 1: Voron (speed 1000) ticks BEFORE the attacker, so no
+        // DoT ticks yet — the only intake this round is the transformed direct hit.
         const input = BASE_PLAYER_SIDE({
             numRounds: 2,
             teamActors: [playerVoron('voron', 'M4')],
@@ -273,9 +274,14 @@ describe('Voron replaces a direct hit with a generic DoT (D/turns per tick, SP-A
         });
         const result = runCombat({ ...input, bus: createEventBus() });
         const round1 = result.rounds.find((r) => r.round === 1)!;
-        const intake = round1.perActorIncoming?.['voron'];
-        const netHp = intake ? intake.incoming - intake.shieldAbsorbed - intake.barrierAbsorbed : 0;
-        expect(netHp).toBe(0);
+        // Replicate battleSimulator's `incomingHpThisRound` formula exactly.
+        const taken = round1.perTargetDamage?.['voron'] ?? 0;
+        const inc = round1.perActorIncoming?.['voron'];
+        const simHpLoss = inc
+            ? Math.max(0, inc.incoming - inc.shieldAbsorbed - inc.barrierAbsorbed)
+            : taken;
+        // Pre-fix: 5000 (raw hit leaked through the perTargetDamage fallback). Post-fix: 0.
+        expect(simHpLoss).toBe(0);
     });
 
     it('the created generic DoT ticks at exactly D/turns × 0.8 (SP-A’s 20%-less-from-DoT reduction applies)', () => {

--- a/src/utils/combat/__tests__/transformIncomingToDot.test.ts
+++ b/src/utils/combat/__tests__/transformIncomingToDot.test.ts
@@ -260,6 +260,24 @@ describe('Voron replaces a direct hit with a generic DoT (D/turns per tick, SP-A
         expect(totalHpLost).toBeCloseTo(totalTickDamage, 6);
     });
 
+    it('records ZERO net incoming HP in the sim intake bucket for the transform round (battle-sim HP fix)', () => {
+        // The positional battle sim derives each ship's HP% from `perActorIncoming`
+        // (incoming − shieldAbsorbed − barrierAbsorbed), NOT hp-changed. A transformed direct hit
+        // must net to zero there — the hit is DEFERRED into a DoT, not lost as HP this turn.
+        // Round 1: Voron (speed 1000) ticks BEFORE the attacker, so no DoT ticks yet — the only
+        // intake this round is the transformed direct hit, which must net to 0 (pre-fix: 5000).
+        const input = BASE_PLAYER_SIDE({
+            numRounds: 2,
+            teamActors: [playerVoron('voron', 'M4')],
+            enemyAttackers: [offensiveEnemy('enemy-1', 'M1', 'front')],
+        });
+        const result = runCombat({ ...input, bus: createEventBus() });
+        const round1 = result.rounds.find((r) => r.round === 1)!;
+        const intake = round1.perActorIncoming?.['voron'];
+        const netHp = intake ? intake.incoming - intake.shieldAbsorbed - intake.barrierAbsorbed : 0;
+        expect(netHp).toBe(0);
+    });
+
     it('the created generic DoT ticks at exactly D/turns × 0.8 (SP-A’s 20%-less-from-DoT reduction applies)', () => {
         const input = BASE_PLAYER_SIDE({
             numRounds: 2,

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3450,7 +3450,15 @@ export function runCombat(input: CombatEngineInput): {
                             sourceId: victim.id,
                             perTickAmount: damage / turns,
                         });
-                        damage = 0; // the direct hit is replaced — no shield/HP drain this turn
+                        // The direct hit is REPLACED by the DoT — no shield/HP drain this turn.
+                        // Reverse the `.incoming` recorded above so the battle sim's HP derivation
+                        // (incoming − shield − barrier) nets to zero real HP loss for this hit; the
+                        // converted damage instead lands over time via the generic-DoT ticks, each
+                        // of which records its own `.incoming` when it fires. Unlike the Barrier
+                        // path this hit is DEFERRED, not blocked, so it is NOT booked as
+                        // barrier/shield absorbed.
+                        sink.addIncoming(-damage, victim.id);
+                        damage = 0;
                     }
                 }
             }
@@ -6165,7 +6173,7 @@ export function runCombat(input: CombatEngineInput): {
                         if (stasisBreakPending.has(actor.id)) {
                             stasisBreakPending.delete(actor.id);
                             for (const name of STASIS_BUFFS)
-                                statusEngine.removeTimedEnemyStatus(actor.id, name);
+                                statusEngine.reduceTimedEnemyStatus(actor.id, name);
                         }
                         // Synthesize a minimal no-action result so the post-round
                         // `focusTurns.length` guard does not throw (the focus actor
@@ -6453,7 +6461,7 @@ export function runCombat(input: CombatEngineInput): {
                         if (stasisBreakPending.has(actor.id)) {
                             stasisBreakPending.delete(actor.id);
                             for (const name of STASIS_BUFFS)
-                                statusEngine.removeTimedEnemyStatus(actor.id, name);
+                                statusEngine.reduceTimedEnemyStatus(actor.id, name);
                         }
                     } // end stasis gate (walked-team branch)
                 } else if (actor.kind === 'enemy' && actor.id === enemy.id) {
@@ -7255,7 +7263,7 @@ export function runCombat(input: CombatEngineInput): {
                         if (stasisBreakPending.has(actor.id)) {
                             stasisBreakPending.delete(actor.id);
                             for (const name of STASIS_BUFFS)
-                                statusEngine.removeTimedEnemyStatus(actor.id, name);
+                                statusEngine.reduceTimedEnemyStatus(actor.id, name);
                         }
                     } // end stasis gate (real-enemy branch)
                 }

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3403,6 +3403,9 @@ export function runCombat(input: CombatEngineInput): {
                 }
             }
             sink.addIncoming(damage, victim.id);
+            // SP-E: amount of THIS hit converted into a DoT (Voron/Orel). Reported in the returned
+            // outcome so the caller excludes it from the per-victim damage-taken credit.
+            let transformedToDot = 0;
             // SP-E: Voron/Orel — "when directly damaged, transforms the damage into a Damage over
             // Time effect lasting N turns". DIRECT INTAKE ONLY (byDirectDamage) — a DoT tick never
             // re-transforms (no recursive conversion). Never fires when Barrier is already
@@ -3451,13 +3454,14 @@ export function runCombat(input: CombatEngineInput): {
                             perTickAmount: damage / turns,
                         });
                         // The direct hit is REPLACED by the DoT — no shield/HP drain this turn.
-                        // Reverse the `.incoming` recorded above so the battle sim's HP derivation
-                        // (incoming − shield − barrier) nets to zero real HP loss for this hit; the
-                        // converted damage instead lands over time via the generic-DoT ticks, each
-                        // of which records its own `.incoming` when it fires. Unlike the Barrier
-                        // path this hit is DEFERRED, not blocked, so it is NOT booked as
-                        // barrier/shield absorbed.
+                        // Reverse the `.incoming` recorded above AND report the converted amount so
+                        // the caller drops it from the per-victim damage-taken credit; together
+                        // these make the battle sim's HP derivation net to zero real HP loss for
+                        // this hit (the converted damage instead lands over time via the generic-DoT
+                        // ticks, each recording its own `.incoming`). Unlike the Barrier path this
+                        // hit is DEFERRED, not blocked, so it is NOT booked as barrier/shield absorbed.
                         sink.addIncoming(-damage, victim.id);
+                        transformedToDot = damage;
                         damage = 0;
                     }
                 }
@@ -3850,7 +3854,7 @@ export function runCombat(input: CombatEngineInput): {
                     }
                 }
             }
-            return { shieldBefore, hpDamage, barriered: false };
+            return { shieldBefore, hpDamage, barriered: false, transformedToDot };
         };
         // Legacy healing-mode player intake — a THIN wrapper over applyVictimDamage. The sink
         // accumulates the victim's incoming / shield-absorbed / barrier-absorbed into its per-actor
@@ -6061,7 +6065,8 @@ export function runCombat(input: CombatEngineInput): {
                                 // PR7 Task 5: set the DEFERRED Stasis break for every covered victim
                                 // (unconditional — covered victims have no same-turn re-apply vector).
                                 // Mirrors the anchor's stasisBreakPending mark; the victim's own skip
-                                // branch consumes it (removeTimedEnemyStatus) on its NEXT turn.
+                                // branch consumes it (reduceTimedEnemyStatus — shaves one turn off
+                                // Stasis, does NOT fully clear it) on its NEXT turn.
                                 for (const victimId of coveredStasisVictims) {
                                     stasisBreakPending.set(victimId, true);
                                 }

--- a/src/utils/combat/positionalApply.ts
+++ b/src/utils/combat/positionalApply.ts
@@ -31,6 +31,11 @@ export interface VictimDamageOutcome {
     shieldBefore: number;
     hpDamage: number;
     barriered: boolean;
+    /** SP-E Voron/Orel: the portion of this hit that was CONVERTED into a Damage-over-Time
+     *  effect instead of landing as damage this turn. The caller subtracts it from the
+     *  per-victim damage-taken credit so a transformed hit reads as 0 damage taken this round
+     *  (the converted amount arrives over time via DoT ticks). Absent/0 for every normal hit. */
+    transformedToDot?: number;
 }
 
 /** Per-cell damage scale keyed off the resolved CellRole. */
@@ -210,7 +215,9 @@ export function applyPositionalDamage(args: {
             const ampPct = outgoingAmplificationFor?.(victim, didCrit) ?? 0;
             const dmg = ampPct !== 0 ? dmgBase * (1 + ampPct / 100) : dmgBase;
             const outcome = applyToVictim(victim, dmg, isAnchor);
-            emitHit?.(victim, dmg, didCrit);
+            // A hit converted into a DoT (Voron/Orel) counts as 0 damage taken this round — the
+            // converted amount lands over time via DoT ticks — so exclude it from the credit.
+            emitHit?.(victim, dmg - (outcome.transformedToDot ?? 0), didCrit);
             onVictimResolved?.(victim, dmg, outcome, didCrit);
         }
     }

--- a/src/utils/combat/statusEngine.ts
+++ b/src/utils/combat/statusEngine.ts
@@ -183,6 +183,12 @@ export interface StatusEngine {
      *  co-applied debuffs on the same victim. Used by §4.5 direct-damage Stasis break.
      *  Lazy-empty / unknown id / unknown name → safe no-op. */
     removeTimedEnemyStatus(targetId: string, buffName: string): void;
+    /** Reduce a SINGLE named timed enemy status on `targetId` by one turn, deleting it only if
+     *  that reaches 0. Targeted like removeTimedEnemyStatus, but a reduce (not a wipe): used by
+     *  §4.5 direct-damage Stasis break so a hit shaves one turn off Stasis instead of clearing it.
+     *  A 'permanent'/'recurring' entry is left untouched. Lazy-empty / unknown id / unknown name →
+     *  safe no-op. */
+    reduceTimedEnemyStatus(targetId: string, buffName: string): void;
     /** Remove a named buff family from ALL of `actorId`'s self stores (timed selfMaps,
      *  accumulating accumSelfMaps, persistent persistentSelfMaps). Lazy-empty / unknown id /
      *  unknown name → safe no-op. */
@@ -1041,6 +1047,19 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
         map.delete(deriveFamilyKey(buffName).familyKey);
     };
 
+    /** §4.5 direct-damage Stasis break: shave ONE turn off the named timed enemy status instead
+     *  of wiping it (the game reduces Stasis' turn count on a direct hit, not removes it). Delete
+     *  only when the count reaches 0. 'permanent'/'recurring' entries are non-numeric → left as-is. */
+    const reduceTimedEnemyStatus = (targetId: string, buffName: string): void => {
+        const map = enemyMaps.get(targetId);
+        if (!map) return;
+        const key = deriveFamilyKey(buffName).familyKey;
+        const s = map.get(key);
+        if (!s || typeof s.turnsRemaining !== 'number') return;
+        s.turnsRemaining -= 1;
+        if (s.turnsRemaining <= 0) map.delete(key);
+    };
+
     /** Remove a named buff family from ALL of `actorId`'s self stores. The three self-side
      *  doors a buff can arrive through each use a different key:
      *   - timed `selfMaps` are keyed by `deriveFamilyKey(buffName).familyKey`,
@@ -1495,6 +1514,7 @@ export function createStatusEngine(input: StatusEngineInput): StatusEngine {
         decrementEnemy,
         clearRemovable,
         removeTimedEnemyStatus,
+        reduceTimedEnemyStatus,
         removeSelfBuffByName,
         cleanse,
         reduceNewestDebuffDuration,

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -511,7 +511,17 @@ export function registerReactiveListeners(args: {
                         // excluded — an opposing crit is NOT an ally crit, even though a
                         // walked enemy now emits ability-performed.
                         if (!isSameSideAlly(e.actorId, ownerId)) return;
-                        const n = e.critHits ?? (e.didCrit ? 1 : 0);
+                        // Charge gain is once PER ATTACK that crits (Hermes: "gains 1 charge"
+                        // per ally-crit event) — a multi-hit or AoE crit grants a single charge,
+                        // not one per critting (hit, victim) pair. Every other on-ally-crit rider
+                        // (Sentinel's reactive damage/heal, Howler's cleanse/Blast) stays
+                        // per-critting-hit via critHits.
+                        const n =
+                            intent.ability.config.type === 'charge'
+                                ? e.didCrit
+                                    ? 1
+                                    : 0
+                                : (e.critHits ?? (e.didCrit ? 1 : 0));
                         // Stamp the crit-ing ally via damagedAllyId (Phase 3 PR-G, Howler) so an
                         // 'ally'-target reactive (cleanse/buff/heal — Sentinel's repair) lands on
                         // THAT ally, mirroring the on-ally-debuffed/on-ally-purged siblings. ALSO


### PR DESCRIPTION
Four independent combat-sim bug fixes, each TDD-first (failing test verified RED before the fix).

## Fixes

**1. Hermes — charge per attack that crits, not per crit**
The `on-ally-crit` listener enqueued once per critting hit/victim pair (`n = critHits`). For a charge-gain ability it now enqueues once when the attack crit at all (`didCrit`). Scoped to the charge branch — Sentinel's reactive damage/heal and Howler's cleanse/Blast still fire per critting hit. A multi-hit or AoE crit now grants Hermes exactly 1 charge.

**2. Stasis — direct damage reduces the turn count, not removes it**
New `statusEngine.reduceTimedEnemyStatus` (decrement by 1, delete only at 0) replaces the full-delete `removeTimedEnemyStatus` at the three deferred-break consume sites in `engine.ts`. Each direct hit shaves one turn off Stasis instead of clearing it.

**3. DoTs shown as debuffs**
`assembleBattleResult` folded `buff-applied`/`debuff-applied` but never `dot-applied`. Added a branch folding DoTs into the victim's `activeDebuffs` with a stack-independent family label (Corrosion / Inferno / Bomb / Damage over Time). `ShipRoundCard` already renders `activeDebuffs`, so they now display in the battle playback.

**4. Voron/Orel transform HP in the sim**
The full hit was recorded into the sim's `.incoming` bucket before the transform zeroed it, with no offset (unlike the Barrier path), so the battle playback double-counted the converted hit. The transform now reverses that `.incoming` — net HP loss is 0, and the converted damage lands over time via DoT ticks. HP bar now reflects real remaining HP.

## Scope note
The raw "damage taken" stat card still shows the intended pre-transform hit for Voron (only the HP% — the reported "real hp" — was corrected).

## Verification
- Each fix has a failing test first, routed through production code (Hermes/Stasis/Voron via `runCombat`, DoT display via `assembleBattleResult`).
- Existing tests that encoded the old behavior updated to the new semantics (Stasis break tests, per-footprint break, two `on-ally-crit` charge tests split into charge/non-charge cases).
- Full suite green (4385), tsc + lint clean.
- Changelog entries added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)