### PR TITLE
fix: ship-kit correctness Wave 7 — engine WRONG-EXEC (Warden + Lingshe; Demolisher was a false positive)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -6,6 +6,8 @@ export const CURRENT_VERSION = '1.64.0';
 // CHANGELOG (with the new version + today's date), clear this array back to [],
 // and bump CURRENT_VERSION. All three steps must happen together.
 export const UNRELEASED_CHANGES: string[] = [
+    'Combat sim: Lingshe now gains Stealth only when she herself detonates a Bomb (her charged skill), instead of gaining it from any Bomb bursting anywhere in the battle — including bombs that simply expire on their own or that another ship detonates.',
+    'Combat sim: Warden now inflicts Out. Damage Down II when it inflicts a debuff (via its active Provoke or charged Corrosion II), matching its passive — previously this follow-up debuff never applied at all.',
     "Combat sim: enemy-adjacency splash is now modeled. Vindicator's Provoke and charged Out. Damage Down I hit the enemies adjacent to the target (the target excluded), and Asphyxiator's Stasis hits the target and its adjacent enemies — instead of being misapplied as a self-buff on the caster. Meiying's Stasis now also correctly hits all adjacent enemies.",
     "Combat sim: Asphyxiator's active skill now inflicts Inferno III on the targeted enemy AND its board neighbours, matching her skill text — previously the Inferno DoT only ever landed on the primary target.",
     "Combat sim: Demolisher's passive splash is now modeled — when a Bomb explodes on an enemy, Demolisher deals 100% of the Bomb's damage to all enemies adjacent to it. This splash ignores Defense and cannot critically hit, matching the skill text; previously it was dropped entirely.",

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -127,7 +127,14 @@ export type AbilityTrigger =
     | 'on-ally-critically-repaired'
     | 'on-ally-crit'
     | 'on-stasis-applied'
+    // VICTIM-scoped: a Bomb bursts on an opposing actor, regardless of who caused it
+    // ("When a Bomb explodes on an enemy …" — Demolisher's splash/charge-removal, Valkyrie).
     | 'on-bomb-detonated'
+    // DETONATOR-scoped: THIS unit actively causes a Bomb to detonate ("When this Unit
+    // detonates a Bomb …" — Lingshe's Stealth grant). Filtered on the bomb-detonated event's
+    // `detonatorId` (the actor whose skill forced/triggered the burst), NOT `actorId` (the
+    // bomb's original applier). Natural countdown expiry has no detonator → never fires this.
+    | 'on-self-bomb-detonated'
     | 'on-attacked'
     | 'on-ally-attacked'
     | 'on-ally-destroyed'
@@ -269,6 +276,8 @@ export const LIVE_TRIGGERS = new Set<AbilityTrigger>([
     'on-ally-crit',
     'on-stasis-applied',
     'on-bomb-detonated',
+    // Ship-kit W7 (Lingshe): DETONATOR-scoped bomb-detonation reaction (see AbilityTrigger).
+    'on-self-bomb-detonated',
     'on-attacked',
     'on-ally-attacked',
     'on-destroyed',

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -1880,10 +1880,13 @@ describe('detectReactiveTrigger', () => {
         expect(detectReactiveTrigger(text, 'Speed Up II')).toBe('start-of-round');
     });
 
-    it('classifies a bomb-detonate self-buff as on-bomb-detonated — Lingshe', () => {
+    // Ship-kit W7: "this Unit DETONATES a Bomb" is DETONATOR-scoped → on-self-bomb-detonated
+    // (fires only when Lingshe herself causes the burst), split OUT of the VICTIM-scoped
+    // on-bomb-detonated ("a Bomb explodes on an enemy" — Demolisher/Valkyrie).
+    it('classifies a bomb-detonate self-buff as on-self-bomb-detonated — Lingshe', () => {
         const text =
             'When this Unit detonates a <unit-skill>Bomb</unit-skill> it gains <unit-skill>Stealth</unit-skill> for 1 turn.';
-        expect(detectReactiveTrigger(text, 'Stealth')).toBe('on-bomb-detonated');
+        expect(detectReactiveTrigger(text, 'Stealth')).toBe('on-self-bomb-detonated');
     });
 
     it('does NOT classify passive-voice "is critically damaged" as on-crit', () => {

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -1225,14 +1225,15 @@ describe('buildShipAbilities', () => {
             expect(buff.config).toMatchObject({ type: 'buff', duration: 1 });
         });
 
-        it('Lingshe passive buff: on-bomb-detonated', () => {
+        // Ship-kit W7: "this Unit detonates a Bomb" is DETONATOR-scoped → on-self-bomb-detonated.
+        it('Lingshe passive buff: on-self-bomb-detonated', () => {
             const s = ship({
                 firstPassiveSkillText:
                     'When this Unit detonates a <unit-skill>Bomb</unit-skill> it gains <unit-skill>Stealth</unit-skill> for 1 turn.',
             });
             const passive = slot(buildShipAbilities(s).slots, 'passive')!;
             const buff = namedBuff(passive.abilities, 'Stealth')!;
-            expect(buff.trigger).toBe('on-bomb-detonated');
+            expect(buff.trigger).toBe('on-self-bomb-detonated');
         });
     });
 

--- a/src/utils/abilities/__tests__/reactiveTriggerPromotionTriage.test.ts
+++ b/src/utils/abilities/__tests__/reactiveTriggerPromotionTriage.test.ts
@@ -285,10 +285,14 @@ describe('cluster 6 — on-bomb-detonated', () => {
 
     const LINGSHE_P3 =
         'When this Unit detonates a <unit-skill>Bomb</unit-skill> it gains <unit-skill>Stealth</unit-skill> for 1 turn.';
-    it('Lingshe: Stealth on own-detonation already rides on-bomb-detonated (FP lock)', () => {
+    // Ship-kit W7: the earlier triage FP-lock ("already rides on-bomb-detonated") was itself the
+    // bug — Lingshe's "when this Unit DETONATES a Bomb" is DETONATOR-scoped and now rides the
+    // dedicated on-self-bomb-detonated trigger, so a bomb bursting on an enemy from ANY source no
+    // longer wrongly grants her Stealth (only bursts SHE causes do).
+    it('Lingshe: Stealth on own-detonation rides on-self-bomb-detonated (W7 — detonator-scoped)', () => {
         const ab = abilitiesFor({ firstPassiveSkillText: LINGSHE_P3 }, 'passive');
         const buff = ab.find((a) => a.type === 'buff');
-        expect(buff?.trigger).toBe('on-bomb-detonated');
+        expect(buff?.trigger).toBe('on-self-bomb-detonated');
     });
 });
 

--- a/src/utils/abilities/__tests__/wave7Parse.test.ts
+++ b/src/utils/abilities/__tests__/wave7Parse.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Ship-kit Wave 7 — parser trigger classification (production path via buildShipAbilities).
+ *
+ * Two distinct bomb-detonation semantics previously collapsed onto ONE trigger
+ * (`on-bomb-detonated`):
+ *   - Demolisher / Valkyrie: "When a Bomb explodes on an enemy …" — VICTIM-scoped, fires on any
+ *     bomb bursting on the opposing side.  → stays `on-bomb-detonated`.
+ *   - Lingshe: "When this Unit detonates a Bomb …" — DETONATOR-scoped, fires only when THIS unit
+ *     actively causes a detonation.  → new `on-self-bomb-detonated`.
+ *
+ * Separately, Warden's "when this Unit inflicts a Debuff, it inflicts Out. Damage Down II" was
+ * mis-parsed as `on-cast` (the existing recognizer only matched the gerund "inflicting/applying",
+ * not the present-tense "inflicts"), landing it in a passive-slot enemy-timed path that the engine
+ * never dispatches. It must route to the existing reactive `on-debuff-inflicted` trigger.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { detectReactiveTrigger } from '../../skillTextParser';
+import type { Ship } from '../../../types/ship';
+
+// Verbatim from docs/ship-skills.csv.
+const WARDEN_PASSIVE_R2 =
+    'When directly damaged, this Unit inflicts <unit-skill>Corrosion I</unit-skill> for 2 turns on that enemy and repairs itself 3% of its Max HP.<br /><br />Additionally, when this Unit inflicts a <unit-skill>Debuff</unit-skill>, it inflicts <unit-skill>Out. Damage Down II</unit-skill> for 1 turn.';
+const LINGSHE_PASSIVE_R4 =
+    'When this Unit detonates a <unit-skill>Bomb</unit-skill> it gains <unit-skill>Stealth</unit-skill> for 2 turn.<br /><br />\n\nThis Unit deals 1% more detonation damage per 10% crit power it has.';
+const DEMOLISHER_PASSIVE_R2 =
+    "When a Bomb explodes on an enemy, this Unit <unit-aid>removes 2 charges</unit-aid> from the enemy's Charged Skill and deals <unit-damage>100% of the Bomb's damage</unit-damage> to all adjavent enemies. This damage ignores Defense and cannot result in a critical hit.";
+
+const shipWith = (over: Partial<Ship>): Ship =>
+    ({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}], // R4 — the highest passive applies
+        ...over,
+    }) as Ship;
+
+const wardenShip = (): Ship =>
+    shipWith({
+        activeSkillText:
+            'This Unit deals <unit-damage>165% damage</unit-damage> and applies <unit-skill>Provoke</unit-skill> for 1 turn.',
+        secondPassiveSkillText: WARDEN_PASSIVE_R2,
+    });
+
+const lingsheShip = (): Ship =>
+    shipWith({
+        activeSkillText:
+            'This Unit inflicts 3 stacks of <unit-skill>Bomb I</unit-skill> for 4 turns.',
+        thirdPassiveSkillText: LINGSHE_PASSIVE_R4,
+    });
+
+const demolisherShip = (): Ship =>
+    shipWith({
+        activeSkillText:
+            'This Unit deals <unit-damage>170% damage</unit-damage> and inflicts <unit-skill>Bomb III</unit-skill> for 2 turns.',
+        secondPassiveSkillText: DEMOLISHER_PASSIVE_R2,
+    });
+
+const passiveAbilities = (ship: Ship) =>
+    buildShipAbilities(ship).slots.find((s) => s.slot === 'passive')?.abilities ?? [];
+
+describe('Wave 7 parser — bomb-detonation trigger split', () => {
+    it("Lingshe's Stealth self-buff rides the DETONATOR-scoped on-self-bomb-detonated trigger", () => {
+        const stealth = passiveAbilities(lingsheShip()).find(
+            (a) => a.type === 'buff' && a.config.type === 'buff' && a.config.buffName === 'Stealth'
+        );
+        expect(stealth).toBeDefined();
+        expect(stealth!.trigger).toBe('on-self-bomb-detonated');
+    });
+
+    it("Demolisher's splash damage stays VICTIM-scoped on on-bomb-detonated (regression)", () => {
+        const splash = passiveAbilities(demolisherShip()).find((a) => a.type === 'damage');
+        expect(splash).toBeDefined();
+        expect(splash!.trigger).toBe('on-bomb-detonated');
+    });
+
+    it("Demolisher's charge-removal stays VICTIM-scoped on on-bomb-detonated (regression)", () => {
+        const charge = passiveAbilities(demolisherShip()).find((a) => a.type === 'charge');
+        expect(charge).toBeDefined();
+        expect(charge!.trigger).toBe('on-bomb-detonated');
+    });
+
+    it('detectReactiveTrigger: "detonates a Bomb" → on-self-bomb-detonated', () => {
+        expect(
+            detectReactiveTrigger(
+                'When this Unit detonates a Bomb it gains Stealth for 2 turn.',
+                'Stealth'
+            )
+        ).toBe('on-self-bomb-detonated');
+    });
+
+    it('detectReactiveTrigger: "bomb explodes on an enemy" → on-bomb-detonated', () => {
+        expect(
+            detectReactiveTrigger(
+                'When a Bomb explodes on an enemy, this Unit gains Stealth for 2 turns.',
+                'Stealth'
+            )
+        ).toBe('on-bomb-detonated');
+    });
+});
+
+describe('Wave 7 parser — Warden self-inflicted-debuff reactive', () => {
+    it("Warden's Out. Damage Down II rides on-debuff-inflicted (not on-cast)", () => {
+        const debuff = passiveAbilities(wardenShip()).find(
+            (a) =>
+                a.type === 'debuff' &&
+                a.config.type === 'debuff' &&
+                a.config.buffName === 'Out. Damage Down II'
+        );
+        expect(debuff).toBeDefined();
+        expect(debuff!.trigger).toBe('on-debuff-inflicted');
+    });
+
+    it('detectReactiveTrigger: present-tense "when this Unit inflicts a Debuff" → on-debuff-inflicted', () => {
+        expect(
+            detectReactiveTrigger(
+                'When this Unit inflicts a Debuff, it inflicts Out. Damage Down II for 1 turn.',
+                'Out. Damage Down II'
+            )
+        ).toBe('on-debuff-inflicted');
+    });
+});

--- a/src/utils/combat/__tests__/triggers.test.ts
+++ b/src/utils/combat/__tests__/triggers.test.ts
@@ -766,25 +766,27 @@ describe('Phase 3 reactive triggers', () => {
     });
 
     // ----------------------------------------------------------------------
-    // Scenario 11 — generation cap: a self-amplifying on-debuff-inflicted timed
-    // enemy debuff (its own application emits debuff-applied, re-triggering it).
-    // The family rule absorbs the re-apply, but a landed-but-family-blocked
-    // application still emits ⇒ unbounded chain ⇒ throws MAX_INTENT_GENERATIONS.
+    // Scenario 11 — self-chain guard (Ship-kit W7): an on-debuff-inflicted DEBUFF whose own
+    // application would re-trigger itself (Warden's Out. Damage Down II shape). BEFORE W7 this
+    // was an unbounded chain that threw MAX_INTENT_GENERATIONS; the guard now brands the reaction's
+    // own debuff-applied (`viaDebuffInflictedReaction`) so the on-debuff-inflicted listener skips
+    // it — the chain is BOUNDED (Def Down applies from the cast-path Seed Down infliction, then
+    // does NOT feed itself). No throw. The generation-cap backstop still exists for genuinely
+    // pathological loops (see the separate 'exposes a finite MAX_INTENT_GENERATIONS backstop' test).
     // ----------------------------------------------------------------------
-    it('scenario 11: self-amplifying debuff trigger throws the generation cap error (no hang)', () => {
+    it('scenario 11: a self-amplifying on-debuff-inflicted debuff is now BOUNDED (W7 self-chain guard), no throw', () => {
         const loopSkills = (): ShipSkills => ({
             slots: [
                 {
                     slot: 'active',
                     abilities: [
                         ab({ type: 'damage', config: { type: 'damage', multiplier: 120 } }),
-                        // Seed: a normal on-cast timed debuff inflicts once per cast, emitting
-                        // debuff-applied (sourceId attacker) → kicks off the self-amplifying chain.
+                        // Seed: a normal on-cast timed debuff inflicts once per cast, emitting an
+                        // UNBRANDED debuff-applied (sourceId attacker) → feeds Def Down once.
                         timedEnemyDebuff('Seed Down'),
-                        // Self-amplifying: trigger:'on-debuff-inflicted' on a debuff whose own
-                        // application emits debuff-applied → re-triggers itself. The family rule
-                        // absorbs the re-apply (tier equal, not longer), but a landed-but-family-
-                        // blocked application STILL emits, so the chain never terminates.
+                        // trigger:'on-debuff-inflicted' whose own application emits debuff-applied.
+                        // Pre-W7 that re-triggered itself (unbounded); now the W7 guard brands its
+                        // own event so it cannot re-feed this listener → bounded.
                         ab({
                             type: 'debuff',
                             target: 'enemy',
@@ -803,16 +805,25 @@ describe('Phase 3 reactive triggers', () => {
                 },
             ],
         });
-        expect(() =>
-            runCombat(
-                baseInput({
-                    shipSkills: loopSkills(),
-                    hasChargedSkill: false,
-                    chargeCount: 0,
-                    numRounds: 3,
-                })
-            )
-        ).toThrow(/MAX_INTENT_GENERATIONS/);
+        const bus = createEventBus();
+        let defDown = 0;
+        bus.on('debuff-applied', (e) => {
+            if (e.type === 'debuff-applied' && e.buffName === 'Def Down') defDown++;
+        });
+        // Completing at all proves the generation cap is not hit.
+        const result = runCombat(
+            baseInput({
+                shipSkills: loopSkills(),
+                hasChargedSkill: false,
+                chargeCount: 0,
+                numRounds: 3,
+                bus,
+            })
+        );
+        expect(result.rounds).toHaveLength(3);
+        // Def Down applies once per active cast (fed by Seed Down), never self-amplifying.
+        expect(defDown).toBeGreaterThan(0);
+        expect(defDown).toBeLessThanOrEqual(3);
     });
 
     // ----------------------------------------------------------------------

--- a/src/utils/combat/__tests__/wave7LingsheStealthScope.integration.test.ts
+++ b/src/utils/combat/__tests__/wave7LingsheStealthScope.integration.test.ts
@@ -1,0 +1,267 @@
+/**
+ * wave7LingsheStealthScope.integration.test.ts — Ship-kit Wave 7 (Lingshe).
+ *
+ * Lingshe R4 passive: "When this Unit detonates a Bomb it gains Stealth for 2 turn." This shared
+ * the `on-bomb-detonated` trigger with Demolisher's VICTIM-scoped "when a Bomb explodes on an
+ * enemy", and the listener had NO detonator filter — so Lingshe gained Stealth from ANY bomb
+ * bursting on an enemy (a natural countdown-0 expiry, another ship's detonation, anything).
+ *
+ * The fix:
+ *   - parser: "detonates a bomb" → new DETONATOR-scoped `on-self-bomb-detonated` trigger.
+ *   - event: `bomb-detonated` carries `detonatorId` — the actor who ACTIVELY caused the burst
+ *     (the detonate()/countdown-reduce caster), UNDEFINED for a natural countdown-0 expiry.
+ *   - listener: on-self-bomb-detonated fires only when `detonatorId === ownerId`.
+ *
+ * So Lingshe gains Stealth ONLY when she herself forces a detonation — never from a bomb that
+ * merely expires (or that another ship detonates). Drives the REAL engine via runCombat, mirroring
+ * bombCountdownReduce.test.ts's regression harness (positioned victim, security 0 → unconditional
+ * landing, `__testTapActors` to seed pending bombs).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import { PendingBomb } from '../state';
+import type { Ability, ShipSkills } from '../../../types/abilities';
+import type { Ship } from '../../../types/ship';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+
+// Verbatim from docs/ship-skills.csv (Lingshe third_passive_skill_text — the R4 variant).
+const LINGSHE_PASSIVE_R4 =
+    'When this Unit detonates a <unit-skill>Bomb</unit-skill> it gains <unit-skill>Stealth</unit-skill> for 2 turn.<br /><br />\n\nThis Unit deals 1% more detonation damage per 10% crit power it has.';
+
+const lingsheShip = (): Ship =>
+    ({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}], // R4 — third passive applies
+        thirdPassiveSkillText: LINGSHE_PASSIVE_R4,
+    }) as Ship;
+
+// Lingshe's REAL production-parsed passive slot (the on-self-bomb-detonated Stealth grant).
+const lingshePassiveSlot = (): ShipSkills['slots'][number] => {
+    const passive = buildShipAbilities(lingsheShip()).slots.find((s) => s.slot === 'passive');
+    if (!passive) throw new Error('Lingshe passive slot missing');
+    return passive;
+};
+
+// A minimal bomb-countdown-reduce active (the forced-detonation driver). Slot is irrelevant to the
+// detonator identity — reduceEnemyBombs stamps detonatorId = the acting caster regardless of slot.
+const reduceActive = (): Ability => ({
+    id: 'lingshe-reduce',
+    type: 'bomb-countdown-reduce',
+    target: 'all-enemies',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'bomb-countdown-reduce', turns: 1 },
+});
+
+// A no-op active (0% damage) — used for the "natural expiry" case where Lingshe does NOTHING that
+// could detonate a bomb herself.
+const noopActive = (): Ability => ({
+    id: 'lingshe-noop',
+    type: 'damage',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'damage', multiplier: 0 },
+});
+
+const lingsheSkills = (active: Ability): ShipSkills => ({
+    slots: [{ slot: 'active', abilities: [active] }, lingshePassiveSlot()],
+});
+
+const parsedFrontTarget = (): ParsedTarget => ({ raw: 'front', side: 'enemy', selection: 'front' });
+const singleTargetPattern = (): ParsedPattern => ({
+    raw: 'base',
+    shape: 'base',
+    range: 0,
+    modifiers: {},
+});
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+const victimAt = (id: string, hp: number): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp, speed: 1, security: 0 },
+        chargeCount: 0,
+        startCharged: false,
+        position: 'M4',
+        shipSkills: { slots: [{ slot: 'active', abilities: [] }] },
+    }) as EnemyAttacker;
+
+const bomb = (countdown: number, sourceId: string): PendingBomb => ({
+    countdown,
+    damagePerStack: 1000,
+    stacks: 1,
+    tier: 100,
+    sourceId,
+    affinityMult: 1,
+    detonationDamageModifier: 0,
+    splashModifier: 0,
+});
+
+const BASE = (over: Partial<CombatEngineInput> = {}): CombatEngineInput => ({
+    attack: 100,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: lingsheSkills(noopActive()),
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 2,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    hacking: 200,
+    healTargetId: 'attacker',
+    position: 'M4',
+    target: parsedFrontTarget(),
+    pattern: singleTargetPattern(),
+    ...over,
+});
+
+const run = (input: CombatEngineInput) => {
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    bus.on('bomb-detonated', (e) => events.push(e as CombatEvent));
+    bus.on('buff-applied', (e) => events.push(e as CombatEvent));
+    const result = runCombat({ ...input, bus });
+    return { events, result };
+};
+
+const stealthGrants = (events: CombatEvent[], ownerId: string): number =>
+    events.filter(
+        (e) => e.type === 'buff-applied' && e.actorId === ownerId && e.buffName === 'Stealth'
+    ).length;
+
+describe('Lingshe Stealth-on-detonate — DETONATOR-scoped (Ship-kit W7)', () => {
+    it('does NOT gain Stealth from a bomb that naturally expires (nobody detonated it)', () => {
+        const { events } = run(
+            BASE({
+                shipSkills: lingsheSkills(noopActive()),
+                enemyAttackers: [victimAt('victim', 1_000_000)],
+                // A countdown-1 bomb applied by a DIFFERENT actor — it reaches 0 on the enemy's
+                // own turn and bursts via processBombs (natural expiry → detonatorId undefined).
+                __testTapActors: (actors) => {
+                    actors
+                        .find((a) => a.id === 'victim')
+                        ?.pendingBombs.push(bomb(1, 'other-applier'));
+                },
+            })
+        );
+        // The bomb DID detonate (natural expiry)...
+        const det = events.filter((e) => e.type === 'bomb-detonated');
+        expect(det.length).toBeGreaterThan(0);
+        // ...with NO detonator (natural expiry).
+        expect(det.every((e) => e.type === 'bomb-detonated' && e.detonatorId === undefined)).toBe(
+            true
+        );
+        // ...so Lingshe gains NO Stealth (the pre-fix global listener would have granted it).
+        expect(stealthGrants(events, 'attacker')).toBe(0);
+    });
+
+    it('gains Stealth when SHE forces a detonation (detonatorId = Lingshe)', () => {
+        const { events } = run(
+            BASE({
+                shipSkills: lingsheSkills(reduceActive()),
+                enemyAttackers: [victimAt('victim', 1_000_000)],
+                // A countdown-1 bomb applied by ANOTHER actor — Lingshe's reduce forces it to 0
+                // THIS cast (detonatorId = Lingshe even though she didn't apply it).
+                __testTapActors: (actors) => {
+                    actors
+                        .find((a) => a.id === 'victim')
+                        ?.pendingBombs.push(bomb(1, 'other-applier'));
+                },
+            })
+        );
+        const det = events.filter((e) => e.type === 'bomb-detonated');
+        expect(det.length).toBeGreaterThan(0);
+        // The burst is credited to the ORIGINAL applier (actorId) but the DETONATOR is Lingshe.
+        expect(det.some((e) => e.type === 'bomb-detonated' && e.actorId === 'other-applier')).toBe(
+            true
+        );
+        expect(det.every((e) => e.type === 'bomb-detonated' && e.detonatorId === 'attacker')).toBe(
+            true
+        );
+        // Lingshe gains Stealth from HER detonation.
+        expect(stealthGrants(events, 'attacker')).toBeGreaterThan(0);
+    });
+});
+
+describe('Lingshe Stealth-on-detonate — team symmetry (enemy-side Lingshe)', () => {
+    // An enemy-side Lingshe forcing a detonation on a PLAYER-side bomb must gain Stealth the same
+    // way — detonatorId is the acting caster regardless of side.
+    const enemyLingshe = (): EnemyAttacker => ({
+        id: 'lingshe-enemy',
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            speed: 200,
+            hp: 1_000_000,
+            defence: 0,
+            hacking: 200,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        position: 'M4',
+        shipSkills: lingsheSkills(reduceActive()),
+    });
+
+    it('an enemy-side Lingshe gains Stealth from HER own forced detonation on a player bomb', () => {
+        const bus = createEventBus();
+        const events: CombatEvent[] = [];
+        bus.on('bomb-detonated', (e) => events.push(e as CombatEvent));
+        bus.on('buff-applied', (e) => events.push(e as CombatEvent));
+        runCombat({
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [{ slot: 'active', abilities: [] }] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 2,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            defence: 0,
+            hp: 1_000_000_000,
+            security: 0, // player focus takes the forced burst without resisting the reduce
+            speed: 1,
+            healTargetId: 'attacker',
+            enemyAttackers: [enemyLingshe()],
+            __testTapActors: (actors) => {
+                // Seed a bomb on the PLAYER focus ('attacker') for the enemy Lingshe to detonate.
+                actors
+                    .find((a) => a.id === 'attacker')
+                    ?.pendingBombs.push(bomb(1, 'player-applier'));
+            },
+            bus,
+        });
+        const det = events.filter((e) => e.type === 'bomb-detonated');
+        expect(det.length).toBeGreaterThan(0);
+        expect(
+            det.every((e) => e.type === 'bomb-detonated' && e.detonatorId === 'lingshe-enemy')
+        ).toBe(true);
+        expect(stealthGrants(events, 'lingshe-enemy')).toBeGreaterThan(0);
+    });
+});

--- a/src/utils/combat/__tests__/wave7WardenDebuffInflicted.integration.test.ts
+++ b/src/utils/combat/__tests__/wave7WardenDebuffInflicted.integration.test.ts
@@ -1,0 +1,157 @@
+/**
+ * wave7WardenDebuffInflicted.integration.test.ts — Ship-kit Wave 7 (Warden).
+ *
+ * Warden's passive: "…Additionally, when this Unit inflicts a Debuff, it inflicts Out. Damage
+ * Down II for 1 turn." Parsed as {type:'debuff', target:'enemy', duration:1} with trigger 'on-cast'
+ * (the recognizer only matched the gerund "inflicting"), which classifies it as a passive-slot
+ * ENEMY-side TIMED status. That status has NO dispatch site — the per-turn timed loop fires only
+ * `sourceSlot === action` (active/charged), and the combat-start seeder reads only the SELF side —
+ * so "Out. Damage Down II" never appeared, across every qualifying turn.
+ *
+ * The fix routes it to the existing reactive `on-debuff-inflicted` trigger (parser: present-tense
+ * self-subject recognizer). Warden inflicts Provoke every active turn, so Out. Damage Down II now
+ * lands on those turns. The follow-up is ITSELF a debuff, so the on-debuff-inflicted listener
+ * carries a `!e.reactive` self-chain guard (else its own reactive debuff-applied would re-enter
+ * and blow MAX_INTENT_GENERATIONS).
+ *
+ * Real production kit via buildShipAbilities (mirrors apexSelfShieldGate.integration.test.ts).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, type CombatEngineInput } from '../engine';
+import { createEventBus } from '../events';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import type { ShipSkills } from '../../../types/abilities';
+import type { Ship } from '../../../types/ship';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+// Verbatim from docs/ship-skills.csv (Warden).
+const WARDEN_ACTIVE =
+    'This Unit deals <unit-damage>165% damage</unit-damage> and applies <unit-skill>Provoke</unit-skill> for 1 turn.';
+const WARDEN_PASSIVE_R2 =
+    'When directly damaged, this Unit inflicts <unit-skill>Corrosion I</unit-skill> for 2 turns on that enemy and repairs itself 3% of its Max HP.<br /><br />Additionally, when this Unit inflicts a <unit-skill>Debuff</unit-skill>, it inflicts <unit-skill>Out. Damage Down II</unit-skill> for 1 turn.';
+
+const wardenShip = (): Ship =>
+    ({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}], // R2 — the second passive (the one carrying Out. Damage Down II)
+        activeSkillText: WARDEN_ACTIVE,
+        secondPassiveSkillText: WARDEN_PASSIVE_R2,
+    }) as Ship;
+
+// Warden's REAL production-parsed active + passive slots.
+const wardenSkills = (): ShipSkills => {
+    const built = buildShipAbilities(wardenShip());
+    const active = built.slots.find((s) => s.slot === 'active');
+    const passive = built.slots.find((s) => s.slot === 'passive');
+    if (!active || !passive) throw new Error('Warden active/passive slots missing');
+    return { slots: [active, passive] };
+};
+
+const OUT_DD = 'Out. Damage Down II';
+
+describe('Warden Out. Damage Down II — self-inflicted-debuff reactive (Ship-kit W7)', () => {
+    const makeInput = (): CombatEngineInput => ({
+        attack: 10_000,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: wardenSkills(),
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 3,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 100,
+        hacking: 999, // >> enemy security so the reactive Out. Damage Down II lands
+        healTargetId: 'attacker',
+    });
+
+    it('player-side: Out. Damage Down II lands (was never dispatched) and does NOT self-chain', () => {
+        const bus = createEventBus();
+        let outDd = 0;
+        bus.on('debuff-applied', (e) => {
+            if (e.type === 'debuff-applied' && e.sourceId === 'attacker' && e.buffName === OUT_DD)
+                outDd++;
+        });
+        // Completing at all proves no MAX_INTENT_GENERATIONS throw (the self-chain is guarded).
+        const result = runCombat({ ...makeInput(), bus });
+        expect(result.rounds).toHaveLength(3);
+        // Fires on Warden's own debuff-inflicting turns — at least once, and BOUNDED (a runaway
+        // self-chain would be caught by the generation cap long before any sane count).
+        expect(outDd).toBeGreaterThan(0);
+        expect(outDd).toBeLessThanOrEqual(3);
+    });
+});
+
+describe('Warden Out. Damage Down II — team symmetry (enemy-side Warden inflicts on the player)', () => {
+    const enemyWarden = (): EnemyAttacker => ({
+        id: 'warden-enemy',
+        stats: {
+            attack: 10_000,
+            crit: 0,
+            critDamage: 0,
+            speed: 40,
+            hp: 1_000_000,
+            defence: 0,
+            hacking: 999,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        shipSkills: wardenSkills(),
+    });
+
+    const focusInput = (): CombatEngineInput => ({
+        attack: 0,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: { slots: [{ slot: 'active', abilities: [] }] },
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 3,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 200, // focus acts first; the enemy Warden acts after and inflicts on the focus
+        healTargetId: 'attacker',
+        enemyAttackers: [enemyWarden()],
+    });
+
+    it('an enemy-side Warden inflicts Out. Damage Down II on the player focus, no self-chain', () => {
+        const bus = createEventBus();
+        let outDd = 0;
+        bus.on('debuff-applied', (e) => {
+            if (
+                e.type === 'debuff-applied' &&
+                e.sourceId === 'warden-enemy' &&
+                e.buffName === OUT_DD
+            )
+                outDd++;
+        });
+        const result = runCombat({ ...focusInput(), bus });
+        expect(result.rounds).toHaveLength(3);
+        expect(outDd).toBeGreaterThan(0);
+        expect(outDd).toBeLessThanOrEqual(3);
+    });
+});

--- a/src/utils/combat/__tests__/wave7WardenDebuffInflicted.integration.test.ts
+++ b/src/utils/combat/__tests__/wave7WardenDebuffInflicted.integration.test.ts
@@ -10,9 +10,10 @@
  *
  * The fix routes it to the existing reactive `on-debuff-inflicted` trigger (parser: present-tense
  * self-subject recognizer). Warden inflicts Provoke every active turn, so Out. Damage Down II now
- * lands on those turns. The follow-up is ITSELF a debuff, so the on-debuff-inflicted listener
- * carries a `!e.reactive` self-chain guard (else its own reactive debuff-applied would re-enter
- * and blow MAX_INTENT_GENERATIONS).
+ * lands on those turns. The follow-up is ITSELF a debuff, so its own debuff-applied is branded
+ * `viaDebuffInflictedReaction` and the on-debuff-inflicted listener skips it — a precise self-chain
+ * guard (else the reaction would re-enter and blow MAX_INTENT_GENERATIONS), while debuffs from
+ * other reactive triggers (on-crit/on-attacked) still chain as before.
  *
  * Real production kit via buildShipAbilities (mirrors apexSelfShieldGate.integration.test.ts).
  */

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -5334,6 +5334,10 @@ export function runCombat(input: CombatEngineInput): {
                         type: 'bomb-detonated',
                         actorId,
                         victimId: victim.id,
+                        // Ship-kit W7: the positional detonate caster IS the detonator (the burst
+                        // is caused by this cast's detonate ability — SP-F F1: "the detonating
+                        // caster (actorId) is the source-attacker").
+                        detonatorId: actorId,
                         round: r,
                         stacks: result.bombStacks,
                         damage: result.bomb,

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -24,8 +24,10 @@ import { DoTType } from '../../types/calculator';
  *    (`PendingBomb.sourceId`) for `processBombs` AND for SP-F F3/Lingshe's forced early
  *    detonation via `bomb-countdown-reduce`; the attacker-turn `detonate()` aggregate
  *    branch instead emits the casting `actor.id`. Either way — any actor, not always
- *    'attacker'. Only feeds log/attribution: the on-bomb-detonated listener is global
- *    and ignores `actorId`.
+ *    'attacker'. `actorId` feeds log/attribution; the VICTIM-scoped `on-bomb-detonated`
+ *    listener is global over `actorId` (keys off `victimId` being opposing). The separate
+ *    DETONATOR-scoped `on-self-bomb-detonated` listener (Ship-kit W7/Lingshe) keys off the
+ *    additive `detonatorId` field (who actively caused the burst; undefined for natural expiry).
  *  - `control-applied`: emitted on the CAST path when the firing skill carries a `control`
  *    ability (e.g. Defiant's charged Stasis inflict). `casterId` is the applying actor;
  *    `effect` is the control effect. Present-only-when-fired. Emitting it does NOT make the
@@ -92,13 +94,20 @@ export type CombatEvent =
     | ({ type: 'buff-expired'; actorId: string; round: number; buffName: string } & ReactiveStamp)
     /** Discrete infliction events ONLY — emitted once at the round of application.
      *  `sourceId` is the actor that inflicted the debuff (e.g. 'attacker' or a team
-     *  actor id). NOT emitted for recurring/aura per-round re-applications. */
+     *  actor id). NOT emitted for recurring/aura per-round re-applications.
+     *  `viaDebuffInflictedReaction` (Ship-kit W7): set when this debuff was applied BY an
+     *  `on-debuff-inflicted`-triggered ability (Warden's Out. Damage Down II). The
+     *  `on-debuff-inflicted` listener ignores such events so a debuff-inflicted reaction whose
+     *  own follow-up is itself a debuff cannot re-trigger ITSELF (an unbounded self-chain that
+     *  would otherwise hit MAX_INTENT_GENERATIONS). Debuffs from OTHER reactive triggers
+     *  (on-crit/on-attacked) carry no flag and still feed on-debuff-inflicted as before. */
     | ({
           type: 'debuff-applied';
           sourceId: string;
           targetId: string;
           round: number;
           buffName: string;
+          viaDebuffInflictedReaction?: true;
       } & ReactiveStamp)
     | ({
           type: 'debuff-resisted';
@@ -250,11 +259,18 @@ export type CombatEvent =
      *  casting `actor.id` instead. Any actor, not always 'attacker'. `victimId` = the actor
      *  the bomb detonated ON (the bomb's holder) — distinct from `actorId`, which stays the
      *  applier/caster per the above. Added for Wave 5 C2 (Demolisher adjacent-enemy splash
-     *  anchoring, consumed by C3); purely additive, no behaviour change. */
+     *  anchoring, consumed by C3); purely additive, no behaviour change.
+     *  `detonatorId` (Ship-kit W7/Lingshe) = the actor who ACTIVELY caused this burst — the
+     *  caster of the detonating skill (`detonate()`/positional detonate) or the
+     *  `bomb-countdown-reduce` caster (Lingshe's charge). UNDEFINED for a natural countdown-0
+     *  expiry (`processBombs`), which nobody "detonates". Distinct from `actorId` (the applier)
+     *  and `victimId` (the holder); consumed only by the DETONATOR-scoped `on-self-bomb-detonated`
+     *  trigger, so every existing listener that reads actorId/victimId is unaffected. */
     | {
           type: 'bomb-detonated';
           actorId: string;
           victimId: string;
+          detonatorId?: string;
           round: number;
           stacks: number;
           damage: number;

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -903,6 +903,11 @@ function reduceBombsOnVictim(
     turns: number,
     round: number,
     bus: CombatEventBus,
+    // Ship-kit W7: the actor whose bomb-countdown-reduce cast is forcing this detonation (Lingshe).
+    // Distinct from `bomb.sourceId` (the ORIGINAL applier, kept as `actorId` for attribution) — it
+    // becomes the event's `detonatorId` so Lingshe's on-self-bomb-detonated Stealth grant fires
+    // for a burst SHE caused even on bombs another ship applied.
+    detonatorId: string,
     forceDetonateBomb?: (victim: CombatActor, sourceId: string, damage: number) => void
 ): void {
     for (let i = victim.pendingBombs.length - 1; i >= 0; i--) {
@@ -918,6 +923,7 @@ function reduceBombsOnVictim(
             type: 'bomb-detonated',
             actorId: bomb.sourceId,
             victimId: victim.id,
+            detonatorId,
             round,
             stacks: bomb.stacks,
             damage: burst,
@@ -950,6 +956,9 @@ function reduceEnemyBombs(args: {
     opposingVictimById: Map<string, CombatActor> | undefined;
     round: number;
     bus: CombatEventBus;
+    // Ship-kit W7: the caster forcing these detonations (Lingshe) — becomes each burst's
+    // `detonatorId`. See reduceBombsOnVictim.
+    detonatorId: string;
     landsTimedEnemyApplicationLive: (application?: 'inflict' | 'apply') => boolean;
     forceDetonateBomb?: (victim: CombatActor, sourceId: string, damage: number) => void;
 }): void {
@@ -970,6 +979,7 @@ function reduceEnemyBombs(args: {
                 ab.config.turns,
                 args.round,
                 args.bus,
+                args.detonatorId,
                 args.forceDetonateBomb
             );
         }
@@ -2282,6 +2292,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         opposingVictimById,
         round: r,
         bus,
+        detonatorId: actor.id, // Ship-kit W7: the countdown-reduce caster is the detonator.
         landsTimedEnemyApplicationLive,
         forceDetonateBomb: args.forceDetonateBomb,
     });
@@ -2320,6 +2331,10 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                     type: 'bomb-detonated',
                     actorId: actor.id,
                     victimId: enemy.id,
+                    // Ship-kit W7: this cast's own detonate ability caused the burst — the caster
+                    // IS the detonator (here actorId and detonatorId coincide, but they diverge on
+                    // the reduceBombsOnVictim path where actorId is the original applier).
+                    detonatorId: actor.id,
                     round: r,
                     stacks,
                     damage,

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -446,7 +446,17 @@ export function registerReactiveListeners(args: {
                     break;
                 case 'on-debuff-inflicted':
                     bus.on('debuff-applied', (e) => {
-                        if (e.sourceId === ownerId) enqueue(intent);
+                        // Ship-kit W7 (Warden): `!e.viaDebuffInflictedReaction` breaks a SELF-chain.
+                        // Warden's "when this Unit inflicts a Debuff → Out. Damage Down II" follow-up
+                        // is ITSELF a debuff; without this guard its own debuff-applied would re-enter
+                        // this listener and re-apply every generation until MAX_INTENT_GENERATIONS
+                        // throws. The flag is set ONLY on debuffs applied by an on-debuff-inflicted-
+                        // triggered ability, so debuffs from OTHER reactive triggers (on-crit's
+                        // Crit Shred feeding an on-debuff-inflicted charge — triggers.test scenario 10)
+                        // still chain here as before. Existing consumers (Butcher/Pestilence/APEX)
+                        // inflict their gating debuffs from non-on-debuff-inflicted paths, unaffected.
+                        if (e.sourceId === ownerId && !e.viaDebuffInflictedReaction)
+                            enqueue(intent);
                     });
                     bus.on('dot-applied', (e) => {
                         if (e.sourceId === ownerId) enqueue(intent);
@@ -652,6 +662,20 @@ export function registerReactiveListeners(args: {
                                 triggerDamage: e.damage,
                             },
                         });
+                    });
+                    break;
+                case 'on-self-bomb-detonated':
+                    // Ship-kit W7 (Lingshe): DETONATOR-scoped — fires only when THIS owner ACTIVELY
+                    // caused the burst ("When this Unit detonates a Bomb it gains Stealth"). The
+                    // `detonatorId` field names the detonating caster (detonate()/positional
+                    // detonate → the caster; reduceBombsOnVictim → the countdown-reduce caster) and
+                    // is UNDEFINED for a natural countdown-0 expiry, which nobody detonates. Keys off
+                    // `detonatorId`, NOT `actorId` (the bomb's original applier) — so a bomb Lingshe
+                    // detonates that some OTHER ship applied still grants her Stealth, and a bomb
+                    // SHE applied that expires naturally (or another ship detonates) does not.
+                    // Team-symmetric: any owner registered on either side gates identically.
+                    bus.on('bomb-detonated', (e) => {
+                        if (e.detonatorId === ownerId) enqueue(intent);
                     });
                     break;
                 case 'on-stasis-applied':
@@ -2508,12 +2532,19 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                     applicationTargetId
                 );
                 // Discrete infliction event — sourceId = the owner so the application is chainable.
+                // Ship-kit W7: brand the event when THIS reaction is itself an on-debuff-inflicted
+                // follow-up (Warden's Out. Damage Down II), so the on-debuff-inflicted listener
+                // skips it and the reaction cannot re-trigger itself (bounded, no generation-cap
+                // throw). Other reactive debuffs (on-crit/on-attacked) stay unbranded → still chain.
                 ctx.bus.emit({
                     type: 'debuff-applied',
                     sourceId: intent.ownerId,
                     targetId: debuffTargetId,
                     round: ctx.round,
                     buffName: cfg.buffName,
+                    ...(intent.ability.trigger === 'on-debuff-inflicted'
+                        ? { viaDebuffInflictedReaction: true as const }
+                        : {}),
                 });
             } else {
                 // A persistent-stacking name (would have landed as a never-expiring stack)

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1291,13 +1291,24 @@ const EVERY_TURN_RE = /\b(?:each|every)\s+turn\b/i;
 // phrase uses no application verb (Chakara's R2 passive; unique in the corpus). findVerb treats
 // it as a self-receive ('gains') so the buff segments extract.
 const STARTS_ROUND_WITH_RE = /\bstarts?\s+(?:each|every|the)\s+round\s+with\b/i;
+// VICTIM-scoped bomb-burst phrasing → on-bomb-detonated. Fires whenever a Bomb bursts on an
+// opposing actor, regardless of WHO caused it (the engine listener keys off the opposing victim).
 // Phase 3 PR-D: "explodes on (an|the) enemy" generalises the trigger beyond the literal word
 // "bomb" so Valkyrie's named bomb-type effect ("an Echoing Burst explodes on an enemy") also
 // rides on-bomb-detonated. Verified against docs/ship-skills.csv (grep "explod"): Demolisher
-// ("a/A bomb explodes on an enemy", already covered by the "bomb explodes" alternate) and
-// Valkyrie are the ONLY two rows using "explod" in the whole corpus, so this alternate cannot
-// co-trigger any other ship's kit.
-const BOMB_DETONATE_RE = /(?:detonates? a bomb|bomb explodes|explodes on (?:an|the) enemy)/i;
+// ("a/A bomb explodes on an enemy") and Valkyrie are the ONLY two rows using "explod" in the
+// whole corpus, so this alternate cannot co-trigger any other ship's kit.
+// Ship-kit W7: the DETONATOR-scoped "detonates a bomb" alternate was SPLIT OUT into
+// SELF_DETONATES_BOMB_RE below — it is a different trigger (on-self-bomb-detonated), fired only
+// when THIS unit actively causes the burst, not on any bomb bursting on an enemy.
+const BOMB_DETONATE_RE = /(?:bomb explodes|explodes on (?:an|the) enemy)/i;
+// DETONATOR-scoped "When this Unit detonates a Bomb …" → on-self-bomb-detonated (Lingshe's
+// Stealth grant). Corpus-verified (docs/ship-skills.csv, grep "detonates a"): Lingshe is the ONLY
+// ship whose reactive clause uses this phrasing (its OTHER passives use "inflicts a Bomb", a
+// different trigger; the active/charge "detonates <Corrosion|Inferno|Bomb> effects" are cast-path
+// detonation abilities, not reactive-trigger clauses). Distinct from BOMB_DETONATE_RE so a bomb
+// bursting on an enemy from ANY source no longer wrongly grants Lingshe Stealth.
+const SELF_DETONATES_BOMB_RE = /detonates?\s+a\s+bomb/i;
 // "when an enemy cleanses a debuff" — a player reaction to an ENEMY cleanse (Phase 4c PR 4):
 // Arum's Out. Damage Down debuff, Yarrow/Larkspur's Gelecek Contagion buff. Routes the
 // buff/debuff grant onto the LIVE on-enemy-cleansed trigger. Reference data: docs/ship-skills.csv.
@@ -1334,6 +1345,14 @@ const KILL_TRIGGER_RE =
     /\bon\s+(?:a\s+)?kill\b|killing\s+an\s+(?:enemy|opponent)|when\s+an\s+enemy\s+dies/i;
 // "On inflicting a debuff" / "upon applying a debuff" → on-debuff-inflicted (Butcher Marauder Rage II).
 const APPLYING_DEBUFF_RE = /\b(?:upon|on|after|when)\s+(?:inflicting|applying)\s+(?:a\s+)?debuff/i;
+// Ship-kit W7: present-tense SELF-subject "when this Unit inflicts a Debuff" → on-debuff-inflicted
+// (Warden's Out. Damage Down II follow-up). APPLYING_DEBUFF_RE above only matches the gerund
+// ("on inflicting"), so this present-tense form previously fell through to on-cast — landing a
+// passive-slot enemy timed debuff in a dispatch path the engine never fires. SELF-scoped ("this
+// Unit") so it never co-matches an ally/enemy-subject infliction (those are on-ally-debuff-
+// inflicted / on-attacked, resolved elsewhere). Corpus-verified: Warden is the only ship with
+// this exact phrasing.
+const SELF_INFLICTS_DEBUFF_RE = /\bwhen\s+this\s+unit\s+inflicts\s+(?:a\s+)?debuff/i;
 // "If its debuff is resisted" — Ravager's INFLICTOR-side reaction (the debuff THIS unit
 // inflicted got resisted). Distinct from the resister-side "when this Unit resists a debuff"
 // (parseOnResistHpDamage). Corpus-verified: Ravager is the only "its debuff is resisted" row.
@@ -1415,6 +1434,10 @@ export function detectReactiveTrigger(
     // docs/ship-skills.csv — Volk/Xcellence's start-of-turn heal/shield use separate,
     // non-buff parse paths untouched by this branch).
     if (START_OF_TURN_CHARGE_RE.test(clause)) return 'start-of-turn';
+    // Ship-kit W7: DETONATOR-scoped "this Unit detonates a Bomb" (Lingshe) is checked BEFORE the
+    // victim-scoped "bomb explodes" family — the two are mutually exclusive by phrasing, but this
+    // ordering makes the detonator reading win unambiguously.
+    if (SELF_DETONATES_BOMB_RE.test(clause)) return 'on-self-bomb-detonated';
     if (BOMB_DETONATE_RE.test(clause)) return 'on-bomb-detonated';
     // "when Cheat Death activates" → on-cheat-death-activated (Yazid's Barrier grant in the
     // repair sentence). Tycho's below-40%-HP Barrier is a different reactive (deferred), so this
@@ -1447,6 +1470,8 @@ export function detectReactiveTrigger(
     if (ENEMY_REPAIRS_RE.test(clause)) return 'on-enemy-repaired';
     if (KILL_TRIGGER_RE.test(clause)) return 'on-enemy-destroyed';
     if (APPLYING_DEBUFF_RE.test(clause)) return 'on-debuff-inflicted';
+    // Ship-kit W7: present-tense self-subject "when this Unit inflicts a Debuff" (Warden).
+    if (SELF_INFLICTS_DEBUFF_RE.test(clause)) return 'on-debuff-inflicted';
     // Paracelsus: "Upon being killed by direct Damage … grants allies <buff>" — the named-buff
     // half of an on-destroyed clause. Mirrors Faust's detectKilledByDirectDamageTrigger (which
     // routes the purge half); here the buffName-scoped clause carries the same phrase.
@@ -1766,12 +1791,14 @@ export function detectAllyCritDotTrigger(
 
 /**
  * Returns 'on-bomb-detonated' when `anchorPos` (the ability's raw-text anchor position) falls
- * inside the sentence carrying a bomb-detonation phrase (BOMB_DETONATE_RE — "detonates a bomb" /
- * "bomb explodes" / "explodes on an enemy"); otherwise undefined. Position-scoped on the RAW
- * text (mirrors detectAllyCritDotTrigger). This is the HEAL-builder counterpart to the existing
- * buff (detectReactiveTrigger, Lingshe) and charge-removal (parseChargeRemoval, Demolisher)
- * on-bomb-detonated readings of the same phrasing (Phase 3 PR-D: Valkyrie's self+lowest-HP-ally
- * repair on Echoing Burst detonation). Reference data: docs/ship-skills.csv.
+ * inside the sentence carrying the VICTIM-scoped bomb-burst phrase (BOMB_DETONATE_RE — "bomb
+ * explodes" / "explodes on an enemy"); otherwise undefined. Position-scoped on the RAW text
+ * (mirrors detectAllyCritDotTrigger). This is the HEAL-builder counterpart to the charge-removal
+ * (parseChargeRemoval, Demolisher) on-bomb-detonated reading of the same phrasing (Phase 3 PR-D:
+ * Valkyrie's self+lowest-HP-ally repair on Echoing Burst detonation). The DETONATOR-scoped
+ * "detonates a bomb" phrasing (Lingshe) is deliberately NOT matched here — it rides the separate
+ * on-self-bomb-detonated trigger via detectReactiveTrigger (Ship-kit W7). Reference data:
+ * docs/ship-skills.csv.
  */
 export function detectBombDetonatedTrigger(
     text: string | null | undefined,


### PR DESCRIPTION
## Ship-kit correctness — Wave 7 (engine-side WRONG-EXEC)

Investigated all 3 Wave 7 "parsed correctly but never fires / fires wrong" findings via `trace:ship` + engine instrumentation. **One of the three was a false positive.**

### ❌ Demolisher active Bomb III — FALSE POSITIVE (no code change)
The bomb dot **is** attempted on every active cast. It fails to land only because the standard audit scenario's enemy **security (150) exceeds Demolisher's hacking (~90)** → hit chance = `hacking − security` = 0% (`docs/combat-system.md` §8 hacking-based hit check). Landing-roll failures are **silent** (no resist event), which the ledger mis-read as "never attempted." Confirmed: lowering the enemy security → the bomb lands + detonates normally.

> ⚠️ **Meta:** the audit scenario zeroes *all* hacking-based DoT/debuff landing for any ship with hacking < 150 — other "DoT never applies" ledger findings may be similarly contaminated.

### ✅ Warden "Out. Damage Down II" — FIXED
The passive `{debuff, target:enemy, duration:1}` was mis-parsed `on-cast` (the recognizer only matched the gerund "inflicting"), landing it in a passive-slot enemy-**timed** path with **zero dispatch site** (the per-turn loop fires only active/charged slots; the combat-start seeder reads only the self side). Fix:
- Parser `SELF_INFLICTS_DEBUFF_RE` → routes "when this Unit inflicts a Debuff" to the existing reactive **`on-debuff-inflicted`** trigger.
- Its follow-up is *itself* a debuff, so a precise **self-chain guard** (`viaDebuffInflictedReaction` flag on `debuff-applied` → the `on-debuff-inflicted` listener skips its own product). Debuffs from other reactive triggers (on-crit/on-attacked) still chain as before.
- *Not* an engine dispatch change — 6 other ships share the passive/enemy/timed shape and several are genuinely conditional/ally-triggered.

### ✅ Lingshe Stealth-on-detonate — FIXED
"When this Unit **detonates** a Bomb → Stealth" shared `on-bomb-detonated` with Demolisher's VICTIM-scoped "when a Bomb **explodes on an enemy**", and the listener had **no detonator filter** → Lingshe gained Stealth from *any* bomb bursting on an enemy (natural expiry, another ship's detonation, anything). Fix:
- Parser split: `SELF_DETONATES_BOMB_RE` → new **DETONATOR-scoped `on-self-bomb-detonated`** trigger.
- New **`detonatorId`** field on the `bomb-detonated` event — the actor who *actively caused* the burst (detonate()/countdown-reduce caster); **undefined for a natural countdown-0 expiry**.
- New `triggers.ts` listener filtering `detonatorId === ownerId`. Team-symmetric.

## Tests
- New: `wave7Parse.test.ts` (parser trigger classification, production path), `wave7WardenDebuffInflicted.integration.test.ts` (fires + no self-chain, team-symmetric), `wave7LingsheStealthScope.integration.test.ts` (natural-expiry → no Stealth; own-detonation → Stealth; team-symmetric).
- Updated 3 existing Lingshe expectations (`on-bomb-detonated` → `on-self-bomb-detonated`) and `triggers.test.ts` scenario 11 (self-amplifying on-debuff-inflicted debuff is now **bounded**, not a generation-cap throw).
- **4724 tests pass · lint clean · `audit:skills` 0 findings.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)