### PR TITLE
feat(combat): Barrier suppresses Protection redirect + Meatshield Protection→DoT transform

### DIFF
--- a/scripts/auditSkills.allowlist.ts
+++ b/scripts/auditSkills.allowlist.ts
@@ -114,16 +114,4 @@ export const ALLOWLIST: AllowEntry[] = [
         rules: ['accumulate-detonate'],
         reason: 'Passive mentions "When an Echoing Burst explodes" as a heal-on-burst reaction, not an infliction. The charged skill correctly parses the accumulate-detonate; the passive reference is filtered by the parser guard.',
     },
-
-    // ── SP-F F5: Meatshield — Protection→DoT sibling clause, DEFERRED ───────────
-    // Meatshield's R4 refit-active passive carries THREE sentences. SP-F F5 ships the
-    // defense-substitution clause ("dealt as if that ally had this Unit's defense" — the new
-    // `defense-substitution` ability, ally-scoped, target 'all-allies'). This entry covers the
-    // OTHER, still-unmodelled sentence: "Any damage this Unit takes from Protection is
-    // transformed into a Damage over Time effect for 2 turns."
-    {
-        ship: 'Meatshield',
-        rules: ['transform-incoming-to-dot'],
-        reason: "SP-F F5 SHIPPED the sibling defense-substitution clause (approximation — see AbilityType's 'defense-substitution' doc comment) but deliberately did NOT build this clause. It strictly requires the Protection-as-damage-transfer mechanic (a Defender intercepting ally damage) to exist first — no damage is ever \"transferred by Protection\" in this model, so there is nothing to convert into a DoT. Protection-transfer itself is deferred to a future SP pending a locked mitigation-ordering + speed-chained-redirect rule (design doc §1); it also affects Lionheart's Protection grant and Meatshield's own R3 \"steal Protection\". The generic self-DoT transform primitive (SP-E, `transform-incoming-to-dot` — Voron/Orel) is ready to receive this clause once Protection-transfer lands; both Meatshield skill-text columns (passive2/passive3) carry the clause, hence two raw findings suppressed by this one ship-scoped entry.",
-    },
 ];

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -85,6 +85,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat sim: Protection now redirects damage from any living ally, not only adjacent ones.',
     'Combat sim: a consumable Protection holder (e.g. Lionheart) no longer loses its Protection when another protector fully absorbs the redirected hit before it — Protection is only consumed when it actually intercepted damage.',
     "Combat sim: Meatshield's refit passive now converts damage it intercepts via Protection into a 2-turn Damage-over-Time effect on itself, instead of taking it as instant HP loss.",
+    "Combat sim: when a Barrier fully absorbs an incoming hit, that hit is no longer redirected to the target's protectors — Protection only redirects damage the target would actually take.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -84,6 +84,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat sim: Lionheart now gains 10 stacks of Protection each round and absorbs the first hit redirected from an ally, then loses all Protection until the next round.',
     'Combat sim: Protection now redirects damage from any living ally, not only adjacent ones.',
     'Combat sim: a consumable Protection holder (e.g. Lionheart) no longer loses its Protection when another protector fully absorbs the redirected hit before it — Protection is only consumed when it actually intercepted damage.',
+    "Combat sim: Meatshield's refit passive now converts damage it intercepts via Protection into a 2-turn Damage-over-Time effect on itself, instead of taking it as instant HP loss.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -418,7 +418,12 @@ export type IncomingCondition =
     // SP-E: Orel — the transform fires only when the ATTACKER of this hit currently carries
     // Taunt (self-buff) or Provoke (debuff placed on it by someone else). Distinct from
     // 'attacker-has-dot' (a DoT-status fact) — this checks control-status membership.
