### PR TITLE
fix: ship-kit correctness Wave 5 — enemy-adjacency splash (6 findings + Meiying bonus)

### DIFF
--- a/src/components/skills/AbilityCard.tsx
+++ b/src/components/skills/AbilityCard.tsx
@@ -83,6 +83,8 @@ const TARGET_OPTIONS: { value: AbilityTarget; label: string }[] = [
     { value: 'adjacent-allies', label: 'Adjacent allies' },
     { value: 'enemy', label: 'Enemy' },
     { value: 'all-enemies', label: 'All enemies' },
+    { value: 'adjacent-enemies', label: 'Adjacent enemies' },
+    { value: 'target-and-adjacent-enemies', label: 'Target + adjacent enemies' },
 ];
 
 const MODIFIER_CHANNEL_OPTIONS: { value: ModifierChannel; label: string }[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -6,8 +6,9 @@ export const CURRENT_VERSION = '1.64.0';
 // CHANGELOG (with the new version + today's date), clear this array back to [],
 // and bump CURRENT_VERSION. All three steps must happen together.
 export const UNRELEASED_CHANGES: string[] = [
-    "Combat sim: Vindicator's Provoke and Asphyxiator's Stasis now correctly apply to the target's adjacent enemies on the board (Provoke to the neighbours only, Stasis to the target and its neighbours), instead of being misapplied as a self-buff on the caster.",
+    "Combat sim: enemy-adjacency splash is now modeled. Vindicator's Provoke and charged Out. Damage Down I hit the enemies adjacent to the target (the target excluded), and Asphyxiator's Stasis hits the target and its adjacent enemies — instead of being misapplied as a self-buff on the caster. Meiying's Stasis now also correctly hits all adjacent enemies.",
     "Combat sim: Asphyxiator's active skill now inflicts Inferno III on the targeted enemy AND its board neighbours, matching her skill text — previously the Inferno DoT only ever landed on the primary target.",
+    "Combat sim: Demolisher's passive splash is now modeled — when a Bomb explodes on an enemy, Demolisher deals 100% of the Bomb's damage to all enemies adjacent to it. This splash ignores Defense and cannot critically hit, matching the skill text; previously it was dropped entirely.",
     "Combat sim: Zeolite's +30% damage passive and IonScorp's 200% charged damage now only apply against Defender-class enemies, matching their skill text — previously Zeolite's bonus applied to every target and IonScorp's charged skill always dealt its base 190%.",
     "Combat sim: APEX's charged skill now only inflicts Disable when APEX currently has a Shield ('If this Unit has Shield…'), instead of Disabling the target on every charged cast.",
     'Combat sim: FrontLine now gains +2500 Defense while it has an active Shield, matching its passive — the bonus is re-evaluated each hit, so it applies while shielded and drops off once the shield is gone.',

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -6,6 +6,7 @@ export const CURRENT_VERSION = '1.64.0';
 // CHANGELOG (with the new version + today's date), clear this array back to [],
 // and bump CURRENT_VERSION. All three steps must happen together.
 export const UNRELEASED_CHANGES: string[] = [
+    "Combat sim: Vindicator's Provoke and Asphyxiator's Stasis now correctly apply to the target's adjacent enemies on the board (Provoke to the neighbours only, Stasis to the target and its neighbours), instead of being misapplied as a self-buff on the caster.",
     "Combat sim: Zeolite's +30% damage passive and IonScorp's 200% charged damage now only apply against Defender-class enemies, matching their skill text — previously Zeolite's bonus applied to every target and IonScorp's charged skill always dealt its base 190%.",
     "Combat sim: APEX's charged skill now only inflicts Disable when APEX currently has a Shield ('If this Unit has Shield…'), instead of Disabling the target on every charged cast.",
     'Combat sim: FrontLine now gains +2500 Defense while it has an active Shield, matching its passive — the bonus is re-evaluated each hit, so it applies while shielded and drops off once the shield is gone.',

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -7,6 +7,7 @@ export const CURRENT_VERSION = '1.64.0';
 // and bump CURRENT_VERSION. All three steps must happen together.
 export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Vindicator's Provoke and Asphyxiator's Stasis now correctly apply to the target's adjacent enemies on the board (Provoke to the neighbours only, Stasis to the target and its neighbours), instead of being misapplied as a self-buff on the caster.",
+    "Combat sim: Asphyxiator's active skill now inflicts Inferno III on the targeted enemy AND its board neighbours, matching her skill text — previously the Inferno DoT only ever landed on the primary target.",
     "Combat sim: Zeolite's +30% damage passive and IonScorp's 200% charged damage now only apply against Defender-class enemies, matching their skill text — previously Zeolite's bonus applied to every target and IonScorp's charged skill always dealt its base 190%.",
     "Combat sim: APEX's charged skill now only inflicts Disable when APEX currently has a Shield ('If this Unit has Shield…'), instead of Disabling the target on every charged cast.",
     'Combat sim: FrontLine now gains +2500 Defense while it has an active Shield, matching its passive — the bonus is re-evaluated each hit, so it applies while shielded and drops off once the shield is gone.',

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -2494,6 +2494,19 @@ const DocumentationPage: React.FC = () => {
                                         and current shield pool for the round.
                                     </p>
                                     <p className="text-theme-text mb-2">
+                                        <span className="text-primary">Enemy Adjacency:</span> Some
+                                        skills splash their effect onto enemies adjacent to the
+                                        target on the board, either including the targeted enemy
+                                        (e.g. Asphyxiator&apos;s Inferno and Stasis) or hitting only
+                                        its neighbours (e.g. Vindicator&apos;s Provoke and Out.
+                                        Damage Down, Meiying&apos;s Stasis). Demolisher&apos;s
+                                        passive also detonates a splash equal to 100% of the
+                                        exploded Bomb&apos;s damage onto the bombed enemy&apos;s
+                                        neighbours, ignoring Defense and unable to critically hit.
+                                        This resolves on the positioned board; in the single-target
+                                        DPS calculator there are no neighbours, so it has no effect.
+                                    </p>
+                                    <p className="text-theme-text mb-2">
                                         <span className="text-primary">Team Ships:</span> Pick a
                                         ship into any of the four team slots and its real skills are
                                         parsed and simulated — the same full ability editor as the

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -619,6 +619,10 @@ export type AbilityConfig =
            *  100, critPenalty 0, no debuff-landing disadvantage. Read at the three affinity seams
            *  in playerTurn.ts. Absent → the real computed matchup (byte-identical default). */
           forceAffinityAdvantage?: boolean;
+          /** Ship-kit W5 (Demolisher bomb-splash): this damage bypasses the target's Defense
+           *  mitigation term. Consumed by the REACTIVE damage executor (applyReactiveDamage,
+           *  Task C3); the on-cast damage path ignores it. Absent → normal mitigation. */
+          ignoresDefense?: boolean;
       }
     | {
           type: 'counter';

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -92,6 +92,9 @@ export type AbilityTarget =
     | 'adjacent-allies' // Fortifying Shroud: living same-side allies on neighbouring board
     // cells (non-positional → all same-side allies). Resolved via
     // IntentExecContext.adjacentAllyIdsFor.
+    | 'adjacent-enemies' // living opposing actors adjacent to the anchor (target excluded).
+    // Resolved via adjacentAllyIdsFor(anchorId) with the enemy TARGET as anchor.
+    | 'target-and-adjacent-enemies' // the anchor (primary target) PLUS its adjacent enemies.
     | 'enemy'
     | 'all-enemies'
     | 'enemy-most-buffs'

--- a/src/types/calculator.ts
+++ b/src/types/calculator.ts
@@ -102,6 +102,10 @@ export interface DoTApplicationEntry {
     stacks: number; // stacks applied per use
     duration: number; // rounds before expiry (corrosion/inferno), or countdown for bombs
     autoFilled?: boolean;
+    /** Ship-kit W5: enemy-adjacency splash scope for this DoT. Absent → single primary
+     *  target (default). 'target-and-adjacent-enemies' → primary + its board-neighbours;
+     *  'adjacent-enemies' → neighbours only. Consumed by the DoT fan-out in playerTurn. */
+    splashTarget?: 'adjacent-enemies' | 'target-and-adjacent-enemies';
 }
 
 export type DoTApplicationConfig = DoTApplicationEntry[];

--- a/src/types/calculator.ts
+++ b/src/types/calculator.ts
@@ -167,7 +167,14 @@ export interface SelectedGameBuff {
     // For enemy debuffs: 'inflict' (resistible) vs 'apply' (guaranteed), parsed from the skill verb.
     application?: 'inflict' | 'apply';
     /** Parser ally/enemy-scope (team walk): granular target of the granting clause; absent on manual picks. */
-    effectTarget?: 'self' | 'ally' | 'all-allies' | 'enemy' | 'all-enemies';
+    effectTarget?:
+        | 'self'
+        | 'ally'
+        | 'all-allies'
+        | 'enemy'
+        | 'all-enemies'
+        | 'adjacent-enemies'
+        | 'target-and-adjacent-enemies';
     // Lionheart: Protection removed entirely after it redirects a hit (consumable). Carried to
     // the buff ability config so the engine clears stacks post-redirect.
     clearAllOnRedirect?: boolean;

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -4332,6 +4332,9 @@ describe('buildShipAbilities — control-twin gating parity (epic PR2)', () => {
         );
         expect(debuff).toBeDefined();
         expect(debuff!.trigger).toBe('on-enemy-destroyed');
+        // Wave 5 Task C1: ADJACENT_ENEMY_ONLY_RE widening reclassified "on all adjacent
+        // enemies" from `enemy` to `adjacent-enemies` — lock it in against regression.
+        expect(debuff!.target).toBe('adjacent-enemies');
         const control = passive?.abilities.find(
             (a) =>
                 a.type === 'control' && a.config.type === 'control' && a.config.effect === 'stasis'

--- a/src/utils/abilities/__tests__/wave5DemolisherParse.test.ts
+++ b/src/utils/abilities/__tests__/wave5DemolisherParse.test.ts
@@ -91,6 +91,31 @@ describe.skipIf(!csvAvailable())(
     }
 );
 
+// Synthetic fixture: feed a hand-written Demolisher-shaped passive text through the real
+// `buildShipAbilities` (NOT docs/ship-skills.csv), so the bomb-splash parser→builder wiring
+// stays covered in CI even when the gitignored reference CSV is absent (the suite above skips
+// there).
+describe('Task C1 — Demolisher bomb-splash parser routing (synthetic, CSV-independent)', () => {
+    it('routes a synthetic R2 passive 100% splash to on-bomb-detonated / adjacent-enemies / ignoresDefense+noCrit', () => {
+        const text =
+            "When a Bomb explodes on an enemy, this Unit deals <unit-damage>100% of the Bomb's damage</unit-damage> to all adjacent enemies. This damage ignores Defense and cannot result in a critical hit.";
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const s = ship({ refits: [{}, {}] as any, secondPassiveSkillText: text });
+        const { slots } = buildShipAbilities(s);
+        const passive = slot(slots, 'passive');
+        expect(passive).toBeDefined();
+
+        const splash = abilitiesOfType(passive!.abilities, 'damage').find(
+            (a) => a.config.type === 'damage' && a.config.multiplier === 100
+        );
+        expect(splash).toBeDefined();
+        expect(splash?.trigger).toBe('on-bomb-detonated');
+        expect(splash?.target).toBe('adjacent-enemies');
+        expect(splash?.config.type === 'damage' && splash.config.ignoresDefense).toBe(true);
+        expect(splash?.config.type === 'damage' && splash.config.noCrit).toBe(true);
+    });
+});
+
 describe('Task C1 — parseIgnoresDefense / extended parseNoCrit (synthetic)', () => {
     it('parseIgnoresDefense detects "ignores Defense"', () => {
         expect(

--- a/src/utils/abilities/__tests__/wave5DemolisherParse.test.ts
+++ b/src/utils/abilities/__tests__/wave5DemolisherParse.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { Ability, Skill } from '../../../types/abilities';
+import { parseNoCrit, parseIgnoresDefense } from '../../skillTextParser';
+import {
+    csvAvailable,
+    loadShipSkillRecords,
+    ShipSkillRecord,
+} from '../../../../scripts/lib/shipSkillCsv';
+
+/**
+ * Regression tests for Task C1 (ship-kit correctness audit, Wave 5): parser routing for
+ * Demolisher's R2 passive bomb-splash damage (adjacent-enemies target, on-bomb-detonated
+ * trigger, ignoresDefense + noCrit flags). PARSER-LAYER ONLY — the reactive execution
+ * (Tasks C2/C3) is not wired yet. Skips gracefully when the gitignored reference CSV is
+ * absent (clean checkout / CI).
+ */
+
+function ship(over: Partial<Ship>): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}, {}, {}], ...over } as Ship;
+}
+
+function slot(skills: Skill[], name: string): Skill | undefined {
+    return skills.find((s) => s.slot === name);
+}
+
+function abilitiesOfType(abilities: Ability[], type: string): Ability[] {
+    return abilities.filter((a) => a.type === type);
+}
+
+function recordFor(name: string): ShipSkillRecord {
+    const rec = loadShipSkillRecords().find((r) => r.name.toUpperCase() === name.toUpperCase());
+    if (!rec) throw new Error(`docs/ship-skills.csv: no record found for "${name}"`);
+    return rec;
+}
+
+describe.skipIf(!csvAvailable())(
+    'Task C1 — Demolisher bomb-splash parser routing (verbatim docs/ship-skills.csv)',
+    () => {
+        it('routes the R2 passive 100% splash to on-bomb-detonated / adjacent-enemies / ignoresDefense+noCrit', () => {
+            const rec = recordFor('Demolisher');
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const s = ship({ refits: [{}, {}] as any, secondPassiveSkillText: rec.passives[1] });
+            const { slots } = buildShipAbilities(s);
+            const passive = slot(slots, 'passive');
+            expect(passive).toBeDefined();
+
+            const splash = abilitiesOfType(passive!.abilities, 'damage').find(
+                (a) => a.config.type === 'damage' && a.config.multiplier === 100
+            );
+            expect(splash).toBeDefined();
+            expect(splash?.trigger).toBe('on-bomb-detonated');
+            expect(splash?.target).toBe('adjacent-enemies');
+            expect(splash?.config.type === 'damage' && splash.config.ignoresDefense).toBe(true);
+            expect(splash?.config.type === 'damage' && splash.config.noCrit).toBe(true);
+        });
+
+        it('leaves the active 170% damage as on-cast / enemy / can-crit (no ignoresDefense/noCrit)', () => {
+            const rec = recordFor('Demolisher');
+            const s = ship({ activeSkillText: rec.active });
+            const { slots } = buildShipAbilities(s);
+            const active = slot(slots, 'active');
+            expect(active).toBeDefined();
+
+            const hit = abilitiesOfType(active!.abilities, 'damage').find(
+                (a) => a.config.type === 'damage' && a.config.multiplier === 170
+            );
+            expect(hit).toBeDefined();
+            expect(hit?.trigger).toBe('on-cast');
+            expect(hit?.target).toBe('enemy');
+            expect(hit?.config.type === 'damage' && hit.config.ignoresDefense).toBeFalsy();
+            expect(hit?.config.type === 'damage' && hit.config.noCrit).toBeFalsy();
+        });
+
+        it('leaves the charged 240% damage as on-cast / enemy', () => {
+            const rec = recordFor('Demolisher');
+            const s = ship({ chargeSkillText: rec.charge, chargeSkillCharge: rec.chargeCharge });
+            const { slots } = buildShipAbilities(s);
+            const charged = slot(slots, 'charged');
+            expect(charged).toBeDefined();
+
+            const hit = abilitiesOfType(charged!.abilities, 'damage').find(
+                (a) => a.config.type === 'damage' && a.config.multiplier === 240
+            );
+            expect(hit).toBeDefined();
+            expect(hit?.trigger).toBe('on-cast');
+            expect(hit?.target).toBe('enemy');
+        });
+    }
+);
+
+describe('Task C1 — parseIgnoresDefense / extended parseNoCrit (synthetic)', () => {
+    it('parseIgnoresDefense detects "ignores Defense"', () => {
+        expect(
+            parseIgnoresDefense('This damage ignores Defense and cannot result in a critical hit.')
+        ).toBe(true);
+    });
+
+    it('parseIgnoresDefense is false when absent', () => {
+        expect(parseIgnoresDefense('This Unit deals 170% damage.')).toBe(false);
+    });
+
+    it('parseNoCrit recognizes "cannot result in a critical hit" (Demolisher form)', () => {
+        expect(
+            parseNoCrit('This damage ignores Defense and cannot result in a critical hit.')
+        ).toBe(true);
+    });
+
+    it('parseNoCrit still recognizes the original "cannot critically hit" form', () => {
+        expect(parseNoCrit('This attack cannot critically hit.')).toBe(true);
+    });
+
+    it('parseNoCrit still excludes heal/repair subjects', () => {
+        expect(parseNoCrit('This repair cannot critically hit.')).toBe(false);
+    });
+});

--- a/src/utils/abilities/__tests__/wave5Enum.test.ts
+++ b/src/utils/abilities/__tests__/wave5Enum.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { skillNeedsOpposingVictim } from '../applyAbilities';
+import type { Skill } from '../../../types/abilities';
+
+const mk = (target: string): Skill =>
+    ({
+        abilities: [{ type: 'debuff', target, config: { type: 'debuff', buffName: 'X' } }],
+    }) as unknown as Skill;
+
+describe('wave5 adjacent-enemies enum', () => {
+    it('adjacent-enemies counts as opposing-victim-facing', () => {
+        expect(skillNeedsOpposingVictim(mk('adjacent-enemies'))).toBe(true);
+    });
+    it('target-and-adjacent-enemies counts as opposing-victim-facing', () => {
+        expect(skillNeedsOpposingVictim(mk('target-and-adjacent-enemies'))).toBe(true);
+    });
+});

--- a/src/utils/abilities/__tests__/wave5ParserDebuffControl.test.ts
+++ b/src/utils/abilities/__tests__/wave5ParserDebuffControl.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { Ability, Skill } from '../../../types/abilities';
+import {
+    csvAvailable,
+    loadShipSkillRecords,
+    ShipSkillRecord,
+} from '../../../../scripts/lib/shipSkillCsv';
+
+/**
+ * Task A2 (ship-kit correctness audit, Wave 5) — the parser must recognise enemy-adjacency
+ * phrasing ("all enemies adjacent to X") and route debuff + control abilities to the new
+ * `adjacent-enemies` / `target-and-adjacent-enemies` AbilityTarget scopes, WITHOUT wrongly
+ * widening a sibling single-target debuff that shares the same sentence (Asphyxiator's Defense
+ * Down III + Inferno III, joined by "then"). Each test runs the ship's VERBATIM
+ * docs/ship-skills.csv slot text through the production `buildShipAbilities` build so the bug
+ * is only visible at the full multi-sentence level. Skips gracefully when the gitignored
+ * reference CSV is absent (clean checkout / CI).
+ */
+
+function ship(over: Partial<Ship>): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}, {}, {}], ...over } as Ship;
+}
+
+function slot(skills: Skill[], name: string): Skill | undefined {
+    return skills.find((s) => s.slot === name);
+}
+
+function abilitiesOfType(abilities: Ability[], type: string): Ability[] {
+    return abilities.filter((a) => a.type === type);
+}
+
+function recordFor(name: string): ShipSkillRecord {
+    const rec = loadShipSkillRecords().find((r) => r.name.toUpperCase() === name.toUpperCase());
+    if (!rec) throw new Error(`docs/ship-skills.csv: no record found for "${name}"`);
+    return rec;
+}
+
+describe.skipIf(!csvAvailable())(
+    'Task A2 — parser enemy-adjacency scope for debuffs + control (verbatim docs/ship-skills.csv)',
+    () => {
+        it('Asphyxiator active: Defense Down III stays enemy (must NOT widen via the same-sentence Inferno adjacency clause)', () => {
+            const rec = recordFor('Asphyxiator');
+            const { slots } = buildShipAbilities(ship({ activeSkillText: rec.active }));
+            const active = slot(slots, 'active')!;
+            expect(active).toBeDefined();
+
+            const dd = abilitiesOfType(active.abilities, 'debuff').find(
+                (a) => a.config.type === 'debuff' && a.config.buffName === 'Defense Down III'
+            );
+            expect(dd).toBeDefined();
+            expect(dd?.target).toBe('enemy');
+        });
+
+        it('Asphyxiator charged: Inc. DoT Damage Up III stays enemy', () => {
+            const rec = recordFor('Asphyxiator');
+            const { slots } = buildShipAbilities(
+                ship({ chargeSkillText: rec.charge, chargeSkillCharge: rec.chargeCharge })
+            );
+            const charged = slot(slots, 'charged')!;
+            expect(charged).toBeDefined();
+
+            const dotUp = abilitiesOfType(charged.abilities, 'debuff').find(
+                (a) => a.config.type === 'debuff' && a.config.buffName === 'Inc. DoT Damage Up III'
+            );
+            expect(dotUp).toBeDefined();
+            expect(dotUp?.target).toBe('enemy');
+        });
+
+        it('Asphyxiator charged: Stasis debuff scopes to target-and-adjacent-enemies and keeps its >=3 enemy-debuff condition', () => {
+            const rec = recordFor('Asphyxiator');
+            const { slots } = buildShipAbilities(
+                ship({ chargeSkillText: rec.charge, chargeSkillCharge: rec.chargeCharge })
+            );
+            const charged = slot(slots, 'charged')!;
+            expect(charged).toBeDefined();
+
+            const stasis = abilitiesOfType(charged.abilities, 'debuff').find(
+                (a) => a.config.type === 'debuff' && a.config.buffName === 'Stasis'
+            );
+            expect(stasis).toBeDefined();
+            expect(stasis?.target).toBe('target-and-adjacent-enemies');
+
+            const gate = stasis?.conditions?.find(
+                (c) => c.subject === 'enemy-debuff' && c.countThreshold === 3
+            );
+            expect(gate).toBeDefined();
+            expect(gate?.countComparator).toBe('gte');
+        });
+
+        it('Asphyxiator charged: Stasis control ability scopes to target-and-adjacent-enemies', () => {
+            const rec = recordFor('Asphyxiator');
+            const { slots } = buildShipAbilities(
+                ship({ chargeSkillText: rec.charge, chargeSkillCharge: rec.chargeCharge })
+            );
+            const charged = slot(slots, 'charged')!;
+            expect(charged).toBeDefined();
+
+            const stasisControl = abilitiesOfType(charged.abilities, 'control').find(
+                (a) => a.config.type === 'control' && a.config.effect === 'stasis'
+            );
+            expect(stasisControl).toBeDefined();
+            expect(stasisControl?.target).toBe('target-and-adjacent-enemies');
+        });
+
+        it('Vindicator active: Provoke debuff scopes to adjacent-enemies', () => {
+            const rec = recordFor('Vindicator');
+            const { slots } = buildShipAbilities(ship({ activeSkillText: rec.active }));
+            const active = slot(slots, 'active')!;
+            expect(active).toBeDefined();
+
+            const provoke = abilitiesOfType(active.abilities, 'debuff').find(
+                (a) => a.config.type === 'debuff' && a.config.buffName === 'Provoke'
+            );
+            expect(provoke).toBeDefined();
+            expect(provoke?.target).toBe('adjacent-enemies');
+        });
+
+        it('Vindicator active: Provoke control ability scopes to adjacent-enemies', () => {
+            const rec = recordFor('Vindicator');
+            const { slots } = buildShipAbilities(ship({ activeSkillText: rec.active }));
+            const active = slot(slots, 'active')!;
+            expect(active).toBeDefined();
+
+            const provokeControl = abilitiesOfType(active.abilities, 'control').find(
+                (a) => a.config.type === 'control' && a.config.effect === 'provoke'
+            );
+            expect(provokeControl).toBeDefined();
+            expect(provokeControl?.target).toBe('adjacent-enemies');
+        });
+
+        it('Vindicator charged: Corrosion II stays enemy (must NOT widen via the sibling Out. Damage Down I adjacency clause)', () => {
+            // Corrosion II is a DoT (DOT_TIER_MAP), built by dotAbility() as type:'dot' with a
+            // hard-coded target:'enemy' — untouched by this task's parser change (DoT adjacency
+            // is a later task). Asserted here as a smoke check that the sibling Out. Damage Down I
+            // adjacency clause in the same charge text doesn't leak into it.
+            const rec = recordFor('Vindicator');
+            const { slots } = buildShipAbilities(
+                ship({ chargeSkillText: rec.charge, chargeSkillCharge: rec.chargeCharge })
+            );
+            const charged = slot(slots, 'charged')!;
+            expect(charged).toBeDefined();
+
+            const corrosion = abilitiesOfType(charged.abilities, 'dot').find(
+                (a) =>
+                    a.config.type === 'dot' &&
+                    a.config.dotType === 'corrosion' &&
+                    a.config.tier === 6
+            );
+            expect(corrosion).toBeDefined();
+            expect(corrosion?.target).toBe('enemy');
+        });
+
+        it('Vindicator charged: Out. Damage Down I scopes to adjacent-enemies', () => {
+            const rec = recordFor('Vindicator');
+            const { slots } = buildShipAbilities(
+                ship({ chargeSkillText: rec.charge, chargeSkillCharge: rec.chargeCharge })
+            );
+            const charged = slot(slots, 'charged')!;
+            expect(charged).toBeDefined();
+
+            const damageDown = abilitiesOfType(charged.abilities, 'debuff').find(
+                (a) => a.config.type === 'debuff' && a.config.buffName === 'Out. Damage Down I'
+            );
+            expect(damageDown).toBeDefined();
+            expect(damageDown?.target).toBe('adjacent-enemies');
+        });
+    }
+);

--- a/src/utils/abilities/__tests__/wave5ParserDebuffControl.test.ts
+++ b/src/utils/abilities/__tests__/wave5ParserDebuffControl.test.ts
@@ -169,3 +169,61 @@ describe.skipIf(!csvAvailable())(
         });
     }
 );
