### PR TITLE
feat: ship kit correctness-audit harness + full-roster ledger

### DIFF
--- a/docs/superpowers/plans/2026-07-16-ship-kit-correctness-audit.md
+++ b/docs/superpowers/plans/2026-07-16-ship-kit-correctness-audit.md
@@ -217,7 +217,8 @@ git commit -m "refactor: extract shared ship-skill CSV reader for the kit-audit 
   - `const SHIP_DATA_BY_NAME: Map<string, import('../../src/constants/ships').` ... (a `Map<string, ShipData>` keyed on display name).
 
 Notes on construction:
-- Skill text comes from the CSV record (authoritative). Stats/affinity/rarity/faction/role come from `SHIPS[key]` (matched by `ShipData.name === record.name`).
+- Skill text comes from the CSV record (authoritative). Stats/affinity/rarity/faction/role come from `SHIPS[key]`, matched **case-insensitively** (the CSV `name` column is inconsistently cased — `AEGIS`, `APEX` are all-caps while `Akula`, `Amartya` are mixed-case — but `ShipData.name` is always canonical mixed-case). Both the SHIPS lookup and the CSV-record lookup key on `name.toUpperCase()`.
+- The returned `Ship.name` is the **canonical** `SHIPS` name (`data.name`, e.g. `Aegis`), NOT the raw CSV casing — so bundles/ledger use one consistent spelling regardless of whether the caller passed `AEGIS` or `Aegis`.
 - `refits` is synthesized as an array of `refitLevel` empty objects (`[{}, {}, {}, {}]` for R4) so `getShipSkillRows` selects the intended passive tier. `refitLevel` defaults to 4.
 - `baseStats` maps `ShipData` fields → `BaseStats` (`hp, attack, defence, hacking, security, crit=critRate, critDamage, speed`).
 
@@ -272,28 +273,30 @@ export interface BuildTraceShipOpts {
     refitLevel?: RefitLevel;
 }
 
+// Keyed on the UPPERCASED name because the CSV name column is inconsistently cased
+// (AEGIS/APEX all-caps vs Akula/Amartya mixed) while ShipData.name is canonical mixed-case.
 export const SHIP_DATA_BY_NAME: Map<string, ShipData> = new Map(
-    Object.values(SHIPS).map((d) => [d.name, d])
+    Object.values(SHIPS).map((d) => [d.name.toUpperCase(), d])
 );
 
 let recordCache: Map<string, ShipSkillRecord> | null = null;
 function recordFor(name: string): ShipSkillRecord | undefined {
     if (!recordCache) {
-        recordCache = new Map(loadShipSkillRecords().map((r) => [r.name, r]));
+        recordCache = new Map(loadShipSkillRecords().map((r) => [r.name.toUpperCase(), r]));
     }
-    return recordCache.get(name);
+    return recordCache.get(name.toUpperCase());
 }
 
 export function buildTraceShip(name: string, opts: BuildTraceShipOpts = {}): Ship | null {
-    const data = SHIP_DATA_BY_NAME.get(name);
+    const data = SHIP_DATA_BY_NAME.get(name.toUpperCase());
     if (!data) return null;
     const rec = recordFor(name);
     const refitLevel = opts.refitLevel ?? 4;
     const refits: Refit[] = Array.from({ length: refitLevel }, () => ({}) as Refit);
 
     return {
-        id: `trace:${name}`,
-        name,
+        id: `trace:${data.name}`,
+        name: data.name, // canonical SHIPS casing, not the raw CSV casing
         rarity: data.rarity ?? 'legendary',
         faction: data.faction ?? 'MPL',
         type: data.role ?? 'ATTACKER',
@@ -683,11 +686,13 @@ export function buildKitBundle(
             target: (ability as { target?: string }).target,
             trigger: ability.trigger,
             summary: JSON.stringify(ability.config),
-            observed: logHasEventForShip(combatLog, eventTypes, name),
+            // Search by the ship's CANONICAL name (buildTraceShip normalizes CSV casing) —
+            // the combat log contains ship.name, which may differ from the caller's raw `name`.
+            observed: logHasEventForShip(combatLog, eventTypes, ship.name),
         };
     });
 
