### PR TITLE
feat(combat): Protection follow-ups — efficiency gate, all-allies coverage, Lionheart round-start Protection

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -83,6 +83,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim now models Protection as a damage transfer: a ship holding Protection stacks (e.g. Meatshield) intercepts 10% per stack of the direct damage its allies take, absorbed on the protector's own defense — the attacker's affinity match-up against the original target is unchanged. Multiple protectors cascade in speed order.",
     'Combat sim: Lionheart now gains 10 stacks of Protection each round and absorbs the first hit redirected from an ally, then loses all Protection until the next round.',
     'Combat sim: Protection now redirects damage from any living ally, not only adjacent ones.',
+    'Combat sim: a consumable Protection holder (e.g. Lionheart) no longer loses its Protection when another protector fully absorbs the redirected hit before it — Protection is only consumed when it actually intercepted damage.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -81,6 +81,8 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: AoE healing is now modelled. Support healers (e.g. Hermes) repair EVERY ally within their targeting pattern each cast — just like buffs — instead of a single ally. This also fixes player-team healers that previously healed no one (their heal was routed to a fixed ally outside the healing pattern), so player and enemy healers now behave identically. Healers whose skill explicitly targets one ally (e.g. Volk's 'ally with the most missing health') still heal a single lowest-HP ally.",
     "Combat sim: AoE heals now restore each ally's real HP (previously only one ally per team was actually healed), and the Abundant Renewal implant now works — when a healer over-repairs an ally, that ally gains a Shield equal to a share of the over-repaired amount. Each over-repaired ally gets its own shield scaled to its own overheal, on both teams.",
     "Combat sim now models Protection as a damage transfer: a ship holding Protection stacks (e.g. Meatshield) intercepts 10% per stack of the direct damage its allies take, absorbed on the protector's own defense — the attacker's affinity match-up against the original target is unchanged. Multiple protectors cascade in speed order.",
+    'Combat sim: Lionheart now gains 10 stacks of Protection each round and absorbs the first hit redirected from an ally, then loses all Protection until the next round.',
+    'Combat sim: Protection now redirects damage from any living ally, not only adjacent ones.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3376,10 +3376,16 @@ const DocumentationPage: React.FC = () => {
                                     redirected share is absorbed against the protector&apos;s own
                                     defense rather than the original target&apos;s, so the
                                     attacker&apos;s affinity match-up against the original target is
-                                    unaffected. When more than one ally holds Protection, the faster
-                                    protector intercepts first and only its unabsorbed remainder
-                                    cascades to the next. More implant and gear-set effects will be
-                                    added in future updates.
+                                    unaffected. Protection covers all living allies (not only
+                                    adjacent ones), allowing any protected ship to intercept damage
+                                    for any teammate. When more than one ally holds Protection, the
+                                    faster protector intercepts first and only its unabsorbed
+                                    remainder cascades to the next. <strong>Lionheart</strong> uses
+                                    a once-per-round variant: it gains 10 stacks of Protection at
+                                    the start of each round, and after it absorbs the first hit
+                                    redirected from an ally, it loses all Protection until the next
+                                    round. More implant and gear-set effects will be added in future
+                                    updates.
                                 </p>
                             </div>
                         </div>

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -557,6 +557,9 @@ export type AbilityConfig =
           isStackable: boolean;
           maxStacks?: number;
           stackTrigger?: StackTrigger;
+          /** Lionheart: a redirected hit clears the WHOLE Protection pool (distinct from a normal
+           *  per-hit consume). Absent → no clear-on-redirect behavior. */
+          clearAllOnRedirect?: boolean;
           duration?: number | 'recurring';
           /** "Once per battle" reactive buff grant (Tycho/Shelter/Los on-hp-threshold-crossed
            *  crossing grants): the executor fires AT MOST ONCE per combat, tracked by a
@@ -572,6 +575,7 @@ export type AbilityConfig =
               stacks: number;
               isStackable: boolean;
               maxStacks?: number;
+              clearAllOnRedirect?: boolean;
               duration: number;
           }>;
       }
@@ -583,6 +587,7 @@ export type AbilityConfig =
           isStackable: boolean;
           maxStacks?: number;
           stackTrigger?: StackTrigger;
+          clearAllOnRedirect?: boolean;
           application: 'inflict' | 'apply';
           duration?: number | 'recurring';
       }

--- a/src/types/calculator.ts
+++ b/src/types/calculator.ts
@@ -168,6 +168,9 @@ export interface SelectedGameBuff {
     application?: 'inflict' | 'apply';
     /** Parser ally-scope (team walk): granular target of the granting clause; absent on manual picks. */
     effectTarget?: 'self' | 'ally' | 'all-allies' | 'enemy';
