### PR TITLE
Combat log fidelity + per-turn stat snapshots

### DIFF
--- a/src/components/simulator/RoundEventLog.tsx
+++ b/src/components/simulator/RoundEventLog.tsx
@@ -122,7 +122,13 @@ const formatters: Record<
     buff: noteLine,
     debuff: noteLine,
     'dot-applied': noteLine,
-    'dot-ticked': noteLine,
+    'dot-ticked': (entry, ctx) => {
+        const t = entry.targets[0];
+        const who = ctx.nameOf(entry.actorId);
+        if (!t || t.amount === undefined) return who;
+        // DoT tick: "{victim}: {amount} (DoT)". The tick's damage lives on targets[0].amount.
+        return `${who}: ${fmt(t.amount)} (DoT)`;
+    },
     control: noteLine,
     cleanse: noteLine,
     purge: noteLine,

--- a/src/components/simulator/RoundEventLog.tsx
+++ b/src/components/simulator/RoundEventLog.tsx
@@ -196,6 +196,7 @@ const TurnStatsSummary: React.FC<{ snapshot: StatsSnapshot }> = ({ snapshot }) =
             <button
                 type="button"
                 onClick={() => setOpen((o) => !o)}
+                aria-expanded={open}
                 className="text-xs text-theme-text-secondary hover:text-theme-text transition-colors"
             >
                 Stats · HP {fmt(snapshot.currentHp)}/{fmt(snapshot.maxHp)}

--- a/src/components/simulator/RoundEventLog.tsx
+++ b/src/components/simulator/RoundEventLog.tsx
@@ -84,7 +84,7 @@ const renderTargets = (
             </span>
         );
     }
