### PR TITLE
chore: fix ship-kit audit scenario security calibration (debuffs can now land)

### DIFF
--- a/scripts/lib/traceScenario.ts
+++ b/scripts/lib/traceScenario.ts
@@ -63,13 +63,31 @@ const plainAlly = (): Ship => fillerBase('trace-ally-plain', 'PlainAlly', 'ATTAC
 const fragileAlly = (): Ship =>
     fillerBase('trace-ally-fragile', 'FragileAlly', 'ATTACKER', { hp: 40_000, defence: 100, speed: 105 });
 
+// Audit-calibration: the enemies carry LOW security (20) so the reviewed ship's hacking-based
+// debuffs/DoTs actually LAND and can be observed. The whole corpus has BASE hacking 64–122
+// (median ~87, no gear in this synthetic scenario), and landing chance = clamp(hacking − security,
+// 0, 100)/100 — so the old fillerBase security (150, above every ship's hacking) gave a CATEGORICAL
+// 0% landing for every hacking-based effect: every DoT/debuff ship looked broken (e.g. Demolisher's
+// Bomb III "never applied" was purely this, not an engine bug). At security 20 a median ship lands
+// ~67% and the lowest-hacking ship ~44% — enough to reliably surface the ability over 30 rounds
+// while still leaving a realistic resist tail. This is an OBSERVABILITY concession, not a realism
+// claim; resist behaviour has its own dedicated unit tests (dynamicLanding / anchorDebuffLanding).
+// DO NOT raise this back toward ship-hacking magnitude without re-checking the DoT/debuff findings.
+const ENEMY_SECURITY = 20;
+
 const enemyAttacker = (id: string, name: string, affinity: AffinityName, attack: number): Ship => ({
-    ...fillerBase(id, name, 'ATTACKER', { attack, hp: 240_000, speed: 100 }),
+    ...fillerBase(id, name, 'ATTACKER', { attack, hp: 240_000, speed: 100, security: ENEMY_SECURITY }),
     affinity,
 });
 
 const enemyDebuffer = (id: string, name: string, attack: number): Ship => ({
-    ...fillerBase(id, name, 'ATTACKER', { attack, hp: 240_000, speed: 105, hacking: 260 }),
+    ...fillerBase(id, name, 'ATTACKER', {
+        attack,
+        hp: 240_000,
+        speed: 105,
+        hacking: 260,
+        security: ENEMY_SECURITY,
+    }),
     activeSkillText:
         'This Unit deals <unit-damage>100% damage</unit-damage> and inflicts <unit-skill>Defense Down II</unit-skill> for 2 turns.',
 });


### PR DESCRIPTION
## Problem
The kit-audit trace scenario's enemy **security = 150** (`fillerBase` default), which is above **every** ship's base hacking — corpus range **64–122, median 87** (no gear in this synthetic scenario). Since hacking-based debuff/DoT landing = `clamp(hacking − security, 0, 100) / 100`, this gave a **categorical 0% landing** for the entire hacking-based debuff/DoT class: every corrosion/inferno/bomb/stat-debuff ship *looked* like it "never applied" its effect.

This is exactly what made **Demolisher's Bomb III a false-positive engine finding in Wave 7** (the dot was attempted every cast but silently resisted at 0%, which reads identically to "never fired").

## Fix
Lower the enemy security to **20** (`ENEMY_SECURITY`) so a median-hacking ship lands ~67% and the lowest ~44% — enough to reliably surface the ability over 30 rounds while keeping a realistic resist tail.

- **Harness-only** (`scripts/lib/traceScenario.ts`) — no product impact; the user-facing DPS calculator / battle simulator use real ship & enemy stats.
- Resist behaviour keeps its dedicated unit tests (`dynamicLanding`, `anchorDebuffLandingRealAffinity`).
- Documented inline with the rationale + a "don't raise it back" warning.

## Re-verification (`trace:ship --all`)
- ✅ Demolisher's **Bomb III** and Crocus's **Corrosion** now land + show as observed (were categorically 0% before).
- The DoT/debuff abilities that **remain** unobserved are **not** landing artifacts — they're control/named-status types (Stasis, Concentrate Fire — the observed-checkbox doesn't map these) or ships that die early (Incinerator R2, Lingshe R4).
- **No Wave 8 backlog finding was a security false positive** — the remaining items are model/parse gaps (missing trigger, wrong target, missing gate), unaffected by landing.

4724 tests pass · lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)