+
+// Synthetic fixtures: feed hand-written skill text through the real `buildShipAbilities`
+// (NOT docs/ship-skills.csv), so the parser→builder wiring for enemy-adjacency scoping stays
+// covered in CI even when the gitignored reference CSV is absent (the suite above skips there).
+describe('Task A2 — parser enemy-adjacency scope for debuffs + control (synthetic, CSV-independent)', () => {
+    it('charged: a debuff inflicted "on all enemies adjacent to the original target" scopes to adjacent-enemies', () => {
+        // Uses a real debuff name (Defense Down I) — the auto-fill path only emits a debuff
+        // ability for buff names present in the BUFFS constant, so a wholly fictional name
+        // would silently drop out here (unlike the DoT/damage paths, which don't gate on it).
+        const text =
+            'This Unit inflicts <unit-skill>Defense Down I</unit-skill> on all enemies adjacent to the original target for 2 turns.';
+        const { slots } = buildShipAbilities(ship({ chargeSkillText: text }));
+        const charged = slot(slots, 'charged')!;
+        expect(charged).toBeDefined();
+
+        const debuff = abilitiesOfType(charged.abilities, 'debuff').find(
+            (a) => a.config.type === 'debuff' && a.config.buffName === 'Defense Down I'
+        );
+        expect(debuff).toBeDefined();
+        expect(debuff?.target).toBe('adjacent-enemies');
+    });
+
+    it('active: a control inflicted "on the targeted enemy and all enemies adjacent to it" scopes to target-and-adjacent-enemies', () => {
+        const text =
+            'This Unit inflicts <unit-skill>Provoke</unit-skill> on the targeted enemy and all enemies adjacent to it for 2 turns.';
+        const { slots } = buildShipAbilities(ship({ activeSkillText: text }));
+        const active = slot(slots, 'active')!;
+        expect(active).toBeDefined();
+
+        const provokeControl = abilitiesOfType(active.abilities, 'control').find(
+            (a) => a.config.type === 'control' && a.config.effect === 'provoke'
+        );
+        expect(provokeControl).toBeDefined();
+        expect(provokeControl?.target).toBe('target-and-adjacent-enemies');
+    });
+
+    it('sibling-clause isolation: a "then"-joined debuff does not inherit its sibling\'s adjacency phrase', () => {
+        // Real debuff names (Attack Down I / Defense Down I) for the same BUFFS-lookup reason
+        // as above.
+        const text =
+            'This Unit inflicts <unit-skill>Attack Down I</unit-skill> for 1 turn, then inflicts <unit-skill>Defense Down I</unit-skill> for 3 turns on the targeted enemy and all enemies adjacent to it.';
+        const { slots } = buildShipAbilities(ship({ activeSkillText: text }));
+        const active = slot(slots, 'active')!;
+        expect(active).toBeDefined();
+
+        const attackDown = abilitiesOfType(active.abilities, 'debuff').find(
+            (a) => a.config.type === 'debuff' && a.config.buffName === 'Attack Down I'
+        );
+        expect(attackDown).toBeDefined();
+        expect(attackDown?.target).toBe('enemy');
+
+        const defenseDown = abilitiesOfType(active.abilities, 'debuff').find(
+            (a) => a.config.type === 'debuff' && a.config.buffName === 'Defense Down I'
+        );
+        expect(defenseDown).toBeDefined();
+        expect(defenseDown?.target).toBe('target-and-adjacent-enemies');
+    });
+});

--- a/src/utils/abilities/__tests__/wave5ParserDot.test.ts
+++ b/src/utils/abilities/__tests__/wave5ParserDot.test.ts
@@ -70,6 +70,38 @@ describe.skipIf(!csvAvailable())(
     }
 );
 
+// Synthetic fixtures: feed hand-written skill text through the real `buildShipAbilities`
+// (NOT docs/ship-skills.csv), so the DoT adjacency parser→builder wiring stays covered in CI
+// even when the gitignored reference CSV is absent (the suite above skips there).
+describe('Task B1 — DoT enemy-adjacency splash target (synthetic, CSV-independent)', () => {
+    it('active Inferno III DoT targets target-and-adjacent-enemies (splash phrase present)', () => {
+        const text =
+            'This Unit inflicts <unit-skill>Inferno III</unit-skill> for 3 turns on the targeted enemy and all enemies adjacent to it.';
+        const { slots } = buildShipAbilities(ship({ activeSkillText: text }));
+        const active = slot(slots, 'active');
+        expect(active).toBeDefined();
+
+        const infernoDots = abilitiesOfType(active!.abilities, 'dot').filter(
+            (a) => a.config.type === 'dot' && a.config.dotType === 'inferno'
+        );
+        expect(infernoDots.length).toBeGreaterThan(0);
+        expect(infernoDots[0].target).toBe('target-and-adjacent-enemies');
+    });
+
+    it('charged-slot Inferno III DoT stays enemy (no adjacency phrase)', () => {
+        const text = 'This Unit inflicts <unit-skill>Inferno III</unit-skill> for 3 turns.';
+        const { slots } = buildShipAbilities(ship({ chargeSkillText: text }));
+        const charged = slot(slots, 'charged');
+        expect(charged).toBeDefined();
+
+        const infernoDots = abilitiesOfType(charged!.abilities, 'dot').filter(
+            (a) => a.config.type === 'dot' && a.config.dotType === 'inferno'
+        );
+        expect(infernoDots.length).toBeGreaterThan(0);
+        expect(infernoDots[0].target).toBe('enemy');
+    });
+});
+
 describe('adjacentEnemyScopeForName — synthetic clause isolation (CSV-independent)', () => {
     it('"on the targeted enemy and all enemies adjacent to it" resolves to target-and-adjacent-enemies', () => {
         const text =

--- a/src/utils/abilities/__tests__/wave5ParserDot.test.ts
+++ b/src/utils/abilities/__tests__/wave5ParserDot.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { Ability, Skill } from '../../../types/abilities';
+import { adjacentEnemyScopeForName } from '../../skillTextParser';
+import {
+    csvAvailable,
+    loadShipSkillRecords,
+    ShipSkillRecord,
+} from '../../../../scripts/lib/shipSkillCsv';
+
+/**
+ * Regression tests for Task B1 (ship-kit correctness audit, Wave 5): the Asphyxiator ACTIVE
+ * Inferno III DoT carries an enemy-adjacency splash phrase ("on the targeted enemy and all
+ * enemies adjacent to it") that the DoT builder (`buildShipAbilities.ts`, dotAbility) previously
+ * hardcoded to `target: 'enemy'` and ignored. The CHARGED Inferno III sentence has no adjacency
+ * phrase (the adjacency phrasing there belongs to a SEPARATE Stasis sentence), so it must stay
+ * 'enemy'. Skips gracefully when the gitignored reference CSV is absent (clean checkout / CI).
+ */
+
+function ship(over: Partial<Ship>): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}, {}, {}], ...over } as Ship;
+}
+
+function slot(skills: Skill[], name: string): Skill | undefined {
+    return skills.find((s) => s.slot === name);
+}
+
+function abilitiesOfType(abilities: Ability[], type: string): Ability[] {
+    return abilities.filter((a) => a.type === type);
+}
+
+function recordFor(name: string): ShipSkillRecord {
+    const rec = loadShipSkillRecords().find((r) => r.name.toUpperCase() === name.toUpperCase());
+    if (!rec) throw new Error(`docs/ship-skills.csv: no record found for "${name}"`);
+    return rec;
+}
+
+describe.skipIf(!csvAvailable())(
+    'Task B1 — Asphyxiator active Inferno DoT splash target (verbatim docs/ship-skills.csv)',
+    () => {
+        it('active Inferno III DoT targets target-and-adjacent-enemies (splash phrase present)', () => {
+            const rec = recordFor('Asphyxiator');
+            const s = ship({ activeSkillText: rec.active, chargeSkillText: rec.charge });
+            const { slots } = buildShipAbilities(s);
+            const active = slot(slots, 'active');
+            expect(active).toBeDefined();
+
+            const infernoDots = abilitiesOfType(active!.abilities, 'dot').filter(
+                (a) => a.config.type === 'dot' && a.config.dotType === 'inferno'
+            );
+            expect(infernoDots.length).toBeGreaterThan(0);
+            expect(infernoDots[0].target).toBe('target-and-adjacent-enemies');
+        });
+
+        it('charged Inferno III DoT stays enemy (no adjacency phrase in the Inferno sentence)', () => {
+            const rec = recordFor('Asphyxiator');
+            const s = ship({ activeSkillText: rec.active, chargeSkillText: rec.charge });
+            const { slots } = buildShipAbilities(s);
+            const charged = slot(slots, 'charged');
+            expect(charged).toBeDefined();
+
+            const infernoDots = abilitiesOfType(charged!.abilities, 'dot').filter(
+                (a) => a.config.type === 'dot' && a.config.dotType === 'inferno'
+            );
+            expect(infernoDots.length).toBeGreaterThan(0);
+            expect(infernoDots[0].target).toBe('enemy');
+        });
+    }
+);
+
+describe('adjacentEnemyScopeForName — synthetic clause isolation (CSV-independent)', () => {
+    it('"on the targeted enemy and all enemies adjacent to it" resolves to target-and-adjacent-enemies', () => {
+        const text =
+            'This Unit deals 175% damage, then inflicts X for 3 turns on the targeted enemy and all enemies adjacent to it.';
+        expect(adjacentEnemyScopeForName(text, 'X')).toBe('target-and-adjacent-enemies');
+    });
+
+    it('"inflicts X for 3 turns." (no adjacency phrase) resolves to null', () => {
+        const text = 'This Unit deals 215% damage, and inflicts X for 3 turns.';
+        expect(adjacentEnemyScopeForName(text, 'X')).toBeNull();
+    });
+
+    it('"on all enemies adjacent to the original target" resolves to adjacent-enemies', () => {
+        const text =
+            'This Unit inflicts X for 2 turns on all enemies adjacent to the original target.';
+        expect(adjacentEnemyScopeForName(text, 'X')).toBe('adjacent-enemies');
+    });
+});

