### PR TITLE
chore(combat): consolidate duplicated per-recipient heal-apply branch

### DIFF
--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -2793,17 +2793,13 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                     const perRecipientActor = healing.teamBattle
                         ? healing.recipientActor(rid)
                         : undefined;
-                    if (perRecipientActor) {
+                    if (perRecipientActor || rid === healing.targetId) {
+                        // applyHealToTarget defaults victim to the heal target when
+                        // perRecipientActor is undefined (healing-calculator single-target path).
                         const { consumed, overheal } = healing.applyHealToTarget(
                             raw,
                             perRecipientActor
                         );
-                        healing.credit(actor.id, 'effectiveHeal', consumed);
-                        healing.credit(actor.id, 'overheal', overheal);
-                        overhealSum += overheal;
-                        if (overheal > 0) perTargetOverheal = overheal;
-                    } else if (rid === healing.targetId) {
-                        const { consumed, overheal } = healing.applyHealToTarget(raw);
                         healing.credit(actor.id, 'effectiveHeal', consumed);
                         healing.credit(actor.id, 'overheal', overheal);
                         overhealSum += overheal;


### PR DESCRIPTION
Addresses the single CodeRabbit nitpick from #245.

The `perRecipientActor` / `rid === healing.targetId` branches in the player cast-heal path were identical except for the `victim` argument. Since `applyHealToTarget(raw, victim = healTarget)` defaults `victim` to the heal target when passed `undefined`, the two branches collapse into one.

**Pure refactor — no behavior change.** Full suite 4408/4408 green (golden audit unchanged), tsc + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZfYr4TNPVeCWH31AGqhzc
