### PR TITLE
feat(combat): consume Protection buff as ally damage-transfer

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -80,6 +80,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat sim: ships now enter combat with their fully-geared Security (and Shield Penetration), instead of falling back to un-geared base values — a ship showing 359 Security on its details page now fights with 359, not its base value. This affects how reliably debuffs land.',
     "Combat sim: AoE healing is now modelled. Support healers (e.g. Hermes) repair EVERY ally within their targeting pattern each cast — just like buffs — instead of a single ally. This also fixes player-team healers that previously healed no one (their heal was routed to a fixed ally outside the healing pattern), so player and enemy healers now behave identically. Healers whose skill explicitly targets one ally (e.g. Volk's 'ally with the most missing health') still heal a single lowest-HP ally.",
     "Combat sim: AoE heals now restore each ally's real HP (previously only one ally per team was actually healed), and the Abundant Renewal implant now works — when a healer over-repairs an ally, that ally gains a Shield equal to a share of the over-repaired amount. Each over-repaired ally gets its own shield scaled to its own overheal, on both teams.",
+    "Combat sim now models Protection as a damage transfer: a ship holding Protection stacks (e.g. Meatshield) intercepts 10% per stack of the direct damage its allies take, absorbed on the protector's own defense — the attacker's affinity match-up against the original target is unchanged. Multiple protectors cascade in speed order.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3368,8 +3368,18 @@ const DocumentationPage: React.FC = () => {
                                     damage-over-time) grows the lower her HP falls.{' '}
                                     <strong>Vindicator</strong> retaliates when it resists an enemy
                                     debuff, dealing damage equal to 30% of its own max HP back to
-                                    the ship that attempted it. More implant and gear-set effects
-                                    will be added in future updates.
+                                    the ship that attempted it. <strong>Protection</strong> (e.g.{' '}
+                                    <strong>Meatshield</strong>) now works as a damage transfer
+                                    instead of a plain unremovable buff: each stack a living ally
+                                    holds intercepts 10% of the direct damage another ally would
+                                    take, redirecting that share onto the protector instead — the
+                                    redirected share is absorbed against the protector&apos;s own
+                                    defense rather than the original target&apos;s, so the
+                                    attacker&apos;s affinity match-up against the original target is
+                                    unaffected. When more than one ally holds Protection, the faster
+                                    protector intercepts first and only its unabsorbed remainder
+                                    cascades to the next. More implant and gear-set effects will be
+                                    added in future updates.
                                 </p>
                             </div>
                         </div>

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -48,13 +48,16 @@ export type AbilityType =
     | 'convert-dot'
     // SP-F F5 (Meatshield, R4 refit-active passive — APPROXIMATION): "Any direct damage dealt
     // to a non-defender ally that is not transferred by Protection is dealt as if that ally
-    // had this Unit's defense." Protection-as-damage-transfer (a Defender intercepting ally
-    // damage) is a DEFERRED mechanic, so nothing is ever "transferred by Protection" in this
-    // model — the "not transferred" gate is vacuously satisfied, and ALL direct damage to a
-    // living non-defender ally is mitigated using the carrier's effective defence instead of
-    // the ally's own. Always-on passive, target:'all-allies'. See AbilityConfig's
-    // 'defense-substitution' variant (a no-op marker — consumed at the engine's defence-read
-    // sites, never through the ability-fold/executor pipeline).
+    // had this Unit's defense." Protection-as-damage-transfer (a living ally holding Protection
+    // stacks intercepting a fraction of an ally's direct hit, BEFORE the ally's own defence
+    // applies) IS implemented (engine.ts's `protectorsFor` + the transfer block in
+    // `applyVictimDamage`, via `protectionCascade`). This variant applies to the NON-TRANSFERRED
+    // REMAINDER only: the transferred portion is re-mitigated on the protector's own defence, and
+    // the ally's retained `(1 − redirectFraction)` share is what gets substituted with the
+    // carrier's effective defence instead of the ally's own. So the R4 wording is realized
+    // literally, not vacuously satisfied. Always-on passive, target:'all-allies'. See
+    // AbilityConfig's 'defense-substitution' variant (a no-op marker — consumed at the engine's
+    // defence-read sites, never through the ability-fold/executor pipeline).
     | 'defense-substitution'
     // SP-F F3 (Lingshe): "reduces all Bombs on the enemy targets by N turn(s), Bombs reduced
     // to 0 turns by this skill will detonate. This reduction effect requires hacking." Enemy-
@@ -826,8 +829,9 @@ export type AbilityConfig =
           extendChanceFromCritPower?: boolean;
       }
     // SP-F F5 (Meatshield defense-substitution, approximation — see AbilityType's
-    // 'defense-substitution' doc comment for the full rule + the deferred-Protection
-    // rationale). No fields: a bare presence marker, mirroring 'damage-reflection'/
+    // 'defense-substitution' doc comment for the full rule + how it composes with the now-
+    // implemented Protection transfer). No fields: a bare presence marker, mirroring
+    // 'damage-reflection'/
     // 'buff-duration-extension'. The engine collects every carrier of this config into a
     // dedicated per-owner set and substitutes the carrier's effective defence for a living
     // non-defender ally's own defence at every defence-read site.