+    // Lionheart: Protection removed entirely after it redirects a hit (consumable). Carried to
+    // the buff ability config so the engine clears stacks post-redirect.
+    clearAllOnRedirect?: boolean;
 }
 
 export interface DPSShipConfig {

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -2227,6 +2227,42 @@ describe('parseAllSkillEffects', () => {
         expect(result.find((e) => e.source === 'active')?.buffName).toBe('Defense Down II');
         expect(result.find((e) => e.source === 'charge')?.buffName).toBe('Attack Up III');
     });
+
+    // Lionheart R4 refit-active passive (docs/ship-skills.csv, verbatim). Its round-start
+    // Protection grant is a FIXED pool (a redirect clears it entirely) — refresh-to-10, not
+    // accumulate. maxStacks/clearAllOnRedirect tag this so the engine (Task 4) can cap +
+    // clear it, distinct from Meatshield's accumulating start-of-combat grant below.
+    it('Lionheart: round-start Protection grant carries maxStacks + clearAllOnRedirect', () => {
+        const lionheart = {
+            refits: [{}, {}, {}, {}],
+            thirdPassiveSkillText:
+                'At the start of combat, this Unit grants all adjacent allies 10% of its HP.<br /><br />At the start of the round, this Unit gains 10 stacks of <unit-skill>Protection</unit-skill>.<br />After taking damage redirected through <unit-skill>Protection</unit-skill>, all <unit-skill>Protection</unit-skill> is removed.',
+        } as unknown as Ship;
+        const effects = parseAllSkillEffects(lionheart);
+        const prot = effects.find((e) => e.buffName === 'Protection');
+        expect(prot).toBeDefined();
+        expect(prot!.stacks).toBe(10);
+        expect(prot!.stackTrigger).toBe('per-round');
+        expect(prot!.maxStacks).toBe(10);
+        expect(prot!.clearAllOnRedirect).toBe(true);
+    });
+
+    // Negative case: Meatshield's R4 refit-active passive also grants/mentions Protection, but
+    // is an accumulating start-of-combat one-shot with an UNRELATED "transformed into a DoT"
+    // clause — not a redirect-clear. Must stay byte-identical (no maxStacks/clearAllOnRedirect).
+    it('does NOT tag Meatshield\'s Protection grant with maxStacks/clearAllOnRedirect (unrelated "transformed into a DoT" clause)', () => {
+        const meatshield = {
+            refits: [{}, {}, {}, {}],
+            thirdPassiveSkillText:
+                "At the start of combat, this Unit gains 3 stacks of <unit-skill>Protection</unit-skill>.<br /><br />Any damage this Unit takes from <unit-skill>Protection</unit-skill> is transformed into a <unit-aid>Damage over Time effect</unit-aid> for 2 turns.<br /><br />Any direct damage dealt to a non-defender ally that is not transferred by <unit-skill>Protection</unit-skill> is dealt as if that ally had this Unit's defense.",
+        } as unknown as Ship;
+        const effects = parseAllSkillEffects(meatshield);
+        const prot = effects.find((e) => e.buffName === 'Protection');
+        expect(prot).toBeDefined();
+        expect(prot!.stacks).toBe(3);
+        expect(prot!.maxStacks).toBeUndefined();
+        expect(prot!.clearAllOnRedirect).toBeUndefined();
+    });
 });
 
 describe('detectGrantConditions', () => {

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -1508,6 +1508,26 @@ describe('buildShipAbilities', () => {
         });
     });
 
+    // Lionheart R4 refit-active passive (docs/ship-skills.csv, verbatim): the round-start
+    // Protection grant is a consumable FIXED pool (a redirected hit clears it entirely), so it
+    // must refresh to 10 each round rather than accumulate — maxStacks + clearAllOnRedirect are
+    // threaded through to the buff config for the engine (Task 4) to consume.
+    it('Lionheart: Protection buff ability carries maxStacks:10 + clearAllOnRedirect', () => {
+        const s = ship({
+            thirdPassiveSkillText:
+                'At the start of combat, this Unit grants all adjacent allies 10% of its HP.<br /><br />At the start of the round, this Unit gains 10 stacks of <unit-skill>Protection</unit-skill>.<br />After taking damage redirected through <unit-skill>Protection</unit-skill>, all <unit-skill>Protection</unit-skill> is removed.',
+        });
+        const passive = slot(buildShipAbilities(s).slots, 'passive')!;
+        const prot = passive.abilities.find(
+            (a) => a.config.type === 'buff' && a.config.buffName === 'Protection'
+        );
+        expect(prot).toBeDefined();
+        expect(prot!.config.type === 'buff' && prot!.config.stackTrigger).toBe('per-round');
+        expect(prot!.config.type === 'buff' && prot!.config.isStackable).toBe(true);
+        expect(prot!.config.type === 'buff' && prot!.config.maxStacks).toBe(10);
+        expect(prot!.config.type === 'buff' && prot!.config.clearAllOnRedirect).toBe(true);
+    });
+
     // Cleanse-triggered & ally-damage-triggered PASSIVE repairs resolve their real recipient
     // (user-verified 2026-06-07). A bare passive repair (no explicit recipient phrase) is normally
     // a self-heal, but two trigger shapes flip it to the ally: (A) an "when an ally … damaged"

--- a/src/utils/abilities/buffAbilityConverters.ts
+++ b/src/utils/abilities/buffAbilityConverters.ts
@@ -28,6 +28,7 @@ export function abilityToSelectedBuff(ability: Ability, slot: SkillSlot): Select
         skillSource,
         skillDuration: c.duration,
         ...(c.type === 'debuff' ? { application: c.application } : {}),
+        ...(c.clearAllOnRedirect ? { clearAllOnRedirect: true } : {}),
     };
 }
 
@@ -53,6 +54,7 @@ export function selectedBuffToAbility(buff: SelectedGameBuff, target: AbilityTar
                   isStackable: buff.isStackable,
                   maxStacks: buff.maxStacks,
                   stackTrigger: buff.stackTrigger,
+                  ...(buff.clearAllOnRedirect ? { clearAllOnRedirect: true } : {}),
                   duration,
                   // Default to the resistible 'inflict' (the common case + matches makeDefaultAbility);
                   // only an explicitly-parsed 'apply' verb makes a debuff guaranteed.
@@ -66,6 +68,7 @@ export function selectedBuffToAbility(buff: SelectedGameBuff, target: AbilityTar
                   isStackable: buff.isStackable,
                   maxStacks: buff.maxStacks,
                   stackTrigger: buff.stackTrigger,
+                  ...(buff.clearAllOnRedirect ? { clearAllOnRedirect: true } : {}),
                   duration,
               },
     };