--- a/src/utils/abilities/applyAbilities.ts
+++ b/src/utils/abilities/applyAbilities.ts
@@ -172,6 +172,8 @@ const ENEMY_FACING_TARGETS: ReadonlySet<Ability['target']> = new Set([
     'all-enemies',
     'enemy-most-buffs',
     'enemy-highest-attack',
+    'adjacent-enemies',
+    'target-and-adjacent-enemies',
 ]);
 
 /**

--- a/src/utils/abilities/applyAbilities.ts
+++ b/src/utils/abilities/applyAbilities.ts
@@ -214,6 +214,10 @@ export function dotsFromSkill(skill: Skill | undefined): DoTApplicationConfig {
             tier: ability.config.tier,
             stacks: ability.config.stacks,
             duration: ability.config.duration,
+            ...(ability.target === 'adjacent-enemies' ||
+            ability.target === 'target-and-adjacent-enemies'
+                ? { splashTarget: ability.target }
+                : {}),
         });
     }
     return config;

--- a/src/utils/abilities/buffAbilityConverters.ts
+++ b/src/utils/abilities/buffAbilityConverters.ts
@@ -33,7 +33,14 @@ export function abilityToSelectedBuff(ability: Ability, slot: SkillSlot): Select
 }
 
 export function selectedBuffToAbility(buff: SelectedGameBuff, target: AbilityTarget): Ability {
-    const isEnemy = target === 'enemy' || target === 'all-enemies';
+    // Wave 5 (Task A2): the two enemy-adjacency scopes are enemy-side debuffs too (Vindicator's
+    // Provoke, Asphyxiator's Stasis) — without this they'd fall through to the buff branch below
+    // and lose their debuff config (application verb, resistibility).
+    const isEnemy =
+        target === 'enemy' ||
+        target === 'all-enemies' ||
+        target === 'adjacent-enemies' ||
+        target === 'target-and-adjacent-enemies';
     const duration: number | 'recurring' | undefined =
         typeof buff.skillDuration === 'number' || buff.skillDuration === 'recurring'
             ? buff.skillDuration

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -117,6 +117,7 @@ import {
     findBuffNamePos,
     maskAbbrev,
     detectExtraActionCoTrigger,
+    detectEnemyGrantScope,
 } from '../skillTextParser';
 import {
     buildDoTAutoFill,
@@ -129,6 +130,17 @@ import { selectedBuffToAbility } from './buffAbilityConverters';
 
 let counter = 0;
 const nextId = () => `ab${counter++}`;
+
+// Maps a parsed ControlEffect back to the display name used in the skill text's <unit-skill>
+// tag (mirrors CONTROL_INFLICTS' `tag` field in skillTextParser.ts), so the control-ability
+// target-scoping step (Wave 5, Task A2) can key `detectEnemyGrantScope` on the right buff name.
+const CONTROL_EFFECT_DISPLAY_NAME: Record<ControlEffect, string> = {
+    stasis: 'Stasis',
+    provoke: 'Provoke',
+    'concentrate-fire': 'Concentrate Fire',
+    disable: 'Disable',
+    taunt: 'Taunt',
+};
 
 /** Strips the inline game markup tags so plain-text regexes can match the row text. */
 function stripTags(text: string): string {
@@ -1796,12 +1808,20 @@ function abilitiesFromText(
     // forced-targeting; the control ability only sources the `control-applied` event
     // (reaction substrate, e.g. Defiant's shield-on-Stasis). Carries no conditions (see the
     // gated-control caveat below); no damage/modifier → DPS pipeline ignores it.
+    // Wave 5 (Task A2): an enemy-side control's target is re-derived via detectEnemyGrantScope
+    // (same clause-adjacency detection as the paired named-status SkillEffect, keyed on the
+    // effect's display name) so an enemy-adjacency phrasing ("Stasis ... on the targeted enemy
+    // and all enemies adjacent to the enemy") routes the control to the same adjacency scope as
+    // its paired debuff, instead of always collapsing to plain 'enemy'.
     for (const ctrl of parseControlInflicts(text)) {
+        const controlTargetName = CONTROL_EFFECT_DISPLAY_NAME[ctrl.effect];
+        const controlTarget =
+            ctrl.side === 'enemy' ? detectEnemyGrantScope(text, controlTargetName) : ctrl.side;
         out.push({
             ability: {
                 id: nextId(),
                 type: 'control',
-                target: ctrl.side, // 'enemy' for inflicted, 'self' for Taunt
+                target: controlTarget, // 'enemy'/adjacency for inflicted, 'self' for Taunt
                 trigger: 'on-cast',
                 // Control abilities carry no conditions: a GATED control (e.g. Crocus's "if
                 // target has >3 debuffs" Stasis) therefore emits control-applied unconditionally

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -84,6 +84,7 @@ import {
     detectAllyShieldDestroyedTrigger,
     detectCleanseOncePerRound,
     parseNoCrit,
+    parseIgnoresDefense,
     parseForceAffinityAdvantage,
     parseDoesntBreakStasis,
     parseChargeLossImmune,
@@ -119,6 +120,7 @@ import {
     detectExtraActionCoTrigger,
     detectEnemyGrantScope,
     adjacentEnemyScopeForName,
+    adjacentEnemyScopeAtPos,
 } from '../skillTextParser';
 import {
     buildDoTAutoFill,
@@ -1109,6 +1111,9 @@ function abilitiesFromText(
     } else if (mult > 0) {
         const hits = parseHitCount(text);
         const noCrit = parseNoCrit(text);
+        // Ship-kit W5 (Demolisher bomb-splash): "This damage ignores Defense" — bypasses the
+        // target's Defense mitigation term at the reactive damage executor (Task C3).
+        const ignoresDefense = parseIgnoresDefense(text);
         // SP-F F4 (Wusheng): "deals 220% damage with affinity advantage" forces this on-cast hit
         // (and its paired Stasis 'apply' landing) to affinity advantage at the engine seams.
         const forceAffinityAdvantage = parseForceAffinityAdvantage(text);
@@ -1130,6 +1135,7 @@ function abilitiesFromText(
             detectEndOfRoundDamageTrigger(text, damagePos) ??
             detectRoundStartContinuationTrigger(text, damagePos) ??
             detectAllyCritTrigger(text, damagePos) ??
+            detectBombDetonatedTrigger(text, damagePos) ??
             'on-cast';
         // SP-F F1: emit the BASE branch FIRST (out[0]) so the ungated `.find`-first reads of
         // noCrit/hits below resolve sensibly, and so it stays out[0] for the conditional-scaling
@@ -1147,6 +1153,7 @@ function abilitiesFromText(
                     ...(hits !== undefined ? { hits } : {}),
                     ...(noCrit ? { noCrit: true } : {}),
                     ...(forceAffinityAdvantage ? { forceAffinityAdvantage: true } : {}),
+                    ...(ignoresDefense ? { ignoresDefense: true } : {}),
                 },
                 autoFilled: true,
             },
@@ -1172,6 +1179,25 @@ function abilitiesFromText(
         // text is unaffected. out[0] is safe to mutate here (SP-F F1's out[0] invariant).
         if (damageTrigger === 'start-of-round' && parseHighestSpeedEnemyTarget(text, damagePos)) {
             out[0].ability.target = 'enemy-highest-speed';
+        }
+        // Ship-kit W5 (Demolisher bomb-splash): the reactive bomb-detonated damage clause
+        // ("... deals 100% of the Bomb's damage to all adjavent enemies") re-targets from the
+        // default 'enemy' to the adjacency scope. GATED on damageTrigger === 'on-bomb-detonated'
+        // (same pattern as the end-of-round/start-of-round retargets above) rather than a bare
+        // sentence-position check: an on-cast damage clause can share its SENTENCE with an
+        // unrelated debuff/control clause that owns its own adjacency phrase (Asphyxiator's
+        // "...deals 175% damage, then inflicts Inferno III... on the targeted enemy and all
+        // enemies adjacent to it" — the adjacency belongs to Inferno III, not the 175% hit;
+        // Vindicator's "...deals 100% damage and applies Provoke... to all enemies adjacent to
+        // the target" — the adjacency belongs to Provoke, not the 100% hit). Both are corpus
+        // regressions caught by the Task C1 corpus-regression check and fixed by this gate,
+        // which restricts the position-scoped adjacency read to the one trigger only Demolisher's
+        // passive carries.
+        if (damageTrigger === 'on-bomb-detonated') {
+            const adjacentDamageScope = adjacentEnemyScopeAtPos(text, damagePos);
+            if (adjacentDamageScope) {
+                out[0].ability.target = adjacentDamageScope;
+            }
         }
         if (instead) {
             // Replacement branch (Provoked/Taunted): reuses the base's hits/noCrit — both

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -118,6 +118,7 @@ import {
     maskAbbrev,
     detectExtraActionCoTrigger,
     detectEnemyGrantScope,
+    adjacentEnemyScopeForName,
 } from '../skillTextParser';
 import {
     buildDoTAutoFill,
@@ -2893,6 +2894,11 @@ export function buildShipAbilities(ship: Ship): ShipSkills {
                 ? detectReactiveTrigger(rowText, entry.type)
                 : undefined;
             if (reactiveTrigger) ability.trigger = reactiveTrigger;
+            // Enemy-adjacency splash (Asphyxiator active Inferno III: "on the targeted enemy
+            // and all enemies adjacent to it"). Charged Inferno's adjacency phrase belongs to a
+            // separate Stasis sentence, so it resolves to null and the DoT stays 'enemy'.
+            const adjacentScope = rowText ? adjacentEnemyScopeForName(rowText, entry.type) : null;
+            if (adjacentScope) ability.target = adjacentScope;
             return { ability, pos: pos >= 0 ? pos : MAX_POS };
         });
         if (!dots.length) continue;

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -3379,18 +3379,11 @@ export function buildShipAbilities(ship: Ship): ShipSkills {
     //     exists), i.e. a dead, mislabeled entry forever. Drop the control ability outright
     //     instead — the named debuff/buff twin remains the sole model of the effect, and no
     //     spurious on-cast control-applied fires.
-    const CONTROL_TWIN_TAG: Record<ControlEffect, string> = {
-        stasis: 'Stasis',
-        provoke: 'Provoke',
-        'concentrate-fire': 'Concentrate Fire',
-        disable: 'Disable',
-        taunt: 'Taunt',
-    };
     for (const positioned of bySlot.values()) {
         for (let i = positioned.length - 1; i >= 0; i--) {
             const ability = positioned[i].ability;
             if (ability.type !== 'control' || ability.config.type !== 'control') continue;
-            const tag = CONTROL_TWIN_TAG[ability.config.effect];
+            const tag = CONTROL_EFFECT_DISPLAY_NAME[ability.config.effect];
             const twinType = ability.config.effect === 'taunt' ? 'buff' : 'debuff';
             const twin = positioned.find(
                 (p) =>

--- a/src/utils/calculators/skillBuffAutoFill.ts
+++ b/src/utils/calculators/skillBuffAutoFill.ts
@@ -4,6 +4,17 @@ import { BUFFS } from '../../constants/buffs';
 import { parseAllSkillEffects, SkillEffect, detectFullyCharged } from '../skillTextParser';
 import { parseBuffEffects, isStackable } from './buffParser';
 
+// Every enemy-side SkillEffect target scope (single-target, whole-team, and the two
+// enemy-adjacency scopes added in Wave 5 Task A2). Everything else (self/ally/all-allies) is
+// player-side. Shared by the selfBuffs/enemyDebuffs bucketing below so a new enemy-side scope
+// only needs to be added here, not duplicated across both filters.
+const ENEMY_SIDE_TARGETS = new Set<SkillEffect['target']>([
+    'enemy',
+    'all-enemies',
+    'adjacent-enemies',
+    'target-and-adjacent-enemies',
+]);
+
 // DoT buff name prefixes — these go to the DoT config, not the buff picker
 const DOT_PREFIXES = new Set(['Corrosion', 'Inferno', 'Bomb']);
 function isDoTBuffName(name: string): boolean {
@@ -32,13 +43,12 @@ export function buildSkillBuffAutoFill(ship: Ship): SkillBuffAutoFill {
         // selfBuffs = all PLAYER-SIDE effects (self/ally/all-allies). The legacy DPS picker
         // path treats every entry here as player-side (unchanged); the builder reads each
         // entry's effectTarget to route ally/all-allies grants to the right actors.
-        selfBuffs: toSelectedBuffs(
-            effects.filter((e) => e.target !== 'enemy' && e.target !== 'all-enemies')
-        ),
-        // enemyDebuffs = both single-target ('enemy') and whole-team ('all-enemies') debuffs —
-        // the builder reads effectTarget to stamp the right ability target either way.
+        selfBuffs: toSelectedBuffs(effects.filter((e) => !ENEMY_SIDE_TARGETS.has(e.target))),
+        // enemyDebuffs = single-target ('enemy'), whole-team ('all-enemies'), and the two
+        // enemy-adjacency scopes ('adjacent-enemies' / 'target-and-adjacent-enemies', Wave 5
+        // Task A2) — the builder reads effectTarget to stamp the right ability target either way.
         enemyDebuffs: toSelectedBuffs(
-            effects.filter((e) => e.target === 'enemy' || e.target === 'all-enemies'),
+            effects.filter((e) => ENEMY_SIDE_TARGETS.has(e.target)),
             sourceChargeCount,
             sourceStartCharged
         ),

--- a/src/utils/combat/__tests__/adjacency.test.ts
+++ b/src/utils/combat/__tests__/adjacency.test.ts
@@ -39,4 +39,9 @@ describe('adjacentAllyIds', () => {
         expect(adjacentAllyIds('owner', [a('owner', 'M2')])).toEqual([]);
         expect(adjacentAllyIds('owner', [])).toEqual([]);
     });
+
+    it('anchor not in roster: returns [] rather than the whole-roster fallback (Wave 5 hardening)', () => {
+        const actors = [a('other1', 'M2'), a('other2', 'T2')];
+        expect(adjacentAllyIds('not-in-roster', actors)).toEqual([]);
+    });
 });

--- a/src/utils/combat/__tests__/adjacentEnemiesDebuff.integration.test.ts
+++ b/src/utils/combat/__tests__/adjacentEnemiesDebuff.integration.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Ship-kit Wave 5, Task A3 — engine fan-out for the two enemy-adjacency `AbilityTarget` scopes
+ * (`adjacent-enemies` / `target-and-adjacent-enemies`) added in Task A1 and parsed in Task A2
+ * (Vindicator Provoke / Out. Damage Down I → `adjacent-enemies`; Asphyxiator Stasis →
+ * `target-and-adjacent-enemies`). Prior to this task, engine.ts:211's self-vs-enemy
+ * classification does not list either scope, so both fall through to `self` — the applied
+ * status is misregistered as a SELF buff on the caster instead of an enemy debuff on the board
+ * neighbours. This file drives the fix through a real positional battle (`simulateBattle`) using
+ * synthetic ships whose skill text carries the SAME two adjacency phrasings the parser recognises
+ * (`detectAdjacentEnemyScope` in skillTextParser.ts — verbatim structure from Vindicator/
+ * Asphyxiator in docs/ship-skills.csv), so the parser → engine pipeline is exercised end to end.
+ *
+ * Board layout (src/utils/targeting/board.ts hex adjacency): the primary target sits at M4 (the
+ * unique front/col-4 cell in this roster, so single-target `front` selection deterministically
+ * picks it). neighbors(M4) = [M3, T3, T4, B3, B4] — nbrA (M3) and nbrB (T3) are real neighbours;
+ * `far` (T1) is not (`{q:0,r:0}` vs M4's `{q:2,r:1}` — no hex-adjacency), proving the fan-out
+ * doesn't leak to the whole roster.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateBattle } from '../../calculators/battleSimulator';
+import { runCombat, CombatEngineInput } from '../engine';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import { createEventBus, CombatEvent } from '../events';
+import type { Ship } from '../../../types/ship';
+import type { Position } from '../../../types/encounters';
+import { flattenCombatLog } from '../log/__testutils__/flattenCombatLog';
+
+const DEBUFF_NAME = 'Defense Down II';
+
+// Verbatim-shaped phrasing (matches skillTextParser's ADJACENT_ENEMY_ONLY_RE / real Vindicator
+// text: "... to all enemies adjacent to the target."). "applies" (not "inflicts") is a guaranteed
+// (non-resistible) application verb — isolates the fan-out/classification behaviour from any
+// hacking-vs-security landing RNG.
+const ADJACENT_ONLY_TEXT = `This Unit applies <unit-skill>${DEBUFF_NAME}</unit-skill> for 2 turns to all enemies adjacent to the target.`;
+// Verbatim-shaped phrasing (matches TARGET_AND_ADJACENT_ENEMY_RE / real Asphyxiator text: "... on
+// the targeted enemy and all enemies adjacent to it.").
+const TARGET_AND_ADJACENT_TEXT = `This Unit applies <unit-skill>${DEBUFF_NAME}</unit-skill> for 2 turns to the targeted enemy and all enemies adjacent to it.`;
+
+const ship = (id: string, over: Partial<Ship>): Ship =>
+    ({
+        id,
+        name: id,
+        rarity: 'legendary',
+        faction: 'TERRAN_COMBINE',
+        type: 'Attacker',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        affinity: 'antimatter',
+        activePattern: 'Pattern-Base',
+        activeTarget: 'front',
+        chargeSkillCharge: 0,
+        ...over,
+    }) as Ship;
+
+interface Placement {
+    ship: Ship;
+    position: Position;
+    statOverrides: {
+        attack: number;
+        crit: number;
+        critDamage: number;
+        defensePenetration: number;
+        hacking: number;
+        defence: number;
+        hp: number;
+    };
+}
+
+const place = (s: Ship, position: Position, attack: number, hp: number): Placement => ({
+    ship: s,
+    position,
+    statOverrides: {
+        attack,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        hacking: 200,
+        defence: 0,
+        hp,
+    },
+});
+
+const adjacentOnlyCaster = (id: string): Ship => ship(id, { activeSkillText: ADJACENT_ONLY_TEXT });
+const targetAndAdjacentCaster = (id: string): Ship =>
+    ship(id, { activeSkillText: TARGET_AND_ADJACENT_TEXT });
+const plain = (id: string): Ship =>
+    ship(id, { activeSkillText: 'This Unit deals <unit-damage>1% damage</unit-damage>.' });
+
+/** Every `kind:'debuff'` log entry attributed to `actorId` for `DEBUFF_NAME`, across the whole
+ *  run — `note` carries the buff name (buildCombatLog.ts's `debuff-applied` mapping), one entry
+ *  per landed recipient (emitDebuffApplied is called once per recipient id in the fan-out loop). */
+const debuffRecipients = (result: ReturnType<typeof simulateBattle>, actorId: string): string[] =>
+    flattenCombatLog(result)
+        .filter((e) => e.kind === 'debuff' && e.actorId === actorId && e.note === DEBUFF_NAME)
+        .map((e) => e.targets[0]?.targetId)
+        .filter((id): id is string => id !== undefined);
+
+describe('Ship-kit W5 Task A3: adjacent-enemies debuff fan-out (positional, player caster)', () => {
+    const run = (caster: Ship) =>
+        simulateBattle({
+            playerTeam: [place(caster, 'M4', 1, 1e9)],
+            enemyTeam: [
+                place(plain('tgt'), 'M4', 1, 1e9), // primary target (unique front cell)
+                place(plain('nbrA'), 'M3', 1, 1e9), // neighbour of M4
+                place(plain('nbrB'), 'T3', 1, 1e9), // neighbour of M4
+                place(plain('far'), 'T1', 1, 1e9), // NOT a neighbour of M4
+            ],
+            rounds: 1,
+        });
+
+    const TGT = 'e:tgt:0';
+    const NBR_A = 'e:nbrA:1';
+    const NBR_B = 'e:nbrB:2';
+    const FAR = 'e:far:3';
+
+    it('adjacent-only: the primary target is excluded, both neighbours receive it, the non-neighbour does not', () => {
+        const result = run(adjacentOnlyCaster('atk'));
+        const recipients = debuffRecipients(result, 'attacker');
+
+        expect(recipients).not.toContain(TGT);
+        expect(recipients).toContain(NBR_A);
+        expect(recipients).toContain(NBR_B);
+        expect(recipients).not.toContain(FAR);
+    });
+
+    it('target+adjacent: the primary target AND both neighbours receive it, the non-neighbour does not', () => {
+        const result = run(targetAndAdjacentCaster('atk'));
+        const recipients = debuffRecipients(result, 'attacker');
+
+        expect(recipients).toContain(TGT);
+        expect(recipients).toContain(NBR_A);
+        expect(recipients).toContain(NBR_B);
+        expect(recipients).not.toContain(FAR);
+    });
+});
+
+describe('Ship-kit W5 Task A3: team symmetry — an ENEMY-side caster fans out onto its PLAYER-side mirror', () => {
+    const run = (caster: Ship) =>
+        simulateBattle({
+            playerTeam: [
+                place(plain('tgt'), 'M4', 1, 1e9),
+                place(plain('nbrA'), 'M3', 1, 1e9),
+                place(plain('nbrB'), 'T3', 1, 1e9),
+                place(plain('far'), 'T1', 1, 1e9),
+            ],
+            enemyTeam: [place(caster, 'M4', 1, 1e9)],
+            rounds: 1,
+        });
+
+    // player[0] is always the reserved focus id 'attacker'; the rest are `p:<shipId>:<idx>`
+    // (battleSimulator.ts's naming convention). The caster is the sole enemy → `e:atk:0`.
+    const TGT = 'attacker';
+    const NBR_A = 'p:nbrA:1';
+    const NBR_B = 'p:nbrB:2';
+    const FAR = 'p:far:3';
+    const CASTER = 'e:atk:0';
+
+    it('adjacent-only cast by an enemy lands on the player neighbours, not the primary target', () => {
+        const result = run(adjacentOnlyCaster('atk'));
+        const recipients = debuffRecipients(result, CASTER);
+
+        expect(recipients).not.toContain(TGT);
+        expect(recipients).toContain(NBR_A);
+        expect(recipients).toContain(NBR_B);
+        expect(recipients).not.toContain(FAR);
+    });
+
+    it('target+adjacent cast by an enemy lands on the player target AND its neighbours', () => {
+        const result = run(targetAndAdjacentCaster('atk'));
+        const recipients = debuffRecipients(result, CASTER);
+
+        expect(recipients).toContain(TGT);
+        expect(recipients).toContain(NBR_A);
+        expect(recipients).toContain(NBR_B);
+        expect(recipients).not.toContain(FAR);
+    });
+});
+
+/**
+ * Control-path smoke test: buildShipAbilities additively emits a `type:'control'` ability
+ * alongside a named control-effect debuff (Stasis/Provoke/…, CONTROL_EFFECT_DISPLAY_NAME —
+ * buildShipAbilities.ts:1817) whose `target` is RE-DERIVED from the named twin's
+ * `detectEnemyGrantScope` (buildShipAbilities.ts:1811-1819, Task A2) — so a real Vindicator
+ * Provoke / Asphyxiator Stasis cast carries a control ability with `target:'adjacent-enemies'` /
+ * `'target-and-adjacent-enemies'` too. playerTurn.ts's control-applied loop only special-cases
+ * `ctrl.target === 'enemy'` (Block-Debuff/resisted-suppression) — a non-'enemy' string just
+ * always emits (same as the pre-existing standalone-control path), so the new target values must
+ * not throw. This does not assert control-applied semantics (out of scope here, unchanged by
+ * this task) — only that the control-twin's presence doesn't break the fan-out this task owns.
+ */
+describe('Ship-kit W5 Task A3: control-path smoke test (real control-effect buff names)', () => {
+    const controlCaster = (id: string, text: string): Ship => ship(id, { activeSkillText: text });
+
+    it('a Provoke (adjacent-enemies) cast does not throw and still fans out to neighbours only', () => {
+        const provokeText = `This Unit applies <unit-skill>Provoke</unit-skill> for 1 turn to all enemies adjacent to the target.`;
+        const run = () =>
+            simulateBattle({
+                playerTeam: [place(controlCaster('atk', provokeText), 'M4', 1, 1e9)],
+                enemyTeam: [
+                    place(plain('tgt'), 'M4', 1, 1e9),
+                    place(plain('nbrA'), 'M3', 1, 1e9),
+                    place(plain('nbrB'), 'T3', 1, 1e9),
+                ],
+                rounds: 1,
+            });
+
+        expect(run).not.toThrow();
+        const result = run();
+        const recipients = flattenCombatLog(result)
+            .filter((e) => e.kind === 'debuff' && e.actorId === 'attacker' && e.note === 'Provoke')
+            .map((e) => e.targets[0]?.targetId);
+        expect(recipients).not.toContain('e:tgt:0');
+        expect(recipients).toContain('e:nbrA:1');
+        expect(recipients).toContain('e:nbrB:2');
+    });
+
+    it('a Stasis (target-and-adjacent-enemies) cast does not throw and still fans out to target+neighbours', () => {
+        const stasisText = `This Unit applies <unit-skill>Stasis</unit-skill> for 1 turn to the targeted enemy and all enemies adjacent to it.`;
+        const run = () =>
+            simulateBattle({
+                playerTeam: [place(controlCaster('atk', stasisText), 'M4', 1, 1e9)],
+                enemyTeam: [
+                    place(plain('tgt'), 'M4', 1, 1e9),
+                    place(plain('nbrA'), 'M3', 1, 1e9),
+                    place(plain('nbrB'), 'T3', 1, 1e9),
+                ],
+                rounds: 1,
+            });
+
+        expect(run).not.toThrow();
+        const result = run();
+        const recipients = flattenCombatLog(result)
+            .filter((e) => e.kind === 'debuff' && e.actorId === 'attacker' && e.note === 'Stasis')
+            .map((e) => e.targets[0]?.targetId);
+        expect(recipients).toContain('e:tgt:0');
+        expect(recipients).toContain('e:nbrA:1');
+        expect(recipients).toContain('e:nbrB:2');
+    });
+});
+
+/**
+ * DPS invariance: the DPS calculator's single-dummy mode calls `runCombat` DIRECTLY with no
+ * `position`/`pattern`/`enemyAttackers`/`positionalTeamBattle` — the vestigial `enemy` sink actor
+ * (engine.ts's `createActor({ id: 'enemy', ... })`) is the sole opponent, and `targetId` is never
+ * threaded onto the turn args (buildTurnArgs's player-side guard: `tgt.id !== enemy.id`). This is
+ * the DPS page's real non-positional shape (dpsSimulator.ts calls `runCombat` the same way), NOT
+ * `simulateBattle` (which always sets `positionalTeamBattle: true` and gives every enemy a real
+ * position). Today's plain `enemy`-target debuff still lands on the dummy in this mode (the
+ * legacy `targetId === undefined && !positionalLanding → [undefined]` fallback resolves the dummy
+ * itself as victim) — `target-and-adjacent-enemies` must match that (dummy only, no neighbours to
+ * fan out to); `adjacent-enemies` must apply to nobody (no primary-target anchor to resolve
+ * neighbours from).
+ */
+describe('Ship-kit W5 Task A3: DPS invariance (single-dummy, non-positional)', () => {
+    const BASE: Omit<CombatEngineInput, 'shipSkills' | 'bus'> = {
+        attack: 1000,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 100,
+        hacking: 200,
+        enemySecurity: 0,
+    };
+
+    const runDummy = (caster: Ship) => {
+        const bus = createEventBus();
+        const debuffsApplied: Extract<CombatEvent, { type: 'debuff-applied' }>[] = [];
+        bus.on('debuff-applied', (e) => debuffsApplied.push(e));
+        runCombat({ ...BASE, shipSkills: buildShipAbilities(caster), bus });
+        return debuffsApplied.filter((e) => e.buffName === DEBUFF_NAME);
+    };
+
+    it('adjacent-enemies applies to nobody (no real board, no anchor to fan neighbours from)', () => {
+        const applied = runDummy(adjacentOnlyCaster('atk'));
+        expect(applied).toHaveLength(0);
+    });
+
+    it("target-and-adjacent-enemies applies to exactly the dummy — today's plain-`enemy` behaviour", () => {
+        const applied = runDummy(targetAndAdjacentCaster('atk'));
+        expect(applied).toHaveLength(1);
+        expect(applied[0]?.targetId).toBe('enemy');
+    });
+});

--- a/src/utils/combat/__tests__/adjacentEnemiesDot.integration.test.ts
+++ b/src/utils/combat/__tests__/adjacentEnemiesDot.integration.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Ship-kit Wave 5, Task B2 — engine fan-out for a `target-and-adjacent-enemies` DoT
+ * (Asphyxiator active Inferno III, set by Task B1's parser work). Prior to this task,
+ * `dotsFromSkill` (applyAbilities.ts) drops the ability's `target` entirely, and the
+ * `applyNewDoTs` call site (playerTurn.ts) only ever pushes onto the single resolved
+ * primary target's containers — so a splash-scoped DoT lands on the primary target ONLY,
+ * never its board-neighbours. This file drives the fix through a real positional battle
+ * (`simulateBattle`), mirroring Task A3's debuff fan-out test
+ * (`adjacentEnemiesDebuff.integration.test.ts`) for roster/board layout.
+ *
+ * Board layout (src/utils/targeting/board.ts hex adjacency): the primary target sits at M4
+ * (the unique front/col-4 cell in this roster, so single-target `front` selection
+ * deterministically picks it). neighbors(M4) = [M3, T3, T4, B3, B4] — nbrA (M3) and nbrB (T3)
+ * are real neighbours; `far` (T1) is not (`{q:0,r:0}` vs M4's `{q:2,r:1}` — no hex-adjacency),
+ * proving the fan-out doesn't leak to the whole roster.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateBattle } from '../../calculators/battleSimulator';
+import { runCombat, CombatEngineInput } from '../engine';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import { createEventBus, CombatEvent } from '../events';
+import type { Ship } from '../../../types/ship';
+import type { Position } from '../../../types/encounters';
+import { flattenCombatLog } from '../log/__testutils__/flattenCombatLog';
+
+// Verbatim-shaped phrasing (matches Asphyxiator's real active Inferno III sentence structure:
+// "... then inflicts Inferno III for 3 turns on the targeted enemy and all enemies adjacent to
+// it."). Parsed via `adjacentEnemyScopeForName` (Task B1) into `target: 'target-and-adjacent-
+// enemies'` on the `dot` ability, which `dotsFromSkill` (Task B2 Step 1) turns into
+// `splashTarget: 'target-and-adjacent-enemies'` on the DoT application entry.
+const SPLASH_INFERNO_TEXT =
+    'This Unit deals <unit-damage>1% damage</unit-damage>, then inflicts <unit-skill>Inferno III</unit-skill> for 3 turns on the targeted enemy and all enemies adjacent to it.';
+
+// Baseline: the SAME Inferno III DoT with plain `target: 'enemy'` (no adjacency phrase) — used
+// for the DPS-invariance byte-identical comparison.
+const PLAIN_INFERNO_TEXT =
+    'This Unit deals <unit-damage>1% damage</unit-damage> and inflicts <unit-skill>Inferno III</unit-skill> for 3 turns.';
+
+const ship = (id: string, over: Partial<Ship>): Ship =>
+    ({
+        id,
+        name: id,
+        rarity: 'legendary',
+        faction: 'TERRAN_COMBINE',
+        type: 'Attacker',
+        baseStats: {} as Ship['baseStats'],
+        equipment: {},
+        implants: {},
+        refits: [],
+        affinity: 'antimatter',
+        activePattern: 'Pattern-Base',
+        activeTarget: 'front',
+        chargeSkillCharge: 0,
+        ...over,
+    }) as Ship;
+
+interface Placement {
+    ship: Ship;
+    position: Position;
+    statOverrides: {
+        attack: number;
+        crit: number;
+        critDamage: number;
+        defensePenetration: number;
+        hacking: number;
+        defence: number;
+        hp: number;
+    };
+}
+
+// hacking 200 vs default security 0 → debuffLandingChance saturates to 1.0, so the shared DoT
+// landing roll (roundDebuffLanded, playerTurn.ts) always lands — deterministic, no RNG flake.
+const place = (s: Ship, position: Position, attack: number, hp: number): Placement => ({
+    ship: s,
+    position,
+    statOverrides: {
+        attack,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        hacking: 200,
+        defence: 0,
+        hp,
+    },
+});
+
+const splashCaster = (id: string): Ship => ship(id, { activeSkillText: SPLASH_INFERNO_TEXT });
+const plainCaster = (id: string): Ship => ship(id, { activeSkillText: PLAIN_INFERNO_TEXT });
+const dummy = (id: string): Ship =>
+    ship(id, { activeSkillText: 'This Unit deals <unit-damage>1% damage</unit-damage>.' });
+
+/** Every `kind: 'dot-applied'` inferno entry attributed to `actorId`, across the whole run —
+ *  one entry per landed recipient (emitDotApplied is called once per recipient in the fan-out
+ *  loop, same pattern as A3's debuff-applied fan-out). */
+const infernoRecipients = (result: ReturnType<typeof simulateBattle>, actorId: string): string[] =>
+    flattenCombatLog(result)
+        .filter(
+            (e) =>
+                e.kind === 'dot-applied' && e.actorId === actorId && e.note?.startsWith('inferno')
+        )
+        .map((e) => e.targets[0]?.targetId)
+        .filter((id): id is string => id !== undefined);
+
+describe('Ship-kit W5 Task B2: target-and-adjacent-enemies Inferno DoT fan-out (positional, player caster)', () => {
+    const run = (caster: Ship) =>
+        simulateBattle({
+            playerTeam: [place(caster, 'M4', 1000, 1e9)],
+            enemyTeam: [
+                place(dummy('tgt'), 'M4', 1, 1e9), // primary target (unique front cell)
+                place(dummy('nbrA'), 'M3', 1, 1e9), // neighbour of M4
+                place(dummy('nbrB'), 'T3', 1, 1e9), // neighbour of M4
+                place(dummy('far'), 'T1', 1, 1e9), // NOT a neighbour of M4
+            ],
+            rounds: 1,
+        });
+
+    const TGT = 'e:tgt:0';
+    const NBR_A = 'e:nbrA:1';
+    const NBR_B = 'e:nbrB:2';
+    const FAR = 'e:far:3';
+
+    it('the primary target AND both neighbours accrue Inferno; the non-neighbour does not', () => {
+        const result = run(splashCaster('atk'));
+        const recipients = infernoRecipients(result, 'attacker');
+
+        expect(recipients).toContain(TGT);
+        expect(recipients).toContain(NBR_A);
+        expect(recipients).toContain(NBR_B);
+        expect(recipients).not.toContain(FAR);
+    });
+});
+
+describe('Ship-kit W5 Task B2: team symmetry — an ENEMY-side caster splashes onto its PLAYER-side mirror', () => {
+    const run = (caster: Ship) =>
+        simulateBattle({
+            playerTeam: [
+                place(dummy('tgt'), 'M4', 1, 1e9),
+                place(dummy('nbrA'), 'M3', 1, 1e9),
+                place(dummy('nbrB'), 'T3', 1, 1e9),
+                place(dummy('far'), 'T1', 1, 1e9),
+            ],
+            enemyTeam: [place(caster, 'M4', 1000, 1e9)],
+            rounds: 1,
+        });
+
+    // player[0] is always the reserved focus id 'attacker'; the rest are `p:<shipId>:<idx>`
+    // (battleSimulator.ts's naming convention). The caster is the sole enemy → `e:atk:0`.
+    const TGT = 'attacker';
+    const NBR_A = 'p:nbrA:1';
+    const NBR_B = 'p:nbrB:2';
+    const FAR = 'p:far:3';
+    const CASTER = 'e:atk:0';
+
+    it('splashes onto the player target AND its neighbours, not the non-neighbour', () => {
+        const result = run(splashCaster('atk'));
+        const recipients = infernoRecipients(result, CASTER);
+
+        expect(recipients).toContain(TGT);
+        expect(recipients).toContain(NBR_A);
+        expect(recipients).toContain(NBR_B);
+        expect(recipients).not.toContain(FAR);
+    });
+});
+
+/**
+ * DPS invariance: the DPS calculator's single-dummy mode calls `runCombat` DIRECTLY with no
+ * `position`/`pattern`/`enemyAttackers`/`positionalTeamBattle` — the vestigial `enemy` sink
+ * actor is the sole opponent, `targetId` is never threaded, and `adjacentEnemyIdsFor` is never
+ * supplied. The splash fan-out's own guard (`targetId !== undefined && adjacentEnemyIdsFor`)
+ * means it can never fire here — so a `target-and-adjacent-enemies` Inferno DoT must produce
+ * BYTE-IDENTICAL `dot-applied` events to the SAME DoT with plain `target: 'enemy'` (this is the
+ * real DPS-page shape; dpsSimulator.ts calls runCombat the same way).
+ */
+describe('Ship-kit W5 Task B2: DPS invariance (single-dummy, non-positional)', () => {
+    const BASE: Omit<CombatEngineInput, 'shipSkills' | 'bus'> = {
+        attack: 1000,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 3,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 100,
+        hacking: 200,
+        enemySecurity: 0,
+    };
+
+    const runDots = (caster: Ship) => {
+        const bus = createEventBus();
+        const dotsApplied: Extract<CombatEvent, { type: 'dot-applied' }>[] = [];
+        bus.on('dot-applied', (e) => dotsApplied.push(e));
+        runCombat({ ...BASE, shipSkills: buildShipAbilities(caster), bus });
+        return dotsApplied.filter((e) => e.dotType === 'inferno');
+    };
+
+    it('target-and-adjacent-enemies produces byte-identical dot-applied events to plain target:enemy', () => {
+        const splashApplied = runDots(splashCaster('atk'));
+        const plainApplied = runDots(plainCaster('atk'));
+
+        expect(splashApplied.length).toBeGreaterThan(0);
+        // Strip the non-deterministic/irrelevant `round` timing dimension isn't needed here —
+        // both runs use the identical deterministic BASE, so a straight equality (minus any
+        // ReactiveStamp-only fields, none present for a cast-time application) proves the
+        // splash-config path is a complete no-op in this mode.
+        expect(splashApplied).toEqual(plainApplied);
+        // Never lands on anyone but the dummy sink — no splash leakage even by accident.
+        expect(splashApplied.every((e) => e.targetId === 'enemy')).toBe(true);
+    });
+});

--- a/src/utils/combat/__tests__/adjacentEnemiesDot.integration.test.ts
+++ b/src/utils/combat/__tests__/adjacentEnemiesDot.integration.test.ts
@@ -63,14 +63,21 @@ interface Placement {
         critDamage: number;
         defensePenetration: number;
         hacking: number;
+        security?: number;
         defence: number;
         hp: number;
     };
 }
 
-// hacking 200 vs default security 0 → debuffLandingChance saturates to 1.0, so the shared DoT
+// hacking 200 vs default security 100 → debuffLandingChance saturates to 1.0, so the shared DoT
 // landing roll (roundDebuffLanded, playerTurn.ts) always lands — deterministic, no RNG flake.
-const place = (s: Ship, position: Position, attack: number, hp: number): Placement => ({
+const place = (
+    s: Ship,
+    position: Position,
+    attack: number,
+    hp: number,
+    security?: number
+): Placement => ({
     ship: s,
     position,
     statOverrides: {
@@ -79,6 +86,7 @@ const place = (s: Ship, position: Position, attack: number, hp: number): Placeme
         critDamage: 0,
         defensePenetration: 0,
         hacking: 200,
+        ...(security !== undefined ? { security } : {}),
         defence: 0,
         hp,
     },
@@ -124,6 +132,48 @@ describe('Ship-kit W5 Task B2: target-and-adjacent-enemies Inferno DoT fan-out (
         const recipients = infernoRecipients(result, 'attacker');
 
         expect(recipients).toContain(TGT);
+        expect(recipients).toContain(NBR_A);
+        expect(recipients).toContain(NBR_B);
+        expect(recipients).not.toContain(FAR);
+    });
+});
+
+/**
+ * Per-victim independence (code-review fix, B2): the review found the splash loop nested
+ * inside the PRIMARY target's own Block-Debuff-immunity/landing gates, so a neighbour's
+ * Inferno depended on the PRIMARY's security and the PRIMARY's single shared landing roll —
+ * never the neighbour's own (reintroducing the defect PR #185 fixed for non-DoT debuffs).
+ * Here the PRIMARY ('tgt') is given security 300 — hacking 200 vs security 300 clamps
+ * debuffLandingChance to 0, so the PRIMARY's shared `roundDebuffLanded()` roll deterministically
+ * FAILS (no RNG mocking; same saturation mechanism the `place` helper's default 100 security
+ * relies on for a deterministic PASS). Both neighbours keep the default security (100) → their
+ * OWN `landsDebuffOnVictim` roll deterministically LANDS. Under the OLD (pre-fix) placement the
+ * splash loop lived inside `if (dotsLanded)` — which is false here — so neither neighbour would
+ * receive Inferno at all; this assertion is the load-bearing proof the splash is independent.
+ */
+describe('Ship-kit W5 Task B2: per-victim independence — a neighbour lands Inferno even when the PRIMARY resists', () => {
+    const run = (caster: Ship) =>
+        simulateBattle({
+            playerTeam: [place(caster, 'M4', 1000, 1e9)],
+            enemyTeam: [
+                place(dummy('tgt'), 'M4', 1, 1e9, 300), // primary target: security 300 → its own landing roll always fails
+                place(dummy('nbrA'), 'M3', 1, 1e9), // neighbour of M4, default security → always lands
+                place(dummy('nbrB'), 'T3', 1, 1e9), // neighbour of M4, default security → always lands
+                place(dummy('far'), 'T1', 1, 1e9), // NOT a neighbour of M4
+            ],
+            rounds: 1,
+        });
+
+    const TGT = 'e:tgt:0';
+    const NBR_A = 'e:nbrA:1';
+    const NBR_B = 'e:nbrB:2';
+    const FAR = 'e:far:3';
+
+    it('the primary resists its own DoT but both neighbours still accrue Inferno independently', () => {
+        const result = run(splashCaster('atk'));
+        const recipients = infernoRecipients(result, 'attacker');
+
+        expect(recipients).not.toContain(TGT);
         expect(recipients).toContain(NBR_A);
         expect(recipients).toContain(NBR_B);
         expect(recipients).not.toContain(FAR);

--- a/src/utils/combat/__tests__/bombDetonatedVictimId.test.ts
+++ b/src/utils/combat/__tests__/bombDetonatedVictimId.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Task C2 (Wave 5) — `bomb-detonated` gains a `victimId` field (the enemy the bomb detonated
+ * on) alongside the existing `actorId` (the bomb's original applier). Purely additive plumbing:
+ * C3 (Demolisher's adjacent-enemy splash) anchors its fan-out on `victimId`.
+ *
+ * Covers the two most structurally distinct emit paths:
+ *   1. Natural countdown-0 burst via `processBombs` (non-positional DPS-dummy enemy turn) —
+ *      mirrors `engine.events.test.ts`'s Case 5 harness (`baseInput`/`collect`).
+ *   2. Attacker-turn `detonate()` aggregate bomb branch (legacy non-positional path) — mirrors
+ *      `detonationRecipe.test.ts`'s "legacy (no positional)" harness.
+ * In both, `actorId` (the applier) and `victimId` (the bombed enemy) are asserted independently
+ * to prove the new field is NOT just a copy of the existing one.
+ */
+import { describe, expect, it } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { runPlayerTurn, PlayerActorRuntime, PlayerTurnArgs } from '../playerTurn';
+import { createActor, PendingBomb } from '../state';
+import { createEventBus, CombatEvent } from '../events';
+import { createStatusEngine } from '../statusEngine';
+import { makeRateGate } from '../../calculators/rateAccumulator';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import { AffinityName } from '../../../types/ship';
+
+// ---------------------------------------------------------------------------
+// Path 1: natural countdown-0 detonation via processBombs (enemy turn, DPS dummy).
+// ---------------------------------------------------------------------------
+
+let idCounter = 0;
+const ab = (partial: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `g${++idCounter}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...partial,
+});
+
+const bombSkills = (): ShipSkills => ({
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                ab({ type: 'damage', config: { type: 'damage', multiplier: 120 } }),
+                ab({
+                    type: 'dot',
+                    config: { type: 'dot', dotType: 'bomb', tier: 10, stacks: 2, duration: 2 },
+                }),
+            ],
+        },
+        {
+            slot: 'charged',
+            abilities: [ab({ type: 'damage', config: { type: 'damage', multiplier: 280 } })],
+        },
+    ],
+});
+
+const baseInput = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 15000,
+    crit: 50,
+    critDamage: 150,
+    defensePenetration: 10,
+    chargeCount: 3,
+    shipSkills: bombSkills(),
+    enemyDefense: 8000,
+    enemyHp: 400000,
+    numRounds: 6,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: true,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 6000,
+    hp: 30000,
+    ...overrides,
+});
+
+const collectBombDetonated = (input: CombatEngineInput) => {
+    idCounter = 0;
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    bus.on('bomb-detonated', (e) => events.push(e as CombatEvent));
+    runCombat({ ...input, bus });
+    return events;
+};
+
+describe('bomb-detonated victimId — processBombs natural countdown-0 path', () => {
+    it("stamps victimId as the bombed enemy's id ('enemy', the DPS dummy), distinct from actorId (the applier, 'attacker')", () => {
+        const events = collectBombDetonated(baseInput({ numRounds: 4 }));
+
+        const bombDetonated = events.filter((e) => e.type === 'bomb-detonated');
+        expect(bombDetonated.length).toBeGreaterThan(0);
+        for (const e of bombDetonated) {
+            if (e.type !== 'bomb-detonated') throw new Error('unreachable');
+            expect(e.actorId).toBe('attacker');
+            expect(e.victimId).toBe('enemy');
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Path 2: attacker-turn detonate() aggregate bomb branch (legacy non-positional).
+// ---------------------------------------------------------------------------
+
+const ATTACKER_AFFINITY: AffinityName = 'thermal';
+const AFFINITY_DAMAGE_MODIFIER = 25;
+const ENEMY_DEFENCE = 850;
+
+function makeRuntime(skills: ShipSkills): PlayerActorRuntime {
+    const actor = createActor({
+        id: 'attacker',
+        side: 'player',
+        kind: 'attacker',
+        stats: {
+            attack: 12000,
+            crit: 50,
+            critDamage: 65,
+            defensePenetration: 20,
+            shieldPenetration: 0,
+            defence: 0,
+            hp: 20000,
+            speed: 100,
+        },
+        chargeCount: 0,
+        startCharged: false,
+    });
+
+    return {
+        actor,
+        focus: true,
+        castSkills: skills,
+        reactiveAbilities: [],
+        timedSelfBySlot: [],
+        timedEnemyBySlot: [],
+        hasChargedSkill: false,
+        attack: 12000,
+        crit: 50,
+        critDamage: 65,
+        defensePenetration: 20,
+        defence: 0,
+        hp: 20000,
+        healModifier: 0,
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        affinityDamageModifier: AFFINITY_DAMAGE_MODIFIER,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        affinityDisadvantage: false,
+        attackerAffinity: ATTACKER_AFFINITY,
+        activeCritGate: () => false,
+        chargedCritGate: () => false,
+        activeHealCritGate: () => false,
+        chargedHealCritGate: () => false,
+        debuffLandingGate: makeRateGate(),
+        extendChanceGate: makeRateGate(),
+        landsTimedEnemyApplication: () => true,
+        selfBuffLookup: new Map(),
+        enemyDebuffLookup: new Map(),
+    };
+}
+
+function makeBomb(): PendingBomb {
+    return {
+        countdown: 3,
+        damagePerStack: 5000,
+        stacks: 2,
+        tier: 100,
+        sourceId: 'ally-applier',
+        affinityMult: 1,
+        detonationDamageModifier: 0,
+        splashModifier: 0,
+    };
+}
+
+function makeArgs(runtime: PlayerActorRuntime, pendingBombs: PendingBomb[]): PlayerTurnArgs {
+    const enemy = createActor({
+        id: 'enemy-victim',
+        side: 'enemy',
+        kind: 'enemy',
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            shieldPenetration: 0,
+            defence: ENEMY_DEFENCE,
+            hp: 10_000_000,
+            speed: 50,
+        },
+    });
+
+    const statusEngine = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+    statusEngine.beginRound(1);
+
+    return {
+        runtime,
+        enemy,
+        statusEngine,
+        corrosionEntries: [],
+        infernoEntries: [],
+        genericDoTEntries: [],
+        pendingBombs,
+        pendingAccumulators: [],
+        enemyDefense: ENEMY_DEFENCE,
+        enemyHp: 10_000_000,
+        enemyType: undefined,
+        bus: createEventBus(),
+        round: 1,
+    } as PlayerTurnArgs;
+}
+
+const SKILLS: ShipSkills = {
+    slots: [
+        {
+            slot: 'active',
+            abilities: [
+                {
+                    id: 'hit',
+                    type: 'damage',
+                    target: 'enemy',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config: { type: 'damage', multiplier: 80, hits: 1 },
+                } as Ability,
+                {
+                    id: 'detonate',
+                    type: 'damage',
+                    target: 'enemy',
+                    trigger: 'on-cast',
+                    conditions: [],
+                    config: { type: 'detonate-dot', dotType: 'bomb', powerPct: 100 },
+                } as Ability,
+            ],
+        },
+    ],
+};
+
+describe('bomb-detonated victimId — attacker-turn detonate() aggregate path', () => {
+    it("stamps victimId as the bomb's holder ('enemy-victim'), distinct from actorId (this path's documented actorId = the casting attacker's id, not the bomb's original applier)", () => {
+        const runtime = makeRuntime(SKILLS);
+        const pendingBombs = [makeBomb()];
+        const args = makeArgs(runtime, pendingBombs);
+
+        const emitted: Extract<CombatEvent, { type: 'bomb-detonated' }>[] = [];
+        args.bus.on('bomb-detonated', (e) => emitted.push(e));
+
+        runPlayerTurn(args);
+
+        expect(emitted).toHaveLength(1);
+        // This path's documented quirk (events.ts jsdoc): the attacker-turn detonate() aggregate
+        // branch emits the CASTING actor's id, not bomb.sourceId — 'attacker', not 'ally-applier'.
+        expect(emitted[0].actorId).toBe('attacker');
+        expect(emitted[0].victimId).toBe('enemy-victim');
+    });
+});

--- a/src/utils/combat/__tests__/demolisherBombSplash.integration.test.ts
+++ b/src/utils/combat/__tests__/demolisherBombSplash.integration.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Ship-kit W5 Task C3 — Demolisher's reactive bomb-splash: when a Bomb detonates on an enemy,
+ * deal 100% of the Bomb's OWN damage to all enemies adjacent to the bombed enemy (the bomb
+ * victim excluded), ignoring Defense and never critting. The ability is already parsed (Task
+ * C1: `{ type:'damage', multiplier:100, target:'adjacent-enemies', trigger:'on-bomb-detonated',
+ * config:{ ignoresDefense:true, noCrit:true } }`) and `bomb-detonated` already carries
+ * `victimId` (Task C2). This suite wires the reactive EXECUTION (triggers.ts's `adjacent-
+ * enemies` victim resolution + engine.ts's flat-basis/defense-bypass `applyReactiveDamage`).
+ *
+ * Harness: mirrors perVictimTimedDetonation.integration.test.ts (raw `runCombat`, positional
+ * `enemyAttackers`, a bomb pre-seeded directly via `__testTapActors` rather than driven through
+ * a real cast — isolates the reactive-splash mechanics from bomb-application/DoT-tier math) and
+ * bombDetonatedVictimId.test.ts's bus-tap idiom for asserting the raw `bomb-detonated`/
+ * `reactive-damage-performed` events rather than parsing the rendered combat log.
+ *
+ * Board layout (src/utils/targeting/board.ts hex adjacency): the bomb lands on 'tgt' at M4.
+ * neighbors(M4) = [M3, T3, T4, B3, B4] — nbrA (M3) and nbrB (T3) are real neighbours; `far` (T1)
+ * is not (mirrors adjacentEnemiesDot.integration.test.ts's B2 roster).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { Position } from '../../../types/encounters';
+import type { CombatActor, PendingBomb } from '../state';
+import type { CombatEvent } from '../events';
+import { createEventBus } from '../events';
+
+// The Demolisher passive splash ability (Task C1's parsed shape, verbatim):
+// "... deals 100% of the Bomb's damage to all adjacent enemies. This damage ignores Defense
+// and cannot result in a critical hit."
+const splashAbility = (): Ability => ({
+    id: 'demolisher-splash',
+    type: 'damage',
+    target: 'adjacent-enemies',
+    trigger: 'on-bomb-detonated',
+    conditions: [],
+    config: { type: 'damage', multiplier: 100, noCrit: true, ignoresDefense: true },
+});
+
+const casterShipSkills = (): ShipSkills => ({
+    slots: [{ slot: 'passive', abilities: [splashAbility()] }],
+});
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+// A positioned enemy victim: zero offense (attack 0), finite HP, configurable defence.
+const enemyAt = (
+    id: string,
+    position: Position,
+    defence: number,
+    hp = 1_000_000_000
+): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence, hp, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        shipSkills: { slots: [] } as ShipSkills,
+    }) as EnemyAttacker;
+
+// A bomb pre-seeded with countdown 1 — bursts on the holder's OWN very first turn (round 1).
+// burst = damagePerStack × stacks × affinityMult (neutral mults) = 1000 × 2 = 2000.
+const bomb = (sourceId: string): PendingBomb => ({
+    countdown: 1,
+    damagePerStack: 1000,
+    stacks: 2,
+    tier: 300,
+    sourceId,
+    affinityMult: 1,
+    detonationDamageModifier: 0,
+    splashModifier: 0,
+});
+
+// Raw runCombat input: the CASTER is the focus 'attacker' (player side), positioned (so the
+// enemy-side bombed victim's own-turn positional timed-burst gate — isPositional(pos,
+// opposingRoster) — is satisfied), carrying ONLY the passive splash ability (zero-offense: no
+// active slot, mirrors the "zero-offense parked actor" idiom used elsewhere in this suite).
+const CASTER_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 1000,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: casterShipSkills(),
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    position: 'M4',
+    enemyAttackers: [
+        enemyAt('tgt', 'M4', 0), // the bomb holder
+        enemyAt('nbrA', 'M3', 5000), // neighbour of M4, HIGH defence
+        enemyAt('nbrB', 'T3', 0), // neighbour of M4, zero defence
+        enemyAt('far', 'T1', 0), // NOT a neighbour of M4
+    ],
+    ...overrides,
+});
+
+// Tap the raw bus for bomb-detonated + reactive-damage-performed (bombDetonatedVictimId's idiom).
+const collect = (input: CombatEngineInput) => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    const types: CombatEvent['type'][] = ['bomb-detonated', 'reactive-damage-performed'];
+    for (const t of types) bus.on(t, (e) => events.push(e as CombatEvent));
+    const result = runCombat({ ...input, bus });
+    return { events, result };
+};
+
+type ReactiveDamagePerformed = Extract<CombatEvent, { type: 'reactive-damage-performed' }>;
+type BombDetonated = Extract<CombatEvent, { type: 'bomb-detonated' }>;
+
+describe('Ship-kit W5 Task C3: Demolisher reactive bomb-splash to adjacent enemies', () => {
+    it('board-neighbours of the bombed enemy each take splash damage; the bombed enemy and a non-neighbour do not', () => {
+        const { events } = collect(
+            CASTER_BASE({
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors.find((a) => a.id === 'tgt')?.pendingBombs.push(bomb('attacker'));
+                },
+            })
+        );
+
+        const bombDet = events.filter((e): e is BombDetonated => e.type === 'bomb-detonated');
+        expect(bombDet).toHaveLength(1);
+        expect(bombDet[0]).toMatchObject({ actorId: 'attacker', victimId: 'tgt', damage: 2000 });
+
+        const splashes = events.filter(
+            (e): e is ReactiveDamagePerformed => e.type === 'reactive-damage-performed'
+        );
+        const byTarget = new Map(splashes.map((e) => [e.targetId, e]));
+
+        // 1. Both board-neighbours took splash damage.
+        expect(byTarget.get('nbrA')).toBeDefined();
+        expect(byTarget.get('nbrB')).toBeDefined();
+        // 2. The bombed enemy itself does NOT take extra splash (adjacent-only).
+        expect(byTarget.get('tgt')).toBeUndefined();
+        // 3. A NON-neighbour enemy takes no splash (real positional adjacency).
+        expect(byTarget.get('far')).toBeUndefined();
+        // Exactly the two neighbours, nothing else.
+        expect(splashes).toHaveLength(2);
+
+        // 4. Ignores Defense: nbrA (defence 5000) takes EXACTLY the flat bomb-damage figure
+        //    (event.damage), identical to nbrB (defence 0) — defence had zero effect.
+        expect(byTarget.get('nbrA')?.amount).toBe(bombDet[0].damage);
+        expect(byTarget.get('nbrB')?.amount).toBe(bombDet[0].damage);
+
+        // 5. Never crits: both splash procs report didCrit falsy.
+        expect(byTarget.get('nbrA')?.didCrit).toBeFalsy();
+        expect(byTarget.get('nbrB')?.didCrit).toBeFalsy();
+
+        // All splash procs are attributed to the caster ('attacker'), the ability's owner.
+        expect(splashes.every((e) => e.sourceId === 'attacker')).toBe(true);
+    });
+
+    it('team symmetry: an ENEMY-side Demolisher splashes onto PLAYER-side neighbours of the bombed player', () => {
+        // Mirror roster: the bombed victim is the focus 'attacker' (player side, M4); its
+        // neighbours + non-neighbour are PLAYER-side walked team actors (teamActors is the only
+        // way to get a multi-actor POSITIONED roster on the player side). The caster moves to the
+        // enemy side (enemyAttackers), carrying the same passive splash ability. Positions are
+        // side-LOCAL (adjacency resolves within the same side's roster only, per adjacentAllyIds/
+        // bySide), so reusing M3/T3/T1 labels here does not collide with the enemy-side caster.
+        const teamNeighbour = (
+            id: string,
+            position: Position,
+            defence: number
+        ): TeamActorEngineInput =>
+            ({
+                id,
+                speed: 1,
+                chargeCount: 0,
+                startCharged: false,
+                selfBuffs: [],
+                enemyDebuffs: [],
+                position,
+                walk: {
+                    shipSkills: { slots: [] } as ShipSkills,
+                    stats: {
+                        attack: 0,
+                        crit: 0,
+                        critDamage: 0,
+                        defensePenetration: 0,
+                        defence,
+                        hp: 1_000_000_000,
+                        hacking: 0,
+                    },
+                    selfDotModifier: 0,
+                    defensePenetrationBuff: 0,
+                    affinityDamageModifier: 0,
+                    affinityCritCap: 100,
+                    affinityCritPenalty: 0,
+                    hasChargedSkill: false,
+                },
+            }) as TeamActorEngineInput;
+
+        const { events } = collect(
+            CASTER_BASE({
+                // The focus 'attacker' IS the bomb victim now (still M4), with no offense of its
+                // own — mirrors the zero-offense caster idiom, just swapped roles.
+                shipSkills: { slots: [] } as ShipSkills,
+                enemyAttackers: [
+                    // The caster moves to the enemy side; it still needs A position (any) so
+                    // isPositional(attacker.position, enemyAttackerActors) is satisfied for the
+                    // focus player's own positional timed-burst gate.
+                    { ...enemyAt('e-caster', 'M4', 0), shipSkills: casterShipSkills() },
+                ],
+                teamActors: [
+                    teamNeighbour('nbrA', 'M3', 5000),
+                    teamNeighbour('nbrB', 'T3', 0),
+                    teamNeighbour('far', 'T1', 0),
+                ],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors.find((a) => a.id === 'attacker')?.pendingBombs.push(bomb('e-caster'));
+                },
+            })
+        );
+
+        const bombDet = events.filter((e): e is BombDetonated => e.type === 'bomb-detonated');
+        expect(bombDet).toHaveLength(1);
+        expect(bombDet[0]).toMatchObject({
+            actorId: 'e-caster',
+            victimId: 'attacker',
+            damage: 2000,
+        });
+
+        const splashes = events.filter(
+            (e): e is ReactiveDamagePerformed => e.type === 'reactive-damage-performed'
+        );
+        const byTarget = new Map(splashes.map((e) => [e.targetId, e]));
+
+        expect(byTarget.get('nbrA')).toBeDefined();
+        expect(byTarget.get('nbrB')).toBeDefined();
+        expect(byTarget.get('attacker')).toBeUndefined(); // the bombed player itself, excluded
+        expect(byTarget.get('far')).toBeUndefined(); // non-neighbour
+        expect(splashes).toHaveLength(2);
+        expect(byTarget.get('nbrA')?.amount).toBe(bombDet[0].damage); // ignores Defense
+        expect(byTarget.get('nbrB')?.amount).toBe(bombDet[0].damage);
+        expect(splashes.every((e) => e.sourceId === 'e-caster')).toBe(true);
+    });
+
+    it('DPS invariance: single-dummy (non-positional) mode never splashes and leaves DPS byte-identical', () => {
+        // No position/enemyAttackers — the legacy focus-dummy path. The dummy is the sole
+        // enemy-side actor, so adjacentAllyIdsFor(dummy) resolves to the empty set (no OTHER
+        // same-side actor exists) — DPS-inert by construction, not by a special-cased guard.
+        const NONPOS_BASE = (overrides: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+            attack: 1000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 3,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            shipSkills: { slots: [] } as ShipSkills,
+            ...overrides,
+        });
+
+        const withSplash = (): { result: ReturnType<typeof runCombat>; events: CombatEvent[] } => {
+            const { events, result } = collect(
+                NONPOS_BASE({
+                    shipSkills: casterShipSkills(),
+                    __testTapActors: (actors: CombatActor[]) => {
+                        actors.find((a) => a.id === 'enemy')?.pendingBombs.push(bomb('attacker'));
+                    },
+                })
+            );
+            return { result, events };
+        };
+
+        const baseline = (): ReturnType<typeof runCombat> => {
+            const bus = createEventBus();
+            return runCombat({
+                ...NONPOS_BASE({
+                    // No passive at all — the true DPS baseline this caster would produce
+                    // without the splash reactive ability wired.
+                    shipSkills: { slots: [] } as ShipSkills,
+                    __testTapActors: (actors: CombatActor[]) => {
+                        actors.find((a) => a.id === 'enemy')?.pendingBombs.push(bomb('attacker'));
+                    },
+                }),
+                bus,
+            });
+        };
+
+        const { result, events } = withSplash();
+        // The natural bomb-detonation on the dummy still fires (sanity — the harness is live)...
+        expect(events.some((e) => e.type === 'bomb-detonated')).toBe(true);
+        // ...but it NEVER produces a splash proc.
+        expect(events.some((e) => e.type === 'reactive-damage-performed')).toBe(false);
+
+        // DPS output (per-round damage/detonation figures) is byte-identical to the no-passive
+        // baseline — the extra reactive ability is a complete no-op in this mode.
+        const base = baseline();
+        expect(result.rounds).toEqual(base.rounds);
+    });
+});

--- a/src/utils/combat/__tests__/demolisherBombSplash.integration.test.ts
+++ b/src/utils/combat/__tests__/demolisherBombSplash.integration.test.ts
@@ -247,6 +247,66 @@ describe('Ship-kit W5 Task C3: Demolisher reactive bomb-splash to adjacent enemi
         expect(splashes.every((e) => e.sourceId === 'e-caster')).toBe(true);
     });
 
+    it('CRITICAL review fix: a bomb detonating on a PLAYER ally (own side) does NOT splash the enemy roster', () => {
+        // Reviewer repro: the on-bomb-detonated listener (triggers.ts) previously enqueued for
+        // EVERY bomb detonation with no side guard. Here 'attacker' is the player-side Demolisher
+        // owner, but the bomb bursts on 'ally' — a SEPARATE actor on the OWNER'S OWN side (e.g.
+        // an enemy's Bomb landing on a player teammate). Pre-fix: the listener fired anyway,
+        // stamped eventCtx.victimId = 'ally', and the adjacent-enemies executor called
+        // ctx.adjacentOpposingIdsFor('ally') — which looks 'ally' up in the ENEMY roster, fails
+        // to find it (owner undefined), and (adjacency.ts's non-positional fallback) returned the
+        // ENTIRE living enemy roster with adjacency ignored — splashing tgt/nbrA/nbrB/far all at
+        // once. Post-fix: isOpposing('ally') is false for the player-side listener, so the
+        // splash never fires at all.
+        const { events } = collect(
+            CASTER_BASE({
+                teamActors: [
+                    {
+                        id: 'ally',
+                        speed: 1,
+                        chargeCount: 0,
+                        startCharged: false,
+                        selfBuffs: [],
+                        enemyDebuffs: [],
+                        position: 'T4',
+                        walk: {
+                            shipSkills: { slots: [] } as ShipSkills,
+                            stats: {
+                                attack: 0,
+                                crit: 0,
+                                critDamage: 0,
+                                defensePenetration: 0,
+                                defence: 0,
+                                hp: 1_000_000_000,
+                                hacking: 0,
+                            },
+                            selfDotModifier: 0,
+                            defensePenetrationBuff: 0,
+                            affinityDamageModifier: 0,
+                            affinityCritCap: 100,
+                            affinityCritPenalty: 0,
+                            hasChargedSkill: false,
+                        },
+                    } as TeamActorEngineInput,
+                ],
+                __testTapActors: (actors: CombatActor[]) => {
+                    actors.find((a) => a.id === 'ally')?.pendingBombs.push(bomb('some-enemy'));
+                },
+            })
+        );
+
+        // Sanity: the own-side bomb still detonates (the harness is live) ...
+        const bombDet = events.filter((e): e is BombDetonated => e.type === 'bomb-detonated');
+        expect(bombDet.some((e) => e.victimId === 'ally')).toBe(true);
+
+        // ... but produces ZERO reactive splash — none of the enemy roster (tgt/nbrA/nbrB/far)
+        // takes any damage from it.
+        const splashes = events.filter(
+            (e): e is ReactiveDamagePerformed => e.type === 'reactive-damage-performed'
+        );
+        expect(splashes).toHaveLength(0);
+    });
+
     it('DPS invariance: single-dummy (non-positional) mode never splashes and leaves DPS byte-identical', () => {
         // No position/enemyAttackers — the legacy focus-dummy path. The dummy is the sole
         // enemy-side actor, so adjacentAllyIdsFor(dummy) resolves to the empty set (no OTHER

--- a/src/utils/combat/adjacency.ts
+++ b/src/utils/combat/adjacency.ts
@@ -19,10 +19,15 @@ interface AdjacencyActor {
  * "Living" = `destroyedRound === undefined` (engine's canonical destroyed signal).
  */
 export function adjacentAllyIds(ownerId: string, actors: AdjacencyActor[]): string[] {
-    const living = actors.filter((x) => x.destroyedRound === undefined && x.id !== ownerId);
     const owner = actors.find((x) => x.id === ownerId);
+    // Wave 5 hardening: if the anchor isn't in this roster at all, it has no neighbours here —
+    // return [] rather than falling through to the whole-roster fallback below. Every current
+    // `adjacent-allies` caller queries the owner's OWN side, where the owner is always present,
+    // so this guard is inert on the existing corpus; it only protects a future wrong-roster call.
+    if (owner === undefined) return [];
+    const living = actors.filter((x) => x.destroyedRound === undefined && x.id !== ownerId);
     const anyOtherPositioned = actors.some((x) => x.id !== ownerId && x.position != null);
-    if (owner?.position != null && anyOtherPositioned) {
+    if (owner.position != null && anyOtherPositioned) {
         const nbrs = new Set<Position>(neighbors(owner.position));
         return living.filter((x) => x.position != null && nbrs.has(x.position)).map((x) => x.id);
     }

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -1341,6 +1341,11 @@ interface ReactiveSideCtx {
     perRoundFireCounts?: Map<string, number>;
     /** Per-side adjacent-allies resolver (Fortifying Shroud). See IntentExecContext. */
     adjacentAllyIdsFor: (ownerId: string) => string[];
+    /** Ship-kit W5 Task C3 (Demolisher bomb-splash): OPPOSING-side adjacent-ids resolver — mirrors
+     *  `livingOpposingActorIds`'s same-direction wiring (player drain → enemy roster, enemy drain
+     *  → player roster), but narrowed to board-neighbours of the given anchor instead of the
+     *  whole roster. See IntentExecContext. */
+    adjacentOpposingIdsFor?: (anchorId: string) => string[];
     /** Per-side support footprint resolver (pattern-scoped reactive grants). See IntentExecContext. */
     footprintAllyIdsFor: (ownerId: string) => string[] | undefined;
 }
@@ -4624,7 +4629,16 @@ export function runCombat(input: CombatEngineInput): {
             hits: number,
             noCrit: boolean,
             hpBasisPct?: number,
-            allowDeadOwner?: boolean
+            allowDeadOwner?: boolean,
+            // Ship-kit W5 Task C3 (Demolisher bomb-splash). `flatBasis`: this proc is a FLAT copy
+            // of some OTHER already-resolved damage figure (the bomb's own burst,
+            // eventCtx.triggerDamage) rather than owner-attack × multiplier — raw is computed
+            // directly, skipping `victimHitDamage` ENTIRELY (no defense, no crit roll, no
+            // affinity). `ignoresDefense` (without `flatBasis`): the normal attack-basis/crit walk
+            // still runs, but the victim's Defense term is bypassed (defence: 0) — kept minimal,
+            // for generality beyond Demolisher's own (flat) path. Both absent (every pre-C3
+            // caller) → byte-identical to the pre-C3 body below.
+            opts?: { ignoresDefense?: boolean; flatBasis?: number }
         ): { dealt: number; didCrit: boolean } | void => {
             const owner = allActorsById.get(ownerId);
             const victim = allActorsById.get(victimId);
@@ -4649,54 +4663,80 @@ export function runCombat(input: CombatEngineInput): {
             const ownerStats = effectiveStatsOf(statusEngine, selfBuffLookup, owner);
             const victimStats = effectiveStatsOf(statusEngine, selfBuffLookup, victim);
 
-            // Deterministic per-(owner, ability) crit gate — a NEW map (reactiveDamageCritGates),
-            // never Math.random. `noCrit` short-circuits the roll entirely: a flagged ability
-            // (Grif "cannot critically hit", Rhodium "cannot critically hit") never creates a gate
-            // key, so it can never crit by construction, matching the flag rather than relying on
-            // the executor to withhold crit eligibility. A 0%-crit owner ALSO skips the roll — a
-            // guaranteed-miss draw would still consume a value from the shared seeded RNG stream
-            // and perturb every later gate's schedule (proc gates, debuff landing) for ships that
-            // can never crit anyway. Live-checked per call, so a mid-fight crit buff starts
-            // drawing from that point on.
-            const didCrit =
-                !noCrit &&
-                ownerStats.crit > 0 &&
-                rollRateGate(
-                    reactiveDamageCritGates,
-                    `${ownerId}:${abilityId}`,
-                    ownerStats.crit / 100
+            let raw: number;
+            let didCrit: boolean;
+
+            if (opts?.flatBasis !== undefined) {
+                // Ship-kit W5 Task C3 (Demolisher bomb-splash): a FLAT copy of the triggering
+                // event's OWN already-resolved damage (the bomb's burst) — raw = flatBasis ×
+                // multiplier/100 (100% = a straight copy), computed DIRECTLY with no
+                // `victimHitDamage` call at all: no owner-attack basis, no Defense mitigation, no
+                // crit roll (a flat copy can never crit by design — `noCrit` is honoured by
+                // construction, not by a flag check), and deliberately NO affinity
+                // re-application. Affinity rationale: the bomb's `damage` already resolved the
+                // ORIGINAL applier's affinity matchup against the BOMBED victim; re-running
+                // affinity math here would apply THIS neighbour's affinity to a hit that never
+                // actually had a matchup against it — the burst is a single already-realized
+                // number being copied, not a new attack being rolled. Mirrors the
+                // bomb-splash-on-death precedent (engine.ts ~4187, `splashDamageForBomb`), which
+                // is likewise flat/no-affinity.
+                raw = Math.round((opts.flatBasis * multiplier) / 100);
+                didCrit = false;
+            } else {
+                // Deterministic per-(owner, ability) crit gate — a NEW map (reactiveDamageCritGates),
+                // never Math.random. `noCrit` short-circuits the roll entirely: a flagged ability
+                // (Grif "cannot critically hit", Rhodium "cannot critically hit") never creates a gate
+                // key, so it can never crit by construction, matching the flag rather than relying on
+                // the executor to withhold crit eligibility. A 0%-crit owner ALSO skips the roll — a
+                // guaranteed-miss draw would still consume a value from the shared seeded RNG stream
+                // and perturb every later gate's schedule (proc gates, debuff landing) for ships that
+                // can never crit anyway. Live-checked per call, so a mid-fight crit buff starts
+                // drawing from that point on.
+                didCrit =
+                    !noCrit &&
+                    ownerStats.crit > 0 &&
+                    rollRateGate(
+                        reactiveDamageCritGates,
+                        `${ownerId}:${abilityId}`,
+                        ownerStats.crit / 100
+                    );
+
+                // Vindicator on-resist: raw = owner effective max HP × hpBasisPct% (mitigated below the
+                // same as any direct hit — defence + affinity + crit). Otherwise attack × multiplier.
+                const basisStat =
+                    hpBasisPct !== undefined ? recipientMaxHp(ownerId) : ownerStats.attack;
+                const basisPct = hpBasisPct !== undefined ? hpBasisPct : multiplier;
+
+                raw = victimHitDamage(
+                    {
+                        effectiveAttack: basisStat,
+                        // Fold hit count into the multiplier and pass hits:1 (mirrors
+                        // applyCounterAttack) — models the reactive proc as ONE consolidated hit.
+                        multiplierPct: basisPct * hits,
+                        secondaryStatValue: 0,
+                        hits: 1,
+                        effectiveCritDamage: ownerStats.critDamage,
+                        outgoingDamageBuffPct: 0,
+                        incomingDamageModifierPct: 0,
+                        defensePenetrationPct: ownerStats.defensePenetration,
+                        attackerAffinity: owner.affinity ?? 'antimatter',
+                    },
+                    {
+                        // SP-F F5: Meatshield defense-substitution (approximation) — see the
+                        // substitutedDefenceFor doc comment above for the full rule. Ship-kit W5
+                        // Task C3: `ignoresDefense` (non-flat generality path) bypasses the
+                        // victim's Defense term entirely (defence: 0) instead of the normal
+                        // substituted defence.
+                        defence: opts?.ignoresDefense
+                            ? 0
+                            : substitutedDefenceFor(victim, victimStats.defence),
+                        defenceModifierPct: 0,
+                        affinity: victim.affinity ?? 'antimatter',
+                    },
+                    didCrit,
+                    1 // roleScale: a reactive proc is a single full hit
                 );
-
-            // Vindicator on-resist: raw = owner effective max HP × hpBasisPct% (mitigated below the
-            // same as any direct hit — defence + affinity + crit). Otherwise attack × multiplier.
-            const basisStat =
-                hpBasisPct !== undefined ? recipientMaxHp(ownerId) : ownerStats.attack;
-            const basisPct = hpBasisPct !== undefined ? hpBasisPct : multiplier;
-
-            const raw = victimHitDamage(
-                {
-                    effectiveAttack: basisStat,
-                    // Fold hit count into the multiplier and pass hits:1 (mirrors
-                    // applyCounterAttack) — models the reactive proc as ONE consolidated hit.
-                    multiplierPct: basisPct * hits,
-                    secondaryStatValue: 0,
-                    hits: 1,
-                    effectiveCritDamage: ownerStats.critDamage,
-                    outgoingDamageBuffPct: 0,
-                    incomingDamageModifierPct: 0,
-                    defensePenetrationPct: ownerStats.defensePenetration,
-                    attackerAffinity: owner.affinity ?? 'antimatter',
-                },
-                {
-                    // SP-F F5: Meatshield defense-substitution (approximation) — see the
-                    // substitutedDefenceFor doc comment above for the full rule.
-                    defence: substitutedDefenceFor(victim, victimStats.defence),
-                    defenceModifierPct: 0,
-                    affinity: victim.affinity ?? 'antimatter',
-                },
-                didCrit,
-                1 // roleScale: a reactive proc is a single full hit
-            );
+            }
             // Guard: swallows zero/negative procs (defensive — a 0-attack or 0-multiplier proc
             // credits nothing), matching the pre-fix zero-damage guard.
             if (raw <= 0) {
@@ -6154,6 +6194,9 @@ export function runCombat(input: CombatEngineInput): {
                         // D-PR11: live adjacent-allies resolver (Fortifying Shroud). Sourced
                         // per-side from sideCtx; positional neighbours, else all same-side allies.
                         adjacentAllyIdsFor: sideCtx.adjacentAllyIdsFor,
+                        // Ship-kit W5 Task C3: OPPOSING-side counterpart (Demolisher bomb-splash's
+                        // 'adjacent-enemies' anchor resolution). See IntentExecContext.
+                        adjacentOpposingIdsFor: sideCtx.adjacentOpposingIdsFor,
                         footprintAllyIdsFor: sideCtx.footprintAllyIdsFor,
                     });
                 }
@@ -6308,6 +6351,10 @@ export function runCombat(input: CombatEngineInput): {
             oncePerRoundConsumed,
             perRoundFireCounts,
             adjacentAllyIdsFor: bySide('player').adjacentAllyIdsFor,
+            // Ship-kit W5 Task C3: a player-owned reactive's 'adjacent-enemies' anchor (the bomb
+            // victim) lives on the ENEMY side — mirrors livingOpposingActorIds' direction, not
+            // adjacentAllyIdsFor's (which stays bound to this drain's OWN side, player).
+            adjacentOpposingIdsFor: bySide('enemy').adjacentAllyIdsFor,
             footprintAllyIdsFor: bySide('player').footprintAllyIdsFor,
         });
         // Enemy drain (enemy-team PR1) — binds the SEPARATE enemy queue + enemy-side ctx.
@@ -6341,6 +6388,9 @@ export function runCombat(input: CombatEngineInput): {
             oncePerRoundConsumed,
             perRoundFireCounts,
             adjacentAllyIdsFor: bySide('enemy').adjacentAllyIdsFor,
+            // Ship-kit W5 Task C3: mirror of playerDrainCtx's wiring — an enemy-owned reactive's
+            // 'adjacent-enemies' anchor lives on the PLAYER side.
+            adjacentOpposingIdsFor: bySide('player').adjacentAllyIdsFor,
             footprintAllyIdsFor: bySide('enemy').footprintAllyIdsFor,
         });
         // SP-U U3: side-parameterized drain replacing the former separate `drainIntents`/

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -5279,6 +5279,7 @@ export function runCombat(input: CombatEngineInput): {
                     bus.emit({
                         type: 'bomb-detonated',
                         actorId,
+                        victimId: victim.id,
                         round: r,
                         stacks: result.bombStacks,
                         damage: result.bomb,
@@ -5376,6 +5377,7 @@ export function runCombat(input: CombatEngineInput): {
                     bus.emit({
                         type: 'bomb-detonated',
                         actorId,
+                        victimId: actor.id,
                         round: r,
                         stacks,
                         damage,
@@ -7335,6 +7337,7 @@ export function runCombat(input: CombatEngineInput): {
                             bus.emit({
                                 type: 'bomb-detonated',
                                 actorId,
+                                victimId: enemy.id,
                                 round: r,
                                 stacks,
                                 damage,

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -207,8 +207,17 @@ function registerActorAbilityStatuses(
         for (const ability of slot.abilities) {
             const cfg = ability.config;
             if (cfg.type !== 'buff' && cfg.type !== 'debuff') continue;
+            // Ship-kit W5 Task A3: the two enemy-adjacency scopes (Vindicator Provoke/Out. Damage
+            // Down I → 'adjacent-enemies'; Asphyxiator Stasis → 'target-and-adjacent-enemies')
+            // are enemy-side debuffs scoped to the resolved target's board neighbours, not self
+            // buffs — omitting them here silently misregisters the status on the CASTER.
             const side: 'self' | 'enemy' =
-                ability.target === 'enemy' || ability.target === 'all-enemies' ? 'enemy' : 'self';
+                ability.target === 'enemy' ||
+                ability.target === 'all-enemies' ||
+                ability.target === 'adjacent-enemies' ||
+                ability.target === 'target-and-adjacent-enemies'
+                    ? 'enemy'
+                    : 'self';
             const accumulating = !!cfg.stackTrigger && cfg.isStackable;
             // Cheat-Death-family grants from a FIRING slot (Hermes/Hayyan charged skills) are
             // cast-path persistent grants, NOT always-on auras: they apply when the slot fires
@@ -5499,6 +5508,15 @@ export function runCombat(input: CombatEngineInput): {
                 // bySide(a.side) (identical for player and enemy casters). Consumed only by a
                 // buff-steal ability whose config carries grantAdjacentAllies.
                 adjacentAllyIds: bySide(a.side).adjacentAllyIdsFor(a.id),
+                // Ship-kit W5 Task A3: resolves the board-neighbours of an ENEMY-side anchor
+                // (the resolved target `tgt`, not the caster) for the 'adjacent-enemies' /
+                // 'target-and-adjacent-enemies' debuff fan-out. Reuses the same side-dispatching
+                // adjacentAllyIdsFor the reactive-trigger registration (~2856) and the buff-steal
+                // grant above already use — passing the target's id resolves ITS OWN side's
+                // neighbours, which (since the target is always opposing this actor) are the
+                // adjacent enemies, team-symmetric for free (bySide handles both directions).
+                adjacentEnemyIdsFor: (anchorId: string): string[] =>
+                    bySide(isEnemySide(anchorId) ? 'enemy' : 'player').adjacentAllyIdsFor(anchorId),
                 // B1/PR7b: thread targetId for BOTH directions so player-applied ABILITY debuffs route
                 // to the resolved victim's per-actor store (applyTimedAbilityStatus keys off targetId;
                 // the aggregate ability-read timedAbilityStatuses('enemy',actor.id,targetId) follows

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -247,8 +247,18 @@ export type CombatEvent =
      *  normalized value. `actorId` = the bomb's ORIGINAL applier (`PendingBomb.sourceId`)
      *  for `processBombs` and for SP-F F3/Lingshe's forced early detonation via
      *  `bomb-countdown-reduce`; the attacker-turn `detonate()` aggregate branch emits the
-     *  casting `actor.id` instead. Any actor, not always 'attacker'. */
-    | { type: 'bomb-detonated'; actorId: string; round: number; stacks: number; damage: number }
+     *  casting `actor.id` instead. Any actor, not always 'attacker'. `victimId` = the actor
+     *  the bomb detonated ON (the bomb's holder) — distinct from `actorId`, which stays the
+     *  applier/caster per the above. Added for Wave 5 C2 (Demolisher adjacent-enemy splash
+     *  anchoring, consumed by C3); purely additive, no behaviour change. */
+    | {
+          type: 'bomb-detonated';
+          actorId: string;
+          victimId: string;
+          round: number;
+          stacks: number;
+          damage: number;
+      }
     /** A `control` ability resolved on the cast path. `casterId` is the applying actor;
      *  `effect` is the control effect (e.g. 'stasis'). Present-only-when-fired; emitting it
      *  does NOT simulate the control's combat effect. */

--- a/src/utils/combat/log/__tests__/buildCombatLog.test.ts
+++ b/src/utils/combat/log/__tests__/buildCombatLog.test.ts
@@ -1147,7 +1147,14 @@ describe('buildCombatLog', () => {
         const events: CombatEvent[] = [
             ev({ type: 'round-started', round: 1 }),
             ev({ type: 'turn-started', actorId: 'A', round: 1 }),
-            ev({ type: 'bomb-detonated', actorId: 'A', round: 1, stacks: 3, damage: 9000 }),
+            ev({
+                type: 'bomb-detonated',
+                actorId: 'A',
+                victimId: 'B',
+                round: 1,
+                stacks: 3,
+                damage: 9000,
+            }),
             ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
             ev({ type: 'round-ended', round: 1 }),
         ];

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -2371,47 +2371,6 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                         ...(critHits > 0 ? { viaCrit: true } : {}),
                     }),
             });
-
-            // Ship-kit W5: fan splash-scoped DoTs (Asphyxiator active Inferno) onto the
-            // target's board-neighbours. 'target-and-adjacent-enemies' already hit the primary
-            // via the call above; here we add each adjacent enemy. 'adjacent-enemies'
-            // (neighbours only) was filtered OUT of the primary apply above and is applied only
-            // here. Positional-only: adjacentEnemyIdsFor returns [] / is undefined for the DPS
-            // dummy sink (targetId undefined there), so DPS is byte-identical. Gated by the
-            // same `dotsLanded` shared roll as the primary — a splash never applies when the
-            // round's DoT landing roll failed. affinityMult reused as the caster's own value
-            // (correct for the corpus: Asphyxiator's splash is Inferno, which doesn't consume
-            // affinityMult at apply time; only pendingBombs snapshot it, and no corpus bomb-DoT
-            // splashes exist) — true per-victim affinity is deferred.
-            const splashDots = dotsConfig.filter((d) => d.splashTarget !== undefined);
-            if (splashDots.length > 0 && targetId !== undefined && adjacentEnemyIdsFor) {
-                for (const rid of adjacentEnemyIdsFor(targetId)) {
-                    const victim = opposingVictimById?.get(rid);
-                    if (!victim) continue;
-                    applyNewDoTs({
-                        dotsConfig: splashDots,
-                        effectiveAttack,
-                        affinityMult,
-                        detonationDamageModifier: dmgStats.detonationDamageModifier,
-                        splashModifier: dmgStats.bombSplashModifier,
-                        sourceId: actor.id,
-                        corrosionEntries: victim.corrosionEntries,
-                        infernoEntries: victim.infernoEntries,
-                        genericDoTEntries: victim.genericDoTEntries,
-                        pendingBombs: victim.pendingBombs,
-                        emitDotApplied: (dotType, stacks) =>
-                            bus.emit({
-                                type: 'dot-applied',
-                                sourceId: actor.id,
-                                targetId: rid,
-                                round: r,
-                                dotType,
-                                stacks,
-                                ...(critHits > 0 ? { viaCrit: true } : {}),
-                            }),
-                    });
-                }
-            }
         }
 
         // Step 3a: 'inflicted'-scope extensions grow ONLY this cast's new DoTs
@@ -2434,6 +2393,49 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
 
         if (dotsLanded) {
             applyAccumulators({ gatedSkill, pendingAccumulators, sourceId: actor.id });
+        }
+    }
+
+    // Ship-kit W5: fan splash-scoped DoTs (Asphyxiator active Inferno) onto the target's
+    // board-neighbours. 'target-and-adjacent-enemies' hits the primary via the block above
+    // ('adjacent-enemies', neighbours-only, is filtered OUT of the primary apply and applied
+    // ONLY here). Runs INDEPENDENTLY of the primary's Block-Debuff immunity/`dotsLanded` gate
+    // above (review fix, B2) — each neighbour rolls its OWN landing via `landsDebuffOnVictim`
+    // (Block-Debuff + hacking-vs-security, mirrors PR #185 for non-DoT debuffs), so a neighbour
+    // can be hit even when the primary resists (immune or failed its own roll), and vice versa.
+    // Positional-only: adjacentEnemyIdsFor returns [] / is undefined for the DPS dummy sink
+    // (targetId undefined there), so DPS is byte-identical. affinityMult reused as the caster's
+    // own value (correct for the corpus: Asphyxiator's splash is Inferno, which doesn't consume
+    // affinityMult at apply time; only pendingBombs snapshot it, and no corpus bomb-DoT splashes
+    // exist) — true per-victim affinity is deferred.
+    const splashDots = dotsConfig.filter((d) => d.splashTarget !== undefined);
+    if (splashDots.length > 0 && targetId !== undefined && adjacentEnemyIdsFor) {
+        for (const rid of adjacentEnemyIdsFor(targetId)) {
+            const victim = opposingVictimById?.get(rid);
+            if (!victim) continue;
+            if (!landsDebuffOnVictim('inflict', victim)) continue; // per-victim landing gate
+            applyNewDoTs({
+                dotsConfig: splashDots,
+                effectiveAttack,
+                affinityMult,
+                detonationDamageModifier: dmgStats.detonationDamageModifier,
+                splashModifier: dmgStats.bombSplashModifier,
+                sourceId: actor.id,
+                corrosionEntries: victim.corrosionEntries,
+                infernoEntries: victim.infernoEntries,
+                genericDoTEntries: victim.genericDoTEntries,
+                pendingBombs: victim.pendingBombs,
+                emitDotApplied: (dotType, stacks) =>
+                    bus.emit({
+                        type: 'dot-applied',
+                        sourceId: actor.id,
+                        targetId: rid,
+                        round: r,
+                        dotType,
+                        stacks,
+                        ...(critHits > 0 ? { viaCrit: true } : {}),
+                    }),
+            });
         }
     }
 

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -917,6 +917,7 @@ function reduceBombsOnVictim(
         bus.emit({
             type: 'bomb-detonated',
             actorId: bomb.sourceId,
+            victimId: victim.id,
             round,
             stacks: bomb.stacks,
             damage: burst,
@@ -2315,7 +2316,14 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
             infernoEntries,
             pendingBombs,
             emitBombDetonated: (stacks, damage) =>
-                bus.emit({ type: 'bomb-detonated', actorId: actor.id, round: r, stacks, damage }),
+                bus.emit({
+                    type: 'bomb-detonated',
+                    actorId: actor.id,
+                    victimId: enemy.id,
+                    round: r,
+                    stacks,
+                    damage,
+                }),
         });
     }
 

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -2344,9 +2344,13 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         // the entries this cast adds below (the slice from these indices onward).
         const corrosionEntriesBefore = corrosionEntries.length;
         const infernoEntriesBefore = infernoEntries.length;
+        // Ship-kit W5 Task B2: 'adjacent-enemies' (neighbours-only) is filtered OUT of the
+        // primary apply — it is applied only via the splash loop below. Corpus has no
+        // adjacent-only DoT, so primaryDots === dotsConfig today → zero behaviour change.
+        const primaryDots = dotsConfig.filter((d) => d.splashTarget !== 'adjacent-enemies');
         if (dotsLanded) {
             applyNewDoTs({
-                dotsConfig,
+                dotsConfig: primaryDots,
                 effectiveAttack,
                 affinityMult,
                 detonationDamageModifier: dmgStats.detonationDamageModifier,
@@ -2367,6 +2371,47 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                         ...(critHits > 0 ? { viaCrit: true } : {}),
                     }),
             });
+
+            // Ship-kit W5: fan splash-scoped DoTs (Asphyxiator active Inferno) onto the
+            // target's board-neighbours. 'target-and-adjacent-enemies' already hit the primary
+            // via the call above; here we add each adjacent enemy. 'adjacent-enemies'
+            // (neighbours only) was filtered OUT of the primary apply above and is applied only
+            // here. Positional-only: adjacentEnemyIdsFor returns [] / is undefined for the DPS
+            // dummy sink (targetId undefined there), so DPS is byte-identical. Gated by the
+            // same `dotsLanded` shared roll as the primary — a splash never applies when the
+            // round's DoT landing roll failed. affinityMult reused as the caster's own value
+            // (correct for the corpus: Asphyxiator's splash is Inferno, which doesn't consume
+            // affinityMult at apply time; only pendingBombs snapshot it, and no corpus bomb-DoT
+            // splashes exist) — true per-victim affinity is deferred.
+            const splashDots = dotsConfig.filter((d) => d.splashTarget !== undefined);
+            if (splashDots.length > 0 && targetId !== undefined && adjacentEnemyIdsFor) {
+                for (const rid of adjacentEnemyIdsFor(targetId)) {
+                    const victim = opposingVictimById?.get(rid);
+                    if (!victim) continue;
+                    applyNewDoTs({
+                        dotsConfig: splashDots,
+                        effectiveAttack,
+                        affinityMult,
+                        detonationDamageModifier: dmgStats.detonationDamageModifier,
+                        splashModifier: dmgStats.bombSplashModifier,
+                        sourceId: actor.id,
+                        corrosionEntries: victim.corrosionEntries,
+                        infernoEntries: victim.infernoEntries,
+                        genericDoTEntries: victim.genericDoTEntries,
+                        pendingBombs: victim.pendingBombs,
+                        emitDotApplied: (dotType, stacks) =>
+                            bus.emit({
+                                type: 'dot-applied',
+                                sourceId: actor.id,
+                                targetId: rid,
+                                round: r,
+                                dotType,
+                                stacks,
+                                ...(critHits > 0 ? { viaCrit: true } : {}),
+                            }),
+                    });
+                }
+            }
         }
 
         // Step 3a: 'inflicted'-scope extensions grow ONLY this cast's new DoTs

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -479,6 +479,13 @@ export interface PlayerTurnArgs {
      *  Absent/[] → the grant is caster-only (byte-identical for every ship without that flag,
      *  and for non-positional/DPS callers that never supply it). */
     adjacentAllyIds?: string[];
+    /** Ship-kit W5 Task A3: resolves the board-neighbours of an ENEMY-side anchor id (the
+     *  resolved `targetId`, not the caster) — feeds the `adjacent-enemies` /
+     *  `target-and-adjacent-enemies` debuff recipientIds fan-out below. Supplied by
+     *  engine.ts's `buildTurnArgs` (team-symmetric via `bySide`/`isEnemySide`, same pattern as
+     *  `adjacentAllyIds` above). Absent → both scopes degrade to their DPS/non-positional
+     *  fallback (see the recipientIds computation). */
+    adjacentEnemyIdsFor?: (anchorId: string) => string[];
     /** Sub-project I, PR I3 (Layer 1) — `all-allies`-targeted passive `modifier` abilities
      *  gathered from THIS actor's living same-side allies (source excluded — see
      *  engine.ts's `buildTurnArgs`). Merged into `modifierAbilities` below alongside the
@@ -1001,6 +1008,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         targetId,
         enemyMostBuffsId,
         adjacentAllyIds,
+        adjacentEnemyIdsFor,
         enemyBuffNames: enemyBuffNamesArg = [],
         stealthedEnemyCount: stealthedEnemyCountArg = 0,
         // No default — undefined is the DPS-parity sentinel (see PlayerTurnArgs doc).
@@ -1489,16 +1497,36 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
             (a) => a.config.type === 'debuff' && a.config.buffName === status.payload.buffName
         );
         const isAllEnemies = matchingAbility?.target === 'all-enemies';
+        // Ship-kit W5 Task A3: 'adjacent-enemies' / 'target-and-adjacent-enemies' fan the status
+        // over the resolved target's board neighbours (adjacentEnemyIdsFor, engine.ts's
+        // buildTurnArgs — team-symmetric via bySide). Only meaningful once a real `targetId` is
+        // resolved (positional cast on a real opposing actor); DPS/non-positional callers never
+        // supply `adjacentEnemyIdsFor` (or `targetId` is undefined there), so this is [] then.
+        const abTarget = matchingAbility?.target;
+        const adjacentEnemyRecipients: string[] =
+            targetId !== undefined && adjacentEnemyIdsFor ? adjacentEnemyIdsFor(targetId) : [];
         const recipientIds: (string | undefined)[] =
-            positionalLanding && isAllEnemies
-                ? (aoeVictimIds ?? [])
-                : isAllEnemies && aoeVictimIds && aoeVictimIds.length > 0
-                  ? aoeVictimIds
-                  : targetId !== undefined
-                    ? [targetId]
-                    : positionalLanding
-                      ? []
-                      : [undefined];
+            abTarget === 'adjacent-enemies'
+                ? adjacentEnemyRecipients
+                : abTarget === 'target-and-adjacent-enemies'
+                  ? targetId !== undefined
+                      ? [targetId, ...adjacentEnemyRecipients]
+                      : // DPS-parity fallback: no real anchor to fan out from (mirrors the
+                        // plain-'enemy' tail below) — non-positional lands on the dummy sink
+                        // (`[undefined]` → victim resolves to `enemy`), positional-with-no-target
+                        // (shouldn't occur for a real opposing cast) no-ops.
+                        positionalLanding
+                        ? []
+                        : [undefined]
+                  : positionalLanding && isAllEnemies
+                    ? (aoeVictimIds ?? [])
+                    : isAllEnemies && aoeVictimIds && aoeVictimIds.length > 0
+                      ? aoeVictimIds
+                      : targetId !== undefined
+                        ? [targetId]
+                        : positionalLanding
+                          ? []
+                          : [undefined];
 
         let anyLanded = false;
         for (const vid of recipientIds) {

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -628,7 +628,23 @@ export function registerReactiveListeners(args: {
                     bus.on('round-ended', () => enqueue(intent));
                     break;
                 case 'on-bomb-detonated':
-                    bus.on('bomb-detonated', () => enqueue(intent));
+                    // Ship-kit W5 Task C3 (Demolisher): stamp the bomb VICTIM's id + the burst's
+                    // own damage into eventCtx so the reactive `damage` executor's `adjacent-
+                    // enemies` branch can anchor its fan-out on the bombed enemy (NOT the owner)
+                    // and scale the splash off the bomb's own payout rather than the owner's
+                    // attack. Both fields are existing eventCtx channels (on-attacked already
+                    // stamps them for the counter-routing / damage-taken-basis consumers) — this
+                    // listener is just a second writer, gated by its own distinct event type.
+                    bus.on('bomb-detonated', (e) =>
+                        enqueue({
+                            ...intent,
+                            eventCtx: {
+                                ...intent.eventCtx,
+                                victimId: e.victimId,
+                                triggerDamage: e.damage,
+                            },
+                        })
+                    );
                     break;
                 case 'on-stasis-applied':
                     bus.on('control-applied', (e) => {
@@ -1190,6 +1206,15 @@ export interface IntentExecContext {
      *  `adjacent-allies` buff target. Engine-populated per side. Absent / undefined → the
      *  recipient resolver falls back to ctx.playerIds (all same-side allies). */
     adjacentAllyIdsFor?: (ownerId: string) => string[];
+    /** Ship-kit W5 Task C3 (Demolisher bomb-splash): OPPOSING-side ids adjacent to `anchorId` on
+     *  the board (living, anchor excluded), feeding the `adjacent-enemies` reactive-damage
+     *  target. Distinct from `adjacentAllyIdsFor` (which is bound to the DRAIN side, i.e. the
+     *  owner's OWN side — correct for an 'adjacent-allies' buff, but wrong here: the anchor is
+     *  the bombed enemy, on the side OPPOSITE the owner). Engine-populated per drain side as the
+     *  OPPOSING side's `adjacentAllyIdsFor` (mirrors `livingOpposingActorIds`'s same-direction
+     *  wiring). Absent / no anchor → the executor treats the fan-out as empty (never falls back
+     *  to the dummy sink). */
+    adjacentOpposingIdsFor?: (anchorId: string) => string[];
     /** Living ally ids on the owner's ACTIVE support pattern footprint (reactives). Absent when
      *  non-positional or the owner has no support pattern → legacy team-wide routing. */
     footprintAllyIdsFor?: (ownerId: string) => string[] | undefined;
@@ -1216,7 +1241,13 @@ export interface IntentExecContext {
      *  never mutated a specific victim's HP (was credit-only pre-fix). Absent → the damage
      *  branch is inert (unit fixtures / DPS mode w/o delegate). `allowDeadOwner` (PR-B1,
      *  Paracelsus) lets an on-destroyed retaliation fire even though its owner is already
-     *  stamped destroyedRound — the reaction is BORN of that same death. */
+     *  stamped destroyedRound — the reaction is BORN of that same death. Ship-kit W5 Task C3
+     *  (Demolisher bomb-splash) adds `opts`: `flatBasis` (present) computes `raw` as a straight
+     *  `flatBasis × multiplier/100` copy — no owner-attack basis, no defense mitigation, no crit
+     *  roll (deliberately no affinity re-application either — see engine.ts's applyReactiveDamage
+     *  doc for the full rationale). `ignoresDefense` (without `flatBasis`) is the non-flat
+     *  generality path: the normal attack-basis/crit walk runs, but the victim's Defense term is
+     *  bypassed (defence: 0). Both undefined (every pre-C3 caller) → byte-identical to before. */
     applyReactiveDamage?: (
         ownerId: string,
         victimId: string,
@@ -1225,7 +1256,8 @@ export interface IntentExecContext {
         hits: number,
         noCrit: boolean,
         hpBasisPct?: number,
-        allowDeadOwner?: boolean
+        allowDeadOwner?: boolean,
+        opts?: { ignoresDefense?: boolean; flatBasis?: number }
         // Returns the mitigated/credited amount + crit flag so the caller can surface the proc in
         // the combat log (reactive-damage-performed); void/0 when the proc was guarded (dead
         // victim, non-positive) or the delegate is absent (unit fixtures).
@@ -3076,6 +3108,20 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
             // ability's per-victim enemy conditions (hp-threshold <50% / enemy-debuff Inferno). The
             // once-per-round gate above already fired ONCE for the whole proc (all victims share it).
             victimIds = resolveAoEReactiveDamageVictims(intent, ctx);
+        } else if (tgt === 'adjacent-enemies') {
+            // Ship-kit W5 Task C3 (Demolisher bomb-splash): anchor on the BOMB VICTIM
+            // (eventCtx.victimId, stamped by the on-bomb-detonated listener above) rather than
+            // ctx.enemy/counterTargetId — the splash must land on the bombed enemy's own
+            // adjacent enemies, not "an enemy of the owner". `ctx.adjacentOpposingIdsFor` (NOT
+            // `adjacentAllyIdsFor`, which is bound to the OWNER's own drain side — wrong
+            // direction here: the anchor is on the side OPPOSITE the owner) resolves the
+            // anchor's OWN-side neighbours within the OPPOSING roster — team-symmetric (a player
+            // owner reads the enemy roster and vice versa) and excludes the anchor itself. No
+            // anchor (a damage-type ability reached via some OTHER trigger, or a fixture that
+            // never stamped victimId) → empty, never falls back to the dummy sink.
+            const anchorId = intent.eventCtx?.victimId;
+            victimIds =
+                anchorId !== undefined ? (ctx.adjacentOpposingIdsFor?.(anchorId) ?? []) : [];
         } else {
             victimIds = [intent.eventCtx?.counterTargetId ?? ctx.enemy.id];
         }
@@ -3087,7 +3133,19 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                 intent.ability.id,
                 cfg.multiplier,
                 cfg.hits ?? 1,
-                cfg.noCrit ?? false
+                cfg.noCrit ?? false,
+                undefined, // hpBasisPct — inert on this path (the hpBasisPct branch above returns early)
+                false, // allowDeadOwner
+                // Ship-kit W5 Task C3: flatBasis/ignoresDefense are ONLY ever non-inert for
+                // Demolisher's splash (the sole ability carrying cfg.ignoresDefense===true AND
+                // reachable via a trigger — on-bomb-detonated — that stamps eventCtx.triggerDamage;
+                // every other reactive `damage` ability either has cfg.ignoresDefense undefined
+                // OR fires from a trigger that never stamps triggerDamage, so this object is a
+                // no-op passenger for them — byte-identical to the pre-C3 call with no 9th arg).
+                {
+                    ignoresDefense: cfg.ignoresDefense === true,
+                    flatBasis: intent.eventCtx?.triggerDamage,
+                }
             );
             emitReactiveDamageLog(ctx, intent.ownerId, victimId, outcome);
         }

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -3133,6 +3133,18 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
         } else {
             victimIds = [intent.eventCtx?.counterTargetId ?? ctx.enemy.id];
         }
+        // Wave 5 hardening: flatBasis (the flat bomb-damage basis) must apply ONLY to the
+        // bomb-splash — gate it on the actual trigger, not merely on eventCtx.triggerDamage
+        // being present. triggerDamage is also stamped by on-crit/on-attacked listeners for
+        // OTHER mechanics (basis:'damage-dealt'/'damage-taken' reactive heals/shields), so an
+        // adjacent-enemies damage ability reached via one of those triggers would otherwise
+        // silently pick up a flat-copy basis it was never meant to have. Byte-identical today —
+        // Demolisher's splash is the only adjacent-enemies damage ability and it fires from
+        // on-bomb-detonated.
+        const flatBasis =
+            intent.ability.trigger === 'on-bomb-detonated'
+                ? intent.eventCtx?.triggerDamage
+                : undefined;
         for (const victimId of victimIds) {
             if (victimId === undefined) continue;
             const outcome = ctx.applyReactiveDamage?.(
@@ -3152,7 +3164,7 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                 // no-op passenger for them — byte-identical to the pre-C3 call with no 9th arg).
                 {
                     ignoresDefense: cfg.ignoresDefense === true,
-                    flatBasis: intent.eventCtx?.triggerDamage,
+                    flatBasis,
                 }
             );
             emitReactiveDamageLog(ctx, intent.ownerId, victimId, outcome);

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -635,7 +635,15 @@ export function registerReactiveListeners(args: {
                     // attack. Both fields are existing eventCtx channels (on-attacked already
                     // stamps them for the counter-routing / damage-taken-basis consumers) — this
                     // listener is just a second writer, gated by its own distinct event type.
-                    bus.on('bomb-detonated', (e) =>
+                    bus.on('bomb-detonated', (e) => {
+                        // Only react to a bomb that exploded on an ENEMY (opposing this owner) —
+                        // the corpus clauses are "When a Bomb explodes on an enemy…". Without
+                        // this, an own-side bomb burst (e.g. an enemy's Bomb on a player ally)
+                        // would fire the splash and mis-resolve the anchor against the wrong
+                        // roster (adjacentOpposingIdsFor falls back to the FULL opposing roster
+                        // when the anchor isn't found there). Mirrors the isOpposing guard every
+                        // sibling on-enemy-* case above uses.
+                        if (!isOpposing(e.victimId)) return;
                         enqueue({
                             ...intent,
                             eventCtx: {
@@ -643,8 +651,8 @@ export function registerReactiveListeners(args: {
                                 victimId: e.victimId,
                                 triggerDamage: e.damage,
                             },
-                        })
-                    );
+                        });
+                    });
                     break;
                 case 'on-stasis-applied':
                     bus.on('control-applied', (e) => {

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -4557,10 +4557,20 @@ export interface SkillEffect {
     // Player-side granularity (team-walk ally-scope): 'self' = caster only, 'ally' = a single
     // chosen ally, 'all-allies' = every player actor. 'enemy' = single-target enemy debuff,
     // 'all-enemies' = enemy debuff scoped to the whole opposing team (detectEnemyGrantScope).
+    // 'adjacent-enemies' / 'target-and-adjacent-enemies' = enemy debuff scoped to the anchor's
+    // neighbours (excluded/included respectively) — see detectAdjacentEnemyScope. Engine fan-out
+    // for these two is a later task; this file only resolves the scope.
     // The combat engine routes 'ally'/'all-allies' grants from a walked team ship onto the right
     // actors, and fans an 'all-enemies' debuff over aoeVictimIds generically; for the attacker's
     // own sim 'self' and 'all-allies' both fold onto its side (zero churn).
-    target: 'self' | 'ally' | 'all-allies' | 'enemy' | 'all-enemies';
+    target:
+        | 'self'
+        | 'ally'
+        | 'all-allies'
+        | 'enemy'
+        | 'all-enemies'
+        | 'adjacent-enemies'
+        | 'target-and-adjacent-enemies';
     duration: number | 'recurring' | null;
     stacks?: number;
     source: SkillSource;
@@ -4998,6 +5008,43 @@ function detectGrantScope(skillText: string, buffName: string): 'self' | 'ally' 
     return 'self';
 }
 
+// "all enemies adjacent to X" must NOT match the plain all-enemies widen. Two flavours:
+//  - "the targeted enemy and all enemies adjacent to it/the enemy" → anchor INCLUDED
+//  - "(to) all enemies adjacent to the (original) target"           → anchor EXCLUDED
+// Tolerates the docs/ship-skills.csv "adjavent" typo. (Demolisher's bare "all adjavent
+// enemies" — no "target" word — is added by a later task; do not add it here.)
+const TARGET_AND_ADJACENT_ENEMY_RE =
+    /targeted\s+enemy\s+and\s+all\s+enem(?:y|ies)\s+adja[cv]ent\s+to\s+(?:it|the\s+enemy)/i;
+const ADJACENT_ENEMY_ONLY_RE =
+    /all\s+enem(?:y|ies)\s+adja[cv]ent\s+to\s+(?:the\s+)?(?:original\s+)?target/i;
+
+/**
+ * Detects whether a resolved (sentence/sub-clause scoped) buff clause carries one of the two
+ * enemy-adjacency phrasings, returning the matching `AbilityTarget` scope or null when neither
+ * applies. Exported so later tasks (DoT adjacency, engine fan-out) can reuse the same detection.
+ */
+export function detectAdjacentEnemyScope(
+    clause: string
+): 'adjacent-enemies' | 'target-and-adjacent-enemies' | null {
+    if (TARGET_AND_ADJACENT_ENEMY_RE.test(clause)) return 'target-and-adjacent-enemies';
+    if (ADJACENT_ENEMY_ONLY_RE.test(clause)) return 'adjacent-enemies';
+    return null;
+}
+
+// Within an already sentence-scoped clause, isolate the sub-clause that OWNS `buffName` by
+// splitting on the "then" connector (Asphyxiator joins Defense Down III + Inferno III with
+// "then" in one sentence, so Defense Down III's clause would otherwise wrongly see the Inferno
+// adjacency phrase). Returns the sub-clause containing the buff name, or the whole clause if not
+// split (or if the buff name isn't found in any part — defensive fallback). Used only for
+// adjacency/scope detection; deliberately does NOT touch `resolveBuffClause` itself, which is
+// corpus-wide and used by many other detectors.
+function narrowToBuffSubClause(clause: string, buffName: string): string {
+    const parts = clause.split(/\bthen\b/i);
+    const maskedName = maskAbbrev(buffName).toLowerCase();
+    const owning = parts.find((p) => findBuffNamePos(maskAbbrev(p).toLowerCase(), maskedName) >= 0);
+    return owning ?? clause;
+}
+
 /**
  * Resolves the enemy-side scope of an inflicted/applied debuff from its granting clause, mirroring
  * `detectGrantScope`'s clause resolution (`resolveBuffClause`, so "Inc."/"Out." abbreviation
@@ -5005,10 +5052,34 @@ function detectGrantScope(skillText: string, buffName: string): 'self' | 'ally' 
  * ally one. Same broad, sentence-level phrasing check `parsePurge` uses for its own 'enemy' vs
  * 'all-enemies' split (`/all\s+enemies/`) — most debuffs are single-target ('enemy'); only an
  * explicit "on all enemies" grant widens to the whole opposing team.
+ *
+ * Enemy-adjacency phrasing ("all enemies adjacent to X") is checked FIRST, on the buff's own
+ * sub-clause (narrowToBuffSubClause) rather than the whole sentence, so it both (a) doesn't get
+ * mistaken for the plain all-enemies widen and (b) doesn't leak across a "then"-joined sibling
+ * clause in the same sentence (Asphyxiator: Defense Down III + Inferno III adjacency).
+ *
+ * The plain all-enemies fallback deliberately runs on the UNNARROWED `resolved` sentence (minus
+ * any adjacency phrasing, stripped below) rather than the narrowed sub-clause: Curator's charge
+ * ("deals 125% damage to all enemies, then inflicts ... Crit Rate Down III") is a genuine
+ * corpus idiom where a "then"-joined debuff inherits the ANTECEDENT clause's "all enemies"
+ * receiver — narrowing to the debuff's own sub-clause would wrongly lose that and collapse it to
+ * 'enemy'. Only the literal adjacency phrasing (already positively identified by
+ * detectAdjacentEnemyScope's regexes) is stripped first, so a sibling "then"-joined ADJACENCY
+ * clause (Asphyxiator: Defense Down III + Inferno III) still can't fool the plain /all\s+enemies/
+ * substring test into widening a clause that was never enemy-adjacent.
  */
-function detectEnemyGrantScope(skillText: string, buffName: string): 'enemy' | 'all-enemies' {
+export function detectEnemyGrantScope(
+    skillText: string,
+    buffName: string
+): 'enemy' | 'all-enemies' | 'adjacent-enemies' | 'target-and-adjacent-enemies' {
     const resolved = resolveBuffClause(skillText, buffName).toLowerCase();
-    return /all\s+enemies/.test(resolved) ? 'all-enemies' : 'enemy';
+    const scoped = narrowToBuffSubClause(resolved, buffName);
+    const adjacent = detectAdjacentEnemyScope(scoped);
+    if (adjacent) return adjacent;
+    const withoutAdjacencyPhrasing = resolved
+        .replace(TARGET_AND_ADJACENT_ENEMY_RE, '')
+        .replace(ADJACENT_ENEMY_ONLY_RE, '');
+    return /all\s+enemies/.test(withoutAdjacencyPhrasing) ? 'all-enemies' : 'enemy';
 }
 
 /**

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -5046,6 +5046,20 @@ function narrowToBuffSubClause(clause: string, buffName: string): string {
 }
 
 /**
+ * Resolve the enemy-adjacency scope for a named effect (DoT type name, buff name, control
+ * effect) using the same clause resolution the debuff-scope path uses: sentence-scope via
+ * resolveBuffClause, then narrow to the name's "then"-sub-clause, then adjacency-match.
+ * Returns null when the effect's clause carries no enemy-adjacency phrasing.
+ */
+export function adjacentEnemyScopeForName(
+    skillText: string,
+    name: string
+): 'adjacent-enemies' | 'target-and-adjacent-enemies' | null {
+    const resolved = resolveBuffClause(skillText, name).toLowerCase();
+    return detectAdjacentEnemyScope(narrowToBuffSubClause(resolved, name));
+}
+
+/**
  * Resolves the enemy-side scope of an inflicted/applied debuff from its granting clause, mirroring
  * `detectGrantScope`'s clause resolution (`resolveBuffClause`, so "Inc."/"Out." abbreviation
  * periods don't break sentence splitting) but testing for an "all enemies" receiver instead of an

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -2852,8 +2852,12 @@ export function parseAccumulateDetonate(
 // "<subject> cannot critically hit" — the no-crit attaches to whatever noun precedes it.
 // We flag the ATTACK as no-crit unless that subject is a repair/heal (e.g. Pallas's "this
 // repair cannot critically hit", which sits after an unrelated "the damage dealt").
-// Tolerates the "cannont" misspelling in the source data (Provider).
-const NO_CRIT_RE = /(\w+)\s+(?:cannot|cannont)\s+critically\s+hit\b/gi;
+// Tolerates the "cannont" misspelling in the source data (Provider). Ship-kit W5 (Demolisher
+// passive): "cannot result in a critical hit" is an alternate phrasing of the same no-crit
+// clause ("This damage ... cannot result in a critical hit"), added alongside the original
+// "critically hit" form.
+const NO_CRIT_RE =
+    /(\w+)\s+(?:cannot|cannont)\s+(?:critically\s+hit|result\s+in\s+a\s+critical\s+hit)\b/gi;
 const NO_CRIT_HEAL_SUBJECTS = new Set(['repair', 'repairs', 'heal', 'heals']);
 
 /** Whether a skill's attack/damage cannot critically hit. Reference data: docs/ship-skills.csv. */
@@ -2863,6 +2867,16 @@ export function parseNoCrit(text: string | null | undefined): boolean {
         if (!NO_CRIT_HEAL_SUBJECTS.has(m[1].toLowerCase())) return true;
     }
     return false;
+}
+
+// Ship-kit W5 (Demolisher bomb-splash): "This damage ignores Defense ..." — the splash damage
+// bypasses the target's Defense mitigation term entirely. Boolean only; the flag rides the
+// damage config (ignoresDefense) and is consumed by the REACTIVE damage executor (Task C3).
+const IGNORES_DEFENSE_RE = /ignores?\s+defense/i;
+/** Whether a skill's damage clause ignores the target's Defense (Demolisher bomb-splash).
+ *  Reference data: docs/ship-skills.csv. */
+export function parseIgnoresDefense(text: string | null | undefined): boolean {
+    return !!text && IGNORES_DEFENSE_RE.test(stripUnitTags(text));
 }
 
 // SP-F F4 (Wusheng): "deals 220% damage WITH AFFINITY ADVANTAGE …" — the charged hit is forced
@@ -5011,12 +5025,14 @@ function detectGrantScope(skillText: string, buffName: string): 'self' | 'ally' 
 // "all enemies adjacent to X" must NOT match the plain all-enemies widen. Two flavours:
 //  - "the targeted enemy and all enemies adjacent to it/the enemy" → anchor INCLUDED
 //  - "(to) all enemies adjacent to the (original) target"           → anchor EXCLUDED
-// Tolerates the docs/ship-skills.csv "adjavent" typo. (Demolisher's bare "all adjavent
-// enemies" — no "target" word — is added by a later task; do not add it here.)
+//  - "all adjacent enemies" (bare, no "target"/"to" — Demolisher's passive bomb-splash:
+//    "deals 100% of the Bomb's damage to all adjavent enemies") → anchor EXCLUDED, same
+//    scope as the "to ... target" flavour above.
+// Tolerates the docs/ship-skills.csv "adjavent" typo.
 const TARGET_AND_ADJACENT_ENEMY_RE =
     /targeted\s+enemy\s+and\s+all\s+enem(?:y|ies)\s+adja[cv]ent\s+to\s+(?:it|the\s+enemy)/i;
 const ADJACENT_ENEMY_ONLY_RE =
-    /all\s+enem(?:y|ies)\s+adja[cv]ent\s+to\s+(?:the\s+)?(?:original\s+)?target/i;
+    /all\s+enem(?:y|ies)\s+adja[cv]ent\s+to\s+(?:the\s+)?(?:original\s+)?target|all\s+adja[cv]ent\s+enem(?:y|ies)/i;
 
 /**
  * Detects whether a resolved (sentence/sub-clause scoped) buff clause carries one of the two
@@ -5057,6 +5073,23 @@ export function adjacentEnemyScopeForName(
 ): 'adjacent-enemies' | 'target-and-adjacent-enemies' | null {
     const resolved = resolveBuffClause(skillText, name).toLowerCase();
     return detectAdjacentEnemyScope(narrowToBuffSubClause(resolved, name));
+}
+
+/**
+ * Position-scoped enemy-adjacency resolver for a NAMELESS damage clause (a base-damage ability
+ * has no buff name to anchor on, unlike adjacentEnemyScopeForName). Mirrors phrasePosTrigger's
+ * raw-text sentence scoping (rawSentenceAround) so `anchorPos` — a position into the raw `text`,
+ * same basis as the trigger detectors' `damagePos` — maps to the sentence actually carrying the
+ * damage clause, and an unrelated adjacency phrase elsewhere in the text can't leak in.
+ * Ship-kit W5 (Demolisher passive): "... deals 100% of the Bomb's damage to all adjavent
+ * enemies" resolves to 'adjacent-enemies'.
+ */
+export function adjacentEnemyScopeAtPos(
+    text: string,
+    anchorPos: number
+): 'adjacent-enemies' | 'target-and-adjacent-enemies' | null {
+    const sentence = rawSentenceAround(text, anchorPos);
+    return sentence === undefined ? null : detectAdjacentEnemyScope(sentence);
 }
 
 /**


### PR DESCRIPTION
## Wave 5 — Enemy-adjacency splash (`adjacent-enemies`)

Fifth wave of the ship-kit correctness backlog (`docs/ship-kit-fix-plan.md`). Adds two new `AbilityTarget` scopes so splash clauses hit the primary target's adjacent enemies instead of collapsing to a single target, plus a new `ignoresDefense` damage flag for Demolisher's bomb-splash.

Spec: `docs/superpowers/specs/2026-07-18-ship-kit-wave5.md` · Plan: `docs/superpowers/plans/2026-07-18-ship-kit-wave5.md`

### New model primitives
- **`adjacent-enemies`** (anchor excluded) and **`target-and-adjacent-enemies`** (anchor + neighbours) `AbilityTarget` values. Recipient resolution reuses the side-dispatching `adjacentAllyIdsFor` (anchored on the enemy target), so it is team-symmetric for free.
- **`ignoresDefense`** flag on the damage config + reactive-executor support.
- **`victimId`** on the `bomb-detonated` event (so reactive splash can anchor on the bombed enemy).

### Findings closed
- **Vindicator** — active Provoke + charged Out. Damage Down I now hit the enemies adjacent to the target (target excluded), instead of being misapplied as a self-buff.
- **Asphyxiator** — charged Stasis hits the target + its adjacent enemies; active Inferno III DoT splashes to the target + neighbours.
- **Demolisher** — passive bomb-splash now modeled: on bomb detonation, deals 100% of the bomb's damage to enemies adjacent to the bombed enemy, ignoring Defense and never critting (previously dropped entirely).
- **Sibling over-widen bug** — Asphyxiator Defense Down III / Vindicator Corrosion II no longer wrongly widen to all-enemies (the `/all enemies/` check was matching "all enemies adjacent to X").
- **Bonus:** Meiying's passive Stasis ("on all adjacent enemies") correctly reclassified to `adjacent-enemies`.

### Correctness guarantees
- **DPS output unchanged** — in the single-dummy DPS scenario, adjacent-enemies resolves to nobody and target-and-adjacent to just the dummy (= today's `enemy`). All fidelity gain is in the positional sim.
- **Team-symmetric** — every fan-out (debuff/control, DoT, reactive bomb-splash) routes through a side-dispatching resolver.
- **Per-victim landing** — the DoT splash rolls landing per neighbour (mirrors PR #185), not off the primary's roll.
- **Parser surgical** — `resolveBuffClause` untouched; only Asphyxiator/Vindicator/Demolisher/Meiying change target corpus-wide.

### Testing
Built subagent-driven with per-task spec+quality reviews and a final whole-branch review (READY TO MERGE, no Critical/Important). Build-level parser tests + positional-sim integration tests per ship (real board adjacency — non-neighbour enemies excluded), DPS-invariance assertions, and team-symmetry both sides. Full suite: 4693 green, tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)