--- a/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
+++ b/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Protection damage transfer — ENGINE integration (Task 5, apply seam in applyVictimDamage).
+ *
+ * A living ally that holds >=1 Protection stack intercepts a fraction (10%/stack) of an ally's
+ * DIRECT hit. The redirected chunk keeps the ORIGINAL target's affinity/outgoing (both already
+ * baked into the hit's `damage`) and re-mitigates on the PROTECTOR's own defense — realized by
+ * the mit-ratio inside `protectionCascade`. This file drives the wiring END-TO-END through
+ * `runCombat` and reads the post-transfer per-actor intake from `RoundData.perActorIncoming`.
+ *
+ * Harness note (seeding Protection where `protectorsFor` can see it): `protectorsFor` reads
+ * `statusEngine.snapshot(id).activeSelfBuffs`, which surfaces only SCHEDULED (non ability-sourced)
+ * self-buffs, and scheduled self-buffs land on the 'attacker' owner. So the reliably snapshot-
+ * visible protector in this harness is the FOCUS ('attacker'); the VICTIM is a team-actor ally it
+ * is adjacent to (non-positional adjacency = all same-side allies). We seed the focus with a
+ * per-round accumulating 'Protection' buff (rate = N, maxStacks = N) so round 1's top-of-round
+ * tick lands exactly N stacks in the focus's snapshot. See the report for the production-visibility
+ * caveat (real Meatshield-style Protection is granted as an AURA ability status, which snapshot
+ * excludes — a Task 2/4 design concern outside this task's scope).
+ *
+ * The multi-protector CASCADE math + fastest-first ordering intent (the original test (c)) is
+ * covered as a pure-function property in protectionTransfer.test.ts ("multi-protector cascade:
+ * each protector skims the PREVIOUS protector chunk"). Two snapshot-visible protectors cannot be
+ * staged end-to-end in this harness (only 'attacker' carries scheduled self-buffs), so (c) is
+ * asserted at that `protectionCascade` seam here for completeness.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { calculateDamageReduction } from '../../autogear/priorityScore';
+import { protectionCascade } from '../protectionTransfer';
+import type { SelectedGameBuff } from '../../../types/calculator';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+/** A flat enemy attacker (no shipSkills → engine synthesizes a single 100% basic hit). An optional
+ *  `affinityDamageModifier` folds the attacker's affinity edge vs its TARGET into the hit. */
+const manualEnemy = (id: string, attack: number, affinityDamageModifier = 0): EnemyAttacker => ({
+    id,
+    stats: { attack, crit: 0, critDamage: 0, speed: 50 },
+    chargeCount: 0,
+    startCharged: false,
+    affinityDamageModifier,
+});
+
+/** A walked player team actor (a pure victim stat block, role ATTACKER so it is a valid victim). */
+const teamActor = (id: string, defence: number): TeamActorEngineInput => ({
+    id,
+    speed: 100,
+    chargeCount: 0,
+    startCharged: false,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    role: 'ATTACKER',
+    walk: {
+        shipSkills: { slots: [] },
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            hacking: 0,
+            defence,
+            hp: 1_000_000_000,
+        },
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        hasChargedSkill: false,
+    },
+});
+
+/** A per-round accumulating 'Protection' self-buff: rate = stacks, capped at stacks, so the round-1
+ *  top-of-round accumulation lands EXACTLY `stacks` in the owner's snapshot. */
+const protectionAccum = (stacks: number): SelectedGameBuff => ({
+    id: 'prot-1',
+    buffName: 'Protection',
+    stacks,
+    parsedEffects: {},
+    isStackable: true,
+    maxStacks: stacks,
+    stackTrigger: 'per-round',
+});
+
+/** Total damage the actor actually TOOK across the run (post-transfer), read from the per-actor
+ *  intake bucket (NOT the `attacked` event, which reports the pre-transfer hit value). */
+const totalIncoming = (input: CombatEngineInput, id: string): number => {
+    const res = runCombat(input);
+    let sum = 0;
+    for (const rd of res.rounds) sum += rd.perActorIncoming?.[id]?.incoming ?? 0;
+    return sum;
+};
+
+/** Count of reactive-damage-performed events targeting `id`. */
+const reactiveEventsTargeting = (input: CombatEngineInput, id: string): number => {
+    const bus = createEventBus();
+    let n = 0;
+    bus.on(
+        'reactive-damage-performed',
+        (e: Extract<CombatEvent, { type: 'reactive-damage-performed' }>) => {
+            if (e.targetId === id) n++;
+        }
+    );
+    runCombat({ ...input, bus });
+    return n;
+};
+
+const ENEMY_ATTACK = 1000;
+const PROTECTOR_DEFENCE = 300; // < victim defence (0) so the redirected chunk is amplified.
+const mit = (defence: number): number =>
+    defence > 0 ? 1 - calculateDamageReduction(defence) / 100 : 1;
+
+const BASE_INPUT = (overrides: Partial<CombatEngineInput>): CombatEngineInput => ({
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [] }, // the focus deals no offence itself; it is only the protector.
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: PROTECTOR_DEFENCE, // the focus (protector) defence — drives the redirected chunk's mit.
+    hp: 1_000_000_000,
+    healTargetId: 'ally-1',
+    ...overrides,
+});
+
+describe('Protection damage transfer (integration)', () => {
+    it('a 3-stack protector takes 30% of the target hit (re-mitigated on its own defense); target keeps 70%', () => {
+        // Focus ('attacker') is a 3-stack Protection protector; the team ally 'ally-1' (defence 0)
+        // is the direct-hit victim. One enemy fires a single 1000 hit at the ally.
+        const withProtector = (withProt: boolean): CombatEngineInput =>
+            BASE_INPUT({
+                selfBuffs: withProt ? [protectionAccum(3)] : [],
+                teamActors: [teamActor('ally-1', 0)],
+                enemyAttackers: [manualEnemy('enemy-1', ENEMY_ATTACK)],
+            });
+
+        const victimWithout = totalIncoming(withProtector(false), 'ally-1');
+        const victimWith = totalIncoming(withProtector(true), 'ally-1');
+        const protectorWith = totalIncoming(withProtector(true), 'attacker');
+
+        // Control: full unmitigated hit lands on the 0-defence ally.
+        expect(victimWithout).toBeCloseTo(ENEMY_ATTACK, 6);
+        // Target keeps EXACTLY 70% (3 stacks → 30% transferred).
+        expect(victimWith).toBeCloseTo(0.7 * victimWithout, 6);
+        // Protector chunk = 0.30 × fullTargetDamage × mit(D_p)/mit(D_t). D_t = 0 → mit(D_t) = 1.
+        const expectedChunk = 0.3 * ENEMY_ATTACK * (mit(PROTECTOR_DEFENCE) / mit(0));
+        expect(protectorWith).toBeCloseTo(expectedChunk, 4);
+        // …and it is genuinely re-mitigated (protector defence > 0 → chunk < the raw 30% slice).
+        expect(protectorWith).toBeLessThan(0.3 * ENEMY_ATTACK);
+
+        // One aggregate reactive-damage-performed surfaces per protector (the per-stack sub-hits
+        // are applied via recursive applyVictimDamage but the HP-curve/log surface is one event
+        // carrying chunk.total — see the wiring; the brief's "one per stack" comment is inaccurate).
+        expect(reactiveEventsTargeting(withProtector(true), 'attacker')).toBe(1);
+    });
+
+    it('redirect keeps the TARGET affinity, not the protector matchup', () => {
+        // The enemy carries a +25% affinity edge vs its TARGET (the ally), folded into the hit via
+        // affinityDamageModifier (thermal→chemical-style advantage). The protector's OWN matchup
+        // (a hypothetical −25%) must NEVER be re-resolved onto the redirected chunk: the wiring
+        // passes the already-affinity-baked `damage` into protectionCascade, which only swaps the
+        // DEFENSE factor. So the chunk scales with the +25%, not a −25%.
+        const AFF = 25;
+        const build = (withProt: boolean): CombatEngineInput =>
+            BASE_INPUT({
+                selfBuffs: withProt ? [protectionAccum(3)] : [],
+                teamActors: [teamActor('ally-1', 0)],
+                enemyAttackers: [manualEnemy('enemy-1', ENEMY_ATTACK, AFF)],
+            });
+
+        // The +25% edge is real: the ally-without-protector takes 1.25× the base hit.
+        const fullTargetDamage = totalIncoming(build(false), 'ally-1');
+        expect(fullTargetDamage).toBeCloseTo(ENEMY_ATTACK * (1 + AFF / 100), 4);
+
+        const victimWith = totalIncoming(build(true), 'ally-1');
+        const protectorWith = totalIncoming(build(true), 'attacker');
+        // Target still keeps exactly 70% of its (affinity-boosted) hit.
+        expect(victimWith).toBeCloseTo(0.7 * fullTargetDamage, 6);
+
+        // The protector chunk reflects the TARGET's +25% edge (ratio ≈ 1.0 vs the +25% expectation).
+        const expectedChunk = 0.3 * fullTargetDamage * (mit(PROTECTOR_DEFENCE) / mit(0));
+        expect(protectorWith / expectedChunk).toBeCloseTo(1.0, 3);
+        // …and it is NOT the −25% trap: had the redirect wrongly re-resolved to the protector's own
+        // −25% matchup, the chunk would be ~0.6× the +25% expectation (0.75/1.25). It is not.
+        expect(protectorWith / expectedChunk).toBeGreaterThan(0.9);
+    });
+
+    it("two protectors cascade by speed: slower protector skims the faster one's chunk", () => {
+        // Two snapshot-visible protectors cannot be staged in the runCombat harness (only the
+        // 'attacker' owner carries scheduled self-buffs — see the file header), so the cascade
+        // property is asserted at the protectionCascade seam the wiring calls. Fastest-first order
+        // is protectorsFor's responsibility; the cascade consumes the already-ordered list. Here P1
+        // (2 stacks) is the faster protector, P2 (1 stack) the slower.
+        // D=1000, targetMit=0.25 → P = 4000. frac1 = 0.2, frac2 = 0.1.
+        const cascade = protectionCascade(1000, 0.25, [
+            { mit: 0.5, stacks: 2 }, // P1 — faster
+            { mit: 0.4, stacks: 1 }, // P2 — slower
+        ]);
+        // P1 inflow (P-space) = frac1 × P = 0.2 × 4000 = 800; P1 keeps (1 − frac2) × 800 × mit1.
+        expect(cascade.chunks[0].total).toBeCloseTo((1 - 0.1) * 800 * 0.5, 6); // 360
+        // P2 derives from P1's inflow (frac2 × 800 = 80), NOT the original hit; keeps 80 × mit2.
+        expect(cascade.chunks[1].total).toBeCloseTo(0.1 * 800 * 0.4, 6); // 32
+        // The target loses only the FIRST hop (frac1), not the full transferred sum.
+        expect(cascade.targetRemainder).toBeCloseTo((1 - 0.2) * 1000, 6); // 800
+    });
+});

--- a/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
+++ b/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
@@ -29,6 +29,7 @@ import { createEventBus, CombatEvent } from '../events';
 import { calculateDamageReduction } from '../../autogear/priorityScore';
 import { protectionCascade } from '../protectionTransfer';
 import type { SelectedGameBuff } from '../../../types/calculator';
+import type { Ability, ShipSkills } from '../../../types/abilities';
 
 type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
 
@@ -42,8 +43,13 @@ const manualEnemy = (id: string, attack: number, affinityDamageModifier = 0): En
     affinityDamageModifier,
 });
 