--- a/src/utils/calculators/__tests__/battleSimulatorDefenseSubstitution.test.ts
+++ b/src/utils/calculators/__tests__/battleSimulatorDefenseSubstitution.test.ts
@@ -156,14 +156,25 @@ const incomingDamageR1 = (result: ReturnType<typeof simulateBattle>): number => 
 };
 
 describe('simulateBattle — Meatshield defense-substitution on the REAL production path (Critical fix)', () => {
-    it('a DEFENDER ally is NOT substituted: damage taken is IDENTICAL with or without the Meatshield teammate', () => {
+    it("a DEFENDER ally is NOT substituted, but still gets Meatshield's Protection-transfer reduction (transfer is role-agnostic; only substitution is defender-gated)", () => {
+        // Positions here (ally M4, Meatshield M1) are NOT hex-neighbours. Protection coverage is
+        // ALL living same-side allies, independent of board adjacency (confirmed model, PR #247 +
+        // the adjacency-narrowing fix) — so Meatshield's self-granted 3 Protection stacks still
+        // redirect 30% of the ally's incoming hit to itself, re-mitigated on Meatshield's OWN
+        // defence, REGARDLESS of the ally's role. Only the SEPARATE defense-substitution clause
+        // ("...dealt as if that ally had this Unit's defense") is gated to non-defenders — the
+        // R4 text itself scopes substitution to the UN-transferred remainder of a non-defender
+        // ally's damage, so a DEFENDER's remainder keeps ITS OWN (unsubstituted) defence.
         const alone = incomingDamageR1(simulateBattle(allyAloneInput('DEFENDER')));
         const withMeatshield = incomingDamageR1(
             simulateBattle(allyWithMeatshieldInput('DEFENDER'))
         );
 
         expect(alone).toBeGreaterThan(0);
-        expect(withMeatshield).toBeCloseTo(alone, 5);
+        // Exactly the 3-stack (30%) Protection-transfer reduction — no additional substitution
+        // discount (which would further shrink this below 0.7x, since Meatshield's defence 5000
+        // vastly exceeds the ally's own 200).
+        expect(withMeatshield).toBeCloseTo(alone * 0.7, 6);
     });
 
     it('an ATTACKER (non-defender) ally IS substituted: damage taken drops when the Meatshield teammate is present', () => {

--- a/src/utils/calculators/skillBuffAutoFill.ts
+++ b/src/utils/calculators/skillBuffAutoFill.ts
@@ -82,7 +82,11 @@ function toSelectedBuffs(
             stacks: effect.stacks ?? 1,
             parsedEffects,
             isStackable: stackInfo.stackable,
-            maxStacks: stackInfo.maxStacks,
+            // Lionheart: a consumable Protection grant (maxStacks set by the parser) is a FIXED
+            // pool that refreshes each round rather than accumulating past it — prefer the
+            // parser's grant-count cap over the buff description's own stack ceiling. Meatshield
+            // sets no effect.maxStacks, so it keeps stackInfo.maxStacks (byte-identical).
+            maxStacks: effect.maxStacks ?? stackInfo.maxStacks,
             autoFilled: true,
             skillSource: effect.source,
             skillDuration: effect.duration,
@@ -92,6 +96,7 @@ function toSelectedBuffs(
             ...(effect.application !== undefined ? { application: effect.application } : {}),
             // Carry the granular ally-scope so the builder can stamp the right ability target.
             effectTarget: effect.target,
+            ...(effect.clearAllOnRedirect ? { clearAllOnRedirect: true } : {}),
         });
     }
 

--- a/src/utils/combat/__tests__/lionheartProtection.integration.test.ts
+++ b/src/utils/combat/__tests__/lionheartProtection.integration.test.ts
@@ -33,12 +33,15 @@ const manualEnemy = (id: string, attack: number): EnemyAttacker => ({
 
 /** A walked player team actor (a pure victim/protector stat block, role ATTACKER so it is a
  *  valid victim). Optional `passive` slots carry an ability (e.g. Lionheart's Protection grant).
+ *  Optional `hp` (default a large sink) lets a protector be given a LOW hp so it can be killed
+ *  by its own redirected chunk mid-round (used by the chunk.total===0 guard test below).
  */
 const teamActor = (
     id: string,
     defence: number,
     passive?: ShipSkills['slots'],
-    speed = 100
+    speed = 100,
+    hp = 1_000_000_000
 ): TeamActorEngineInput => ({
     id,
     speed,
@@ -56,7 +59,7 @@ const teamActor = (
             defensePenetration: 0,
             hacking: 0,
             defence,
-            hp: 1_000_000_000,
+            hp,
         },
         selfDotModifier: 0,
         defensePenetrationBuff: 0,
@@ -66,6 +69,28 @@ const teamActor = (
         hasChargedSkill: false,
     },
 });
+
+/** A passive slot that grants SELF `Protection` the AURA way (Meatshield-style: a static buff
+ *  config, no duration, isStackable) — used as the "Other" fully-stacked, SLOWER protector in
+ *  the chunk.total===0 guard test below. Distinct from `lionheartProtectionPassive`'s per-round
+ *  accumulating shape; either shape reads through the same all-sources stack resolver. */
+const otherProtectionAuraPassive = (stacks: number): ShipSkills['slots'][number] => {
+    const ability: Ability = {
+        id: 'other-protection',
+        type: 'buff',
+        target: 'self',
+        trigger: 'on-cast',
+        conditions: [],
+        config: {
+            type: 'buff',
+            buffName: 'Protection',
+            parsedEffects: {},
+            stacks,
+            isStackable: true,
+        },
+    };
+    return { slot: 'passive', abilities: [ability] };
+};
 
 /** Lionheart R4's round-start Protection grant, as the parser really emits it: a per-round
  *  ACCUMULATING buff (rate = stacks = 10, capped at maxStacks = 10) whose config carries
@@ -142,5 +167,69 @@ describe('Lionheart Protection — clear-on-redirect (integration)', () => {
         // Round 2: beginRound's top-of-round tick re-accumulates 0 -> 10 (refresh-to-10) ->
         // the redirect resumes on round 2's first hit.
         expect(lionheartR2).toBeGreaterThan(0);
+    });
+});
+
+// ───────────────────────────────────────────────────────────────────────────────────────
+// Finding 1 (final-review) — the clear-on-redirect loop must be gated on the protector's OWN
+// cascade chunk having actually redirected something (`chunk.total > 0`), not fired
+// unconditionally for every `clearProtectionOnRedirectIds` member present in `protectors`.
+//
+// Reachable scenario: TWO protectors cover the same victim — Lionheart (FASTER, 10 stacks via
+// its per-round accumulating grant) and a second, SLOWER, fully-stacked (10 stacks, aura-granted)
+// protector "other". `protectionCascade`'s cascade math (protectionTransfer.ts) computes each
+// protector's `kept` share as `(1 - nextFrac) * flow * mit`, where `nextFrac` is the fraction the
+// NEXT (slower) protector in the chain drains before the current protector's share is realized.
+// Because "other" also has max stacks (frac = 1.0), Lionheart's OWN kept share collapses to
+// `(1 - 1.0) * flow * mit = 0` — "other" fully drains whatever cascades through Lionheart before
+// Lionheart's cut is realized, even though Lionheart is the FASTER (first) protector in the chain
+// and genuinely holds 10 Protection stacks. This is the `chunk.total === 0` case the guard exists
+// for. Verified directly with `protectionCascade` inputs mirroring this exact setup (both
+// protectors at max stacks, mit=1): chunks = [{total: 0}, {total: 1000}] — confirming Lionheart's
+// own chunk is genuinely 0 while "other" absorbs the full redirected amount.
+//
+// "other" is given deliberately low HP (500) so it DIES partway through absorbing its ~1000
+// chunk (10 sub-hits of ~100 each) — removing it from `protectorsFor` for the round's SECOND
+// hit. That isolates the observable difference: with the buggy unconditional clear, Lionheart's
+// Protection is wiped after hit 1 (despite its chunk being 0) -> by hit 2, BOTH protectors are
+// gone (other dead, Lionheart cleared) -> the ally eats the full second hit. With the guard, hit
+// 1 leaves Lionheart's Protection intact (its chunk was 0, so the clear never fires) -> by hit 2,
+// Lionheart is the sole living protector and still redirects it in full.
+describe('Lionheart Protection — clear-on-redirect guard: chunk.total === 0 must NOT clear (Finding 1)', () => {
+    const OTHER_DEFENCE = 0;
+    const OTHER_HP = 500; // < the ~1000 total chunk "other" absorbs on hit 1 -> dies mid-hit-1.
+
+    const guardInput: CombatEngineInput = {
+        ...BASE_INPUT,
+        numRounds: 1,
+        teamActors: [
+            teamActor('ally-1', 0), // the direct-hit victim (no Protection of its own).
+            teamActor('lionheart', LIONHEART_DEFENCE, [lionheartProtectionPassive()], 100), // FASTER protector.
+            teamActor('other', OTHER_DEFENCE, [otherProtectionAuraPassive(10)], 50, OTHER_HP), // SLOWER, max-stack, low-HP protector.
+        ],
+        enemyAttackers: [
+            manualEnemy('enemy-A', ENEMY_ATTACK),
+            manualEnemy('enemy-B', ENEMY_ATTACK),
+        ],
+    };
+
+    it("Lionheart's own chunk is drained to 0 by a slower, fully-stacked protector on hit 1 (that protector then dies); Lionheart's Protection must survive to redirect hit 2 in full", () => {
+        const res = runCombat(guardInput);
+
+        const allyR1 = res.rounds[0]?.perActorIncoming?.['ally-1']?.incoming ?? 0;
+        const lionheartR1 = res.rounds[0]?.perActorIncoming?.['lionheart']?.incoming ?? 0;
+        const otherR1 = res.rounds[0]?.perActorIncoming?.['other']?.incoming ?? 0;
+
+        // "other" (the last/slowest protector in the cascade) absorbed the (near-)full hit-1
+        // amount and died from it — confirms the chunk-math setup landed as designed.
+        expect(otherR1).toBeGreaterThan(0);
+
+        // THE GUARD ASSERTION: with the fix, Lionheart's Protection was NOT cleared after hit 1
+        // (its own chunk there was 0) — so it is still the sole living protector for hit 2 and
+        // redirects that hit in full. Under the unconditional-clear bug, Lionheart would have
+        // been cleared after hit 1 (despite absorbing nothing), "other" is already dead, so hit 2
+        // would land entirely on the ally instead (allyR1 ~= ENEMY_ATTACK, lionheartR1 ~= 0).
+        expect(allyR1).toBeCloseTo(0, 4);
+        expect(lionheartR1).toBeGreaterThan(0);
     });
 });

--- a/src/utils/combat/__tests__/lionheartProtection.integration.test.ts
+++ b/src/utils/combat/__tests__/lionheartProtection.integration.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Lionheart Protection — clear-on-redirect ENGINE integration (Task 4, consumer of Task 1's
+ * `hasAnyProtectionGrant` precompute + Task 3's `clearAllOnRedirect` buff-config field).
+ *
+ * Lionheart R4 grants itself 10 stacks of Protection at the top of every round (a real
+ * ABILITY-SOURCED ACCUMULATING status: `type:'buff'`, `stackTrigger:'per-round'`,
+ * `isStackable:true`, `maxStacks:10` — registered via `registerActorAbilityStatuses` into
+ * `accumSelfMaps`, read via `selfBuffStacksForOwner`'s 3-source fold). At 10 stacks (100%
+ * redirect fraction, 10%/stack), Lionheart intercepts the FIRST ally hit each round in full —
+ * then, per its kit text ("all Protection is removed" after a redirect), the WHOLE pool is
+ * cleared (not just decremented), so a SECOND hit the same round is NOT redirected. The next
+ * round's `beginRound` top-of-round tick re-accumulates 0 -> min(0+10,10) = 10, so the redirect
+ * resumes.
+ *
+ * This mirrors protectionTransfer.integration.test.ts's "PRODUCTION PATH" aura-protector test,
+ * but the protector's Protection is the real accumulating-ability shape (not the static aura
+ * helper `protectionAuraPassive`), and TWO enemies fire at the SAME adjacent ally in round 1 so
+ * both the redirect and its one-shot consumption are exercised within a single round.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import type { Ability, ShipSkills } from '../../../types/abilities';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+/** A flat enemy attacker (no shipSkills -> engine synthesizes a single 100% basic hit). */
+const manualEnemy = (id: string, attack: number): EnemyAttacker => ({
+    id,
+    stats: { attack, crit: 0, critDamage: 0, speed: 50 },
+    chargeCount: 0,
+    startCharged: false,
+});
+
+/** A walked player team actor (a pure victim/protector stat block, role ATTACKER so it is a
+ *  valid victim). Optional `passive` slots carry an ability (e.g. Lionheart's Protection grant).
+ */
+const teamActor = (
+    id: string,
+    defence: number,
+    passive?: ShipSkills['slots'],
+    speed = 100
+): TeamActorEngineInput => ({
+    id,
+    speed,
+    chargeCount: 0,
+    startCharged: false,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    role: 'ATTACKER',
+    walk: {
+        shipSkills: { slots: passive ?? [] },
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            hacking: 0,
+            defence,
+            hp: 1_000_000_000,
+        },
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        hasChargedSkill: false,
+    },
+});
+
+/** Lionheart R4's round-start Protection grant, as the parser really emits it: a per-round
+ *  ACCUMULATING buff (rate = stacks = 10, capped at maxStacks = 10) whose config carries
+ *  `clearAllOnRedirect: true` — the field Task 3 threaded onto the buff-config type and this
+ *  task's engine consumer (`clearProtectionOnRedirectIds`) scans for. */
+const lionheartProtectionPassive = (): ShipSkills['slots'][number] => {
+    const ability: Ability = {
+        id: 'lionheart-protection',
+        type: 'buff',
+        target: 'self',
+        trigger: 'on-cast',
+        conditions: [],
+        config: {
+            type: 'buff',
+            buffName: 'Protection',
+            parsedEffects: {},
+            stacks: 10,
+            isStackable: true,
+            maxStacks: 10,
+            stackTrigger: 'per-round',
+            clearAllOnRedirect: true,
+        },
+    };
+    return { slot: 'passive', abilities: [ability] };
+};
+
+const ENEMY_ATTACK = 1000;
+const LIONHEART_DEFENCE = 300;
+
+const BASE_INPUT: CombatEngineInput = {
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [] }, // the focus deals no offence itself; it is only a bystander.
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 2,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healTargetId: 'ally-1', // both manual enemies fire at this single shared victim.
+    teamActors: [
+        teamActor('ally-1', 0), // the direct-hit victim (no Protection of its own).
+        teamActor('lionheart', LIONHEART_DEFENCE, [lionheartProtectionPassive()]), // the protector.
+    ],
+    enemyAttackers: [manualEnemy('enemy-A', ENEMY_ATTACK), manualEnemy('enemy-B', ENEMY_ATTACK)],
+};
+
+describe('Lionheart Protection — clear-on-redirect (integration)', () => {
+    it('redirects the FIRST ally-hit each round, then clears — the SECOND hit is NOT redirected; refresh-to-10 re-grants the redirect next round', () => {
+        const res = runCombat(BASE_INPUT);
+
+        const lionheartR1 = res.rounds[0]?.perActorIncoming?.['lionheart']?.incoming ?? 0;
+        const allyR1 = res.rounds[0]?.perActorIncoming?.['ally-1']?.incoming ?? 0;
+        const lionheartR2 = res.rounds[1]?.perActorIncoming?.['lionheart']?.incoming ?? 0;
+
+        // Round 1, hit 1 (enemy-A): 10 stacks = 100% redirect fraction -> Lionheart takes the
+        // WHOLE hit (re-mitigated on its own defence); the ally takes nothing from this hit.
+        expect(lionheartR1).toBeGreaterThan(0);
+        // Round 1, hit 2 (enemy-B): Protection was cleared after hit 1 -> NOT redirected -> the
+        // ally takes this hit directly. If the clear loop did not reach the ability-sourced
+        // accumulating Protection, this hit would ALSO redirect and allyR1 would be 0.
+        expect(allyR1).toBeGreaterThan(0);
+        // Round 2: beginRound's top-of-round tick re-accumulates 0 -> 10 (refresh-to-10) ->
+        // the redirect resumes on round 2's first hit.
+        expect(lionheartR2).toBeGreaterThan(0);
+    });
+});

--- a/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
+++ b/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
@@ -309,6 +309,25 @@ describe('Protection damage transfer (integration)', () => {
         expect(slowProtector).toBeCloseTo(wouldBeDirectSkim * frac1, 4);
     });
 
+    it('no Protection anywhere on the board → no redirect (hasAnyProtectionGrant gate short-circuits protectorsFor)', () => {
+        // No ability anywhere on the board grants Protection (focus selfBuffs empty, no aura
+        // passives on the team actor) — hasAnyProtectionGrant is false, so protectorsFor
+        // short-circuits to [] and the ally eats the full, non-redirected hit.
+        const input = BASE_INPUT({
+            selfBuffs: [],
+            teamActors: [teamActor('ally-1', 0)],
+            enemyAttackers: [manualEnemy('enemy-1', ENEMY_ATTACK)],
+        });
+
+        const victim = totalIncoming(input, 'ally-1');
+        const focus = totalIncoming(input, 'attacker');
+
+        // Full hit lands on the ally — no redirect.
+        expect(victim).toBeCloseTo(ENEMY_ATTACK, 6);
+        // No chunk was ever redirected to the focus (which would be the protector if Protection existed).
+        expect(focus).toBe(0);
+    });
+
     it('PRODUCTION PATH: aura-granted Protection on a NON-focus team-actor protector fires the redirect (reads exactly the granted stacks, no double-count)', () => {
         // The whole point of the all-sources read: a real Meatshield grants Protection as an AURA
         // (activeAbilityStatuses), which the old snapshot()-only read MISSED — and it sits on a

--- a/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
+++ b/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
@@ -358,6 +358,36 @@ describe('Protection damage transfer (integration)', () => {
         const expectedChunk = 0.3 * ENEMY_ATTACK * (mit(PROTECTOR_DEFENCE) / mit(0));
         expect(protector).toBeCloseTo(expectedChunk, 4);
     });
+
+    it('positional mode: Protection covers a NON-adjacent ally (all-allies, not hex-neighbours)', () => {
+        // Wiring `position` on the victim AND another player actor makes `anyOtherPositioned`
+        // true, so `adjacentAllyIdsFor` (adjacency.ts) would narrow to hex-neighbours instead of
+        // falling back to "all living same-side allies". T1's hex-neighbours are {T2, M1, M2}
+        // (see board.ts's AXIAL table / DIRECTIONS) — T4 is deliberately NOT one of them. Under
+        // the OLD adjacency-based resolution this protector would be excluded from
+        // `protectorsFor`; Protection's confirmed model (coverage = ALL living same-side allies,
+        // independent of board adjacency) must still redirect to it.
+        const input = BASE_INPUT({
+            selfBuffs: [], // the focus carries no Protection — the protector is a team actor.
+            defence: 0,
+            teamActors: [
+                { ...teamActor('ally-1', 0), position: 'T1' }, // victim
+                {
+                    ...teamActor('prot-1', PROTECTOR_DEFENCE, [protectionAuraPassive(3)]),
+                    position: 'T4', // NOT a hex-neighbour of T1 — proves all-allies coverage.
+                },
+            ],
+            enemyAttackers: [manualEnemy('enemy-1', ENEMY_ATTACK)],
+        });
+
+        const victim = totalIncoming(input, 'ally-1');
+        const protectorIncoming = totalIncoming(input, 'prot-1');
+
+        // The redirect fires even though the protector is NOT a hex-neighbour of the victim.
+        expect(protectorIncoming).toBeGreaterThan(0);
+        // Same 3-stack magnitude as the non-positional aura test above (identical coverage).
+        expect(victim).toBeCloseTo(0.7 * ENEMY_ATTACK, 6);
+    });
 });
 
 // ───────────────────────────────────────────────────────────────────────────────────────

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2920,9 +2920,14 @@ export function runCombat(input: CombatEngineInput): {
     // defenseSubstitutionCarrierIds. Fastest-first ordering drives the multi-protector cascade.
     const protectorsFor = (victim: CombatActor): { actor: CombatActor; stacks: number }[] => {
         if (!hasAnyProtectionGrant) return [];
-        const allyIds = bySide(isEnemySide(victim.id) ? 'enemy' : 'player').adjacentAllyIdsFor(
-            victim.id
-        );
+        // Protection coverage = ALL living same-side allies (no self-cover), independent of
+        // board adjacency. `adjacentAllyIdsFor` narrows to hex-neighbours in positional
+        // encounters, which would wrongly shrink coverage — genuinely adjacency-scoped
+        // mechanics (Lionheart's pre-combat HP gift, Centurion) keep using it; Protection
+        // does not. Behavior-identical to before in non-positional production.
+        const allyIds = [...allActorsById.values()]
+            .filter((a) => a.side === victim.side && a.currentHp > 0 && a.id !== victim.id)
+            .map((a) => a.id);
         const out: { actor: CombatActor; stacks: number }[] = [];
         for (const id of allyIds) {
             if (id === victim.id) continue;

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2894,6 +2894,24 @@ export function runCombat(input: CombatEngineInput): {
             }
         }
     }
+    // Ships whose Protection is consumable (Lionheart R4: "all Protection is removed" after a
+    // redirect). Scanned once from both runtime maps, slot-agnostic, mirroring hasAnyProtectionGrant.
+    const clearProtectionOnRedirectIds = new Set<string>();
+    for (const rt of [...runtimesById.values(), ...enemyPlayerRuntimeByActorId.values()]) {
+        for (const slot of rt.castSkills.slots) {
+            if (
+                slot.abilities.some(
+                    (a) =>
+                        a.config.type === 'buff' &&
+                        a.config.buffName === 'Protection' &&
+                        a.config.clearAllOnRedirect === true
+                )
+            ) {
+                clearProtectionOnRedirectIds.add(rt.actor.id);
+                break;
+            }
+        }
+    }
     // Board-level Protection gate: true iff ANY ability on the board grants Protection, OR any
     // actor carries a SCHEDULED Protection self-buff (SelectedGameBuff — the DPS/Healing
     // Calculator's manual "active buffs" input, e.g. protectionAccum in tests; independent of any
@@ -2914,6 +2932,9 @@ export function runCombat(input: CombatEngineInput): {
                 )
             )
         );
+    // NOTE: neither `hasAnyProtectionGrant` nor `clearProtectionOnRedirectIds` scans
+    // `reactiveAbilities` (partitioned out of `castSkills` above) — no ship grants Protection
+    // reactively today. If one is added, both gates need a matching branch over the reactive list.
     // Protection damage transfer (deferred mechanic, now consumed). A protector is any living
     // ally that holds >=1 Protection stack; it intercepts a fraction of its allies' direct
     // damage. Side-agnostic by construction (resolves allies via bySide), mirroring
@@ -3625,6 +3646,16 @@ export function runCombat(input: CombatEngineInput): {
                             triggerActorId: actingActorId,
                         });
                     });
+                    // Lionheart R4: a consumable protector loses ALL Protection after it
+                    // redirects a hit. The cascade was precomputed from pre-hit stacks, so THIS
+                    // hit already redirected fully; clearing now only affects later hits this
+                    // round. `removeSelfBuffByName` zeroes the accumulating stacks (Overload
+                    // precedent) → next round's beginRound re-accumulates to maxStacks (=10).
+                    for (const p of protectors) {
+                        if (clearProtectionOnRedirectIds.has(p.actor.id)) {
+                            statusEngine.removeSelfBuffByName(p.actor.id, 'Protection');
+                        }
+                    }
                     // The victim now only takes the non-transferred remainder.
                     damage = cascade.targetRemainder;
                 }

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2894,11 +2894,32 @@ export function runCombat(input: CombatEngineInput): {
             }
         }
     }