-    return { name, refitLevel: overrides.refitLevel ?? 4, skillRows, abilities, combatLog, outcome };
+    return { name: ship.name, refitLevel: overrides.refitLevel ?? 4, skillRows, abilities, combatLog, outcome };
 }
 
 export function renderKitBundleMarkdown(bundle: KitBundleResult): string {

--- a/docs/superpowers/plans/2026-07-16-ship-kit-correctness-audit.md
+++ b/docs/superpowers/plans/2026-07-16-ship-kit-correctness-audit.md
@@ -244,8 +244,18 @@ describe('buildTraceShip', () => {
         expect(ship!.refits).toHaveLength(4);
     });
 
-    it('returns null for a name with no SHIPS base stats', () => {
+    it('returns null when there is neither SHIPS data nor a CSV record', () => {
         expect(buildTraceShip('NotARealShip_zzz')).toBeNull();
+    });
+
+    it.skipIf(!csvAvailable())('traces a CSV-only ship (no SHIPS entry) on the default baseline', () => {
+        // Centurion has skill text in the CSV but no SHIPS entry — must still trace.
+        const ship = buildTraceShip('Centurion');
+        expect(ship).not.toBeNull();
+        expect(ship!.name).toBe('Centurion');
+        expect(ship!.baseStats.hp).toBe(200_000); // default baseline
+        expect(ship!.affinity).toBe('antimatter'); // neutral fallback
+        expect((ship!.activeSkillText ?? '').length).toBeGreaterThan(0); // CSV skill text present
     });
 
     it.skipIf(!csvAvailable())('honours a lower refit level', () => {
@@ -289,42 +299,47 @@ function recordFor(name: string): ShipSkillRecord | undefined {
 
 export function buildTraceShip(name: string, opts: BuildTraceShipOpts = {}): Ship | null {
     const data = SHIP_DATA_BY_NAME.get(name.toUpperCase());
-    if (!data) return null;
     const rec = recordFor(name);
+    // Need at least ONE source. Eight CSV ships (Amartya, Centurion, Enforcer, Graphite, Hemlock,
+    // Lingshe, Meatshield, Wildfire) have skill text but NO SHIPS entry — trace them on a default
+    // stat baseline (affinity 'antimatter' = always-neutral, so no affinity distortion) so the
+    // parser+execution audit still covers all 147. Return null only when NEITHER source exists.
+    if (!data && !rec) return null;
+    const canonicalName = data?.name ?? rec!.name;
     const refitLevel = opts.refitLevel ?? 4;
     const refits: Refit[] = Array.from({ length: refitLevel }, () => ({}) as Refit);
 
     return {
-        id: `trace:${data.name}`,
-        name: data.name, // canonical SHIPS casing, not the raw CSV casing
-        rarity: data.rarity ?? 'legendary',
-        faction: data.faction ?? 'MPL',
-        type: data.role ?? 'ATTACKER',
-        affinity: data.affinity ?? 'antimatter',
+        id: `trace:${canonicalName}`,
+        name: canonicalName, // canonical SHIPS casing when available, else the CSV name
+        rarity: data?.rarity ?? 'legendary',
+        faction: data?.faction ?? 'MPL',
+        type: data?.role ?? 'ATTACKER',
+        affinity: data?.affinity ?? 'antimatter',
         baseStats: {
-            hp: data.hp ?? 200_000,
-            attack: data.attack ?? 2000,
-            defence: data.defense ?? 300,
-            hacking: data.hacking ?? 200,
-            security: data.security ?? 150,
-            crit: data.critRate ?? 50,
-            critDamage: data.critDamage ?? 150,
-            speed: data.speed ?? 100,
+            hp: data?.hp ?? 200_000,
+            attack: data?.attack ?? 2000,
+            defence: data?.defense ?? 300,
+            hacking: data?.hacking ?? 200,
+            security: data?.security ?? 150,
+            crit: data?.critRate ?? 50,
+            critDamage: data?.critDamage ?? 150,
+            speed: data?.speed ?? 100,
         },
         equipment: {},
         implants: {},
         refits,
         // CSV skill text is authoritative; fall back to SHIPS text only if the CSV lacks a record.
-        activeSkillText: rec?.active || data.activeSkillText,
-        chargeSkillText: rec?.charge || data.chargeSkillText,
-        chargeSkillCharge: rec?.chargeCharge ?? data.chargeSkillCharge ?? 0,
-        firstPassiveSkillText: rec?.passives[0] || data.firstPassiveSkillText,
-        secondPassiveSkillText: rec?.passives[1] || data.secondPassiveSkillText,
-        thirdPassiveSkillText: rec?.passives[2] || data.thirdPassiveSkillText,
-        activeTarget: data.activeTarget,
-        activePattern: data.activePattern,
-        chargedTarget: data.chargedTarget,
-        chargedPattern: data.chargedPattern,
+        activeSkillText: rec?.active || data?.activeSkillText,
+        chargeSkillText: rec?.charge || data?.chargeSkillText,
+        chargeSkillCharge: rec?.chargeCharge ?? data?.chargeSkillCharge ?? 0,
+        firstPassiveSkillText: rec?.passives[0] || data?.firstPassiveSkillText,
+        secondPassiveSkillText: rec?.passives[1] || data?.secondPassiveSkillText,
+        thirdPassiveSkillText: rec?.passives[2] || data?.thirdPassiveSkillText,
+        activeTarget: data?.activeTarget,
+        activePattern: data?.activePattern,
+        chargedTarget: data?.chargedTarget,
+        chargedPattern: data?.chargedPattern,
     };
 }
 ```

--- a/docs/superpowers/plans/2026-07-16-ship-kit-correctness-audit.md
+++ b/docs/superpowers/plans/2026-07-16-ship-kit-correctness-audit.md
@@ -1,0 +1,968 @@
+# Ship Kit Correctness Audit — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a reproducible trace-bundle harness (skill text + parsed abilities + real combat-log) over all 147 ships, then run a batched review→escalate→adversarial-verify Workflow that produces a ranked, verified ship-kit correctness ledger.
+
+**Architecture:** A set of headless `scripts/` modules (siblings to `auditSkills.ts`) build a per-ship "kit bundle". A standardized `simulateBattle` scenario runs each reviewed ship as the focus actor against a fixed roster; the mature combat log (`LOG_EVENT_TYPES`) is the execution oracle. A Workflow fans the 147 ships across review subagents, escalates untriggered/wrong-exec branches to forced micro-scenarios, adversarially verifies every candidate finding, and emits the ledger. This project ends at the ledger — fixes are scoped separately.
+
+**Tech Stack:** TypeScript, `tsx` (script runner), Vitest (harness smoke tests), the existing combat engine (`buildShipAbilities`, `simulateBattle`), the Workflow tool.
+
+## Global Constraints
+
+- **Skill-text source of truth:** `docs/ship-skills.csv` (tagged), NOT `src/constants/ships.ts`. Parsed abilities and the combat trace both derive from CSV text. Copy verbatim; do not re-word.
+- **docs/ is gitignored.** Design/plan docs under `docs/superpowers/` are force-tracked (`git add -f`); the CSV and generated bundles/ledger are dev-only and NOT committed.
+- **CSV-dependent tests must skip when the CSV is absent** (clean checkouts / CI) via a `csvAvailable()` guard — mirror `skillAuditCoverage.test.ts`.
+- **Tests live under `src/**/__tests__/`** (vitest `include: ['src/**/*']`) and import script code by relative path (e.g. `../../../../scripts/...`), exactly like `skillAuditCoverage.test.ts`.
+- **Never run `vitest -u`** and never touch golden snapshots. The golden audit spans the WHOLE `npm test`.
+- **`.env` must be present** before running the full suite (husky pre-commit runs vitest); copy the main repo's `.env` into any worktree.
+- **Refit resolution:** only the refit-active passive applies, resolved by `getShipSkillRows` (R4 needs ≥4 refits, R2 needs ≥2, else R0). Default trace = highest available passive (synthesize 4 refits); escalate to R0/R2 only when a ship's passives differ meaningfully.
+- **Engine gotcha (must respect in scenario design):** giving ANY player-side ship an ally-targeted heal active flips `engine.ts`'s `dummyEnemyIsVestigial` gate to false and silently zeroes every player ship's `all-enemies` reactive against the real roster. Filler allies in the standard scenario therefore use enemy-targeted DAMAGE actives only. A reviewed ship that is itself a healer is flagged for escalation of any `all-enemies` reactive passive it carries.
+
+---
+
+## File Structure
+
+- `scripts/lib/shipSkillCsv.ts` — **create.** Shared CSV primitives (`parseCsvLine`, `readCsvRecords`, `csvAvailable`) + `loadShipSkillRecords()` returning structured per-ship skill text. Consumed by `auditSkills.ts` (refactored to use it) and the harness.
+- `scripts/lib/traceShipFactory.ts` — **create.** `buildTraceShip(name, opts)` merges CSV skill text + `SHIPS[name]` stats into a full `Ship`; `SHIP_DATA_BY_NAME` lookup.
+- `scripts/lib/traceScenario.ts` — **create.** `buildStandardScenario(reviewed, overrides?)` → `BattleSimulationInput` (reviewed ship at focus + fixed fillers + fixed enemy roster); `ScenarioOverrides` type.
+- `scripts/lib/kitBundle.ts` — **create.** `buildKitBundle(name, overrides?)` (text + parsed abilities + combat-log + per-clause observed labels) and `renderKitBundleMarkdown(bundle)`.
+- `scripts/lib/kitLedger.ts` — **create.** `renderLedgerMarkdown(findings)` + `renderLedgerJson(findings)` from confirmed findings.
+- `scripts/traceShip.ts` — **create.** CLI: `--all` or ship names + override flags → writes `docs/kit-bundles/<Name>.{json,md}`.
+- `scripts/writeKitLedger.ts` — **create.** CLI: reads a findings JSON → writes `docs/ship-kit-correctness-ledger.{md,json}`.
+- `scripts/auditSkills.ts` — **modify.** Delete its local `parseCsvLine`/`readCsvRecords`; import from `scripts/lib/shipSkillCsv.ts`. Behavior must stay identical (audit still reports 0 findings).
+- Tests (create): `src/utils/abilities/__tests__/shipSkillCsv.test.ts`, `traceShipFactory.test.ts`, `traceScenario.test.ts`, `kitBundle.test.ts`, `kitLedger.test.ts` (co-located with existing audit tests).
+
+---
+
+### Task 1: Shared CSV reader
+
+**Files:**
+- Create: `scripts/lib/shipSkillCsv.ts`
+- Modify: `scripts/auditSkills.ts` (remove local `parseCsvLine` + `readCsvRecords`; import from the lib)
+- Test: `src/utils/abilities/__tests__/shipSkillCsv.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `parseCsvLine(line: string): string[]`
+  - `readCsvRecords(raw: string): string[]`
+  - `csvAvailable(csvPath?: string): boolean`
+  - `interface ShipSkillRecord { name: string; active: string; charge: string; chargeCharge: number; passives: [string, string, string]; }`
+  - `loadShipSkillRecords(csvPath?: string): ShipSkillRecord[]`
+  - `const CSV_PATH = 'docs/ship-skills.csv'`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/utils/abilities/__tests__/shipSkillCsv.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+    parseCsvLine,
+    csvAvailable,
+    loadShipSkillRecords,
+} from '../../../../scripts/lib/shipSkillCsv';
+
+describe('shipSkillCsv', () => {
+    it('parses a quoted field containing commas and escaped quotes', () => {
+        expect(parseCsvLine('a,"b,c","d""e"')).toEqual(['a', 'b,c', 'd"e']);
+    });
+
+    it.skipIf(!csvAvailable())('loads structured records with a resolvable name', () => {
+        const records = loadShipSkillRecords();
+        expect(records.length).toBeGreaterThan(100);
+        const aegis = records.find((r) => r.name === 'Aegis');
+        expect(aegis).toBeDefined();
+        expect(aegis!.active.length).toBeGreaterThan(0);
+        expect(aegis!.passives).toHaveLength(3);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest --run src/utils/abilities/__tests__/shipSkillCsv.test.ts`
+Expected: FAIL — cannot resolve `../../../../scripts/lib/shipSkillCsv`.
+
+- [ ] **Step 3: Write the shared module**
+
+Move the CSV primitives out of `auditSkills.ts` verbatim (the `parseCsvLine` and `readCsvRecords` functions — including the multi-line-record accumulation logic) and add the structured loader:
+
+```ts
+// scripts/lib/shipSkillCsv.ts
+import { readFileSync, existsSync } from 'fs';
+
+export const CSV_PATH = 'docs/ship-skills.csv';
+
+// Verbatim copy from auditSkills.ts — handles quoted fields, escaped quotes, embedded commas.
+export function parseCsvLine(line: string): string[] {
+    const fields: string[] = [];
+    let cur = '';
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i++) {
+        const c = line[i];
+        if (inQuotes) {
+            if (c === '"') {
+                if (line[i + 1] === '"') {
+                    cur += '"';
+                    i++;
+                } else inQuotes = false;
+            } else cur += c;
+        } else if (c === '"') inQuotes = true;
+        else if (c === ',') {
+            fields.push(cur);
+            cur = '';
+        } else cur += c;
+    }
+    fields.push(cur);
+    return fields;
+}
+
+// Verbatim copy from auditSkills.ts — accumulates physical lines until quotes balance so
+// multi-line quoted passives (Centurion, Chimei, Curator, Enforcer, Graphite, Lingshe) survive.
+export function readCsvRecords(raw: string): string[] {
+    const physicalLines = raw.split('\n');
+    const records: string[] = [];
+    let buffer: string[] = [];
+    let quoteCount = 0;
+    for (const line of physicalLines) {
+        buffer.push(line);
+        quoteCount += (line.match(/"/g) ?? []).length;
+        if (quoteCount % 2 === 0) {
+            records.push(buffer.join('\n'));
+            buffer = [];
+        }
+    }
+    if (buffer.length) records.push(buffer.join('\n'));
+    return records;
+}
+
+export function csvAvailable(csvPath: string = CSV_PATH): boolean {
+    return existsSync(csvPath);
+}
+
+export interface ShipSkillRecord {
+    name: string;
+    active: string;
+    charge: string;
+    chargeCharge: number;
+    passives: [string, string, string];
+}
+
+const clean = (s: string | undefined): string =>
+    s && s !== 'null' && s.trim().length > 0 ? s : '';
+
+export function loadShipSkillRecords(csvPath: string = CSV_PATH): ShipSkillRecord[] {
+    // Header: name,active_skill_text,charge_skill_charge,charge_skill_text,
+    //         first_passive_skill_text,second_passive_skill_text,third_passive_skill_text
+    const records = readCsvRecords(readFileSync(csvPath, 'utf8'));
+    const out: ShipSkillRecord[] = [];
+    for (let i = 1; i < records.length; i++) {
+        const f = parseCsvLine(records[i]);
+        if (f.length < 7) continue;
+        const [name, active, chargeCharge, charge, p1, p2, p3] = f;
+        out.push({
+            name: name.trim(),
+            active: clean(active),
+            charge: clean(charge),
+            chargeCharge: Number(chargeCharge) || 0,
+            passives: [clean(p1), clean(p2), clean(p3)],
+        });
+    }
+    return out;
+}
+```
+
+- [ ] **Step 4: Refactor `auditSkills.ts` to import from the lib**
+
+In `scripts/auditSkills.ts`: delete the local `parseCsvLine` and `readCsvRecords` function definitions and the local `existsSync` CSV check; add at the top with the other imports:
+
+```ts
+import { parseCsvLine, readCsvRecords, csvAvailable, CSV_PATH } from './lib/shipSkillCsv';
+```
+
+Keep `auditSkills.ts`'s own `readShips()` (it builds the `{name, slots}` shape the audit rules need) — it now calls the imported `readCsvRecords`/`parseCsvLine`. If `auditSkills.ts` already exports a `csvAvailable`, re-export the lib's instead of redefining.
+
+- [ ] **Step 5: Run harness test + verify the audit is unchanged**
+
+Run: `npx vitest --run src/utils/abilities/__tests__/shipSkillCsv.test.ts`
+Expected: PASS.
+
+Run: `npm run audit:skills`
+Expected: `Audited 147 ships → 0 findings.` (byte-identical to before this task).
+
+Run: `npx vitest --run src/utils/abilities/__tests__/skillAuditCoverage.test.ts`
+Expected: PASS (the audit regression guard still green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/shipSkillCsv.ts scripts/auditSkills.ts src/utils/abilities/__tests__/shipSkillCsv.test.ts
+git commit -m "refactor: extract shared ship-skill CSV reader for the kit-audit harness"
+```
+
+---
+
+### Task 2: Trace-ship factory
+
+**Files:**
+- Create: `scripts/lib/traceShipFactory.ts`
+- Test: `src/utils/abilities/__tests__/traceShipFactory.test.ts`
+
+**Interfaces:**
+- Consumes: `loadShipSkillRecords`, `csvAvailable` (Task 1); `SHIPS` (`src/constants/ships.ts`); `Ship`, `Refit` (`src/types/ship.ts`).
+- Produces:
+  - `type RefitLevel = 0 | 2 | 4`
+  - `interface BuildTraceShipOpts { refitLevel?: RefitLevel; }`
+  - `buildTraceShip(name: string, opts?: BuildTraceShipOpts): Ship | null` — null when `name` is not in `SHIPS` (no baseStats available → caller records HARNESS-ERROR).
+  - `const SHIP_DATA_BY_NAME: Map<string, import('../../src/constants/ships').` ... (a `Map<string, ShipData>` keyed on display name).
+
+Notes on construction:
+- Skill text comes from the CSV record (authoritative). Stats/affinity/rarity/faction/role come from `SHIPS[key]` (matched by `ShipData.name === record.name`).
+- `refits` is synthesized as an array of `refitLevel` empty objects (`[{}, {}, {}, {}]` for R4) so `getShipSkillRows` selects the intended passive tier. `refitLevel` defaults to 4.
+- `baseStats` maps `ShipData` fields → `BaseStats` (`hp, attack, defence, hacking, security, crit=critRate, critDamage, speed`).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/utils/abilities/__tests__/traceShipFactory.test.ts
+import { describe, it, expect } from 'vitest';
+import { csvAvailable } from '../../../../scripts/lib/shipSkillCsv';
+import { buildTraceShip } from '../../../../scripts/lib/traceShipFactory';
+
+describe('buildTraceShip', () => {
+    it.skipIf(!csvAvailable())('merges CSV skill text with SHIPS base stats', () => {
+        const ship = buildTraceShip('Aegis');
+        expect(ship).not.toBeNull();
+        expect(ship!.name).toBe('Aegis');
+        expect(ship!.baseStats.hp).toBeGreaterThan(0);
+        expect(ship!.baseStats.attack).toBeGreaterThan(0);
+        expect(ship!.affinity).toBe('antimatter');
+        // CSV active text flows onto the ship (authoritative source).
+        expect(ship!.activeSkillText).toContain('shield');
+        // Default refit level 4 → four synthesized refits so R4 passive resolves if present.
+        expect(ship!.refits).toHaveLength(4);
+    });
+
+    it('returns null for a name with no SHIPS base stats', () => {
+        expect(buildTraceShip('NotARealShip_zzz')).toBeNull();
+    });
+
+    it.skipIf(!csvAvailable())('honours a lower refit level', () => {
+        const r0 = buildTraceShip('Aegis', { refitLevel: 0 });
+        expect(r0!.refits).toHaveLength(0);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest --run src/utils/abilities/__tests__/traceShipFactory.test.ts`
+Expected: FAIL — cannot resolve `traceShipFactory`.
+
+- [ ] **Step 3: Write the factory**
+
+```ts
+// scripts/lib/traceShipFactory.ts
+import type { Ship, Refit, ShipData } from '../../src/types/ship';
+import { SHIPS } from '../../src/constants/ships';
+import { loadShipSkillRecords, ShipSkillRecord } from './shipSkillCsv';
+
+export type RefitLevel = 0 | 2 | 4;
+export interface BuildTraceShipOpts {
+    refitLevel?: RefitLevel;
+}
+
+export const SHIP_DATA_BY_NAME: Map<string, ShipData> = new Map(
+    Object.values(SHIPS).map((d) => [d.name, d])
+);
+
+let recordCache: Map<string, ShipSkillRecord> | null = null;
+function recordFor(name: string): ShipSkillRecord | undefined {
+    if (!recordCache) {
+        recordCache = new Map(loadShipSkillRecords().map((r) => [r.name, r]));
+    }
+    return recordCache.get(name);
+}
+
+export function buildTraceShip(name: string, opts: BuildTraceShipOpts = {}): Ship | null {
+    const data = SHIP_DATA_BY_NAME.get(name);
+    if (!data) return null;
+    const rec = recordFor(name);
+    const refitLevel = opts.refitLevel ?? 4;
+    const refits: Refit[] = Array.from({ length: refitLevel }, () => ({}) as Refit);
+
+    return {
+        id: `trace:${name}`,
+        name,
+        rarity: data.rarity ?? 'legendary',
+        faction: data.faction ?? 'MPL',
+        type: data.role ?? 'ATTACKER',
+        affinity: data.affinity ?? 'antimatter',
+        baseStats: {
+            hp: data.hp ?? 200_000,
+            attack: data.attack ?? 2000,
+            defence: data.defense ?? 300,
+            hacking: data.hacking ?? 200,
+            security: data.security ?? 150,
+            crit: data.critRate ?? 50,
+            critDamage: data.critDamage ?? 150,
+            speed: data.speed ?? 100,
+        },
+        equipment: {},
+        implants: {},
+        refits,
+        // CSV skill text is authoritative; fall back to SHIPS text only if the CSV lacks a record.
+        activeSkillText: rec?.active || data.activeSkillText,
+        chargeSkillText: rec?.charge || data.chargeSkillText,
+        chargeSkillCharge: rec?.chargeCharge ?? data.chargeSkillCharge ?? 0,
+        firstPassiveSkillText: rec?.passives[0] || data.firstPassiveSkillText,
+        secondPassiveSkillText: rec?.passives[1] || data.secondPassiveSkillText,
+        thirdPassiveSkillText: rec?.passives[2] || data.thirdPassiveSkillText,
+        activeTarget: data.activeTarget,
+        activePattern: data.activePattern,
+        chargedTarget: data.chargedTarget,
+        chargedPattern: data.chargedPattern,
+    };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest --run src/utils/abilities/__tests__/traceShipFactory.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/traceShipFactory.ts src/utils/abilities/__tests__/traceShipFactory.test.ts
+git commit -m "feat: buildTraceShip merges CSV skill text with SHIPS base stats for the kit-audit harness"
+```
+
+---
+
+### Task 3: Standardized scenario builder
+
+**Files:**
+- Create: `scripts/lib/traceScenario.ts`
+- Test: `src/utils/abilities/__tests__/traceScenario.test.ts`
+
+**Interfaces:**
+- Consumes: `Ship` (`src/types/ship.ts`); `BattlePlacement`, `BattleSimulationInput`, `simulateBattle` (`src/utils/calculators/battleSimulator.ts`); `Position` (`src/types/encounters.ts`).
+- Produces:
+  - `interface ScenarioOverrides { rounds?: number; reviewedCrit?: number; reviewedHpScale?: number; enemyAttackScale?: number; enemyAffinity?: import('../../src/types/ship').AffinityName; includeFragileAlly?: boolean; }`
+  - `buildStandardScenario(reviewed: Ship, overrides?: ScenarioOverrides): BattleSimulationInput`
+
+Design (mirrors `simGoldenFixtures.ts`):
+- Reviewed ship at **`M4`** (focus, `player[0]`), `statOverrides` copied from its `baseStats` (× `reviewedHpScale` on hp, `reviewedCrit` wins on crit when set).
+- **Filler allies** (fixed): one ATTACKER (`M1`) + one DEFENDER with an on-attacked counter (`B4`), both with enemy-targeted **damage** actives only (never an ally-heal — respects the `dummyEnemyIsVestigial` gotcha). When `includeFragileAlly` is set, add a low-HP ATTACKER (`B1`) that dies early to fire on-ally-death triggers.
+- **Fixed enemy roster:** three attackers across rows T/M/B (`T1/M1→use distinct cells/B1`) with real damage actives + one applying a debuff, tuned to (a) drop the reviewed ship's HP through gates and (b) plausibly kill the fragile ally, without one-round-lethality. Enemy attack × `enemyAttackScale` (default 1); first enemy's affinity set from `enemyAffinity` when provided.
+- **Rounds:** default **30** (charge branches fire; multi-round DoT/reactive repeat).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/utils/abilities/__tests__/traceScenario.test.ts
+import { describe, it, expect } from 'vitest';
+import { buildStandardScenario } from '../../../../scripts/lib/traceScenario';
+import { simulateBattle } from '../../../../src/utils/calculators/battleSimulator';
+import type { Ship } from '../../../../src/types/ship';
+
+const reviewed: Ship = {
+    id: 'trace:Test',
+    name: 'Test',
+    rarity: 'legendary',
+    faction: 'MPL',
+    type: 'ATTACKER',
+    affinity: 'antimatter',
+    baseStats: { hp: 250_000, attack: 3000, defence: 300, hacking: 220, security: 150, crit: 50, critDamage: 150, speed: 120 },
+    equipment: {},
+    implants: {},
+    refits: [],
+    activeSkillText: 'This Unit deals <unit-damage>120% damage</unit-damage>.',
+    activeTarget: 'front',
+    activePattern: 'Pattern-Base',
+};
+
+describe('buildStandardScenario', () => {
+    it('places the reviewed ship as the focus actor with fillers and enemies', () => {
+        const input = buildStandardScenario(reviewed);
+        expect(input.playerTeam[0].ship.name).toBe('Test');
+        expect(input.playerTeam[0].position).toBe('M4');
+        expect(input.playerTeam.length).toBeGreaterThanOrEqual(3);
+        expect(input.enemyTeam.length).toBeGreaterThanOrEqual(3);
+        expect(input.rounds).toBe(30);
+    });
+
+    it('produces a runnable battle with a non-empty combat log', () => {
+        const result = simulateBattle(buildStandardScenario(reviewed));
+        expect(result.combatLog.length).toBeGreaterThan(0);
+        // The reviewed ship acted at least once (its active fired).
+        const acted = result.combatLog.some((round) =>
+            JSON.stringify(round).includes('Test')
+        );
+        expect(acted).toBe(true);
+    });
+
+    it('adds a fragile ally when requested', () => {
+        const input = buildStandardScenario(reviewed, { includeFragileAlly: true });
+        expect(input.playerTeam.length).toBe(4);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest --run src/utils/abilities/__tests__/traceScenario.test.ts`
+Expected: FAIL — cannot resolve `traceScenario`.
+
+- [ ] **Step 3: Write the scenario builder**
+
+```ts
+// scripts/lib/traceScenario.ts
+import type { Ship } from '../../src/types/ship';
+import type { AffinityName } from '../../src/types/ship';
+import type { Position } from '../../src/types/encounters';
+import type { BattlePlacement, BattleSimulationInput } from '../../src/utils/calculators/battleSimulator';
+
+export interface ScenarioOverrides {
+    rounds?: number;
+    reviewedCrit?: number;
+    reviewedHpScale?: number;
+    enemyAttackScale?: number;
+    enemyAffinity?: AffinityName;
+    includeFragileAlly?: boolean;
+}
+
+const placement = (
+    ship: Ship,
+    position: Position,
+    over: Partial<{ hp: number; crit: number; attack: number }> = {}
+): BattlePlacement => ({
+    ship,
+    position,
+    statOverrides: {
+        attack: over.attack ?? ship.baseStats.attack,
+        crit: over.crit ?? ship.baseStats.crit,
+        critDamage: ship.baseStats.critDamage,
+        defensePenetration: 0,
+        hacking: ship.baseStats.hacking,
+        security: ship.baseStats.security,
+        defence: ship.baseStats.defence,
+        hp: over.hp ?? ship.baseStats.hp,
+        speed: ship.baseStats.speed,
+    },
+});
+
+const fillerBase = (id: string, name: string, type: Ship['type'], stats: Partial<Ship['baseStats']>): Ship => ({
+    id,
+    name,
+    rarity: 'legendary',
+    faction: 'MPL',
+    type,
+    affinity: 'antimatter',
+    baseStats: {
+        hp: 260_000, attack: 1500, defence: 300, hacking: 200, security: 150,
+        crit: 50, critDamage: 150, speed: 100, ...stats,
+    },
+    equipment: {},
+    implants: {},
+    refits: [],
+    activeSkillText: 'This Unit deals <unit-damage>100% damage</unit-damage>.',
+    activeTarget: 'front',
+    activePattern: 'Pattern-Base',
+});
+
+// Filler ally with an on-attacked counter (a real reactive to co-exist alongside the reviewed
+// ship). Enemy-targeted damage active only — NEVER an ally-heal (dummyEnemyIsVestigial gotcha).
+const counterAlly = (): Ship => ({
+    ...fillerBase('trace-ally-counter', 'CounterAlly', 'DEFENDER', { attack: 1200, defence: 500, speed: 95 }),
+    firstPassiveSkillText:
+        'When this Unit is directly damaged as a primary target, it deals <unit-damage>70% damage</unit-damage> to that enemy.',
+});
+
+const plainAlly = (): Ship => fillerBase('trace-ally-plain', 'PlainAlly', 'ATTACKER', { attack: 1800, speed: 110 });
+
+const fragileAlly = (): Ship =>
+    fillerBase('trace-ally-fragile', 'FragileAlly', 'ATTACKER', { hp: 40_000, defence: 100, speed: 105 });
+
+const enemyAttacker = (id: string, name: string, affinity: AffinityName, attack: number): Ship => ({
+    ...fillerBase(id, name, 'ATTACKER', { attack, hp: 240_000, speed: 100 }),
+    affinity,
+});
+
+const enemyDebuffer = (id: string, name: string, attack: number): Ship => ({
+    ...fillerBase(id, name, 'ATTACKER', { attack, hp: 240_000, speed: 105, hacking: 260 }),
+    activeSkillText:
+        'This Unit deals <unit-damage>100% damage</unit-damage> and inflicts <unit-skill>Defense Down II</unit-skill> for 2 turns.',
+});
+
+export function buildStandardScenario(reviewed: Ship, overrides: ScenarioOverrides = {}): BattleSimulationInput {
+    const hpScale = overrides.reviewedHpScale ?? 1;
+    const atkScale = overrides.enemyAttackScale ?? 1;
+    const enemyAff = overrides.enemyAffinity ?? 'chemical';
+
+    const playerTeam: BattlePlacement[] = [
+        placement(reviewed, 'M4', {
+            hp: Math.round(reviewed.baseStats.hp * hpScale),
+            crit: overrides.reviewedCrit ?? reviewed.baseStats.crit,
+        }),
+        placement(plainAlly(), 'M1'),
+        placement(counterAlly(), 'B4'),
+    ];
+    if (overrides.includeFragileAlly) playerTeam.push(placement(fragileAlly(), 'B1'));
+
+    const enemyTeam: BattlePlacement[] = [
+        placement(enemyAttacker('trace-e-1', 'EnemyA', enemyAff, Math.round(1600 * atkScale)), 'T1'),
+        placement(enemyDebuffer('trace-e-2', 'EnemyB', Math.round(1600 * atkScale)), 'M2'),
+        placement(enemyAttacker('trace-e-3', 'EnemyC', 'electric', Math.round(1500 * atkScale)), 'B2'),
+    ];
+
+    return { playerTeam, enemyTeam, rounds: overrides.rounds ?? 30 };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest --run src/utils/abilities/__tests__/traceScenario.test.ts`
+Expected: PASS.
+
+If the "reviewed ship acted" assertion fails, the reviewed ship's `activeTarget`/`activePattern` may be undefined for a real ship whose CSV row lacks targeting — that is handled in Task 4 (the CLI supplies targeting fallbacks); this synthetic-ship test already sets them.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/traceScenario.ts src/utils/abilities/__tests__/traceScenario.test.ts
+git commit -m "feat: standardized battle scenario builder for the kit-audit harness"
+```
+
+---
+
+### Task 4: Kit-bundle builder + observed-clause labeler
+
+**Files:**
+- Create: `scripts/lib/kitBundle.ts`
+- Test: `src/utils/abilities/__tests__/kitBundle.test.ts`
+
+**Interfaces:**
+- Consumes: `buildTraceShip` (Task 2); `buildStandardScenario`, `ScenarioOverrides` (Task 3); `getShipSkillRows` (`src/utils/ship/skillRows.ts`); `buildShipAbilities` (`src/utils/abilities/buildShipAbilities.ts`); `simulateBattle` (`src/utils/calculators/battleSimulator.ts`); `Ability` (`src/types/abilities.ts`).
+- Produces:
+  - `interface ClauseTrace { slot: string; type: string; target?: string; trigger?: string; summary: string; observed: boolean; }`
+  - `interface KitBundle { name: string; refitLevel: number; skillRows: { label: string; text: string }[]; abilities: ClauseTrace[]; combatLog: unknown[]; outcome: unknown; }`
+  - `type KitBundleResult = KitBundle | { name: string; error: string };`
+  - `buildKitBundle(name: string, overrides?: ScenarioOverrides & { refitLevel?: 0 | 2 | 4 }): KitBundleResult`
+  - `renderKitBundleMarkdown(bundle: KitBundleResult): string`
+  - `const ABILITY_TYPE_TO_LOG_EVENTS: Record<string, string[]>`
+
+Observed-labeler heuristic: an ability is `observed` when the combat log contains ≥1 event whose `type` is in `ABILITY_TYPE_TO_LOG_EVENTS[ability.type]` AND references the reviewed ship as actor/source. This is a routing aid for escalation — the reviewer makes the actual correctness judgment; it does not decide findings.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/utils/abilities/__tests__/kitBundle.test.ts
+import { describe, it, expect } from 'vitest';
+import { csvAvailable } from '../../../../scripts/lib/shipSkillCsv';
+import { buildKitBundle, renderKitBundleMarkdown } from '../../../../scripts/lib/kitBundle';
+
+describe('buildKitBundle', () => {
+    it('returns an error record for an unknown ship', () => {
+        const b = buildKitBundle('NotARealShip_zzz');
+        expect('error' in b).toBe(true);
+    });
+
+    it.skipIf(!csvAvailable())('produces all three sections for a real ship', () => {
+        const b = buildKitBundle('Aegis');
+        expect('error' in b).toBe(false);
+        if ('error' in b) return;
+        expect(b.skillRows.length).toBeGreaterThan(0);
+        expect(b.abilities.length).toBeGreaterThan(0);
+        expect(b.combatLog.length).toBeGreaterThan(0);
+        // At least one clause was observed executing in the standardized scenario.
+        expect(b.abilities.some((a) => a.observed)).toBe(true);
+    });
+
+    it.skipIf(!csvAvailable())('renders markdown with the three section headers', () => {
+        const md = renderKitBundleMarkdown(buildKitBundle('Aegis'));
+        expect(md).toContain('## Skill text');
+        expect(md).toContain('## Parsed abilities');
+        expect(md).toContain('## Execution trace');
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest --run src/utils/abilities/__tests__/kitBundle.test.ts`
+Expected: FAIL — cannot resolve `kitBundle`.
+
+- [ ] **Step 3: Write the bundle builder**
+
+```ts
+// scripts/lib/kitBundle.ts
+import { buildTraceShip } from './traceShipFactory';
+import { buildStandardScenario, ScenarioOverrides } from './traceScenario';
+import { getShipSkillRows } from '../../src/utils/ship/skillRows';
+import { buildShipAbilities } from '../../src/utils/abilities/buildShipAbilities';
+import { simulateBattle } from '../../src/utils/calculators/battleSimulator';
+import type { Ability } from '../../src/types/abilities';
+
+export const ABILITY_TYPE_TO_LOG_EVENTS: Record<string, string[]> = {
+    damage: ['attacked', 'ability-performed'],
+    counter: ['reactive-damage-performed', 'attacked'],
+    'additional-damage': ['attacked', 'ability-performed'],
+    heal: ['heal-performed', 'reactive-heal-performed'],
+    shield: ['shield-applied'],
+    buff: ['buff-applied'],
+    debuff: ['debuff-applied', 'debuff-resisted'],
+    dot: ['dot-applied', 'dot-ticked'],
+    control: ['control-applied'],
+    cleanse: ['cleanse-performed'],
+    purge: ['purge-performed'],
+    charge: ['charge-changed'],
+    modifier: ['buff-applied', 'stats-snapshot'],
+};
+
+export interface ClauseTrace {
+    slot: string;
+    type: string;
+    target?: string;
+    trigger?: string;
+    summary: string;
+    observed: boolean;
+}
+export interface KitBundle {
+    name: string;
+    refitLevel: number;
+    skillRows: { label: string; text: string }[];
+    abilities: ClauseTrace[];
+    combatLog: unknown[];
+    outcome: unknown;
+}
+export type KitBundleResult = KitBundle | { name: string; error: string };
+
+const TARGETING_FALLBACK = { activeTarget: 'front', activePattern: 'Pattern-Base' };
+
+// Does the log mention the reviewed ship by name in an entry of one of the expected types?
+function logHasEventForShip(log: unknown[], eventTypes: string[], shipName: string): boolean {
+    const needle = JSON.stringify(log);
+    // Coarse: the hierarchical log embeds actor names + event kind strings. A precise per-event
+    // walk is unnecessary — this only routes UNTRIGGERED clauses to escalation.
+    return eventTypes.some((t) => needle.includes(t)) && needle.includes(shipName);
+}
+
+export function buildKitBundle(
+    name: string,
+    overrides: ScenarioOverrides & { refitLevel?: 0 | 2 | 4 } = {}
+): KitBundleResult {
+    const ship = buildTraceShip(name, { refitLevel: overrides.refitLevel });
+    if (!ship) return { name, error: 'no SHIPS base stats for this name' };
+    // Supply targeting fallbacks so the reviewed ship's active resolves a victim in the sim.
+    if (!ship.activeTarget) ship.activeTarget = TARGETING_FALLBACK.activeTarget;
+    if (!ship.activePattern) ship.activePattern = TARGETING_FALLBACK.activePattern;
+
+    const skillRows = getShipSkillRows(ship).map((r) => ({ label: r.label, text: r.text }));
+    const built = buildShipAbilities(ship);
+    const allAbilities: { slot: string; ability: Ability }[] = built.slots.flatMap((s) =>
+        s.abilities.map((ability) => ({ slot: s.slot, ability }))
+    );
+
+    let combatLog: unknown[] = [];
+    let outcome: unknown = null;
+    try {
+        const result = simulateBattle(buildStandardScenario(ship, overrides));
+        combatLog = result.combatLog;
+        outcome = result.outcome;
+    } catch (e) {
+        return { name, error: `simulateBattle threw: ${(e as Error).message}` };
+    }
+
+    const abilities: ClauseTrace[] = allAbilities.map(({ slot, ability }) => {
+        const eventTypes = ABILITY_TYPE_TO_LOG_EVENTS[ability.type] ?? [];
+        return {
+            slot,
+            type: ability.type,
+            target: (ability as { target?: string }).target,
+            trigger: ability.trigger,
+            summary: JSON.stringify(ability.config),
+            observed: logHasEventForShip(combatLog, eventTypes, name),
+        };
+    });
+
+    return { name, refitLevel: overrides.refitLevel ?? 4, skillRows, abilities, combatLog, outcome };
+}
+
+export function renderKitBundleMarkdown(bundle: KitBundleResult): string {
+    if ('error' in bundle) return `# ${bundle.name}\n\n**HARNESS-ERROR:** ${bundle.error}\n`;
+    const rows = bundle.skillRows.map((r) => `- **${r.label}:** ${r.text}`).join('\n');
+    const abils = bundle.abilities
+        .map((a) => `- [${a.observed ? 'x' : ' '}] \`${a.slot}\` **${a.type}** (target=${a.target ?? '-'}, trigger=${a.trigger ?? '-'}) — ${a.summary}`)
+        .join('\n');
+    return [
+        `# ${bundle.name} (refit R${bundle.refitLevel})`,
+        `\n## Skill text\n\n${rows}`,
+        `\n## Parsed abilities\n\n_(checkbox = observed executing in the standardized scenario)_\n\n${abils}`,
+        `\n## Execution trace\n\nOutcome: \`${JSON.stringify(bundle.outcome)}\`\n\n\`\`\`json\n${JSON.stringify(bundle.combatLog, null, 2)}\n\`\`\``,
+    ].join('\n');
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest --run src/utils/abilities/__tests__/kitBundle.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/kitBundle.ts src/utils/abilities/__tests__/kitBundle.test.ts
+git commit -m "feat: kit-bundle builder (text + parsed abilities + combat-log trace) for the kit audit"
+```
+
+---
+
+### Task 5: traceShip CLI + ledger writer
+
+**Files:**
+- Create: `scripts/traceShip.ts`
+- Create: `scripts/lib/kitLedger.ts`
+- Create: `scripts/writeKitLedger.ts`
+- Test: `src/utils/abilities/__tests__/kitLedger.test.ts`
+- Modify: `package.json` (add `trace:ship` and `audit:kit-ledger` scripts)
+
+**Interfaces:**
+- Consumes: `buildKitBundle`, `renderKitBundleMarkdown` (Task 4); `loadShipSkillRecords`, `csvAvailable` (Task 1).
+- Produces (kitLedger):
+  - `interface Finding { ship: string; slot: string; layer: 'parser' | 'executor' | 'both'; verdict: 'WRONG-PARSE' | 'WRONG-EXEC' | 'MISSING'; expected: string; observed: string; severity: 'high' | 'med' | 'low'; fixPointer: string; }`
+  - `interface LedgerInput { shipsAudited: number; clausesReviewed: number; findings: Finding[]; refuted: number; untriggeredVerified: number; }`
+  - `renderLedgerMarkdown(input: LedgerInput): string`
+  - `renderLedgerJson(input: LedgerInput): string`
+
+The `traceShip.ts` CLI iterates `--all` (every CSV record name) or the named ships, calls `buildKitBundle`, and writes `docs/kit-bundles/<Name>.json` + `<Name>.md` (creating the dir). This is a plain CLI (no unit test beyond the kitBundle test); its smoke check is Step 4 below.
+
+- [ ] **Step 1: Write the failing ledger test**
+
+```ts
+// src/utils/abilities/__tests__/kitLedger.test.ts
+import { describe, it, expect } from 'vitest';
+import { renderLedgerMarkdown, renderLedgerJson, LedgerInput } from '../../../../scripts/lib/kitLedger';
+
+const input: LedgerInput = {
+    shipsAudited: 147,
+    clausesReviewed: 500,
+    refuted: 3,
+    untriggeredVerified: 12,
+    findings: [
+        { ship: 'Zeta', slot: 'charged', layer: 'parser', verdict: 'WRONG-PARSE', expected: 'heal 30%', observed: 'heal 20%', severity: 'high', fixPointer: 'skillTextParser.ts' },
+        { ship: 'Alpha', slot: 'passive', layer: 'executor', verdict: 'MISSING', expected: 'on-ally-death buff', observed: 'never fires', severity: 'low', fixPointer: 'combat/triggers.ts' },
+    ],
+};
+
+describe('kitLedger', () => {
+    it('ranks findings high → low in the markdown', () => {
+        const md = renderLedgerMarkdown(input);
+        expect(md.indexOf('Zeta')).toBeLessThan(md.indexOf('Alpha'));
+        expect(md).toContain('147');
+        expect(md).toContain('| Zeta |');
+    });
+
+    it('emits valid JSON with the same finding count', () => {
+        const parsed = JSON.parse(renderLedgerJson(input));
+        expect(parsed.findings).toHaveLength(2);
+        expect(parsed.shipsAudited).toBe(147);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest --run src/utils/abilities/__tests__/kitLedger.test.ts`
+Expected: FAIL — cannot resolve `kitLedger`.
+
+- [ ] **Step 3: Write kitLedger, the CLIs, and package.json scripts**
+
+```ts
+// scripts/lib/kitLedger.ts
+export interface Finding {
+    ship: string;
+    slot: string;
+    layer: 'parser' | 'executor' | 'both';
+    verdict: 'WRONG-PARSE' | 'WRONG-EXEC' | 'MISSING';
+    expected: string;
+    observed: string;
+    severity: 'high' | 'med' | 'low';
+    fixPointer: string;
+}
+export interface LedgerInput {
+    shipsAudited: number;
+    clausesReviewed: number;
+    findings: Finding[];
+    refuted: number;
+    untriggeredVerified: number;
+}
+
+const RANK: Record<Finding['severity'], number> = { high: 0, med: 1, low: 2 };
+
+export function renderLedgerMarkdown(input: LedgerInput): string {
+    const sorted = [...input.findings].sort((a, b) => RANK[a.severity] - RANK[b.severity]);
+    const bySev = (s: Finding['severity']) => input.findings.filter((f) => f.severity === s).length;
+    const rows = sorted
+        .map((f) => `| ${f.ship} | ${f.slot} | ${f.layer} | ${f.verdict} | ${f.severity} | ${f.expected} | ${f.observed} | ${f.fixPointer} |`)
+        .join('\n');
+    return [
+        `# Ship Kit Correctness Ledger`,
+        ``,
+        `- Ships audited: **${input.shipsAudited}**`,
+        `- Clauses reviewed: **${input.clausesReviewed}**`,
+        `- Confirmed findings: **${input.findings.length}** (high ${bySev('high')} / med ${bySev('med')} / low ${bySev('low')})`,
+        `- Candidates refuted in verify: **${input.refuted}**`,
+        `- Untriggered clauses verified clean via escalation: **${input.untriggeredVerified}**`,
+        ``,
+        `| Ship | Slot | Layer | Verdict | Severity | Expected | Observed | Fix pointer |`,
+        `| --- | --- | --- | --- | --- | --- | --- | --- |`,
+        rows,
+        ``,
+    ].join('\n');
+}
+
+export function renderLedgerJson(input: LedgerInput): string {
+    return JSON.stringify(input, null, 2);
+}
+```
+
+```ts
+// scripts/traceShip.ts
+/* eslint-disable no-console */
+import { mkdirSync, writeFileSync } from 'fs';
+import { loadShipSkillRecords, csvAvailable } from './lib/shipSkillCsv';
+import { buildKitBundle, renderKitBundleMarkdown } from './lib/kitBundle';
+
+const OUT_DIR = 'docs/kit-bundles';
+
+function main() {
+    if (!csvAvailable()) {
+        console.error('docs/ship-skills.csv not found — nothing to trace.');
+        process.exit(1);
+    }
+    const args = process.argv.slice(2);
+    const names = args.includes('--all')
+        ? loadShipSkillRecords().map((r) => r.name)
+        : args.filter((a) => !a.startsWith('--'));
+    if (names.length === 0) {
+        console.error('Usage: npm run trace:ship -- --all | <ShipName> [<ShipName> ...]');
+        process.exit(1);
+    }
+    mkdirSync(OUT_DIR, { recursive: true });
+    let errors = 0;
+    for (const name of names) {
+        const bundle = buildKitBundle(name);
+        if ('error' in bundle) errors++;
+        const safe = name.replace(/[^\w-]/g, '_');
+        writeFileSync(`${OUT_DIR}/${safe}.json`, JSON.stringify(bundle, null, 2));
+        writeFileSync(`${OUT_DIR}/${safe}.md`, renderKitBundleMarkdown(bundle));
+    }
+    console.log(`Wrote ${names.length} kit bundles to ${OUT_DIR}/ (${errors} harness errors).`);
+}
+main();
+```
+
+```ts
+// scripts/writeKitLedger.ts
+/* eslint-disable no-console */
+import { readFileSync, writeFileSync } from 'fs';
+import { renderLedgerMarkdown, renderLedgerJson, LedgerInput } from './lib/kitLedger';
+
+function main() {
+    const inPath = process.argv[2];
+    if (!inPath) {
+        console.error('Usage: npm run audit:kit-ledger -- <findings.json>');
+        process.exit(1);
+    }
+    const input = JSON.parse(readFileSync(inPath, 'utf8')) as LedgerInput;
+    writeFileSync('docs/ship-kit-correctness-ledger.md', renderLedgerMarkdown(input));
+    writeFileSync('docs/ship-kit-correctness-ledger.json', renderLedgerJson(input));
+    console.log('Wrote docs/ship-kit-correctness-ledger.{md,json}');
+}
+main();
+```
+
+In `package.json` `"scripts"`, add alongside `audit:skills`:
+
+```json
+"trace:ship": "tsx scripts/traceShip.ts",
+"audit:kit-ledger": "tsx scripts/writeKitLedger.ts"
+```
+
+- [ ] **Step 4: Run ledger test + a CLI smoke check**
+
+Run: `npx vitest --run src/utils/abilities/__tests__/kitLedger.test.ts`
+Expected: PASS.
+
+Run: `npm run trace:ship -- Aegis Akula`
+Expected: `Wrote 2 kit bundles to docs/kit-bundles/ (0 harness errors).` and `docs/kit-bundles/Aegis.md` exists with the three section headers.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/traceShip.ts scripts/writeKitLedger.ts scripts/lib/kitLedger.ts src/utils/abilities/__tests__/kitLedger.test.ts package.json
+git commit -m "feat: traceShip CLI + kit-correctness ledger writer"
+```
+
+---
+
+### Task 6: Author and run the audit Workflow, then write the ledger
+
+This task produces the deliverable. It is an **execution task** (no TDD cycle): it (1) generates all bundles, (2) runs a review→escalate→verify Workflow over them, (3) assembles the findings JSON, (4) writes the ledger. Requires explicit Workflow opt-in (already given during brainstorming).
+
+**Files:**
+- Uses: `scripts/traceShip.ts`, `scripts/writeKitLedger.ts` (Task 5).
+- Produces (dev-only, not committed): `docs/kit-bundles/*.{json,md}`, `docs/ship-kit-correctness-ledger.{md,json}`.
+
+- [ ] **Step 1: Generate all kit bundles**
+
+Run: `npm run trace:ship -- --all`
+Expected: `Wrote 147 kit bundles to docs/kit-bundles/ (N harness errors).` Record N and the erroring ship names (they become HARNESS-ERROR rows in the ledger, not silent skips).
+
+- [ ] **Step 2: Verify the full test suite is green before the audit run**
+
+Run: `npm test`
+Expected: all green (baseline confirmed; `.env` present per Global Constraints).
+
+- [ ] **Step 3: Author and run the review Workflow**
+
+Invoke the `Workflow` tool with a script that:
+- **Batch/pipeline stage** — reads the 147 bundle markdown files (batched ~10–12 per review agent), each agent given `docs/combat-system.md` + the locked game-rules reference (combat-realism memory). Each agent emits, per clause, a `{verdict, layer, expected, observed, severity}` record using the Task 4 verdict taxonomy. Schema-constrained output.
+- **Escalation stage** — for every `UNTRIGGERED` and `WRONG-EXEC` record, re-run `buildKitBundle` with scenario overrides (`reviewedHpScale: 0.1` to force low-HP gates, `reviewedCrit: 100` to force crits, `includeFragileAlly: true` for on-ally-death, `enemyAffinity`/`refitLevel` as needed) and re-verdict.
+- **Verify stage** — every surviving `WRONG-PARSE`/`WRONG-EXEC`/`MISSING` candidate goes to a fresh adversarial agent tasked to REFUTE it (default "not a bug" when uncertain). Only survivors are kept, tagged `CONFIRMED`; refuted ones counted into `refuted`.
+- **Return** — a `LedgerInput` object (`shipsAudited`, `clausesReviewed`, `findings`, `refuted`, `untriggeredVerified`).
+
+Write the returned object to `docs/kit-findings.json`.
+
+- [ ] **Step 4: Write the ledger**
+
+Run: `npm run audit:kit-ledger -- docs/kit-findings.json`
+Expected: `Wrote docs/ship-kit-correctness-ledger.{md,json}`.
+
+- [ ] **Step 5: Orchestrator spot-check of confirmed findings**
+
+Manually verify a sample of `high`-severity findings against the ship's CSV text + a fresh `buildKitBundle` run (the false-positive guard — memory warns agent audit findings can be stale-doc/mis-read false positives). Downgrade or drop any that don't reproduce; note the spot-check in the ledger summary.
+
+- [ ] **Step 6: Present the ledger**
+
+Surface `docs/ship-kit-correctness-ledger.md` to the user (SendUserFile) as the deliverable. Do NOT commit generated bundles/ledger (docs/ is gitignored; these are dev-only). Fixes for confirmed findings are scoped as a separate follow-up effort.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Trace-bundle harness (text + parsed abilities + combat-log) → Tasks 2–4. ✓
+- Standardized scenario, reviewed ship as focus, fixed roster, ~30 rounds, charge fires → Task 3. ✓
+- Refit-active resolution + default highest passive → Task 2 (`refitLevel` default 4) + Global Constraints. ✓
+- Batch → per-clause verdict taxonomy → escalate → adversarial verify → Task 6 Step 3 + Task 4 taxonomy. ✓
+- Ledger `.md` + `.json`, ranked, summary, HARNESS-ERROR rows, suggested-fix pointer → Task 5 + Task 6 Steps 1/4. ✓
+- CSV = source of truth; docs gitignored; CSV-absent test skips; no `vitest -u`; `.env` for suite → Global Constraints. ✓
+- Engine `dummyEnemyIsVestigial` gotcha respected in scenario (fillers never heal) → Task 3 design + Global Constraints. ✓
+- Analysis-only scope (fixes separate) → Task 6 Step 6. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step carries complete code; no "similar to Task N" references. ✓
+
+**Type consistency:** `ShipSkillRecord`, `buildTraceShip`, `ScenarioOverrides`, `buildStandardScenario`, `KitBundle`/`ClauseTrace`/`buildKitBundle`/`renderKitBundleMarkdown`, `Finding`/`LedgerInput`/`renderLedgerMarkdown`/`renderLedgerJson` names are consistent across the tasks that define and consume them. `refitLevel` typed `0 | 2 | 4` in both `traceShipFactory` and `kitBundle`. ✓

--- a/docs/superpowers/plans/2026-07-16-ship-kit-correctness-audit.md
+++ b/docs/superpowers/plans/2026-07-16-ship-kit-correctness-audit.md
@@ -548,15 +548,16 @@ git commit -m "feat: standardized battle scenario builder for the kit-audit harn
 
 **Interfaces:**
 - Consumes: `buildTraceShip` (Task 2); `buildStandardScenario`, `ScenarioOverrides` (Task 3); `getShipSkillRows` (`src/utils/ship/skillRows.ts`); `buildShipAbilities` (`src/utils/abilities/buildShipAbilities.ts`); `simulateBattle` (`src/utils/calculators/battleSimulator.ts`); `Ability` (`src/types/abilities.ts`).
+- Also consumes: `CombatLogRound`, `CombatLogEntry`, `CombatLogEntryKind` (`src/utils/combat/log/types.ts`).
 - Produces:
   - `interface ClauseTrace { slot: string; type: string; target?: string; trigger?: string; summary: string; observed: boolean; }`
-  - `interface KitBundle { name: string; refitLevel: number; skillRows: { label: string; text: string }[]; abilities: ClauseTrace[]; combatLog: unknown[]; outcome: unknown; }`
+  - `interface KitBundle { name: string; refitLevel: number; skillRows: { label: string; text: string }[]; abilities: ClauseTrace[]; combatLog: CombatLogRound[]; outcome: unknown; }`
   - `type KitBundleResult = KitBundle | { name: string; error: string };`
   - `buildKitBundle(name: string, overrides?: ScenarioOverrides & { refitLevel?: 0 | 2 | 4 }): KitBundleResult`
   - `renderKitBundleMarkdown(bundle: KitBundleResult): string`
-  - `const ABILITY_TYPE_TO_LOG_EVENTS: Record<string, string[]>`
+  - `const ABILITY_TYPE_TO_LOG_KINDS: Record<string, CombatLogEntryKind[]>`
 
-Observed-labeler heuristic: an ability is `observed` when the combat log contains ≥1 event whose `type` is in `ABILITY_TYPE_TO_LOG_EVENTS[ability.type]` AND references the reviewed ship as actor/source. This is a routing aid for escalation — the reviewer makes the actual correctness judgment; it does not decide findings.
+**CRITICAL — combat-log structure (confirmed against `src/utils/combat/log/types.ts`):** the log is `CombatLogRound[]`, each round has `startOfRound: CombatLogEntry[]`, `turns: CombatLogTurn[]` (each turn `{ actorId, entries: CombatLogEntry[] }`), and `endOfRound: CombatLogEntry[]`. Every `CombatLogEntry` carries `{ kind: CombatLogEntryKind, actorId, targets, reactions: CombatLogEntry[] }` — entries key on **`actorId`, never a ship name**. The reviewed ship is ALWAYS `player[0]` → the reserved focus id `'attacker'` (minted by `simulateBattle`). So the observed-labeler walks the log, collects the `kind`s of every entry whose `actorId === 'attacker'` (recursing into nested `reactions` — reactive/counter/start-and-end-of-round procs land there), and marks an ability `observed` when that kind-set intersects `ABILITY_TYPE_TO_LOG_KINDS[ability.type]`. Do NOT substring-search a ship name — the name never appears in the log. This is a routing aid for escalation; the reviewer makes the actual correctness judgment.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -607,21 +608,26 @@ import { getShipSkillRows } from '../../src/utils/ship/skillRows';
 import { buildShipAbilities } from '../../src/utils/abilities/buildShipAbilities';
 import { simulateBattle } from '../../src/utils/calculators/battleSimulator';
 import type { Ability } from '../../src/types/abilities';
+import type { CombatLogRound, CombatLogEntry, CombatLogEntryKind } from '../../src/utils/combat/log/types';
 
-export const ABILITY_TYPE_TO_LOG_EVENTS: Record<string, string[]> = {
-    damage: ['attacked', 'ability-performed'],
-    counter: ['reactive-damage-performed', 'attacked'],
-    'additional-damage': ['attacked', 'ability-performed'],
-    heal: ['heal-performed', 'reactive-heal-performed'],
-    shield: ['shield-applied'],
-    buff: ['buff-applied'],
-    debuff: ['debuff-applied', 'debuff-resisted'],
+// The reviewed ship is always player[0], whose engine actor id is the reserved 'attacker'.
+const FOCUS_ACTOR_ID = 'attacker';
+
+// Maps a parsed ability's `type` to the combat-log entry `kind`s it would produce when it fires.
+export const ABILITY_TYPE_TO_LOG_KINDS: Record<string, CombatLogEntryKind[]> = {
+    damage: ['attack'],
+    counter: ['attack'],
+    'additional-damage': ['attack'],
+    heal: ['heal'],
+    shield: ['shield'],
+    buff: ['buff'],
+    debuff: ['debuff', 'debuff-resisted'],
     dot: ['dot-applied', 'dot-ticked'],
-    control: ['control-applied'],
-    cleanse: ['cleanse-performed'],
-    purge: ['purge-performed'],
+    control: ['control'],
+    cleanse: ['cleanse'],
+    purge: ['purge'],
     charge: ['charge-changed'],
-    modifier: ['buff-applied', 'stats-snapshot'],
+    modifier: ['buff'],
 };
 
 export interface ClauseTrace {
@@ -637,19 +643,30 @@ export interface KitBundle {
     refitLevel: number;
     skillRows: { label: string; text: string }[];
     abilities: ClauseTrace[];
-    combatLog: unknown[];
+    combatLog: CombatLogRound[];
     outcome: unknown;
 }
 export type KitBundleResult = KitBundle | { name: string; error: string };
 
 const TARGETING_FALLBACK = { activeTarget: 'front', activePattern: 'Pattern-Base' };
 
-// Does the log mention the reviewed ship by name in an entry of one of the expected types?
-function logHasEventForShip(log: unknown[], eventTypes: string[], shipName: string): boolean {
-    const needle = JSON.stringify(log);
-    // Coarse: the hierarchical log embeds actor names + event kind strings. A precise per-event
-    // walk is unnecessary — this only routes UNTRIGGERED clauses to escalation.
-    return eventTypes.some((t) => needle.includes(t)) && needle.includes(shipName);
+// Collect the entry kinds of every log entry whose actor is `actorId`, recursing into nested
+// reactions (counters / start-and-end-of-round procs land there). Entries key on actorId, never
+// a ship name — so the reviewed ship is found by its reserved focus id, not by its display name.
+function collectActorEntryKinds(log: CombatLogRound[], actorId: string): Set<CombatLogEntryKind> {
+    const kinds = new Set<CombatLogEntryKind>();
+    const visit = (entries: CombatLogEntry[]): void => {
+        for (const e of entries) {
+            if (e.actorId === actorId) kinds.add(e.kind);
+            if (e.reactions?.length) visit(e.reactions);
+        }
+    };
+    for (const round of log) {
+        visit(round.startOfRound ?? []);
+        for (const turn of round.turns ?? []) visit(turn.entries ?? []);
+        visit(round.endOfRound ?? []);
+    }
+    return kinds;
 }
 
 export function buildKitBundle(
@@ -668,7 +685,7 @@ export function buildKitBundle(
         s.abilities.map((ability) => ({ slot: s.slot, ability }))
     );
 
-    let combatLog: unknown[] = [];
+    let combatLog: CombatLogRound[] = [];
     let outcome: unknown = null;
     try {
         const result = simulateBattle(buildStandardScenario(ship, overrides));
@@ -678,17 +695,17 @@ export function buildKitBundle(
         return { name, error: `simulateBattle threw: ${(e as Error).message}` };
     }
 
+    // Kinds the reviewed ship (focus actor) actually produced in this scenario.
+    const focusKinds = collectActorEntryKinds(combatLog, FOCUS_ACTOR_ID);
     const abilities: ClauseTrace[] = allAbilities.map(({ slot, ability }) => {
-        const eventTypes = ABILITY_TYPE_TO_LOG_EVENTS[ability.type] ?? [];
+        const expectedKinds = ABILITY_TYPE_TO_LOG_KINDS[ability.type] ?? [];
         return {
             slot,
             type: ability.type,
             target: (ability as { target?: string }).target,
             trigger: ability.trigger,
             summary: JSON.stringify(ability.config),
-            // Search by the ship's CANONICAL name (buildTraceShip normalizes CSV casing) —
-            // the combat log contains ship.name, which may differ from the caller's raw `name`.
-            observed: logHasEventForShip(combatLog, eventTypes, ship.name),
+            observed: expectedKinds.some((k) => focusKinds.has(k)),
         };
     });
 

--- a/docs/superpowers/specs/2026-07-16-ship-kit-correctness-audit-design.md
+++ b/docs/superpowers/specs/2026-07-16-ship-kit-correctness-audit-design.md
@@ -1,0 +1,164 @@
+# Ship Kit Correctness Audit — Design
+
+**Date:** 2026-07-16
+**Status:** Approved (brainstorm complete)
+**Type:** Analysis / audit project (produces a ranked, verified findings ledger — not fixes)
+
+## Problem
+
+The existing `audit:skills` tool reports **0 findings** across 147 ships, but by its own
+docstring it only catches *coverage gaps* — cases where the skill text clearly contains a
+mechanic but `buildShipAbilities` produced **no** matching ability. It explicitly has **no
+ground truth for correctness** and does **not** check whether the combat sim actually
+*executes* a parsed ability faithfully.
+
+So the coverage layer is green, but two failure classes are unmeasured:
+
+- **Wrong parse** — the parser emits *an* ability, but with the wrong value, target, trigger,
+  condition, or a dropped sub-effect vs. the intended mechanic.
+- **Wrong / missing execution** — the parse is right, but the engine executes it incorrectly,
+  partially, or not at all.
+
+We want a per-ship correctness pass over the **entire 147-ship roster** that surfaces both
+classes, verified against false positives, and ranked into a fix backlog.
+
+## Ground truth
+
+There is no automated oracle for correctness. The **skill text** in `docs/ship-skills.csv`
+(refit-active passive resolved) is the source of intended behavior; `docs/combat-system.md`
+and the locked combat-rules reference define how mechanics are supposed to resolve. A finding
+is therefore a judgment: read the text → form the intended mechanic → compare against the
+parsed `Ability` model **and** the combat-log of a real battle. This judgment nature is why an
+adversarial verify stage is mandatory (agent audit findings have a known false-positive rate).
+
+## Approach (chosen: A)
+
+**Trace-bundle harness + parallel review with escalation & adversarial verify.**
+
+Alternatives considered and rejected: (B) characterization tests per ship — huge upfront cost,
+and expectations are partly derived from the same parser (circular); (C) manual trace in the
+live UI — highest fidelity but not scalable to 147 and not reproducible.
+
+## Architecture
+
+Three layers, driven by a **Workflow** (user opted in) that runs batch → escalate → verify in
+the background and returns the ledger.
+
+### 1. Trace-bundle harness — `scripts/traceShip.ts`
+
+A headless CLI (sibling to `scripts/auditSkills.ts`) that takes ship name(s) or `--all` and
+emits a **kit bundle** per ship, as JSON plus a readable markdown rendering:
+
+1. **Skill text** — read from `docs/ship-skills.csv` using the same record reader `auditSkills`
+   uses (handles multi-line quoted passives). Refit-active passive resolved via
+   `getShipSkillRows` (`src/utils/ship/skillRows.ts`); **refit index recorded** so reviewers
+   know which passive is live.
+2. **Parsed abilities** — `buildShipAbilities(ship)` output, pretty-printed: type, target,
+   trigger, condition, values, scaling.
+3. **Execution trace** — the combat log (`LOG_EVENT_TYPES` from
+   `src/utils/calculators/battleSimulator.ts`) of a **standardized scenario** run through
+   `simulateBattle`.
+
+Each parsed clause in the bundle is labelled **triggered** or **not-observed** in the scenario,
+so "the sim ran it" is distinguishable from "the scenario never exercised it."
+
+The harness accepts **scenario overrides** (starting HP%, enemy affinity, forced crit, ally
+death, charge state, refit index) so the escalation tier can reuse it to force specific
+branches.
+
+### 2. Standardized scenario
+
+Identical for all 147 ships (the reviewed ship is the only variable → reproducible, diffable):
+
+- **Reviewed ship as the focus actor** (`player[0]`, id `'attacker'`) so its active fires.
+  Team-symmetry (engine acts identically on either side) makes this valid even for
+  enemy-designed ships.
+- **2–3 filler allies** — enables ally-scoped grants and on-ally-death / on-ally-crit triggers.
+- **Fixed standard enemy roster**, tuned strong enough to (a) drop the ship's HP through
+  threshold gates, (b) attack the ship so on-attacked / reflect / counter fire, and (c)
+  plausibly kill a filler ally within the window.
+- **~30 rounds**, **charged skill enabled** (charge branch executes), consistent gear/stat
+  baseline.
+
+A single standardized scenario will not fire every conditional/reactive/charge branch by
+design — untriggered branches are surfaced (not silently passed) and handed to escalation.
+
+### 3. Review pipeline (Workflow)
+
+**Batch.** 147 ships → ~13 batches of ≈10–12 ships, one review subagent each. Every subagent
+receives its batch's kit bundles + `docs/combat-system.md` + the locked game-rules reference
+(Stasis/affinity/stat-layers/cleanse-purge/Crit-Power terminology/legendary-stage-3-only enemy
+effects/cross-leader pct summing).
+
+**Per-clause verdict.** For every clause of a ship's skill text:
+
+| field    | values |
+|----------|--------|
+| verdict  | `MATCH` / `WRONG-PARSE` / `WRONG-EXEC` / `MISSING` / `UNTRIGGERED` |
+| layer    | `parser` / `executor` / `both` |
+| expected | one-line intended mechanic from the text |
+| observed | what the parsed ability + combat log actually did |
+| severity | `high` (core kit broken) / `med` / `low` (edge/cosmetic) |
+
+`MATCH` and `UNTRIGGERED` are terminal for tier 1. `WRONG-PARSE` / `WRONG-EXEC` / `MISSING`
+are candidate findings.
+
+**Escalation (tier 2).** Two queues re-run the harness with scenario overrides:
+- `UNTRIGGERED` → tailored micro-scenario forcing that branch (low-HP start, specific enemy
+  affinity, forced crit, ally death, charge state). Re-verdicts to `MATCH` or a real finding.
+- `WRONG-EXEC` candidates → focused executor trace confirming the log discrepancy is real, not
+  a scenario artifact.
+
+**Verify.** Every surviving candidate gets an **adversarial re-check** by a fresh agent tasked
+to *refute* it (default "not a bug" when uncertain). Survivors → ledger, tagged `CONFIRMED`.
+Refuted ones dropped but recorded as `REFUTED` for transparency.
+
+## Output — the ledger
+
+- **`docs/ship-kit-correctness-ledger.md`** (docs/ is gitignored, matching `skill-audit.md`):
+  - Summary header: ships audited, clauses reviewed, confirmed findings by severity, counts of
+    refuted and untriggered-verified.
+  - Findings table, ranked `high → low`: ship, slot/clause, layer, expected vs observed,
+    severity, suggested-fix pointer (`skillTextParser.ts` rule vs a `combat/` executor).
+  - Appendix: per-ship MATCH/UNTRIGGERED-verified roster, so clean ships are provably covered.
+- **`docs/ship-kit-correctness-ledger.json`** — machine-readable findings, for turning into a
+  fix backlog later (mirrors the gap-sweep JSON pattern).
+
+**Scope boundary:** this project ends at a ranked, verified backlog. Fixes are scoped
+separately, per-finding, afterward — a 147-ship audit is not blurred into an open-ended fix
+marathon.
+
+## Components & interfaces
+
+| Unit | Purpose | Depends on |
+|------|---------|-----------|
+| `scripts/traceShip.ts` | Emit kit bundles (text + parsed abilities + combat-log trace); accept scenario overrides | `buildShipAbilities`, `simulateBattle`, `getShipSkillRows`, CSV reader |
+| standardized-scenario builder | Construct the fixed team/enemy/rounds/gear scenario | `simulateBattle` input types |
+| review Workflow script | batch → escalate → adversarial verify → ledger | `traceShip.ts` output, Agent subagents |
+| ledger writer | Render `.md` + `.json` from confirmed findings | verify-stage output |
+
+## Error handling
+
+- Ships whose CSV record fails to parse or whose `simulateBattle` throws → recorded as a
+  `HARNESS-ERROR` row (not silently skipped), so coverage is provable.
+- The harness must not `vitest -u` or touch golden snapshots; it reuses the same headless
+  entry points the tests use.
+- Worktree/`.env` gotchas: the harness only needs the CSV + engine code (no Supabase), but the
+  Workflow's agents that run tests must have `.env` present (per memory).
+
+## Testing
+
+- The harness itself gets a small smoke test: one known ship produces a bundle with all three
+  sections populated and at least one triggered clause.
+- The audit's *findings* are validated by the adversarial verify stage, not by unit tests
+  (there is no correctness oracle to assert against).
+
+## Open risks
+
+- **Scenario tuning** — the standard enemy roster must be strong enough to exercise HP-gated
+  and reactive branches but not so lethal the ship dies round 1. Needs a tuning pass during
+  implementation.
+- **Refit coverage** — only the refit-active passive is traced by default; ships with
+  meaningfully different passives per refit may need per-refit escalation. Flag during review.
+- **Verify-stage cost** — adversarial verification across ~13 batches of findings is the
+  most expensive stage; batch it and cap per the Workflow's concurrency.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
         "e2e:ui": "cd e2e && npm run test:ui",
         "e2e:install": "cd e2e && npm ci && npx playwright install --with-deps chromium",
         "audit:skills": "tsx scripts/auditSkills.ts",
+        "trace:ship": "tsx scripts/traceShip.ts",
+        "audit:kit-ledger": "tsx scripts/writeKitLedger.ts",
         "fetch:ship-skills": "tsx scripts/fetch-ship-skills.ts"
     },
     "browserslist": {

--- a/scripts/auditSkills.ts
+++ b/scripts/auditSkills.ts
@@ -10,7 +10,7 @@
  * Usage: npm run audit:skills
  * Writes a grouped report to docs/skill-audit.md and prints a summary.
  */
-import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { pathToFileURL } from 'url';
 import { buildShipAbilities } from '../src/utils/abilities/buildShipAbilities';
 import {
@@ -21,34 +21,15 @@ import {
 import { Ship } from '../src/types/ship';
 import { Ability } from '../src/types/abilities';
 import { ALLOWLIST } from './auditSkills.allowlist';
+import {
+    parseCsvLine,
+    readCsvRecords,
+    csvAvailable as libCsvAvailable,
+    CSV_PATH,
+} from './lib/shipSkillCsv';
 
 // Paths are relative to the repo root (npm run sets cwd there).
-const CSV_PATH = 'docs/ship-skills.csv';
 const OUT_PATH = 'docs/skill-audit.md';
-
-// ─── CSV ───────────────────────────────────────────────────────────────────
-function parseCsvLine(line: string): string[] {
-    const fields: string[] = [];
-    let cur = '';
-    let inQuotes = false;
-    for (let i = 0; i < line.length; i++) {
-        const c = line[i];
-        if (inQuotes) {
-            if (c === '"') {
-                if (line[i + 1] === '"') {
-                    cur += '"';
-                    i++;
-                } else inQuotes = false;
-            } else cur += c;
-        } else if (c === '"') inQuotes = true;
-        else if (c === ',') {
-            fields.push(cur);
-            cur = '';
-        } else cur += c;
-    }
-    fields.push(cur);
-    return fields;
-}
 
 interface ShipRow {
     name: string;
@@ -57,39 +38,16 @@ interface ShipRow {
 
 // RESOLVED (2026-07-02, was a KNOWN GAP): six CSV records (Centurion, Chimei, Curator,
 // Enforcer, Graphite, Lingshe) carry literal newlines inside quoted passive texts — a naive
-// line-per-record reader silently dropped them (141 of 147 records audited). Fixed below by
+// line-per-record reader silently dropped them (141 of 147 records audited). Fixed by
 // accumulating physical lines into a record buffer until quotes are balanced (see
-// `readCsvRecords`) before splitting into fields. Recovering these six surfaced two
-// pre-existing findings, fixed ahead of the reader change: the `detonation` rule's keyword
-// false-positived on Chimei's "Out. Detonation Damage Up III" buff NAME (fixed via a negative
-// lookahead — see the rule above); Lingshe's "gains Stealth on detonating a Bomb" passive
-// clause is already gated by the parser's on-bomb-detonated trigger (verified via
+// `readCsvRecords` in `./lib/shipSkillCsv`) before splitting into fields. Recovering these six
+// surfaced two pre-existing findings, fixed ahead of the reader change: the `detonation` rule's
+// keyword false-positived on Chimei's "Out. Detonation Damage Up III" buff NAME (fixed via a
+// negative lookahead — see the rule above); Lingshe's "gains Stealth on detonating a Bomb"
+// passive clause is already gated by the parser's on-bomb-detonated trigger (verified via
 // `detectReactiveTrigger`'s `BOMB_DETONATE_RE`), so it never reaches `ungatedEffects` — no
 // code change needed there. The pre-combat-stat rule below was verified out-of-band against
 // all 147 records: it hits exactly Lionheart/Centurion/Enforcer/Defiant/Stalwart, all handled.
-function readCsvRecords(raw: string): string[] {
-    const physicalLines = raw.split('\n');
-    const records: string[] = [];
-    let buffer: string[] = [];
-    let quoteCount = 0;
-    for (const line of physicalLines) {
-        buffer.push(line);
-        quoteCount += (line.match(/"/g) ?? []).length;
-        // Even quote count = no unterminated quoted field spanning this line boundary — the
-        // buffered lines form one complete record. Re-join with '\n' so multi-line skill text
-        // is preserved (parseCsvLine treats embedded newlines as ordinary characters).
-        if (quoteCount % 2 === 0) {
-            const record = buffer.join('\n');
-            buffer = [];
-            quoteCount = 0;
-            if (record.trim().length > 0) records.push(record);
-        }
-    }
-    // Any leftover buffered lines (unbalanced quotes through EOF) are dropped — malformed CSV,
-    // not a multi-line record.
-    return records;
-}
-
 function readShips(): ShipRow[] {
     const records = readCsvRecords(readFileSync(CSV_PATH, 'utf8'));
     const rows: ShipRow[] = [];
@@ -532,7 +490,7 @@ export function unusedAllowlistPairs(): { ship: string; rule: string; reason: st
 
 /** True when the (gitignored) reference CSV is present — false in CI/clean checkouts. */
 export function csvAvailable(): boolean {
-    return existsSync(CSV_PATH);
+    return libCsvAvailable(CSV_PATH);
 }
 
 /** Pure pass: every coverage finding across all ships (no I/O side effects beyond reading the CSV). */

--- a/scripts/lib/kitBundle.ts
+++ b/scripts/lib/kitBundle.ts
@@ -2,7 +2,7 @@ import { getShipSkillRows } from '../../src/utils/ship/skillRows';
 import { buildShipAbilities } from '../../src/utils/abilities/buildShipAbilities';
 import { simulateBattle } from '../../src/utils/calculators/battleSimulator';
 import type { Ability } from '../../src/types/abilities';
-import type { CombatLogRound, CombatLogEntry, CombatLogEntryKind } from '../../src/utils/combat/log/types';
+import type { CombatLogRound, CombatLogEntry, CombatLogEntryKind, CombatLogTarget } from '../../src/utils/combat/log/types';
 import { buildStandardScenario, ScenarioOverrides } from './traceScenario';
 import { buildTraceShip } from './traceShipFactory';
 
@@ -49,7 +49,7 @@ const TARGETING_FALLBACK = { activeTarget: 'front', activePattern: 'Pattern-Base
 // Collect the entry kinds of every log entry whose actor is `actorId`, recursing into nested
 // reactions (counters / start-and-end-of-round procs land there). Entries key on actorId, never
 // a ship name — so the reviewed ship is found by its reserved focus id, not by its display name.
-function collectActorEntryKinds(log: CombatLogRound[], actorId: string): Set<CombatLogEntryKind> {
+export function collectActorEntryKinds(log: CombatLogRound[], actorId: string): Set<CombatLogEntryKind> {
     const kinds = new Set<CombatLogEntryKind>();
     const visit = (entries: CombatLogEntry[]): void => {
         for (const e of entries) {
@@ -119,5 +119,73 @@ export function renderKitBundleMarkdown(bundle: KitBundleResult): string {
         `\n## Skill text\n\n${rows}`,
         `\n## Parsed abilities\n\n_(checkbox = observed executing in the standardized scenario)_\n\n${abils}`,
         `\n## Execution trace\n\nOutcome: \`${JSON.stringify(bundle.outcome)}\`\n\n\`\`\`json\n${JSON.stringify(bundle.combatLog, null, 2)}\n\`\`\``,
+    ].join('\n');
+}
+
+export function renderKitReviewMarkdown(bundle: KitBundleResult): string {
+    if ('error' in bundle) return `# ${bundle.name}\n\n**HARNESS-ERROR:** ${bundle.error}\n`;
+
+    const skill = bundle.skillRows.map((r) => `- **${r.label}:** ${r.text}`).join('\n');
+    const abils = bundle.abilities
+        .map((a) => `- [${a.observed ? 'x' : ' '}] \`${a.slot}\` **${a.type}** (target=${a.target ?? '-'}, trigger=${a.trigger ?? '-'}) — ${a.summary}`)
+        .join('\n');
+
+    const FOCUS = 'attacker';
+    const transcript: string[] = [];
+    const deaths: string[] = [];
+    let focusHpLow = 100;
+
+    const fmtTargets = (ts: CombatLogTarget[]): string =>
+        ts
+            .map(
+                (t) =>
+                    `${t.targetId}` +
+                    (t.amount != null ? ` amt=${Math.round(t.amount)}` : '') +
+                    (t.didCrit ? ' crit' : '') +
+                    (t.didHit === false ? ' MISS' : '') +
+                    (t.resultingHpPct != null ? ` hp%=${Math.round(t.resultingHpPct)}` : '')
+            )
+            .join(', ');
+
+    const walk = (round: number, phase: string, e: CombatLogEntry, depth: number): void => {
+        if (e.actorId === FOCUS) {
+            transcript.push(
+                `R${round} ${phase} ${'· '.repeat(depth)}${e.kind}` +
+                    (e.slot ? `(${e.slot})` : '') +
+                    (e.skillName ? ` "${e.skillName}"` : '') +
+                    (e.targets.length ? ` -> ${fmtTargets(e.targets)}` : '') +
+                    (e.note ? ` [${e.note}]` : '')
+            );
+        }
+        for (const t of e.targets) {
+            if (t.targetId === FOCUS && t.resultingHpPct != null) {
+                focusHpLow = Math.min(focusHpLow, t.resultingHpPct);
+            }
+        }
+        if (e.kind === 'death') {
+            deaths.push(`${e.targets.map((t) => t.targetId).join(',') || e.actorId} @R${round}`);
+        }
+        for (const r of e.reactions ?? []) walk(round, phase, r, depth + 1);
+    };
+
+    for (const round of bundle.combatLog) {
+        for (const e of round.startOfRound ?? []) walk(round.round, 'SoR', e, 0);
+        for (const turn of round.turns ?? []) for (const e of turn.entries ?? []) walk(round.round, 'turn', e, 0);
+        for (const e of round.endOfRound ?? []) walk(round.round, 'EoR', e, 0);
+    }
+
+    const focusKinds = [...collectActorEntryKinds(bundle.combatLog, FOCUS)].sort().join(', ') || '(none)';
+    const summary = [
+        `Focus-actor kinds observed: ${focusKinds}`,
+        `Focus HP low-water mark: ${Math.round(focusHpLow)}%`,
+        deaths.length ? `Deaths: ${deaths.join('; ')}` : 'Deaths: none',
+    ].join('\n');
+
+    return [
+        `# ${bundle.name} (refit R${bundle.refitLevel}) — outcome: \`${JSON.stringify(bundle.outcome)}\``,
+        `\n## Skill text\n\n${skill}`,
+        `\n## Parsed abilities\n\n_(checkbox = the reviewed ship, as focus actor, produced a matching log entry in the standard scenario)_\n\n${abils}`,
+        `\n## Execution summary\n\n${summary}`,
+        `\n## Focus-actor transcript (actorId 'attacker' + its reactions)\n\n\`\`\`\n${transcript.join('\n') || '(no focus-actor entries)'}\n\`\`\``,
     ].join('\n');
 }

--- a/scripts/lib/kitBundle.ts
+++ b/scripts/lib/kitBundle.ts
@@ -70,7 +70,7 @@ export function buildKitBundle(
     overrides: ScenarioOverrides & { refitLevel?: 0 | 2 | 4 } = {}
 ): KitBundleResult {
     const ship = buildTraceShip(name, { refitLevel: overrides.refitLevel });
-    if (!ship) return { name, error: 'no SHIPS base stats for this name' };
+    if (!ship) return { name, error: 'no SHIPS base stats and no CSV skill record for this name' };
     // Supply targeting fallbacks so the reviewed ship's active resolves a victim in the sim.
     if (!ship.activeTarget) ship.activeTarget = TARGETING_FALLBACK.activeTarget;
     if (!ship.activePattern) ship.activePattern = TARGETING_FALLBACK.activePattern;

--- a/scripts/lib/kitBundle.ts
+++ b/scripts/lib/kitBundle.ts
@@ -1,0 +1,123 @@
+import { getShipSkillRows } from '../../src/utils/ship/skillRows';
+import { buildShipAbilities } from '../../src/utils/abilities/buildShipAbilities';
+import { simulateBattle } from '../../src/utils/calculators/battleSimulator';
+import type { Ability } from '../../src/types/abilities';
+import type { CombatLogRound, CombatLogEntry, CombatLogEntryKind } from '../../src/utils/combat/log/types';
+import { buildStandardScenario, ScenarioOverrides } from './traceScenario';
+import { buildTraceShip } from './traceShipFactory';
+
+// The reviewed ship is always player[0], whose engine actor id is the reserved 'attacker'.
+const FOCUS_ACTOR_ID = 'attacker';
+
+// Maps a parsed ability's `type` to the combat-log entry `kind`s it would produce when it fires.
+export const ABILITY_TYPE_TO_LOG_KINDS: Record<string, CombatLogEntryKind[]> = {
+    damage: ['attack'],
+    counter: ['attack'],
+    'additional-damage': ['attack'],
+    heal: ['heal'],
+    shield: ['shield'],
+    buff: ['buff'],
+    debuff: ['debuff', 'debuff-resisted'],
+    dot: ['dot-applied', 'dot-ticked'],
+    control: ['control'],
+    cleanse: ['cleanse'],
+    purge: ['purge'],
+    charge: ['charge-changed'],
+    modifier: ['buff'],
+};
+
+export interface ClauseTrace {
+    slot: string;
+    type: string;
+    target?: string;
+    trigger?: string;
+    summary: string;
+    observed: boolean;
+}
+export interface KitBundle {
+    name: string;
+    refitLevel: number;
+    skillRows: { label: string; text: string }[];
+    abilities: ClauseTrace[];
+    combatLog: CombatLogRound[];
+    outcome: unknown;
+}
+export type KitBundleResult = KitBundle | { name: string; error: string };
+
+const TARGETING_FALLBACK = { activeTarget: 'front', activePattern: 'Pattern-Base' };
+
+// Collect the entry kinds of every log entry whose actor is `actorId`, recursing into nested
+// reactions (counters / start-and-end-of-round procs land there). Entries key on actorId, never
+// a ship name — so the reviewed ship is found by its reserved focus id, not by its display name.
+function collectActorEntryKinds(log: CombatLogRound[], actorId: string): Set<CombatLogEntryKind> {
+    const kinds = new Set<CombatLogEntryKind>();
+    const visit = (entries: CombatLogEntry[]): void => {
+        for (const e of entries) {
+            if (e.actorId === actorId) kinds.add(e.kind);
+            if (e.reactions?.length) visit(e.reactions);
+        }
+    };
+    for (const round of log) {
+        visit(round.startOfRound ?? []);
+        for (const turn of round.turns ?? []) visit(turn.entries ?? []);
+        visit(round.endOfRound ?? []);
+    }
+    return kinds;
+}
+
+export function buildKitBundle(
+    name: string,
+    overrides: ScenarioOverrides & { refitLevel?: 0 | 2 | 4 } = {}
+): KitBundleResult {
+    const ship = buildTraceShip(name, { refitLevel: overrides.refitLevel });
+    if (!ship) return { name, error: 'no SHIPS base stats for this name' };
+    // Supply targeting fallbacks so the reviewed ship's active resolves a victim in the sim.
+    if (!ship.activeTarget) ship.activeTarget = TARGETING_FALLBACK.activeTarget;
+    if (!ship.activePattern) ship.activePattern = TARGETING_FALLBACK.activePattern;
+
+    const skillRows = getShipSkillRows(ship).map((r) => ({ label: r.label, text: r.text }));
+    const built = buildShipAbilities(ship);
+    const allAbilities: { slot: string; ability: Ability }[] = built.slots.flatMap((s) =>
+        s.abilities.map((ability) => ({ slot: s.slot, ability }))
+    );
+
+    let combatLog: CombatLogRound[] = [];
+    let outcome: unknown = null;
+    try {
+        const result = simulateBattle(buildStandardScenario(ship, overrides));
+        combatLog = result.combatLog;
+        outcome = result.outcome;
+    } catch (e) {
+        return { name, error: `simulateBattle threw: ${(e as Error).message}` };
+    }
+
+    // Kinds the reviewed ship (focus actor) actually produced in this scenario.
+    const focusKinds = collectActorEntryKinds(combatLog, FOCUS_ACTOR_ID);
+    const abilities: ClauseTrace[] = allAbilities.map(({ slot, ability }) => {
+        const expectedKinds = ABILITY_TYPE_TO_LOG_KINDS[ability.type] ?? [];
+        return {
+            slot,
+            type: ability.type,
+            target: (ability as { target?: string }).target,
+            trigger: ability.trigger,
+            summary: JSON.stringify(ability.config),
+            observed: expectedKinds.some((k) => focusKinds.has(k)),
+        };
+    });
+
+    return { name: ship.name, refitLevel: overrides.refitLevel ?? 4, skillRows, abilities, combatLog, outcome };
+}
+
+export function renderKitBundleMarkdown(bundle: KitBundleResult): string {
+    if ('error' in bundle) return `# ${bundle.name}\n\n**HARNESS-ERROR:** ${bundle.error}\n`;
+    const rows = bundle.skillRows.map((r) => `- **${r.label}:** ${r.text}`).join('\n');
+    const abils = bundle.abilities
+        .map((a) => `- [${a.observed ? 'x' : ' '}] \`${a.slot}\` **${a.type}** (target=${a.target ?? '-'}, trigger=${a.trigger ?? '-'}) — ${a.summary}`)
+        .join('\n');
+    return [
+        `# ${bundle.name} (refit R${bundle.refitLevel})`,
+        `\n## Skill text\n\n${rows}`,
+        `\n## Parsed abilities\n\n_(checkbox = observed executing in the standardized scenario)_\n\n${abils}`,
+        `\n## Execution trace\n\nOutcome: \`${JSON.stringify(bundle.outcome)}\`\n\n\`\`\`json\n${JSON.stringify(bundle.combatLog, null, 2)}\n\`\`\``,
+    ].join('\n');
+}

--- a/scripts/lib/kitLedger.ts
+++ b/scripts/lib/kitLedger.ts
@@ -1,0 +1,45 @@
+export interface Finding {
+    ship: string;
+    slot: string;
+    layer: 'parser' | 'executor' | 'both';
+    verdict: 'WRONG-PARSE' | 'WRONG-EXEC' | 'MISSING';
+    expected: string;
+    observed: string;
+    severity: 'high' | 'med' | 'low';
+    fixPointer: string;
+}
+export interface LedgerInput {
+    shipsAudited: number;
+    clausesReviewed: number;
+    findings: Finding[];
+    refuted: number;
+    untriggeredVerified: number;
+}
+
+const RANK: Record<Finding['severity'], number> = { high: 0, med: 1, low: 2 };
+
+export function renderLedgerMarkdown(input: LedgerInput): string {
+    const sorted = [...input.findings].sort((a, b) => RANK[a.severity] - RANK[b.severity]);
+    const bySev = (s: Finding['severity']) => input.findings.filter((f) => f.severity === s).length;
+    const rows = sorted
+        .map((f) => `| ${f.ship} | ${f.slot} | ${f.layer} | ${f.verdict} | ${f.severity} | ${f.expected} | ${f.observed} | ${f.fixPointer} |`)
+        .join('\n');
+    return [
+        `# Ship Kit Correctness Ledger`,
+        ``,
+        `- Ships audited: **${input.shipsAudited}**`,
+        `- Clauses reviewed: **${input.clausesReviewed}**`,
+        `- Confirmed findings: **${input.findings.length}** (high ${bySev('high')} / med ${bySev('med')} / low ${bySev('low')})`,
+        `- Candidates refuted in verify: **${input.refuted}**`,
+        `- Untriggered clauses verified clean via escalation: **${input.untriggeredVerified}**`,
+        ``,
+        `| Ship | Slot | Layer | Verdict | Severity | Expected | Observed | Fix pointer |`,
+        `| --- | --- | --- | --- | --- | --- | --- | --- |`,
+        rows,
+        ``,
+    ].join('\n');
+}
+
+export function renderLedgerJson(input: LedgerInput): string {
+    return JSON.stringify(input, null, 2);
+}

--- a/scripts/lib/kitLedger.ts
+++ b/scripts/lib/kitLedger.ts
@@ -19,7 +19,14 @@ export interface LedgerInput {
 const RANK: Record<Finding['severity'], number> = { high: 0, med: 1, low: 2 };
 
 export function renderLedgerMarkdown(input: LedgerInput): string {
-    const sorted = [...input.findings].sort((a, b) => RANK[a.severity] - RANK[b.severity]);
+    // Severity first; then ship, then slot as deterministic tiebreakers so same-severity
+    // ordering is stable regardless of input order (the ledger is a reproducible artifact).
+    const sorted = [...input.findings].sort(
+        (a, b) =>
+            RANK[a.severity] - RANK[b.severity] ||
+            a.ship.localeCompare(b.ship) ||
+            a.slot.localeCompare(b.slot)
+    );
     const bySev = (s: Finding['severity']) => input.findings.filter((f) => f.severity === s).length;
     const rows = sorted
         .map((f) => `| ${f.ship} | ${f.slot} | ${f.layer} | ${f.verdict} | ${f.severity} | ${f.expected} | ${f.observed} | ${f.fixPointer} |`)

--- a/scripts/lib/shipSkillCsv.ts
+++ b/scripts/lib/shipSkillCsv.ts
@@ -1,0 +1,87 @@
+import { readFileSync, existsSync } from 'fs';
+
+export const CSV_PATH = 'docs/ship-skills.csv';
+
+// Verbatim copy from auditSkills.ts — handles quoted fields, escaped quotes, embedded commas.
+export function parseCsvLine(line: string): string[] {
+    const fields: string[] = [];
+    let cur = '';
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i++) {
+        const c = line[i];
+        if (inQuotes) {
+            if (c === '"') {
+                if (line[i + 1] === '"') {
+                    cur += '"';
+                    i++;
+                } else inQuotes = false;
+            } else cur += c;
+        } else if (c === '"') inQuotes = true;
+        else if (c === ',') {
+            fields.push(cur);
+            cur = '';
+        } else cur += c;
+    }
+    fields.push(cur);
+    return fields;
+}
+
+// Verbatim copy from auditSkills.ts — accumulates physical lines until quotes balance so
+// multi-line quoted passives (Centurion, Chimei, Curator, Enforcer, Graphite, Lingshe) survive.
+export function readCsvRecords(raw: string): string[] {
+    const physicalLines = raw.split('\n');
+    const records: string[] = [];
+    let buffer: string[] = [];
+    let quoteCount = 0;
+    for (const line of physicalLines) {
+        buffer.push(line);
+        quoteCount += (line.match(/"/g) ?? []).length;
+        // Even quote count = no unterminated quoted field spanning this line boundary — the
+        // buffered lines form one complete record. Re-join with '\n' so multi-line skill text
+        // is preserved (parseCsvLine treats embedded newlines as ordinary characters).
+        if (quoteCount % 2 === 0) {
+            const record = buffer.join('\n');
+            buffer = [];
+            quoteCount = 0;
+            if (record.trim().length > 0) records.push(record);
+        }
+    }
+    // Any leftover buffered lines (unbalanced quotes through EOF) are dropped — malformed CSV,
+    // not a multi-line record.
+    return records;
+}
+
+export function csvAvailable(csvPath: string = CSV_PATH): boolean {
+    return existsSync(csvPath);
+}
+
+export interface ShipSkillRecord {
+    name: string;
+    active: string;
+    charge: string;
+    chargeCharge: number;
+    passives: [string, string, string];
+}
+
+const clean = (s: string | undefined): string =>
+    s && s !== 'null' && s.trim().length > 0 ? s : '';
+
+export function loadShipSkillRecords(csvPath: string = CSV_PATH): ShipSkillRecord[] {
+    // Header: name,active_skill_text,charge_skill_charge,charge_skill_text,
+    //         first_passive_skill_text,second_passive_skill_text,third_passive_skill_text
+    const records = readCsvRecords(readFileSync(csvPath, 'utf8'));
+    const out: ShipSkillRecord[] = [];
+    for (let i = 1; i < records.length; i++) {
+        const f = parseCsvLine(records[i]);
+        if (f.length < 7) continue;
+        const [name, active, chargeCharge, charge, p1, p2, p3] = f;
+        out.push({
+            name: name.trim(),
+            active: clean(active),
+            charge: clean(charge),
+            chargeCharge: Number(chargeCharge) || 0,
+            passives: [clean(p1), clean(p2), clean(p3)],
+        });
+    }
+    return out;
+}

--- a/scripts/lib/traceArgs.ts
+++ b/scripts/lib/traceArgs.ts
@@ -1,0 +1,53 @@
+import type { ScenarioOverrides } from './traceScenario';
+
+export interface TraceArgs {
+    all: boolean;
+    names: string[];
+    overrides: ScenarioOverrides & { refitLevel?: 0 | 2 | 4 };
+    outSuffix?: string;
+}
+
+// Flags: --all | --hp-scale <n> | --crit <n> | --enemy-attack-scale <n>
+//        | --enemy-affinity <chemical|electric|thermal|antimatter> | --fragile-ally
+//        | --refit <0|2|4> | --rounds <n> | --out-suffix <str>
+// Bare tokens (not starting with --) are ship names.
+export function parseTraceArgs(argv: string[]): TraceArgs {
+    const out: TraceArgs = { all: false, names: [], overrides: {} };
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        const next = (): string => argv[++i];
+        switch (a) {
+            case '--all':
+                out.all = true;
+                break;
+            case '--hp-scale':
+                out.overrides.reviewedHpScale = Number(next());
+                break;
+            case '--crit':
+                out.overrides.reviewedCrit = Number(next());
+                break;
+            case '--enemy-attack-scale':
+                out.overrides.enemyAttackScale = Number(next());
+                break;
+            case '--enemy-affinity':
+                out.overrides.enemyAffinity = next() as ScenarioOverrides['enemyAffinity'];
+                break;
+            case '--fragile-ally':
+                out.overrides.includeFragileAlly = true;
+                break;
+            case '--refit':
+                out.overrides.refitLevel = Number(next()) as 0 | 2 | 4;
+                break;
+            case '--rounds':
+                out.overrides.rounds = Number(next());
+                break;
+            case '--out-suffix':
+                out.outSuffix = next();
+                break;
+            default:
+                if (!a.startsWith('--')) out.names.push(a);
+                break;
+        }
+    }
+    return out;
+}

--- a/scripts/lib/traceScenario.ts
+++ b/scripts/lib/traceScenario.ts
@@ -1,0 +1,99 @@
+import type { Ship, AffinityName } from '../../src/types/ship';
+import type { Position } from '../../src/types/encounters';
+import type { BattlePlacement, BattleSimulationInput } from '../../src/utils/calculators/battleSimulator';
+
+export interface ScenarioOverrides {
+    rounds?: number;
+    reviewedCrit?: number;
+    reviewedHpScale?: number;
+    enemyAttackScale?: number;
+    enemyAffinity?: AffinityName;
+    includeFragileAlly?: boolean;
+}
+
+const placement = (
+    ship: Ship,
+    position: Position,
+    over: Partial<{ hp: number; crit: number; attack: number }> = {}
+): BattlePlacement => ({
+    ship,
+    position,
+    statOverrides: {
+        attack: over.attack ?? ship.baseStats.attack,
+        crit: over.crit ?? ship.baseStats.crit,
+        critDamage: ship.baseStats.critDamage,
+        defensePenetration: 0,
+        hacking: ship.baseStats.hacking,
+        security: ship.baseStats.security,
+        defence: ship.baseStats.defence,
+        hp: over.hp ?? ship.baseStats.hp,
+        speed: ship.baseStats.speed,
+    },
+});
+
+const fillerBase = (id: string, name: string, type: Ship['type'], stats: Partial<Ship['baseStats']>): Ship => ({
+    id,
+    name,
+    rarity: 'legendary',
+    faction: 'MPL',
+    type,
+    affinity: 'antimatter',
+    baseStats: {
+        hp: 260_000, attack: 1500, defence: 300, hacking: 200, security: 150,
+        crit: 50, critDamage: 150, speed: 100, ...stats,
+    },
+    equipment: {},
+    implants: {},
+    refits: [],
+    activeSkillText: 'This Unit deals <unit-damage>100% damage</unit-damage>.',
+    activeTarget: 'front',
+    activePattern: 'Pattern-Base',
+});
+
+// Filler ally with an on-attacked counter (a real reactive to co-exist alongside the reviewed
+// ship). Enemy-targeted damage active only — NEVER an ally-heal (dummyEnemyIsVestigial gotcha).
+const counterAlly = (): Ship => ({
+    ...fillerBase('trace-ally-counter', 'CounterAlly', 'DEFENDER', { attack: 1200, defence: 500, speed: 95 }),
+    firstPassiveSkillText:
+        'When this Unit is directly damaged as a primary target, it deals <unit-damage>70% damage</unit-damage> to that enemy.',
+});
+
+const plainAlly = (): Ship => fillerBase('trace-ally-plain', 'PlainAlly', 'ATTACKER', { attack: 1800, speed: 110 });
+
+const fragileAlly = (): Ship =>
+    fillerBase('trace-ally-fragile', 'FragileAlly', 'ATTACKER', { hp: 40_000, defence: 100, speed: 105 });
+
+const enemyAttacker = (id: string, name: string, affinity: AffinityName, attack: number): Ship => ({
+    ...fillerBase(id, name, 'ATTACKER', { attack, hp: 240_000, speed: 100 }),
+    affinity,
+});
+
+const enemyDebuffer = (id: string, name: string, attack: number): Ship => ({
+    ...fillerBase(id, name, 'ATTACKER', { attack, hp: 240_000, speed: 105, hacking: 260 }),
+    activeSkillText:
+        'This Unit deals <unit-damage>100% damage</unit-damage> and inflicts <unit-skill>Defense Down II</unit-skill> for 2 turns.',
+});
+
+export function buildStandardScenario(reviewed: Ship, overrides: ScenarioOverrides = {}): BattleSimulationInput {
+    const hpScale = overrides.reviewedHpScale ?? 1;
+    const atkScale = overrides.enemyAttackScale ?? 1;
+    const enemyAff = overrides.enemyAffinity ?? 'chemical';
+
+    const playerTeam: BattlePlacement[] = [
+        placement(reviewed, 'M4', {
+            hp: Math.round(reviewed.baseStats.hp * hpScale),
+            crit: overrides.reviewedCrit ?? reviewed.baseStats.crit,
+        }),
+        placement(plainAlly(), 'M1'),
+        placement(counterAlly(), 'B4'),
+    ];
+    if (overrides.includeFragileAlly) playerTeam.push(placement(fragileAlly(), 'B1'));
+
+    const enemyTeam: BattlePlacement[] = [
+        placement(enemyAttacker('trace-e-1', 'EnemyA', enemyAff, Math.round(1600 * atkScale)), 'T1'),
+        placement(enemyDebuffer('trace-e-2', 'EnemyB', Math.round(1600 * atkScale)), 'M2'),
+        placement(enemyAttacker('trace-e-3', 'EnemyC', 'electric', Math.round(1500 * atkScale)), 'B2'),
+    ];
+
+    return { playerTeam, enemyTeam, rounds: overrides.rounds ?? 30 };
+}

--- a/scripts/lib/traceShipFactory.ts
+++ b/scripts/lib/traceShipFactory.ts
@@ -1,6 +1,6 @@
 import type { Ship, Refit, ShipData } from '../../src/types/ship';
 import { SHIPS } from '../../src/constants/ships';
-import { loadShipSkillRecords, ShipSkillRecord } from './shipSkillCsv';
+import { loadShipSkillRecords, csvAvailable, ShipSkillRecord } from './shipSkillCsv';
 
 export type RefitLevel = 0 | 2 | 4;
 export interface BuildTraceShipOpts {
@@ -16,6 +16,9 @@ export const SHIP_DATA_BY_NAME: Map<string, ShipData> = new Map(
 let recordCache: Map<string, ShipSkillRecord> | null = null;
 function recordFor(name: string): ShipSkillRecord | undefined {
     if (!recordCache) {
+        // Clean checkout: the CSV is gitignored/absent. Return no record rather than letting
+        // readFileSync throw — SHIPS-only lookups (and the neither-source null path) stay safe.
+        if (!csvAvailable()) return undefined;
         recordCache = new Map(loadShipSkillRecords().map((r) => [r.name.toUpperCase(), r]));
     }
     return recordCache.get(name.toUpperCase());

--- a/scripts/lib/traceShipFactory.ts
+++ b/scripts/lib/traceShipFactory.ts
@@ -23,41 +23,46 @@ function recordFor(name: string): ShipSkillRecord | undefined {
 
 export function buildTraceShip(name: string, opts: BuildTraceShipOpts = {}): Ship | null {
     const data = SHIP_DATA_BY_NAME.get(name.toUpperCase());
-    if (!data) return null;
     const rec = recordFor(name);
+    // Need at least ONE source. Eight CSV ships (Amartya, Centurion, Enforcer, Graphite, Hemlock,
+    // Lingshe, Meatshield, Wildfire) have skill text but NO SHIPS entry — trace them on a default
+    // stat baseline (affinity 'antimatter' = always-neutral, so no affinity distortion) so the
+    // parser+execution audit still covers all 147. Return null only when NEITHER source exists.
+    if (!data && !rec) return null;
+    const canonicalName = data?.name ?? rec!.name;
     const refitLevel = opts.refitLevel ?? 4;
     const refits: Refit[] = Array.from({ length: refitLevel }, () => ({}) as Refit);
 
     return {
-        id: `trace:${data.name}`,
-        name: data.name, // canonical SHIPS casing, not the raw CSV casing
-        rarity: data.rarity ?? 'legendary',
-        faction: data.faction ?? 'MPL',
-        type: data.role ?? 'ATTACKER',
-        affinity: data.affinity ?? 'antimatter',
+        id: `trace:${canonicalName}`,
+        name: canonicalName, // canonical SHIPS casing when available, else the CSV name
+        rarity: data?.rarity ?? 'legendary',
+        faction: data?.faction ?? 'MPL',
+        type: data?.role ?? 'ATTACKER',
+        affinity: data?.affinity ?? 'antimatter',
         baseStats: {
-            hp: data.hp ?? 200_000,
-            attack: data.attack ?? 2000,
-            defence: data.defense ?? 300,
-            hacking: data.hacking ?? 200,
-            security: data.security ?? 150,
-            crit: data.critRate ?? 50,
-            critDamage: data.critDamage ?? 150,
-            speed: data.speed ?? 100,
+            hp: data?.hp ?? 200_000,
+            attack: data?.attack ?? 2000,
+            defence: data?.defense ?? 300,
+            hacking: data?.hacking ?? 200,
+            security: data?.security ?? 150,
+            crit: data?.critRate ?? 50,
+            critDamage: data?.critDamage ?? 150,
+            speed: data?.speed ?? 100,
         },
         equipment: {},
         implants: {},
         refits,
         // CSV skill text is authoritative; fall back to SHIPS text only if the CSV lacks a record.
-        activeSkillText: rec?.active || data.activeSkillText,
-        chargeSkillText: rec?.charge || data.chargeSkillText,
-        chargeSkillCharge: rec?.chargeCharge ?? data.chargeSkillCharge ?? 0,
-        firstPassiveSkillText: rec?.passives[0] || data.firstPassiveSkillText,
-        secondPassiveSkillText: rec?.passives[1] || data.secondPassiveSkillText,
-        thirdPassiveSkillText: rec?.passives[2] || data.thirdPassiveSkillText,
-        activeTarget: data.activeTarget,
-        activePattern: data.activePattern,
-        chargedTarget: data.chargedTarget,
-        chargedPattern: data.chargedPattern,
+        activeSkillText: rec?.active || data?.activeSkillText,
+        chargeSkillText: rec?.charge || data?.chargeSkillText,
+        chargeSkillCharge: rec?.chargeCharge ?? data?.chargeSkillCharge ?? 0,
+        firstPassiveSkillText: rec?.passives[0] || data?.firstPassiveSkillText,
+        secondPassiveSkillText: rec?.passives[1] || data?.secondPassiveSkillText,
+        thirdPassiveSkillText: rec?.passives[2] || data?.thirdPassiveSkillText,
+        activeTarget: data?.activeTarget,
+        activePattern: data?.activePattern,
+        chargedTarget: data?.chargedTarget,
+        chargedPattern: data?.chargedPattern,
     };
 }

--- a/scripts/lib/traceShipFactory.ts
+++ b/scripts/lib/traceShipFactory.ts
@@ -1,0 +1,63 @@
+import type { Ship, Refit, ShipData } from '../../src/types/ship';
+import { SHIPS } from '../../src/constants/ships';
+import { loadShipSkillRecords, ShipSkillRecord } from './shipSkillCsv';
+
+export type RefitLevel = 0 | 2 | 4;
+export interface BuildTraceShipOpts {
+    refitLevel?: RefitLevel;
+}
+
+// Keyed on the UPPERCASED name because the CSV name column is inconsistently cased
+// (AEGIS/APEX all-caps vs Akula/Amartya mixed) while ShipData.name is canonical mixed-case.
+export const SHIP_DATA_BY_NAME: Map<string, ShipData> = new Map(
+    Object.values(SHIPS).map((d) => [d.name.toUpperCase(), d])
+);
+
+let recordCache: Map<string, ShipSkillRecord> | null = null;
+function recordFor(name: string): ShipSkillRecord | undefined {
+    if (!recordCache) {
+        recordCache = new Map(loadShipSkillRecords().map((r) => [r.name.toUpperCase(), r]));
+    }
+    return recordCache.get(name.toUpperCase());
+}
+
+export function buildTraceShip(name: string, opts: BuildTraceShipOpts = {}): Ship | null {
+    const data = SHIP_DATA_BY_NAME.get(name.toUpperCase());
+    if (!data) return null;
+    const rec = recordFor(name);
+    const refitLevel = opts.refitLevel ?? 4;
+    const refits: Refit[] = Array.from({ length: refitLevel }, () => ({}) as Refit);
+
+    return {
+        id: `trace:${data.name}`,
+        name: data.name, // canonical SHIPS casing, not the raw CSV casing
+        rarity: data.rarity ?? 'legendary',
+        faction: data.faction ?? 'MPL',
+        type: data.role ?? 'ATTACKER',
+        affinity: data.affinity ?? 'antimatter',
+        baseStats: {
+            hp: data.hp ?? 200_000,
+            attack: data.attack ?? 2000,
+            defence: data.defense ?? 300,
+            hacking: data.hacking ?? 200,
+            security: data.security ?? 150,
+            crit: data.critRate ?? 50,
+            critDamage: data.critDamage ?? 150,
+            speed: data.speed ?? 100,
+        },
+        equipment: {},
+        implants: {},
+        refits,
+        // CSV skill text is authoritative; fall back to SHIPS text only if the CSV lacks a record.
+        activeSkillText: rec?.active || data.activeSkillText,
+        chargeSkillText: rec?.charge || data.chargeSkillText,
+        chargeSkillCharge: rec?.chargeCharge ?? data.chargeSkillCharge ?? 0,
+        firstPassiveSkillText: rec?.passives[0] || data.firstPassiveSkillText,
+        secondPassiveSkillText: rec?.passives[1] || data.secondPassiveSkillText,
+        thirdPassiveSkillText: rec?.passives[2] || data.thirdPassiveSkillText,
+        activeTarget: data.activeTarget,
+        activePattern: data.activePattern,
+        chargedTarget: data.chargedTarget,
+        chargedPattern: data.chargedPattern,
+    };
+}

--- a/scripts/traceShip.ts
+++ b/scripts/traceShip.ts
@@ -1,0 +1,32 @@
+/* eslint-disable no-console */
+import { mkdirSync, writeFileSync } from 'fs';
+import { loadShipSkillRecords, csvAvailable } from './lib/shipSkillCsv';
+import { buildKitBundle, renderKitBundleMarkdown } from './lib/kitBundle';
+
+const OUT_DIR = 'docs/kit-bundles';
+
+function main() {
+    if (!csvAvailable()) {
+        console.error('docs/ship-skills.csv not found — nothing to trace.');
+        process.exit(1);
+    }
+    const args = process.argv.slice(2);
+    const names = args.includes('--all')
+        ? loadShipSkillRecords().map((r) => r.name)
+        : args.filter((a) => !a.startsWith('--'));
+    if (names.length === 0) {
+        console.error('Usage: npm run trace:ship -- --all | <ShipName> [<ShipName> ...]');
+        process.exit(1);
+    }
+    mkdirSync(OUT_DIR, { recursive: true });
+    let errors = 0;
+    for (const name of names) {
+        const bundle = buildKitBundle(name);
+        if ('error' in bundle) errors++;
+        const safe = name.replace(/[^\w-]/g, '_');
+        writeFileSync(`${OUT_DIR}/${safe}.json`, JSON.stringify(bundle, null, 2));
+        writeFileSync(`${OUT_DIR}/${safe}.md`, renderKitBundleMarkdown(bundle));
+    }
+    console.log(`Wrote ${names.length} kit bundles to ${OUT_DIR}/ (${errors} harness errors).`);
+}
+main();

--- a/scripts/traceShip.ts
+++ b/scripts/traceShip.ts
@@ -2,6 +2,7 @@
 import { mkdirSync, writeFileSync } from 'fs';
 import { loadShipSkillRecords, csvAvailable } from './lib/shipSkillCsv';
 import { buildKitBundle, renderKitBundleMarkdown } from './lib/kitBundle';
+import { parseTraceArgs } from './lib/traceArgs';
 
 const OUT_DIR = 'docs/kit-bundles';
 
@@ -10,10 +11,8 @@ function main() {
         console.error('docs/ship-skills.csv not found — nothing to trace.');
         process.exit(1);
     }
-    const args = process.argv.slice(2);
-    const names = args.includes('--all')
-        ? loadShipSkillRecords().map((r) => r.name)
-        : args.filter((a) => !a.startsWith('--'));
+    const parsed = parseTraceArgs(process.argv.slice(2));
+    const names = parsed.all ? loadShipSkillRecords().map((r) => r.name) : parsed.names;
     if (names.length === 0) {
         console.error('Usage: npm run trace:ship -- --all | <ShipName> [<ShipName> ...]');
         process.exit(1);
@@ -21,9 +20,9 @@ function main() {
     mkdirSync(OUT_DIR, { recursive: true });
     let errors = 0;
     for (const name of names) {
-        const bundle = buildKitBundle(name);
+        const bundle = buildKitBundle(name, parsed.overrides);
         if ('error' in bundle) errors++;
-        const safe = name.replace(/[^\w-]/g, '_');
+        const safe = name.replace(/[^\w-]/g, '_') + (parsed.outSuffix ? `.${parsed.outSuffix}` : '');
         writeFileSync(`${OUT_DIR}/${safe}.json`, JSON.stringify(bundle, null, 2));
         writeFileSync(`${OUT_DIR}/${safe}.md`, renderKitBundleMarkdown(bundle));
     }

--- a/scripts/traceShip.ts
+++ b/scripts/traceShip.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { mkdirSync, writeFileSync } from 'fs';
 import { loadShipSkillRecords, csvAvailable } from './lib/shipSkillCsv';
-import { buildKitBundle, renderKitBundleMarkdown } from './lib/kitBundle';
+import { buildKitBundle, renderKitReviewMarkdown } from './lib/kitBundle';
 import { parseTraceArgs } from './lib/traceArgs';
 
 const OUT_DIR = 'docs/kit-bundles';
@@ -24,7 +24,7 @@ function main() {
         if ('error' in bundle) errors++;
         const safe = name.replace(/[^\w-]/g, '_') + (parsed.outSuffix ? `.${parsed.outSuffix}` : '');
         writeFileSync(`${OUT_DIR}/${safe}.json`, JSON.stringify(bundle, null, 2));
-        writeFileSync(`${OUT_DIR}/${safe}.md`, renderKitBundleMarkdown(bundle));
+        writeFileSync(`${OUT_DIR}/${safe}.md`, renderKitReviewMarkdown(bundle));
     }
     console.log(`Wrote ${names.length} kit bundles to ${OUT_DIR}/ (${errors} harness errors).`);
 }

--- a/scripts/writeKitLedger.ts
+++ b/scripts/writeKitLedger.ts
@@ -1,0 +1,16 @@
+/* eslint-disable no-console */
+import { readFileSync, writeFileSync } from 'fs';
+import { renderLedgerMarkdown, renderLedgerJson, LedgerInput } from './lib/kitLedger';
+
+function main() {
+    const inPath = process.argv[2];
+    if (!inPath) {
+        console.error('Usage: npm run audit:kit-ledger -- <findings.json>');
+        process.exit(1);
+    }
+    const input = JSON.parse(readFileSync(inPath, 'utf8')) as LedgerInput;
+    writeFileSync('docs/ship-kit-correctness-ledger.md', renderLedgerMarkdown(input));
+    writeFileSync('docs/ship-kit-correctness-ledger.json', renderLedgerJson(input));
+    console.log('Wrote docs/ship-kit-correctness-ledger.{md,json}');
+}
+main();

--- a/src/utils/abilities/__tests__/kitBundle.test.ts
+++ b/src/utils/abilities/__tests__/kitBundle.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { csvAvailable } from '../../../../scripts/lib/shipSkillCsv';
-import { buildKitBundle, renderKitBundleMarkdown } from '../../../../scripts/lib/kitBundle';
+import {
+    buildKitBundle,
+    renderKitBundleMarkdown,
+    renderKitReviewMarkdown,
+} from '../../../../scripts/lib/kitBundle';
 
 describe('buildKitBundle', () => {
     it('returns an error record for an unknown ship', () => {
@@ -24,5 +28,21 @@ describe('buildKitBundle', () => {
         expect(md).toContain('## Skill text');
         expect(md).toContain('## Parsed abilities');
         expect(md).toContain('## Execution trace');
+    });
+});
+
+describe('renderKitReviewMarkdown', () => {
+    it.skipIf(!csvAvailable())('renders the compact review sections for a real ship', () => {
+        const md = renderKitReviewMarkdown(buildKitBundle('Aegis'));
+        expect(md).toContain('## Skill text');
+        expect(md).toContain('## Parsed abilities');
+        expect(md).toContain('## Execution summary');
+        expect(md).toContain('## Focus-actor transcript');
+        expect(md).toContain('Focus-actor kinds observed:');
+    });
+
+    it('renders a harness error', () => {
+        const md = renderKitReviewMarkdown(buildKitBundle('NotARealShip_zzz'));
+        expect(md).toContain('**HARNESS-ERROR:**');
     });
 });

--- a/src/utils/abilities/__tests__/kitBundle.test.ts
+++ b/src/utils/abilities/__tests__/kitBundle.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { csvAvailable } from '../../../../scripts/lib/shipSkillCsv';
+import { buildKitBundle, renderKitBundleMarkdown } from '../../../../scripts/lib/kitBundle';
+
+describe('buildKitBundle', () => {
+    it('returns an error record for an unknown ship', () => {
+        const b = buildKitBundle('NotARealShip_zzz');
+        expect('error' in b).toBe(true);
+    });
+
+    it.skipIf(!csvAvailable())('produces all three sections for a real ship', () => {
+        const b = buildKitBundle('Aegis');
+        expect('error' in b).toBe(false);
+        if ('error' in b) return;
+        expect(b.skillRows.length).toBeGreaterThan(0);
+        expect(b.abilities.length).toBeGreaterThan(0);
+        expect(b.combatLog.length).toBeGreaterThan(0);
+        // At least one clause was observed executing in the standardized scenario.
+        expect(b.abilities.some((a) => a.observed)).toBe(true);
+    });
+
+    it.skipIf(!csvAvailable())('renders markdown with the three section headers', () => {
+        const md = renderKitBundleMarkdown(buildKitBundle('Aegis'));
+        expect(md).toContain('## Skill text');
+        expect(md).toContain('## Parsed abilities');
+        expect(md).toContain('## Execution trace');
+    });
+});

--- a/src/utils/abilities/__tests__/kitLedger.test.ts
+++ b/src/utils/abilities/__tests__/kitLedger.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import {
+    renderLedgerMarkdown,
+    renderLedgerJson,
+    LedgerInput,
+} from '../../../../scripts/lib/kitLedger';
+
+const input: LedgerInput = {
+    shipsAudited: 147,
+    clausesReviewed: 500,
+    refuted: 3,
+    untriggeredVerified: 12,
+    findings: [
+        {
+            ship: 'Zeta',
+            slot: 'charged',
+            layer: 'parser',
+            verdict: 'WRONG-PARSE',
+            expected: 'heal 30%',
+            observed: 'heal 20%',
+            severity: 'high',
+            fixPointer: 'skillTextParser.ts',
+        },
+        {
+            ship: 'Alpha',
+            slot: 'passive',
+            layer: 'executor',
+            verdict: 'MISSING',
+            expected: 'on-ally-death buff',
+            observed: 'never fires',
+            severity: 'low',
+            fixPointer: 'combat/triggers.ts',
+        },
+    ],
+};
+
+describe('kitLedger', () => {
+    it('ranks findings high → low in the markdown', () => {
+        const md = renderLedgerMarkdown(input);
+        expect(md.indexOf('Zeta')).toBeLessThan(md.indexOf('Alpha'));
+        expect(md).toContain('147');
+        expect(md).toContain('| Zeta |');
+    });
+
+    it('emits valid JSON with the same finding count', () => {
+        const parsed = JSON.parse(renderLedgerJson(input));
+        expect(parsed.findings).toHaveLength(2);
+        expect(parsed.shipsAudited).toBe(147);
+    });
+});

--- a/src/utils/abilities/__tests__/shipSkillCsv.test.ts
+++ b/src/utils/abilities/__tests__/shipSkillCsv.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import {
+    parseCsvLine,
+    csvAvailable,
+    loadShipSkillRecords,
+} from '../../../../scripts/lib/shipSkillCsv';
+
+describe('shipSkillCsv', () => {
+    it('parses a quoted field containing commas and escaped quotes', () => {
+        expect(parseCsvLine('a,"b,c","d""e"')).toEqual(['a', 'b,c', 'd"e']);
+    });
+
+    it.skipIf(!csvAvailable())('loads structured records with a resolvable name', () => {
+        const records = loadShipSkillRecords();
+        expect(records.length).toBeGreaterThan(100);
+        const aegis = records.find((r) => r.name === 'AEGIS');
+        expect(aegis).toBeDefined();
+        expect(aegis!.active.length).toBeGreaterThan(0);
+        expect(aegis!.passives).toHaveLength(3);
+    });
+});

--- a/src/utils/abilities/__tests__/traceArgs.test.ts
+++ b/src/utils/abilities/__tests__/traceArgs.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { parseTraceArgs } from '../../../../scripts/lib/traceArgs';
+
+describe('parseTraceArgs', () => {
+    it('parses --all with no names or overrides', () => {
+        expect(parseTraceArgs(['--all'])).toEqual({
+            all: true,
+            names: [],
+            overrides: {},
+        });
+    });
+
+    it('parses bare ship name tokens with no overrides', () => {
+        expect(parseTraceArgs(['Aegis', 'Akula'])).toEqual({
+            all: false,
+            names: ['Aegis', 'Akula'],
+            overrides: {},
+        });
+    });
+
+    it('parses a full set of scenario-override flags alongside a ship name', () => {
+        expect(
+            parseTraceArgs([
+                'Centurion',
+                '--hp-scale',
+                '0.1',
+                '--crit',
+                '100',
+                '--fragile-ally',
+                '--refit',
+                '2',
+                '--out-suffix',
+                'lowhp',
+            ])
+        ).toEqual({
+            all: false,
+            names: ['Centurion'],
+            overrides: {
+                reviewedHpScale: 0.1,
+                reviewedCrit: 100,
+                includeFragileAlly: true,
+                refitLevel: 2,
+            },
+            outSuffix: 'lowhp',
+        });
+    });
+});

--- a/src/utils/abilities/__tests__/traceScenario.test.ts
+++ b/src/utils/abilities/__tests__/traceScenario.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { buildStandardScenario } from '../../../../scripts/lib/traceScenario';
+import { simulateBattle } from '../../../../src/utils/calculators/battleSimulator';
+import type { Ship } from '../../../../src/types/ship';
+
+const reviewed: Ship = {
+    id: 'trace:Test',
+    name: 'Test',
+    rarity: 'legendary',
+    faction: 'MPL',
+    type: 'ATTACKER',
+    affinity: 'antimatter',
+    baseStats: {
+        hp: 250_000,
+        attack: 3000,
+        defence: 300,
+        hacking: 220,
+        security: 150,
+        crit: 50,
+        critDamage: 150,
+        speed: 120,
+    },
+    equipment: {},
+    implants: {},
+    refits: [],
+    activeSkillText: 'This Unit deals <unit-damage>120% damage</unit-damage>.',
+    activeTarget: 'front',
+    activePattern: 'Pattern-Base',
+};
+
+describe('buildStandardScenario', () => {
+    it('places the reviewed ship as the focus actor with fillers and enemies', () => {
+        const input = buildStandardScenario(reviewed);
+        expect(input.playerTeam[0].ship.name).toBe('Test');
+        expect(input.playerTeam[0].position).toBe('M4');
+        expect(input.playerTeam.length).toBeGreaterThanOrEqual(3);
+        expect(input.enemyTeam.length).toBeGreaterThanOrEqual(3);
+        expect(input.rounds).toBe(30);
+    });
+
+    it('produces a runnable battle with a non-empty combat log', () => {
+        const result = simulateBattle(buildStandardScenario(reviewed));
+        expect(result.combatLog.length).toBeGreaterThan(0);
+        // The reviewed ship acted at least once (its active fired). The reviewed ship is always
+        // playerTeam[0], which the engine assigns the reserved focus actorId 'attacker' (see
+        // `FOCUS_ID` in battleSimulator.ts) — combat log entries carry actorIds, not ship names,
+        // so this is the correct way to detect the reviewed ship's turns (not a name substring
+        // match, which would never appear in the log).
+        const acted = result.combatLog.some((round) =>
+            round.turns.some((turn) => turn.actorId === 'attacker' && turn.entries.length > 0)
+        );
+        expect(acted).toBe(true);
+    });
+
+    it('adds a fragile ally when requested', () => {
+        const input = buildStandardScenario(reviewed, { includeFragileAlly: true });
+        expect(input.playerTeam.length).toBe(4);
+    });
+});

--- a/src/utils/abilities/__tests__/traceShipFactory.test.ts
+++ b/src/utils/abilities/__tests__/traceShipFactory.test.ts
@@ -18,9 +18,22 @@ describe('buildTraceShip', () => {
         expect(ship!.refits).toHaveLength(4);
     });
 
-    it('returns null for a name with no SHIPS base stats', () => {
+    it('returns null when there is neither SHIPS data nor a CSV record', () => {
         expect(buildTraceShip('NotARealShip_zzz')).toBeNull();
     });
+
+    it.skipIf(!csvAvailable())(
+        'traces a CSV-only ship (no SHIPS entry) on the default baseline',
+        () => {
+            // Centurion has skill text in the CSV but no SHIPS entry — must still trace.
+            const ship = buildTraceShip('Centurion');
+            expect(ship).not.toBeNull();
+            expect(ship!.name).toBe('Centurion');
+            expect(ship!.baseStats.hp).toBe(200_000); // default baseline
+            expect(ship!.affinity).toBe('antimatter'); // neutral fallback
+            expect((ship!.activeSkillText ?? '').length).toBeGreaterThan(0); // CSV skill text present
+        }
+    );
 
     it.skipIf(!csvAvailable())('honours a lower refit level', () => {
         const r0 = buildTraceShip('Aegis', { refitLevel: 0 });

--- a/src/utils/abilities/__tests__/traceShipFactory.test.ts
+++ b/src/utils/abilities/__tests__/traceShipFactory.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { csvAvailable } from '../../../../scripts/lib/shipSkillCsv';
+import { buildTraceShip } from '../../../../scripts/lib/traceShipFactory';
+
+describe('buildTraceShip', () => {
+    it.skipIf(!csvAvailable())('merges CSV skill text with SHIPS base stats', () => {
+        const ship = buildTraceShip('Aegis');
+        expect(ship).not.toBeNull();
+        expect(ship!.name).toBe('Aegis');
+        expect(ship!.baseStats.hp).toBeGreaterThan(0);
+        expect(ship!.baseStats.attack).toBeGreaterThan(0);
+        expect(ship!.affinity).toBe('antimatter');
+        // CSV active text flows onto the ship (authoritative source) — the CSV text is
+        // HTML-tagged ("<unit-damage>Shield...") while the SHIPS.ts fallback text is plain
+        // ("a shield equal to..."), so this marker only appears if the CSV record won.
+        expect(ship!.activeSkillText).toContain('<unit-damage>');
+        // Default refit level 4 → four synthesized refits so R4 passive resolves if present.
+        expect(ship!.refits).toHaveLength(4);
+    });
+
+    it('returns null for a name with no SHIPS base stats', () => {
+        expect(buildTraceShip('NotARealShip_zzz')).toBeNull();
+    });
+
+    it.skipIf(!csvAvailable())('honours a lower refit level', () => {
+        const r0 = buildTraceShip('Aegis', { refitLevel: 0 });
+        expect(r0!.refits).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Summary

Adds a headless **ship-kit correctness-audit harness** under `scripts/` (siblings to `auditSkills.ts`) and uses it to produce a full-roster correctness ledger. This is **dev tooling + tests only** — no product/runtime code changes.

The harness traces every ship's kit through three layers and compares them per-clause:
**skill text** (`docs/ship-skills.csv`, source of truth) → **parsed abilities** (`buildShipAbilities`) → **real combat-log** (`simulateBattle`).

## What's included

- **`scripts/lib/shipSkillCsv.ts`** — shared CSV reader (extracted from `auditSkills.ts`, which now imports it; audit output byte-identical: 147 ships → 0 findings).
- **`scripts/lib/traceShipFactory.ts`** — `buildTraceShip` merges CSV skill text + `SHIPS` base stats (case-insensitive name match; CSV-only fallback recovers 8 ships absent from `SHIPS`).
- **`scripts/lib/traceScenario.ts`** — a fixed standardized battle (reviewed ship as focus vs a tuned roster; fillers use damage actives only, respecting the `dummyEnemyIsVestigial` gate).
- **`scripts/lib/kitBundle.ts`** — per-ship bundle (text + parsed abilities + combat-log) with an `actorId`-based observed-clause labeler and a compact review renderer.
- **`scripts/lib/traceArgs.ts` + `scripts/traceShip.ts`** — CLI (`npm run trace:ship -- --all`) with scenario-override flags for escalation.
- **`scripts/lib/kitLedger.ts` + `scripts/writeKitLedger.ts`** — ranked ledger writer (`npm run audit:kit-ledger`).
- 6 new test files under `src/utils/abilities/__tests__/` (CSV-guarded via `csvAvailable()`).

## Audit result (dev-only artifact, not committed)

147 ships / 967 clauses audited by a 101-agent review→adversarial-verify workflow: **57 confirmed findings** (34 high / 20 med / 3 low; mostly parser-layer), with 31 candidates refuted by adversarial verification. Example confirmed bugs: `cleanses 1</unit-aid>debuff` tag-concatenation defeats the cleanse regex (Cultivator); enemy-side "all enemies" debuffs parsed single-target (Amartya); the `Inc./Out.` abbreviation-period sentence-split resurfacing in the shield-flip path (Graphite). Fixes for these are a separate follow-up effort.

## Testing

- `npm test` — 4551 passed (370 files)
- `npm run lint` — clean
- `npm run audit:skills` — 147 ships → 0 findings (unchanged by the shared-reader refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