-/** A walked player team actor (a pure victim stat block, role ATTACKER so it is a valid victim). */
-const teamActor = (id: string, defence: number): TeamActorEngineInput => ({
+/** A walked player team actor (a pure victim stat block, role ATTACKER so it is a valid victim).
+ *  Optional `passive` slots carry an ability (e.g. an aura Protection grant) for the actor. */
+const teamActor = (
+    id: string,
+    defence: number,
+    passive?: ShipSkills['slots']
+): TeamActorEngineInput => ({
     id,
     speed: 100,
     chargeCount: 0,
@@ -52,7 +58,7 @@ const teamActor = (id: string, defence: number): TeamActorEngineInput => ({
     enemyDebuffs: [],
     role: 'ATTACKER',
     walk: {
-        shipSkills: { slots: [] },
+        shipSkills: { slots: passive ?? [] },
         stats: {
             attack: 0,
             crit: 0,
@@ -82,6 +88,29 @@ const protectionAccum = (stacks: number): SelectedGameBuff => ({
     maxStacks: stacks,
     stackTrigger: 'per-round',
 });
+
+/** A passive slot that grants SELF `Protection` the PRODUCTION way — an AURA (buff config with an
+ *  undefined duration + isStackable), the same classification a real Meatshield's start-of-combat
+ *  "gains N stacks of Protection" passive parses to (SP-G G1b). It flows through
+ *  `activeAbilityStatuses`, NOT `snapshot().activeSelfBuffs` — so it exercises the exact source the
+ *  old `snapshot()`-only read missed. */
+const protectionAuraPassive = (stacks: number): ShipSkills['slots'][number] => {
+    const ability: Ability = {
+        id: 'meatshield-protection',
+        type: 'buff',
+        target: 'self',
+        trigger: 'on-cast',
+        conditions: [],
+        config: {
+            type: 'buff',
+            buffName: 'Protection',
+            parsedEffects: {},
+            stacks,
+            isStackable: true,
+        },
+    };
+    return { slot: 'passive', abilities: [ability] };
+};
 
 /** Total damage the actor actually TOOK across the run (post-transfer), read from the per-actor
  *  intake bucket (NOT the `attacked` event, which reports the pre-transfer hit value). */
@@ -215,5 +244,36 @@ describe('Protection damage transfer (integration)', () => {
         expect(cascade.chunks[1].total).toBeCloseTo(0.1 * 800 * 0.4, 6); // 32
         // The target loses only the FIRST hop (frac1), not the full transferred sum.
         expect(cascade.targetRemainder).toBeCloseTo((1 - 0.2) * 1000, 6); // 800
+    });
+
+    it('PRODUCTION PATH: aura-granted Protection on a NON-focus team-actor protector fires the redirect (reads exactly the granted stacks, no double-count)', () => {
+        // The whole point of the all-sources read: a real Meatshield grants Protection as an AURA
+        // (activeAbilityStatuses), which the old snapshot()-only read MISSED — and it sits on a
+        // TEAM actor, not the focus. Here 'prot-1' (a non-focus team actor) grants ITSELF 3 stacks
+        // of Protection via an aura passive; 'ally-1' (also a team actor) is the direct-hit victim.
+        const input = BASE_INPUT({
+            selfBuffs: [], // the FOCUS carries NO Protection — the protector is a team actor.
+            defence: 0, // focus is irrelevant here
+            teamActors: [
+                teamActor('ally-1', 0), // victim
+                teamActor('prot-1', PROTECTOR_DEFENCE, [protectionAuraPassive(3)]), // aura protector
+            ],
+            enemyAttackers: [manualEnemy('enemy-1', ENEMY_ATTACK)],
+        });
+
+        const victim = totalIncoming(input, 'ally-1');
+        const protector = totalIncoming(input, 'prot-1');
+
+        // The redirect FIRES from an aura-granted, non-focus protector — proving the all-sources
+        // read (not snapshot-only) is what makes real Protection live.
+        expect(protector).toBeGreaterThan(0);
+        // DOUBLE-COUNT GUARD: the victim keeps EXACTLY 70% → the resolver read EXACTLY 3 stacks
+        // (0.30 transferred). A double-count (3 in snapshot + 3 in aura = 6) would transfer 0.60
+        // and leave 40% — this asserts the single-source read (the aura instance appears in ONLY
+        // the activeAbilityStatuses source, never also snapshot).
+        expect(victim).toBeCloseTo(0.7 * ENEMY_ATTACK, 6);
+        // Protector chunk matches the same 3-stack magnitude as the focus-seeded case (a).
+        const expectedChunk = 0.3 * ENEMY_ATTACK * (mit(PROTECTOR_DEFENCE) / mit(0));
+        expect(protector).toBeCloseTo(expectedChunk, 4);
     });
 });

--- a/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
+++ b/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
@@ -18,10 +18,12 @@
  * excludes — a Task 2/4 design concern outside this task's scope).
  *
  * The multi-protector CASCADE math + fastest-first ordering intent (the original test (c)) is
- * covered as a pure-function property in protectionTransfer.test.ts ("multi-protector cascade:
- * each protector skims the PREVIOUS protector chunk"). Two snapshot-visible protectors cannot be
- * staged end-to-end in this harness (only 'attacker' carries scheduled self-buffs), so (c) is
- * asserted at that `protectionCascade` seam here for completeness.
+ * ALSO covered as a pure-function property in protectionTransfer.test.ts ("multi-protector
+ * cascade: each protector skims the PREVIOUS protector chunk") and is additionally driven
+ * END-TO-END here (two AURA-granted, non-focus team-actor protectors of different speeds — the
+ * same PRODUCTION PATH pattern as the aura test below), since two snapshot-visible ('attacker'-
+ * owned) protectors cannot be staged in this harness (only 'attacker' carries scheduled
+ * self-buffs).
  */
 import { describe, it, expect } from 'vitest';
 import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
@@ -30,6 +32,7 @@ import { calculateDamageReduction } from '../../autogear/priorityScore';
 import { protectionCascade } from '../protectionTransfer';
 import type { SelectedGameBuff } from '../../../types/calculator';
 import type { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
 
 type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
 
@@ -44,14 +47,17 @@ const manualEnemy = (id: string, attack: number, affinityDamageModifier = 0): En
 });
 
 /** A walked player team actor (a pure victim stat block, role ATTACKER so it is a valid victim).
- *  Optional `passive` slots carry an ability (e.g. an aura Protection grant) for the actor. */
+ *  Optional `passive` slots carry an ability (e.g. an aura Protection grant) for the actor.
+ *  Optional `speed` (default 100) lets multi-protector tests stage a deterministic fastest-first
+ *  cascade order (`protectorsFor` sorts protectors by effective speed descending). */
 const teamActor = (
     id: string,
     defence: number,
-    passive?: ShipSkills['slots']
+    passive?: ShipSkills['slots'],
+    speed = 100
 ): TeamActorEngineInput => ({
     id,
-    speed: 100,
+    speed,
     chargeCount: 0,
     startCharged: false,
     selfBuffs: [],
@@ -227,12 +233,11 @@ describe('Protection damage transfer (integration)', () => {
         expect(protectorWith / expectedChunk).toBeGreaterThan(0.9);
     });
 
-    it("two protectors cascade by speed: slower protector skims the faster one's chunk", () => {
-        // Two snapshot-visible protectors cannot be staged in the runCombat harness (only the
-        // 'attacker' owner carries scheduled self-buffs — see the file header), so the cascade
-        // property is asserted at the protectionCascade seam the wiring calls. Fastest-first order
-        // is protectorsFor's responsibility; the cascade consumes the already-ordered list. Here P1
-        // (2 stacks) is the faster protector, P2 (1 stack) the slower.
+    it("two protectors cascade by speed: slower protector skims the faster one's chunk (pure protectionCascade seam)", () => {
+        // Fastest-first order is protectorsFor's responsibility; the cascade consumes the
+        // already-ordered list. Here P1 (2 stacks) is the faster protector, P2 (1 stack) the
+        // slower. The END-TO-END equivalent (real aura-granted protectors, driven through
+        // applyVictimDamage) is the next test below.
         // D=1000, targetMit=0.25 → P = 4000. frac1 = 0.2, frac2 = 0.1.
         const cascade = protectionCascade(1000, 0.25, [
             { mit: 0.5, stacks: 2 }, // P1 — faster
@@ -244,6 +249,64 @@ describe('Protection damage transfer (integration)', () => {
         expect(cascade.chunks[1].total).toBeCloseTo(0.1 * 800 * 0.4, 6); // 32
         // The target loses only the FIRST hop (frac1), not the full transferred sum.
         expect(cascade.targetRemainder).toBeCloseTo((1 - 0.2) * 1000, 6); // 800
+    });
+
+    it("PRODUCTION PATH multi-protector cascade: two AURA-granted protectors of DIFFERENT speeds — the slower one derives from the faster one's chunk, not the original hit", () => {
+        // Two non-focus team actors each grant THEMSELVES Protection via the production aura
+        // path (mirrors the single-protector "PRODUCTION PATH" test above). 'prot-fast' (speed
+        // 150, 2 stacks) is faster than 'prot-slow' (speed 50, 1 stack); protectorsFor sorts by
+        // effective speed descending, so 'prot-fast' is P1 and 'prot-slow' is P2 in the cascade.
+        const FAST_STACKS = 2; // frac1 = 0.2
+        const SLOW_STACKS = 1; // frac2 = 0.1
+        const FAST_DEFENCE = PROTECTOR_DEFENCE; // 300
+        const SLOW_DEFENCE = 600;
+        const input = BASE_INPUT({
+            selfBuffs: [], // focus carries no Protection — both protectors are team actors.
+            defence: 0,
+            teamActors: [
+                teamActor('ally-1', 0), // victim, 0 defence → targetMit = 1 → P = ENEMY_ATTACK.
+                teamActor(
+                    'prot-fast',
+                    FAST_DEFENCE,
+                    [protectionAuraPassive(FAST_STACKS)],
+                    150 // faster
+                ),
+                teamActor(
+                    'prot-slow',
+                    SLOW_DEFENCE,
+                    [protectionAuraPassive(SLOW_STACKS)],
+                    50 // slower
+                ),
+            ],
+            enemyAttackers: [manualEnemy('enemy-1', ENEMY_ATTACK)],
+        });
+
+        const victim = totalIncoming(input, 'ally-1');
+        const fastProtector = totalIncoming(input, 'prot-fast');
+        const slowProtector = totalIncoming(input, 'prot-slow');
+
+        const frac1 = 0.1 * FAST_STACKS;
+        const frac2 = 0.1 * SLOW_STACKS;
+        const P = ENEMY_ATTACK; // targetMit = mit(0) = 1
+
+        // Target loses only the FIRST hop (frac1 of its own hit).
+        expect(victim).toBeCloseTo((1 - frac1) * ENEMY_ATTACK, 4);
+
+        // Faster protector keeps (1 − frac2) of its P-space inflow (frac1 × P), re-mitigated on
+        // its OWN defence.
+        const expectedFast = (1 - frac2) * frac1 * P * mit(FAST_DEFENCE);
+        expect(fastProtector).toBeCloseTo(expectedFast, 4);
+
+        // THE CASCADE ASSERTION: the slower protector's damage derives from the FASTER
+        // protector's chunk (frac2 × (frac1 × P)), NOT from the original hit (frac2 × P).
+        const expectedSlow = frac2 * (frac1 * P) * mit(SLOW_DEFENCE);
+        expect(slowProtector).toBeCloseTo(expectedSlow, 4);
+
+        // Proof it is genuinely cascaded, not a direct skim of the original hit: a direct skim
+        // of frac2 off the untouched original hit would be materially LARGER (no frac1 discount).
+        const wouldBeDirectSkim = frac2 * P * mit(SLOW_DEFENCE);
+        expect(slowProtector).toBeLessThan(wouldBeDirectSkim * 0.5);
+        expect(slowProtector).toBeCloseTo(wouldBeDirectSkim * frac1, 4);
     });
 
     it('PRODUCTION PATH: aura-granted Protection on a NON-focus team-actor protector fires the redirect (reads exactly the granted stacks, no double-count)', () => {
@@ -361,5 +424,124 @@ describe('Protection transfer × defense-substitution composition (Task 6)', () 
     it('control: WITHOUT Protection stacks, the ally still gets the full substituted-defence hit (pure defense-substitution, no transfer)', () => {
         const allyDamage = totalIncoming(buildInput(false), 'ally-1');
         expect(allyDamage).toBeCloseTo(ENEMY_ATTACK * mit(CARRIER_DEFENCE), 4);
+    });
+});
+
+// ───────────────────────────────────────────────────────────────────────────────────────
+// Enemy-side symmetry (spec §8): the engine is team-agnostic by construction — `protectorsFor`
+// resolves `bySide(isEnemySide(victim.id) ? 'enemy' : 'player')`, and the transfer block runs
+// inside the shared `applyVictimDamage` core regardless of which sink (`playerSink`/`enemySink`)
+// invokes it. This proves the redirect fires identically when the ATTACKER is on the PLAYER side
+// and the protector+victim are on the ENEMY side (the mirror image of every test above).
+//
+// Staging note: a player→enemy hit only reaches `applyVictimDamage` (via `applyOutgoingToEnemy`)
+// on the POSITIONAL apply path (drivePositionalApply) — reachable in this harness by giving the
+// focus a board `position` + parsed `target`/`pattern` against a positioned `enemyAttackers[]`
+// roster (mirrors src/utils/combat/__tests__/positionalDamage.integration.test.ts). The victim
+// ('enemy-front') is positioned so the focus's `target:'front'` selection resolves it; the
+// protector ('enemy-protector') is deliberately left UNPOSITIONED so `adjacentAllyIdsFor` falls
+// back to "all living same-side allies" (adjacency.ts's non-positional branch — true whenever no
+// OTHER same-side actor besides the owner carries a position), avoiding the need to compute a real
+// hex-neighbour cell. Both enemy actors have `attack: 0` (pure damageable targets) so only the
+// focus's positional hit is in play. The post-transfer per-actor intake is read the SAME way as
+// every player-side test above (`totalIncoming` / `perActorIncoming`) — `applyOutgoingToEnemy`
+// records into that identical bucket, keyed by the enemy victim's id.
+describe('Protection transfer — enemy-side symmetry (protector + victim on the ENEMY side)', () => {
+    // A no-passive single-hit basic-attack active slot (mirrors positionalDamage.integration.test.ts's
+    // `basicAttack()`): multiplier 100 (1x), 1 hit, target:'enemy' — so the focus's firing-hit
+    // damage equals its raw attack stat against a 0-defence victim.
+    const positionalBasicAttack = (): ShipSkills['slots'][number] => ({
+        slot: 'active',
+        abilities: [
+            {
+                id: 'sym-basic-attack',
+                type: 'damage',
+                target: 'enemy',
+                trigger: 'on-cast',
+                conditions: [],
+                config: { type: 'damage', multiplier: 100 },
+            } as Ability,
+        ],
+    });
+    const parsedTargetFront: ParsedTarget = { raw: 'front', side: 'enemy', selection: 'front' };
+    const basePattern: ParsedPattern = { raw: 'base', shape: 'base', range: 0, modifiers: {} };
+
+    it('an enemy-side protector redirects a PLAYER attack the same way a player-side protector redirects an enemy attack; the enemy target keeps 70%', () => {
+        const FOCUS_ATTACK = ENEMY_ATTACK; // same magnitude as the core player-side test, for a direct numeric mirror.
+
+        const build = (withProt: boolean): CombatEngineInput => ({
+            attack: FOCUS_ATTACK,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [positionalBasicAttack()] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            // Healing mode is required for `enemyAttackers` to be built into real CombatActors at
+            // all (engine.ts throws "enemyAttackers require healTargetId" otherwise) — same
+            // requirement every test above already carries via `healTargetId`.
+            healTargetId: 'attacker',
+            position: 'M4',
+            target: parsedTargetFront,
+            pattern: basePattern,
+            enemyAttackers: [
+                {
+                    id: 'enemy-front', // the VICTIM — positioned so target:'front' resolves it.
+                    stats: {
+                        attack: 0,
+                        crit: 0,
+                        critDamage: 0,
+                        defence: 0,
+                        hp: 1_000_000_000,
+                        speed: 1,
+                    },
+                    chargeCount: 0,
+                    startCharged: false,
+                    position: 'M4',
+                    shipSkills: { slots: [] },
+                },
+                {
+                    id: 'enemy-protector', // the PROTECTOR — deliberately unpositioned (see file note above).
+                    stats: {
+                        attack: 0,
+                        crit: 0,
+                        critDamage: 0,
+                        defence: PROTECTOR_DEFENCE,
+                        hp: 1_000_000_000,
+                        speed: 1,
+                    },
+                    chargeCount: 0,
+                    startCharged: false,
+                    shipSkills: { slots: withProt ? [protectionAuraPassive(3)] : [] },
+                },
+            ],
+        });
+
+        const victimWithout = totalIncoming(build(false), 'enemy-front');
+        const victimWith = totalIncoming(build(true), 'enemy-front');
+        const protectorWith = totalIncoming(build(true), 'enemy-protector');
+
+        // Control: the unprotected enemy target takes the full firing-hit damage.
+        expect(victimWithout).toBeCloseTo(FOCUS_ATTACK, 6);
+        // Target keeps EXACTLY 70% — identical fraction to the player-side core test.
+        expect(victimWith).toBeCloseTo(0.7 * victimWithout, 6);
+        // Protector chunk = 0.30 × fullTargetDamage × mit(D_p)/mit(D_t); D_t = 0 → mit(D_t) = 1.
+        const expectedChunk = 0.3 * FOCUS_ATTACK * (mit(PROTECTOR_DEFENCE) / mit(0));
+        expect(protectorWith).toBeCloseTo(expectedChunk, 4);
+        // The protector actually took damage (the redirect fired), not a zero no-op.
+        expect(protectorWith).toBeGreaterThan(0);
     });
 });

--- a/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
+++ b/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
@@ -277,3 +277,89 @@ describe('Protection damage transfer (integration)', () => {
         expect(protector).toBeCloseTo(expectedChunk, 4);
     });
 });
+
+// ───────────────────────────────────────────────────────────────────────────────────────
+// Task 6 — composition with `defense-substitution` (Meatshield R4, engine.ts:2907-2925).
+//
+// A carrier that BOTH substitutes its (high) defence for non-defender allies' incoming damage
+// AND holds Protection stacks. Design doc §6: because transfer peels off P BEFORE the defence
+// term, the non-transferred remainder correctly reads the SUBSTITUTED defence (this "just
+// works" via the shared defence-read sites). But the transfer block's OWN `targetMit` (used to
+// recover pre-defence P from the post-defence `damage`) must ALSO use the substituted defence —
+// not the victim's own — or the recovered P (and every protector chunk) is skewed. This is the
+// bug Task 6 fixes (engine.ts's Protection-transfer block, `targetMit` computation).
+// ───────────────────────────────────────────────────────────────────────────────────────
+describe('Protection transfer × defense-substitution composition (Task 6)', () => {
+    const CARRIER_DEFENCE = 8000; // high, mirrors the spec's Cultivator-order-of-magnitude example.
+    const STACKS = 3;
+    const FRAC = 0.1 * STACKS;
+
+    const defenseSubstitutionAbility: Ability = {
+        id: 'meatshield-defense-sub',
+        type: 'defense-substitution',
+        target: 'all-allies',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'defense-substitution' },
+    };
+    const defenseSubstitutionSlot: ShipSkills['slots'][number] = {
+        slot: 'passive',
+        abilities: [defenseSubstitutionAbility],
+    };
+
+    /** Carrier = Meatshield-style: BOTH the R4 defense-substitution passive (substitutes its own
+     *  HIGH defence for non-defender allies' incoming damage) AND N Protection stacks (redirects a
+     *  fraction of allies' direct damage to itself). Protects 'ally-1', a LOW (0) defence
+     *  non-defender ally (this file's `teamActor` hardcodes role 'ATTACKER'). */
+    const buildInput = (grantProtection: boolean): CombatEngineInput =>
+        BASE_INPUT({
+            selfBuffs: [], // focus is an inert bystander — carries neither ability.
+            defence: 0,
+            teamActors: [
+                teamActor('ally-1', 0),
+                teamActor(
+                    'carrier',
+                    CARRIER_DEFENCE,
+                    grantProtection
+                        ? [defenseSubstitutionSlot, protectionAuraPassive(STACKS)]
+                        : [defenseSubstitutionSlot]
+                ),
+            ],
+            enemyAttackers: [manualEnemy('enemy-1', ENEMY_ATTACK)],
+        });
+
+    it('non-transferred remainder reads the SUBSTITUTED (carrier) defence; transferred chunk recovers P from that same substituted mitigation', () => {
+        const input = buildInput(true);
+        const allyDamage = totalIncoming(input, 'ally-1');
+        const carrierDamage = totalIncoming(input, 'carrier');
+
+        const substitutedMit = mit(CARRIER_DEFENCE);
+        const expectedRemainder = (1 - FRAC) * ENEMY_ATTACK * substitutedMit;
+        const expectedChunk = FRAC * ENEMY_ATTACK * substitutedMit;
+
+        // (1) Composition holds: the ally's retained (1 - frac) share is computed AS IF it had
+        // the carrier's HIGH defence (substitution), not its own (0, unmitigated) defence —
+        // much smaller than the unsubstituted (1 - frac) x full hit would be.
+        expect(allyDamage).toBeCloseTo(expectedRemainder, 4);
+        expect(allyDamage).toBeLessThan((1 - FRAC) * ENEMY_ATTACK);
+
+        // (2) THE FIX: the protector (carrier) chunk correctly recovers the pre-defence P from
+        // the SUBSTITUTED mitigation (not the ally's own 0-defence no-op mitigation), then
+        // re-mitigates on the protector's own defence (here, the same carrier).
+        expect(carrierDamage).toBeCloseTo(expectedChunk, 4);
+
+        // (3) Proof the fix matters: under the OLD bug (`targetMit` read off the victim's OWN
+        // defence — 0, so targetMit = 1 short-circuits), the recovered P is just `damage`
+        // unchanged, giving the chunk an extra spurious `substitutedMit` factor — a materially
+        // SMALLER value than the correct chunk above. This is what the old code would have
+        // produced; assert the real (fixed) result diverges from it well beyond noise.
+        const oldBuggyChunk = FRAC * ENEMY_ATTACK * substitutedMit * substitutedMit;
+        expect(oldBuggyChunk).toBeLessThan(expectedChunk);
+        expect(carrierDamage).toBeGreaterThan(oldBuggyChunk * 1.5);
+    });
+
+    it('control: WITHOUT Protection stacks, the ally still gets the full substituted-defence hit (pure defense-substitution, no transfer)', () => {
+        const allyDamage = totalIncoming(buildInput(false), 'ally-1');
+        expect(allyDamage).toBeCloseTo(ENEMY_ATTACK * mit(CARRIER_DEFENCE), 4);
+    });
+});

--- a/src/utils/combat/__tests__/protectionTransfer.test.ts
+++ b/src/utils/combat/__tests__/protectionTransfer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { protectionCascade } from '../protectionTransfer';
+import { protectionCascade, protectionStacks } from '../protectionTransfer';
 
 describe('protectionCascade', () => {
     it('single protector: target keeps (1 - 0.1*stacks), protector chunk swaps defense via mit ratio', () => {
@@ -37,5 +37,14 @@ describe('protectionCascade', () => {
         const r = protectionCascade(1000, 0.25, []);
         expect(r.targetRemainder).toBe(1000);
         expect(r.chunks).toEqual([]);
+    });
+});
+
+describe('protectionStacks', () => {
+    it('sums Protection entries, defaults a stackless entry to 1, ignores others', () => {
+        expect(protectionStacks([{ buffName: 'Protection', stacks: 3 }])).toBe(3);
+        expect(protectionStacks([{ buffName: 'Protection' }])).toBe(1);
+        expect(protectionStacks([{ buffName: 'Buff Protection', stacks: 5 }])).toBe(0);
+        expect(protectionStacks([])).toBe(0);
     });
 });

--- a/src/utils/combat/__tests__/protectionTransfer.test.ts
+++ b/src/utils/combat/__tests__/protectionTransfer.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { protectionCascade } from '../protectionTransfer';
+
+describe('protectionCascade', () => {
+    it('single protector: target keeps (1 - 0.1*stacks), protector chunk swaps defense via mit ratio', () => {
+        // D=1000, targetMit=0.25, protector mit=0.5, 2 stacks -> frac=0.2
+        const r = protectionCascade(1000, 0.25, [{ mit: 0.5, stacks: 2 }]);
+        expect(r.targetRemainder).toBeCloseTo(800, 6);
+        // total = 0.2 * 1000 * (0.5/0.25) = 400 ; per stack = 200
+        expect(r.chunks).toHaveLength(1);
+        expect(r.chunks[0].total).toBeCloseTo(400, 6);
+        expect(r.chunks[0].perStack).toBeCloseTo(200, 6);
+        expect(r.chunks[0].stacks).toBe(2);
+    });
+
+    it('multi-protector cascade: each protector skims the PREVIOUS protector chunk, not the original', () => {
+        // D=1000, targetMit=0.25 -> P=4000. P1 mit=0.5 stacks=2 (frac1=0.2); P2 mit=0.4 stacks=1 (frac2=0.1)
+        const r = protectionCascade(1000, 0.25, [
+            { mit: 0.5, stacks: 2 },
+            { mit: 0.4, stacks: 1 },
+        ]);
+        expect(r.targetRemainder).toBeCloseTo(800, 6); // target loses only frac1
+        // flow1 = 0.2*4000 = 800 ; P1 keeps (1-0.1)*800*0.5 = 360
+        expect(r.chunks[0].total).toBeCloseTo(360, 6);
+        // flow2 = 0.1*800 = 80 ; P2 keeps 80*0.4 = 32
+        expect(r.chunks[1].total).toBeCloseTo(32, 6);
+    });
+
+    it('caps redirect at 100% (10 stacks) so target can reach zero', () => {
+        const r = protectionCascade(1000, 0.25, [{ mit: 0.5, stacks: 12 }]);
+        expect(r.targetRemainder).toBeCloseTo(0, 6);
+        // total = 1.0 * 1000 * (0.5/0.25) = 2000
+        expect(r.chunks[0].total).toBeCloseTo(2000, 6);
+    });
+
+    it('no protectors: target keeps everything, no chunks', () => {
+        const r = protectionCascade(1000, 0.25, []);
+        expect(r.targetRemainder).toBe(1000);
+        expect(r.chunks).toEqual([]);
+    });
+});

--- a/src/utils/combat/__tests__/selfBuffStacksForOwner.test.ts
+++ b/src/utils/combat/__tests__/selfBuffStacksForOwner.test.ts
@@ -1,0 +1,87 @@
+/**
+ * selfBuffStacksForOwner — stacks-aware sibling of selfBuffNamesForOwners.
+ *
+ * The Protection damage-transfer resolver needs the STACK COUNT of a self-buff, aggregated across
+ * ALL three status sources (scheduled snapshot self-buffs + timed ability statuses + aura/accum
+ * ability statuses). Reading snapshot().activeSelfBuffs ALONE misses aura-granted buffs (real
+ * Meatshield Protection, SP-G G1b) and any non-'attacker' owner — the exact trap this helper fixes.
+ */
+import { describe, it, expect } from 'vitest';
+import { createStatusEngine, RegisteredAbilityStatus } from '../statusEngine';
+import { selfBuffStacksForOwner } from '../triggers';
+
+const auraProtection = (stacks: number): RegisteredAbilityStatus => ({
+    kind: 'aura',
+    side: 'self',
+    sourceSlot: 'passive',
+    conditions: [],
+    payload: { buffName: 'Protection', stacks, parsedEffects: {}, isStackable: true },
+});
+
+describe('selfBuffStacksForOwner', () => {
+    it('reads an AURA-granted stackable buff (the production Meatshield path snapshot() alone misses)', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.registerAbilityStatuses([auraProtection(3)], 'prot-1');
+        eng.beginRound(1);
+        // The aura lives ONLY in the activeAbilityStatuses source — snapshot excludes it…
+        expect(eng.snapshot('prot-1').activeSelfBuffs).toHaveLength(0);
+        // …yet the helper surfaces its 3 stacks. No double-count (a single instance is in ONE source
+        // only): the result is EXACTLY 3, not 6.
+        expect(selfBuffStacksForOwner(eng, 'prot-1', 'Protection')).toBe(3);
+    });
+
+    it('returns 0 for a different buff name (exact-name match)', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.registerAbilityStatuses([auraProtection(3)], 'prot-1');
+        eng.beginRound(1);
+        expect(selfBuffStacksForOwner(eng, 'prot-1', 'Focus')).toBe(0);
+    });
+
+    it('returns 0 for an owner with no Protection at all', () => {
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        eng.beginRound(1);
+        expect(selfBuffStacksForOwner(eng, 'nobody', 'Protection')).toBe(0);
+    });
+
+    it('a stackless entry (isStackable false → no reported count) defaults to 1', () => {
+        // Non-stackable aura: activeAbilityStatuses does NOT surface a `stacks` count, so the entry
+        // is present but stackless → the helper counts it as 1 (the `?? 1` default).
+        const eng = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        const nonStackable: RegisteredAbilityStatus = {
+            kind: 'aura',
+            side: 'self',
+            sourceSlot: 'passive',
+            conditions: [],
+            payload: { buffName: 'Protection', stacks: 1, parsedEffects: {} }, // isStackable omitted
+        };
+        eng.registerAbilityStatuses([nonStackable], 'prot-1');
+        eng.beginRound(1);
+        expect(selfBuffStacksForOwner(eng, 'prot-1', 'Protection')).toBe(1);
+    });
+
+    it('aggregates DISTINCT instances across sources (aura + a scheduled accumulating snapshot buff)', () => {
+        // A scheduled per-round accumulating 'Protection' seeds the 'attacker' snapshot (2 stacks
+        // after round-1 tick); an aura 'Protection' (3 stacks) registered on the SAME owner lives in
+        // the ability-status source. These are TWO distinct instances in DISJOINT sources, so the
+        // total is their sum (2 + 3 = 5) — confirming the helper reads every source, and that
+        // summing does not conflate the two into one nor drop either.
+        const eng = createStatusEngine({
+            selfBuffs: [
+                {
+                    id: 'sched-prot',
+                    buffName: 'Protection',
+                    stacks: 2,
+                    parsedEffects: {},
+                    isStackable: true,
+                    maxStacks: 2,
+                    stackTrigger: 'per-round',
+                },
+            ],
+            enemyDebuffs: [],
+        });
+        eng.registerAbilityStatuses([auraProtection(3)], 'attacker');
+        eng.beginRound(1); // ticks the scheduled accum to 2
+        // Snapshot carries ONLY the scheduled accum instance (2); the aura is in the other source (3).
+        expect(selfBuffStacksForOwner(eng, 'attacker', 'Protection')).toBe(5);
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -100,6 +100,7 @@ import {
 import { adjacentAllyIds } from './adjacency';
 import { supportFootprintAllyIds } from './supportFootprint';
 import type { PreFightCombatModifiers } from './preFight/types';
+import { protectionCascade, protectionStacks } from './protectionTransfer';
 
 /** Backstop for pathological extra-action loops (a non-once-per-round grant whose
  *  conditions stay true re-fires on the extra turn it granted). Real texts are
@@ -2892,6 +2893,29 @@ export function runCombat(input: CombatEngineInput): {
             }
         }
     }
+    // Protection damage transfer (deferred mechanic, now consumed). A protector is any living
+    // ally that holds >=1 Protection stack; it intercepts a fraction of its allies' direct
+    // damage. Side-agnostic by construction (resolves allies via bySide), mirroring
+    // defenseSubstitutionCarrierIds. Fastest-first ordering drives the multi-protector cascade.
+    const protectorsFor = (victim: CombatActor): { actor: CombatActor; stacks: number }[] => {
+        const allyIds = bySide(isEnemySide(victim.id) ? 'enemy' : 'player').adjacentAllyIdsFor(
+            victim.id
+        );
+        const out: { actor: CombatActor; stacks: number }[] = [];
+        for (const id of allyIds) {
+            if (id === victim.id) continue;
+            const actor = allActorsById.get(id);
+            if (!actor || actor.currentHp <= 0) continue;
+            const stacks = protectionStacks(statusEngine.snapshot(id).activeSelfBuffs);
+            if (stacks > 0) out.push({ actor, stacks });
+        }
+        out.sort((a, b) => {
+            const sa = effectiveStatsOf(statusEngine, selfBuffLookup, a.actor).speed;
+            const sb = effectiveStatsOf(statusEngine, selfBuffLookup, b.actor).speed;
+            return sb - sa !== 0 ? sb - sa : a.actor.id.localeCompare(b.actor.id);
+        });
+        return out;
+    };
     // "Any direct damage dealt to a non-defender ally that is not transferred by Protection is
     // dealt as if that ally had this Unit's defense." Protection-as-damage-transfer is DEFERRED
     // (design doc §1) — nothing is ever "transferred by Protection" in this model, so the "not
@@ -3489,6 +3513,80 @@ export function runCombat(input: CombatEngineInput): {
                         }
                     );
                     damage = damage * (1 - blocked);
+                }
+            }
+            // Protection damage transfer. A living ally holding Protection stacks intercepts a
+            // fraction (10%/stack) of this victim's direct hit. The redirected chunk keeps the
+            // ORIGINAL target's affinity/outgoing (both baked into `damage`) and re-mitigates on
+            // the PROTECTOR's own defense — realized by the mit-ratio inside protectionCascade.
+            // Guards mirror the reflect block: direct damage only, and never a redirected/
+            // reflected/counter application (loop-safe).
+            if (
+                cause?.byDirectDamage &&
+                !cause.isProtectionTransfer &&
+                !cause.isReflected &&
+                !cause.isCounter &&
+                damage > 0
+            ) {
+                const protectors = protectorsFor(victim);
+                if (protectors.length > 0) {
+                    const victimDef = effectiveStatsOf(
+                        statusEngine,
+                        selfBuffLookup,
+                        victim
+                    ).defence;
+                    const targetMit =
+                        victimDef > 0 ? 1 - calculateDamageReduction(victimDef) / 100 : 1;
+                    const cascade = protectionCascade(
+                        damage,
+                        targetMit,
+                        protectors.map((p) => ({
+                            stacks: p.stacks,
+                            mit:
+                                effectiveStatsOf(statusEngine, selfBuffLookup, p.actor).defence > 0
+                                    ? 1 -
+                                      calculateDamageReduction(
+                                          effectiveStatsOf(statusEngine, selfBuffLookup, p.actor)
+                                              .defence
+                                      ) /
+                                          100
+                                    : 1,
+                        }))
+                    );
+                    // Redirect each protector's chunk BEFORE the victim's own HP is touched.
+                    protectors.forEach((p, i) => {
+                        const chunk = cascade.chunks[i];
+                        if (!chunk || chunk.total <= 0) return;
+                        const protectorSink = p.actor.side === 'player' ? playerSink : enemySink;
+                        // Apply as `stacks` equal sub-hits (matches the in-game per-stack procs and
+                        // sets up the deferred DoT-transform, which acts per redirected chunk).
+                        for (let s = 0; s < chunk.stacks; s++) {
+                            applyVictimDamage(chunk.perStack, p.actor, protectorSink, {
+                                killerId: cause.killerId,
+                                byDirectDamage: true,
+                                isProtectionTransfer: true,
+                                shieldPenetrationPct: 0,
+                                bombPortion: 0,
+                            });
+                        }
+                        // Surface on the HP curve + reactive log (mirrors the reflect block).
+                        roundPerTargetDamage.set(
+                            p.actor.id,
+                            (roundPerTargetDamage.get(p.actor.id) ?? 0) + chunk.total
+                        );
+                        bus.emit({
+                            type: 'reactive-damage-performed',
+                            sourceId: victim.id,
+                            targetId: p.actor.id,
+                            round: r,
+                            amount: chunk.total,
+                            reactive: true,
+                            duringTurnOf: actingActorId,
+                            triggerActorId: actingActorId,
+                        });
+                    });
+                    // The victim now only takes the non-transferred remainder.
+                    damage = cascade.targetRemainder;
                 }
             }
             sink.addIncoming(damage, victim.id);

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -94,13 +94,14 @@ import {
     provokerOf,
     registerReactiveListeners,
     selfBuffNamesForOwners,
+    selfBuffStacksForOwner,
     victimEnemyBuffs,
     victimSelfBuffs,
 } from './triggers';
 import { adjacentAllyIds } from './adjacency';
 import { supportFootprintAllyIds } from './supportFootprint';
 import type { PreFightCombatModifiers } from './preFight/types';
-import { protectionCascade, protectionStacks } from './protectionTransfer';
+import { protectionCascade } from './protectionTransfer';
 
 /** Backstop for pathological extra-action loops (a non-once-per-round grant whose
  *  conditions stay true re-fires on the extra turn it granted). Real texts are
@@ -2906,7 +2907,11 @@ export function runCombat(input: CombatEngineInput): {
             if (id === victim.id) continue;
             const actor = allActorsById.get(id);
             if (!actor || actor.currentHp <= 0) continue;
-            const stacks = protectionStacks(statusEngine.snapshot(id).activeSelfBuffs);
+            // Aggregate across ALL status sources (scheduled snapshot + timed + aura/accum ability
+            // statuses) — NOT snapshot().activeSelfBuffs alone, which misses aura-granted Protection
+            // (real Meatshield / SP-G G1b) and any non-'attacker' owner (the Cheat-Death-detection
+            // trap documented below at the Barrier/Cheat-Death read sites).
+            const stacks = selfBuffStacksForOwner(statusEngine, id, 'Protection');
             if (stacks > 0) out.push({ actor, stacks });
         }
         out.sort((a, b) => {

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3535,13 +3535,21 @@ export function runCombat(input: CombatEngineInput): {
             ) {
                 const protectors = protectorsFor(victim);
                 if (protectors.length > 0) {
+                    // `damage` was already mitigated by whatever defence the caller used at its
+                    // read site — for a defense-substitution victim (Meatshield R4), that's the
+                    // CARRIER's substituted defence, not the victim's own. Recomputing `targetMit`
+                    // must use that same substituted value or the recovered pre-defence `P` (and
+                    // therefore every protector chunk) is skewed. `substitutedDefenceFor` is a
+                    // no-op fallback to `victimDef` when no carrier applies, so this is
+                    // byte-identical to before for every non-substitution case.
                     const victimDef = effectiveStatsOf(
                         statusEngine,
                         selfBuffLookup,
                         victim
                     ).defence;
+                    const targetDef = substitutedDefenceFor(victim, victimDef);
                     const targetMit =
-                        victimDef > 0 ? 1 - calculateDamageReduction(victimDef) / 100 : 1;
+                        targetDef > 0 ? 1 - calculateDamageReduction(targetDef) / 100 : 1;
                     const cascade = protectionCascade(
                         damage,
                         targetMit,

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3404,6 +3404,10 @@ export function runCombat(input: CombatEngineInput): {
                 /** G PR1: true when THIS application is a counterattack (Stalwart). The reflect
                  *  re-entry guard skips when set → a counter is never itself reflected (loop-safe). */
                 isCounter?: boolean;
+                /** Protection transfer: true when THIS application is a redirected Protection
+                 *  chunk. The transfer block (Task 4) skips when set → a redirected chunk's own
+                 *  cascade was already precomputed, so it never re-triggers (loop-safe). */
+                isProtectionTransfer?: boolean;
                 /** Epic PR12 (A): true when this victim IS the attacker's resolved anchor/primary
                  *  target (Nosorog's `requirePrimaryTarget` reflect gate). Undefined/true for every
                  *  non-positional (inherently single-target) call site; explicitly false only for

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2922,17 +2922,18 @@ export function runCombat(input: CombatEngineInput): {
         return out;
     };
     // "Any direct damage dealt to a non-defender ally that is not transferred by Protection is
-    // dealt as if that ally had this Unit's defense." Protection-as-damage-transfer is DEFERRED
-    // (design doc §1) — nothing is ever "transferred by Protection" in this model, so the "not
-    // transferred" gate is vacuously satisfied: this substitutes for EVERY living non-defender
-    // ally of a living carrier, unconditionally. Called from EVERY defence-read site
-    // (defenseProfileOf, the reactive read, both victimDefenceFor bindings) so every attack type
-    // sees the same mitigation — wiring it into only one path would silently diverge across
-    // attack types. `fallback` is the site's OWN pre-substitution defence value (raw stats,
-    // buffed/effective, or a last-turn-ctx read — whichever that site already computed), so a
-    // victim with no applicable carrier is byte-identical to before this task. Multi-carrier tie-
-    // break (no known in-game dup case): the HIGHEST effective defence among living, same-side
-    // carriers wins.
+    // dealt as if that ally had this Unit's defense." Protection-as-damage-transfer is now
+    // IMPLEMENTED (see `protectorsFor` above + the transfer block in `applyVictimDamage`, which
+    // peels `redirectFraction × P` off a hit BEFORE this substitution is applied) — so this
+    // function only ever substitutes for the NON-TRANSFERRED remainder of a living non-defender
+    // ally's damage; the transferred portion is a separate hit re-mitigated on the protector's own
+    // defence via `protectionCascade`. Called from EVERY defence-read site (defenseProfileOf, the
+    // reactive read, both victimDefenceFor bindings) so every attack type sees the same
+    // mitigation — wiring it into only one path would silently diverge across attack types.
+    // `fallback` is the site's OWN pre-substitution defence value (raw stats, buffed/effective, or
+    // a last-turn-ctx read — whichever that site already computed), so a victim with no applicable
+    // carrier is byte-identical to before this task. Multi-carrier tie-break (no known in-game dup
+    // case): the HIGHEST effective defence among living, same-side carriers wins.
     const substitutedDefenceFor = (victim: CombatActor, fallback: number): number => {
         if (victim.currentHp <= 0) return fallback; // dead victims are never substituted
         // DEFENDER victims are never substituted (R4 text: "non-defender ally"). Substitution

--- a/src/utils/combat/protectionTransfer.ts
+++ b/src/utils/combat/protectionTransfer.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure Protection damage-transfer cascade.
+ *
+ * For ONE direct hit that landed `fullTargetDamage` on a target (already including the
+ * target's affinity, outgoing buffs, and DEFENSE mitigation `targetMit`), compute how much
+ * the target keeps and how much each protector absorbs.
+ *
+ * Working in P-space (P = pre-target-defense damage = fullTargetDamage / targetMit) keeps
+ * the affinity + outgoing factors that are baked into `fullTargetDamage` intact for every
+ * protector chunk — only the DEFENSE factor is swapped (mitᵢ vs targetMit). That is the
+ * empirically-confirmed rule: the redirect keeps the ORIGINAL TARGET's affinity, and
+ * re-mitigates on the PROTECTOR's own defense.
+ *
+ * Multi-protector = speed-ordered CASCADE: protector i skims fracᵢ of protector (i-1)'s
+ * inflow, not of the original hit. The original target loses only the first hop.
+ */
+export interface ProtectorInput {
+    /** Protector's damage-through factor (1 - reduction/100), in (0,1]. */
+    mit: number;
+    /** Protection stacks on this protector (>= 1). */
+    stacks: number;
+}
+
+export interface ProtectionChunk {
+    stacks: number;
+    perStack: number;
+    total: number;
+}
+
+export interface CascadeResult {
+    targetRemainder: number;
+    chunks: ProtectionChunk[];
+}
+
+const fracFor = (stacks: number): number => Math.min(1, 0.1 * stacks);
+
+export function protectionCascade(
+    fullTargetDamage: number,
+    targetMit: number,
+    protectors: ProtectorInput[]
+): CascadeResult {
+    if (protectors.length === 0 || targetMit <= 0 || fullTargetDamage <= 0) {
+        return { targetRemainder: fullTargetDamage, chunks: [] };
+    }
+
+    const P = fullTargetDamage / targetMit; // pre-target-defense damage
+    const frac1 = fracFor(protectors[0].stacks);
+    const targetRemainder = (1 - frac1) * fullTargetDamage;
+
+    const chunks: ProtectionChunk[] = [];
+    let flow = frac1 * P; // P-space inflow to the current protector
+    for (let i = 0; i < protectors.length; i++) {
+        const nextFrac = i + 1 < protectors.length ? fracFor(protectors[i + 1].stacks) : 0;
+        const kept = (1 - nextFrac) * flow * protectors[i].mit; // this protector's HP damage
+        chunks.push({
+            stacks: protectors[i].stacks,
+            perStack: kept / protectors[i].stacks,
+            total: kept,
+        });
+        flow = nextFrac * flow; // pass the remainder to the next protector
+    }
+    return { targetRemainder, chunks };
+}

--- a/src/utils/combat/protectionTransfer.ts
+++ b/src/utils/combat/protectionTransfer.ts
@@ -61,3 +61,9 @@ export function protectionCascade(
     }
     return { targetRemainder, chunks };
 }
+
+export function protectionStacks(activeSelfBuffs: { buffName: string; stacks?: number }[]): number {
+    return activeSelfBuffs
+        .filter((b) => b.buffName === 'Protection')
+        .reduce((sum, b) => sum + (b.stacks ?? 1), 0);
+}

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1469,6 +1469,44 @@ export function countOwnersWithSelfBuff(
     return count;
 }
 
+/** Total STACK count of a single named self-buff held by `ownerId`, aggregated across the SAME
+ *  three sources as {@link selfBuffNamesForOwners} (scheduled snapshot self-buffs + timed ability
+ *  statuses + aura/accum ability statuses). This is the stacks-aware sibling of the name-only
+ *  reads: consumers that need the count (Protection damage-transfer's per-stack fraction) cannot
+ *  use `snapshot().activeSelfBuffs` alone — that surfaces only SCHEDULED (non ability-sourced)
+ *  buffs on the 'attacker' owner, so an aura-granted Protection (Meatshield / SP-G G1b) or any
+ *  non-'attacker' owner's Protection would be invisible (the trap documented at the Cheat-Death
+ *  detection site in engine.ts). A single status instance lands in EXACTLY ONE of the three
+ *  sources (payload-carrying statuses are excluded from snapshot; timed and aura/accum live in
+ *  disjoint maps), so summing across all three does not double-count. A stackless entry counts as
+ *  1; a seeded-but-inert (stacks === 0) entry counts as 0. */
+export function selfBuffStacksForOwner(
+    statusEngine: StatusEngine,
+    ownerId: string,
+    buffName: string
+): number {
+    let total = 0;
+    for (const ab of statusEngine.snapshot(ownerId).activeSelfBuffs) {
+        if (ab.buffName === buffName && (ab.stacks === undefined || ab.stacks > 0))
+            total += ab.stacks ?? 1;
+    }
+    for (const s of statusEngine.timedAbilityStatuses('self', ownerId)) {
+        if (
+            s.active.buffName === buffName &&
+            (s.active.stacks === undefined || s.active.stacks > 0)
+        )
+            total += s.active.stacks ?? 1;
+    }
+    for (const s of statusEngine.activeAbilityStatuses('self', () => NEUTRAL_NAMES_CTX, ownerId)) {
+        if (
+            s.active.buffName === buffName &&
+            (s.active.stacks === undefined || s.active.stacks > 0)
+        )
+            total += s.active.stacks ?? 1;
+    }
+    return total;
+}
+
 /** Enemy-debuff NAMES carried in the per-TARGET store keyed by `targetId` (an actor's
  *  OWN debuffs). Scheduled non-payload debuffs come from snapshot(_, targetId).activeEnemyDebuffs;
  *  payload-carrying ability debuffs (timed + aura/accum) come from the ability-status reads


### PR DESCRIPTION
## Summary

Consumes the `Protection` buff in the combat engine — until now defined-but-inert. A ship holding Protection stacks intercepts **10% per stack** of the **direct** damage its allies take, absorbed on the **protector's own defence** while keeping the **original target's affinity**.

The damage model was reverse-engineered from controlled in-game fights (Butcher → Cultivator, protected by Meatshield) and validated to the digit:

| Measurement | Model | Observed |
|---|---|---|
| Culti, no Meatshield (full hit) | 22,273 | 22,572 |
| Culti, with Meatshield (keeps 70%) | 15,591 | 15,801 |
| Meatshield /stack, def 4008 | 4,692 | 4,643 |
| Meatshield /stack, def ×1.45 | 3,784 | 3,743 |
| Split (with/without) | 0.7000 | **0.7000 exact** |

`P = raw × crit × skill × affinity(attacker→TARGET) × outgoing` (pre-target-defence). Target keeps `(1−frac)×P×mit(target def)`; protector takes `frac×P×mit(protector def)`.

## Behaviour

- **Coverage:** all allies; no self-cover; **direct damage only**.
- **Multi-protector = speed-ordered cascade** — each protector skims the *previous* protector's chunk (loop-guarded via a new `isProtectionTransfer` re-entry flag).
- **Team-symmetric** — enemy-side protectors behave identically (side-agnostic resolver + sink).
- **Composes with `defense-substitution`** (Meatshield R4): the transfer peels off first; the ally's non-transferred remainder gets the substituted defence — realising the R4 wording literally.
- Stacks are read from **all status sources** including ability-sourced **auras** (how production Meatshield grants Protection) — not just the scheduled-buff snapshot.

## Implementation

- `protectionTransfer.ts` — pure cascade + stack selector (unit-tested).
- `triggers.ts` — `selfBuffStacksForOwner` (3-source stacks read, mirrors `selfBuffNamesForOwners`).
- `engine.ts` — `protectorsFor` resolver + transfer block in `applyVictimDamage` (follows the Reflect model), `isProtectionTransfer` guard.
- Integration tests: single-protector split, target-affinity preservation, production-aura path on a non-focus actor, multi-protector cascade e2e, enemy-side symmetry, and `defense-substitution` interleave.

## Testing

Full suite **356 files / 4426 tests green**, `audit:skills` at 0, no pre-existing combat fixture moved. Final whole-branch review (Opus): ready to merge, no Critical/Important.

## Deferred follow-ups (non-blocking)

- Per-stack log events (in-game shows N separate procs; currently one log row per protector — HP is correct).
- Setup-time `hasAnyProtectionGrant` gate (micro-optimisation).
- `triggerFrequency` field, to land with the Lionheart `first-hit-per-round` variant.
- Barrier-immune-victim redirect edge; a narrow `targetMit`-fallback precision nuance on buffed non-substituted victims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