+    // Board-level Protection gate: true iff ANY ability on the board grants Protection, OR any
+    // actor carries a SCHEDULED Protection self-buff (SelectedGameBuff — the DPS/Healing
+    // Calculator's manual "active buffs" input, e.g. protectionAccum in tests; independent of any
+    // ability). `selfBuffLookup` (built above from `[...selfBuffs, ...teamActors.flatMap(t =>
+    // t.selfBuffs)]`) already indexes every scheduled self-buff by name, so re-using it here is
+    // the cheapest correct check for that source. A board-level boolean (not a per-actor carrier
+    // Set) is deliberate — Protection can be stolen/transferred onto a ship that carries no grant
+    // of its own (deferred mechanic), and the boolean only asserts "Protection is possible here,"
+    // which is the gate protectorsFor needs. Scans ALL slots (not just passive, unlike
+    // defenseSubstitutionCarrierIds) because Lionheart's round-start grant and a future
+    // charge-slot steal are not passive-slot auras.
+    const hasAnyProtectionGrant =
+        (selfBuffLookup.get('Protection')?.length ?? 0) > 0 ||
+        [...runtimesById.values(), ...enemyPlayerRuntimeByActorId.values()].some((rt) =>
+            rt.castSkills.slots.some((slot) =>
+                slot.abilities.some(
+                    (a) => a.config.type === 'buff' && a.config.buffName === 'Protection'
+                )
+            )
+        );
     // Protection damage transfer (deferred mechanic, now consumed). A protector is any living
     // ally that holds >=1 Protection stack; it intercepts a fraction of its allies' direct
     // damage. Side-agnostic by construction (resolves allies via bySide), mirroring
     // defenseSubstitutionCarrierIds. Fastest-first ordering drives the multi-protector cascade.
     const protectorsFor = (victim: CombatActor): { actor: CombatActor; stacks: number }[] => {
+        if (!hasAnyProtectionGrant) return [];
         const allyIds = bySide(isEnemySide(victim.id) ? 'enemy' : 'player').adjacentAllyIdsFor(
             victim.id
         );

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3651,11 +3651,18 @@ export function runCombat(input: CombatEngineInput): {
                     // hit already redirected fully; clearing now only affects later hits this
                     // round. `removeSelfBuffByName` zeroes the accumulating stacks (Overload
                     // precedent) → next round's beginRound re-accumulates to maxStacks (=10).
-                    for (const p of protectors) {
+                    // Gate on the protector's OWN chunk having actually redirected something —
+                    // a faster protector upstream in the cascade can absorb the hit fully,
+                    // leaving THIS protector's chunk at 0 even though it holds Protection stacks;
+                    // the kit text ("after taking damage redirected through Protection") only
+                    // fires the clear when a redirected chunk was actually taken.
+                    protectors.forEach((p, i) => {
+                        const chunk = cascade.chunks[i];
+                        if (!chunk || chunk.total <= 0) return;
                         if (clearProtectionOnRedirectIds.has(p.actor.id)) {
                             statusEngine.removeSelfBuffByName(p.actor.id, 'Protection');
                         }
-                    }
+                    });
                     // The victim now only takes the non-transferred remainder.
                     damage = cascade.targetRemainder;
                 }

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -4681,6 +4681,11 @@ export function parseSkillEffects(
         // unrelated "at the start of combat" clause (Lionheart's HP-grant sentence precedes its
         // round-start Protection grant with no intervening tag) that would otherwise false-positive
         // the later per-round grant as a one-shot. Verified corpus-wide unique to Lionheart.
+        // NB: this raw `lastIndexOf('.')` sentence split does NOT mask buff-name abbreviation
+        // periods ("Inc."/"Out."), unlike the sentence-split scoping in skillTextParser's clause
+        // splitter and auditSkills. Safe today because such abbreviation periods live inside
+        // `<unit-skill>` tags, not in the inter-tag text `prevText` reads here — but a future
+        // untagged abbreviation clause could over-narrow this current-sentence slice.
         const lastSentenceBoundary = prevText.lastIndexOf('.');
         const currentClauseText =
             lastSentenceBoundary === -1 ? prevText : prevText.slice(lastSentenceBoundary + 1);

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -4180,6 +4180,10 @@ export interface SkillEffect {
     stackTrigger?: StackTrigger;
     // Enemy debuffs only: 'inflict' verbs are resistible, 'apply' verbs are guaranteed.
     application?: 'inflict' | 'apply';
+    // Lionheart: a consumable Protection ("all Protection is removed" after a redirect) has a
+    // FIXED pool — the round-start grant refreshes to `maxStacks`, it does not accumulate.
+    maxStacks?: number;
+    clearAllOnRedirect?: boolean;
 }
 
 // Application verbs grouped by the side they target, covering each verb's
@@ -4207,6 +4211,13 @@ const DURATION_RE = /for\s+(\d+)\s+turns?/i;
 const RECURRING_RE = /every\s+turn/i;
 // Matches "N stacks of" at the END of a text segment (immediately before the tag)
 const STACKS_RE = /(\d+)\s+stacks?\s+of\s*$/i;
+// Lionheart refit passive: "After taking damage redirected through Protection, all Protection
+// is removed." Marks the ship's Protection grant as consumable (clear-all-on-redirect) and,
+// because such Protection is a fixed pool, caps its round-start accumulation at the grant count
+// (refresh-to-N, not accumulate). Reference data: docs/ship-skills.csv. Tested against
+// tag-stripped text (stripUnitTags) since "Protection" is <unit-skill>-wrapped in the raw string.
+const CLEAR_PROTECTION_ON_REDIRECT_RE =
+    /after taking damage redirected through protection,\s*all protection is removed/i;
 // Matches text that is ONLY connectors between tags (e.g. " and ", ", ", " or "), optionally
 // tolerating ONE bridging application verb between conjoined tags governed by different verbs —
 // "gains X and inflicts Y ... for N turns" (Bayah) has "inflicts" sitting between the two buff
@@ -4665,7 +4676,15 @@ export function parseSkillEffects(
         // isAccumulatingBuff gate is false and the pre-combat relabel fires. The N-stack count and
         // the persistent 'recurring' duration are preserved (seeded once at combat start).
         let stackTrigger: StackTrigger | undefined;
-        const startOfCombatOneShot = START_OF_COMBAT_GRANT_RE.test(prevText);
+        // Scope the one-shot check to the CURRENT sentence only (text since the last sentence
+        // boundary), not the whole prevText blob — a multi-sentence passive can carry an earlier,
+        // unrelated "at the start of combat" clause (Lionheart's HP-grant sentence precedes its
+        // round-start Protection grant with no intervening tag) that would otherwise false-positive
+        // the later per-round grant as a one-shot. Verified corpus-wide unique to Lionheart.
+        const lastSentenceBoundary = prevText.lastIndexOf('.');
+        const currentClauseText =
+            lastSentenceBoundary === -1 ? prevText : prevText.slice(lastSentenceBoundary + 1);
+        const startOfCombatOneShot = START_OF_COMBAT_GRANT_RE.test(currentClauseText);
         if (stacks !== undefined && duration === 'recurring' && !startOfCombatOneShot) {
             if (source === 'passive1' || source === 'passive2' || source === 'passive3') {
                 stackTrigger = 'per-round';
@@ -4676,6 +4695,14 @@ export function parseSkillEffects(
             }
         }
 
+        // Lionheart: a Protection grant is consumable (a redirected hit clears the whole pool) —
+        // cap the round-start accumulation at the grant count (refresh-to-N) and tag it so the
+        // engine (Task 4) clears stacks post-redirect. Meatshield sets no such clause on its OWN
+        // accumulating/one-shot Protection grants, so it is unaffected (byte-identical).
+        const isConsumableProtection =
+            buffName === 'Protection' &&
+            CLEAR_PROTECTION_ON_REDIRECT_RE.test(stripUnitTags(skillText));
+
         effects.push({
             buffName,
             target,
@@ -4683,6 +4710,8 @@ export function parseSkillEffects(
             ...(stacks !== undefined ? { stacks } : {}),
             ...(stackTrigger !== undefined ? { stackTrigger } : {}),
             ...(application !== undefined ? { application } : {}),
+            ...(isConsumableProtection && stacks !== undefined ? { maxStacks: stacks } : {}),
+            ...(isConsumableProtection ? { clearAllOnRedirect: true } : {}),
             source,
         });
     }


### PR DESCRIPTION
## Summary

Three follow-ups to the shipped Protection damage-transfer mechanic (PR #247), plus two necessary pre-existing fixes surfaced during implementation.

1. **Efficiency gate** (`perf`) — a board-level `hasAnyProtectionGrant` boolean so `protectorsFor` short-circuits on the common case (no Protection anywhere on the board), instead of doing a 3-source stack read per adjacent ally on every direct hit. Behavior-preserving. The gate ORs the ability-config scan with a `selfBuffLookup` check so it stays true for Protection arriving via scheduled self-buffs (a real DPS/Healing-calculator path), not just ability grants.
2. **All-allies coverage** (`fix`) — `protectorsFor` now resolves all living same-side allies directly instead of via the adjacency helper, which narrows to hex-neighbours in positional encounters. Protection's confirmed model is "coverage = ALL allies," so it must not narrow.
3. **Lionheart round-start Protection** (`feat`) — Lionheart's refit passive is now modeled: it gains 10 stacks of Protection each round (refresh-to-10, via `maxStacks:10` capping the existing per-round accumulation) and, after it absorbs the first hit redirected from an ally, loses all Protection until the next round (a new `clearAllOnRedirect` field consumed in the transfer block via `removeSelfBuffByName`). Net: a once-per-round bodyguard.

## Notable during implementation

- **Behavior-change note (all-allies):** the design initially assumed this was a no-op in production ("every path is non-positional"). That premise was inaccurate — `simulateBattle` wires board positions — so this is a genuine, *intended* behavior change: Protection now redirects damage from non-adjacent allies in the real sim. No DPS/healing golden moved (grep-confirmed untouched). One pre-existing defense-substitution test expectation was updated (`alone` → `alone*0.7`) — a DEFENDER ally is not *substituted* but IS Protection-*transferred* at 30%; verified correct against the cascade math, not a masked regression.
- **Pre-existing parser fix (in scope):** `startOfCombatOneShot` tested the whole preceding text blob, so Lionheart's earlier "at the start of combat" HP-grant sentence false-matched its later round-start Protection grant, leaving it non-accumulating (which would make refresh-to-10 meaningless). Scoped the one-shot check to the current sentence. Corpus-wide only Lionheart's parse changes (`audit:skills` re-run at 0; Meatshield byte-identical, stays accumulating/uncapped).

## Testing

- Full `npm test`: 357 files / 4433 tests green; `audit:skills` 0 findings; `tsc --noEmit` + lint clean.
- New tests: no-Protection gate short-circuit; positional-mode all-allies coverage; Lionheart parser (refresh-to-10 + clear-on-redirect, with a Meatshield-negative assertion) and buff-config threading; Lionheart engine integration (hit 1 redirected, hit 2 not, round-2 refresh resumes); a multi-protector cascade guard test proving `clearAllOnRedirect` only fires when the protector actually redirected (`chunk.total > 0`).
- No golden movement; team-symmetric (all scans cover both runtime maps).

## Deferred (still open from PR #247)

Per-stack log events; Protection→DoT transform sibling (Meatshield R2/R3) + dynamic stack-stealing; barrier-immune-victim redirect edge; `targetMit`-fallback precision nuance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZfYr4TNPVeCWH31AGqhzc