-    if (entry.targets.length === 0) return null;
+    if (entry.targets.length === 0) return <span>{header}</span>;
     return (
         <div>
             <div>{header}</div>

--- a/src/components/simulator/RoundEventLog.tsx
+++ b/src/components/simulator/RoundEventLog.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { BattleResult } from '../../utils/calculators/battleSimulator';
 import { fmt } from '../../utils/simulator/boardOverlays';
+import { CollapsibleAccordion } from '../ui/CollapsibleAccordion';
 import type {
     CombatLogRound,
     CombatLogTurn,
     CombatLogEntry,
     CombatLogTarget,
     CombatLogEntryKind,
+    StatsSnapshot,
 } from '../../utils/combat/log/types';
 
 interface RoundEventLogProps {
@@ -174,6 +176,42 @@ const EntryView: React.FC<{ entry: CombatLogEntry; ctx: FormatterCtx }> = ({ ent
     </li>
 );
 
+/**
+ * Task 6d: a collapsible summary of the acting ship's live modelled stats for this turn.
+ * Collapsed by default — the header line (a sanctioned raw `<button>`, per the full-width
+ * accordion-header toggle exception) shows the compact HP line; expanding it reveals the
+ * remaining stats inside `CollapsibleAccordion` (a controlled, stateless container — this
+ * component owns the open/closed state itself).
+ */
+const TurnStatsSummary: React.FC<{ snapshot: StatsSnapshot }> = ({ snapshot }) => {
+    const [open, setOpen] = useState(false);
+    const shieldSuffix = snapshot.shieldPool > 0 ? ` (+${fmt(snapshot.shieldPool)} shield)` : '';
+    return (
+        <div className="ml-2 mt-1">
+            <button
+                type="button"
+                onClick={() => setOpen((o) => !o)}
+                className="text-xs text-theme-text-secondary hover:text-theme-text transition-colors"
+            >
+                Stats · HP {fmt(snapshot.currentHp)}/{fmt(snapshot.maxHp)}
+                {shieldSuffix}
+            </button>
+            <CollapsibleAccordion isOpen={open}>
+                <ul className="grid grid-cols-2 gap-x-4 text-xs text-theme-text-secondary">
+                    <li>Attack: {fmt(snapshot.attack)}</li>
+                    <li>Defence: {fmt(snapshot.defence)}</li>
+                    <li>Crit: {Math.round(snapshot.crit)}%</li>
+                    <li>Crit Power: {Math.round(snapshot.critDamage)}%</li>
+                    <li>Def Pen: {fmt(snapshot.defensePenetration)}</li>
+                    <li>Speed: {Math.round(snapshot.speed)}</li>
+                    <li>Hacking: {fmt(snapshot.hacking)}</li>
+                    <li>Security: {fmt(snapshot.security)}</li>
+                </ul>
+            </CollapsibleAccordion>
+        </div>
+    );
+};
+
 /** A single turn: a charge-aware header followed by its chronological entries. */
 const TurnView: React.FC<{ turn: CombatLogTurn; ctx: FormatterCtx }> = ({ turn, ctx }) => {
     const header =
@@ -185,6 +223,7 @@ const TurnView: React.FC<{ turn: CombatLogTurn; ctx: FormatterCtx }> = ({ turn, 
             <div className="text-theme-text-secondary font-semibold border-t border-dark-border mt-1 pt-1">
                 {header}
             </div>
+            {turn.statsSnapshot && <TurnStatsSummary snapshot={turn.statsSnapshot} />}
             {turn.entries.length > 0 && (
                 <ul className="ml-2 space-y-1">
                     {turn.entries.map((entry, i) => (

--- a/src/components/simulator/RoundEventLog.tsx
+++ b/src/components/simulator/RoundEventLog.tsx
@@ -127,9 +127,14 @@ const formatters: Record<
     'dot-ticked': (entry, ctx) => {
         const t = entry.targets[0];
         const who = ctx.nameOf(entry.actorId);
-        if (!t || t.amount === undefined) return who;
-        // DoT tick: "{victim}: {amount} (DoT)". The tick's damage lives on targets[0].amount.
-        return `${who}: ${fmt(t.amount)} (DoT)`;
+        // DoT tick: "{victim}: {dotType} ×{stacks} → {amount}" — note carries "{dotType}
+        // ×{stacks}" (mirrors dot-applied's format); amount lives on targets[0].amount.
+        // Fall back gracefully if either is missing (forward-compatible with older events).
+        if (entry.note && t?.amount !== undefined)
+            return `${who}: ${entry.note} → ${fmt(t.amount)}`;
+        if (entry.note) return `${who}: ${entry.note}`;
+        if (t?.amount !== undefined) return `${who}: ${fmt(t.amount)}`;
+        return who;
     },
     control: noteLine,
     cleanse: noteLine,

--- a/src/components/simulator/__tests__/RoundEventLog.test.tsx
+++ b/src/components/simulator/__tests__/RoundEventLog.test.tsx
@@ -68,9 +68,9 @@ const round: CombatLogRound = {
         {
             kind: 'dot-ticked',
             actorId: 'selenite',
-            targets: [],
+            targets: [{ targetId: 'selenite', amount: 300 }],
             reactions: [],
-            note: 'corrosion ×3',
+            note: undefined,
         },
     ],
 };
@@ -111,7 +111,35 @@ describe('RoundEventLog', () => {
     it('renders the end-of-round group with its drained entries', () => {
         render(<RoundEventLog round={round} roster={roster} />);
         expect(screen.getByText(/— end of round —/)).toBeInTheDocument();
-        expect(screen.getByText(/Enemy Selenite: corrosion ×3/)).toBeInTheDocument();
+        expect(screen.getByText(/Enemy Selenite: 300 \(DoT\)/)).toBeInTheDocument();
+    });
+
+    it('renders DoT tick damage with its amount', () => {
+        const round = {
+            round: 1,
+            startOfRound: [],
+            turns: [
+                {
+                    actorId: 'A',
+                    chargeBefore: 0,
+                    chargeMax: 0,
+                    entries: [
+                        {
+                            kind: 'dot-ticked' as const,
+                            actorId: 'A',
+                            targets: [{ targetId: 'A', amount: 1234 }],
+                            reactions: [],
+                        },
+                    ],
+                },
+            ],
+            endOfRound: [],
+        };
+        const roster: BattleResult['roster'] = [
+            { actorId: 'A', side: 'player', name: 'Anemone', position: 'T1' },
+        ];
+        render(<RoundEventLog round={round} roster={roster} />);
+        expect(screen.getByText(/1,234/)).toBeInTheDocument();
     });
 
     it('shows a fallback message when the round has no content', () => {

--- a/src/components/simulator/__tests__/RoundEventLog.test.tsx
+++ b/src/components/simulator/__tests__/RoundEventLog.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import RoundEventLog from '../RoundEventLog';
 import type { BattleResult } from '../../../utils/calculators/battleSimulator';
 import type { CombatLogRound } from '../../../utils/combat/log/types';
@@ -146,5 +147,45 @@ describe('RoundEventLog', () => {
         const empty: CombatLogRound = { round: 1, startOfRound: [], turns: [], endOfRound: [] };
         render(<RoundEventLog round={empty} roster={roster} />);
         expect(screen.getByText('No events this round.')).toBeInTheDocument();
+    });
+
+    it('shows a collapsed stats summary under a turn and expands to the full block', async () => {
+        const round: CombatLogRound = {
+            round: 1,
+            startOfRound: [],
+            endOfRound: [],
+            turns: [
+                {
+                    actorId: 'A',
+                    chargeBefore: 0,
+                    chargeMax: 0,
+                    entries: [],
+                    statsSnapshot: {
+                        attack: 5000,
+                        defence: 3000,
+                        crit: 70,
+                        critDamage: 150,
+                        defensePenetration: 0,
+                        speed: 120,
+                        hacking: 200,
+                        security: 100,
+                        currentHp: 40000,
+                        maxHp: 50000,
+                        shieldPool: 0,
+                    },
+                },
+            ],
+        };
+        render(
+            <RoundEventLog
+                round={round}
+                roster={[{ actorId: 'A', side: 'player', name: 'A', position: 'T1' }]}
+            />
+        );
+        // Collapsed summary shows HP.
+        expect(screen.getByText(/40,000\s*\/\s*50,000/)).toBeInTheDocument();
+        // Expanding reveals a detail stat (attack) not shown in the collapsed line.
+        await userEvent.click(screen.getByRole('button', { name: /stats/i }));
+        expect(screen.getByText(/5,000/)).toBeInTheDocument();
     });
 });

--- a/src/components/simulator/__tests__/RoundEventLog.test.tsx
+++ b/src/components/simulator/__tests__/RoundEventLog.test.tsx
@@ -143,6 +143,58 @@ describe('RoundEventLog', () => {
         expect(screen.getByText(/1,234/)).toBeInTheDocument();
     });
 
+    it('renders the actor name for a target-less entry that still carries a nested reaction', () => {
+        // Rare case: a resisted-debuff-only cast has no targets recorded on the entry itself,
+        // but its reaction (e.g. Ravager's counter) still nests underneath it. The bullet must
+        // show the acting ship, not render blank.
+        const round: CombatLogRound = {
+            round: 1,
+            startOfRound: [],
+            turns: [
+                {
+                    actorId: 'ravager',
+                    chargeBefore: 0,
+                    chargeMax: 0,
+                    entries: [
+                        {
+                            kind: 'attack',
+                            actorId: 'ravager',
+                            skillName: 'Ravage',
+                            targets: [],
+                            reactions: [
+                                {
+                                    kind: 'attack',
+                                    actorId: 'hexa',
+                                    targets: [
+                                        {
+                                            targetId: 'ravager',
+                                            amount: 500,
+                                            didHit: true,
+                                            resultingHpPct: 90,
+                                        },
+                                    ],
+                                    reactions: [],
+                                    note: undefined,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            endOfRound: [],
+        };
+        const roster: BattleResult['roster'] = [
+            { actorId: 'ravager', side: 'enemy', name: 'Ravager', position: 'T1' },
+            { actorId: 'hexa', side: 'enemy', name: 'Hexa', position: 'T2' },
+        ];
+        render(<RoundEventLog round={round} roster={roster} />);
+        // The target-less entry still shows the actor + skill name (not blank).
+        expect(screen.getByText(/Enemy Ravager Ravage/)).toBeInTheDocument();
+        // The nested reaction still renders underneath it.
+        expect(screen.getByText(/↳ reacts:/)).toBeInTheDocument();
+        expect(screen.getByText(/Enemy Hexa → Enemy Ravager: 500 → 90%/)).toBeInTheDocument();
+    });
+
     it('shows a fallback message when the round has no content', () => {
         const empty: CombatLogRound = { round: 1, startOfRound: [], turns: [], endOfRound: [] };
         render(<RoundEventLog round={empty} roster={roster} />);

--- a/src/components/simulator/__tests__/RoundEventLog.test.tsx
+++ b/src/components/simulator/__tests__/RoundEventLog.test.tsx
@@ -71,7 +71,7 @@ const round: CombatLogRound = {
             actorId: 'selenite',
             targets: [{ targetId: 'selenite', amount: 300 }],
             reactions: [],
-            note: undefined,
+            note: 'inferno ×2',
         },
     ],
 };
@@ -112,10 +112,10 @@ describe('RoundEventLog', () => {
     it('renders the end-of-round group with its drained entries', () => {
         render(<RoundEventLog round={round} roster={roster} />);
         expect(screen.getByText(/— end of round —/)).toBeInTheDocument();
-        expect(screen.getByText(/Enemy Selenite: 300 \(DoT\)/)).toBeInTheDocument();
+        expect(screen.getByText(/Enemy Selenite: inferno ×2 → 300/)).toBeInTheDocument();
     });
 
-    it('renders DoT tick damage with its amount', () => {
+    it('renders DoT tick type, stack count, and amount', () => {
         const round = {
             round: 1,
             startOfRound: [],
@@ -130,6 +130,7 @@ describe('RoundEventLog', () => {
                             actorId: 'A',
                             targets: [{ targetId: 'A', amount: 1234 }],
                             reactions: [],
+                            note: 'corrosion ×3',
                         },
                     ],
                 },
@@ -140,7 +141,7 @@ describe('RoundEventLog', () => {
             { actorId: 'A', side: 'player', name: 'Anemone', position: 'T1' },
         ];
         render(<RoundEventLog round={round} roster={roster} />);
-        expect(screen.getByText(/1,234/)).toBeInTheDocument();
+        expect(screen.getByText(/Anemone: corrosion ×3 → 1,234/)).toBeInTheDocument();
     });
 
     it('renders the actor name for a target-less entry that still carries a nested reaction', () => {

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -73,6 +73,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Damage-over-Time effects (Corrosion, Inferno, Bomb, and transform DoTs) now show up in a ship's active debuff list in the battle playback, alongside its other debuffs.",
     'Combat sim: fixed the HP shown for Voron (and Orel) after a hit is converted into a Damage-over-Time effect — the battle playback no longer double-counts the converted hit, so the HP bar reflects the real remaining HP.',
     'Combat log now shows damage-over-time (corrosion/inferno) tick damage each round.',
+    'Combat log now shows counter-attacks and damage reflection.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -74,6 +74,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat sim: fixed the HP shown for Voron (and Orel) after a hit is converted into a Damage-over-Time effect — the battle playback no longer double-counts the converted hit, so the HP bar reflects the real remaining HP.',
     'Combat log now shows damage-over-time (corrosion/inferno) tick damage each round.',
     'Combat log now shows counter-attacks and damage reflection.',
+    "Combat log turns now include a collapsible snapshot of the acting ship's current modelled stats (HP, attack, defence, crit, speed, hacking, security).",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -72,6 +72,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat sim: direct damage to a ship in Stasis now reduces its remaining Stasis by one turn instead of removing Stasis entirely — the target wakes up sooner with each hit rather than immediately.',
     "Combat sim: Damage-over-Time effects (Corrosion, Inferno, Bomb, and transform DoTs) now show up in a ship's active debuff list in the battle playback, alongside its other debuffs.",
     'Combat sim: fixed the HP shown for Voron (and Orel) after a hit is converted into a Damage-over-Time effect — the battle playback no longer double-counts the converted hit, so the HP bar reflects the real remaining HP.',
+    'Combat log now shows damage-over-time (corrosion/inferno) tick damage each round.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3229,8 +3229,9 @@ const DocumentationPage: React.FC = () => {
                                         <strong>Per-turn stat snapshot:</strong> Each turn has a
                                         collapsible &quot;Stats&quot; row showing the acting
                                         ship&apos;s current modelled HP, attack, defence, crit,
-                                        speed, hacking, and security — with all live buffs/debuffs
-                                        folded in — so you can verify a buff actually landed.
+                                        speed, hacking, and security including active stat
+                                        buffs/debuffs (defense penetration shows the base value
+                                        only) — so you can verify a buff actually landed.
                                     </li>
                                 </ul>
                             </div>

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3228,8 +3228,8 @@ const DocumentationPage: React.FC = () => {
                                     <li>
                                         <strong>Per-turn stat snapshot:</strong> Each turn has a
                                         collapsible &quot;Stats&quot; row showing the acting
-                                        ship&apos;s current modelled HP, attack, defence, crit,
-                                        speed, hacking, and security including active stat
+                                        ship&apos;s current modelled HP, attack, defence, crit, crit
+                                        power, speed, hacking, and security including active stat
                                         buffs/debuffs (defense penetration shows the base value
                                         only) — so you can verify a buff actually landed.
                                     </li>

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3225,6 +3225,13 @@ const DocumentationPage: React.FC = () => {
                                         charged skill variant. Charge gains, resets, and
                                         manipulations each appear as explicit lines.
                                     </li>
+                                    <li>
+                                        <strong>Per-turn stat snapshot:</strong> Each turn has a
+                                        collapsible &quot;Stats&quot; row showing the acting
+                                        ship&apos;s current modelled HP, attack, defence, crit,
+                                        speed, hacking, and security — with all live buffs/debuffs
+                                        folded in — so you can verify a buff actually landed.
+                                    </li>
                                 </ul>
                             </div>
 

--- a/src/utils/calculators/battleSimulator.ts
+++ b/src/utils/calculators/battleSimulator.ts
@@ -221,6 +221,8 @@ export const LOG_EVENT_TYPES = [
     // Log-only reactive procs (drain-time damage/heal that emit no ability-performed/heal-performed).
     'reactive-damage-performed',
     'reactive-heal-performed',
+    // Task 6: log-only per-turn acting-actor stat snapshot (no listener subscribes).
+    'stats-snapshot',
 ] as const satisfies readonly CombatEvent['type'][];
 
 // Compile-time proof that LOG_EVENT_TYPES ⊇ ASSEMBLED_EVENT_TYPES (bus subscribes to LOG;

--- a/src/utils/calculators/battleSimulator.ts
+++ b/src/utils/calculators/battleSimulator.ts
@@ -881,6 +881,7 @@ export function simulateBattle(
         // and therefore differs from the representative-security basis — the intended per-target
         // behaviour covered by the heterogeneous-security team-vs-team test in twoTeamBattle.test.ts.
         hacking: focus.stats.hacking,
+        security: focus.stats.security,
         enemySecurity: enemyRepSecurity,
         position: focus.position,
         target: focus.targeting?.target,

--- a/src/utils/combat/__tests__/counterReflectLog.integration.test.ts
+++ b/src/utils/combat/__tests__/counterReflectLog.integration.test.ts
@@ -1,0 +1,319 @@
+/**
+ * counterReflectLog.integration.test.ts — Task 3: counter-attacks and reflects surface in the
+ * combat log.
+ *
+ * Both mechanisms apply real mitigated damage (via `applyVictimDamage`) but, pre-fix, emit NO
+ * `reactive-damage-performed` event, so the reaction is invisible in `combatLog` even though the
+ * HP change is real. This mirrors the shipped Sentinel pattern
+ * (sentinelReactionLog.integration.test.ts / reflectGearSet.integration.test.ts's combatLog #4
+ * case): drive a real two-ship `simulateBattle`, flatten the resulting `combatLog`, and assert a
+ * reactive `attack` entry is attributed to the REACTOR (counter owner / reflector), nested under
+ * the TRIGGERING attacker's turn entry — not a top-level entry in the reactor's own turn.
+ *
+ * Non-vacuity: without the engine/trigger emit fix, `applyCounterAttack`/the reflect block still
+ * apply real HP damage (proven via `totalDamageTaken` in the sibling suites), but no
+ * `reactive-damage-performed` event fires, so these log-shape assertions are red.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateBattle, BattlePlacement } from '../../calculators/battleSimulator';
+import { flattenCombatLog } from '../log/__testutils__/flattenCombatLog';
+import { Ship, AffinityName } from '../../../types/ship';
+import type { Position } from '../../../types/encounters';
+
+const place = (
+    ship: Ship,
+    position: Position,
+    overrides: Partial<BattlePlacement['statOverrides']> = {}
+): BattlePlacement => ({
+    ship,
+    position,
+    statOverrides: {
+        attack: 5000,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        hacking: 200,
+        defence: 0,
+        hp: 1_000_000,
+        ...overrides,
+    } as BattlePlacement['statOverrides'],
+});
+
+/** A ship that fires a single-hit 100% direct attack on the front enemy every turn. */
+function makeAttacker(id: string, name: string, affinity: AffinityName): Ship {
+    return {
+        id,
+        name,
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'ATTACKER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {} as Ship['equipment'],
+        implants: {},
+        refits: [],
+        affinity,
+        activeSkillText: 'This Unit deals <unit-damage>100% damage</unit-damage>.',
+        chargeSkillCharge: 0,
+        activeTarget: 'front',
+        activePattern: 'Pattern-Base',
+    } as Partial<Ship> as Ship;
+}
+
+/** Resolve a roster actorId by ship display name (the player focus is 'attacker'; others are
+ *  slot-suffixed `p:<id>:<i>` / `e:<id>:<i>`, so match on the stable name instead). */
+function actorIdByName(result: ReturnType<typeof simulateBattle>, name: string): string {
+    return result.roster.find((r) => r.name === name)!.actorId;
+}
+
+// ---------------------------------------------------------------------------
+// 3a: Counter-attack (Stalwart) — the counter owner's retaliation surfaces as a nested
+// reactive `attack` entry under the attacking hero's turn.
+// ---------------------------------------------------------------------------
+
+const STALWART_P1 =
+    'When this Unit is directly damaged as a primary target, it deals <unit-damage>30% damage</unit-damage> to that enemy and gains <unit-skill>Legion Discipline II</unit-skill> for 3 turns.';
+
+/** A counter-bearing ship: a self-repair active (no offence) + Stalwart's on-attacked counter
+ *  passive (verbatim, docs/ship-skills.csv). Refits [{},{},{},{}] make the refit-active first
+ *  passive apply — the SAME fixture shape as reflectGearSet.integration.test.ts's combatLog #4
+ *  case (which proves the co-located buff reaction nests correctly; this test adds the DAMAGE
+ *  side of that same reaction). */
+function makeCounterShip(id: string, name: string, affinity: AffinityName): Ship {
+    return {
+        id,
+        name,
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'DEFENDER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {} as Ship['equipment'],
+        implants: {},
+        refits: [{}, {}, {}, {}],
+        affinity,
+        activeSkillText: 'This Unit repairs 30% of its Max HP.',
+        firstPassiveSkillText: STALWART_P1,
+        chargeSkillCharge: 0,
+        activeTarget: 'allies',
+        activePattern: 'Pattern-Base',
+    } as Partial<Ship> as Ship;
+}
+
+describe('Counter-attacks surface in the combat log (real sim path)', () => {
+    // Player focus 'hero' is a plain attacker; the ENEMY carries Stalwart's counter passive. Each
+    // round hero directly hits the enemy (primary target) → the enemy's on-attacked counter fires
+    // back at hero.
+    const build = () =>
+        simulateBattle({
+            playerTeam: [place(makeAttacker('hero', 'Hero', 'thermal'), 'M4')],
+            enemyTeam: [place(makeCounterShip('foe', 'Foe', 'antimatter'), 'M4')],
+            rounds: 4,
+        });
+
+    it('surfaces a counter-attack as a nested reactive entry in the combat log', () => {
+        const result = build();
+        const counterOwnerId = actorIdByName(result, 'Foe');
+        const heroId = actorIdByName(result, 'Hero');
+
+        const flat = flattenCombatLog(result);
+        const counterEntries = flat.filter(
+            (e) => e.kind === 'attack' && e.actorId === counterOwnerId
+        );
+        expect(counterEntries.length).toBeGreaterThan(0);
+        expect(counterEntries[0].targets[0].amount).toBeGreaterThan(0);
+        expect(counterEntries[0].targets[0].targetId).toBe(heroId);
+
+        // Nested under the attacking hero's turn — NOT a top-level entry anywhere.
+        const topLevelCounterOccurrences = result.combatLog
+            .flatMap((round) => round.turns.flatMap((turn) => turn.entries))
+            .filter((entry) => entry.kind === 'attack' && entry.actorId === counterOwnerId);
+        expect(topLevelCounterOccurrences).toHaveLength(0);
+
+        const entriesWithCounterReaction = result.combatLog
+            .flatMap((round) => round.turns.flatMap((turn) => turn.entries))
+            .filter((entry) =>
+                entry.reactions.some((re) => re.kind === 'attack' && re.actorId === counterOwnerId)
+            );
+        expect(entriesWithCounterReaction.length).toBeGreaterThan(0);
+        // The trigger is the hero's OWN attack entry (not the reactor's own turn).
+        expect(entriesWithCounterReaction[0].actorId).toBe(heroId);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 3b: Reflect (Nosorog / Reflect gear set) — the reflector's thorns hit surfaces as a nested
+// reactive `attack` entry under the attacking enemy's turn.
+// ---------------------------------------------------------------------------
+
+/** Nosorog's verbatim reflect passive (docs/ship-skills.csv, Nosorog passive2/3). */
+const NOSOROG_REFLECT =
+    'This Unit reflects 40% of the Damage taken back to the enemy when directly damaged as a primary target.';
+
+/** A NON-DAMAGING player Nosorog: self-repair active (never deals direct damage to the enemy, so
+ *  any damage the enemy takes is PURELY reflected thorns) + the reflect passive on the R0 slot
+ *  (no refits needed — firstPassiveSkillText applies at R0). */
+function makeReflectNosorog(id: string, name: string, affinity: AffinityName): Ship {
+    return {
+        id,
+        name,
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'DEFENDER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {} as Ship['equipment'],
+        implants: {},
+        refits: [],
+        affinity,
+        activeSkillText: 'This Unit repairs 30% of its Max HP.',
+        firstPassiveSkillText: NOSOROG_REFLECT,
+        chargeSkillCharge: 0,
+        activeTarget: 'allies',
+        activePattern: 'Pattern-Base',
+    } as Partial<Ship> as Ship;
+}
+
+describe('Reflects surface in the combat log (real sim path)', () => {
+    // A player Nosorog reflector (front, M4) faces a real enemy attacker. Every enemy hit lands
+    // on Nosorog (primary target) → the reflect passive bounces a mitigated hit back at the enemy.
+    const build = () =>
+        simulateBattle({
+            playerTeam: [
+                place(makeReflectNosorog('nosorog', 'Nosorog', 'thermal'), 'M4', {
+                    hp: 1_000_000,
+                    attack: 0,
+                }),
+            ],
+            enemyTeam: [
+                place(makeAttacker('foe', 'Foe', 'antimatter'), 'M4', {
+                    hp: 1_000_000,
+                    attack: 5000,
+                }),
+            ],
+            rounds: 4,
+        });
+
+    it('surfaces a reflected hit as a nested reactive entry in the combat log', () => {
+        const result = build();
+        const nosorogId = actorIdByName(result, 'Nosorog');
+        const foeId = actorIdByName(result, 'Foe');
+
+        const flat = flattenCombatLog(result);
+        const reflectEntries = flat.filter((e) => e.kind === 'attack' && e.actorId === nosorogId);
+        expect(reflectEntries.length).toBeGreaterThan(0);
+        expect(reflectEntries[0].targets[0].amount).toBeGreaterThan(0);
+        expect(reflectEntries[0].targets[0].targetId).toBe(foeId);
+
+        // Nested under the attacking enemy's turn — NOT a top-level entry anywhere.
+        const topLevelReflectOccurrences = result.combatLog
+            .flatMap((round) => round.turns.flatMap((turn) => turn.entries))
+            .filter((entry) => entry.kind === 'attack' && entry.actorId === nosorogId);
+        expect(topLevelReflectOccurrences).toHaveLength(0);
+
+        const entriesWithReflectReaction = result.combatLog
+            .flatMap((round) => round.turns.flatMap((turn) => turn.entries))
+            .filter((entry) =>
+                entry.reactions.some((re) => re.kind === 'attack' && re.actorId === nosorogId)
+            );
+        expect(entriesWithReflectReaction.length).toBeGreaterThan(0);
+        // The trigger is the enemy's OWN attack entry (not the reflector's own turn).
+        expect(entriesWithReflectReaction[0].actorId).toBe(foeId);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 3b regression — reflect must nest under the ATTACK entry, NOT a preceding
+// non-reactive entry (charge-changed / self-buff) the attacker's active cast
+// emits BEFORE the deferred positional apply.
+//
+// This is the case the reviewer used to prove the original buffer-based fix was
+// wrong: the reflect fires inside applyVictimDamage DURING the enemy's positional
+// apply, which happens AFTER runPlayerTurn emitted the enemy's self-charge-gain
+// `charge-changed` (playerTurn ~2043) but BEFORE the engine's deferred
+// `ability-performed`. A naive inline emit (or a "buffer only when the turn has no
+// non-reactive entry yet" heuristic) nests the reflect under the charge-changed
+// entry. The engine-defer fix buffers the reflect row through drivePositionalApply
+// and flushes it right after emitDeferredAbilityPerformed, so it routes to the
+// just-created attack entry. RED on the pre-fix code (inline emit) — the reflect
+// nests under kind:'charge-changed'; GREEN after — it nests under kind:'attack'.
+// ---------------------------------------------------------------------------
+
+/** An enemy attacker whose ACTIVE deals 100% damage AND self-grants a charge (ungated), and which
+ *  carries a charged skill (chargeSkillCharge 3) so `hasChargedSkill` is true → the self-charge
+ *  gain fires and emits a `charge-changed` (reason 'manip') entry BEFORE the attack each active
+ *  turn. chargeSkillCharge is set high enough that within the battle it never actually fires the
+ *  charged skill, so every turn is an ACTIVE cast that both self-charges and deals the reflecting
+ *  hit. */
+function makeChargingAttacker(id: string, name: string, affinity: AffinityName): Ship {
+    return {
+        id,
+        name,
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'ATTACKER',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {} as Ship['equipment'],
+        implants: {},
+        refits: [],
+        affinity,
+        activeSkillText:
+            "This Unit deals <unit-damage>100% damage</unit-damage> and adds <unit-aid>1 charge</unit-aid> to it's Charged Skill.",
+        chargeSkillText: 'This Unit deals <unit-damage>300% damage</unit-damage>.',
+        chargeSkillCharge: 3,
+        activeTarget: 'front',
+        activePattern: 'Pattern-Base',
+    } as Partial<Ship> as Ship;
+}
+
+describe('Reflects nest under the attack, not a preceding charge/buff entry (regression)', () => {
+    it('nests the reflect under the attacker attack entry even when the active self-grants charge first', () => {
+        const result = simulateBattle({
+            playerTeam: [
+                place(makeReflectNosorog('nosorog', 'Nosorog', 'thermal'), 'M4', {
+                    hp: 1_000_000,
+                    attack: 0,
+                }),
+            ],
+            enemyTeam: [
+                place(makeChargingAttacker('foe', 'Foe', 'antimatter'), 'M4', {
+                    hp: 1_000_000,
+                    attack: 5000,
+                }),
+            ],
+            rounds: 4,
+        });
+        const nosorogId = actorIdByName(result, 'Nosorog');
+        const foeId = actorIdByName(result, 'Foe');
+
+        // Non-vacuity: the enemy DID emit a charge-changed entry in its own turn (the exact
+        // preceding non-reactive entry that the bug mis-nested the reflect under).
+        const enemyTurnEntries = result.combatLog
+            .flatMap((round) => round.turns.filter((t) => t.actorId === foeId))
+            .flatMap((t) => t.entries);
+        expect(enemyTurnEntries.some((e) => e.kind === 'charge-changed')).toBe(true);
+
+        // The reflect reaction exists and is attributed to the reflector.
+        const reflectReactions = enemyTurnEntries.flatMap((e) =>
+            e.reactions.filter((re) => re.kind === 'attack' && re.actorId === nosorogId)
+        );
+        expect(reflectReactions.length).toBeGreaterThan(0);
+        expect(reflectReactions[0].targets[0].amount).toBeGreaterThan(0);
+        expect(reflectReactions[0].targets[0].targetId).toBe(foeId);
+
+        // CORE OF THE FIX: every reflect reaction hangs off an ATTACK entry — NEVER off the
+        // charge-changed (or any non-attack) entry that preceded the attack in the same turn.
+        const triggersOfReflect = enemyTurnEntries.filter((e) =>
+            e.reactions.some((re) => re.kind === 'attack' && re.actorId === nosorogId)
+        );
+        expect(triggersOfReflect.length).toBeGreaterThan(0);
+        for (const trigger of triggersOfReflect) {
+            expect(trigger.kind).toBe('attack');
+            expect(trigger.actorId).toBe(foeId);
+        }
+        // And no charge-changed entry ever carries a reflect reaction.
+        const chargeEntriesWithReflect = enemyTurnEntries.filter(
+            (e) =>
+                e.kind === 'charge-changed' &&
+                e.reactions.some((re) => re.kind === 'attack' && re.actorId === nosorogId)
+        );
+        expect(chargeEntriesWithReflect).toHaveLength(0);
+    });
+});

--- a/src/utils/combat/__tests__/genericDot.test.ts
+++ b/src/utils/combat/__tests__/genericDot.test.ts
@@ -37,14 +37,18 @@ describe('generic DoT', () => {
         ];
         let credited = 0;
         let tickedDamage: number | undefined;
+        let tickedStacks: number | undefined;
         tickDoTs({
             corrosionEntries: [],
             infernoEntries: [],
             genericDoTEntries: gen,
             enemyHp: 1_000_000,
             ctxFor: () => undefined,
-            emitTicked: (dotType, damage) => {
-                if (dotType === 'generic') tickedDamage = damage;
+            emitTicked: (dotType, damage, stacks) => {
+                if (dotType === 'generic') {
+                    tickedDamage = damage;
+                    tickedStacks = stacks;
+                }
             },
             credit: (_sourceId, dotType, damage) => {
                 if (dotType === 'generic') credited += damage;
@@ -53,6 +57,8 @@ describe('generic DoT', () => {
 
         expect(credited).toBe(300);
         expect(tickedDamage).toBe(300);
+        // The emitted stacks is the summed TICKING stacks for this DoT type (here: one entry, 1 stack).
+        expect(tickedStacks).toBe(1);
         expect(gen[0].remainingRounds).toBe(2);
 
         // Two more ticks exhaust remainingRounds → the entry expires (array empties).
@@ -122,5 +128,40 @@ describe('generic DoT', () => {
         };
         expect(stack.family).toBe('Acidic Decay');
         expect(stack.unremovable).toBe(true);
+    });
+
+    // Combat-log fidelity: `emitTicked`'s 3rd arg is the per-dotType SUMMED TICKING stacks
+    // (only entries that actually tick — i.e. have a resolvable applier ctx — are counted).
+    it('emitTicked receives the summed ticking stacks for corrosion, excluding entries with no ctx', () => {
+        const corrosion: ActiveDoTStack[] = [
+            { stacks: 2, tier: 10, remainingRounds: 2, sourceId: 'applier-a' },
+            { stacks: 1, tier: 10, remainingRounds: 2, sourceId: 'applier-b' },
+            // No ctx for this applier (faster-enemy round 1) — its 5 stacks must NOT be counted.
+            { stacks: 5, tier: 10, remainingRounds: 2, sourceId: 'no-ctx-applier' },
+        ];
+        const ctx = {
+            effectiveAttack: 100,
+            dotMult: 1,
+            affinityMult: 1,
+            effectiveDefence: 0,
+            effectiveMaxHp: 0,
+            outgoingHealPct: 0,
+            incomingHealPct: 0,
+        };
+        let tickedStacks: number | undefined;
+        tickDoTs({
+            corrosionEntries: corrosion,
+            infernoEntries: [],
+            genericDoTEntries: [],
+            enemyHp: 100_000,
+            ctxFor: (sourceId) => (sourceId === 'no-ctx-applier' ? undefined : ctx),
+            emitTicked: (dotType, _damage, stacks) => {
+                if (dotType === 'corrosion') tickedStacks = stacks;
+            },
+            credit: () => {},
+        });
+
+        // 2 (applier-a) + 1 (applier-b) = 3; the no-ctx entry's 5 stacks are excluded.
+        expect(tickedStacks).toBe(3);
     });
 });

--- a/src/utils/combat/__tests__/statsSnapshot.integration.test.ts
+++ b/src/utils/combat/__tests__/statsSnapshot.integration.test.ts
@@ -14,8 +14,15 @@
  */
 import { describe, it, expect } from 'vitest';
 import { simulateDPS } from '../../calculators/dpsSimulator';
+import {
+    simulateBattle,
+    BattlePlacement,
+    BattleSimulationInput,
+} from '../../calculators/battleSimulator';
 import { createEventBus, CombatEvent } from '../events';
 import { Ability } from '../../../types/abilities';
+import type { Ship } from '../../../types/ship';
+import type { Position } from '../../../types/encounters';
 
 const damageAbility = (multiplier: number, id = 'dmg'): Ability => ({
     id,
@@ -66,5 +73,93 @@ describe('stats-snapshot event (Task 6a)', () => {
         expect(snap!.stats.attack).toBeGreaterThan(BASE_ATTACK_A); // buff folded in
         expect(snap!.stats.currentHp).toBeGreaterThan(0);
         expect(snap!.round).toBeGreaterThan(0);
+    });
+
+    /** Bug repro: the FOCUS player's own `security` (e.g. Code Guard's hacking→security fold)
+     *  never reached the engine's `attacker` actor — `effectiveStatsOf(...).security` read
+     *  `(undefined ?? 0) + buff`, so the per-turn snapshot always showed 0 for the focus,
+     *  regardless of the ship's real (gear-resolved) security. Team actors and enemies were
+     *  unaffected (they thread security via toWalkStats/toEnemyStats already). */
+    it("surfaces the FOCUS actor's own security in its stats-snapshot turn (not 0)", () => {
+        const FOCUS_SECURITY = 359;
+
+        const focusShip: Ship = {
+            id: 'focus-ship',
+            name: 'Focus',
+            rarity: 'legendary',
+            faction: 'MPL',
+            type: 'ATTACKER',
+            baseStats: {
+                hp: 100_000,
+                attack: 1000,
+                defence: 0,
+                hacking: 200,
+                security: FOCUS_SECURITY,
+                crit: 0,
+                critDamage: 0,
+                speed: 100,
+            },
+            equipment: {},
+            implants: {},
+            refits: [],
+            affinity: 'antimatter',
+            activeSkillText: 'This Unit deals <unit-damage>100% damage</unit-damage>.',
+            activeTarget: 'back',
+            activePattern: 'Pattern-Base',
+            chargeSkillCharge: 0,
+        };
+
+        const enemyShip: Ship = {
+            id: 'enemy-ship',
+            name: 'Enemy',
+            rarity: 'legendary',
+            faction: 'MPL',
+            type: 'ATTACKER',
+            baseStats: {
+                hp: 100_000,
+                attack: 0,
+                defence: 0,
+                hacking: 200,
+                security: 100,
+                crit: 0,
+                critDamage: 0,
+                speed: 50,
+            },
+            equipment: {},
+            implants: {},
+            refits: [],
+            affinity: 'antimatter',
+            activeSkillText: 'This Unit deals <unit-damage>100% damage</unit-damage>.',
+            activeTarget: 'front',
+            activePattern: 'Pattern-Base',
+            chargeSkillCharge: 0,
+        };
+
+        const placement = (ship: Ship, position: Position): BattlePlacement => ({
+            ship,
+            position,
+            statOverrides: {
+                attack: ship.baseStats.attack,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: ship.baseStats.hacking,
+                defence: ship.baseStats.defence,
+                hp: ship.baseStats.hp,
+                speed: ship.baseStats.speed,
+            },
+        });
+
+        const input: BattleSimulationInput = {
+            playerTeam: [placement(focusShip, 'M4')],
+            enemyTeam: [placement(enemyShip, 'T1')],
+            rounds: 1,
+        };
+
+        const result = simulateBattle(input);
+        const turn = result.combatLog[0]?.turns.find((t) => t.actorId === 'attacker');
+        expect(turn).toBeDefined();
+        expect(turn!.statsSnapshot).toBeDefined();
+        expect(turn!.statsSnapshot!.security).toBe(FOCUS_SECURITY);
     });
 });

--- a/src/utils/combat/__tests__/statsSnapshot.integration.test.ts
+++ b/src/utils/combat/__tests__/statsSnapshot.integration.test.ts
@@ -1,0 +1,70 @@
+/**
+ * statsSnapshot.integration.test.ts — Task 6a: a LOG-ONLY `stats-snapshot` event emitted once
+ * per turn for the acting actor, immediately after `turn-started`.
+ *
+ * `simulateBattle`/`simulateDPS` expose no per-event callback hook — the only way to observe an
+ * engine emission from a test is to subscribe to the engine's OWN event bus, which `runCombat`
+ * (via `simulateDPS`) accepts as a write-only tap (`input.bus`). This mirrors the pattern used by
+ * `dynamicSpeed.smoke.test.ts` (bus passed into `simulateDPS`, listeners registered before the run).
+ *
+ * Non-vacuity: the attacker starts with a pre-resolved "Attack Up" self-buff (a start-of-combat
+ * buff, present from round 1 via `selfBuffs`/`toSimBuffs` — Layer 1 of the effective-stats fold),
+ * so the snapshot's `attack` must exceed the raw base `attack` input. Pre-fix (no `stats-snapshot`
+ * emission at all) this test is RED — no listener ever fires.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateDPS } from '../../calculators/dpsSimulator';
+import { createEventBus, CombatEvent } from '../events';
+import { Ability } from '../../../types/abilities';
+
+const damageAbility = (multiplier: number, id = 'dmg'): Ability => ({
+    id,
+    type: 'damage',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'damage', multiplier },
+});
+
+const BASE_ATTACK_A = 1000;
+
+describe('stats-snapshot event (Task 6a)', () => {
+    it('emits a stats-snapshot per turn reflecting live buffed stats', () => {
+        const bus = createEventBus();
+        const seen: Extract<CombatEvent, { type: 'stats-snapshot' }>[] = [];
+        bus.on('stats-snapshot', (e) => seen.push(e));
+
+        simulateDPS({
+            attack: BASE_ATTACK_A,
+            crit: 0,
+            critDamage: 150,
+            defensePenetration: 0,
+            chargeCount: 0,
+            enemyDefense: 0,
+            enemyHp: 1_000_000,
+            hp: 500_000,
+            rounds: 2,
+            selfBuffs: [
+                {
+                    id: 'atk-up',
+                    buffName: 'Attack Up',
+                    stacks: 1,
+                    parsedEffects: { attack: 30 },
+                    isStackable: false,
+                },
+            ],
+            enemyDebuffs: [],
+            shipSkills: { slots: [{ slot: 'active', abilities: [damageAbility(100)] }] },
+            hacking: 250,
+            enemySecurity: 100,
+            bus,
+        });
+
+        expect(seen.length).toBeGreaterThan(0);
+        const snap = seen.find((e) => e.actorId === 'attacker');
+        expect(snap).toBeDefined();
+        expect(snap!.stats.attack).toBeGreaterThan(BASE_ATTACK_A); // buff folded in
+        expect(snap!.stats.currentHp).toBeGreaterThan(0);
+        expect(snap!.round).toBeGreaterThan(0);
+    });
+});

--- a/src/utils/combat/__tests__/twoTeamBattle.test.ts
+++ b/src/utils/combat/__tests__/twoTeamBattle.test.ts
@@ -1503,10 +1503,16 @@ describe('bug repro: enemy supporter turn skipped after the focus player dies', 
         expect(aliveAt(1)).toBe(true);
         expect(aliveAt(2)).toBe(false);
 
-        // Round 1 (focus alive): the non-positional attacker fires a real attack entry.
-        const round1 = result.combatLog.find((r) => r.round === 1);
-        const round1Turn = round1?.turns.find((t) => t.actorId === DEADBOUND);
-        expect(round1Turn?.entries.some((e) => e.kind === 'attack')).toBe(true);
+        // Round 1 (focus alive): the non-positional attacker's ability DOES fire — its
+        // computed damage is credited via `ability-performed` regardless of the victim it
+        // resolves to (proven via `damageDealt`, independent of the combat log). Its legacy-
+        // victim fallback lands on the side's dummy sink rather than a real opposing actor,
+        // so no `attacked` event follows and the combat log's now-empty attack entry is
+        // correctly pruned as a phantom row (Task 4) — the SAME shape as round 4's genuine
+        // skip. `damageDealt` is the one signal that still tells the two cases apart.
+        const round1 = result.rounds.find((r) => r.round === 1);
+        const round1Ship = round1?.ships.find((s) => s.actorId === DEADBOUND);
+        expect(round1Ship?.damageDealt).toBeGreaterThan(0);
 
         // Round 4 (focus long dead, no positional re-target available): the attacker's turn
         // stays cadence-only — no skill-fired-derived entries at all. This is the PRESERVED
@@ -1516,6 +1522,11 @@ describe('bug repro: enemy supporter turn skipped after the focus player dies', 
         const round4Turn = round4?.turns.find((t) => t.actorId === DEADBOUND);
         expect(round4Turn).toBeDefined();
         expect(round4Turn!.entries.length).toBe(0);
+
+        const round4Ship = result.rounds
+            .find((r) => r.round === 4)
+            ?.ships.find((s) => s.actorId === DEADBOUND);
+        expect(round4Ship?.damageDealt).toBe(0);
     });
 
     it('threshold flip: an ally-only ACTIVE runs but the enemy-facing CHARGED skill skips, per-round, at the charge threshold', () => {

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3298,6 +3298,37 @@ export function runCombat(input: CombatEngineInput): {
         // verbatim. Kept inside runCombat — it captures statusEngine/bus/r/recipientMaxHp/
         // cheatDeathConsumed/cheatDeathConsumedRound/recordDestroyed/BARRIER_BUFFS/
         // CHEAT_DEATH_BUFFS/selfBuffNamesForOwners exactly as before.
+        //
+        // Task 3 (combat-log) — deferred reflect log emit. Reflect thorns fire from INSIDE
+        // applyVictimDamage. On the POSITIONAL path they run DURING drivePositionalApply, BEFORE
+        // the attacker's aggregate `ability-performed` is emitted (emitDeferredAbilityPerformed,
+        // post-apply). Emitting the reflect's LOG-ONLY `reactive-damage-performed` inline there
+        // would nest it under whatever non-reactive entry already exists in the attacker's turn
+        // (e.g. a self charge-gain / self-buff the attacker's active cast emitted BEFORE the
+        // attack), not under the attack. So while `deferReflectLogs` is set (⟺ inside
+        // drivePositionalApply) we BUFFER the reflect rows and flush them right AFTER
+        // emitDeferredAbilityPerformed creates the attack entry, so routeReaction nests them under
+        // it. On every NON-deferred path (legacy non-positional apply, where runPlayerTurn already
+        // emitted `ability-performed` BEFORE the apply) the flag is false → inline emit, byte-
+        // identical, and the attack entry already exists to nest under. NO combat listener
+        // subscribes to `reactive-damage-performed` → it can never chain.
+        let deferReflectLogs = false;
+        const pendingReflectLogs: { sourceId: string; targetId: string; amount: number }[] = [];
+        const flushReflectLogs = (): void => {
+            for (const row of pendingReflectLogs) {
+                bus.emit({
+                    type: 'reactive-damage-performed',
+                    sourceId: row.sourceId,
+                    targetId: row.targetId,
+                    round: r,
+                    amount: row.amount,
+                    reactive: true,
+                    duringTurnOf: actingActorId,
+                    triggerActorId: actingActorId,
+                });
+            }
+            pendingReflectLogs.length = 0;
+        };
         const applyVictimDamage = (
             rawDamage: number,
             victim: CombatActor,
@@ -3850,6 +3881,32 @@ export function runCombat(input: CombatEngineInput): {
                                 attacker.id,
                                 (roundPerTargetDamage.get(attacker.id) ?? 0) + reflected
                             );
+                            // Log-only reflect surface (see the deferReflectLogs doc above
+                            // applyVictimDamage). On the deferred (positional) path we BUFFER the
+                            // row and flush it after emitDeferredAbilityPerformed creates the
+                            // attack entry, so it nests under the attack (not a preceding
+                            // charge/buff entry). Off the deferred path the attacker's
+                            // ability-performed already exists → emit inline. Stamp duringTurnOf
+                            // with the acting attacker either way; didCrit omitted (reflects don't
+                            // crit).
+                            if (deferReflectLogs) {
+                                pendingReflectLogs.push({
+                                    sourceId: victim.id,
+                                    targetId: attacker.id,
+                                    amount: reflected,
+                                });
+                            } else {
+                                bus.emit({
+                                    type: 'reactive-damage-performed',
+                                    sourceId: victim.id,
+                                    targetId: attacker.id,
+                                    round: r,
+                                    amount: reflected,
+                                    reactive: true,
+                                    duringTurnOf: actingActorId,
+                                    triggerActorId: actingActorId,
+                                });
+                            }
                         }
                     }
                 }
@@ -3962,7 +4019,7 @@ export function runCombat(input: CombatEngineInput): {
             abilityId: string,
             multiplier: number,
             hits: number
-        ): void => {
+        ): { dealt: number; didCrit: boolean } | void => {
             const owner = allActorsById.get(ownerId);
             const attacker = allActorsById.get(attackerId);
             // Guards: owner alive, attacker alive, not self (spec rule 6).
@@ -4030,6 +4087,7 @@ export function runCombat(input: CombatEngineInput): {
                 attacker.id,
                 (roundPerTargetDamage.get(attacker.id) ?? 0) + raw
             );
+            return { dealt: raw, didCrit };
         };
 
         // PR4b: the reactive `damage` executor branch (triggers.ts cfg.type==='damage') — Grif's
@@ -4358,125 +4416,138 @@ export function runCombat(input: CombatEngineInput): {
             // perVictimOutgoingDeltaPct. Unsupplied → delta stays 0 for every victim.
             preTurnVictimStatus?: Map<string, PreTurnVictimStatusSnapshot>;
         }): { anyCrit: boolean; critPairs: number } => {
-            return applyPositionalDamage({
-                hitCrits: args.hitCrits ?? [],
-                scalars: args.scalars,
-                pattern: args.pattern,
-                actorPosition: args.actingPosition,
-                target: args.target,
-                opposingLiving: args.opposingLiving,
-                statusOf: statusLookupFor(args.opposingLiving),
-                acting: {
-                    ignoresForcedTargeting: args.ignoresForcedTargeting,
-                    provokedBy: provokerOf(statusEngine, args.actingId),
-                },
-                defenseProfileOf: (v) => {
-                    const m = victimIncomingModifiers(v.id);
-                    return {
-                        // SP-F F5: Meatshield defense-substitution (approximation) — see the
-                        // substitutedDefenceFor doc comment above for the full rule.
-                        defence: substitutedDefenceFor(v, v.stats.defence),
-                        // B1/PR7b: per-victim defense-debuff sourcing (was hardcoded 0).
-                        // Direction-agnostic — v.id keys the victim's own enemy-debuff store
-                        // regardless of side.
-                        defenceModifierPct: m.enemyDefenseModifier,
-                        // B1/PR7b + D-PR12: per-victim incoming-damage modifier; combines
-                        // enemy-debuff (Out. Damage Up) AND victim's own self-buffs (Inc. Damage
-                        // Down/Up). Attacker-sourced scalars (outgoing buff, pen) stay attacker-fixed.
-                        incomingDamageModifierPct: m.incomingDamageModifier,
-                        affinity: v.affinity ?? 'antimatter',
-                        // Sub-project I, PR I2: this footprint victim's own enemy-status-gated
-                        // outgoing-modifier delta vs the attacker-fixed positionalScalars term.
-                        outgoingDamageDeltaPct: perVictimOutgoingDeltaPct(
-                            args.perVictimOutgoing,
-                            args.preTurnVictimStatus,
-                            v
-                        ),
-                        // SP-F F4: this victim's 'Defensive Affinity Override' (Isha/Nayra) forces
-                        // the incoming attacker to affinity DISADVANTAGE against it. Detected per
-                        // victim (anchor AND covered) via the victim's own self-buff store — the
-                        // positional counterpart to playerTurn's `victimHasDefensiveOverride`.
-                        forceAffinityDisadvantage: selfBuffNamesForOwners(statusEngine, [
-                            v.id,
-                        ]).includes('Defensive Affinity Override'),
-                    };
-                },
-                applyToVictim: args.applyToVictim,
-                // Pure ACCUMULATOR (not a bus emit): record per-victim damage into the
-                // per-round map so the RoundData row can expose perTargetDamage. Identical
-                // across all three sites (focus / team / enemy), so it lives here.
-                // §4.5 NOTE: the Stasis break is NOT wired here. It fires via `onHitBreakStasis`
-                // inside runPlayerTurn (BEFORE the ability timed-debuff loop) so a Stasis
-                // re-application from the same attack's debuff ability is not inadvertently
-                // removed. The break fires for the resolved `targetId` (the selected victim);
-                // AoE footprint victims are a future Task-3 follow-up.
-                emitHit: (victim, damage) => {
-                    roundPerTargetDamage.set(
-                        victim.id,
-                        (roundPerTargetDamage.get(victim.id) ?? 0) + damage
-                    );
-                },
-                // E2: forward the per-direction leech hook (unsupplied by all current callers).
-                onVictimResolved: args.onVictimResolved,
-                // Per-victim crit: forward the firing turn's per-victim crit resolver.
-                rollVictimCrit: args.rollVictimCrit,
-                // D-PR3: victim-side incoming %-reduction, per footprint victim per sub-hit. Shared
-                // across all three sites (focus / walked-team / enemy) since drivePositionalApply
-                // makes ONE applyPositionalDamage call. incomingReductionForHit returns 0 for actors
-                // with no incoming-reduction ability → byte-identical when no such equipment exists.
-                incomingReductionFor: (victim, didCrit) => {
-                    const equip = incomingReductionForHit(incomingAbilitiesOf(victim.id), {
-                        didCrit,
-                        attackerStealthed: isStealthed(args.actingId),
-                        victimStealthed: isStealthed(victim.id),
-                        victimStasised: isStasised(victim.id),
-                        hitIndexThisRound: 0, // unused by reduction (only block reads it)
-                        attackerHasDot: attackerHasDot(args.actingId),
-                        victimHasBarrierRecharging: hasBarrierRecharging(victim.id),
-                        victimHasShield: hasShield(victim.id),
-                        selfHpPct: selfHpPctOf(victim.id),
-                        attackerTauntedOrProvoked: attackerTauntedOrProvoked(args.actingId),
-                    });
-                    if (!didCrit) return equip;
-                    // F3 crit-conditional pre-fight damage modifiers, gated per sub-hit on
-                    // didCrit — the SAME crit-family mechanism as the equip reduction above
-                    // (a hit that crits sees the extra reduction on its whole damage).
-                    // SIGN CONVENTION: this channel is a REDUCTION (positive = less damage),
-                    // while the leader data is benefit/penalty-phrased pct points:
-                    //   victim incomingCritDamage  -10 → takes 10% smaller crits → +10 reduction;
-                    //   attacker outgoingCritDamage -10 (Negotiator III on enemies) → its crits
-                    //   deal 10% less → +10 reduction; positive values invert symmetrically.
-                    // Hence both terms are NEGATED. Absent → 0 → byte-identical.
-                    const victimCritTerm = -(victim.preFight?.incomingCritDamage ?? 0);
-                    const attackerCritTerm = -(
-                        allActorsById.get(args.actingId)?.preFight?.outgoingCritDamage ?? 0
-                    );
-                    return equip + victimCritTerm + attackerCritTerm;
-                },
-                // D-PR4: attacker-side outgoing amplification (Menace/Giant Slayer), per footprint
-                // victim per sub-hit. outgoingAmplificationForHit returns 0 for attackers with no
-                // outgoing-amplification ability → byte-identical when no such equipment exists.
-                outgoingAmplificationFor: (victim, didCrit) => {
-                    // Fast path: skip the per-victim effectiveStatsOf folds when the attacker has no
-                    // outgoing-amplification ability (the overwhelmingly common case) — matches the
-                    // aggregate path's `ampAbilities.length > 0` guard. Byte-identical (returns 0).
-                    const outs = outgoingAbilitiesOf(args.actingId);
-                    if (outs.length === 0) return 0;
-                    const attacker = allActorsById.get(args.actingId);
-                    if (!attacker) return 0;
-                    return outgoingAmplificationForHit(
-                        outs,
-                        {
+            // Task 3: this is the ONE deferred (positional) apply path — reflects fired here must
+            // buffer their log row until emitDeferredAbilityPerformed creates the attack entry
+            // (see the deferReflectLogs doc above applyVictimDamage). try/finally so the flag
+            // always clears, even if applyPositionalDamage throws.
+            deferReflectLogs = true;
+            try {
+                return applyPositionalDamage({
+                    hitCrits: args.hitCrits ?? [],
+                    scalars: args.scalars,
+                    pattern: args.pattern,
+                    actorPosition: args.actingPosition,
+                    target: args.target,
+                    opposingLiving: args.opposingLiving,
+                    statusOf: statusLookupFor(args.opposingLiving),
+                    acting: {
+                        ignoresForcedTargeting: args.ignoresForcedTargeting,
+                        provokedBy: provokerOf(statusEngine, args.actingId),
+                    },
+                    defenseProfileOf: (v) => {
+                        const m = victimIncomingModifiers(v.id);
+                        return {
+                            // SP-F F5: Meatshield defense-substitution (approximation) — see the
+                            // substitutedDefenceFor doc comment above for the full rule.
+                            defence: substitutedDefenceFor(v, v.stats.defence),
+                            // B1/PR7b: per-victim defense-debuff sourcing (was hardcoded 0).
+                            // Direction-agnostic — v.id keys the victim's own enemy-debuff store
+                            // regardless of side.
+                            defenceModifierPct: m.enemyDefenseModifier,
+                            // B1/PR7b + D-PR12: per-victim incoming-damage modifier; combines
+                            // enemy-debuff (Out. Damage Up) AND victim's own self-buffs (Inc. Damage
+                            // Down/Up). Attacker-sourced scalars (outgoing buff, pen) stay attacker-fixed.
+                            incomingDamageModifierPct: m.incomingDamageModifier,
+                            affinity: v.affinity ?? 'antimatter',
+                            // Sub-project I, PR I2: this footprint victim's own enemy-status-gated
+                            // outgoing-modifier delta vs the attacker-fixed positionalScalars term.
+                            outgoingDamageDeltaPct: perVictimOutgoingDeltaPct(
+                                args.perVictimOutgoing,
+                                args.preTurnVictimStatus,
+                                v
+                            ),
+                            // SP-F F4: this victim's 'Defensive Affinity Override' (Isha/Nayra) forces
+                            // the incoming attacker to affinity DISADVANTAGE against it. Detected per
+                            // victim (anchor AND covered) via the victim's own self-buff store — the
+                            // positional counterpart to playerTurn's `victimHasDefensiveOverride`.
+                            forceAffinityDisadvantage: selfBuffNamesForOwners(statusEngine, [
+                                v.id,
+                            ]).includes('Defensive Affinity Override'),
+                        };
+                    },
+                    applyToVictim: args.applyToVictim,
+                    // Pure ACCUMULATOR (not a bus emit): record per-victim damage into the
+                    // per-round map so the RoundData row can expose perTargetDamage. Identical
+                    // across all three sites (focus / team / enemy), so it lives here.
+                    // §4.5 NOTE: the Stasis break is NOT wired here. It fires via `onHitBreakStasis`
+                    // inside runPlayerTurn (BEFORE the ability timed-debuff loop) so a Stasis
+                    // re-application from the same attack's debuff ability is not inadvertently
+                    // removed. The break fires for the resolved `targetId` (the selected victim);
+                    // AoE footprint victims are a future Task-3 follow-up.
+                    emitHit: (victim, damage) => {
+                        roundPerTargetDamage.set(
+                            victim.id,
+                            (roundPerTargetDamage.get(victim.id) ?? 0) + damage
+                        );
+                    },
+                    // E2: forward the per-direction leech hook (unsupplied by all current callers).
+                    onVictimResolved: args.onVictimResolved,
+                    // Per-victim crit: forward the firing turn's per-victim crit resolver.
+                    rollVictimCrit: args.rollVictimCrit,
+                    // D-PR3: victim-side incoming %-reduction, per footprint victim per sub-hit. Shared
+                    // across all three sites (focus / walked-team / enemy) since drivePositionalApply
+                    // makes ONE applyPositionalDamage call. incomingReductionForHit returns 0 for actors
+                    // with no incoming-reduction ability → byte-identical when no such equipment exists.
+                    incomingReductionFor: (victim, didCrit) => {
+                        const equip = incomingReductionForHit(incomingAbilitiesOf(victim.id), {
                             didCrit,
-                            targetHigherAttack:
-                                effectiveStatsOf(statusEngine, selfBuffLookup, victim).attack >
-                                effectiveStatsOf(statusEngine, selfBuffLookup, attacker).attack,
-                        },
-                        (abilityId, chance) =>
-                            rollRateGate(procChanceGates, `${args.actingId}:${abilityId}`, chance)
-                    );
-                },
-            });
+                            attackerStealthed: isStealthed(args.actingId),
+                            victimStealthed: isStealthed(victim.id),
+                            victimStasised: isStasised(victim.id),
+                            hitIndexThisRound: 0, // unused by reduction (only block reads it)
+                            attackerHasDot: attackerHasDot(args.actingId),
+                            victimHasBarrierRecharging: hasBarrierRecharging(victim.id),
+                            victimHasShield: hasShield(victim.id),
+                            selfHpPct: selfHpPctOf(victim.id),
+                            attackerTauntedOrProvoked: attackerTauntedOrProvoked(args.actingId),
+                        });
+                        if (!didCrit) return equip;
+                        // F3 crit-conditional pre-fight damage modifiers, gated per sub-hit on
+                        // didCrit — the SAME crit-family mechanism as the equip reduction above
+                        // (a hit that crits sees the extra reduction on its whole damage).
+                        // SIGN CONVENTION: this channel is a REDUCTION (positive = less damage),
+                        // while the leader data is benefit/penalty-phrased pct points:
+                        //   victim incomingCritDamage  -10 → takes 10% smaller crits → +10 reduction;
+                        //   attacker outgoingCritDamage -10 (Negotiator III on enemies) → its crits
+                        //   deal 10% less → +10 reduction; positive values invert symmetrically.
+                        // Hence both terms are NEGATED. Absent → 0 → byte-identical.
+                        const victimCritTerm = -(victim.preFight?.incomingCritDamage ?? 0);
+                        const attackerCritTerm = -(
+                            allActorsById.get(args.actingId)?.preFight?.outgoingCritDamage ?? 0
+                        );
+                        return equip + victimCritTerm + attackerCritTerm;
+                    },
+                    // D-PR4: attacker-side outgoing amplification (Menace/Giant Slayer), per footprint
+                    // victim per sub-hit. outgoingAmplificationForHit returns 0 for attackers with no
+                    // outgoing-amplification ability → byte-identical when no such equipment exists.
+                    outgoingAmplificationFor: (victim, didCrit) => {
+                        // Fast path: skip the per-victim effectiveStatsOf folds when the attacker has no
+                        // outgoing-amplification ability (the overwhelmingly common case) — matches the
+                        // aggregate path's `ampAbilities.length > 0` guard. Byte-identical (returns 0).
+                        const outs = outgoingAbilitiesOf(args.actingId);
+                        if (outs.length === 0) return 0;
+                        const attacker = allActorsById.get(args.actingId);
+                        if (!attacker) return 0;
+                        return outgoingAmplificationForHit(
+                            outs,
+                            {
+                                didCrit,
+                                targetHigherAttack:
+                                    effectiveStatsOf(statusEngine, selfBuffLookup, victim).attack >
+                                    effectiveStatsOf(statusEngine, selfBuffLookup, attacker).attack,
+                            },
+                            (abilityId, chance) =>
+                                rollRateGate(
+                                    procChanceGates,
+                                    `${args.actingId}:${abilityId}`,
+                                    chance
+                                )
+                        );
+                    },
+                });
+            } finally {
+                deferReflectLogs = false;
+            }
         };
 
         // ── Deferred ability-performed emit helper ────────────────────────────────────
@@ -4500,6 +4571,10 @@ export function runCombat(input: CombatEngineInput): {
                 ...(critHits > 0 ? { critHits } : {}),
                 didHit: true,
             });
+            // Task 3: the attack entry now exists — drain any reflect rows buffered during this
+            // cast's per-victim apply so buildCombatLog nests them UNDER this attack (not a
+            // preceding charge/buff entry in the attacker's turn). No-op when none buffered.
+            flushReflectLogs();
         };
 
         // ── Unified per-actor turn resolvers (bySide unification PR6a) ──────────────

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -5670,6 +5670,30 @@ export function runCombat(input: CombatEngineInput): {
                 statusEngine.beginTurn(actor.id);
 
                 bus.emit({ type: 'turn-started', actorId: actor.id, round: r });
+                // Task 6a: LOG-ONLY per-turn snapshot of the acting actor's live modelled stats
+                // (no listener subscribes — see the events.ts doc comment). Reads the SAME
+                // effectiveStatsOf fold every other live-stat call site in this file uses.
+                {
+                    const snapshotEff = effectiveStatsOf(statusEngine, selfBuffLookup, actor);
+                    bus.emit({
+                        type: 'stats-snapshot',
+                        actorId: actor.id,
+                        round: r,
+                        stats: {
+                            attack: snapshotEff.attack,
+                            defence: snapshotEff.defence,
+                            crit: snapshotEff.crit,
+                            critDamage: snapshotEff.critDamage,
+                            defensePenetration: snapshotEff.defensePenetration,
+                            speed: snapshotEff.speed,
+                            hacking: snapshotEff.hacking,
+                            security: snapshotEff.security,
+                            currentHp: actor.currentHp,
+                            maxHp: actor.stats.hp,
+                            shieldPool: actor.shieldPool,
+                        },
+                    });
+                }
                 // Phase 0 Task 5: bump the actor's own-turn counter so every-n-turns conditions
                 // can evaluate the live N. Incremented AFTER turn-started so end-of-turn
                 // (turn-ended) reactive drains — which run later — read the correct N. 1-based

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -996,6 +996,11 @@ export interface CombatEngineInput {
      *  attacker actor. The adapter passes `input.hacking ?? 200` (the OLD landing-formula default); no
      *  production reader until dynamic landing lands (A2 Task 4). */
     hacking?: number;
+    /** Focus attacker's base security. Optional — base for effectiveStatsOf.security on the
+     *  attacker actor. Threaded so the focus actor's own security (e.g. gear-folded via Code
+     *  Guard) reaches both the per-turn stats-snapshot and the live debuff-landing recompute
+     *  when the focus is the target of an enemy debuff, instead of silently defaulting. */
+    security?: number;
     /** DPS dummy enemy's base security (A2 Task 2). Optional — base for effectiveStatsOf.security on the
      *  dummy enemy actor. The adapter passes `input.enemySecurity ?? 100` (the OLD landing-formula default);
      *  no production reader until dynamic landing lands (A2 Task 4). */
@@ -1376,6 +1381,7 @@ export function runCombat(input: CombatEngineInput): {
         defence,
         hp,
         hacking,
+        security,
         enemySecurity,
         allyChargePerRound,
         enemyType,
@@ -1436,6 +1442,9 @@ export function runCombat(input: CombatEngineInput): {
             speed: speed ?? 100,
             // Base hacking (A2 Task 2) — base for effectiveStatsOf.hacking; unread until landing lands (A2 Task 4).
             hacking,
+            // Focus actor's own security — base for effectiveStatsOf.security (stats-snapshot
+            // display) and the live debuff-landing recompute when the focus is targeted.
+            security,
         },
         chargeCount,
         startCharged,

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -838,7 +838,11 @@ export function tickDoTs(args: {
     genericDoTEntries: ActiveDoTStack[];
     enemyHp: number;
     ctxFor: (sourceId: string) => PlayerRoundCtx | undefined;
-    emitTicked: (dotType: TickableDoTType, damage: number) => void;
+    /** `stacks` = the per-dotType SUMMED TICKING stacks (only entries that actually tick this
+     *  call — i.e. have a resolvable applier ctx for corrosion/inferno — are counted; generic
+     *  has no ctx gate so all its entries count). Combat-log fidelity: lets the `dot-ticked`
+     *  event/log line show "{dotType} ×{stacks}" alongside the damage. */
+    emitTicked: (dotType: TickableDoTType, damage: number, stacks: number) => void;
     credit: (sourceId: string, dotType: TickableDoTType, damage: number) => void;
     /** D-PR3 (Vortex Veil): % reduction applied to this carrier's DoT ticks of the given type.
      *  Absent → 0 → byte-identical. */
@@ -855,24 +859,27 @@ export function tickDoTs(args: {
     const corrosionBaseHp = Math.min(args.enemyHp, 500_000);
     const corrosionCredits: Array<{ sourceId: string; d: number }> = [];
     let corrosionSum = 0;
+    let corrosionStacks = 0;
     for (const e of args.corrosionEntries) {
         const ctx = args.ctxFor(e.sourceId);
         if (!ctx) continue; // applier has not acted yet this run (faster-enemy round 1)
         const d = e.stacks * (e.tier / 100) * corrosionBaseHp * dotMultFor(ctx) * ctx.affinityMult;
         corrosionCredits.push({ sourceId: e.sourceId, d });
         corrosionSum += d;
+        corrosionStacks += e.stacks;
     }
     if (corrosionSum > 0) {
         const reductionPct = args.incomingDotReductionPct?.('corrosion') ?? 0;
         const factor = 1 - reductionPct / 100;
         for (const { sourceId, d } of corrosionCredits)
             args.credit(sourceId, 'corrosion', d * factor);
-        args.emitTicked('corrosion', corrosionSum * factor);
+        args.emitTicked('corrosion', corrosionSum * factor, corrosionStacks);
     }
 
     // Step 5: Tick inferno (scales with the applier's effective attack, no outgoing buff)
     const infernoCredits: Array<{ sourceId: string; d: number }> = [];
     let infernoSum = 0;
+    let infernoStacks = 0;
     for (const e of args.infernoEntries) {
         const ctx = args.ctxFor(e.sourceId);
         if (!ctx) continue;
@@ -880,29 +887,32 @@ export function tickDoTs(args: {
             e.stacks * (e.tier / 100) * ctx.effectiveAttack * dotMultFor(ctx) * ctx.affinityMult;
         infernoCredits.push({ sourceId: e.sourceId, d });
         infernoSum += d;
+        infernoStacks += e.stacks;
     }
     if (infernoSum > 0) {
         const reductionPct = args.incomingDotReductionPct?.('inferno') ?? 0;
         const factor = 1 - reductionPct / 100;
         for (const { sourceId, d } of infernoCredits) args.credit(sourceId, 'inferno', d * factor);
-        args.emitTicked('inferno', infernoSum * factor);
+        args.emitTicked('inferno', infernoSum * factor, infernoStacks);
     }
 
     // SP-E: Tick generic DoTs — an ABSOLUTE per-tick amount, independent of stats/HP (no ctxFor
     // gate: unlike corrosion/inferno, a generic tick doesn't need the applier's effective attack
     // or affinity, so it ticks even before the applier's first turn this run).
     let genericSum = 0;
+    let genericStacks = 0;
     const genericCredits: Array<{ sourceId: string; d: number }> = [];
     for (const e of args.genericDoTEntries) {
         const d = (e.perTickAmount ?? 0) * e.stacks;
         genericCredits.push({ sourceId: e.sourceId, d });
         genericSum += d;
+        genericStacks += e.stacks;
     }
     if (genericSum > 0) {
         const reductionPct = args.incomingDotReductionPct?.('generic') ?? 0;
         const factor = 1 - reductionPct / 100;
         for (const { sourceId, d } of genericCredits) args.credit(sourceId, 'generic', d * factor);
-        args.emitTicked('generic', genericSum * factor);
+        args.emitTicked('generic', genericSum * factor, genericStacks);
     }
 
     // Expire DoT stacks after ticking
@@ -5783,13 +5793,14 @@ export function runCombat(input: CombatEngineInput): {
                             // Corrosion scales with the afflicted ship's HP — the tank's own max HP.
                             enemyHp: recipientMaxHp(healTarget.id),
                             ctxFor: (sourceId) => lastTurnCtxByActor.get(sourceId),
-                            emitTicked: (dotType, damage) =>
+                            emitTicked: (dotType, damage, stacks) =>
                                 bus.emit({
                                     type: 'dot-ticked',
                                     targetId: healTarget.id,
                                     round: r,
                                     dotType,
                                     damage,
+                                    stacks,
                                 }),
                             // Sum the ticked damage across all appliers; route it as INCOMING to the tank
                             // (NOT into a player damage row). expireStacks inside tickDoTs ages the entries.
@@ -5861,13 +5872,14 @@ export function runCombat(input: CombatEngineInput): {
                                 // Corrosion scales with the AFFLICTED ship's own max HP.
                                 enemyHp: recipientMaxHp(actor.id),
                                 ctxFor: (sourceId) => lastTurnCtxByActor.get(sourceId),
-                                emitTicked: (dotType, damage) =>
+                                emitTicked: (dotType, damage, stacks) =>
                                     bus.emit({
                                         type: 'dot-ticked',
                                         targetId: actor.id,
                                         round: r,
                                         dotType,
                                         damage,
+                                        stacks,
                                     }),
                                 credit: (sourceId, dotType, damage) => {
                                     total += damage;
@@ -6593,13 +6605,14 @@ export function runCombat(input: CombatEngineInput): {
                         genericDoTEntries,
                         enemyHp,
                         ctxFor: (sourceId) => lastTurnCtxByActor.get(sourceId),
-                        emitTicked: (dotType, damage) =>
+                        emitTicked: (dotType, damage, stacks) =>
                             bus.emit({
                                 type: 'dot-ticked',
                                 targetId: enemy.id,
                                 round: r,
                                 dotType,
                                 damage,
+                                stacks,
                             }),
                         credit: (sourceId, dotType, damage) =>
                             creditDamage(sourceId, dotType, damage),

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -307,6 +307,32 @@ export type CombatEvent =
           newCharge: number;
           reason: 'gen' | 'cast-reset' | 'manip';
       } & ReactiveStamp)
+    /** LOG-ONLY: a per-turn snapshot of the ACTING actor's live modelled stats, emitted
+     *  immediately after `turn-started`. This is an on-turn snapshot, never a reaction — it
+     *  carries NO `ReactiveStamp` and NO combat listener subscribes to it (mirrors the
+     *  `reactive-damage-performed`/`reactive-heal-performed` log-only contract). Exists SOLELY
+     *  so `buildCombatLog` can attach a `statsSnapshot` to the turn view-model; folding it into
+     *  any subscribed/aggregated path would be a bug. `stats` reflects the same
+     *  `effectiveStatsOf(statusEngine, selfBuffLookup, actor)` fold every other live-stat read
+     *  in the engine uses, plus the actor's current HP/shield pool. */
+    | {
+          type: 'stats-snapshot';
+          actorId: string;
+          round: number;
+          stats: {
+              attack: number;
+              defence: number;
+              crit: number;
+              critDamage: number;
+              defensePenetration: number;
+              speed: number;
+              hacking: number;
+              security: number;
+              currentHp: number;
+              maxHp: number;
+              shieldPool: number;
+          };
+      }
     /** Emitted when a player actor is attacked. `targetId` is the attacked actor;
      *  `attackerId` is the attacker. `didCrit` is the individual hit's crit outcome
      *  (present only when that hit critted). Emitted once PER HIT of the enemy's

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -232,6 +232,9 @@ export type CombatEvent =
           // this event too. 'bomb' never appears here (bombs burst via 'bomb-detonated').
           dotType: DoTType;
           damage: number;
+          /** Combat-log fidelity: the per-dotType SUMMED TICKING stacks (see `tickDoTs`'s
+           *  `emitTicked` jsdoc) — lets the log line show "{dotType} ×{stacks}". */
+          stacks: number;
       }
     | { type: 'dot-detonated'; targetId: string; round: number; damage: number }
     /** Emitted on each bomb burst, but the two paths are asymmetric:

--- a/src/utils/combat/log/__tests__/buildCombatLog.test.ts
+++ b/src/utils/combat/log/__tests__/buildCombatLog.test.ts
@@ -1088,7 +1088,7 @@ describe('buildCombatLog', () => {
         expect(entry.note).toContain('corrosion');
     });
 
-    it('dot-ticked: targetId is both the actorId and target; amount is the damage; no skill consumed', () => {
+    it('dot-ticked: targetId is both the actorId and target; amount is the damage; note is "{dotType} ×{stacks}"; no skill consumed', () => {
         const events: CombatEvent[] = [
             ev({ type: 'round-started', round: 1 }),
             ev({ type: 'turn-started', actorId: 'A', round: 1 }),
@@ -1104,8 +1104,9 @@ describe('buildCombatLog', () => {
                 type: 'dot-ticked',
                 targetId: 'B',
                 round: 1,
-                dotType: 'inferno',
-                damage: 250,
+                dotType: 'corrosion',
+                damage: 1234,
+                stacks: 3,
             }),
             ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
             ev({ type: 'round-ended', round: 1 }),
@@ -1119,7 +1120,8 @@ describe('buildCombatLog', () => {
         expect(dotEntry!.actorId).toBe('B'); // ticked target is the actor
         expect(dotEntry!.targets).toHaveLength(1);
         expect(dotEntry!.targets[0].targetId).toBe('B');
-        expect(dotEntry!.targets[0].amount).toBe(250);
+        expect(dotEntry!.targets[0].amount).toBe(1234);
+        expect(dotEntry!.note).toBe('corrosion ×3');
         // skill-fired must NOT have been consumed by dot-ticked
         expect(dotEntry!.skillName).toBeUndefined();
         expect(dotEntry!.slot).toBeUndefined();
@@ -1436,6 +1438,7 @@ describe('buildCombatLog', () => {
                 round: 1,
                 dotType: 'inferno',
                 damage: 250,
+                stacks: 2,
             }),
             ev({ type: 'round-ended', round: 1 }),
         ];

--- a/src/utils/combat/log/__tests__/buildCombatLog.test.ts
+++ b/src/utils/combat/log/__tests__/buildCombatLog.test.ts
@@ -1823,3 +1823,85 @@ describe('buildCombatLog', () => {
         expect(turn.entries[0].targets[0].didHit).toBe(false); // miss target synthesized
     });
 });
+
+// ---------------------------------------------------------------------------
+// Task 6c: the LOG-ONLY stats-snapshot event decorates the turn it belongs to
+// (no entry is created — it is a property on CombatLogTurn, not a CombatLogEntry).
+// ---------------------------------------------------------------------------
+
+describe('buildCombatLog — stats-snapshot (Task 6c)', () => {
+    it('attaches a stats-snapshot to the turn it belongs to', () => {
+        const events: CombatEvent[] = [
+            ev({ type: 'round-started', round: 1 }),
+            ev({ type: 'turn-started', actorId: 'A', round: 1 }),
+            ev({
+                type: 'stats-snapshot',
+                actorId: 'A',
+                round: 1,
+                stats: {
+                    attack: 5000,
+                    defence: 3000,
+                    crit: 70,
+                    critDamage: 150,
+                    defensePenetration: 0,
+                    speed: 120,
+                    hacking: 200,
+                    security: 100,
+                    currentHp: 40000,
+                    maxHp: 50000,
+                    shieldPool: 0,
+                },
+            }),
+            ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
+            ev({ type: 'round-ended', round: 1 }),
+        ];
+        const rounds = buildCombatLog(
+            events,
+            [{ actorId: 'A', side: 'player', name: 'A' }],
+            new Map()
+        );
+        expect(rounds[0].turns[0].statsSnapshot?.attack).toBe(5000);
+        expect(rounds[0].turns[0].statsSnapshot?.currentHp).toBe(40000);
+        // No entry is created for the snapshot — it decorates the turn only.
+        expect(rounds[0].turns[0].entries).toHaveLength(0);
+    });
+
+    it('does not attach the snapshot to a turn belonging to a different actor', () => {
+        const events: CombatEvent[] = [
+            ev({ type: 'round-started', round: 1 }),
+            ev({ type: 'turn-started', actorId: 'A', round: 1 }),
+            ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
+            ev({ type: 'turn-started', actorId: 'B', round: 1 }),
+            ev({
+                type: 'stats-snapshot',
+                actorId: 'A', // stale/mismatched actorId — must not leak onto B's turn
+                round: 1,
+                stats: {
+                    attack: 1,
+                    defence: 1,
+                    crit: 1,
+                    critDamage: 1,
+                    defensePenetration: 1,
+                    speed: 1,
+                    hacking: 1,
+                    security: 1,
+                    currentHp: 1,
+                    maxHp: 1,
+                    shieldPool: 1,
+                },
+            }),
+            ev({ type: 'turn-ended', actorId: 'B', round: 1 }),
+            ev({ type: 'round-ended', round: 1 }),
+        ];
+        const rounds = buildCombatLog(
+            events,
+            [
+                { actorId: 'A', side: 'player', name: 'A' },
+                { actorId: 'B', side: 'enemy', name: 'B' },
+            ],
+            new Map()
+        );
+        expect(rounds[0].turns[0].statsSnapshot).toBeUndefined();
+        expect(rounds[0].turns[1].statsSnapshot).toBeUndefined();
+    });
+});

--- a/src/utils/combat/log/__tests__/buildCombatLog.test.ts
+++ b/src/utils/combat/log/__tests__/buildCombatLog.test.ts
@@ -556,7 +556,10 @@ describe('buildCombatLog', () => {
 
     it('undefined didHit does not synthesize a miss target (strict === false guard)', () => {
         // ability-performed with no didHit field at all (undefined), no attacked events.
-        // The open attack entry should have zero targets — no miss is synthesized.
+        // No miss is synthesized (strict === false guard) — and since the entry then has
+        // zero targets and was not a miss, Task 4's phantom-row suppression removes it
+        // entirely (a bug that loosely treated undefined as a miss would instead leave a
+        // synthesized-miss entry behind, which would NOT be pruned).
         const events: CombatEvent[] = [
             ev({ type: 'round-started', round: 1 }),
             ev({ type: 'turn-started', actorId: 'A', round: 1 }),
@@ -572,8 +575,7 @@ describe('buildCombatLog', () => {
             ev({ type: 'round-ended', round: 1 }),
         ];
         const log = buildCombatLog(events, roster, initialCharge);
-        const entry = log[0].turns[0].entries[0];
-        expect(entry.targets).toHaveLength(0);
+        expect(log[0].turns[0].entries).toHaveLength(0);
     });
 
     // ─── Behavior 1: Charge header reconstruction ─────────────────────────────
@@ -1560,9 +1562,10 @@ describe('buildCombatLog', () => {
         expect(() => buildCombatLog(events, roster, initialCharge)).not.toThrow();
         const log = buildCombatLog(events, roster, initialCharge);
         const turn = log[0].turns[0];
-        // The attack entry exists; the stamped buff-expired produced nothing.
-        expect(turn.entries).toHaveLength(1);
-        expect(turn.entries[0].reactions).toHaveLength(0);
+        // The ability-performed never received an attacked event, so it closes with zero
+        // targets and (didHit: true, not a miss) gets pruned by Task 4's phantom-row
+        // suppression. The stamped buff-expired produced nothing (no throw, no entries).
+        expect(turn.entries).toHaveLength(0);
         expect(log[0].endOfRound).toHaveLength(0);
     });
 
@@ -1755,5 +1758,68 @@ describe('buildCombatLog', () => {
         expect(reaction.targets).toEqual([
             expect.objectContaining({ targetId: 'A', amount: 1152 }),
         ]);
+    });
+
+    // ─── Task 4: suppress phantom empty attack row on buff-only turns ────────
+
+    it('does not emit an empty attack entry for a buff-only cast (no attacked event)', () => {
+        const events: CombatEvent[] = [
+            ev({ type: 'round-started', round: 1 }),
+            ev({ type: 'turn-started', actorId: 'A', round: 1 }),
+            ev({
+                type: 'ability-performed',
+                actorId: 'A',
+                targetId: 'A',
+                round: 1,
+                abilityType: 'buff',
+                didHit: true,
+            }),
+            ev({
+                type: 'buff-applied',
+                actorId: 'A',
+                round: 1,
+                buffName: 'Attack Up',
+                duration: 2,
+            }),
+            ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
+            ev({ type: 'round-ended', round: 1 }),
+        ];
+        const rounds = buildCombatLog(
+            events,
+            [{ actorId: 'A', side: 'player', name: 'A' }],
+            new Map()
+        );
+        const turn = rounds[0].turns[0];
+        // Only the buff entry remains — no empty attack row.
+        expect(turn.entries.map((e) => e.kind)).toEqual(['buff']);
+    });
+
+    it('still renders a genuine miss (targeted attack that missed)', () => {
+        const events: CombatEvent[] = [
+            ev({ type: 'round-started', round: 1 }),
+            ev({ type: 'turn-started', actorId: 'A', round: 1 }),
+            ev({
+                type: 'ability-performed',
+                actorId: 'A',
+                targetId: 'B',
+                round: 1,
+                abilityType: 'damage',
+                didHit: false,
+            }),
+            ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
+            ev({ type: 'round-ended', round: 1 }),
+        ];
+        const rounds = buildCombatLog(
+            events,
+            [
+                { actorId: 'A', side: 'player', name: 'A' },
+                { actorId: 'B', side: 'enemy', name: 'B' },
+            ],
+            new Map()
+        );
+        const turn = rounds[0].turns[0];
+        expect(turn.entries).toHaveLength(1);
+        expect(turn.entries[0].kind).toBe('attack');
+        expect(turn.entries[0].targets[0].didHit).toBe(false); // miss target synthesized
     });
 });

--- a/src/utils/combat/log/buildCombatLog.ts
+++ b/src/utils/combat/log/buildCombatLog.ts
@@ -499,12 +499,14 @@ const handlers: Partial<{ [K in CombatEventType]: Handler<K> }> = {
 
     'dot-ticked': (e, ctx) => {
         if (!ctx.currentTurn && !ctx.currentRound) return;
-        // No consumePendingSkill: a tick is not a cast.
+        // No consumePendingSkill: a tick is not a cast. Note mirrors 'dot-applied''s format so
+        // the renderer can show type + stack count alongside the tick amount.
         const entry: CombatLogEntry = {
             kind: 'dot-ticked',
             actorId: e.targetId,
             targets: [{ targetId: e.targetId, amount: e.damage }],
             reactions: [],
+            note: `${e.dotType} ×${e.stacks}`,
         };
         ctx.attachEntry(entry);
     },

--- a/src/utils/combat/log/buildCombatLog.ts
+++ b/src/utils/combat/log/buildCombatLog.ts
@@ -234,6 +234,28 @@ function createBuildContext(
                     didHit: false,
                 };
                 ctx.openAttackEntry.targets.push(missTarget);
+                return;
+            }
+            // Suppress a phantom attack row: an ability-performed that produced no `attacked`
+            // event and was NOT a miss (buff/heal/utility-only cast). Remove it from the current
+            // turn's entries if present (the only container an on-turn attack entry lands in).
+            // Guarded on `reactions.length === 0`: a reactive trigger (e.g. Ravager's
+            // on-own-debuff-resisted Hacking Module Overdrive grant) can nest under this entry
+            // via routeReaction BEFORE the boundary that finalizes it — pruning the entry would
+            // silently discard that nested reaction along with it, so a non-empty `.reactions[]`
+            // keeps the (now target-less) parent row so its children stay visible in the log.
+            if (
+                ctx.openAttackEntry &&
+                ctx.openAttackEntry.kind === 'attack' &&
+                ctx.openAttackEntry.targets.length === 0 &&
+                ctx.openAttackAbilityDidHit !== false &&
+                ctx.openAttackEntry.reactions.length === 0
+            ) {
+                const entries = ctx.currentTurn?.entries;
+                if (entries) {
+                    const idx = entries.indexOf(ctx.openAttackEntry);
+                    if (idx !== -1) entries.splice(idx, 1);
+                }
             }
         },
 

--- a/src/utils/combat/log/buildCombatLog.ts
+++ b/src/utils/combat/log/buildCombatLog.ts
@@ -298,6 +298,13 @@ const handlers: Partial<{ [K in CombatEventType]: Handler<K> }> = {
         ctx.openTurn(e.actorId);
     },
 
+    // Task 6c: decorates the current turn with its live modelled stats — creates NO entry.
+    'stats-snapshot': (e, ctx) => {
+        if (ctx.currentTurn && ctx.currentTurn.actorId === e.actorId) {
+            ctx.currentTurn.statsSnapshot = e.stats;
+        }
+    },
+
     'turn-ended': (_e, ctx) => {
         ctx.closeOpenAttack(); // also clears pendingSkill
         ctx.currentTurn = undefined;

--- a/src/utils/combat/log/types.ts
+++ b/src/utils/combat/log/types.ts
@@ -11,6 +11,26 @@ export interface CombatLogTurn {
     chargeBefore: number; // charge level at turn start (filled by a later task; 0 for now)
     chargeMax: number; // 0 = no charge skill (filled by a later task)
     entries: CombatLogEntry[]; // chronological within the turn
+    /** Task 6: a snapshot of the acting actor's live modelled stats, taken immediately after
+     *  turn-started (see the `stats-snapshot` CombatEvent). Optional — absent on any turn built
+     *  from an event stream that predates/omits the emission (e.g. hand-crafted test fixtures). */
+    statsSnapshot?: StatsSnapshot;
+}
+
+/** Task 6: per-turn modelled stat snapshot for the acting actor (mirrors the `stats-snapshot`
+ *  CombatEvent's `stats` payload). */
+export interface StatsSnapshot {
+    attack: number;
+    defence: number;
+    crit: number;
+    critDamage: number;
+    defensePenetration: number;
+    speed: number;
+    hacking: number;
+    security: number;
+    currentHp: number;
+    maxHp: number;
+    shieldPool: number;
 }
 
 export type CombatLogEntryKind =

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1077,14 +1077,17 @@ export interface IntentExecContext {
     ) => { dealt: number; didCrit: boolean } | void;
     /** G PR1: apply a full mitigated/crit counter walk from `ownerId` to `attackerId`.
      *  `abilityId` keys the dedicated counter crit-gate. Reuses the engine's no-event
-     *  apply path (no attacked event → no re-counter). */
+     *  apply path (no attacked event → no re-counter).
+     *  Returns the mitigated/credited amount + crit flag so the caller can surface the proc in
+     *  the combat log (reactive-damage-performed); void/0 when the counter was guarded (dead
+     *  owner/attacker, self-hit, non-positive) or the delegate is absent (unit fixtures). */
     applyCounterAttack?: (
         ownerId: string,
         attackerId: string,
         abilityId: string,
         multiplier: number,
         hits: number
-    ) => void;
+    ) => { dealt: number; didCrit: boolean } | void;
     /** G PR1: per-actor-turn once-per-attack guard. Keyed `ownerId:abilityId`. Cleared at each
      *  actor turn-start (engine) so the per-hit `attacked` events of ONE attack collapse to a
      *  single counter; a later attack (different turn) counters again. Absent → no guard (the
@@ -2547,13 +2550,14 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
         if (!passesProcChanceGate(intent, ctx)) return;
         if (!passesOncePerRoundGate(intent, ctx)) return;
         ctx.counterFiredThisTurn?.add(key);
-        ctx.applyCounterAttack?.(
+        const outcome = ctx.applyCounterAttack?.(
             intent.ownerId,
             attackerId,
             intent.ability.id,
             cfg.multiplier,
             cfg.hits ?? 1
         );
+        emitReactiveDamageLog(ctx, intent.ownerId, attackerId, outcome);
         return;
     }
 


### PR DESCRIPTION
## Combat log fidelity + per-turn stat snapshots

Makes the simulator's combat log faithful and adds a per-turn modelled-stat snapshot. All changes are additive / log-only — **DPS and healing goldens are unchanged**, `audit:skills` stays 147→0.

### What's included
- **DoT tick damage is now shown**, with type and stacks — e.g. `Anemone: corrosion ×3 → 1,234` (one line per DoT type ticking on a victim). Previously the tick amount was dropped entirely by the renderer.
- **Counter-attacks and damage reflection now appear** in the log as nested reactive entries (were applied but invisible). Reflects are emitted on a deferred path so they nest under the attack that triggered them (not a preceding charge/buff entry).
- **Empty "buff-only turn" rows removed** — a cast that only applies a buff no longer renders a phantom 0-damage attack row (with a guard so an entry anchoring a nested reaction is never dropped).
- **Per-turn ship stat snapshot** — each turn now has a collapsible summary of the acting ship's current modelled stats (HP, attack, defence, crit, crit power, def pen, speed, hacking, security), reflecting active stat buffs/debuffs.
- **Fix:** the focus ship's own `security` was never threaded into the engine, so its snapshot showed ~0; it now shows the real value (including the Code Guard gear set).

### Notes
- New events (`stats-snapshot`, and the counter/reflect `reactive-damage-performed`) are **log-only** — no combat listener subscribes to them, so they can't chain reactions, and they're excluded from the damage-aggregation event set. Team-symmetric (both sides).
- The Hermes/reactive-passive over-trigger fix (once-per-attack) is intentionally **not** in this PR — it changes combat behavior and moves goldens, so it ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