-    | 'attacker-taunted-or-provoke';
+    | 'attacker-taunted-or-provoke'
+    // Meatshield refit-active passive — the transform fires only when THIS hit is a chunk
+    // redirected onto the unit through Protection (cause.isProtectionTransfer). Distinct from
+    // every other arm (which are attacker/victim status facts) — this is a fact about how the
+    // hit arrived. Evaluated ONLY by the engine's transform-incoming-to-dot block.
+    | 'self-protection-redirect';
 
 /** Per-incoming-hit context assembled by the engine at each victim apply site. */
 export interface IncomingHitContext {
@@ -453,6 +458,11 @@ export interface IncomingHitContext {
      *  defaults 100 (full HP) where unused/inapplicable — inert unless an ability's config
      *  carries `hpScaling`. */
     selfHpPct: number;
+    /** Meatshield: true when THIS hit is a chunk redirected onto the victim via Protection
+     *  (engine sets it from `cause.isProtectionTransfer` at the transform block). OPTIONAL —
+     *  every other construction site omits it (→ undefined → treated as false in conditionMet),
+     *  keeping those sites byte-identical. */
+    viaProtectionRedirect?: boolean;
 }
 
 /**

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -51,6 +51,8 @@ import {
     parseSelfBuffRemovals,
     parsePreCombatStatGrants,
     parseOnResistHpDamage,
+    detectProtectionTransformToDot,
+    detectTransformToDot,
 } from '../skillTextParser';
 import type { Ship } from '../../types/ship';
 
@@ -4880,5 +4882,21 @@ describe('parseOnResistHpDamage (Vindicator p2 reactive)', () => {
     it('returns null for empty input', () => {
         expect(parseOnResistHpDamage('')).toBeNull();
         expect(parseOnResistHpDamage(null)).toBeNull();
+    });
+});
+
+describe('detectProtectionTransformToDot', () => {
+    const meatshield =
+        'Any damage this Unit takes from <unit-skill>Protection</unit-skill> is transformed into a <unit-aid>Damage over Time effect</unit-aid> for 2 turns.';
+    it('parses turns from the Meatshield protection-transform clause', () => {
+        expect(detectProtectionTransformToDot(meatshield)).toEqual({ turns: 2 });
+    });
+    it('does NOT match Voron/Orel "transforms the damage into a DoT"', () => {
+        const voron =
+            'When directly damaged, this Unit transforms the damage into a Damage over Time effect lasting for 3 turns.';
+        expect(detectProtectionTransformToDot(voron)).toBeUndefined();
+    });
+    it('the existing detector does NOT match Meatshield (detectors stay disjoint)', () => {
+        expect(detectTransformToDot(meatshield)).toBeUndefined();
     });
 });

--- a/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
+++ b/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
@@ -578,6 +578,17 @@ describe('SP-F — deep one-offs', () => {
         expect(substitution[0].target).toBe('all-allies');
     });
 
+    it('Meatshield refit-active passive emits a self-protection-redirect DoT transform', () => {
+        const abilities = abilitiesFor({ thirdPassiveSkillText: MEATSHIELD_P4 }, 'passive');
+        const transform = abilities.find((a) => a.config.type === 'transform-incoming-to-dot');
+        expect(transform).toBeDefined();
+        expect(transform?.config).toMatchObject({
+            type: 'transform-incoming-to-dot',
+            turns: 2,
+            condition: 'self-protection-redirect',
+        });
+    });
+
     // forced-affinity — CARRIER: Wusheng (charge_skill_text) — the cleanest single-clause,
     // single-ship instance ("deals damage WITH affinity advantage", no team-composition
     // dependency). RELATED but NOT separately probed: Isha ("gains Offensive Affinity

--- a/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
+++ b/src/utils/abilities/__tests__/modelCompletenessTriage.test.ts
@@ -561,14 +561,13 @@ describe('SP-F — deep one-offs', () => {
     it('Meatshield: "dealt as if that ally had this Unit\'s defense" builds an ally-scoped defense-substitution ability (SP-F F5)', () => {
         const abilities = abilitiesFor({ thirdPassiveSkillText: MEATSHIELD_P4 }, 'passive');
         // SHIPPED: SP-F F5 (defense-substitution, approximation — Protection-transfer
-        // itself stays deferred; see the docs/superpowers spec §6 and the
-        // 'transform-incoming-to-dot' allowlist row below for the sibling DoT-transform
-        // clause, which remains deliberately unmodelled). buildShipAbilities now emits a
-        // dedicated `{ type: 'defense-substitution' }` config for this sentence, ally-
-        // scoped (`target: 'all-allies'`) — distinct from the self-target
+        // itself stays deferred; see the docs/superpowers spec §6). buildShipAbilities now
+        // emits a dedicated `{ type: 'defense-substitution' }` config for this sentence,
+        // ally-scoped (`target: 'all-allies'`) — distinct from the self-target
         // "gains 3 stacks of Protection" buff (auto-filled, recurring) that already built,
-        // and from the still-unbuilt "damage taken from Protection transforms into a DoT"
-        // sibling sentence (deliberately deferred — no assertion on it here).
+        // and from the "damage taken from Protection transforms into a DoT" sibling
+        // sentence, which IS now built (`transform-incoming-to-dot`, condition
+        // 'self-protection-redirect') and asserted in the coexistence test below.
         const substitution = abilities.filter(
             (a) =>
                 a.config.type === 'defense-substitution' &&
@@ -578,7 +577,7 @@ describe('SP-F — deep one-offs', () => {
         expect(substitution[0].target).toBe('all-allies');
     });
 
-    it('Meatshield refit-active passive emits a self-protection-redirect DoT transform', () => {
+    it('Meatshield refit-active passive emits a self-protection-redirect DoT transform alongside its sibling clauses', () => {
         const abilities = abilitiesFor({ thirdPassiveSkillText: MEATSHIELD_P4 }, 'passive');
         const transform = abilities.find((a) => a.config.type === 'transform-incoming-to-dot');
         expect(transform).toBeDefined();
@@ -587,6 +586,23 @@ describe('SP-F — deep one-offs', () => {
             turns: 2,
             condition: 'self-protection-redirect',
         });
+
+        // Coexistence check: the additive push for this DoT-transform clause must not
+        // displace the passive's other two sentences — the "gains 3 stacks of Protection"
+        // grant and the "dealt as if that ally had this Unit's defense" substitution both
+        // still build from the SAME three-sentence fixture.
+        const protection = abilities.find(
+            (a) => a.config.type === 'buff' && a.config.buffName === 'Protection'
+        );
+        expect(protection).toBeDefined();
+
+        const substitution = abilities.filter(
+            (a) =>
+                a.config.type === 'defense-substitution' &&
+                (a.target === 'ally' || a.target === 'all-allies')
+        );
+        expect(substitution).toHaveLength(1);
+        expect(substitution[0].target).toBe('all-allies');
     });
 
     // forced-affinity — CARRIER: Wusheng (charge_skill_text) — the cleanest single-clause,

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -103,6 +103,7 @@ import {
     statusEffectCondition,
     parsePreCombatStatGrants,
     detectTransformToDot,
+    detectProtectionTransformToDot,
     detectConvertDot,
     parseInsteadDamageReplacement,
     parseDefenseSubstitution,
@@ -2453,6 +2454,30 @@ function abilitiesFromText(
                 autoFilled: true,
             },
             pos: transformPos >= 0 ? transformPos : MAX_POS,
+        });
+    }
+
+    // Meatshield refit-active passive: Protection-redirected damage → 2-turn self-DoT. Distinct
+    // detector from the Voron/Orel transform above (disjoint regexes); gated to fire only on a
+    // Protection redirect via condition 'self-protection-redirect'.
+    const protTransform = detectProtectionTransformToDot(text);
+    if (protTransform) {
+        const protPos = text.search(/is\s+transformed\s+into/i);
+        out.push({
+            ability: {
+                id: nextId(),
+                type: 'transform-incoming-to-dot',
+                target: 'self',
+                trigger: 'on-attacked',
+                conditions: [],
+                config: {
+                    type: 'transform-incoming-to-dot',
+                    turns: protTransform.turns,
+                    condition: 'self-protection-redirect',
+                },
+                autoFilled: true,
+            },
+            pos: protPos >= 0 ? protPos : MAX_POS,
         });
     }
 

--- a/src/utils/combat/__tests__/incomingEffects.test.ts
+++ b/src/utils/combat/__tests__/incomingEffects.test.ts
@@ -154,6 +154,15 @@ describe('incomingReductionForHit', () => {
         expect(incomingReductionForHit(a, ctx({ attackerTauntedOrProvoked: true }))).toBe(25);
         expect(incomingReductionForHit(a, ctx({ attackerTauntedOrProvoked: false }))).toBe(0);
     });
+    // Component B: Meatshield's transform gate — a bare incoming-reduction with this condition
+    // is synthetic (the real ability is 'transform-incoming-to-dot'), but conditionMet's arm is
+    // shared plumbing worth pinning directly.
+    it('Meatshield (self-protection-redirect): fires only when the hit is a Protection redirect', () => {
+        const a = [reduction('self-protection-redirect', 25, false)];
+        expect(incomingReductionForHit(a, ctx({ viaProtectionRedirect: true }))).toBe(25);
+        expect(incomingReductionForHit(a, ctx({ viaProtectionRedirect: false }))).toBe(0);
+        expect(incomingReductionForHit(a, ctx())).toBe(0); // omitted → false
+    });
 });
 
 describe('incomingBlockForIntake', () => {

--- a/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
+++ b/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
@@ -359,6 +359,60 @@ describe('Protection damage transfer (integration)', () => {
         expect(protector).toBeCloseTo(expectedChunk, 4);
     });
 
+    it('Barrier on the target suppresses the redirect — protector takes nothing (Component A)', () => {
+        // Same aura-protector harness as the "PRODUCTION PATH" test above (a non-focus team-actor
+        // 'prot-1' grants ITSELF 3 Protection stacks via an aura passive; 'ally-1' is the
+        // direct-hit victim) — but the VICTIM additionally carries an always-active 'Barrier'
+        // self-buff. Barrier must be granted the SAME way Protection is here — as an aura ability
+        // (`type:'buff'`, no `duration`, `target:'self'`) — because a plain entry on a team actor's
+        // `selfBuffs` array only ever folds into the STATUS ENGINE's global 'attacker'-only
+        // snapshot (statusEngine.ts's `alwaysSelf`/`accumSelf`, gated to `ownerId === 'attacker'`
+        // in `snapshot()`); `selfBuffNamesForOwners` would never see it for 'ally-1''s own id.
+        // Routing it through `activeAbilityStatuses('self', ..., 'ally-1')` (the aura branch,
+        // per-owner) is what makes it visible to the victim's OWN `carriesBarrier` check.
+        // Barrier fully nullifies the hit BEFORE the transfer block runs, so nothing is left to
+        // redirect: the protector must take zero, and the victim's own barrierAbsorbed must equal
+        // the full (non-vacuous) hit while its `.incoming` stays what it always is under Barrier
+        // (the damage still "arrives" for accounting — see engine.ts's carriesBarrier comment —
+        // it just never touches HP).
+        const barrierAuraPassive = (): ShipSkills['slots'][number] => {
+            const ability: Ability = {
+                id: 'barrier-self-aura',
+                type: 'buff',
+                target: 'self',
+                trigger: 'on-cast',
+                conditions: [],
+                config: {
+                    type: 'buff',
+                    buffName: 'Barrier',
+                    parsedEffects: {},
+                    stacks: 1,
+                    isStackable: false,
+                },
+            };
+            return { slot: 'passive', abilities: [ability] };
+        };
+        const input = BASE_INPUT({
+            selfBuffs: [], // the focus carries no Protection — the protector is a team actor.
+            defence: 0,
+            teamActors: [
+                teamActor('ally-1', 0, [barrierAuraPassive()]), // victim, Barrier-immune this hit
+                teamActor('prot-1', PROTECTOR_DEFENCE, [protectionAuraPassive(3)]), // aura protector
+            ],
+            enemyAttackers: [manualEnemy('enemy-1', ENEMY_ATTACK)],
+        });
+
+        const protector = totalIncoming(input, 'prot-1');
+        const result = runCombat(input);
+        const round1 = result.rounds[0];
+
+        // Protector takes nothing: no redirect happened (Barrier suppressed it upstream).
+        expect(protector).toBe(0);
+        // Non-vacuous: the hit genuinely reached the victim and was fully absorbed by Barrier —
+        // NOT a no-op where nothing fired at all.
+        expect(round1.perActorIncoming?.['ally-1']?.barrierAbsorbed).toBeCloseTo(ENEMY_ATTACK, 6);
+    });
+
     it('positional mode: Protection covers a NON-adjacent ally (all-allies, not hex-neighbours)', () => {
         // Wiring `position` on the victim AND another player actor makes `anyOtherPositioned`
         // true, so `adjacentAllyIdsFor` (adjacency.ts) would narrow to hex-neighbours instead of

--- a/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
+++ b/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
@@ -413,6 +413,76 @@ describe('Protection damage transfer (integration)', () => {
         expect(round1.perActorIncoming?.['ally-1']?.barrierAbsorbed).toBeCloseTo(ENEMY_ATTACK, 6);
     });
 
+    it('a PROTECTOR that also carries a full incoming-block ability credits ZERO instant damage for the blocked redirected chunk (CodeRabbit: immediateDamage, not chunk.total − transformedToDot)', () => {
+        // Same aura-protector harness as the "PRODUCTION PATH" test above ('prot-1' grants ITSELF
+        // 3 Protection stacks via an aura passive; 'ally-1' is the direct-hit victim) — but the
+        // PROTECTOR additionally carries an always-active, 100%-chance, 100%-block
+        // 'incoming-block' ability on ITSELF (granted the same aura way Protection/Barrier are
+        // granted elsewhere in this file, so it is visible to the protector's OWN block check at
+        // the applyVictimDamage funnel for its redirected sub-hit).
+        //
+        // The redirected chunk still leaves the target (cascade math is computed from the
+        // protector's Protection stacks, independent of its block ability) — 'ally-1' keeps 70%
+        // exactly like the PRODUCTION PATH test. But the protector's OWN incoming-block ability
+        // then fully blocks its post-redirect sub-hit: the protector takes ZERO real damage and
+        // transforms nothing into a DoT. The buggy accounting (`chunk.total − transformedToDot`)
+        // would still credit the FULL chunk as "instant" damage taken by the protector, because
+        // transformedToDot stays 0 for a pure block (no transform ability involved) — the fixed
+        // accounting (summed `immediateDamage`, captured post-block/post-transform inside
+        // applyVictimDamage) must read 0 instead.
+        const blockAuraPassive = (): ShipSkills['slots'][number] => {
+            const ability: Ability = {
+                id: 'full-block-self-aura',
+                type: 'incoming-block',
+                target: 'self',
+                trigger: 'on-cast',
+                conditions: [],
+                config: {
+                    type: 'incoming-block',
+                    condition: 'always',
+                    procChance: 1,
+                    blockPct: 1.0,
+                    oncePerRound: false,
+                },
+            };
+            return { slot: 'passive', abilities: [ability] };
+        };
+        const input = BASE_INPUT({
+            selfBuffs: [], // the focus carries no Protection — the protector is a team actor.
+            defence: 0,
+            teamActors: [
+                teamActor('ally-1', 0), // victim
+                teamActor('prot-1', PROTECTOR_DEFENCE, [
+                    protectionAuraPassive(3),
+                    blockAuraPassive(),
+                ]), // aura protector that ALSO fully blocks its own redirected sub-hit
+            ],
+            enemyAttackers: [manualEnemy('enemy-1', ENEMY_ATTACK)],
+        });
+
+        const victim = totalIncoming(input, 'ally-1');
+        const protector = totalIncoming(input, 'prot-1');
+        const result = runCombat(input);
+        const round1 = result.rounds[0];
+        const reactiveHitsOnProtector = reactiveEventsTargeting(input, 'prot-1');
+
+        // The target still keeps 70% — the redirect itself is unaffected by the protector's OWN
+        // block ability (that ability only gates what the PROTECTOR takes from its own chunk).
+        expect(victim).toBeCloseTo(0.7 * ENEMY_ATTACK, 6);
+        // The protector's `.incoming` bucket shows ZERO — the redirected chunk was fully blocked
+        // before it ever landed as real intake.
+        expect(protector).toBe(0);
+        // THE CORE ASSERTION: the protector's credited round damage must NOT include the (fully
+        // blocked) chunk. `perTargetDamage` is set ONLY when non-empty (RoundData's "absent when
+        // empty" rule), so a wrongly-credited chunk would show up as a truthy, non-zero entry —
+        // the fixed accounting must leave this key ABSENT entirely.
+        expect(round1.perTargetDamage?.['prot-1']).toBeUndefined();
+        // No reactive-damage-performed event should have fired for the protector either — the
+        // `instantTotal > 1e-9` guard must suppress emission for a fully-blocked chunk exactly
+        // like it already does for a fully Barrier-suppressed or fully DoT-transformed one.
+        expect(reactiveHitsOnProtector).toBe(0);
+    });
+
     it('positional mode: Protection covers a NON-adjacent ally (all-allies, not hex-neighbours)', () => {
         // Wiring `position` on the victim AND another player actor makes `anyOtherPositioned`
         // true, so `adjacentAllyIdsFor` (adjacency.ts) would narrow to hex-neighbours instead of

--- a/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
+++ b/src/utils/combat/__tests__/protectionTransfer.integration.test.ts
@@ -648,3 +648,280 @@ describe('Protection transfer — enemy-side symmetry (protector + victim on the
         expect(protectorWith).toBeGreaterThan(0);
     });
 });
+
+// ───────────────────────────────────────────────────────────────────────────────────────
+// Task 4 (Component B runtime) — Meatshield's transform-incoming-to-dot passive turns a
+// Protection-REDIRECTED chunk into a 2-turn self-DoT instead of instant HP loss. Reuses this
+// file's PRODUCTION PATH aura-protector harness (protectionAuraPassive: Protection granted as an
+// aura ability, visible to the all-sources protectorsFor read) plus the SAME 3-stack / 30%
+// magnitude as the core aura test above, so `expectedChunk` below is the IDENTICAL arithmetic
+// (0.3 × ENEMY_ATTACK × mit(PROTECTOR_DEFENCE)/mit(0)) already proven correct for the instant
+// case — only now summed across the DoT's 2 ticks instead of read as one instant hit.
+//
+// Positional requirement (NOT present in the non-positional aura-protector tests above): a
+// non-heal-target team/enemy actor's OWN genericDoTEntries only tick at its own turn-start when
+// `isPositional(actor.position, opposingLiving)` is true (engine.ts's per-victim DoT-tick
+// prologue) — the always-ticking path is reserved for the heal target. So the protector (which is
+// NOT the heal target here — the direct-hit victim is) must carry a board position, mirroring
+// transformIncomingToDot.test.ts's positional harness. The direct-hit victim keeps a LOWER board
+// column than the protector so 'front' targeting is unambiguous.
+//
+// Single-hit isolation: the enemy roster's manualEnemy-style attacker fires every round it is
+// alive (no charge-gating in this harness), so left unchecked it would redirect a fresh chunk
+// every round and contaminate the "ticks sum to ONE chunk" assertion. Each test's direct-hit
+// victim therefore carries a throwaway `damage-reflection` "kill switch" (100% reflect) purely as
+// a test-harness device: the attacker's `stats.hp`/`hp` is seeded at 1, so ANY nonzero reflected
+// sliver (inevitable once the redirect leaves a real remainder on the victim) kills it via the
+// engine's ordinary recordDestroyed path immediately after its round-1 attack — isolating the
+// redirected chunk's DoT lifecycle to exactly that one hit for the remaining 2 rounds of pure
+// ticking. This is NOT a claim about Meatshield/production kits; it only exists to pin the
+// attacker to a single shot inside this test.
+describe('Protection transfer × transform-incoming-to-dot composition (Task 4, Component B runtime)', () => {
+    // Meatshield's R4-style reactive: fires only on a Protection-REDIRECTED hit (Task 2's
+    // 'self-protection-redirect' condition + `viaProtectionRedirect`, Task 3's ability shape).
+    const transformAbility: Ability = {
+        id: 'meatshield-transform',
+        type: 'transform-incoming-to-dot',
+        target: 'self',
+        trigger: 'on-attacked',
+        conditions: [],
+        config: {
+            type: 'transform-incoming-to-dot',
+            turns: 2,
+            condition: 'self-protection-redirect',
+        },
+    };
+    // Test-only kill switch — see file-section comment above.
+    const killSwitchReflect: Ability = {
+        id: 'kill-switch-reflect',
+        // Top-level type:'modifier' is a placeholder (mirrors buildEquipmentAbilities.ts's
+        // REFLECT gear-set entry) — the engine keys on config.type:'damage-reflection', not the
+        // top-level type.
+        type: 'modifier',
+        target: 'self',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'damage-reflection', pct: 100 },
+    };
+    const basicAttack = (): Ability => ({
+        id: 'ks-basic-attack',
+        type: 'damage',
+        target: 'enemy',
+        trigger: 'on-cast',
+        conditions: [],
+        config: { type: 'damage', multiplier: 100 },
+    });
+    const targetFront: ParsedTarget = { raw: 'front', side: 'enemy', selection: 'front' };
+    const basicPattern: ParsedPattern = { raw: 'base', shape: 'base', range: 0, modifiers: {} };
+
+    /** Runs `input` through a fresh bus, collecting every `dot-ticked` (dotType 'generic') event
+     *  landing on `targetId`. Returns the summed tick amount. */
+    const genericDotSum = (input: CombatEngineInput, targetId: string): number => {
+        const bus = createEventBus();
+        let sum = 0;
+        bus.on('dot-ticked', (e: Extract<CombatEvent, { type: 'dot-ticked' }>) => {
+            if (e.dotType === 'generic' && e.targetId === targetId) sum += e.damage;
+        });
+        runCombat({ ...input, bus });
+        return sum;
+    };
+
+    it('PLAYER side: a redirected chunk becomes a 2-turn self-DoT on the protector, not instant HP loss', () => {
+        const input: CombatEngineInput = {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 3,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            healTargetId: 'ally-1',
+            teamActors: [
+                {
+                    id: 'ally-1', // direct-hit victim — front column (M4), the kill-switch reflector.
+                    speed: 10,
+                    chargeCount: 0,
+                    startCharged: false,
+                    selfBuffs: [],
+                    enemyDebuffs: [],
+                    position: 'M4',
+                    walk: {
+                        shipSkills: {
+                            slots: [{ slot: 'passive', abilities: [killSwitchReflect] }],
+                        },
+                        stats: {
+                            attack: 0,
+                            crit: 0,
+                            critDamage: 0,
+                            defensePenetration: 0,
+                            hacking: 0,
+                            defence: 0,
+                            hp: 1_000_000_000,
+                        },
+                        selfDotModifier: 0,
+                        defensePenetrationBuff: 0,
+                        affinityDamageModifier: 0,
+                        affinityCritCap: 100,
+                        affinityCritPenalty: 0,
+                        hasChargedSkill: false,
+                    },
+                },
+                {
+                    id: 'prot-1', // protector — back column (M1), high speed so its own DoT-tick
+                    // step (turn-start) runs BEFORE the redirect lands each round.
+                    speed: 1000,
+                    chargeCount: 0,
+                    startCharged: false,
+                    selfBuffs: [],
+                    enemyDebuffs: [],
+                    position: 'M1',
+                    walk: {
+                        shipSkills: {
+                            slots: [
+                                protectionAuraPassive(3),
+                                { slot: 'passive', abilities: [transformAbility] },
+                            ],
+                        },
+                        stats: {
+                            attack: 0,
+                            crit: 0,
+                            critDamage: 0,
+                            defensePenetration: 0,
+                            hacking: 0,
+                            defence: PROTECTOR_DEFENCE,
+                            hp: 1_000_000_000,
+                        },
+                        selfDotModifier: 0,
+                        defensePenetrationBuff: 0,
+                        affinityDamageModifier: 0,
+                        affinityCritCap: 100,
+                        affinityCritPenalty: 0,
+                        hasChargedSkill: false,
+                    },
+                },
+            ] as TeamActorEngineInput[],
+            enemyAttackers: [
+                {
+                    id: 'enemy-1',
+                    stats: {
+                        attack: ENEMY_ATTACK,
+                        crit: 0,
+                        critDamage: 0,
+                        defence: 0,
+                        hp: 1,
+                        speed: 1,
+                    },
+                    chargeCount: 0,
+                    startCharged: false,
+                    position: 'T1',
+                    target: targetFront,
+                    pattern: basicPattern,
+                    shipSkills: { slots: [{ slot: 'active', abilities: [basicAttack()] }] },
+                },
+            ],
+        };
+
+        const result = runCombat(input);
+        const round1 = result.rounds.find((r) => r.round === 1)!;
+        // Turn of redirect: the protector's instant intake nets to ZERO (fully deferred to DoT).
+        expect(round1.perActorIncoming?.['prot-1']?.incoming ?? 0).toBe(0);
+
+        // The generic DoT ticks on the protector over the following 2 rounds, summing to the
+        // FULL redirected chunk (spread over 2 turns) — the SAME magnitude as the instant-case
+        // aura-protector test above.
+        const tickSum = genericDotSum(input, 'prot-1');
+        const expectedChunk = 0.3 * ENEMY_ATTACK * (mit(PROTECTOR_DEFENCE) / mit(0));
+        expect(tickSum).toBeCloseTo(expectedChunk, 4);
+    });
+
+    it('ENEMY side (team symmetry): identical redirect-to-DoT behavior when the protector + victim are on the ENEMY side', () => {
+        const FOCUS_ATTACK = ENEMY_ATTACK; // same magnitude, direct numeric mirror.
+        const input: CombatEngineInput = {
+            attack: FOCUS_ATTACK,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [{ slot: 'active', abilities: [basicAttack()] }] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 3,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            // Kill-switch symmetry: the FOCUS is the attacker here, so IT is the one that dies to
+            // the reflected sliver after its round-1 attack — seeded at 1 HP for the same reason
+            // the enemy attacker is in the player-side test above.
+            hp: 1,
+            healTargetId: 'attacker',
+            position: 'M4',
+            target: targetFront,
+            pattern: basicPattern,
+            enemyAttackers: [
+                {
+                    id: 'enemy-front', // direct-hit victim — front column (M4), kill-switch reflector.
+                    stats: {
+                        attack: 0,
+                        crit: 0,
+                        critDamage: 0,
+                        defence: 0,
+                        hp: 1_000_000_000,
+                        speed: 1,
+                    },
+                    chargeCount: 0,
+                    startCharged: false,
+                    position: 'M4',
+                    shipSkills: { slots: [{ slot: 'passive', abilities: [killSwitchReflect] }] },
+                },
+                {
+                    id: 'enemy-protector', // protector — back column (M1), high speed.
+                    stats: {
+                        attack: 0,
+                        crit: 0,
+                        critDamage: 0,
+                        defence: PROTECTOR_DEFENCE,
+                        hp: 1_000_000_000,
+                        speed: 1000,
+                    },
+                    chargeCount: 0,
+                    startCharged: false,
+                    position: 'M1',
+                    shipSkills: {
+                        slots: [
+                            protectionAuraPassive(3),
+                            { slot: 'passive', abilities: [transformAbility] },
+                        ],
+                    },
+                },
+            ],
+        };
+
+        const result = runCombat(input);
+        const round1 = result.rounds.find((r) => r.round === 1)!;
+        expect(round1.perActorIncoming?.['enemy-protector']?.incoming ?? 0).toBe(0);
+
+        const tickSum = genericDotSum(input, 'enemy-protector');
+        const expectedChunk = 0.3 * FOCUS_ATTACK * (mit(PROTECTOR_DEFENCE) / mit(0));
+        expect(tickSum).toBeCloseTo(expectedChunk, 4);
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3644,11 +3644,14 @@ export function runCombat(input: CombatEngineInput): {
                         // Meatshield's DoT-transform passive DEFERS the transformed portion to a
                         // self-DoT ticked over the next N rounds (the generic-DoT path books its own
                         // roundPerTargetDamage + .incoming per tick). Only the INSTANT remainder is
-                        // credited/logged this round. transformedTotal is a subset of chunk.total, so
-                        // `instant` is never negative; when nothing transforms it equals chunk.total
-                        // → byte-identical to the pre-change path for every non-Meatshield protector.
+                        // credited/logged this round. transformedTotal is a subset of chunk.total; when
+                        // nothing transforms it is EXACTLY 0 → instant === chunk.total → byte-identical
+                        // to the pre-change path for every non-Meatshield protector. In the fully-
+                        // transformed case a sub-epsilon float sliver can leave `instant` at ±~1e-10;
+                        // the 1e-9 threshold suppresses that phantom near-zero emission (a real chunk
+                        // is always >> 1e-9, so this never affects a genuine instant remainder).
                         const instant = chunk.total - transformedTotal;
-                        if (instant > 0) {
+                        if (instant > 1e-9) {
                             roundPerTargetDamage.set(
                                 p.actor.id,
                                 (roundPerTargetDamage.get(p.actor.id) ?? 0) + instant

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3625,7 +3625,7 @@ export function runCombat(input: CombatEngineInput): {
                         const protectorSink = p.actor.side === 'player' ? playerSink : enemySink;
                         // Apply as `stacks` equal sub-hits (matches the in-game per-stack procs and
                         // sets up the deferred DoT-transform, which acts per redirected chunk).
-                        let transformedTotal = 0;
+                        let instantTotal = 0;
                         for (let s = 0; s < chunk.stacks; s++) {
                             const outcome = applyVictimDamage(
                                 chunk.perStack,
@@ -3639,29 +3639,34 @@ export function runCombat(input: CombatEngineInput): {
                                     bombPortion: 0,
                                 }
                             );
-                            transformedTotal += outcome.transformedToDot ?? 0;
+                            instantTotal += outcome.immediateDamage ?? 0;
                         }
-                        // Meatshield's DoT-transform passive DEFERS the transformed portion to a
-                        // self-DoT ticked over the next N rounds (the generic-DoT path books its own
-                        // roundPerTargetDamage + .incoming per tick). Only the INSTANT remainder is
-                        // credited/logged this round. transformedTotal is a subset of chunk.total; when
-                        // nothing transforms it is EXACTLY 0 → instant === chunk.total → byte-identical
-                        // to the pre-change path for every non-Meatshield protector. In the fully-
-                        // transformed case a sub-epsilon float sliver can leave `instant` at ±~1e-10;
-                        // the 1e-9 threshold suppresses that phantom near-zero emission (a real chunk
-                        // is always >> 1e-9, so this never affects a genuine instant remainder).
-                        const instant = chunk.total - transformedTotal;
-                        if (instant > 1e-9) {
+                        // We sum the post-block, non-transformed INSTANT amount per sub-hit
+                        // (`immediateDamage`, captured inside applyVictimDamage right after its
+                        // transform step resolves) rather than `chunk.total − transformedToDot` —
+                        // that subtraction wrongly counts a portion blocked by the protector's own
+                        // incoming-block ability as instant damage, when in fact it was neither
+                        // taken nor transformed. Meatshield's DoT-transform passive DEFERS the
+                        // transformed portion to a self-DoT ticked over the next N rounds (the
+                        // generic-DoT path books its own roundPerTargetDamage + .incoming per tick);
+                        // only the INSTANT remainder is credited/logged this round. For a protector
+                        // without a block/transform ability, `immediateDamage === chunk.perStack` for
+                        // every sub-hit, so `instantTotal === chunk.total` — byte-identical to the
+                        // pre-change path. In the fully-transformed case a sub-epsilon float sliver
+                        // can leave `instantTotal` at ±~1e-10; the 1e-9 threshold suppresses that
+                        // phantom near-zero emission (a real chunk is always >> 1e-9, so this never
+                        // affects a genuine instant remainder).
+                        if (instantTotal > 1e-9) {
                             roundPerTargetDamage.set(
                                 p.actor.id,
-                                (roundPerTargetDamage.get(p.actor.id) ?? 0) + instant
+                                (roundPerTargetDamage.get(p.actor.id) ?? 0) + instantTotal
                             );
                             bus.emit({
                                 type: 'reactive-damage-performed',
                                 sourceId: victim.id,
                                 targetId: p.actor.id,
                                 round: r,
-                                amount: instant,
+                                amount: instantTotal,
                                 reactive: true,
                                 duringTurnOf: actingActorId,
                                 triggerActorId: actingActorId,
@@ -3756,6 +3761,15 @@ export function runCombat(input: CombatEngineInput): {
                     }
                 }
             }
+            // The post-block, non-transformed instant portion of this hit — captured HERE, right
+            // after the transform step resolves (transform zeroes `damage` on a match) and BEFORE
+            // any shield/HP drain below. For a normal hit (no block/transform/Barrier) this equals
+            // the input `damage` argument byte-for-byte; the incoming-block step above is the only
+            // thing that can have reduced it by this point. The Protection transfer block sums this
+            // per protector sub-hit instead of `chunk.total − transformedToDot`, so a blocked
+            // portion is correctly excluded from the instant-damage credit. The Barrier early-return
+            // below overrides this to 0 (Barrier nullifies — nothing lands, instant or otherwise).
+            const immediateDamage = damage;
             // Capture the pre-drain HP + the target's current effective max HP for the
             // tank-side hp-changed emission below (Phase 4c PR 3). Read BEFORE the drain
             // so oldPct reflects the entering state and a Cheat-Death save's oldPct stays
@@ -3778,7 +3792,12 @@ export function runCombat(input: CombatEngineInput): {
                         newPct: (100 * victim.currentHp) / maxHp,
                     });
                 }
-                return { shieldBefore: victim.shieldPool, hpDamage: 0, barriered: true };
+                return {
+                    shieldBefore: victim.shieldPool,
+                    hpDamage: 0,
+                    barriered: true,
+                    immediateDamage: 0,
+                };
             }
             const shieldBefore = victim.shieldPool;
             // Lifeline (incoming-shield-grant): a PRE-hit threshold shield. When a PURE direct hit
@@ -4170,7 +4189,7 @@ export function runCombat(input: CombatEngineInput): {
                     }
                 }
             }
-            return { shieldBefore, hpDamage, barriered: false, transformedToDot };
+            return { shieldBefore, hpDamage, barriered: false, transformedToDot, immediateDamage };
         };
         // Legacy healing-mode player intake — a THIN wrapper over applyVictimDamage. The sink
         // accumulates the victim's incoming / shield-absorbed / barrier-absorbed into its per-actor

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3574,8 +3574,12 @@ export function runCombat(input: CombatEngineInput): {
             // the PROTECTOR's own defense — realized by the mit-ratio inside protectionCascade.
             // Guards mirror the reflect block: direct damage only, and never a redirected/
             // reflected/counter application (loop-safe).
+            // !carriesBarrier: Barrier sits strictly in front of every incoming-effect mechanism
+            // (matches the incoming-block step and the transform step) — an invulnerable target
+            // has no incoming hit for allies to soak.
             if (
                 cause?.byDirectDamage &&
+                !carriesBarrier &&
                 !cause.isProtectionTransfer &&
                 !cause.isReflected &&
                 !cause.isCounter &&

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3625,30 +3625,45 @@ export function runCombat(input: CombatEngineInput): {
                         const protectorSink = p.actor.side === 'player' ? playerSink : enemySink;
                         // Apply as `stacks` equal sub-hits (matches the in-game per-stack procs and
                         // sets up the deferred DoT-transform, which acts per redirected chunk).
+                        let transformedTotal = 0;
                         for (let s = 0; s < chunk.stacks; s++) {
-                            applyVictimDamage(chunk.perStack, p.actor, protectorSink, {
-                                killerId: cause.killerId,
-                                byDirectDamage: true,
-                                isProtectionTransfer: true,
-                                shieldPenetrationPct: 0,
-                                bombPortion: 0,
+                            const outcome = applyVictimDamage(
+                                chunk.perStack,
+                                p.actor,
+                                protectorSink,
+                                {
+                                    killerId: cause.killerId,
+                                    byDirectDamage: true,
+                                    isProtectionTransfer: true,
+                                    shieldPenetrationPct: 0,
+                                    bombPortion: 0,
+                                }
+                            );
+                            transformedTotal += outcome.transformedToDot ?? 0;
+                        }
+                        // Meatshield's DoT-transform passive DEFERS the transformed portion to a
+                        // self-DoT ticked over the next N rounds (the generic-DoT path books its own
+                        // roundPerTargetDamage + .incoming per tick). Only the INSTANT remainder is
+                        // credited/logged this round. transformedTotal is a subset of chunk.total, so
+                        // `instant` is never negative; when nothing transforms it equals chunk.total
+                        // → byte-identical to the pre-change path for every non-Meatshield protector.
+                        const instant = chunk.total - transformedTotal;
+                        if (instant > 0) {
+                            roundPerTargetDamage.set(
+                                p.actor.id,
+                                (roundPerTargetDamage.get(p.actor.id) ?? 0) + instant
+                            );
+                            bus.emit({
+                                type: 'reactive-damage-performed',
+                                sourceId: victim.id,
+                                targetId: p.actor.id,
+                                round: r,
+                                amount: instant,
+                                reactive: true,
+                                duringTurnOf: actingActorId,
+                                triggerActorId: actingActorId,
                             });
                         }
-                        // Surface on the HP curve + reactive log (mirrors the reflect block).
-                        roundPerTargetDamage.set(
-                            p.actor.id,
-                            (roundPerTargetDamage.get(p.actor.id) ?? 0) + chunk.total
-                        );
-                        bus.emit({
-                            type: 'reactive-damage-performed',
-                            sourceId: victim.id,
-                            targetId: p.actor.id,
-                            round: r,
-                            amount: chunk.total,
-                            reactive: true,
-                            duringTurnOf: actingActorId,
-                            triggerActorId: actingActorId,
-                        });
                     });
                     // Lionheart R4: a consumable protector loses ALL Protection after it
                     // redirects a hit. The cascade was precomputed from pre-hit stacks, so THIS
@@ -3707,6 +3722,9 @@ export function runCombat(input: CombatEngineInput): {
                         victimHasShield: hasShield(victim.id),
                         selfHpPct: selfHpPctOf(victim.id),
                         attackerTauntedOrProvoked: attackerTauntedOrProvoked(attackerId),
+                        // Meatshield: this hit is a Protection-redirected chunk when the caller
+                        // stamped isProtectionTransfer (the per-protector applyVictimDamage below).
+                        viaProtectionRedirect: cause?.isProtectionTransfer ?? false,
                     };
                     const transform = transformAbilities.find(
                         (a) =>

--- a/src/utils/combat/incomingEffects.ts
+++ b/src/utils/combat/incomingEffects.ts
@@ -25,6 +25,8 @@ export function conditionMet(cond: IncomingCondition, ctx: IncomingHitContext): 
             return ctx.victimHasShield;
         case 'attacker-taunted-or-provoke':
             return ctx.attackerTauntedOrProvoked;
+        case 'self-protection-redirect':
+            return ctx.viaProtectionRedirect ?? false;
         case 'always':
             return true;
     }

--- a/src/utils/combat/positionalApply.ts
+++ b/src/utils/combat/positionalApply.ts
@@ -36,6 +36,12 @@ export interface VictimDamageOutcome {
      *  per-victim damage-taken credit so a transformed hit reads as 0 damage taken this round
      *  (the converted amount arrives over time via DoT ticks). Absent/0 for every normal hit. */
     transformedToDot?: number;
+    /** The post-block, non-transformed portion of this hit that landed as INSTANT damage this
+     *  turn (0 for a Barrier-nullified or fully DoT-transformed hit). The Protection transfer
+     *  block sums this across a protector's redirected sub-hits to credit only what actually hit
+     *  instantly — excluding a blocked portion, which `chunk.total − transformedToDot` would
+     *  wrongly count. Absent on outcomes from callers that don't set it. */
+    immediateDamage?: number;
 }
 
 /** Per-cell damage scale keyed off the resolved CellRole. */

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -2433,6 +2433,27 @@ export function detectTransformToDot(
     return { turns, condition };
 }
 
+// Meatshield (refit-active passive) — "Any damage this Unit takes from Protection is transformed
+// into a Damage over Time effect for N turns". DISJOINT from TRANSFORM_TO_DOT_RE (which requires
+// the literal "transform the damage into a", so it never matches this clause, and this regex
+// requires "takes from Protection is transformed", which never matches Voron/Orel). Corpus-
+// verified: only Meatshield's refit-active passive matches (docs/ship-skills.csv).
+const PROTECTION_TRANSFORM_TO_DOT_RE =
+    /damage\s+this\s+unit\s+takes\s+from\s+protection\s+is\s+transformed\s+into\s+a\s+.*?damage\s+over\s+time\s+effect\b[^.]*?\bfor\s+(\d+)\s+turns?\b/i;
+
+/**
+ * Detects Meatshield's "damage taken from Protection is transformed into a DoT for N turns"
+ * reactive self-conversion. Emitted as a 'transform-incoming-to-dot' ability gated to
+ * `condition: 'self-protection-redirect'` so it fires ONLY on Protection-redirected chunks (never
+ * on a normal direct hit to Meatshield). Reference data: docs/ship-skills.csv (Meatshield).
+ */
+export function detectProtectionTransformToDot(text: string): { turns: number } | undefined {
+    const plain = stripUnitTags(text);
+    const m = PROTECTION_TRANSFORM_TO_DOT_RE.exec(plain);
+    if (!m) return undefined;
+    return { turns: parseInt(m[1], 10) };
+}
+
 // Phase 3 PR-F: two DISTINCT "enemy repair" reaction phrasings that both ride the LIVE
 // on-enemy-repaired trigger but route to DIFFERENT actors:
 //  - Ruiner's Bomb infliction ("on any enemy performing a repair") has NO leading "when" (so


### PR DESCRIPTION
Two combat-sim fixes for the Protection damage-transfer system (follows PR #247/#248), both in `applyVictimDamage`.

## Component A — Barrier suppresses the redirect
When a target's Barrier fully nullifies an incoming hit, the hit is no longer redirected to its protectors. The transfer block now gates on `!carriesBarrier`, matching the incoming-block and DoT-transform steps (both already so gated) — Barrier sits strictly in front of every incoming-effect mechanism, so an invulnerable target has no incoming hit for allies to soak. Previously an untested edge; no golden fixture exercised it.

## Component B — Protection→DoT transform (Meatshield refit-active passive)
Meatshield's passive *"Any damage this Unit takes from Protection is transformed into a Damage over Time effect for 2 turns"* now defers redirected chunks into a 2-turn self-DoT instead of instant HP loss.

- Reuses the existing `transform-incoming-to-dot` primitive (Voron/Orel), gated by a new `self-protection-redirect` incoming condition.
- `viaProtectionRedirect?` is **optional** on `IncomingHitContext` — only the engine transform-block ctx sets it (from `cause.isProtectionTransfer`), so the ~17 other construction sites stay byte-identical.
- New parser detector `detectProtectionTransformToDot` stays **disjoint** from Voron/Orel's detector ("takes from protection is transformed" vs "transform the damage into a"); corpus-verified only Meatshield matches. Retired the now-stale audit allowlist entry.
- Transfer-block accounting credits only the instant portion per round (`instant = chunk.total − Σ transformedToDot`, guard `> 1e-9`); the deferred portion books via the generic-DoT tick path. Byte-identical for any protector without a transform ability.

**Deferred (out of scope):** Meatshield's dynamic Protection stack-stealing active/charge; per-stack redirect log-event fidelity.

## Testing
- New integration tests: barriered target → protector takes nothing; redirected chunk → 2-turn self-DoT summing to `chunk.total`, on both player and enemy side (team-symmetry).
- Full suite 4441 green, skill audit 0 non-allowlisted findings, no golden moved.
- Subagent-driven per-task reviews + whole-branch review (all clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
