### PR TITLE
fix: ship-kit correctness Wave 8 — mop-up (14 findings)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -121,6 +121,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Skill parsing target fixes: Rikra's on-kill repair and Panon's Barrier Recharging now correctly apply to themselves (previously Rikra's self-repair could land on a different ally, and Panon applied Barrier Recharging to the enemy — which also stopped her own incoming-damage reduction from working). Panguan's Stealth now triggers on being directly damaged and applies to herself, instead of being granted to the whole team on every cast.",
     "Combat sim: Graphite's charged skill now shields all allies (matching its active skill), instead of only shielding itself.",
     'Combat sim: Amartya now inflicts 2 stacks of Exposed on an enemy defender the instant it gains Taunt, matching her legendary refit passive — previously this was silently gated behind a bogus condition requiring Amartya herself to have Taunt (which never happens), so it never fired at all.',
+    "Combat sim: Meiying's Stasis-on-kill now only triggers when the enemy she kills is carrying a debuff, matching her passive text ('upon killing an enemy with a Debuff') — previously it fired on every kill regardless of the victim's debuff status.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -122,6 +122,18 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat sim: Graphite's charged skill now shields all allies (matching its active skill), instead of only shielding itself.",
     'Combat sim: Amartya now inflicts 2 stacks of Exposed on an enemy defender the instant it gains Taunt, matching her legendary refit passive — previously this was silently gated behind a bogus condition requiring Amartya herself to have Taunt (which never happens), so it never fired at all.',
     "Combat sim: Meiying's Stasis-on-kill now only triggers when the enemy she kills is carrying a debuff, matching her passive text ('upon killing an enemy with a Debuff') — previously it fired on every kill regardless of the victim's debuff status.",
+    "Combat sim: Lionheart's on-crit Attack Up II (active) and Attack Up III (charged) now buff only its adjacent allies, matching 'to all adjacent allies' — previously they buffed the entire team.",
+    "Combat sim: Centurion's charged skill now also grants 2 stacks of Core Charge I to its adjacent allies (in addition to its own 4 stacks) — previously the adjacent-ally grant was dropped.",
+    "Combat sim: Lev's charged skill now grants Crit Power Up II to all allies only when a critical hit occurs, matching 'If a critical hit occurs' — previously it applied on every charged cast regardless of whether the hit crit.",
+    "Combat sim: Chimei's Stealth grant to low-HP non-defender allies now fires at the end of the round, matching her skill text, instead of on cast.",
+    "Combat sim: Selenite's start-of-round Concentrate Fire now targets the enemy with the highest Attack specifically, instead of a generic enemy.",
+    "Combat sim: Quixilver's passive now grants Barrier to all allies, matching 'grants all allies Barrier' — previously it only granted Barrier to itself.",
+    "Combat sim: Xcellence's active skill now also inflicts Stasis for 2 turns, matching her skill text — previously this clause was dropped entirely.",
+    'Combat sim: when an enemy resists a debuff Xcellence inflicts, she now deals damage equal to 115% of her current Shield, matching her passive — previously not modeled.',
+    "Combat sim: when placed adjacent to a Supporter, Madax now increases that Supporter's Defense by 20% of its own Defense, matching its passive — previously this was mis-modeled as a self-heal.",
+    'Combat sim: after applying Corrosion with a critical hit, Wisteria now also inflicts Inferno II for 2 turns, matching its passive — previously only the Corrosion-extend half was modeled.',
+    'Combat sim: Wusheng now loses Stealth when directly damaged while Stealthed, matching its passive — previously the Stealth stayed until normal expiry.',
+    "Combat sim: Lingshe's detonation damage now scales with her crit power (1% more damage per 10% crit power), matching her passive — previously this bonus was not modeled.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -6,6 +6,7 @@ export const CURRENT_VERSION = '1.64.0';
 // CHANGELOG (with the new version + today's date), clear this array back to [],
 // and bump CURRENT_VERSION. All three steps must happen together.
 export const UNRELEASED_CHANGES: string[] = [
+    'Combat sim: Zeolite now purges 1 buff from an enemy Defender whenever it deals damage to one, matching its passive — previously this follow-up purge never applied at all.',
     'Combat sim: Lingshe now gains Stealth only when she herself detonates a Bomb (her charged skill), instead of gaining it from any Bomb bursting anywhere in the battle — including bombs that simply expire on their own or that another ship detonates.',
     'Combat sim: Warden now inflicts Out. Damage Down II when it inflicts a debuff (via its active Provoke or charged Corrosion II), matching its passive — previously this follow-up debuff never applied at all.',
     "Combat sim: enemy-adjacency splash is now modeled. Vindicator's Provoke and charged Out. Damage Down I hit the enemies adjacent to the target (the target excluded), and Asphyxiator's Stasis hits the target and its adjacent enemies — instead of being misapplied as a self-buff on the caster. Meiying's Stasis now also correctly hits all adjacent enemies.",

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -124,6 +124,10 @@ export type AbilityTrigger =
     | 'on-debuff-inflicted'
     | 'on-ally-debuff-inflicted'
     | 'on-ally-crit-dot'
+    // Ship-kit W8 Task 10 (Wisteria): self-subject sibling of on-ally-crit-dot — THIS unit's
+    // OWN crit-cast DoT infliction ("after applying Corrosion with a Critical hit, inflicts
+    // Inferno II for 2 turns"), not an ally's. See buildShipAbilities' dot-effects branch.
+    | 'on-self-crit-dot'
     | 'on-ally-critically-repaired'
     | 'on-ally-crit'
     | 'on-stasis-applied'
@@ -272,6 +276,8 @@ export const LIVE_TRIGGERS = new Set<AbilityTrigger>([
     // Phase 3 PR-H: self-scoped reaction to THIS unit's own cleanse actually removing a debuff.
     'on-own-cleanse',
     'on-ally-crit-dot',
+    // Ship-kit W8 Task 10 (Wisteria): self-subject sibling of on-ally-crit-dot.
+    'on-self-crit-dot',
     'on-ally-critically-repaired',
     'on-ally-crit',
     'on-stasis-applied',

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -932,7 +932,7 @@ export type AbilityConfig =
     // at apply time), so `conditions` stays empty.
     | {
           type: 'pre-combat-stat';
-          stat: 'hp' | 'attack' | 'crit' | 'hacking';
+          stat: 'hp' | 'attack' | 'crit' | 'hacking' | 'defence';
           value: number;
           /** 'flat': absolute points. 'percent-of-own': % of the RECIPIENT's pre-fight stat.
            *  'percent-of-donor': % of the GRANTING ship's pre-fight stat (Lionheart). */

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -622,6 +622,13 @@ export type AbilityConfig =
            *  of attack × multiplier. Reactive-damage path only (applyReactiveDamage); the on-cast
            *  damage path ignores it. */
           hpBasisPct?: number;
+          /** Ship-kit W8 (Xcellence on-resist): sibling of hpBasisPct — when set, the REACTIVE
+           *  damage executor computes the pre-mitigation raw from the owner's CURRENT SHIELD ×
+           *  shieldBasisPct (percent) instead of attack × multiplier. Reactive-damage path only
+           *  (applyReactiveDamage); the on-cast damage path ignores it. Mutually exclusive with
+           *  hpBasisPct in practice (no corpus row sets both), but hpBasisPct wins if both were
+           *  ever set (matches the executor's precedence order). */
+          shieldBasisPct?: number;
           /** SP-F F4 (Wusheng): the charged skill "deals 220% damage WITH affinity advantage".
            *  When set, this cast (and its paired 'apply' debuff landing) is forced to affinity
            *  ADVANTAGE regardless of the real attacker/target matchup — damageMod +25, critCap

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -434,7 +434,18 @@ export type ConditionSubject =
     // subject must never be satisfied by e.g. a landed Stasis. Also a SCALING source (Snakeroot's
     // "for every 4 stacks of damage over time" — reads the raw count, not just a gate). Always
     // derivable:true.
-    | 'enemy-dot-count';
+    | 'enemy-dot-count'
+    // Ship-kit W8 Task 13 (Meiying): binary gate -- the enemy THIS on-enemy-destroyed reaction
+    // just killed carried at least one debuff (of any kind) at the moment it died. Distinct from
+    // `enemy-debuff` (which reads the FIGHT-WIDE enemyDebuffCount/enemyDebuffNames, not a specific
+    // victim) -- this subject is keyed to the SLAIN unit via the reactive intent's
+    // eventCtx.victimId (threaded by the on-enemy-destroyed listener, mirroring victimId's use in
+    // every other Wave 5/7 reactive seam), so a kill on an UNDEBUFFED enemy correctly evaluates to
+    // 0 even while OTHER living enemies carry debuffs. Live-derived by the engine
+    // (ConditionContext.killedEnemyHadDebuff) from the victim's own per-target debuff store at
+    // drain time; defaults false (DPS mode / no victim resolved) -- inert for every OTHER
+    // on-enemy-destroyed ability, which never carries this condition. Always derivable:true.
+    | 'killed-enemy-had-debuff';
 
 export interface Condition {
     subject: ConditionSubject;

--- a/src/types/calculator.ts
+++ b/src/types/calculator.ts
@@ -175,6 +175,7 @@ export interface SelectedGameBuff {
         | 'self'
         | 'ally'
         | 'all-allies'
+        | 'adjacent-allies'
         | 'enemy'
         | 'all-enemies'
         | 'adjacent-enemies'

--- a/src/utils/__tests__/skillTextParser.test.ts
+++ b/src/utils/__tests__/skillTextParser.test.ts
@@ -357,12 +357,18 @@ describe('parsePreCombatStatGrants', () => {
         ).toEqual([]);
     });
 
-    it('does NOT match Madax P2 ("receives 30% more Repairs" — deliberately out of scope)', () => {
-        expect(
-            parsePreCombatStatGrants(
-                "This Unit <unit-damage>repairs itself for 13%</unit-damage> of its Max HP when an enemy dies.<br /><br />When adjacent to a Supporter, this Unit receives 30% more Repairs and increases that Supporter's Defense by 20% of this Unit's Defense."
-            )
-        ).toEqual([]);
+    it('matches Madax P2 ("increases that Supporter\'s Defense by 20%…") as a donor Defense grant to the adjacent Supporter (ship-kit W8 Task 9)', () => {
+        const grants = parsePreCombatStatGrants(
+            "This Unit <unit-damage>repairs itself for 13%</unit-damage> of its Max HP when an enemy dies.<br /><br />When adjacent to a Supporter, this Unit receives 30% more Repairs and increases that Supporter's Defense by 20% of this Unit's Defense."
+        );
+        expect(grants).toHaveLength(1);
+        expect(grants[0]).toMatchObject({
+            stat: 'defence',
+            value: 20,
+            valueKind: 'percent-of-donor',
+            target: 'adjacent-allies',
+            requiresAdjacentRole: 'SUPPORTER',
+        });
     });
 });
 

--- a/src/utils/abilities/__tests__/buffAbilityConverters.test.ts
+++ b/src/utils/abilities/__tests__/buffAbilityConverters.test.ts
@@ -303,6 +303,20 @@ describe('buffAbilitiesToSelectedBuffs', () => {
         expect(enemyDebuffs[0].buffName).toBe('Weaken');
     });
 
+    it('routes an enemy-highest-attack target debuff into enemyDebuffs (Selenite Concentrate Fire)', () => {
+        const ctx = buildStaticBuffContext({});
+        const concentrateFire = debuffAbility({
+            target: 'enemy-highest-attack',
+        });
+        const { selfBuffs, enemyDebuffs } = buffAbilitiesToSelectedBuffs(
+            skills([concentrateFire]),
+            ctx
+        );
+        expect(selfBuffs).toHaveLength(0);
+        expect(enemyDebuffs).toHaveLength(1);
+        expect(enemyDebuffs[0].buffName).toBe('Weaken');
+    });
+
     it('routes an all-allies target buff into selfBuffs', () => {
         const ctx = buildStaticBuffContext({});
         const allAlliesBuff = buffAbility({

--- a/src/utils/abilities/__tests__/buffAbilityConverters.test.ts
+++ b/src/utils/abilities/__tests__/buffAbilityConverters.test.ts
@@ -317,6 +317,31 @@ describe('buffAbilitiesToSelectedBuffs', () => {
         expect(enemyDebuffs[0].buffName).toBe('Weaken');
     });
 
+    it('routes an enemy-most-buffs target debuff into enemyDebuffs', () => {
+        const ctx = buildStaticBuffContext({});
+        const mostBuffs = debuffAbility({
+            target: 'enemy-most-buffs',
+        });
+        const { selfBuffs, enemyDebuffs } = buffAbilitiesToSelectedBuffs(skills([mostBuffs]), ctx);
+        expect(selfBuffs).toHaveLength(0);
+        expect(enemyDebuffs).toHaveLength(1);
+        expect(enemyDebuffs[0].buffName).toBe('Weaken');
+    });
+
+    it('routes an enemy-highest-speed target debuff into enemyDebuffs', () => {
+        const ctx = buildStaticBuffContext({});
+        const highestSpeed = debuffAbility({
+            target: 'enemy-highest-speed',
+        });
+        const { selfBuffs, enemyDebuffs } = buffAbilitiesToSelectedBuffs(
+            skills([highestSpeed]),
+            ctx
+        );
+        expect(selfBuffs).toHaveLength(0);
+        expect(enemyDebuffs).toHaveLength(1);
+        expect(enemyDebuffs[0].buffName).toBe('Weaken');
+    });
+
     it('routes an all-allies target buff into selfBuffs', () => {
         const ctx = buildStaticBuffContext({});
         const allAlliesBuff = buffAbility({

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -3691,16 +3691,22 @@ describe('buildShipAbilities — Iridium passive purge emit (C2b-2 T1)', () => {
             expect(purges[0].trigger).toBe('on-enemy-purged'); // PURGE_MORE_RE path, not generic loop
         });
 
-        it('Zeolite p1: passive emits ZERO purge abilities ("when dealing damage to a Defender" has no detected damage-reaction trigger)', () => {
+        it('Zeolite p1 (Wave 8 Task 12): passive emits ONE purge, on-deal-damage, gated on enemy-type Defender', () => {
             const zeoliteP1 = ship({
                 firstPassiveSkillText:
                     'This Unit <unit-aid>purges 1</unit-aid> buff from the enemy when dealing damage to a Defender.',
             });
-            const passive = slot(buildShipAbilities(zeoliteP1).slots, 'passive');
-            // Either no passive slot at all, or if a slot exists it has no purge abilities.
-            if (passive) {
-                expect(passive.abilities.filter((a) => a.type === 'purge')).toHaveLength(0);
+            const passive = slot(buildShipAbilities(zeoliteP1).slots, 'passive')!;
+            const purges = passive.abilities.filter((a) => a.type === 'purge');
+            expect(purges).toHaveLength(1);
+            expect(purges[0].target).toBe('enemy');
+            expect(purges[0].trigger).toBe('on-deal-damage');
+            if (purges[0].config.type === 'purge') {
+                expect(purges[0].config.count).toBe(1);
             }
+            expect(purges[0].conditions).toEqual([
+                { subject: 'enemy-type', derivable: true, requiredEnemyType: 'Defender' },
+            ]);
         });
 
         it('Zeolite p2 (R2 refit-active): "+30% damage when hitting a Defender" is gated on enemy-type Defender', () => {

--- a/src/utils/abilities/__tests__/buildShipAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildShipAbilities.test.ts
@@ -4759,16 +4759,31 @@ describe('buildShipAbilities — PR1 phantom-ability suppression (reduction/conv
 // passive text, so the phantom DoT does not reproduce for any of the four ships. These tests were
 // RED-checked (asserted the phantom absent) BEFORE any parser change and already passed —
 // confirmed FALSE POSITIVE; no parser change was made for this family. Kept as regression guards.
+// UPDATE (Ship-kit W8 Task 10): Wisteria's "after applying Corrosion with a Critical hit,
+// inflicts Inferno II" clause was itself UNMODELED (a real gap, distinct from the sweep's
+// false-positive phantom-DoT claim) — it now mints a genuine self-crit-dot Inferno II ability.
+// The phantom-Corrosion guard this test exists for still holds (see the updated assertion
+// below); Valerian/Lingshe/Belladonna remain untouched false positives.
 describe('buildShipAbilities — PR1 finding family 2 (confirmed FALSE POSITIVE under real usage)', () => {
-    it('Wisteria passive1 (R0): no phantom Corrosion dot from the "after applying Corrosion" trigger phrase', () => {
+    it('Wisteria passive1 (R0): "after applying Corrosion with a Critical hit, inflicts Inferno II" mints ONLY the Inferno II dot — no phantom Corrosion dot', () => {
+        // Ship-kit W8 Task 10: this clause is now modeled (self-subject on-crit-after-Corrosion
+        // secondary-DoT injection, mirroring Crocus's ally-scoped on-ally-crit-dot). The ORIGINAL
+        // "no phantom Corrosion dot" guard still holds — DOT_TIER_MAP has a bare 'Corrosion' entry
+        // and a naive tag walk would mint a second, wrong dot from the trigger clause's own named
+        // DoT — so this test now asserts exactly ONE dot ability (Inferno II), never two.
         const s = ship({
             refits: [] as never,
             firstPassiveSkillText:
                 'This Unit, after applying <unit-skill>Corrosion</unit-skill> with a Critical hit, inflicts <unit-skill>Inferno II</unit-skill> for 2 turns.',
         });
         const { slots } = buildShipAbilities(s);
-        const passive = slot(slots, 'passive');
-        expect(passive?.abilities.some((a) => a.type === 'dot') ?? false).toBe(false);
+        const passive = slot(slots, 'passive')!;
+        const dots = passive.abilities.filter((a) => a.type === 'dot');
+        expect(dots).toHaveLength(1);
+        expect(dots[0]).toMatchObject({
+            trigger: 'on-self-crit-dot',
+            config: { type: 'dot', dotType: 'inferno', tier: 30, duration: 2 },
+        });
     });
 
     it('Valerian passive2 (R2): no phantom Corrosion dot from "After inflicting Corrosion with a Critical hit"', () => {

--- a/src/utils/abilities/__tests__/wave2ParseBugs.test.ts
+++ b/src/utils/abilities/__tests__/wave2ParseBugs.test.ts
@@ -55,18 +55,16 @@ describe.skipIf(!csvAvailable())(
 
             // The "100% max HP" clause was gating a real grant ("...this Unit grants all
             // allies Barrier for 1 hit"), not the phantom shield — make sure fixing the
-            // phantom didn't also drop the legitimate Barrier buff.
-            // NOTE: we intentionally do NOT assert this Barrier's target. The clause says
-            // "grants all allies Barrier" but the parser currently resolves it to target='self'
-            // — a separate WRONG-PARSE surfaced during Wave 2 but OUT OF SCOPE for it (not in the
-            // ledger; Quixilver's only Wave 2 finding was the phantom shield). Asserting 'self'
-            // here would lock that bug in as expected; a later wave should fix the target and
-            // then tighten this assertion.
+            // phantom didn't also drop the legitimate Barrier buff. Ship-kit W8 Task 6 made
+            // `stripConditionClauses`'s trailing strip receiver-aware, so the "this Unit
+            // grants all allies Barrier" receiver clause now survives and resolves to
+            // all-allies (previously fell back to self — see wave8Targets.test.ts).
             const barrierGrant = passive!.abilities.find(
                 (a) => a.config.type === 'buff' && a.config.buffName === 'Barrier'
             );
             expect(barrierGrant).toBeDefined();
             expect(barrierGrant!.type).toBe('buff');
+            expect(barrierGrant!.target).toBe('all-allies');
         });
 
         it('B2: Rikra passive (R2) — "repairs 60% of its Max HP ... upon killing them" self-heal targets self, not ally', () => {

--- a/src/utils/abilities/__tests__/wave8Gates.test.ts
+++ b/src/utils/abilities/__tests__/wave8Gates.test.ts
@@ -46,3 +46,25 @@ describe.skipIf(!csvAvailable())(
         });
     }
 );
+
+describe.skipIf(!csvAvailable())(
+    'Wave 8 Task 4 — Chimei end-of-round Stealth grant trigger',
+    () => {
+        // Chimei's third passive: "At the end of the round, non-defender allies below 40% HP are
+        // granted Stealth for 1 turn." followed by a SEPARATE "At the start of the round, all allies
+        // with Stealth repairs..." sentence. The Stealth grant must classify as 'end-of-round', not
+        // 'on-cast' (its prior misclassification) — and the sibling start-of-round repair clause
+        // must NOT bleed into this grant's trigger (resolveBuffClause is sentence-scoped, so the two
+        // clauses stay separate). Out of scope for this task: the "non-defender"/"below 40% HP"
+        // conditions themselves — only the trigger classification is fixed here.
+        it("Stealth grant carries trigger 'end-of-round'", () => {
+            const abilities = buildShipAbilities(shipFromCsv('Chimei'));
+            const stealth = abilities.slots
+                .flatMap((s) => s.abilities)
+                .find((a) => a.config.type === 'buff' && a.config.buffName === 'Stealth');
+
+            expect(stealth).toBeDefined();
+            expect(stealth?.trigger).toBe('end-of-round');
+        });
+    }
+);

--- a/src/utils/abilities/__tests__/wave8Gates.test.ts
+++ b/src/utils/abilities/__tests__/wave8Gates.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { csvAvailable, loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
+
+// Build a full-refit Ship carrying a CSV record's texts (mirrors wave6StealthBypass.test.ts's
+// shipFromCsv helper, copied per the Wave 8 Task 1/3 briefs so this file has no cross-wave
+// test-file dependency).
+function shipFromCsv(name: string): Ship {
+    const rec = loadShipSkillRecords().find((r) => r.name.toUpperCase() === name.toUpperCase());
+    if (!rec) throw new Error(`docs/ship-skills.csv: no record for "${name}"`);
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        activeSkillText: rec.active,
+        chargeSkillText: rec.charge,
+        chargeSkillCharge: rec.chargeCharge,
+        firstPassiveSkillText: rec.passives[0],
+        secondPassiveSkillText: rec.passives[1],
+        thirdPassiveSkillText: rec.passives[2],
+    } as Ship;
+}
+
+describe.skipIf(!csvAvailable())(
+    'Wave 8 Task 3 — Lev charged Crit Power Up II gated on self-crit',
+    () => {
+        // Lev charged skill: "...If a critical hit occurs, all hit enemies have their debuffs
+        // extended by 1 turn and all allies are granted Crit Power Up II for 2 turns." The
+        // co-located extend-status ability already gates on this same clause (buildShipAbilities.ts
+        // ~1657, /critical hit occurs/i). The Crit Power Up II buff grant must carry the SAME
+        // self-crit condition — a plain on-cast buff would let it fire on every cast, not just
+        // crits.
+        it('Crit Power Up II targets all-allies and carries a self-crit condition', () => {
+            const abilities = buildShipAbilities(shipFromCsv('Lev'));
+            const cpu = abilities.slots
+                .flatMap((s) => s.abilities)
+                .find((a) => a.config.type === 'buff' && a.config.buffName === 'Crit Power Up II');
+
+            expect(cpu).toBeDefined();
+            expect(cpu?.target).toBe('all-allies');
+            expect(cpu?.trigger).toBe('on-cast');
+            expect(cpu?.conditions).toEqual(
+                expect.arrayContaining([expect.objectContaining({ subject: 'self-crit' })])
+            );
+        });
+    }
+);

--- a/src/utils/abilities/__tests__/wave8GrantScope.test.ts
+++ b/src/utils/abilities/__tests__/wave8GrantScope.test.ts
@@ -52,3 +52,27 @@ describe.skipIf(!csvAvailable())('Wave 8 Task 1 — detectGrantScope adjacent-al
         expect(ability?.target).toBe('all-allies');
     });
 });
+
+describe.skipIf(!csvAvailable())(
+    'Wave 8 Task 2 — Centurion dual-scope Core Charge I grant (occurrence-aware detectGrantScope)',
+    () => {
+        // Centurion charge: "This Unit gains 4 stacks of Core Charge I and grants all adjacent
+        // allies 2 stacks of Core Charge I then deals …" — the SAME buff name is granted TWICE
+        // in one clause, to two DIFFERENT scopes. Both grants must survive as distinct abilities
+        // with their own stack counts.
+        it('Centurion charge: BOTH Core Charge I grants survive (self x4, adjacent-allies x2)', () => {
+            const abilities = buildShipAbilities(shipFromCsv('Centurion'));
+            const buffAbilities = abilities.slots
+                .flatMap((s) => s.abilities)
+                .filter((a) => a.config.type === 'buff' && a.config.buffName === 'Core Charge I');
+
+            const ccSelf = buffAbilities.find((a) => a.target === 'self');
+            const ccAdj = buffAbilities.find((a) => a.target === 'adjacent-allies');
+
+            expect(ccSelf).toBeDefined();
+            expect(ccAdj).toBeDefined();
+            expect(ccSelf?.config.type === 'buff' && ccSelf.config.stacks).toBe(4);
+            expect(ccAdj?.config.type === 'buff' && ccAdj.config.stacks).toBe(2);
+        });
+    }
+);

--- a/src/utils/abilities/__tests__/wave8GrantScope.test.ts
+++ b/src/utils/abilities/__tests__/wave8GrantScope.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { csvAvailable, loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
+
+// Build a full-refit Ship carrying a CSV record's texts (mirrors wave6StealthBypass.test.ts's
+// shipFromCsv helper — copied here per the Wave 8 Task 1 brief so this file has no cross-wave
+// test-file dependency).
+function shipFromCsv(name: string): Ship {
+    const rec = loadShipSkillRecords().find((r) => r.name.toUpperCase() === name.toUpperCase());
+    if (!rec) throw new Error(`docs/ship-skills.csv: no record for "${name}"`);
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        activeSkillText: rec.active,
+        chargeSkillText: rec.charge,
+        chargeSkillCharge: rec.chargeCharge,
+        firstPassiveSkillText: rec.passives[0],
+        secondPassiveSkillText: rec.passives[1],
+        thirdPassiveSkillText: rec.passives[2],
+    } as Ship;
+}
+
+describe.skipIf(!csvAvailable())('Wave 8 Task 1 — detectGrantScope adjacent-allies branch', () => {
+    it('Lionheart active: Attack Up II targets adjacent-allies, trigger on-crit', () => {
+        const abilities = buildShipAbilities(shipFromCsv('Lionheart'));
+        const ability = abilities.slots
+            .flatMap((s) => s.abilities)
+            .find((a) => a.config.type === 'buff' && a.config.buffName === 'Attack Up II');
+        expect(ability?.target).toBe('adjacent-allies');
+        expect(ability?.trigger).toBe('on-crit');
+    });
+
+    it('Lionheart charge: Attack Up III targets adjacent-allies, trigger on-crit', () => {
+        const abilities = buildShipAbilities(shipFromCsv('Lionheart'));
+        const ability = abilities.slots
+            .flatMap((s) => s.abilities)
+            .find((a) => a.config.type === 'buff' && a.config.buffName === 'Attack Up III');
+        expect(ability?.target).toBe('adjacent-allies');
+        expect(ability?.trigger).toBe('on-crit');
+    });
+
+    // Regression guard: a plain all-allies grant (no "adjacent") must STILL resolve to
+    // all-allies — the new branch must not widen beyond the "adjacent allies" phrasing.
+    // Chimei charge: "…and grants Rogue's Liberty for 2 turns to all allies."
+    it("Chimei charge: Rogue's Liberty (plain all-allies grant) still targets all-allies", () => {
+        const abilities = buildShipAbilities(shipFromCsv('Chimei'));
+        const ability = abilities.slots
+            .flatMap((s) => s.abilities)
+            .find((a) => a.config.type === 'buff' && a.config.buffName === "Rogue's Liberty");
+        expect(ability?.target).toBe('all-allies');
+    });
+});

--- a/src/utils/abilities/__tests__/wave8Lingshe.test.ts
+++ b/src/utils/abilities/__tests__/wave8Lingshe.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { csvAvailable, loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
+
+// Build a full-refit Ship carrying a CSV record's texts (Wave 8 convention — copied per-file to
+// avoid a cross-wave test dependency, see wave8Wusheng.test.ts).
+function shipFromCsv(name: string): Ship {
+    const rec = loadShipSkillRecords().find((r) => r.name.toUpperCase() === name.toUpperCase());
+    if (!rec) throw new Error(`docs/ship-skills.csv: no record for "${name}"`);
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        activeSkillText: rec.active,
+        chargeSkillText: rec.charge,
+        chargeSkillCharge: rec.chargeCharge,
+        firstPassiveSkillText: rec.passives[0],
+        secondPassiveSkillText: rec.passives[1],
+        thirdPassiveSkillText: rec.passives[2],
+    } as Ship;
+}
+
+describe.skipIf(!csvAvailable())(
+    'Wave 8 Task 14 — Lingshe crit-power detonation-damage scaling',
+    () => {
+        // Lingshe's refit-active (R4) third_passive_skill_text: "This Unit deals 1% more
+        // detonation damage per 10% crit power it has." (the R2 second_passive_skill_text carries
+        // the "per 20%" variant, but only the refit-active passive applies in-game — resolved via
+        // getShipSkillRows(), consistent with docs/ship-skills.csv's convention).
+        it('emits a detonationDamage modifier scaling 1% per 10% crit power (perUnit 0.1)', () => {
+            const { slots } = buildShipAbilities(shipFromCsv('Lingshe'));
+            const abilities = slots.flatMap((s) => s.abilities);
+            const mod = abilities.find(
+                (a) => a.config.type === 'modifier' && a.config.channel === 'detonationDamage'
+            );
+            expect(mod).toBeDefined();
+            if (mod?.config.type !== 'modifier') throw new Error('unreachable');
+            expect(mod.config.value).toBe(0);
+            expect(mod.target).toBe('self');
+            expect(mod.conditions).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({ subject: 'self-crit-power', derivable: true }),
+                ])
+            );
+            expect(mod.scaling).toEqual(
+                expect.objectContaining({ conditionIndex: 0, perUnit: 0.1 })
+            );
+        });
+
+        it('regression: Wildfire dotDamage crit-power modifier is unaffected by the new clause', () => {
+            const { slots } = buildShipAbilities(shipFromCsv('Wildfire'));
+            const abilities = slots.flatMap((s) => s.abilities);
+            const dotMod = abilities.find(
+                (a) => a.config.type === 'modifier' && a.config.channel === 'dotDamage'
+            );
+            expect(dotMod).toBeDefined();
+            const detMod = abilities.find(
+                (a) => a.config.type === 'modifier' && a.config.channel === 'detonationDamage'
+            );
+            expect(detMod).toBeUndefined();
+        });
+    }
+);

--- a/src/utils/abilities/__tests__/wave8Madax.test.ts
+++ b/src/utils/abilities/__tests__/wave8Madax.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { csvAvailable, loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
+
+// Build a full-refit Ship carrying a CSV record's texts (mirrors wave6StealthBypass.test.ts's
+// shipFromCsv helper, copied per the Wave 8 convention so this file has no cross-wave
+// test-file dependency).
+function shipFromCsv(name: string): Ship {
+    const rec = loadShipSkillRecords().find((r) => r.name.toUpperCase() === name.toUpperCase());
+    if (!rec) throw new Error(`docs/ship-skills.csv: no record for "${name}"`);
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        activeSkillText: rec.active,
+        chargeSkillText: rec.charge,
+        chargeSkillCharge: rec.chargeCharge,
+        firstPassiveSkillText: rec.passives[0],
+        secondPassiveSkillText: rec.passives[1],
+        thirdPassiveSkillText: rec.passives[2],
+    } as Ship;
+}
+
+describe.skipIf(!csvAvailable())(
+    'Wave 8 Task 9 — Madax adjacent-Supporter Defense grant (was mis-parsed self-heal)',
+    () => {
+        // Madax's refit-active (second) passive: "This Unit repairs itself for 13% of its Max
+        // HP when an enemy dies. When adjacent to a Supporter, this Unit receives 30% more
+        // Repairs and increases that Supporter's Defense by 20% of this Unit's Defense." The
+        // "increases that Supporter's Defense by 20%…" clause was mis-parsed as a phantom SELF
+        // heal (HEAL_REPAIR_RE's lazy walk matched the noun "Repairs" and ran past the clause
+        // to its unrelated "20%"). It should instead be a Defense stat-GRANT to the adjacent
+        // Supporter ally, and the legit 13% on-enemy-destroyed self-heal must remain untouched.
+        it('does not emit a phantom self-heal with basis defense/pct 20', () => {
+            const abilities = buildShipAbilities(shipFromCsv('Madax'));
+            const flat = abilities.slots.flatMap((s) => s.abilities);
+            const badHeal = flat.find(
+                (a) =>
+                    a.config.type === 'heal' &&
+                    a.config.basis === 'defense' &&
+                    a.config.pct === 20 &&
+                    a.target === 'self'
+            );
+            expect(badHeal).toBeUndefined();
+        });
+
+        it('keeps the 13% on-enemy-destroyed self-heal unchanged', () => {
+            const abilities = buildShipAbilities(shipFromCsv('Madax'));
+            const flat = abilities.slots.flatMap((s) => s.abilities);
+            const goodHeal = flat.find((a) => a.config.type === 'heal' && a.config.pct === 13);
+            expect(goodHeal).toBeDefined();
+            expect(goodHeal?.target).toBe('self');
+            expect(goodHeal?.trigger).toBe('on-enemy-destroyed');
+        });
+
+        it("emits a Defense stat-grant to the adjacent Supporter (20% of this Unit's Defense)", () => {
+            const abilities = buildShipAbilities(shipFromCsv('Madax'));
+            const flat = abilities.slots.flatMap((s) => s.abilities);
+            const grant = flat.find(
+                (a) => a.config.type === 'pre-combat-stat' && a.config.stat === 'defence'
+            );
+
+            expect(grant).toBeDefined();
+            expect(grant?.target).toBe('adjacent-allies');
+            expect(grant?.trigger).toBe('pre-combat');
+            if (grant?.config.type !== 'pre-combat-stat') throw new Error('unreachable');
+            expect(grant.config.value).toBe(20);
+            expect(grant.config.valueKind).toBe('percent-of-donor');
+            expect(grant.config.requiresAdjacentRole).toBe('SUPPORTER');
+        });
+    }
+);

--- a/src/utils/abilities/__tests__/wave8Meiying.test.ts
+++ b/src/utils/abilities/__tests__/wave8Meiying.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Ship } from '../../../types/ship';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const shipWith = (over: Partial<Ship>): Ship => ({ ...({} as any), ...over }) as Ship;
+
+describe('Wave 8 Task 13 — Meiying Stasis-on-kill gated on a debuffed victim (parser)', () => {
+    // Verbatim docs/ship-skills.csv Meiying first_passive_skill_text: "Upon killing an enemy with
+    // a Debuff, this Unit inflicts Stasis on all adjacent enemies for 1 turn." Target
+    // (adjacent-enemies) and trigger (on-enemy-destroyed) already shipped in Wave 5 — locked here
+    // alongside the NEW killed-enemy-had-debuff condition this task adds.
+    const MEIYING_P1 =
+        'Upon killing an enemy with a Debuff, this Unit inflicts <unit-skill>Stasis</unit-skill> on all adjacent enemies for 1 turn.';
+
+    it('the Stasis debuff carries adjacent-enemies target, on-enemy-destroyed trigger, and a killed-enemy-had-debuff condition', () => {
+        const { slots } = buildShipAbilities(shipWith({ firstPassiveSkillText: MEIYING_P1 }));
+        const passive = slots.find((s) => s.slot === 'passive');
+        const stasis = passive?.abilities.find(
+            (a) => a.config.type === 'debuff' && a.config.buffName === 'Stasis'
+        );
+        expect(stasis).toBeDefined();
+        expect(stasis?.target).toBe('adjacent-enemies');
+        expect(stasis?.trigger).toBe('on-enemy-destroyed');
+        expect(stasis?.conditions).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ subject: 'killed-enemy-had-debuff', derivable: true }),
+            ])
+        );
+    });
+
+    it('regression: a plain kill-reactive grant with NO "with a Debuff" qualifier stays ungated', () => {
+        // Mangler/Ravager/Sokol-shape phrasing: "Upon killing an enemy, this Unit gains <Buff>
+        // for N turns." — no debuff qualifier, so the new gate must NOT attach.
+        const s = shipWith({
+            firstPassiveSkillText:
+                'Upon killing an enemy, this Unit gains <unit-skill>Speed Up I</unit-skill> for 3 turns.',
+        });
+        const { slots } = buildShipAbilities(s);
+        const abilities = slots.flatMap((sl) => sl.abilities);
+        const speedUp = abilities.find(
+            (a) => a.config.type === 'buff' && a.config.buffName === 'Speed Up I'
+        );
+        expect(speedUp).toBeDefined();
+        expect(speedUp?.trigger).toBe('on-enemy-destroyed');
+        expect(speedUp?.conditions.some((c) => c.subject === 'killed-enemy-had-debuff')).toBe(
+            false
+        );
+    });
+});

--- a/src/utils/abilities/__tests__/wave8Targets.test.ts
+++ b/src/utils/abilities/__tests__/wave8Targets.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { csvAvailable, loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
+
+// Build a full-refit Ship carrying a CSV record's texts (mirrors wave6StealthBypass.test.ts's
+// shipFromCsv helper — copied here per the Wave 8 Task 5 brief so this file has no cross-wave
+// test-file dependency).
+function shipFromCsv(name: string): Ship {
+    const rec = loadShipSkillRecords().find((r) => r.name.toUpperCase() === name.toUpperCase());
+    if (!rec) throw new Error(`docs/ship-skills.csv: no record for "${name}"`);
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        activeSkillText: rec.active,
+        chargeSkillText: rec.charge,
+        chargeSkillCharge: rec.chargeCharge,
+        firstPassiveSkillText: rec.passives[0],
+        secondPassiveSkillText: rec.passives[1],
+        thirdPassiveSkillText: rec.passives[2],
+    } as Ship;
+}
+
+describe.skipIf(!csvAvailable())(
+    'Wave 8 Task 5 — Selenite Concentrate Fire targets highest-attack enemy',
+    () => {
+        it('Selenite third passive: Concentrate Fire targets enemy-highest-attack, trigger start-of-round', () => {
+            const abilities = buildShipAbilities(shipFromCsv('Selenite'));
+            const cf = abilities.slots
+                .flatMap((s) => s.abilities)
+                .find(
+                    (a) => a.config.type === 'debuff' && a.config.buffName === 'Concentrate Fire'
+                );
+
+            expect(cf?.target).toBe('enemy-highest-attack');
+            expect(cf?.trigger).toBe('start-of-round');
+        });
+    }
+);

--- a/src/utils/abilities/__tests__/wave8Targets.test.ts
+++ b/src/utils/abilities/__tests__/wave8Targets.test.ts
@@ -38,3 +38,17 @@ describe.skipIf(!csvAvailable())(
         });
     }
 );
+
+describe.skipIf(!csvAvailable())(
+    'Wave 8 Task 6 — Quixilver Barrier grant targets all-allies (receiver-aware condition strip)',
+    () => {
+        it('Quixilver third passive: "…if it has shield equal to 100% of its max HP, this Unit grants all allies Barrier…" resolves Barrier to all-allies, not self', () => {
+            const abilities = buildShipAbilities(shipFromCsv('Quixilver'));
+            const barrier = abilities.slots
+                .flatMap((s) => s.abilities)
+                .find((a) => a.config.type === 'buff' && a.config.buffName === 'Barrier');
+
+            expect(barrier?.target).toBe('all-allies');
+        });
+    }
+);

--- a/src/utils/abilities/__tests__/wave8Wisteria.test.ts
+++ b/src/utils/abilities/__tests__/wave8Wisteria.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { csvAvailable, loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
+
+// Build a full-refit Ship carrying a CSV record's texts (mirrors wave6StealthBypass.test.ts's
+// shipFromCsv helper, copied per the Wave 8 convention so this file has no cross-wave
+// test-file dependency).
+function shipFromCsv(name: string): Ship {
+    const rec = loadShipSkillRecords().find((r) => r.name.toUpperCase() === name.toUpperCase());
+    if (!rec) throw new Error(`docs/ship-skills.csv: no record for "${name}"`);
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        activeSkillText: rec.active,
+        chargeSkillText: rec.charge,
+        chargeSkillCharge: rec.chargeCharge,
+        firstPassiveSkillText: rec.passives[0],
+        secondPassiveSkillText: rec.passives[1],
+        thirdPassiveSkillText: rec.passives[2],
+    } as Ship;
+}
+
+describe.skipIf(!csvAvailable())(
+    'Wave 8 Task 10 — Wisteria self-crit Corrosion → Inferno II injection',
+    () => {
+        // Wisteria's refit-active (R2) passive: "This Unit inflicts Inferno II for 2 turns after
+        // applying Corrosion with a Critical hit and extends the newly applied Corrosion by 1
+        // turn with a chance to hit equal to Crit Power." Two mechanics in ONE clause:
+        //  1. A self-crit-gated secondary DoT injection ("inflicts Inferno II for 2 turns after
+        //     applying Corrosion with a Critical hit") — previously UNMODELED entirely.
+        //  2. The Corrosion extension ("extends the newly applied Corrosion by 1 turn with a
+        //     chance to hit equal to Crit Power") — already modeled as `extend-dot` and must
+        //     keep working unchanged alongside the new dot injection.
+        it('emits an Inferno II dot (duration 2) on the self on-crit-after-Corrosion trigger', () => {
+            const { slots } = buildShipAbilities(shipFromCsv('Wisteria'));
+            const flat = slots.flatMap((s) => s.abilities);
+            const inferno = flat.find(
+                (a) => a.config.type === 'dot' && a.config.dotType === 'inferno'
+            );
+            expect(inferno).toBeDefined();
+            if (inferno?.config.type !== 'dot') throw new Error('unreachable');
+            expect(inferno.config.tier).toBe(30); // Inferno II
+            expect(inferno.config.duration).toBe(2);
+            expect(inferno.trigger).toBe('on-self-crit-dot');
+            expect(inferno.target).toBe('enemy');
+        });
+
+        it('still emits the Corrosion extend-dot ability (self-crit, chance-from-crit-power)', () => {
+            const { slots } = buildShipAbilities(shipFromCsv('Wisteria'));
+            const flat = slots.flatMap((s) => s.abilities);
+            const extend = flat.find((a) => a.config.type === 'extend-dot');
+            expect(extend).toBeDefined();
+            if (extend?.config.type !== 'extend-dot') throw new Error('unreachable');
+            expect(extend.config.turns).toBe(1);
+            expect(extend.config.chanceFromCritPower).toBe(true);
+            expect(extend.config.scope).toBe('inflicted');
+        });
+
+        it("does not mint a phantom Corrosion dot in the passive slot (only Inferno II, not the trigger clause's own named DoT)", () => {
+            // Scoped to the PASSIVE slot: the active/charge skills legitimately inflict their own
+            // Corrosion DoTs (buildDoTAutoFill), unrelated to this self-crit-dot mechanic.
+            const { slots } = buildShipAbilities(shipFromCsv('Wisteria'));
+            const passive = slots.find((s) => s.slot === 'passive')!;
+            const dots = passive.abilities.filter((a) => a.config.type === 'dot');
+            expect(dots).toHaveLength(1);
+            if (dots[0].config.type !== 'dot') throw new Error('unreachable');
+            expect(dots[0].config.dotType).toBe('inferno');
+        });
+    }
+);

--- a/src/utils/abilities/__tests__/wave8Wusheng.test.ts
+++ b/src/utils/abilities/__tests__/wave8Wusheng.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { csvAvailable, loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
+
+// Build a full-refit Ship carrying a CSV record's texts (mirrors wave6StealthBypass.test.ts's
+// shipFromCsv helper, copied per the Wave 8 convention so this file has no cross-wave
+// test-file dependency).
+function shipFromCsv(name: string): Ship {
+    const rec = loadShipSkillRecords().find((r) => r.name.toUpperCase() === name.toUpperCase());
+    if (!rec) throw new Error(`docs/ship-skills.csv: no record for "${name}"`);
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        activeSkillText: rec.active,
+        chargeSkillText: rec.charge,
+        chargeSkillCharge: rec.chargeCharge,
+        firstPassiveSkillText: rec.passives[0],
+        secondPassiveSkillText: rec.passives[1],
+        thirdPassiveSkillText: rec.passives[2],
+    } as Ship;
+}
+
+describe.skipIf(!csvAvailable())(
+    'Wave 8 Task 11 — Wusheng removes Stealth on direct damage',
+    () => {
+        // Wusheng's refit-active (R2) passive: "This Unit gains Stealth for 1 turn after
+        // critically damaging an enemy.<br/><br/>This Unit reduces direct damage by 25% while
+        // Stealth is active. If directly damaged while Stealth is active, remove Stealth.<br/><br/>
+        // This Unit starts combat fully charged." Two previously-modeled mechanics (the on-crit
+        // Stealth grant, the 25% incoming reduction) plus the UNMODELED "remove Stealth on direct
+        // damage" reaction targeted by this task.
+        it('emits a remove-self-buff ability for Stealth on the on-attacked (directly-damaged) trigger', () => {
+            const { slots } = buildShipAbilities(shipFromCsv('Wusheng'));
+            const abilities = slots.flatMap((s) => s.abilities);
+            const remove = abilities.find(
+                (a) => a.config.type === 'remove-self-buff' && a.config.buffName === 'Stealth'
+            );
+            expect(remove).toBeDefined();
+            expect(remove?.trigger).toBe('on-attacked');
+            expect(remove?.target).toBe('self');
+            if (remove?.config.type !== 'remove-self-buff') throw new Error('unreachable');
+            expect(remove.config.scope).toBe('all');
+            // Gated on Stealth still being active — the game text is conditional ("if directly
+            // damaged WHILE Stealth is active"), not an unconditional kill/repair-style removal.
+            expect(remove.conditions).toEqual([
+                { subject: 'self-buff', buffName: 'Stealth', derivable: true },
+            ]);
+        });
+
+        it('still emits the existing 25% incoming-reduction ability gated on self-stealth', () => {
+            const { slots } = buildShipAbilities(shipFromCsv('Wusheng'));
+            const abilities = slots.flatMap((s) => s.abilities);
+            const reduction = abilities.find((a) => a.config.type === 'incoming-reduction');
+            expect(reduction).toBeDefined();
+            if (reduction?.config.type !== 'incoming-reduction') throw new Error('unreachable');
+            expect(reduction.config).toMatchObject({
+                scope: 'direct',
+                condition: 'self-stealth',
+                pct: 25,
+            });
+        });
+
+        it('still emits the on-crit Stealth grant (unaffected by the removal wiring)', () => {
+            const { slots } = buildShipAbilities(shipFromCsv('Wusheng'));
+            const abilities = slots.flatMap((s) => s.abilities);
+            const grant = abilities.find(
+                (a) =>
+                    a.type === 'buff' && a.config.type === 'buff' && a.config.buffName === 'Stealth'
+            );
+            expect(grant).toBeDefined();
+            expect(grant?.trigger).toBe('on-crit');
+        });
+    }
+);

--- a/src/utils/abilities/__tests__/wave8Xcellence.test.ts
+++ b/src/utils/abilities/__tests__/wave8Xcellence.test.ts
@@ -51,3 +51,29 @@ describe.skipIf(!csvAvailable())('Wave 8 Task 7 — Xcellence active untagged St
         expect(stasis?.target).toBe('enemy');
     });
 });
+
+// Xcellence's refit-active passive (R2, docs/ship-skills.csv second_passive_skill_text):
+// "…When an enemy resists a debuff infliction, this Unit deals damage equal to <unit-damage>
+// 115%</unit-damage> of this Unit's current shield.." — a reactive on-resist proc whose basis
+// is the OWNER's current shield rather than max HP (the Vindicator on-resist analog,
+// parseOnResistHpDamage). Subject is "an enemy resists" (the enemy resisted A DEBUFF THIS UNIT
+// inflicted), an INFLICTOR-scoped proc, so it routes on 'on-own-debuff-resisted' (the mirror of
+// Vindicator's self-resisted 'on-debuff-resisted'). Field names verified against the shipped
+// hpBasisPct sibling (buildShipAbilities.ts's Vindicator wiring): multiplier:0, the amount rides
+// a dedicated *BasisPct field, not `pct`.
+describe.skipIf(!csvAvailable())(
+    'Wave 8 Task 8 — Xcellence on-resist shield-basis reactive damage',
+    () => {
+        it('passive emits an on-own-debuff-resisted damage ability with shieldBasisPct 115', () => {
+            const abilities = buildShipAbilities(shipFromCsv('Xcellence'));
+            const passive = abilities.slots.find((s) => s.slot === 'passive')?.abilities ?? [];
+
+            const onResist = passive.find(
+                (a) => a.type === 'damage' && a.trigger === 'on-own-debuff-resisted'
+            );
+            expect(onResist).toBeDefined();
+            expect(onResist?.target).toBe('enemy');
+            expect(onResist?.config).toMatchObject({ type: 'damage', shieldBasisPct: 115 });
+        });
+    }
+);

--- a/src/utils/abilities/__tests__/wave8Xcellence.test.ts
+++ b/src/utils/abilities/__tests__/wave8Xcellence.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { csvAvailable, loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
+
+// Build a full-refit Ship carrying a CSV record's texts (mirrors wave6StealthBypass.test.ts's
+// shipFromCsv helper, copied per the Wave 8 Task 7 brief so this file has no cross-wave
+// test-file dependency).
+function shipFromCsv(name: string): Ship {
+    const rec = loadShipSkillRecords().find((r) => r.name.toUpperCase() === name.toUpperCase());
+    if (!rec) throw new Error(`docs/ship-skills.csv: no record for "${name}"`);
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        activeSkillText: rec.active,
+        chargeSkillText: rec.charge,
+        chargeSkillCharge: rec.chargeCharge,
+        firstPassiveSkillText: rec.passives[0],
+        secondPassiveSkillText: rec.passives[1],
+        thirdPassiveSkillText: rec.passives[2],
+    } as Ship;
+}
+
+// Xcellence's active skill (docs/ship-skills.csv): "This Unit Deals <unit-damage>150%
+// damage</unit-damage> and Inflicts <unit-skill>Speed Down II</unit-skill> for 2 turns and
+// Stasis for 2 turn." — "Stasis" is a BARE word (no <unit-skill> wrapper), unlike Speed Down II.
+// Wave 8 Task 7: the parser previously required the <unit-skill> tag to recognise a Stasis
+// inflict, so this untagged mention was silently dropped (150% damage + Speed Down II parsed;
+// Stasis did not). Duration text is "for 2 turn" (singular typo) — must still parse to 2.
+describe.skipIf(!csvAvailable())('Wave 8 Task 7 — Xcellence active untagged Stasis inflict', () => {
+    it('active emits 150% damage, Speed Down II, and a bare Stasis debuff (duration 2)', () => {
+        const abilities = buildShipAbilities(shipFromCsv('Xcellence'));
+        const active = abilities.slots.find((s) => s.slot === 'active')?.abilities ?? [];
+
+        const damage = active.find((a) => a.config.type === 'damage');
+        expect(damage).toBeDefined();
+        expect(damage?.config.type === 'damage' && damage.config.multiplier).toBe(150);
+
+        const speedDown = active.find(
+            (a) => a.config.type === 'debuff' && a.config.buffName === 'Speed Down II'
+        );
+        expect(speedDown).toBeDefined();
+        expect(speedDown?.config.type === 'debuff' && speedDown.config.duration).toBe(2);
+
+        const stasis = active.find(
+            (a) => a.config.type === 'debuff' && a.config.buffName === 'Stasis'
+        );
+        expect(stasis).toBeDefined();
+        expect(stasis?.config.type === 'debuff' && stasis.config.duration).toBe(2);
+        expect(stasis?.target).toBe('enemy');
+    });
+});

--- a/src/utils/abilities/__tests__/wave8Zeolite.test.ts
+++ b/src/utils/abilities/__tests__/wave8Zeolite.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { buildShipAbilities } from '../buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { csvAvailable, loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
+
+// Build a full-refit Ship carrying a CSV record's texts (Wave 8 convention — copied per-file to
+// avoid a cross-wave test dependency, see wave8Wusheng.test.ts).
+function shipFromCsv(name: string): Ship {
+    const rec = loadShipSkillRecords().find((r) => r.name.toUpperCase() === name.toUpperCase());
+    if (!rec) throw new Error(`docs/ship-skills.csv: no record for "${name}"`);
+    return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}],
+        activeSkillText: rec.active,
+        chargeSkillText: rec.charge,
+        chargeSkillCharge: rec.chargeCharge,
+        firstPassiveSkillText: rec.passives[0],
+        secondPassiveSkillText: rec.passives[1],
+        thirdPassiveSkillText: rec.passives[2],
+    } as Ship;
+}
+
+describe.skipIf(!csvAvailable())(
+    'Wave 8 Task 12 — Zeolite purges a buff when damaging a Defender',
+    () => {
+        // Zeolite's refit-active (R4) passive: "This Unit increases damage by 30% when hitting a
+        // Defender and purges 1 buff from the enemy when dealing damage to a Defender." The +30%
+        // damage gate half shipped in Wave 4; the purge half ("purges 1 buff from the enemy when
+        // dealing damage to a Defender") was deferred — buildShipAbilities.ts's passive-purge
+        // trigger chain had no "when dealing damage to a Defender" detector, so `trigger` came
+        // back undefined and the `continue` guard dropped it.
+        it('emits a purge ability (enemy, count 1) gated on damaging a Defender, IN ADDITION to the +30% damage modifier', () => {
+            const { slots } = buildShipAbilities(shipFromCsv('Zeolite'));
+            // Scoped to the PASSIVE slot: Zeolite's ACTIVE skill separately carries its own
+            // unconditional on-cast purge (a distinct, pre-existing mechanic) — the passive slot
+            // is where the Defender-gated +30%/purge sentence under test actually lives.
+            const passive = slots.find((s) => s.slot === 'passive')!;
+            expect(passive).toBeDefined();
+            const abilities = passive.abilities;
+
+            // Wave-4 half: still present, unaffected.
+            const mod = abilities.find(
+                (a) => a.config.type === 'modifier' && a.config.channel === 'outgoingDamage'
+            );
+            expect(mod).toBeDefined();
+            expect(mod?.conditions).toEqual([
+                { subject: 'enemy-type', derivable: true, requiredEnemyType: 'Defender' },
+            ]);
+
+            // New (Task 12) half: the purge.
+            const purge = abilities.find((a) => a.config.type === 'purge');
+            expect(purge).toBeDefined();
+            expect(purge?.target).toBe('enemy');
+            if (purge?.config.type !== 'purge') throw new Error('unreachable');
+            expect(purge.config.count).toBe(1);
+            // Trigger fires on dealing damage to a Defender — mirrors the Wave-4 +30% gate's
+            // `enemy-type` condition shape exactly (same subject the reactive-purge executor and
+            // the modifier gate both consume).
+            expect(purge?.trigger).toBe('on-deal-damage');
+            expect(purge?.conditions).toEqual([
+                { subject: 'enemy-type', derivable: true, requiredEnemyType: 'Defender' },
+            ]);
+        });
+
+        it('regression: Sefuba/Rhodium/Faust/Iridium-shape purges are unaffected (no enemy-type condition leaks in)', () => {
+            // Sanity check on a NEIGHBOURING purge shape that shares the generic passive-purge
+            // loop: Rhodium's end-of-round purge carries no enemy-type condition.
+            const rhodium = shipFromCsv('Rhodium');
+            const { slots } = buildShipAbilities(rhodium);
+            const abilities = slots.flatMap((s) => s.abilities);
+            const purges = abilities.filter((a) => a.config.type === 'purge');
+            for (const p of purges) {
+                expect(p.conditions.some((c) => c.subject === 'enemy-type')).toBe(false);
+            }
+        });
+    }
+);

--- a/src/utils/abilities/buffAbilityConverters.ts
+++ b/src/utils/abilities/buffAbilityConverters.ts
@@ -42,13 +42,18 @@ export function abilityToSelectedBuff(ability: Ability, slot: SkillSlot): Select
 // Ship-kit W8 (review fix): previously only selectedBuffToAbility had this full set;
 // buffAbilitiesToSelectedBuffs used a narrower inline check and misclassified
 // 'enemy-highest-attack' as a self-buff in the DPS preview panel.
+// Ship-kit W8 (CodeRabbit round): 'enemy-most-buffs' and 'enemy-highest-speed' are likewise
+// enemy-side highest/most selectors (see AbilityTarget in src/types/abilities.ts) — same
+// misclassification risk if a buff/debuff config is ever retargeted to them.
 function isEnemyTarget(target: AbilityTarget): boolean {
     return (
         target === 'enemy' ||
         target === 'all-enemies' ||
         target === 'adjacent-enemies' ||
         target === 'target-and-adjacent-enemies' ||
-        target === 'enemy-highest-attack'
+        target === 'enemy-highest-attack' ||
+        target === 'enemy-most-buffs' ||
+        target === 'enemy-highest-speed'
     );
 }
 

--- a/src/utils/abilities/buffAbilityConverters.ts
+++ b/src/utils/abilities/buffAbilityConverters.ts
@@ -36,11 +36,16 @@ export function selectedBuffToAbility(buff: SelectedGameBuff, target: AbilityTar
     // Wave 5 (Task A2): the two enemy-adjacency scopes are enemy-side debuffs too (Vindicator's
     // Provoke, Asphyxiator's Stasis) — without this they'd fall through to the buff branch below
     // and lose their debuff config (application verb, resistibility).
+    // Ship-kit W8 (Task 5): 'enemy-highest-attack' is likewise an enemy-side selector (Selenite's
+    // round-start Concentrate Fire) — without it here, mergeBuff's retarget to
+    // 'enemy-highest-attack' would silently fall through to the 'buff' branch below and lose the
+    // debuff config (application verb, resistibility), same failure mode as the adjacency scopes.
     const isEnemy =
         target === 'enemy' ||
         target === 'all-enemies' ||
         target === 'adjacent-enemies' ||
-        target === 'target-and-adjacent-enemies';
+        target === 'target-and-adjacent-enemies' ||
+        target === 'enemy-highest-attack';
     const duration: number | 'recurring' | undefined =
         typeof buff.skillDuration === 'number' || buff.skillDuration === 'recurring'
             ? buff.skillDuration

--- a/src/utils/abilities/buffAbilityConverters.ts
+++ b/src/utils/abilities/buffAbilityConverters.ts
@@ -32,20 +32,28 @@ export function abilityToSelectedBuff(ability: Ability, slot: SkillSlot): Select
     };
 }
 
-export function selectedBuffToAbility(buff: SelectedGameBuff, target: AbilityTarget): Ability {
-    // Wave 5 (Task A2): the two enemy-adjacency scopes are enemy-side debuffs too (Vindicator's
-    // Provoke, Asphyxiator's Stasis) — without this they'd fall through to the buff branch below
-    // and lose their debuff config (application verb, resistibility).
-    // Ship-kit W8 (Task 5): 'enemy-highest-attack' is likewise an enemy-side selector (Selenite's
-    // round-start Concentrate Fire) — without it here, mergeBuff's retarget to
-    // 'enemy-highest-attack' would silently fall through to the 'buff' branch below and lose the
-    // debuff config (application verb, resistibility), same failure mode as the adjacency scopes.
-    const isEnemy =
+// Shared enemy-target classifier — used by BOTH selectedBuffToAbility and
+// buffAbilitiesToSelectedBuffs so the two conversion directions can't drift apart on which
+// AbilityTarget values count as "enemy-side". Wave 5 (Task A2): the two enemy-adjacency scopes
+// are enemy-side debuffs too (Vindicator's Provoke, Asphyxiator's Stasis) — without them a
+// buff/debuff round-trip would fall through to the 'buff' branch and lose the debuff config
+// (application verb, resistibility). Ship-kit W8 (Task 5): 'enemy-highest-attack' is likewise an
+// enemy-side selector (Selenite's round-start Concentrate Fire) — same failure mode if omitted.
+// Ship-kit W8 (review fix): previously only selectedBuffToAbility had this full set;
+// buffAbilitiesToSelectedBuffs used a narrower inline check and misclassified
+// 'enemy-highest-attack' as a self-buff in the DPS preview panel.
+function isEnemyTarget(target: AbilityTarget): boolean {
+    return (
         target === 'enemy' ||
         target === 'all-enemies' ||
         target === 'adjacent-enemies' ||
         target === 'target-and-adjacent-enemies' ||
-        target === 'enemy-highest-attack';
+        target === 'enemy-highest-attack'
+    );
+}
+
+export function selectedBuffToAbility(buff: SelectedGameBuff, target: AbilityTarget): Ability {
+    const isEnemy = isEnemyTarget(target);
     const duration: number | 'recurring' | undefined =
         typeof buff.skillDuration === 'number' || buff.skillDuration === 'recurring'
             ? buff.skillDuration
@@ -141,7 +149,7 @@ export function buffAbilitiesToSelectedBuffs(
             if (!conditionsMet(staticGateConditions(ability.conditions), staticCtx)) continue;
             const sb = abilityToSelectedBuff(ability, slot.slot);
             if (!sb) continue;
-            if (ability.target === 'enemy' || ability.target === 'all-enemies') {
+            if (isEnemyTarget(ability.target)) {
                 enemyDebuffs.push(sb);
             } else {
                 selfBuffs.push(sb);

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -26,6 +26,7 @@ import {
     parseDamageReflection,
     parseSecondaryDamage,
     parseOnResistHpDamage,
+    parseOnResistShieldDamage,
     parseKilledByDirectHpDamage,
     parseShieldStrip,
     parseConditionalDamage,
@@ -1417,6 +1418,36 @@ function abilitiesFromText(
                     autoFilled: true,
                 },
                 pos: onKilledIdx >= 0 ? onKilledIdx : MAX_POS,
+            });
+        }
+
+        // Xcellence p2: "When an enemy resists a debuff infliction, this Unit deals damage
+        // equal to X% of this Unit's current shield." Ship-kit W8 — an INFLICTOR-scoped
+        // sibling of the Vindicator proc above: THIS unit inflicted the debuff and the ENEMY
+        // resisted it, so it routes on the on-own-debuff-resisted trigger (not
+        // on-debuff-resisted) — that trigger stamps counterTargetId = the resister, exactly
+        // the enemy this reaction should retaliate against. multiplier:0 — the amount rides
+        // shieldBasisPct (owner's current shield), read by the same reactive-damage executor
+        // that already reads hpBasisPct.
+        const onResistShield = parseOnResistShieldDamage(text);
+        if (onResistShield) {
+            const onResistShieldIdx = text.search(/<unit-damage>/i);
+            out.push({
+                ability: {
+                    id: nextId(),
+                    type: 'damage',
+                    target: 'enemy',
+                    trigger: 'on-own-debuff-resisted',
+                    conditions: [],
+                    config: {
+                        type: 'damage',
+                        multiplier: 0,
+                        hits: 1,
+                        shieldBasisPct: onResistShield.pct,
+                    },
+                    autoFilled: true,
+                },
+                pos: onResistShieldIdx >= 0 ? onResistShieldIdx : MAX_POS,
             });
         }
     }

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -3294,9 +3294,9 @@ export function buildShipAbilities(ship: Ship): ShipSkills {
         // this wires an existing selector, not a new one). Sentence/position-scoped on this buff's
         // own name anchor (mirrors parseHighestSpeedEnemyTarget's damagePos scoping above) and
         // gated on the plain 'enemy' scope only, so a co-located all-enemies/adjacent debuff in
-        // the same row is unaffected. Other ships' Concentrate Fire debuffs (Huanying, Judge,
-        // Lodolite, Stalwart, Vanguard, Yuyan) carry no "highest attack enemy" phrase, so the
-        // narrow regex leaves them at the plain 'enemy' target.
+        // the same row is unaffected. The other seven Concentrate Fire ships in the corpus
+        // (Huanying, Judge, Lodolite, Stalwart, Valkyrie, Vanguard, Yuyan) carry no "highest
+        // attack enemy" phrase, so the narrow regex leaves them at the plain 'enemy' target.
         if (enemyTarget === 'enemy') {
             const slotForThisBuff = slotForBuffSource(buff.skillSource);
             const rowTextForThisBuff = getSkillRowForSlot(ship, slotForThisBuff)?.text ?? '';

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -612,6 +612,32 @@ function parseModifiers(text: string): ParsedModifier[] {
         }
     }
 
+    // Wave 8, Task 14: "N% more detonation damage per M% crit power" (Lingshe refit-active:
+    // "This Unit deals 1% more detonation damage per 10% crit power it has.") → a
+    // detonationDamage-channel modifier scaling with the caster's own live crit power, modelled
+    // EXACTLY on the Wildfire dotDamage crit-power modifier above (~563-613). The detonationDamage
+    // channel is already fully consumed by the engine (applyAbilities.ts, effectiveStats.ts,
+    // detonation.ts/engine.ts) and snapshotted onto each PendingBomb at cast time
+    // (playerTurn.ts:822) — same snapshot-at-application approximation as Voidfire's affinity
+    // snapshot: Lingshe's bonus applies to her own bombs (applier=detonator) but NOT to foreign
+    // bombs she detonates via countdown-reduce.
+    const detonationCritPowerM = plain.match(
+        /(\d+(?:\.\d+)?)%\s+more\s+detonation\s+damage\s+per\s+(\d+(?:\.\d+)?)%\s+crit\s+power/i
+    );
+    if (detonationCritPowerM) {
+        const detValue = parseFloat(detonationCritPowerM[1]);
+        const per = parseFloat(detonationCritPowerM[2]);
+        const conditions: Condition[] = [{ subject: 'self-crit-power', derivable: true }];
+        out.push({
+            channel: 'detonationDamage',
+            value: 0,
+            isMultiplicative: false,
+            target: 'self',
+            conditions,
+            scaling: { conditionIndex: conditions.length - 1, perUnit: detValue / per },
+        });
+    }
+
     // "increases [outgoing] [direct] Damage by [up to] N% [to enemies with <effect> / below X% HP]"
     // → an outgoing-damage bonus (Obsidian). HP-proportional phrasings (Akula's "up to 30%
     // based on the target's current HP percentage") become a scaling modifier on the live

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -72,6 +72,8 @@ import {
     detectEndOfRoundDamageTrigger,
     detectRoundStartContinuationTrigger,
     detectKilledByDirectDamageTrigger,
+    detectDealDamageToRoleTrigger,
+    detectPurgeEnemyTypeCondition,
     detectMostBuffsTarget,
     parseHighestSpeedEnemyTarget,
     parseHighestAttackEnemyTarget,
@@ -2367,10 +2369,12 @@ function abilitiesFromText(
 
     // Emit purge from active/charged (on-cast, C2a) AND from a PASSIVE slot WHEN a purge
     // trigger is detected in the purge's own sentence (C2b-2): Iridium "when directly damaged"
-    // → on-attacked. Rhodium end-of-round + Faust killed-by-direct-damage detectors are added
-    // in later tasks. A passive purge with NO detected trigger is NOT emitted (Sefuba's chain
-    // stays on PURGE_MORE_RE below; Zeolite's "when dealing damage to a Defender" stays
-    // deferred). Purge is enemy-only (no support-flip).
+    // → on-attacked. Rhodium end-of-round + Faust killed-by-direct-damage detectors, plus
+    // Zeolite's "when dealing damage to a Defender" (Wave 8 Task 12) → on-deal-damage, carrying
+    // an `enemy-type` Defender condition (see detectPurgeEnemyTypeCondition below — same
+    // extraction the outgoing-damage-modifier branch above uses for Zeolite's sibling "+30%
+    // damage when hitting a Defender" gate). A passive purge with NO detected trigger is NOT
+    // emitted (Sefuba's chain stays on PURGE_MORE_RE below). Purge is enemy-only (no support-flip).
     //
     // C2b-3 update: Nayra's "if the target was repaired this round, purge all buffs" now emits
     // with conditions:[{subject:'target-repaired-this-round', derivable:true}] (see
@@ -2395,7 +2399,8 @@ function abilitiesFromText(
             detectDamageReactionTrigger(text, purgePos)?.trigger === 'on-attacked'
                 ? ('on-attacked' as const)
                 : (detectEndOfRoundPurgeTrigger(text, purgePos) ?? // Rhodium
-                  detectKilledByDirectDamageTrigger(text, purgePos)); // Faust
+                  detectKilledByDirectDamageTrigger(text, purgePos) ?? // Faust
+                  detectDealDamageToRoleTrigger(text, purgePos)); // Zeolite (Task 12)
         const trigger: AbilityTrigger | undefined =
             slot === 'active' || slot === 'charged' ? 'on-cast' : passiveTrigger;
         if (!trigger) continue; // passive purge with no recognized trigger → not emitted
@@ -2405,13 +2410,24 @@ function abilitiesFromText(
             ? 'enemy-most-buffs'
             : p.target;
         const repairedCond = detectRepairedThisRoundCondition(text, purgePos);
+        // Task 12: an on-deal-damage purge (Zeolite) is gated on the DAMAGED enemy being the
+        // named role (Defender) — reuses the enemy-type extraction shared with the +30%
+        // damage-modifier branch above. Only computed for the on-deal-damage trigger so no
+        // other purge (Iridium/Rhodium/Faust) picks up a spurious condition.
+        const enemyTypeCond =
+            trigger === 'on-deal-damage'
+                ? detectPurgeEnemyTypeCondition(text, purgePos)
+                : undefined;
         out.push({
             ability: {
                 id: nextId(),
                 type: 'purge',
                 target,
                 trigger,
-                conditions: repairedCond ? [repairedCond] : [],
+                conditions: [
+                    ...(repairedCond ? [repairedCond] : []),
+                    ...(enemyTypeCond ? [enemyTypeCond] : []),
+                ],
                 config: {
                     type: 'purge',
                     count: p.count,

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -71,6 +71,7 @@ import {
     detectKilledByDirectDamageTrigger,
     detectMostBuffsTarget,
     parseHighestSpeedEnemyTarget,
+    parseHighestAttackEnemyTarget,
     detectRepairedThisRoundCondition,
     detectEnemyRepairedTrigger,
     detectEnemyDotDamageTrigger,
@@ -3286,7 +3287,31 @@ export function buildShipAbilities(ship: Ship): ShipSkills {
         // Player-side grants carry granular effectTarget (self/ally/all-allies, wired above);
         // enemy debuffs now do too ('enemy' vs 'all-enemies' — detectEnemyGrantScope). Defaults
         // to 'enemy' for round-trip debuffs that predate the effectTarget field.
-        mergeBuff(buff, buff.effectTarget ?? 'enemy');
+        let enemyTarget: AbilityTarget = buff.effectTarget ?? 'enemy';
+        // Ship-kit W8 (Task 5): Selenite p3's round-start "the highest attack enemy is applied
+        // with Concentrate Fire" re-targets from the plain 'enemy' default to 'enemy-highest-
+        // attack' (the selector already resolves live at applyAbilities.ts, used by gear procs —
+        // this wires an existing selector, not a new one). Sentence/position-scoped on this buff's
+        // own name anchor (mirrors parseHighestSpeedEnemyTarget's damagePos scoping above) and
+        // gated on the plain 'enemy' scope only, so a co-located all-enemies/adjacent debuff in
+        // the same row is unaffected. Other ships' Concentrate Fire debuffs (Huanying, Judge,
+        // Lodolite, Stalwart, Vanguard, Yuyan) carry no "highest attack enemy" phrase, so the
+        // narrow regex leaves them at the plain 'enemy' target.
+        if (enemyTarget === 'enemy') {
+            const slotForThisBuff = slotForBuffSource(buff.skillSource);
+            const rowTextForThisBuff = getSkillRowForSlot(ship, slotForThisBuff)?.text ?? '';
+            const buffPos = rowTextForThisBuff
+                ? findBuffNamePos(rowTextForThisBuff, buff.buffName)
+                : -1;
+            if (
+                rowTextForThisBuff &&
+                buffPos >= 0 &&
+                parseHighestAttackEnemyTarget(rowTextForThisBuff, buffPos)
+            ) {
+                enemyTarget = 'enemy-highest-attack';
+            }
+        }
+        mergeBuff(buff, enemyTarget);
     }
 
     // Phase 4c PR 1 (Task 8): damage-reaction DoT inflictions on the PASSIVE row (Warden

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -2633,6 +2633,15 @@ function abilitiesFromText(
     // Overload lose-on-kill (and "removes"/"is lost" phrasings): the 5 Marauder ships drop a
     // named self-buff on a reactive trigger. parseSelfBuffRemovals (Task 5) scopes the trigger to
     // the removal clause's position; the buff is cleared from ALL self stores (scope: 'all').
+    //
+    // Wave 8 Task 11 (Wusheng): an `on-attacked` removal ("if directly damaged … remove Stealth")
+    // additionally gates on the named buff still being ACTIVE at drain time — unlike the Marauder
+    // kill/repair/debuff triggers (which fire unconditionally; removeSelfBuffByName is a safe
+    // no-op if the buff was never present, so those never needed a gate), Wusheng's text is
+    // explicitly conditional ("if directly damaged WHILE Stealth is active"). The generic
+    // `self-buff` ConditionSubject (evaluateConditions.ts) already reads a live buff-presence
+    // count off the owner's snapshot, so this reuses existing machinery rather than adding a new
+    // condition kind.
     for (const rem of parseSelfBuffRemovals(text)) {
         const removePos = findBuffNamePos(text, rem.buffName);
         out.push({
@@ -2641,7 +2650,10 @@ function abilitiesFromText(
                 type: 'remove-self-buff',
                 target: 'self',
                 trigger: rem.trigger,
-                conditions: [],
+                conditions:
+                    rem.trigger === 'on-attacked'
+                        ? [{ subject: 'self-buff', buffName: rem.buffName, derivable: true }]
+                        : [],
                 config: { type: 'remove-self-buff', buffName: rem.buffName, scope: 'all' },
                 autoFilled: true,
             },

--- a/src/utils/abilities/buildShipAbilities.ts
+++ b/src/utils/abilities/buildShipAbilities.ts
@@ -53,6 +53,8 @@ import {
     parseBombCountdownReduce,
     parseAllyCritDot,
     detectAllyCritDotTrigger,
+    parseSelfCritDotEffect,
+    detectSelfCritDotTrigger,
     detectBombDetonatedTrigger,
     detectCritRepairTrigger,
     detectDebuffInflictedTrigger,
@@ -1783,6 +1785,50 @@ function abilitiesFromText(
                 },
                 pos: allyCritDotPos >= 0 ? allyCritDotPos : MAX_POS,
             });
+        }
+    }
+
+    // Ship-kit W8 Task 10 (Wisteria): self-subject sibling of the Crocus on-ally-crit-dot block
+    // above — "This Unit ... after applying <DoT> with a Critical hit, inflicts <DoT> for N
+    // turns" (R0) / "inflicts <DoT> for N turns after applying <DoT> with a Critical hit ..."
+    // (R2, refit-active). Deliberately NOT reusing the parseSkillEffects tag walk the
+    // on-ally-crit-dot block uses above: Wisteria's own TRIGGER clause names a DoT ("applying
+    // Corrosion with a Critical hit"), and DOT_TIER_MAP carries a bare 'Corrosion' entry — that
+    // walk would mint a phantom Corrosion dot from the trigger's own named DoT (see
+    // parseSelfCritDotEffect's comment; buildShipAbilities.test.ts's "no phantom Corrosion dot"
+    // guard covers exactly this). parseSelfCritDotEffect instead anchors on the "inflicts X for
+    // N turns" clause specifically, in EITHER ordering, so only the genuinely injected DoT
+    // (Inferno II) is ever extracted, landing on the SAME reactive on-self-crit-dot trigger
+    // machinery (see triggers.ts/types/abilities.ts).
+    const selfCritDotEffect = parseSelfCritDotEffect(text);
+    if (selfCritDotEffect) {
+        const info = DOT_TIER_MAP[selfCritDotEffect.buffName];
+        if (info) {
+            const selfCritDotPos = findBuffNamePos(text, selfCritDotEffect.buffName);
+            const selfCritDotTrigger = detectSelfCritDotTrigger(
+                text,
+                selfCritDotPos >= 0 ? selfCritDotPos : 0
+            );
+            if (selfCritDotTrigger) {
+                out.push({
+                    ability: {
+                        id: nextId(),
+                        type: 'dot',
+                        target: 'enemy',
+                        trigger: selfCritDotTrigger, // 'on-self-crit-dot'
+                        conditions: [],
+                        config: {
+                            type: 'dot',
+                            dotType: info.type,
+                            tier: info.tier,
+                            stacks: 1,
+                            duration: selfCritDotEffect.turns,
+                        },
+                        autoFilled: true,
+                    },
+                    pos: selfCritDotPos >= 0 ? selfCritDotPos : MAX_POS,
+                });
+            }
         }
     }
 

--- a/src/utils/abilities/evaluateConditions.ts
+++ b/src/utils/abilities/evaluateConditions.ts
@@ -106,6 +106,13 @@ export interface ConditionContext {
      *  supplies a roster (battle sim). Absent (single-ship DPS / any caller without a roster) →
      *  `ally-on-team` falls back to the manual assume-met path, byte-identical to before. */
     allyTeamNames?: string[];
+    /** Ship-kit W8 Task 13 (Meiying) -- true when the enemy THIS on-enemy-destroyed reaction just
+     *  killed carried at least one debuff at the moment it died. Live-derived by the engine from
+     *  the victim's own per-target debuff store (eventCtx.victimId), computed only when a victim
+     *  was actually resolved for this intent. Defaults false (DPS mode / no on-enemy-destroyed
+     *  victim) -- inert for every other reactive trigger and every other on-enemy-destroyed
+     *  ability (none of which carry this condition). */
+    killedEnemyHadDebuff?: boolean;
 }
 
 /** Resolve one condition to a count (>= 0). 0 means "not met". */
@@ -166,6 +173,8 @@ export function evaluateCondition(cond: Condition, ctx: ConditionContext): numbe
         case 'enemy-dot-count':
             if (cond.buffName) return ctx.enemyDotFamilyCounts?.[cond.buffName] ?? 0;
             return ctx.enemyDotCount ?? 0;
+        case 'killed-enemy-had-debuff':
+            return ctx.killedEnemyHadDebuff ? 1 : 0;
         case 'stat-vs-target': {
             const self =
                 cond.compareStat === 'crit-power'

--- a/src/utils/combat/__tests__/preCombatPassives.test.ts
+++ b/src/utils/combat/__tests__/preCombatPassives.test.ts
@@ -8,16 +8,14 @@
  *   M2 ↔ T1, T2, M1, M3, B1, B2 — cells like M4/T4/B4 are NOT adjacent to M2.
  */
 import { describe, it, expect } from 'vitest';
-import {
-    applyPreCombatShipPassives,
-    type PreCombatPlanLike,
-} from '../preCombatPassives';
+import { applyPreCombatShipPassives, type PreCombatPlanLike } from '../preCombatPassives';
 import type { PreFightStatBlock } from '../preFight/types';
 import { buildShipAbilities } from '../../abilities/buildShipAbilities';
 import type { Ship } from '../../../types/ship';
 import type { ShipTypeName } from '../../../constants/shipTypes';
 import type { Position } from '../../../types/encounters';
 import type { ShipSkills } from '../../../types/abilities';
+import { csvAvailable, loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
 
 // ─── Real corpus passive texts (docs/ship-skills.csv verbatim) ─────────────────────────
 const LIONHEART_TEXT =
@@ -156,6 +154,56 @@ describe('applyPreCombatShipPassives — role-conditional (Enforcer)', () => {
     });
 });
 
+/** Real production shipSkills for a ship carrying a CSV record's texts verbatim (mirrors
+ *  wave8Madax.test.ts's helper — full refit so the refit-resolved passive row is honored). */
+function shipFromCsv(name: string): Ship {
+    const rec = loadShipSkillRecords().find((r) => r.name.toUpperCase() === name.toUpperCase());
+    if (!rec) throw new Error(`docs/ship-skills.csv: no record for "${name}"`);
+    return makeShip({
+        refits: [{}, {}, {}, {}] as unknown as Ship['refits'],
+        activeSkillText: rec.active,
+        chargeSkillText: rec.charge,
+        chargeSkillCharge: rec.chargeCharge,
+        firstPassiveSkillText: rec.passives[0],
+        secondPassiveSkillText: rec.passives[1],
+        thirdPassiveSkillText: rec.passives[2],
+    });
+}
+
+describe.skipIf(!csvAvailable())(
+    'applyPreCombatShipPassives — adjacent-allies grant gated by requiresAdjacentRole (Madax)',
+    () => {
+        // Madax's refit-active passive: "...When adjacent to a Supporter, this Unit receives
+        // 30% more Repairs and increases that Supporter's Defense by 20% of this Unit's
+        // Defense." The existence gate (line ~90-96) only asks WHETHER a qualifying adjacent
+        // ally exists; the recipient set for `target: 'adjacent-allies'` must additionally be
+        // FILTERED to just that role — a non-Supporter neighbour must not also receive it.
+        const madaxSkills = (): ShipSkills => buildShipAbilities(shipFromCsv('Madax'));
+
+        it('grants Defense ONLY to the adjacent Supporter, not to a non-Supporter also adjacent', () => {
+            const madax = makePlan('mad', 'M2', {
+                shipSkills: madaxSkills(),
+                stats: { defence: 1000 },
+            });
+            const supporter = makePlan('sup', 'M3', { role: 'SUPPORTER' });
+            const attacker = makePlan('atk', 'T1', { role: 'ATTACKER' }); // also adjacent to M2
+
+            const applied = applyPreCombatShipPassives([madax, supporter, attacker]);
+
+            expect(supporter.stats.defence).toBe(500 + 0.2 * 1000); // 700
+            expect(attacker.stats.defence).toBe(500); // untouched — not a Supporter
+            expect(applied.some((g) => g.recipientId === 'atk' && g.stat === 'defence')).toBe(
+                false
+            );
+            expect(
+                applied.some(
+                    (g) => g.recipientId === 'sup' && g.stat === 'defence' && g.amount === 200
+                )
+            ).toBe(true);
+        });
+    }
+);
+
 describe('applyPreCombatShipPassives — simultaneity (frozen snapshot)', () => {
     it("Defiant's +20% own hp is computed from the PRE-grant snapshot, excluding Lionheart's gift; both apply", () => {
         // Lionheart(M2) ↔ Defiant(M3) adjacent; Supporter(M4) ↔ Defiant(M3) adjacent,
@@ -193,9 +241,7 @@ describe('applyPreCombatShipPassives — slot gating and no-op safety', () => {
         const activeOnly = buildShipAbilities(makeShip({ activeSkillText: LIONHEART_TEXT }));
         expect(
             activeOnly.slots.some(
-                (s) =>
-                    s.slot === 'active' &&
-                    s.abilities.some((a) => a.type === 'pre-combat-stat')
+                (s) => s.slot === 'active' && s.abilities.some((a) => a.type === 'pre-combat-stat')
             )
         ).toBe(true); // precondition: the ability exists on the active slot
         const owner = makePlan('own', 'M2', { shipSkills: activeOnly, stats: { hp: 20_000 } });

--- a/src/utils/combat/__tests__/wave8MeiyingKillGate.integration.test.ts
+++ b/src/utils/combat/__tests__/wave8MeiyingKillGate.integration.test.ts
@@ -1,0 +1,263 @@
+/**
+ * wave8MeiyingKillGate.integration.test.ts — Ship-kit Wave 8 Task 13 (Meiying).
+ *
+ * Meiying's first passive (docs/ship-skills.csv, verbatim): "Upon killing an enemy with a
+ * Debuff, this Unit inflicts Stasis on all adjacent enemies for 1 turn." The target scope
+ * (adjacent-enemies) and trigger (on-enemy-destroyed) shipped in Wave 5/parsed generically; this
+ * task closes the KILL-GATE — the kill must land on a DEBUFFED enemy — and (as a necessary
+ * engine seam this gate rides on) wires the REACTIVE `debuff`-type executor's adjacent-enemies
+ * fan-out, which no prior ship exercised (Wave 5's adjacency work covered the ON-CAST fan-out in
+ * playerTurn.ts and the reactive `damage` executor's bomb-splash branch; Meiying's Stasis-on-kill
+ * is the first reactive DEBUFF consumer of `adjacent-enemies`).
+ *
+ * Harness: mirrors demolisherBombSplash.integration.test.ts's raw `runCombat` + positional
+ * `enemyAttackers` board layout (bomb lands on 'tgt' at M4; nbrA/M3 and nbrB/T3 are real
+ * neighbours, far/T1 is not) and wave8ZeolitePurge.integration.test.ts's "real production-parsed
+ * passive + hand-built active" composition idiom. The kill-gate debuff is seeded via a
+ * guaranteed-landing (`application:'apply'`) on-cast debuff ability placed BEFORE the lethal hit
+ * in the SAME active slot (playerTurn.ts processes a slot's abilities array in order), isolating
+ * the gate from hacking-vs-security landing RNG.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { Ship } from '../../../types/ship';
+import { createEventBus, CombatEvent } from '../events';
+
+// Verbatim docs/ship-skills.csv Meiying first_passive_skill_text.
+const MEIYING_STASIS_ON_KILL =
+    'Upon killing an enemy with a Debuff, this Unit inflicts <unit-skill>Stasis</unit-skill> on all adjacent enemies for 1 turn.';
+
+// The REAL parsed Stasis-on-kill passive slot (adjacent-enemies target, on-enemy-destroyed
+// trigger, killed-enemy-had-debuff condition — see wave8Meiying.test.ts for parser coverage).
+const meiyingPassiveSlot = (): ShipSkills['slots'][number] => {
+    const ship = {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        firstPassiveSkillText: MEIYING_STASIS_ON_KILL,
+    } as Ship;
+    const built = buildShipAbilities(ship);
+    const passive = built.slots.find((s) => s.slot === 'passive');
+    if (!passive) throw new Error('Meiying passive slot missing from buildShipAbilities output');
+    return passive;
+};
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `w8mk${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+// Guaranteed-landing debuff (bypasses hacking-vs-security RNG) seeded onto the front target.
+const debuffFrontTarget = (): Ability =>
+    ab({
+        type: 'debuff',
+        config: {
+            type: 'debuff',
+            buffName: 'Defense Down',
+            parsedEffects: { defense: -10 },
+            stacks: 1,
+            isStackable: false,
+            application: 'apply',
+            duration: 5,
+        },
+    });
+
+// A lethal hit against the front target (huge multiplier vs a low-HP victim, zero defence).
+const lethalHit = (): Ability =>
+    ab({ type: 'damage', config: { type: 'damage', multiplier: 100_000 } });
+
+const frontTarget = (): ParsedTarget => ({ raw: 'front', side: 'enemy', selection: 'front' });
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+const enemyAt = (id: string, position: Position, hp: number): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        shipSkills: { slots: [] } as ShipSkills,
+    }) as EnemyAttacker;
+
+// Caster kit: the real Meiying passive + a hand-built active that kills the front target, WITH
+// or WITHOUT first seeding it a debuff.
+const casterSkills = (killsDebuffedVictim: boolean): ShipSkills => ({
+    slots: [
+        {
+            slot: 'active',
+            abilities: killsDebuffedVictim ? [debuffFrontTarget(), lethalHit()] : [lethalHit()],
+        },
+        meiyingPassiveSlot(),
+    ],
+});
+
+// Every 'debuff-applied' Stasis recipient across the whole run.
+const stasisRecipients = (input: CombatEngineInput): string[] => {
+    const bus = createEventBus();
+    const applied: string[] = [];
+    bus.on('debuff-applied', (e: Extract<CombatEvent, { type: 'debuff-applied' }>) => {
+        if (e.buffName === 'Stasis') applied.push(e.targetId);
+    });
+    runCombat({ ...input, bus });
+    return applied;
+};
+
+describe('Ship-kit W8 Task 13: Meiying Stasis-on-kill — player-side caster', () => {
+    // The focus 'attacker' (Meiying) at M4, targeting 'front'. Enemy roster: 'tgt' at M4 (the
+    // victim, low HP — dies to the lethal hit), 'nbrA'/M3 and 'nbrB'/T3 (real board neighbours of
+    // M4), 'far'/T1 (not a neighbour).
+    const BASE = (
+        shipSkills: ShipSkills,
+        overrides: Partial<CombatEngineInput> = {}
+    ): CombatEngineInput => ({
+        attack: 1000,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills,
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        healTargetId: 'attacker',
+        position: 'M4',
+        target: frontTarget(),
+        pattern: basePattern(),
+        enemyAttackers: [
+            enemyAt('tgt', 'M4', 100),
+            enemyAt('nbrA', 'M3', 1_000_000_000),
+            enemyAt('nbrB', 'T3', 1_000_000_000),
+            enemyAt('far', 'T1', 1_000_000_000),
+        ],
+        ...overrides,
+    });
+
+    it('killing a DEBUFFED enemy inflicts Stasis on its board-neighbours (not the corpse, not a non-neighbour)', () => {
+        const recipients = stasisRecipients(BASE(casterSkills(true)));
+        expect(recipients).toContain('nbrA');
+        expect(recipients).toContain('nbrB');
+        expect(recipients).not.toContain('tgt');
+        expect(recipients).not.toContain('far');
+    });
+
+    it('CONTROL: killing a NON-debuffed enemy inflicts NO Stasis at all (the gate blocks it)', () => {
+        const recipients = stasisRecipients(BASE(casterSkills(false)));
+        expect(recipients).toHaveLength(0);
+    });
+});
+
+describe('Ship-kit W8 Task 13: team symmetry — an enemy-side Meiying gates identically', () => {
+    // Mirror roster: the killed victim is the focus 'attacker' (player side, M4); its neighbours
+    // are PLAYER-side walked team actors. The Meiying caster moves to enemyAttackers, carrying
+    // the same active(debuff?+lethal) + real passive kit, targeting 'front' (the focus at M4).
+    const teamNeighbour = (id: string, position: Position, hp: number): TeamActorEngineInput =>
+        ({
+            id,
+            speed: 1,
+            chargeCount: 0,
+            startCharged: false,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            position,
+            walk: {
+                shipSkills: { slots: [] } as ShipSkills,
+                stats: {
+                    attack: 0,
+                    crit: 0,
+                    critDamage: 0,
+                    defensePenetration: 0,
+                    defence: 0,
+                    hp,
+                    hacking: 0,
+                },
+                selfDotModifier: 0,
+                defensePenetrationBuff: 0,
+                affinityDamageModifier: 0,
+                affinityCritCap: 100,
+                affinityCritPenalty: 0,
+                hasChargedSkill: false,
+            },
+        }) as TeamActorEngineInput;
+
+    const enemyMeiying = (killsDebuffedVictim: boolean): EnemyAttacker =>
+        ({
+            id: 'meiying-enemy',
+            stats: {
+                attack: 100_000,
+                crit: 0,
+                critDamage: 0,
+                defence: 0,
+                hp: 1_000_000_000,
+                speed: 100,
+            },
+            chargeCount: 0,
+            startCharged: false,
+            position: 'M4' as Position,
+            target: frontTarget(),
+            pattern: basePattern(),
+            shipSkills: casterSkills(killsDebuffedVictim),
+        }) as EnemyAttacker;
+
+    const BASE = (killsDebuffedVictim: boolean): CombatEngineInput => ({
+        attack: 0,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: { slots: [] } as ShipSkills,
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 100, // low HP — the focus is the victim, dies to the enemy Meiying's lethal hit
+        healTargetId: 'attacker',
+        position: 'M4',
+        teamActors: [
+            teamNeighbour('nbrA', 'M3', 1_000_000_000),
+            teamNeighbour('nbrB', 'T3', 1_000_000_000),
+            teamNeighbour('far', 'T1', 1_000_000_000),
+        ],
+        enemyAttackers: [enemyMeiying(killsDebuffedVictim)],
+    });
+
+    it('an enemy-side Meiying killing a DEBUFFED player focus inflicts Stasis on its neighbours', () => {
+        const recipients = stasisRecipients(BASE(true));
+        expect(recipients).toContain('nbrA');
+        expect(recipients).toContain('nbrB');
+        expect(recipients).not.toContain('attacker');
+        expect(recipients).not.toContain('far');
+    });
+
+    it('CONTROL: an enemy-side Meiying killing a NON-debuffed player focus inflicts NO Stasis', () => {
+        const recipients = stasisRecipients(BASE(false));
+        expect(recipients).toHaveLength(0);
+    });
+});

--- a/src/utils/combat/__tests__/wave8ZeolitePurge.integration.test.ts
+++ b/src/utils/combat/__tests__/wave8ZeolitePurge.integration.test.ts
@@ -1,0 +1,241 @@
+/**
+ * wave8ZeolitePurge.integration.test.ts — Ship-kit Wave 8 Task 12 (Zeolite).
+ *
+ * Zeolite's refit-active (R4) passive: "This Unit increases damage by 30% when hitting a
+ * Defender and purges 1 buff from the enemy when dealing damage to a Defender." The +30%
+ * damage gate shipped in Wave 4; the purge half ("purges 1 buff from the enemy when dealing
+ * damage to a Defender") was deferred — buildShipAbilities.ts's passive-purge trigger chain had
+ * no "when dealing damage to a Defender" detector, so it was silently dropped.
+ *
+ * The parser now emits a `purge` ability (target enemy, count 1, trigger 'on-deal-damage',
+ * `enemy-type` Defender condition) — see wave8Zeolite.test.ts for the parser-level coverage.
+ * This file proves the ENGINE actually fires it: triggers.ts's on-deal-damage listener already
+ * routes the owner's own damage-dealing turn (Burner's Inferno rider — see
+ * reactiveDotPositionalRouting.test.ts); this task additionally (a) threads the reactive
+ * `victimId` seam onto the `purge` executor's target routing (it previously only read
+ * `counterTargetId`) and (b) re-checks the `enemy-type` gate at drain time against the REAL
+ * victim's ship role via `ctx.roleOf` (the SAME side-agnostic `roleByActorId` map Meatshield's
+ * defense-substitution and Graphite's roleFilter already consume) — the generic drain gate
+ * reads only the single fight-wide `enemyType`, which is undefined for an enemy-owned reaction
+ * and therefore could never be team-symmetric.
+ *
+ * Harness mirrors reactiveDotPositionalRouting.test.ts's Burner shape (positional two-team
+ * battle, position 'M4' / target 'front' on every actor so the focus's own damage lands on the
+ * REAL positioned enemy, not the dummy sink) and lodolitePurgeShieldStrip's self-buff fixture
+ * (a "grants itself Attack Up" ability providing something for the purge to remove).
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { Ship } from '../../../types/ship';
+import type { StatusEngine } from '../statusEngine';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
+
+// Verbatim from docs/ship-skills.csv (Zeolite refit-3/R4 passive).
+const ZEOLITE_PASSIVE_R4 =
+    'This Unit increases <unit-damage>damage by 30%</unit-damage> when hitting a Defender and <unit-aid>purges 1</unit-aid> buff from the enemy when dealing damage to a Defender.';
+// Zeolite's REAL active ALSO carries its own unconditional on-cast purge ("purges 1 buff from
+// the enemy, inflicts Defense Down III …") — a separate, pre-existing mechanic that would
+// confound isolating the passive's on-deal-damage reactive under test here. Swapped for a plain
+// damage active (still real production parsing via buildShipAbilities, just a different text).
+const PLAIN_ACTIVE = 'This Unit deals <unit-damage>100% damage</unit-damage>.';
+
+const zeoliteShip = (): Ship =>
+    ({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        refits: [{}, {}, {}, {}], // R4 — third passive (the "+30%/purge vs Defender" sentence)
+        activeSkillText: PLAIN_ACTIVE,
+        thirdPassiveSkillText: ZEOLITE_PASSIVE_R4,
+    }) as Ship;
+
+// Zeolite's REAL production-parsed active + passive slots.
+const zeoliteSkills = (): ShipSkills => {
+    const built = buildShipAbilities(zeoliteShip());
+    const active = built.slots.find((s) => s.slot === 'active');
+    const passive = built.slots.find((s) => s.slot === 'passive');
+    if (!active || !passive) throw new Error('Zeolite active/passive slots missing');
+    return { slots: [active, passive] };
+};
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `w8zp${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+const hit = (multiplier = 10): Ability =>
+    ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier } });
+
+// Grants itself Attack Up (near-permanent duration so it survives to be observed) — the buff
+// Zeolite's reactive purge is expected to remove from a Defender victim (and leave alone on a
+// non-Defender victim).
+const selfBuff = (): Ability =>
+    ab({
+        type: 'buff',
+        target: 'self',
+        trigger: 'on-cast',
+        config: {
+            type: 'buff',
+            buffName: 'Attack Up',
+            parsedEffects: { attack: 30 },
+            stacks: 1,
+            isStackable: false,
+            duration: 99,
+        },
+    });
+
+const runTapStatus = (input: CombatEngineInput): StatusEngine => {
+    let engine: StatusEngine | undefined;
+    runCombat({ ...input, __testTapStatusEngine: (e) => (engine = e) });
+    if (!engine) throw new Error('status engine tap did not fire');
+    return engine;
+};
+const selfBuffNames = (engine: StatusEngine, id: string): string[] =>
+    engine.timedAbilityStatuses('self', id).map((b) => b.active.buffName);
+
+describe('Wave 8 Task 12: Zeolite purges a buff when damaging a Defender (engine integration)', () => {
+    // A self-buffing enemy at speed 150 (> the focus's 100) so it grants itself Attack Up
+    // BEFORE Zeolite's turn every round — giving the reactive purge something to remove.
+    const buffingEnemy = (role: EnemyAttacker['role']): EnemyAttacker =>
+        ({
+            id: 'enemy-front',
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000, speed: 150 },
+            chargeCount: 0,
+            startCharged: false,
+            position: 'M4' as Position,
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            role,
+            shipSkills: { slots: [{ slot: 'active', abilities: [selfBuff(), hit(0)] }] },
+        }) as EnemyAttacker;
+
+    const focusInput = (): CombatEngineInput => ({
+        attack: 10_000,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: zeoliteSkills(),
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 100,
+        healTargetId: 'attacker',
+        position: 'M4',
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+    });
+
+    it('purges the Attack Up buff off a Defender-classed enemy Zeolite damages', () => {
+        const engine = runTapStatus({
+            ...focusInput(),
+            enemyAttackers: [buffingEnemy('DEFENDER')],
+        });
+        expect(selfBuffNames(engine, 'enemy-front')).not.toContain('Attack Up');
+    });
+
+    it('CONTROL: does NOT purge a non-Defender enemy Zeolite damages (buff survives)', () => {
+        const engine = runTapStatus({
+            ...focusInput(),
+            enemyAttackers: [buffingEnemy('ATTACKER')],
+        });
+        expect(selfBuffNames(engine, 'enemy-front')).toContain('Attack Up');
+    });
+});
+
+describe('Wave 8 Task 12: team symmetry — an enemy-side Zeolite purges a player Defender', () => {
+    // Mirror of the player-side harness: the focus (player) self-buffs at speed 150 (acts
+    // before the enemy Zeolite, speed 100), giving the enemy-owned reactive purge something to
+    // remove from a Defender-classed FOCUS.
+    const selfBuffingFocusSkills = (): ShipSkills => ({
+        slots: [{ slot: 'active', abilities: [selfBuff(), hit(0)] }],
+    });
+
+    const enemyZeolite = (): EnemyAttacker =>
+        ({
+            id: 'zeolite-enemy',
+            stats: {
+                attack: 10_000,
+                crit: 0,
+                critDamage: 0,
+                defence: 0,
+                hp: 1_000_000,
+                speed: 100,
+            },
+            chargeCount: 0,
+            startCharged: false,
+            position: 'M4' as Position,
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            shipSkills: zeoliteSkills(),
+        }) as EnemyAttacker;
+
+    const teamSymFocusInput = (
+        role: NonNullable<TeamActor['role']> | undefined
+    ): CombatEngineInput => ({
+        attack: 0,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: selfBuffingFocusSkills(),
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 150,
+        role,
+        healTargetId: 'attacker',
+        position: 'M4',
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        enemyAttackers: [enemyZeolite()],
+    });
+
+    it('an enemy-side Zeolite purges the Attack Up buff off a Defender-classed player focus', () => {
+        const engine = runTapStatus(teamSymFocusInput('DEFENDER'));
+        expect(selfBuffNames(engine, 'attacker')).not.toContain('Attack Up');
+    });
+
+    it('CONTROL: an enemy-side Zeolite does NOT purge a non-Defender player focus (buff survives)', () => {
+        const engine = runTapStatus(teamSymFocusInput('ATTACKER'));
+        expect(selfBuffNames(engine, 'attacker')).toContain('Attack Up');
+    });
+});

--- a/src/utils/combat/__tests__/wisteriaSelfCritDot.integration.test.ts
+++ b/src/utils/combat/__tests__/wisteriaSelfCritDot.integration.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Coverage follow-up for Wave 8 Task 10 (Wisteria self-crit Corrosion → Inferno II).
+ *
+ * Task 10 (commit 1ccc76f6) added a NEW reactive trigger `on-self-crit-dot`
+ * (src/types/abilities.ts + a listener case in src/utils/combat/triggers.ts ~515-535,
+ * gated on `e.viaCrit && e.sourceId === ownerId`). wave8Wisteria.test.ts only asserts the
+ * parsed ability SHAPE — nothing exercises the reactive ENGINE path proving the trigger
+ * actually dispatches at runtime. This file mirrors allyCritDot.test.ts's structure
+ * (Task 2's direct registerReactiveListeners unit test + Task 5's simulateDPS integration
+ * test) for the self-subject sibling trigger.
+ */
+import { describe, expect, it } from 'vitest';
+import { simulateDPS, DPSSimulationInput } from '../../calculators/dpsSimulator';
+import { CombatEvent } from '../events';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import { registerReactiveListeners, Intent, ReactiveAbility } from '../triggers';
+
+let idCounter = 0;
+const ab = (partial: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `scd${++idCounter}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...partial,
+});
+
+describe('wisteriaSelfCritDot – on-self-crit-dot reactive listener (unit)', () => {
+    // ── Direct unit test of registerReactiveListeners ────────────────────────
+    // Hand-rolled bus, mirrors allyCritDot.test.ts's Task 2 scenario table but flipped:
+    // on-self-crit-dot fires ONLY for the OWNER's own crit-cast dot-applied, never an
+    // ally's or an enemy's, and never without viaCrit.
+    it('enqueues only for the OWNER’s own viaCrit dot-applied, not ally/enemy/non-crit', () => {
+        const listeners = new Map<string, ((e: CombatEvent) => void)[]>();
+        const handBus = {
+            on<T extends CombatEvent['type']>(
+                type: T,
+                listener: (event: Extract<CombatEvent, { type: T }>) => void
+            ) {
+                const existing = listeners.get(type) ?? [];
+                listeners.set(type, [...existing, listener as unknown as (e: CombatEvent) => void]);
+            },
+            emit(event: CombatEvent) {
+                for (const l of listeners.get(event.type) ?? []) l(event);
+            },
+        };
+
+        const enqueued: Intent[] = [];
+
+        const infernoAbility: Ability = {
+            id: 'self-crit-dot-ability',
+            type: 'dot',
+            target: 'enemy',
+            trigger: 'on-self-crit-dot',
+            conditions: [],
+            config: { type: 'dot', dotType: 'inferno', tier: 30, stacks: 1, duration: 2 },
+        };
+
+        const ra: ReactiveAbility = { ability: infernoAbility, sourceSlot: 'passive' };
+
+        registerReactiveListeners({
+            bus: handBus,
+            perOwner: [{ ownerId: 'attacker', reactiveAbilities: [ra] }],
+            enqueue: (intent) => enqueued.push(intent),
+            isOpposing: (id) => id === 'enemy',
+        });
+
+        const baseEvent = {
+            targetId: 'enemy',
+            round: 1,
+            dotType: 'corrosion' as const,
+            stacks: 1,
+        };
+
+        // Scenario A: the OWNER's own cast (attacker) with viaCrit → should enqueue 1.
+        handBus.emit({ type: 'dot-applied', sourceId: 'attacker', viaCrit: true, ...baseEvent });
+        expect(enqueued).toHaveLength(1);
+
+        // Scenario B: another player (team-1) with viaCrit → NOT the owner → excluded → 0 more.
+        handBus.emit({ type: 'dot-applied', sourceId: 'team-1', viaCrit: true, ...baseEvent });
+        expect(enqueued).toHaveLength(1);
+
+        // Scenario C: enemy with viaCrit → excluded → 0 more.
+        handBus.emit({ type: 'dot-applied', sourceId: 'enemy', viaCrit: true, ...baseEvent });
+        expect(enqueued).toHaveLength(1);
+
+        // Scenario D: owner's own cast WITHOUT viaCrit → no crit, skip → 0 more.
+        handBus.emit({ type: 'dot-applied', sourceId: 'attacker', ...baseEvent });
+        expect(enqueued).toHaveLength(1);
+
+        // Scenario E: explicit viaCrit: false on the owner's own cast (the emission never sets
+        // this — it omits the field — but the falsy guard must treat both shapes identically)
+        // → 0 more.
+        handBus.emit({ type: 'dot-applied', sourceId: 'attacker', viaCrit: false, ...baseEvent });
+        expect(enqueued).toHaveLength(1);
+
+        // Sanity: the gate is genuinely load-bearing. If the `e.sourceId === ownerId` half of
+        // the guard were dropped (regressing to "any crit-cast dot, ally included"), Scenario B
+        // alone would have already pushed length to 2 above. Confirms this test would fail
+        // (not vacuously pass) if that clause were removed or broadened.
+        expect(enqueued).toHaveLength(1);
+    });
+});
+
+// ── Integration tests (engine-level, via simulateDPS) ─────────────────────────────────────
+//
+// Fixture: a SINGLE focus actor (id 'attacker') whose active applies damage + Corrosion and
+// whose crit is 100 (every cast crits → viaCrit: true on every self-applied dot-applied event),
+// plus an `on-self-crit-dot` passive reactive Inferno II dot. No team actors are needed —
+// unlike on-ally-crit-dot (which requires an OTHER actor's crit-cast), on-self-crit-dot fires
+// off the owner's OWN crit-cast DoT infliction.
+const BASE: DPSSimulationInput = {
+    attack: 10000,
+    crit: 100,
+    critDamage: 100,
+    defensePenetration: 0,
+    chargeCount: 0,
+    enemyDefense: 0,
+    enemyHp: 10_000_000,
+    rounds: 3,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    // hacking=100, enemySecurity=0 → debuffLandingChance=1.0 → DoTs always land.
+    hacking: 100,
+    enemySecurity: 0,
+    defence: 0,
+    hp: 30000,
+};
+
+/** Active damage+Corrosion + passive on-self-crit-dot Inferno II reactive. */
+const selfCritDotSkills = (): ShipSkills => {
+    idCounter = 0;
+    return {
+        slots: [
+            {
+                slot: 'active',
+                abilities: [
+                    ab({ type: 'damage', config: { type: 'damage', multiplier: 100 } }),
+                    ab({
+                        type: 'dot',
+                        config: {
+                            type: 'dot',
+                            dotType: 'corrosion',
+                            tier: 5,
+                            stacks: 1,
+                            duration: 3,
+                        },
+                    }),
+                ],
+            },
+            {
+                slot: 'passive',
+                abilities: [
+                    ab({
+                        type: 'dot',
+                        target: 'enemy',
+                        trigger: 'on-self-crit-dot',
+                        config: {
+                            type: 'dot',
+                            dotType: 'inferno',
+                            tier: 30,
+                            stacks: 1,
+                            duration: 2,
+                        },
+                    }),
+                ],
+            },
+        ],
+    };
+};
+
+describe('wisteriaSelfCritDot – engine integration (simulateDPS)', () => {
+    // ── Test 1: crit=100 → the owner's own crit-cast Corrosion triggers on-self-crit-dot,
+    // which injects the reactive Inferno II → infernoDamage > 0 on tick rounds.
+    it('crit=100: on-self-crit-dot fires off the owner’s own crit-cast Corrosion, injecting Inferno II (infernoDamage > 0)', () => {
+        idCounter = 0;
+        const result = simulateDPS({ ...BASE, shipSkills: selfCritDotSkills() });
+
+        // Round 1: the active casts (crits, applies Corrosion with viaCrit: true) which
+        // triggers on-self-crit-dot -> Inferno II is injected same round via the executor,
+        // and both DoTs tick from round 1 onward — the reactive Inferno II must show up.
+        const infernoRounds = result.rounds.filter((r) => r.infernoDamage > 0);
+        expect(infernoRounds.length).toBeGreaterThan(0);
+        // Corrosion (the triggering DoT) also ticks every round, unaffected by the addition.
+        for (const row of result.rounds) {
+            expect(row.corrosionDamage).toBeGreaterThan(0);
+        }
+    });
+
+    // ── Test 2: crit=0 → no viaCrit → on-self-crit-dot never fires -> infernoDamage stays 0.
+    // This is the negative mirror proving the trigger depends on viaCrit, not just on
+    // Corrosion being applied at all (Corrosion still lands and ticks every round).
+    it('crit=0: on-self-crit-dot never fires (infernoDamage stays 0 every round) though Corrosion still ticks', () => {
+        idCounter = 0;
+        const result = simulateDPS({
+            ...BASE,
+            crit: 0,
+            critDamage: 0,
+            shipSkills: selfCritDotSkills(),
+        });
+
+        for (const row of result.rounds) {
+            expect(row.infernoDamage).toBe(0);
+        }
+        for (const row of result.rounds) {
+            expect(row.corrosionDamage).toBeGreaterThan(0);
+        }
+    });
+});

--- a/src/utils/combat/__tests__/wushengRemoveStealth.integration.test.ts
+++ b/src/utils/combat/__tests__/wushengRemoveStealth.integration.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Ship-kit Wave 8 Task 11 — Wusheng "if directly damaged while Stealth is active, remove
+ * Stealth" engine dispatch coverage.
+ *
+ * wave8Wusheng.test.ts (abilities/__tests__) only asserts the parsed ability SHAPE — a
+ * `remove-self-buff` ability for Stealth on the `on-attacked` trigger, gated on `self-buff`
+ * Stealth being active. Nothing there exercises the reactive ENGINE path proving the trigger
+ * actually DISPATCHES and the removal actually fires at runtime. This file mirrors
+ * wisteriaSelfCritDot.integration.test.ts's structure: a direct registerReactiveListeners unit
+ * test, plus a full runCombat integration test.
+ *
+ * The `on-attacked` trigger is a pre-existing LIVE trigger (triggers.ts's `case 'on-attacked':`,
+ * registered generically for ANY ability type on that trigger — see e.g. the Task 8
+ * "on-attacked engine integration" suite in triggers.test.ts). This file's job is to prove the
+ * NEW `remove-self-buff` + `on-attacked` combination specifically dispatches and actually removes
+ * the buff, not just that the ability shape parses correctly.
+ */
+import { describe, expect, it } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import { registerReactiveListeners, Intent, ReactiveAbility } from '../triggers';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
+
+// ── Direct unit test of registerReactiveListeners ──────────────────────────────────────────
+describe('Wusheng remove-Stealth-on-attacked — reactive listener (unit)', () => {
+    it('enqueues only for the OWNER’s own "attacked" event (target-scoped, mirrors on-attacked’s standard contract)', () => {
+        const listeners = new Map<string, ((e: CombatEvent) => void)[]>();
+        const handBus = {
+            on<T extends CombatEvent['type']>(
+                type: T,
+                listener: (event: Extract<CombatEvent, { type: T }>) => void
+            ) {
+                const existing = listeners.get(type) ?? [];
+                listeners.set(type, [...existing, listener as unknown as (e: CombatEvent) => void]);
+            },
+            emit(event: CombatEvent) {
+                for (const l of listeners.get(event.type) ?? []) l(event);
+            },
+        };
+
+        const enqueued: Intent[] = [];
+
+        const removeStealthAbility: Ability = {
+            id: 'wusheng-remove-stealth',
+            type: 'remove-self-buff',
+            target: 'self',
+            trigger: 'on-attacked',
+            conditions: [{ subject: 'self-buff', buffName: 'Stealth', derivable: true }],
+            config: { type: 'remove-self-buff', buffName: 'Stealth', scope: 'all' },
+        };
+        const ra: ReactiveAbility = { ability: removeStealthAbility, sourceSlot: 'passive' };
+
+        registerReactiveListeners({
+            bus: handBus,
+            perOwner: [{ ownerId: 'victim', reactiveAbilities: [ra] }],
+            enqueue: (intent) => enqueued.push(intent),
+            isOpposing: (id) => id === 'attacker-enemy',
+        });
+
+        // Scenario A: the OWNER is directly hit → enqueues.
+        handBus.emit({
+            type: 'attacked',
+            targetId: 'victim',
+            attackerId: 'attacker-enemy',
+            round: 1,
+            damage: 100,
+        });
+        expect(enqueued).toHaveLength(1);
+
+        // Scenario B: a DIFFERENT actor is hit → not the owner → excluded.
+        handBus.emit({
+            type: 'attacked',
+            targetId: 'someone-else',
+            attackerId: 'attacker-enemy',
+            round: 1,
+            damage: 100,
+        });
+        expect(enqueued).toHaveLength(1);
+    });
+});
+
+// ── Integration test (engine-level, via runCombat) ─────────────────────────────────────────
+//
+// Positional setup mirroring incomingReductionEngine.test.ts (D-PR3 Task 6): a single positioned
+// PLAYER victim (fastest, casts a self-Stealth buff on its own turn) faces TWO positioned enemy
+// attackers targeting the same 'front' slot, at DIFFERENT speeds so both hits land within round 1
+// in a fixed order: victim casts Stealth first, enemy-1 hits second (Stealth active → the 25%
+// incoming-reduction ability applies AND the new remove-self-buff reactive fires, dropping
+// Stealth), enemy-2 hits third (Stealth now gone → full damage, no reduction).
+//
+// Each enemy hits for a firing 5000 (attack 5000, defence 0). WITH the removal ability: hit 1 is
+// reduced to 3750 (25% off), hit 2 lands the full 5000 → cumulative 8750. WITHOUT the removal
+// ability (only the grant + incoming-reduction, i.e. the pre-Task-11 behaviour): Stealth is NEVER
+// removed, so BOTH hits are reduced → cumulative 7500. The 1250 gap between these two totals is
+// the load-bearing proof that the on-attacked removal genuinely fires mid-round and changes the
+// SECOND hit's damage — not just that the ability shape parses.
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+// Grants the caster Stealth (duration 99) on its own cast. Single round → no re-cast concerns.
+const stealthSelfBuff = (id: string): Ability => ({
+    id,
+    type: 'buff',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: {
+        type: 'buff',
+        buffName: 'Stealth',
+        parsedEffects: {},
+        stacks: 1,
+        isStackable: false,
+        duration: 99,
+    },
+});
+
+// Wusheng's existing 25% direct-scope incoming reduction gated on self-stealth (D-PR3's
+// self-stealth IncomingCondition — unaffected by this task, included so the reduction's
+// interaction with the NEW removal is exercised end-to-end).
+const incomingReductionAbility: Ability = {
+    id: 'wusheng-incoming-reduction',
+    type: 'incoming-reduction',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: {
+        type: 'incoming-reduction',
+        scope: 'direct',
+        condition: 'self-stealth',
+        pct: 25,
+        critFamily: false,
+    },
+};
+
+// The Task 11 ability under test.
+const removeStealthAbility: Ability = {
+    id: 'wusheng-remove-stealth',
+    type: 'remove-self-buff',
+    target: 'self',
+    trigger: 'on-attacked',
+    conditions: [{ subject: 'self-buff', buffName: 'Stealth', derivable: true }],
+    config: { type: 'remove-self-buff', buffName: 'Stealth', scope: 'all' },
+};
+
+const playerVictim = (includeRemoval: boolean, hp: number): TeamActor => ({
+    id: 'victim',
+    speed: 1000, // acts before both enemies so Stealth is up when they attack
+    chargeCount: 0,
+    startCharged: false,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    position: 'M4' as Position,
+    walk: {
+        shipSkills: {
+            slots: [
+                { slot: 'active', abilities: [stealthSelfBuff('victim-stealth')] },
+                {
+                    slot: 'passive',
+                    abilities: includeRemoval
+                        ? [incomingReductionAbility, removeStealthAbility]
+                        : [incomingReductionAbility],
+                },
+            ],
+        } as ShipSkills,
+        stats: {
+            attack: 0,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            hacking: 0,
+            defence: 0,
+            hp,
+        },
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        hasChargedSkill: false,
+    },
+});
+
+// A positioned enemy attacker: attack 5000 x 100% x 1 hit vs defence 0 -> 5000 firing-hit.
+const flatOffensiveEnemy = (id: string, position: Position, speed: number): EnemyAttacker => ({
+    id,
+    stats: { attack: 5000, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed },
+    chargeCount: 0,
+    startCharged: false,
+    position,
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    shipSkills: {
+        slots: [
+            {
+                slot: 'active',
+                abilities: [
+                    {
+                        id: `${id}-hit`,
+                        type: 'damage',
+                        target: 'enemy',
+                        trigger: 'on-cast',
+                        conditions: [],
+                        config: { type: 'damage', multiplier: 100 },
+                    },
+                ],
+            },
+        ],
+    } as ShipSkills,
+});
+
+const BASE = (overrides: Partial<CombatEngineInput>): CombatEngineInput => ({
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: 1_000_000_000,
+    healTargetId: 'attacker', // healing mode → positioned enemy roster is built
+    ...overrides,
+});
+
+const destroyedIds = (input: CombatEngineInput): Set<string> => {
+    const bus = createEventBus();
+    const ids = new Set<string>();
+    bus.on('ship-destroyed', (e) => ids.add(e.actorId));
+    runCombat({ ...input, bus });
+    return ids;
+};
+
+const diesAt = (build: (hp: number) => CombatEngineInput, hp: number, victimId: string): boolean =>
+    destroyedIds(build(hp)).has(victimId);
+
+describe('Wusheng remove-Stealth-on-attacked — engine integration (runCombat)', () => {
+    // enemy-1 (speed 5) acts before enemy-2 (speed 1); both act after the victim (speed 1000).
+    // The victim's HP is set per-call on the TeamActor's walk.stats.hp so diesAt's death-bracket
+    // idiom (survives at hp+1, dies at hp) pins the exact cumulative damage landed.
+    const buildFor = (includeRemoval: boolean, hp: number): CombatEngineInput => {
+        const victim = playerVictim(includeRemoval, hp);
+        return BASE({
+            teamActors: [victim],
+            enemyAttackers: [
+                flatOffensiveEnemy('enemy-1', 'M1', 5),
+                flatOffensiveEnemy('enemy-2', 'M2', 1),
+            ],
+        });
+    };
+
+    it('WITH the removal ability: hit 2 loses the reduction after Stealth is stripped (dies at cumulative 8750, not 7500)', () => {
+        const build = (hp: number) => buildFor(true, hp);
+        // Cumulative with the fix: 3750 (reduced hit 1) + 5000 (full hit 2) = 8750 — strictly
+        // MORE than the 7500 the control scenario (below) totals, proving hit 2 was NOT reduced.
+        expect(diesAt(build, 8750, 'victim')).toBe(true);
+        expect(diesAt(build, 8751, 'victim')).toBe(false);
+    });
+
+    it('control WITHOUT the removal ability: Stealth is never stripped, BOTH hits stay reduced (dies at cumulative 7500)', () => {
+        const build = (hp: number) => buildFor(false, hp);
+        // Cumulative without removal: 3750 + 3750 = 7500 (both hits reduced).
+        expect(diesAt(build, 7500, 'victim')).toBe(true);
+        expect(diesAt(build, 7501, 'victim')).toBe(false);
+        // Never reaches the WITH-removal total of 8750.
+        expect(diesAt(build, 8750, 'victim')).toBe(false);
+    });
+});

--- a/src/utils/combat/__tests__/xcellenceOnResistShieldDamage.integration.test.ts
+++ b/src/utils/combat/__tests__/xcellenceOnResistShieldDamage.integration.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Ship-kit Wave 8 Task 8 follow-up — Xcellence's `on-own-debuff-resisted` shield-basis reactive
+ * damage (ENGINE integration, the runtime coverage `wave8Xcellence.test.ts` deliberately left out —
+ * that file only asserts the parsed ability SHAPE).
+ *
+ * Xcellence's refit-active passive (verbatim from docs/ship-skills.csv, second_passive_skill_text):
+ * "...At the start of each turn this Unit gains Shield equal to 20% of its Max HP.<br /><br />
+ * When an enemy resists a debuff infliction, this Unit deals damage equal to 115% of this Unit's
+ * current shield.." Two live engine mechanics compose here:
+ *   1. A per-turn `start-of-turn` shield grant (20% Max HP), which COMPOUNDS round over round —
+ *      the proc never consumes the pool, it only reads it (engine.ts's `applyReactiveDamage`,
+ *      `shieldBasisPct` branch reads the owner's LIVE `shieldPool`).
+ *   2. The `on-own-debuff-resisted` reactive damage proc (task-8-report.md's engine-executor gap
+ *      fix) — INFLICTOR-scoped: fires on Xcellence when a debuff IT inflicted is resisted by its
+ *      target, dealing 115% of Xcellence's CURRENT (live, compounding) shield.
+ *
+ * Driven through the REAL pipeline: `simulateBattle` (placement-based two-team battle, mirrors
+ * `ravagerResistReaction.integration.test.ts` — the shipped precedent for this SAME
+ * `on-own-debuff-resisted` trigger) → `buildShipAbilities` parses the verbatim CSV passive text
+ * into the `on-own-debuff-resisted` damage ability (`shieldBasisPct: 115`) AND the `start-of-turn`
+ * shield ability (`pct: 20`, `basis: 'hp'`) → the engine drains the shield grant BEFORE the acting
+ * owner's cast each round (SP-G G2), then the reactive damage executor reads the live
+ * `shieldPool` when the owner's OWN inflicted debuff (Speed Down II / Stasis) is resisted.
+ *
+ * Deterministic resist: Xcellence's hacking is forced to 0 while the target's security defaults
+ * to 100 (resolveStats' `security ?? 100`) — the live hacking-vs-security landing chance clamps to
+ * 0, so every debuff Xcellence inflicts is resisted, no RNG pin needed (same trick
+ * ravagerResistReaction.integration.test.ts uses).
+ *
+ * The reactive proc is logged as a bare `kind:'attack'` combat-log entry with NO incrementally-
+ * built target list (buildCombatLog's `reactive-damage-performed` handler, single push) — it sits
+ * alongside Xcellence's OWN primary 150%-of-attack(100) cast (~150 raw damage, `kind:'attack'`
+ * too). The two are told apart by MAGNITUDE: the shield-basis proc is >= 230,000 for a
+ * 1,000,000-HP carrier — three orders of magnitude above the primed 150-damage cast — a reliable,
+ * deterministic split for this fixture (there is no other structural marker; both share
+ * `kind:'attack'`).
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateBattle, BattlePlacement } from '../../calculators/battleSimulator';
+import type { Ship } from '../../../types/ship';
+import type { Position } from '../../../types/encounters';
+import type { CombatLogRound } from '../log/types';
+import { flattenCombatLog, flattenRound } from '../log/__testutils__/flattenCombatLog';
+import { csvAvailable, loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
+
+const CARRIER_HP = 1_000_000;
+
+/** A real Xcellence carrying the VERBATIM docs/ship-skills.csv active/second-passive texts
+ *  (mirrors wave8Xcellence.test.ts's `shipFromCsv`, widened to a full `Ship` so it can be placed
+ *  in a `simulateBattle` two-team battle, mirroring `ravagerResistReaction.integration.test.ts`'s
+ *  `makeRavager`). 4 refits → getShipSkillRows selects secondPassiveSkillText (the R2 passive
+ *  carrying both the shield grant and the on-resist proc), same refit count wave8Xcellence.test.ts
+ *  uses for the same ship. */
+function xcellenceShip(id: string): Ship {
+    const rec = loadShipSkillRecords().find((r) => r.name.toUpperCase() === 'XCELLENCE');
+    if (!rec) throw new Error(`docs/ship-skills.csv: no record for "Xcellence"`);
+    return {
+        id,
+        name: 'Xcellence',
+        rarity: 'legendary',
+        faction: 'ATLAS_SYNDICATE',
+        type: 'Attacker',
+        baseStats: {
+            hp: 0,
+            attack: 0,
+            defence: 0,
+            hacking: 200,
+            security: 100,
+            crit: 0,
+            critDamage: 0,
+            speed: 100,
+        },
+        equipment: {},
+        implants: {},
+        refits: Array.from({ length: 4 }, () => ({})) as unknown as Ship['refits'],
+        affinity: 'chemical',
+        activeSkillText: rec.active,
+        chargeSkillCharge: rec.chargeCharge,
+        chargeSkillText: rec.charge,
+        secondPassiveSkillText: rec.passives[1],
+        activeTarget: 'front',
+        activePattern: 'Pattern-Base',
+    } as Ship;
+}
+
+/** A harmless target — just needs to be alive so Xcellence's debuffs have somewhere to land (and
+ *  miss). Its default security (100) vs Xcellence's forced hacking 0 guarantees a 0% landing
+ *  chance, mirroring ravagerResistReaction.integration.test.ts's `makeTarget`. */
+const makeTarget = (id: string): Ship =>
+    ({
+        id,
+        name: 'Target',
+        rarity: 'legendary',
+        faction: 'AURELIAN_SOVEREIGNTY',
+        type: 'Defender',
+        baseStats: {
+            hp: 0,
+            attack: 0,
+            defence: 0,
+            hacking: 200,
+            security: 100,
+            crit: 0,
+            critDamage: 0,
+            speed: 50,
+        },
+        equipment: {},
+        implants: {},
+        refits: [],
+        affinity: 'antimatter',
+        activeSkillText: 'This Unit deals <unit-damage>10% damage</unit-damage>.',
+        chargeSkillCharge: 0,
+        activeTarget: 'front',
+        activePattern: 'Pattern-Base',
+    }) as Ship;
+
+/** Xcellence placement. `hacking` defaults to 0 (forced resist — every inflicted debuff misses).
+ *  Pass `hacking: 200` for the control case (>= the target's default security 100 → every debuff
+ *  LANDS, the resist proc never fires). `hp: CARRIER_HP` is also the shield-grant basis (20% of
+ *  this Unit's own Max HP per turn). */
+const xcellencePlacement = (ship: Ship, position: Position, hacking = 0): BattlePlacement => ({
+    ship,
+    position,
+    statOverrides: {
+        attack: 100,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        hacking,
+        defence: 0,
+        hp: CARRIER_HP,
+        security: 100,
+        speed: 100,
+    },
+});
+
+const targetPlacement = (ship: Ship, position: Position): BattlePlacement => ({
+    ship,
+    position,
+    statOverrides: {
+        attack: 1,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        hacking: 200,
+        defence: 0,
+        hp: CARRIER_HP,
+        security: 100,
+        speed: 50,
+    },
+});
+
+/** Sums this round's on-resist shield-basis reactive-damage entries attributed to `actorId` (see
+ *  the file header for why a >1,000 magnitude filter is the reliable split vs the primary cast). */
+const onResistDamageForRound = (round: CombatLogRound, actorId: string): number =>
+    flattenRound(round)
+        .filter((e) => e.kind === 'attack' && e.actorId === actorId)
+        .flatMap((e) => e.targets)
+        .filter((t) => (t.amount ?? 0) > 1_000)
+        .reduce((sum, t) => sum + (t.amount ?? 0), 0);
+
+describe.skipIf(!csvAvailable())(
+    'Wave 8 Task 8 — Xcellence on-resist shield-basis reactive damage (engine integration)',
+    () => {
+        it('deals 115% of Xcellence’s LIVE shieldPool per proc, compounding round over round', () => {
+            const result = simulateBattle({
+                playerTeam: [xcellencePlacement(xcellenceShip('xcellence'), 'M4')],
+                enemyTeam: [targetPlacement(makeTarget('target'), 'M4')],
+                rounds: 3,
+            });
+            const round = (n: number): CombatLogRound =>
+                result.combatLog.find((r) => r.round === n)!;
+
+            // Round 1: ONE 20%-of-CARRIER_HP shield grant has landed (start-of-turn, before the
+            // cast) → the proc reads 200,000 as its basis → 115% of that.
+            expect(onResistDamageForRound(round(1), 'attacker')).toBeCloseTo(
+                CARRIER_HP * 0.2 * 1.15,
+                0
+            );
+            // Round 2: TWO grants have landed (the proc never consumes the pool — it only reads
+            // it) → 115% of 400,000 = exactly 2x round 1's credit. Proves the basis COMPOUNDS.
+            expect(onResistDamageForRound(round(2), 'attacker')).toBeCloseTo(
+                CARRIER_HP * 0.4 * 1.15,
+                0
+            );
+            // Round 3: THREE grants → 115% of 600,000 = 3x round 1 — the basis is the LIVE
+            // shieldPool at proc time, not a fixed snapshot from an earlier round.
+            expect(onResistDamageForRound(round(3), 'attacker')).toBeCloseTo(
+                CARRIER_HP * 0.6 * 1.15,
+                0
+            );
+        });
+
+        it('team symmetry: an ENEMY-owned Xcellence fires the identical on-resist proc against a resisting player unit', () => {
+            const result = simulateBattle({
+                playerTeam: [targetPlacement(makeTarget('target'), 'M4')],
+                enemyTeam: [xcellencePlacement(xcellenceShip('xcellence'), 'M4')],
+                rounds: 2,
+            });
+            const round = (n: number): CombatLogRound =>
+                result.combatLog.find((r) => r.round === n)!;
+
+            // Xcellence is enemyTeam[0] → minted id `e:xcellence:0` (battleSimulator.ts id scheme,
+            // same convention ravagerResistReaction.integration.test.ts documents for Ravager).
+            expect(onResistDamageForRound(round(1), 'e:xcellence:0')).toBeCloseTo(
+                CARRIER_HP * 0.2 * 1.15,
+                0
+            );
+            expect(onResistDamageForRound(round(2), 'e:xcellence:0')).toBeCloseTo(
+                CARRIER_HP * 0.4 * 1.15,
+                0
+            );
+        });
+
+        it('control: when Xcellence’s inflicted debuffs LAND (no resist), the on-resist proc never fires', () => {
+            // Same real Xcellence kit, hacking raised to 200 (>= the target's default security
+            // 100) — every inflicted debuff now LANDS instead of resisting. Non-vacuity guard:
+            // proves the credit above is caused by the RESIST, not an unconditional per-cast proc.
+            const result = simulateBattle({
+                playerTeam: [xcellencePlacement(xcellenceShip('xcellence'), 'M4', 200)],
+                enemyTeam: [targetPlacement(makeTarget('target'), 'M4')],
+                rounds: 2,
+            });
+
+            const totalOnResistDamage = result.combatLog.reduce(
+                (sum, r) => sum + onResistDamageForRound(r, 'attacker'),
+                0
+            );
+            expect(totalOnResistDamage).toBe(0);
+
+            // Confirm the trigger condition (a resisted debuff) never actually occurred.
+            const resists = flattenCombatLog(result).filter((e) => e.kind === 'debuff-resisted');
+            expect(resists.length).toBe(0);
+        });
+    }
+);

--- a/src/utils/combat/abilityStatusGating.ts
+++ b/src/utils/combat/abilityStatusGating.ts
@@ -63,6 +63,13 @@ const LIVE_SUBJECTS: ReadonlySet<ConditionSubject> = new Set([
     // neutralize the condition to 'always' and the debuff would inflict unconditionally, exactly
     // the bug this task fixes.
     'self-shield',
+    // Ship-kit W8 Task 13: whether the enemy an on-enemy-destroyed reaction just killed carried a
+    // debuff is live-derivable — the executor folds ConditionContext.killedEnemyHadDebuff in as a
+    // targeted override (keyed to the specific victim, eventCtx.victimId) right before this gate
+    // runs (triggers.ts's executeIntent). Needed for Meiying's Stasis-on-kill (a timed ENEMY
+    // debuff gated on "killing an enemy WITH A DEBUFF") — without this, the condition would be
+    // neutralized to 'always' and Stasis would land unconditionally on every kill.
+    'killed-enemy-had-debuff',
 ]);
 
 /**

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -6176,6 +6176,12 @@ export function runCombat(input: CombatEngineInput): {
                         // corrosionEntries closures above (side-biased to the player's single
                         // opposing focus). Combat-wide map — no per-side sideCtx field needed.
                         actorById: (id) => allActorsById.get(id),
+                        // Ship-kit W8 Task 12: side-agnostic ship-role lookup (the SAME
+                        // roleByActorId map Meatshield's defense-substitution and Graphite's
+                        // roleFilter already consume) — feeds the reactive `purge` branch's
+                        // per-victim `enemy-type` re-check (Zeolite: "when dealing damage to a
+                        // Defender"), team-symmetrically.
+                        roleOf: (id) => roleByActorId.get(id),
                         // SP-E, Task E4: live hacking/critDamage for `id` (either side), feeding
                         // Belladonna's conversion-chance (hacking) and paired extend-chance
                         // (critDamage) gates. Same statusEngine/selfBuffLookup every other

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -4640,6 +4640,11 @@ export function runCombat(input: CombatEngineInput): {
             hits: number,
             noCrit: boolean,
             hpBasisPct?: number,
+            // Ship-kit W8 (Xcellence on-resist): sibling of hpBasisPct — when set (and
+            // hpBasisPct is not), raw = owner's CURRENT SHIELD × shieldBasisPct% instead of
+            // attack × multiplier. Mutually exclusive with hpBasisPct in the corpus; hpBasisPct
+            // takes precedence if both were ever set.
+            shieldBasisPct?: number,
             allowDeadOwner?: boolean,
             // Ship-kit W5 Task C3 (Demolisher bomb-splash). `flatBasis`: this proc is a FLAT copy
             // of some OTHER already-resolved damage figure (the bomb's own burst,
@@ -4713,10 +4718,21 @@ export function runCombat(input: CombatEngineInput): {
                     );
 
                 // Vindicator on-resist: raw = owner effective max HP × hpBasisPct% (mitigated below the
-                // same as any direct hit — defence + affinity + crit). Otherwise attack × multiplier.
+                // same as any direct hit — defence + affinity + crit). Ship-kit W8 (Xcellence):
+                // shieldBasisPct sibling uses the owner's CURRENT SHIELD (live shieldPool) as the
+                // basis instead. Otherwise attack × multiplier.
                 const basisStat =
-                    hpBasisPct !== undefined ? recipientMaxHp(ownerId) : ownerStats.attack;
-                const basisPct = hpBasisPct !== undefined ? hpBasisPct : multiplier;
+                    hpBasisPct !== undefined
+                        ? recipientMaxHp(ownerId)
+                        : shieldBasisPct !== undefined
+                          ? owner.shieldPool
+                          : ownerStats.attack;
+                const basisPct =
+                    hpBasisPct !== undefined
+                        ? hpBasisPct
+                        : shieldBasisPct !== undefined
+                          ? shieldBasisPct
+                          : multiplier;
 
                 raw = victimHitDamage(
                     {

--- a/src/utils/combat/preCombatPassives.ts
+++ b/src/utils/combat/preCombatPassives.ts
@@ -40,7 +40,7 @@ export interface PreCombatPlanLike {
 export interface AppliedPreCombatGrant {
     ownerId: string;
     recipientId: string;
-    stat: 'hp' | 'attack' | 'crit' | 'hacking';
+    stat: 'hp' | 'attack' | 'crit' | 'hacking' | 'defence';
     amount: number;
 }
 
@@ -96,8 +96,7 @@ export function applyPreCombatShipPassives(plans: PreCombatPlanLike[]): AppliedP
                 }
 
                 const perAllyFactor = config.perAdjacentAlly ? adjacentPlans.length : 1;
-                const recipients =
-                    ability.target === 'adjacent-allies' ? adjacentPlans : [owner];
+                const recipients = ability.target === 'adjacent-allies' ? adjacentPlans : [owner];
 
                 for (const recipient of recipients) {
                     const recipientSnapshot = snapshot.get(recipient.id);

--- a/src/utils/combat/preCombatPassives.ts
+++ b/src/utils/combat/preCombatPassives.ts
@@ -96,7 +96,20 @@ export function applyPreCombatShipPassives(plans: PreCombatPlanLike[]): AppliedP
                 }
 
                 const perAllyFactor = config.perAdjacentAlly ? adjacentPlans.length : 1;
-                const recipients = ability.target === 'adjacent-allies' ? adjacentPlans : [owner];
+                // Recipient set: adjacent-allies grants gated by `requiresAdjacentRole` go
+                // ONLY to the adjacent allies matching that role (Madax → "that Supporter's
+                // Defense", not every neighbour) — the existence gate above only asked
+                // WHETHER the grant fires, not WHO receives it. Self-targeted role-gated
+                // grants (Enforcer/Defiant/Stalwart) are unaffected: they always resolve to
+                // [owner] regardless of role, same as before.
+                const recipients =
+                    ability.target === 'adjacent-allies'
+                        ? requiredRole !== undefined
+                            ? adjacentPlans.filter((p) =>
+                                  matchesRoleCategory(p.role, [requiredRole])
+                              )
+                            : adjacentPlans
+                        : [owner];
 
                 for (const recipient of recipients) {
                     const recipientSnapshot = snapshot.get(recipient.id);

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1288,6 +1288,9 @@ export interface IntentExecContext {
         hits: number,
         noCrit: boolean,
         hpBasisPct?: number,
+        /** Ship-kit W8 (Xcellence on-resist): sibling of hpBasisPct — basis is the owner's
+         *  CURRENT SHIELD instead of max HP. Mutually exclusive with hpBasisPct in the corpus. */
+        shieldBasisPct?: number,
         allowDeadOwner?: boolean,
         opts?: { ignoresDefense?: boolean; flatBasis?: number }
         // Returns the mitigated/credited amount + crit flag so the caller can surface the proc in
@@ -3082,13 +3085,14 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
 
     if (cfg.type === 'damage') {
         if (!passesProcChanceGate(intent, ctx)) return;
-        // HP-basis reactive (Vindicator on-resist): REQUIRES a routed inflictor (counterTargetId)
-        // — no fallback to ctx.enemy (you cannot retaliate against no-one). Frequency: one proc per
+        // HP/Shield-basis reactive (Vindicator on-resist HP / Xcellence on-resist Shield,
+        // Ship-kit W8): REQUIRES a routed inflictor (counterTargetId) — no fallback to
+        // ctx.enemy (you cannot retaliate against no-one). Frequency: one proc per
         // triggering enemy action, keyed (owner, ability, round, source) so multiple debuffs
         // resisted from ONE cast collapse to a single proc while two DIFFERENT enemies each proc.
         // (oncePerRoundConsumed is the per-round set; a 3-part key never collides with the 2-part
         // keys passesOncePerRoundGate uses.)
-        if (cfg.hpBasisPct !== undefined) {
+        if (cfg.hpBasisPct !== undefined || cfg.shieldBasisPct !== undefined) {
             const sourceId = intent.eventCtx?.counterTargetId;
             if (sourceId === undefined) return;
             const onceKey = `${intent.ownerId}:${intent.ability.id}:${sourceId}`;
@@ -3098,10 +3102,13 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                 intent.ownerId,
                 sourceId,
                 intent.ability.id,
-                cfg.multiplier, // inert on this path — the engine reads hpBasisPct, not multiplier, when set
+                cfg.multiplier, // inert on this path — the engine reads hpBasisPct/shieldBasisPct, not multiplier, when set
                 cfg.hits ?? 1,
                 cfg.noCrit ?? false,
                 cfg.hpBasisPct,
+                // Ship-kit W8 (Xcellence): shieldBasisPct sibling of hpBasisPct — mutually
+                // exclusive in the corpus (no row sets both).
+                cfg.shieldBasisPct,
                 // PR-B1 (Paracelsus): an on-destroyed retaliation's owner is already dead by the
                 // time this drains — fromOwnDeath (stamped by the on-destroyed listener) lets the
                 // executor's owner-alive gate stand aside for this one reaction, same exemption the
@@ -3185,7 +3192,8 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                 cfg.multiplier,
                 cfg.hits ?? 1,
                 cfg.noCrit ?? false,
-                undefined, // hpBasisPct — inert on this path (the hpBasisPct branch above returns early)
+                undefined, // hpBasisPct — inert on this path (the hpBasisPct/shieldBasisPct branch above returns early)
+                undefined, // shieldBasisPct — inert on this path, same reason
                 false, // allowDeadOwner
                 // Ship-kit W5 Task C3: flatBasis/ignoresDefense are ONLY ever non-inert for
                 // Demolisher's splash (the sole ability carrying cfg.ignoresDefense===true AND

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -900,7 +900,20 @@ export function registerReactiveListeners(args: {
                         // Opposing-scoped: fires when any opposing-side actor is destroyed.
                         // For the player call: dummy wall + enemy attackers.
                         // For the enemy call: any player actor. One enqueue per destruction event.
-                        if (isOpposing(e.actorId)) enqueue(intent);
+                        // Ship-kit W8 Task 13 (Meiying): stamp victimId = the slain actor (mirrors
+                        // every other Wave 5/7 reactive seam) so (a) an `adjacent-enemies`-target
+                        // debuff twin (Stasis) can anchor its fan-out on the KILLED enemy's own
+                        // neighbours (the debuff executor's adjacent-enemies branch below), and
+                        // (b) the drain-time `killed-enemy-had-debuff` condition can read the
+                        // slain unit's OWN debuff store (recordDestroyed runs before this event
+                        // fires and never clears it) rather than the fight-wide enemy-debuff
+                        // count. Inert for every OTHER on-enemy-destroyed ability (Sokol/
+                        // Liberator's extra-action/charge branches never read eventCtx).
+                        if (isOpposing(e.actorId))
+                            enqueue({
+                                ...intent,
+                                eventCtx: { ...intent.eventCtx, victimId: e.actorId },
+                            });
                     });
                     break;
                 case 'on-enemy-repaired':
@@ -2276,7 +2289,23 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
     // non-derivable-on-non-live subjects to 'always'; manual conditions keep literal gating
     // (manualCount). A failed gate is a silent skip (no resisted record).
     const gateConditions = liveGateConditions(scrubbedConditions);
-    if (!conditionsMet(gateConditions, buildDrainContext(ctx, intent.ownerId))) return;
+    const baseDrainCtx = buildDrainContext(ctx, intent.ownerId);
+    // Ship-kit W8 Task 13 (Meiying): the `killed-enemy-had-debuff` gate is keyed to the SPECIFIC
+    // victim THIS on-enemy-destroyed intent carries (eventCtx.victimId, stamped by the listener
+    // above), not the fight-wide owner-scoped context buildDrainContext returns — so it is folded
+    // in here as a targeted override rather than threaded through buildDrainContext's owner-only
+    // signature. Reads the slain actor's OWN per-target debuff store (ownerDebuffNamesFor is the
+    // same reader `selfDebuffNames`/`buildActorConditionContext` already use for a target's
+    // debuffs); no victimId (every other reactive trigger, or DPS mode) → false, byte-identical.
+    const drainCtx =
+        intent.eventCtx?.victimId !== undefined
+            ? {
+                  ...baseDrainCtx,
+                  killedEnemyHadDebuff:
+                      ownerDebuffNamesFor(ctx.statusEngine, intent.eventCtx.victimId).length > 0,
+              }
+            : baseDrainCtx;
+    if (!conditionsMet(gateConditions, drainCtx)) return;
 
     if (cfg.type === 'charge') {
         if (!passesOncePerRoundGate(intent, ctx)) return;
@@ -2546,10 +2575,22 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
         // fan-out, but for enemy-side recipients. Distinct from Ruiner's REPAIRER-targeted Bomb
         // (same on-enemy-repaired trigger, same event), which stays on the singular
         // counterTargetId route below (an empty list falls back to it defensively).
+        // Ship-kit W8 Task 13 (Meiying): `adjacent-enemies` fan-out for a REACTIVE debuff — no
+        // prior reactive `debuff`-type ability used this target (Wave 5's adjacency work covered
+        // the ON-CAST fan-out in playerTurn.ts and the reactive `damage` executor's bomb-splash
+        // branch above; this is the first REACTIVE debuff consumer). Anchors on the SLAIN enemy
+        // (eventCtx.victimId, stamped by the on-enemy-destroyed listener), mirrors the damage
+        // branch's adjacent-enemies resolution exactly: `ctx.adjacentOpposingIdsFor` resolves the
+        // anchor's own-side neighbours within the OPPOSING roster (team-symmetric), excluding the
+        // anchor itself. No anchor → empty, never falls back to the default enemy.
         const applicationTargetIds: (string | undefined)[] =
             intent.ability.repairedRecipientTargeted && intent.eventCtx?.repairedEnemyIds?.length
                 ? intent.eventCtx.repairedEnemyIds
-                : [counterTargetId];
+                : intent.ability.target === 'adjacent-enemies'
+                  ? intent.eventCtx?.victimId !== undefined
+                      ? (ctx.adjacentOpposingIdsFor?.(intent.eventCtx.victimId) ?? [])
+                      : []
+                  : [counterTargetId];
         for (const applicationTargetId of applicationTargetIds) {
             // Block Debuff fold (D-PR15 Task 5): a target carrying Block Debuff auto-resists
             // every incoming timed debuff. Gate immunity into the landing condition so the

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -512,6 +512,27 @@ export function registerReactiveListeners(args: {
                         }
                     });
                     break;
+                case 'on-self-crit-dot':
+                    bus.on('dot-applied', (e) => {
+                        // Ship-kit W8 Task 10 (Wisteria): self-subject sibling of
+                        // on-ally-crit-dot above — THIS unit's OWN crit-cast DoT infliction
+                        // (sourceId === ownerId), not an ally's. One enqueue per qualifying
+                        // infliction event.
+                        if (e.viaCrit && e.sourceId === ownerId) {
+                            enqueue({
+                                ...intent,
+                                eventCtx: {
+                                    ...intent.eventCtx,
+                                    // Land the injected DoT on the SAME enemy this cast just hit
+                                    // (the reactive `dot` executor's victimId seam), not the DPS
+                                    // dummy sink.
+                                    victimId: e.targetId,
+                                    dotType: e.dotType,
+                                },
+                            });
+                        }
+                    });
+                    break;
                 case 'on-ally-critically-repaired':
                     bus.on('heal-performed', (e) => {
                         // The OWNER's own crit repair of an ALLY (Pallas: "when this unit

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -2297,8 +2297,13 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
     // signature. Reads the slain actor's OWN per-target debuff store (ownerDebuffNamesFor is the
     // same reader `selfDebuffNames`/`buildActorConditionContext` already use for a target's
     // debuffs); no victimId (every other reactive trigger, or DPS mode) → false, byte-identical.
+    // Ship-kit W8 (CodeRabbit round): explicitly gated on trigger==='on-enemy-destroyed' — other
+    // triggers (on-deal-damage, on-bomb-detonated, on-ally-crit-dot, on-self-crit-dot,
+    // on-enemy-dot-damage, on-ally-debuff-inflicted) also stamp eventCtx.victimId, but with
+    // different semantics (the current cast's target, not a killed unit); without this guard
+    // their victimId would be misread here as "the enemy this trigger just killed".
     const drainCtx =
-        intent.eventCtx?.victimId !== undefined
+        intent.ability.trigger === 'on-enemy-destroyed' && intent.eventCtx?.victimId !== undefined
             ? {
                   ...baseDrainCtx,
                   killedEnemyHadDebuff:
@@ -3336,7 +3341,14 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
         // same source Meatshield's defense-substitution and Graphite's roleFilter already use).
         // An unknown role (`roleOf` undefined / no ship picked) never matches — conservative,
         // mirrors matchesRoleCategory's contract elsewhere.
-        const enemyTypeCond = intent.ability.conditions.find((c) => c.subject === 'enemy-type');
+        // Ship-kit W8 (CodeRabbit round): scoped to trigger==='on-deal-damage', symmetric with the
+        // scrub above — a hypothetical purge with a genuinely PvE-class `enemy-type` condition on
+        // a DIFFERENT trigger was never scrubbed from gateConditions, so re-deriving+re-evaluating
+        // it here via ctx.roleOf would double-gate/misread it against the wrong target.
+        const enemyTypeCond =
+            intent.ability.trigger === 'on-deal-damage'
+                ? intent.ability.conditions.find((c) => c.subject === 'enemy-type')
+                : undefined;
         if (enemyTypeCond?.requiredEnemyType) {
             const matchesRole = matchesRoleCategory(ctx.roleOf?.(targetId), [
                 enemyTypeCond.requiredEnemyType.toUpperCase() as ShipRoleCategory,

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -6,7 +6,7 @@ import {
     SkillSlot,
 } from '../../types/abilities';
 import { matchesRoleCategory } from '../../constants/shipTypes';
-import type { ShipTypeName } from '../../constants/shipTypes';
+import type { ShipTypeName, ShipRoleCategory } from '../../constants/shipTypes';
 import {
     DoTType,
     EnemyBaseClass,
@@ -1365,6 +1365,15 @@ export interface IntentExecContext {
      *  ally). Mirrors `affinityOf`'s allActorsById source. Optional — absent in unit-test ctxs
      *  that don't exercise convert-dot. */
     actorById?: (actorId: string) => CombatActor | undefined;
+    /** Ship-kit W8 Task 12: resolve ANY actor's ship role (Ship.type) by id, either side — the
+     *  SAME `roleByActorId` map (side-agnostic by key) Meatshield's defense-substitution and
+     *  Graphite's `roleFilter` reaction-time check already consume. Used by the reactive `purge`
+     *  branch to re-check an `enemy-type` gate (scrubbed from the generic drain gate above)
+     *  against the REAL victim of an on-deal-damage purge (Zeolite: "… when dealing damage to a
+     *  Defender"), team-symmetrically. Optional — absent in unit-test ctxs that don't drive it
+     *  (an `enemy-type`-gated purge with no `roleOf` reads `undefined` → matchesRoleCategory
+     *  always false → conservative no-op, byte-identical to before this task). */
+    roleOf?: (actorId: string) => ShipTypeName | undefined;
     /** SP-E, Task E4: live (buff-folded) hacking/critDamage for `actorId`, either side. Used by
      *  the convert-dot executor to compute the conversion chance (hacking) and the paired
      *  crit-power extend chance (critDamage). Optional — absent in unit-test ctxs that don't
@@ -2247,7 +2256,20 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                         !(c.subject === 'hp-threshold' && c.hpSubject !== 'self') &&
                         c.subject !== 'enemy-debuff'
                 )
-              : intent.ability.conditions;
+              : // Ship-kit W8 Task 12 (Zeolite): an on-deal-damage purge's `enemy-type` gate
+                // ("purges 1 buff … when dealing damage to a Defender") must check the ACTUAL
+                // victim THIS event carries (eventCtx.victimId/counterTargetId), not the single
+                // fight-wide `ctx.enemyType` the generic gate below reads — that field describes
+                // only the DPS-mode dummy enemy's class and is hardcoded undefined for an
+                // enemy-owned reaction (see engine.ts's seedPassiveTimedStatuses call site), so it
+                // can never be team-symmetric. Scrubbed here, re-checked in the `purge` branch
+                // below against `ctx.roleOf(targetId)` — `roleByActorId`/`roleOf` is side-agnostic
+                // by key (Meatshield/Graphite precedent), so this works identically for a
+                // player-owned or enemy-owned Zeolite. Gated strictly on
+                // type==='purge' && trigger==='on-deal-damage' so no other purge is touched.
+                intent.ability.type === 'purge' && intent.ability.trigger === 'on-deal-damage'
+                ? intent.ability.conditions.filter((c) => c.subject !== 'enemy-type')
+                : intent.ability.conditions;
 
     // Drain-time condition gate against CURRENT engine state — one gate for every branch,
     // built against the OWNER's snapshot (Task 6). liveGateConditions neutralizes
@@ -3257,11 +3279,30 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
         // enemy. statusEngine is in ctx scope — call it directly (mirrors cleanse). Emit
         // purge-performed UNLESS this purge was itself triggered by a purge (depth-1 guard).
         // Target: enemy-most-buffs (Rhodium) → the opposing actor with the most buffs;
-        // else the routed attacker/killer (counterTargetId — Iridium/Faust) else the turn's enemy.
+        // else the routed attacker/killer (counterTargetId — Iridium/Faust) else the REAL
+        // victim this event carries (eventCtx.victimId — Task 12's on-deal-damage purge,
+        // Zeolite: "purges 1 buff from the enemy when dealing damage to a Defender" — the
+        // owner's own damage target, mirrors the `dot`/`convert-dot` branches' victimId seam)
+        // else the turn's enemy.
         const targetId =
             intent.ability.target === 'enemy-most-buffs'
                 ? (ctx.enemyWithMostBuffs?.(intent.ownerId) ?? ctx.enemyId)
-                : (intent.eventCtx?.counterTargetId ?? ctx.enemyId);
+                : (intent.eventCtx?.counterTargetId ?? intent.eventCtx?.victimId ?? ctx.enemyId);
+        // Task 12 (Zeolite): the `enemy-type` gate was scrubbed from the generic drain-time
+        // condition check above (it only sees the single fight-wide dummy class) — re-check it
+        // HERE against the ACTUAL victim's role via `ctx.roleOf` (side-agnostic —
+        // roleByActorId is populated from BOTH TeamActorInput.role and EnemyActorInput.role, the
+        // same source Meatshield's defense-substitution and Graphite's roleFilter already use).
+        // An unknown role (`roleOf` undefined / no ship picked) never matches — conservative,
+        // mirrors matchesRoleCategory's contract elsewhere.
+        const enemyTypeCond = intent.ability.conditions.find((c) => c.subject === 'enemy-type');
+        if (enemyTypeCond?.requiredEnemyType) {
+            const matchesRole = matchesRoleCategory(ctx.roleOf?.(targetId), [
+                enemyTypeCond.requiredEnemyType.toUpperCase() as ShipRoleCategory,
+            ]);
+            const gateMet = enemyTypeCond.negate ? !matchesRole : matchesRole;
+            if (!gateMet) return;
+        }
         const removed = ctx.statusEngine.purge(targetId, cfg.count);
         if (removed > 0 && !intent.eventCtx?.fromPurgeEvent) {
             ctx.bus.emit({

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1431,6 +1431,14 @@ export function detectReactiveTrigger(
     // observe a real hit count before any turn has fired).
     if (hitCountConditionFromClause(clause.toLowerCase())) return 'on-deal-damage';
     if (START_OF_ROUND_RE.test(clause)) return 'start-of-round';
+    // Ship-kit W8, Task 4: "at the end of the round" → end-of-round (Chimei's non-defender
+    // below-40%-HP Stealth grant). Shares END_OF_ROUND_RE with detectEndOfRoundPurgeTrigger/
+    // detectEndOfRoundDamageTrigger (Rhodium) — same phrase, buff-grant call site. Checked
+    // AFTER start-of-round since resolveBuffClause is sentence-scoped (Chimei's grant sentence
+    // only contains "end of the round"; the sibling "start of the round" repair sentence is a
+    // separate clause keyed on the same buff name but matched first by resolveBuffClause, so it
+    // never reaches here) — this ordering just mirrors the existing rule for readability.
+    if (END_OF_ROUND_RE.test(clause)) return 'end-of-round';
     // Epic PR4: "at the start of (the|its|each|every) turn" — Cobalt's Out. Damage Up II buff
     // shares its governing trailing phrase with its sibling charge ability (already
     // start-of-turn via START_OF_TURN_CHARGE_RE in the charge-specific parser); this was the

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -3942,6 +3942,17 @@ export function parseHealAbilities(text: string | null | undefined): ParsedHealA
             // below by HEAL_ADDITIONAL_RE inheriting the primary's target — skip it here so
             // it isn't double-counted (and so it doesn't inherit the wrong target/basis).
             if (kind === 'heal' && /equal\s+to/i.test(m[0])) continue;
+            // Madax (ship-kit W8 Task 9): "…receives 30% more Repairs and increases that
+            // Supporter's Defense by 20% of this Unit's Defense" — HEAL_REPAIR_RE's lazy
+            // `[^%.;]*?` walk matches the NOUN "Repairs" (not the repair verb) and, finding no
+            // period/semicolon before the next '%', walks straight past the intervening
+            // "increases <role>'s <stat> by" clause to that UNRELATED grant's own "20%",
+            // fabricating a phantom self-heal (basis 'defense', pct 20). That clause is a
+            // stat GRANT to the adjacent Supporter ally, not a repair amount — parsed
+            // separately by PRE_COMBAT_ROLE_GATE_DONOR_STAT_RE below. Reject any repair match
+            // whose captured percentage belongs to this "increases <owner>'s <stat> by N%"
+            // shape rather than a genuine repair amount.
+            if (/\bincreases\b[^%.;]*'s\b[^%.;]*\bby\b/i.test(m[0])) continue;
             // Quixilver: "if it has shield equal to 100% of its max HP" is a THRESHOLD
             // CONDITION gating a Barrier grant elsewhere in the sentence, not a shield GRANT
             // itself — every real shield grant in the corpus is phrased "gains/grants Shield
@@ -4564,10 +4575,11 @@ export function detectFullyCharged(texts: (string | undefined)[]): boolean {
  * PR F4: a permanent pre-fight base-stat grant parsed from a ship passive. Consumed by
  * buildShipAbilities into a `pre-combat-stat` ability (trigger 'pre-combat'); the battle
  * sim's pre-fight layer (F5) applies it to plan stats before round 1. Corpus (docs/
- * ship-skills.csv): Lionheart, Centurion, Enforcer, Defiant, Stalwart.
+ * ship-skills.csv): Lionheart, Centurion, Enforcer, Defiant, Stalwart, Madax (Task 9 —
+ * 'defence' donor grant to the adjacent Supporter, see PRE_COMBAT_ROLE_GATE_DONOR_STAT_RE).
  */
 export interface PreCombatStatGrant {
-    stat: 'hp' | 'attack' | 'crit' | 'hacking';
+    stat: 'hp' | 'attack' | 'crit' | 'hacking' | 'defence';
     value: number;
     /** 'flat': absolute points. 'percent-of-own': % of the RECIPIENT's pre-fight stat.
      *  'percent-of-donor': % of the GRANTING ship's pre-fight stat (Lionheart). */
@@ -4596,17 +4608,41 @@ const PRE_COMBAT_PER_ADJACENT_ATTACK_RE =
 //   C1 trailing gate (Enforcer): "… this Unit gains +15% crit rate and +10% hacking if
 //   adjacent to a supporter."
 //   C2 leading gate (Defiant/Stalwart): "When (this Unit is) adjacent to a Supporter, this
-//   Unit gains 20% HP/Attack." — Madax's "receives 30% more Repairs…" has no "gains" and
-//   deliberately stays unparsed (out of scope).
+//   Unit gains 20% HP/Attack." — Madax's "receives 30% more Repairs…" has no "gains" verb, so
+//   it never matches this pattern; its "increases that Supporter's Defense by 20%…" clause is
+//   a DIFFERENT shape (a donor grant to the adjacent ally, not a self-gain) — see Pattern D
+//   below (Task 9).
 const PRE_COMBAT_ROLE_GATE_TRAILING_RE =
     /this unit gains ([^.;]+?)\s+(?:if|when|while)\s+adjacent to an?\s+(supporter|defender|attacker|debuffer)\b/gi;
 const PRE_COMBAT_ROLE_GATE_LEADING_RE =
     /when (?:this unit is )?adjacent to an?\s+(supporter|defender|attacker|debuffer),\s*this unit gains ([^.;]+?)(?=[.;]|$)/gi;
 
+// Pattern D (Madax, Task 9): "When adjacent to a Supporter, this Unit … increases that
+// Supporter's Defense by 20% of this Unit's Defense." — a DONOR-scaled stat grant to the
+// specific adjacent ally of the named role (not a self-gain, so Pattern C's "gains" verb
+// doesn't apply). Reuses the existing 'adjacent-allies' target (Pattern A, Lionheart) plus
+// the existing requiresAdjacentRole gate (Pattern C) rather than introducing a new target —
+// buildShipAbilities/preCombatPassives already thread both through generically. The role
+// backreference (\1) ties "that <role>'s" back to the same role named in the leading gate.
+const PRE_COMBAT_ROLE_GATE_DONOR_STAT_RE =
+    /when (?:this unit is )?adjacent to an?\s+(supporter|defender|attacker|debuffer),[^.;]*\bincreases\s+that\s+\1'?s\s+(defense|attack|hp|max\s*hp)\s+by\s+(\d+(?:\.\d+)?)\s*%\s*of\s+this\s+unit'?s\s+(?:defense|attack|hp|max\s*hp)/gi;
+
 // Stat-list splitter for pattern C: "+15% crit rate and +10% hacking" / "20% HP" / "20% Attack".
 // crit rate is a percentage-only stat, so "+15% crit rate" is a FLAT 15-point grant; hacking/
 // hp/attack scale the recipient's own stat (percent-of-own).
 const PRE_COMBAT_STAT_LIST_RE = /\+?(\d+(?:\.\d+)?)%\s*(crit(?:ical)?\s*rate|hacking|hp|attack)/gi;
+
+// Stat-keyword mapping for pattern D's granted stat ("Defense"/"Attack"/"HP"/"Max HP") to the
+// engine's PreFightStatBlock key. Distinct from preCombatStatFromKeyword (pattern C — self
+// grants only support hp/attack/crit/hacking) because pattern D also supports 'defence',
+// spelled to match PreFightStatBlock/DerivedCombatStats (British spelling), not
+// ParsedHealAbility's American 'defense'.
+function donorRoleGrantStatFromKeyword(keyword: string): 'defence' | 'attack' | 'hp' {
+    const k = keyword.toLowerCase().replace(/\s+/g, '');
+    if (k === 'defense' || k === 'defence') return 'defence';
+    if (k === 'attack') return 'attack';
+    return 'hp';
+}
 
 function preCombatStatFromKeyword(keyword: string): {
     stat: 'hp' | 'attack' | 'crit' | 'hacking';
@@ -4678,6 +4714,22 @@ export function parsePreCombatStatGrants(text: string | null | undefined): PreCo
     PRE_COMBAT_ROLE_GATE_LEADING_RE.lastIndex = 0;
     while ((m = PRE_COMBAT_ROLE_GATE_LEADING_RE.exec(plain)) !== null) {
         emitRoleGated(m[2], m.index + m[0].indexOf(m[2]), m[1]);
+    }
+
+    // Pattern D (Madax, Task 9): donor-scaled stat grant to the adjacent ally of the named
+    // role — target 'adjacent-allies' (Pattern A's shape) combined with requiresAdjacentRole
+    // (Pattern C's gate), valueKind 'percent-of-donor' (this Unit's own stat, not the
+    // recipient's).
+    PRE_COMBAT_ROLE_GATE_DONOR_STAT_RE.lastIndex = 0;
+    while ((m = PRE_COMBAT_ROLE_GATE_DONOR_STAT_RE.exec(plain)) !== null) {
+        results.push({
+            stat: donorRoleGrantStatFromKeyword(m[2]),
+            value: parseFloat(m[3]),
+            valueKind: 'percent-of-donor',
+            target: 'adjacent-allies',
+            requiresAdjacentRole: m[1].toUpperCase() as ShipRoleCategory,
+            pos: m.index,
+        });
     }
 
     return results;

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1938,8 +1938,15 @@ export function detectDebuffInflictedTrigger(
 //   - `parseSkillEffects` — the named-status *application* path that actually applies the debuff.
 // The control ability is purely additive; nothing here suppresses those other paths.
 //
-// Stasis keeps its ORIGINAL loose regex verbatim (byte-identity, zero golden churn). The three
-// enemy-side effects (Provoke / Concentrate Fire / Disable) anchor on an application verb that is
+// Stasis keeps its ORIGINAL loose regex, PLUS (ship-kit W8 Task 7) an untagged fallback for a
+// bare "Stasis for N turn(s)" inflict (Xcellence's active: "Inflicts <Speed Down II> for 2 turns
+// and Stasis for 2 turn." — Stasis itself carries no <unit-skill> wrapper, unlike Speed Down II).
+// The fallback alternative requires the trailing "for N turn(s)" duration text so it stays
+// anchored to a genuine inflict, not any other bare mention of "Stasis" in the same sentence as
+// an inflict/applies verb (e.g. Defiant's "gains Shield ... when applying Stasis" has no trailing
+// duration and uses "applying", which isn't in the verb set anyway — still excluded). Tagged
+// ships are byte-identical: the tagged alternative is tried first and, being present, always wins.
+// The three enemy-side effects (Provoke / Concentrate Fire / Disable) anchor on an application verb that is
 // either immediately tag-adjacent OR governs a coordinated list ("inflicts <Defense Down II> for
 // 2 turns, and <Provoke>" — Kafa): the verb, then zero-or-more "<unit-skill>…</unit-skill> [for N
 // turns]" items joined by commas/"and", then the target tag. This still ignores a control word in
@@ -1957,7 +1964,8 @@ export function detectDebuffInflictedTrigger(
 const CONTROL_LIST_PREFIX =
     '(?:\\s+<unit-skill>[^<]*<\\/unit-skill>(?:\\s+for\\s+\\d+\\s+turns?)?,?\\s+and)*';
 const ENEMY_INFLICT_VERB = '\\b(?:inflicts?|appl(?:ies|y)|(?:inflicted|applied) with)\\b';
-const STASIS_INFLICT_RE = /\b(?:inflicts?|applies)\b[^.]*?<unit-skill>\s*Stasis\b/i;
+const STASIS_INFLICT_RE =
+    /\b(?:inflicts?|applies)\b[^.]*?(?:<unit-skill>\s*Stasis\b|Stasis\s+for\s+\d+\s*turns?)/i;
 
 const CONTROL_INFLICTS: {
     effect: ControlEffect;
@@ -2022,8 +2030,15 @@ export function parseControlInflicts(
         // builder sorts emission order by `pos`).
         const match = c.re.exec(text);
         if (!match) continue;
+        // Ship-kit W8 Task 7: the <unit-skill> tag is OPTIONAL here too (mirrors STASIS_INFLICT_RE
+        // above) so a bare, untagged inflict (Xcellence's "and Stasis for 2 turn") still locates a
+        // real position instead of falling back to MAX_POS. Only c.re matching at all determines
+        // whether an untagged mention counts as a genuine inflict (Stasis' fallback alternative
+        // requires trailing "for N turns"); this just finds WHERE within that already-confirmed
+        // match the name sits. No effect on the other (still tag-only) control effects, since their
+        // matched text always contains the tag.
         const tagRe = new RegExp(
-            `<unit-skill>\\s*${c.tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`,
+            `(?:<unit-skill>\\s*)?${c.tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`,
             'i'
         );
         const tagMatch = tagRe.exec(match[0]);
@@ -5438,6 +5453,30 @@ export function parseSkillEffects(
             // conjoined path consistent so a trailing "and Cheat Death for N turns" can't stamp
             // a finite window either.
             duration: CHEAT_DEATH_BUFFS.has(canonical) ? 'recurring' : parseInt(conjoined[2], 10),
+            source,
+        });
+    }
+
+    // Supplementary pass (ship-kit W8 Task 7): a BARE, untagged "Stasis" conjoined onto a tagged
+    // enemy inflict ("Inflicts <Speed Down II> for 2 turns and Stasis for 2 turn." — Xcellence's
+    // active). The segment loop above only walks tagged <unit-skill> occurrences, so this trailing
+    // enemy-side Stasis has no governing verb/tag of its own and would otherwise be silently
+    // dropped (mirrors CONJOINED_SELF_GRANT_RE's shape, but for the ENEMY side). Scoped narrowly to
+    // Stasis specifically — it is the only untagged inflict found corpus-wide (docs/ship-skills.csv)
+    // — and anchored on "and Stasis for N turn(s)" so it never matches a bare mention of Stasis in
+    // an unrelated clause (e.g. Defiant's "gains Shield ... when applying Stasis" has no trailing
+    // duration and uses "applying", excluded from the verb set below). `turns?` tolerates the CSV's
+    // "for 2 turn" singular typo, same tolerance as DURATION_RE.
+    const BARE_STASIS_INFLICT_RE =
+        /\b(?:inflicts?|applies)\b[^.]*?\band\s+Stasis\s+for\s+(\d+)\s*turns?/i;
+    const bareStasis = BARE_STASIS_INFLICT_RE.exec(rawText);
+    if (bareStasis && !alreadyEmitted.has('Stasis')) {
+        alreadyEmitted.add('Stasis');
+        effects.push({
+            buffName: 'Stasis',
+            target: 'enemy',
+            duration: parseInt(bareStasis[1], 10),
+            application: 'inflict',
             source,
         });
     }

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -5023,6 +5023,26 @@ function buffGrantSpan(
 }
 
 /**
+ * Finds the character position of the (0-based) Nth occurrence of `name` inside `text` via
+ * repeated plain substring search — a direct generalization of the single-occurrence
+ * `text.indexOf(name)` `detectGrantScope` used before ship-kit W8 Task 2. Returns -1 only when
+ * NO occurrence exists; if fewer than `occurrenceIndex + 1` occurrences exist, returns the LAST
+ * occurrence actually found (defensive: an out-of-range index degrades to "closest available"
+ * rather than losing position entirely).
+ */
+function findNthOccurrencePos(text: string, name: string, occurrenceIndex: number): number {
+    let pos = -1;
+    let searchFrom = 0;
+    for (let n = 0; n <= occurrenceIndex; n++) {
+        const idx = text.indexOf(name, searchFrom);
+        if (idx === -1) return pos;
+        pos = idx;
+        searchFrom = idx + name.length;
+    }
+    return pos;
+}
+
+/**
  * Resolves the player-side ally-scope of a granted buff from its GRANTING CLAUSE, using the
  * same masking-aware clause resolver (`resolveBuffClause`) as condition detection so "Inc."/
  * "Out." abbreviation periods don't break sentence splitting.
@@ -5045,16 +5065,27 @@ function buffGrantSpan(
  *
  * For the attacker's own sim 'self' and 'all-allies' are equivalent (both fold onto the
  * attacker's side); the distinction only matters when the engine walks a team ship's grants.
+ *
+ * `occurrenceIndex` (0-based, ship-kit W8 Task 2): a SAME buff name can be granted to two
+ * DIFFERENT scopes within one clause (Centurion's charge: "This Unit gains 4 stacks of Core
+ * Charge I and grants all adjacent allies 2 stacks of Core Charge I …" — self, then
+ * adjacent-allies). Resolving scope from the buff name's FIRST occurrence (plain `indexOf`)
+ * would make every grant of that name in the clause resolve identically, silently collapsing
+ * the second grant's scope onto the first. The caller (parseSkillEffects, which already walks
+ * one <unit-skill> segment per occurrence) passes which occurrence this call is for so the
+ * governing verb/receiver is read from THAT grant's own span. Defaults to 0 (first occurrence)
+ * — byte-identical for every buff name granted only once in its clause.
  */
 function detectGrantScope(
     skillText: string,
-    buffName: string
+    buffName: string,
+    occurrenceIndex = 0
 ): 'self' | 'ally' | 'all-allies' | 'adjacent-allies' {
     const resolved = resolveBuffClause(skillText, buffName).toLowerCase();
     // Strip trigger/condition sub-clauses so an ally mentioned only as the TRIGGER ("after an
     // ally is critically repaired") doesn't leak ally-scope onto a buff the caster grants itself.
     const clause = stripConditionClauses(resolved);
-    const buffStart = clause.indexOf(buffName.toLowerCase());
+    const buffStart = findNthOccurrencePos(clause, buffName.toLowerCase(), occurrenceIndex);
     const { verb, subject, object } = buffGrantSpan(
         clause,
         buffStart === -1 ? clause.length : buffStart
@@ -5219,12 +5250,21 @@ export function parseSkillEffects(
 
     const segments = parseSkillText(skillText);
     const effects: SkillEffect[] = [];
+    // Ship-kit W8 Task 2: counts how many <unit-skill> tags of THIS buff name have already been
+    // walked, so a buff name granted twice in one clause (Centurion: self x4 + adjacent-allies
+    // x2, same "Core Charge I") resolves each occurrence's scope independently instead of both
+    // collapsing onto the first grant's scope. Incremented for every tagged occurrence (even one
+    // later skipped for lacking a verb) so the count always matches this segment's true position
+    // among the buff name's occurrences in the raw text.
+    const buffNameOccurrence = new Map<string, number>();
 
     for (let i = 0; i < segments.length; i++) {
         const seg = segments[i];
         if (seg.type !== 'unit-skill') continue;
 
         const buffName = seg.text;
+        const occurrenceIndex = buffNameOccurrence.get(buffName) ?? 0;
+        buffNameOccurrence.set(buffName, occurrenceIndex + 1);
 
         // Step 1: Find application verb
         const verb = findVerb(segments, i);
@@ -5240,7 +5280,7 @@ export function parseSkillEffects(
         const side = verbToTarget(verb, buffName, nextText);
         const target: SkillEffect['target'] =
             side === 'self'
-                ? detectGrantScope(skillText, buffName)
+                ? detectGrantScope(skillText, buffName, occurrenceIndex)
                 : detectEnemyGrantScope(skillText, buffName);
         const application = side === 'enemy' ? verbToApplication(verb) : undefined;
 

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1596,6 +1596,14 @@ export function detectPreCombatShieldTrigger(
 // segment on the un-stripped text. Comma/period boundaries never fall inside <unit-skill> tags, so
 // segmentation is identical with or without tags; only the index mapping is fragile.
 const REMOVAL_SEGMENT_BOUNDARY = /[,.;](?=\s|$)|<br\s*\/?>/gi;
+// Ship-kit Wave 8 Task 11 (Wusheng): "If directly damaged while <buff> is active, remove <buff>."
+// Unlike DR_DIRECT_DAMAGE_RE (the general reaction detector, which deliberately excludes "if" —
+// Panon's "If this Unit is directly damaged" is a conditional GRANT, out of scope there), this
+// window-scoped removal detector accepts BOTH "if" and "when": detectRemovalTriggerAt only ever
+// runs on a window already anchored at a removal verb (parseSelfBuffRemovals' scan), so there is
+// no risk of over-matching an unrelated conditional grant sentence — Panon never reaches this
+// function at all (it has no "loses/removes/remove <unit-skill>" clause to scan for).
+const REMOVAL_DIRECT_DAMAGE_RE = /\b(?:if|when)\s+directly\s+damaged\b|\bwhen\s+attacked\b/i;
 function detectRemovalTriggerAt(text: string, idx: number): AbilityTrigger {
     const masked = maskAbbrev(text);
     // Collect segment boundary spans [start,end) keyed by their terminator position so we can find
@@ -1626,12 +1634,23 @@ function detectRemovalTriggerAt(text: string, idx: number): AbilityTrigger {
     if (ENEMY_REPAIRS_RE.test(window)) return 'on-enemy-repaired';
     if (APPLYING_DEBUFF_RE.test(window)) return 'on-debuff-inflicted';
     if (START_OF_ROUND_RE.test(window)) return 'start-of-round';
+    // Wave 8 Task 11: "if/when directly damaged, remove <buff>" (Wusheng) — the self-scoped
+    // direct-damage reaction, mirroring HEAL_DAMAGE_REACTION_RE's "when … directly damaged"
+    // shape but scoped to this removal window only (see REMOVAL_DIRECT_DAMAGE_RE doc above).
+    if (REMOVAL_DIRECT_DAMAGE_RE.test(window)) return 'on-attacked';
     return 'on-cast';
 }
 
 // Active removal: "loses/removes <unit-skill>NAME</unit-skill>" (Mangler/Ravager/Asphyxiator/
-// Butcher-R1/Ruiner). Passive removal: "<unit-skill>NAME</unit-skill> is lost" (Butcher-R2).
-const SELF_BUFF_REMOVAL_ACTIVE_RE = /\b(?:loses|removes)\s+<unit-skill>([^<]+)<\/unit-skill>/gi;
+// Butcher-R1/Ruiner), plus the bare imperative "remove <unit-skill>NAME</unit-skill>" (Wusheng
+// Wave 8 Task 11: "…remove Stealth."). Corpus-verified (docs/ship-skills.csv): the ONLY two
+// "remove[s]? <unit-skill>" matches in the whole sheet are Ruiner's "removes Overload" (already
+// covered by the `removes` alternative) and Wusheng's "remove Stealth" — no ship uses the bare
+// imperative to describe removing a buff FROM AN ENEMY, so broadening to `remove` cannot mint a
+// phantom removal anywhere else. Passive removal: "<unit-skill>NAME</unit-skill> is lost"
+// (Butcher-R2).
+const SELF_BUFF_REMOVAL_ACTIVE_RE =
+    /\b(?:loses|removes|remove)\s+<unit-skill>([^<]+)<\/unit-skill>/gi;
 const SELF_BUFF_REMOVAL_PASSIVE_RE = /<unit-skill>([^<]+)<\/unit-skill>\s+is\s+lost\b/gi;
 
 /**

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1152,8 +1152,12 @@ export function detectGrantConditions(
         }));
     }
 
-    // 2. self-crit (active voice: this unit critically hits/damages — NOT "is critically hit")
-    if (/critically (?:hits|damag)/i.test(low)) {
+    // 2. self-crit (active voice: this unit critically hits/damages — NOT "is critically hit").
+    // Ship-kit Wave 8, Task 3: ALSO matches "if a critical hit occurs" (Lev's charged buff-grant
+    // clause) — the same phrasing the co-located extend-status ability already gates on via
+    // /critical hit occurs/i (buildShipAbilities.ts ~1657). Trigger stays on-cast; this only adds
+    // the condition, mirroring that ability's shape exactly.
+    if (/critically (?:hits|damag)|\bcritical\s+hit\s+occurs\b/i.test(low)) {
         return [{ subject: 'self-crit', derivable: true }];
     }
 

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -5001,7 +5001,10 @@ const ANY_GRANT_VERB_RE =
 // directly damaged, …") isn't mistaken for the buff's receiver. Two comma/clause-boundary
 // anchored forms, lookbehind-free (iOS Safari 15):
 //  - leading:  "When/After/While/If … , <receiver clause>"  → drop up to the first comma
-//  - trailing: "<receiver clause> when/after/while/if …"    → drop from the keyword onward
+//  - trailing: "<condition clause> when/after/while/if …"   → drop from the keyword onward,
+//    UNLESS that trailing condition is itself followed by ", this Unit grants/applies/gives …"
+//    (Quixilver), in which case the strip stops right before that comma so the receiver
+//    clause survives (ship-kit W8 Task 6).
 // The receiver phrasing ("this Unit grants the ally X" / "X allies gain Y") survives, so a
 // genuine post-condition ally receiver (Provider: "…, this Unit grants the ally RoT III") is
 // still classified ally. The clause is the same one `resolveBuffClause` already split on
@@ -5011,10 +5014,19 @@ function stripConditionClauses(clause: string): string {
     let out = clause;
     // Leading "When/After/While/If … ," — only when it precedes the rest via a comma.
     out = out.replace(/^\s*(?:when|after|while|if)\b[^,]*,\s*/i, '');
-    // Trailing " when/after/while/if …" condition (to end of clause).
-    // LOSSY: a post-condition receiver clause is destroyed here; the default-self fallback covers
-    // the live corpus. A future "if …, all allies gain X" phrasing would need receiver-aware stripping.
-    out = out.replace(/\s+\b(?:when|after|while|if)\b.*$/i, '');
+    // Trailing " when/after/while/if …" condition (to end of clause) — receiver-aware
+    // (ship-kit W8 Task 6): when the condition is itself followed by a comma and a
+    // "this Unit grants/applies/gives …" receiver clause (Quixilver: "…if it has shield equal
+    // to 100% of its max HP, this Unit grants all allies Barrier…"), the strip stops right
+    // before that comma so the receiver clause survives instead of being deleted wholesale.
+    // Scoped narrowly to the literal "this unit <verb>" receiver phrasing (matched on the
+    // already-lowercased clause) so ships whose trailing condition has NO such receiver clause
+    // after it still get the original full-strip-to-end-of-clause behavior via the fallback
+    // alternative.
+    out = out.replace(
+        /\s+\b(?:when|after|while|if)\b(?:[\s\S]*?(?=,\s*this unit (?:grants|applies|gives)\b)|[\s\S]*)/i,
+        ''
+    );
     return out;
 }
 

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1113,16 +1113,25 @@ export function detectGrantConditions(
     const appliesDebuffGate = /\b(?:appl|inflict)\w*\s+a\s+debuff\b/i.test(low);
     // "after an ally is critically repaired" — a team-dependent reactive trigger (manual).
     const allyCritRepairGate = /\ball(?:y|ies)\b[^.]*\bcritically\s+repaired\b/i.test(low);
+    // Ship-kit W8 Task 13: "killing an enemy WITH A DEBUFF" (Meiying) — the kill trigger's
+    // qualifier. KILL_TRIGGER_RE resolves the TRIGGER (on-enemy-destroyed) elsewhere; this
+    // separately gates the GRANTED debuff on the slain enemy having carried a debuff.
+    const killedEnemyHadDebuffGate = KILL_WITH_DEBUFF_RE.test(low);
     // Only conditional clauses produce conditions.
     if (
         !/\b(when|if|while|after)\b|affected by|targeting|damaging|against/.test(low) &&
         !appliesDebuffGate &&
-        !allyCritRepairGate
+        !allyCritRepairGate &&
+        !killedEnemyHadDebuffGate
     )
         return [];
 
     if (allyCritRepairGate) {
         return [{ subject: 'ally-critically-repaired', derivable: false }];
+    }
+
+    if (killedEnemyHadDebuffGate) {
+        return [{ subject: 'killed-enemy-had-debuff', derivable: true }];
     }
 
     // Ship-kit Wave 4, Task 3: "If this Unit has Shield" — a self-shield-presence gate
@@ -1369,6 +1378,15 @@ const ENEMY_BUFFED_RE =
 // Asphyxiator/Butcher), "when an enemy dies". Reference data: docs/ship-skills.csv.
 const KILL_TRIGGER_RE =
     /\bon\s+(?:a\s+)?kill\b|killing\s+an\s+(?:enemy|opponent)|when\s+an\s+enemy\s+dies/i;
+// Ship-kit W8 Task 13 (Meiying): "killing an enemy WITH A DEBUFF" — the qualifier
+// KILL_TRIGGER_RE's bare "killing an (enemy|opponent)" alternate drops (that shared regex also
+// feeds the on-enemy-destroyed TRIGGER classification for every OTHER kill-reactive ship —
+// Mangler/Ravager/Butcher/Obsidian/Valiant/Sokol have no such qualifier and must stay ungated).
+// Kept as a SEPARATE regex, consumed only by detectGrantConditions below, so it attaches a
+// gating CONDITION onto the debuff a kill-clause grants without touching trigger resolution any
+// other kill clause shares. Verified corpus-unique to Meiying (docs/ship-skills.csv, grep "with a
+// Debuff").
+const KILL_WITH_DEBUFF_RE = /\bkilling\s+an\s+enemy\s+with\s+a\s+debuff\b/i;
 // "On inflicting a debuff" / "upon applying a debuff" → on-debuff-inflicted (Butcher Marauder Rage II).
 const APPLYING_DEBUFF_RE = /\b(?:upon|on|after|when)\s+(?:inflicting|applying)\s+(?:a\s+)?debuff/i;
 // Ship-kit W7: present-tense SELF-subject "when this Unit inflicts a Debuff" → on-debuff-inflicted

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -362,8 +362,9 @@ export function parseSecondaryDamage(text: string | null | undefined): Secondary
     // prefix keeps non-<br> tags inline (only sentence boundaries are normalized) —
     // sufficient for the known texts, where the guard words are plain prose. This is the
     // SAME guard that keeps Xcellence's "when an enemy resists a debuff infliction, this
-    // Unit deals damage equal to 115% of this Unit's current shield" reactive proc
-    // unmodeled (deferred, not this on-cast mechanic) even though its stat is 'shield' too.
+    // Unit deals damage equal to 115% of this Unit's current shield" reactive proc out of
+    // this on-cast mechanic even though its stat is 'shield' too — it is modeled separately
+    // by parseOnResistShieldDamage below (Ship-kit W8).
     const plainBefore = text.slice(0, match.index).replace(/<br\s*\/?>/gi, '. ');
     const sentenceStart = Math.max(plainBefore.lastIndexOf('. '), plainBefore.lastIndexOf('; '));
     const sentencePrefix = plainBefore.slice(sentenceStart + 1).toLowerCase();
@@ -429,6 +430,27 @@ export function parseOnResistHpDamage(text: string | null | undefined): { pct: n
     if (!text) return null;
     const re =
         /when\s+this\s+unit\s+resists\s+a\s+debuff\b[^.]*?<unit-damage>(?:damage\s+equal\s+to\s+)?(\d+(?:\.\d+)?)%[^<]*<\/unit-damage>\s*of\s+(?:its|this\s+unit'?s)\s+max\s+hp/i;
+    const m = re.exec(text);
+    if (!m) return null;
+    const pct = parseFloat(m[1]);
+    return isNaN(pct) ? null : { pct };
+}
+
+/**
+ * Ship-kit W8 — Xcellence p2 reactive proc: "When an enemy resists a debuff infliction, this
+ * Unit deals damage equal to <unit-damage>115%</unit-damage> of this Unit's current shield.."
+ * INFLICTOR-scoped sibling of parseOnResistHpDamage — the subject is "an enemy" (the resister),
+ * not "this Unit" (contrast Vindicator's "When THIS UNIT resists…"), so this reads as "when an
+ * enemy resists A DEBUFF [THIS UNIT INFLICTED]": the on-own-debuff-resisted trigger (inflictor-
+ * scoped mirror of on-debuff-resisted, triggers.ts ~775), not Vindicator's on-debuff-resisted.
+ * The basis is the owner's CURRENT SHIELD rather than max HP. Standalone REACTIVE damage — NOT
+ * an on-cast rider (parseSecondaryDamage's sentence guard deliberately excludes this same
+ * clause, see its comment above). Returns { pct } or null.
+ */
+export function parseOnResistShieldDamage(text: string | null | undefined): { pct: number } | null {
+    if (!text) return null;
+    const re =
+        /when\s+an\s+enemy\s+resists\s+a\s+debuff\b[^.]*?<unit-damage>(?:damage\s+equal\s+to\s+)?(\d+(?:\.\d+)?)%[^<]*<\/unit-damage>\s*of\s+(?:its|this\s+unit'?s)\s+current\s+shield/i;
     const m = re.exec(text);
     if (!m) return null;
     const pct = parseFloat(m[1]);

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -1823,6 +1823,77 @@ export function detectAllyCritDotTrigger(
     return phrasePosTrigger(text, ALLY_CRIT_DOT_RE, anchorPos, 'on-ally-crit-dot');
 }
 
+// Ship-kit W8 Task 10 (Wisteria): self-subject mirror of ALLY_CRIT_DOT_RE (Crocus's "when an
+// ally inflicts a DoT with a critical hit"). Wisteria's own-cast phrasing instead uses
+// "applying" (not "inflicts a DoT ... with a critical hit") and carries no "ally" subject
+// (self-implied by "This Unit"):
+//  - R0: "This Unit, after applying Corrosion with a Critical hit, inflicts Inferno II for 2
+//    turns."
+//  - R2 (refit-active): "This Unit inflicts Inferno II for 2 turns after applying Corrosion
+//    with a Critical hit and extends the newly applied Corrosion by 1 turn ..."
+// Verified zero-collision across docs/ship-skills.csv: of the 8 ships whose skill text contains
+// "critical hit", Wisteria is the only one pairing "applying ... critical hit" with a
+// same-sentence "inflicts ... for N turns" (Asphyxiator uses "applies" + no re-infliction
+// clause; Valerian/Crocus use "inflicts/inflicting" for the TRIGGER verb, not "applying"). The
+// generic `[^.]*` gap (not `[\w\s]+?`) so this works against BOTH the raw tagged text
+// (phrasePosTrigger's sentence scan) and the stripped text (parseSelfCritDot/
+// parseSelfCritDotEffect below).
+const SELF_CRIT_DOT_RE = /\bafter\s+applying\b[^.]*\bwith\s+a\s+critical\s+hit\b/i;
+
+/** Whether a skill triggers "after applying a DoT with a Critical hit" (self-scoped, manual). */
+export function parseSelfCritDot(text: string | null | undefined): boolean {
+    if (!text) return false;
+    const plain = stripUnitTags(text);
+    return !/\ball(?:y|ies)\b/i.test(plain) && SELF_CRIT_DOT_RE.test(plain);
+}
+
+/**
+ * Returns 'on-self-crit-dot' when `anchorPos` (the ability's raw-text anchor position) falls
+ * inside the sentence carrying the "after applying <DoT> with a Critical hit" phrase (self-
+ * scoped — THIS unit's own crit-cast DoT infliction, not an ally's); otherwise undefined.
+ * Position-scoped on the RAW text (mirrors detectAllyCritDotTrigger). This is the self-subject
+ * sibling of on-ally-crit-dot — see buildShipAbilities' dot-effects branch for the consuming
+ * side (Wisteria). Reference data: docs/ship-skills.csv.
+ */
+export function detectSelfCritDotTrigger(
+    text: string | null | undefined,
+    anchorPos: number
+): AbilityTrigger | undefined {
+    if (!text || /\ball(?:y|ies)\b/i.test(stripUnitTags(text))) return undefined;
+    return phrasePosTrigger(text, SELF_CRIT_DOT_RE, anchorPos, 'on-self-crit-dot');
+}
+
+// Extracts the buffName + duration of the DoT actually INJECTED by the self-crit-dot trigger
+// (e.g. "Inferno II" / 2), in EITHER clause ordering. Deliberately NOT a generic
+// parseSkillEffects tag walk: the trigger clause itself names a DoT ("applying Corrosion with
+// a Critical hit"), and DOT_TIER_MAP carries a bare 'Corrosion' entry — a naive per-tag loop
+// (like the on-ally-crit-dot block above) would mint a phantom Corrosion dot from the TRIGGER'S
+// OWN named DoT, which carries no "for N turns" of its own (buildShipAbilities.test.ts's "no
+// phantom Corrosion dot" guard covers exactly this). Anchoring on the "inflicts X for N turns"
+// clause specifically — in either ordering relative to the trigger clause — means only the
+// genuinely injected DoT is ever extracted. Operates on the STRIPPED text only (buffName must
+// come out clean for the DOT_TIER_MAP lookup).
+const SELF_CRIT_DOT_EFFECT_ORDER_A_RE =
+    /\binflicts\s+([\w\s]+?)\s+for\s+(\d+)\s+turns?\s+after\s+applying\s+[\w\s]+?\s+with\s+a\s+critical\s+hit/i;
+const SELF_CRIT_DOT_EFFECT_ORDER_B_RE =
+    /after\s+applying\s+[\w\s]+?\s+with\s+a\s+critical\s+hit[^.]*?\binflicts\s+([\w\s]+?)\s+for\s+(\d+)\s+turns?/i;
+
+/**
+ * Parses the DoT actually injected by a "after applying <DoT> with a Critical hit" self-crit
+ * trigger (Wisteria: Inferno II / 2 turns), or undefined when absent. See the block comment
+ * above for why this is a dedicated extraction rather than a parseSkillEffects tag walk.
+ */
+export function parseSelfCritDotEffect(
+    text: string | null | undefined
+): { buffName: string; turns: number } | undefined {
+    if (!text || !parseSelfCritDot(text)) return undefined;
+    const plain = stripUnitTags(text);
+    const m =
+        SELF_CRIT_DOT_EFFECT_ORDER_A_RE.exec(plain) ?? SELF_CRIT_DOT_EFFECT_ORDER_B_RE.exec(plain);
+    if (!m) return undefined;
+    return { buffName: m[1].trim(), turns: parseInt(m[2], 10) };
+}
+
 /**
  * Returns 'on-bomb-detonated' when `anchorPos` (the ability's raw-text anchor position) falls
  * inside the sentence carrying the VICTIM-scoped bomb-burst phrase (BOMB_DETONATE_RE — "bomb

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -2411,6 +2411,28 @@ export function parseHighestSpeedEnemyTarget(
     return sentence !== undefined && HIGHEST_SPEED_ENEMY_RE.test(sentence);
 }
 
+// "the highest attack enemy" — Selenite's enemy-highest-attack target axis (Ship-kit W8 Task 5).
+// Narrowly matched (hyphen-or-space between "highest" and "attack") so it doesn't retarget other
+// ships' plain enemy debuffs that merely co-occur with "Attack" text elsewhere in the sentence.
+// Verified against RAW CSV: '…the highest attack enemy is applied with Concentrate Fire for 1
+// turn.'
+const HIGHEST_ATTACK_ENEMY_RE = /\bhighest[- ]attack\s+enemy\b/i;
+
+/**
+ * Returns true when `anchorPos` falls inside the sentence carrying the "highest attack enemy"
+ * phrase (Selenite p3's start-of-round Concentrate Fire debuff); otherwise false.
+ * Position-scoped on the RAW text (mirrors parseHighestSpeedEnemyTarget's sentence-scoping).
+ * Reference data: docs/ship-skills.csv (Selenite).
+ */
+export function parseHighestAttackEnemyTarget(
+    text: string | null | undefined,
+    anchorPos: number
+): boolean {
+    if (!text) return false;
+    const sentence = rawSentenceAround(text, anchorPos);
+    return sentence !== undefined && HIGHEST_ATTACK_ENEMY_RE.test(sentence);
+}
+
 // Shared: find the sentence (on RAW text, boundary = '.'/';' followed by whitespace/end — decimals
 // and abbreviation periods are NOT split, mirroring sentenceBoundsAround) carrying `phrase`; if
 // `anchorPos` falls within that sentence's [start,end) bounds, return `trigger`, else undefined.

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -2479,6 +2479,51 @@ export function detectKilledByDirectDamageTrigger(
     return phrasePosTrigger(text, KILLED_BY_DIRECT_RE, anchorPos, 'on-destroyed');
 }
 
+// Ship-kit W8 Task 12: "… purges 1 buff from the enemy when dealing damage to a Defender"
+// (Zeolite passive). Verified against RAW CSV: 'This Unit purges 1 buff from the enemy when
+// dealing damage to a Defender.' Position-scoped (mirrors detectKilledByDirectDamageTrigger).
+const DEAL_DAMAGE_TO_ROLE_RE =
+    /\bwhen\s+dealing\s+damage\s+to\s+(?:an?\s+)?(?:defender|attacker|debuffer|supporter)s?\b/i;
+
+/**
+ * Returns 'on-deal-damage' when `anchorPos` falls inside the sentence carrying the "when
+ * dealing damage to a <Role>" phrase (Zeolite's passive purge reactive); otherwise undefined.
+ * Reuses the SAME 'on-deal-damage' trigger Burner's on-deal-damage Inferno rider already
+ * drives (triggers.ts) — the owner's own damage-dealing turn, victim-routed via eventCtx.victimId.
+ */
+export function detectDealDamageToRoleTrigger(
+    text: string | null | undefined,
+    anchorPos: number
+): AbilityTrigger | undefined {
+    return phrasePosTrigger(text, DEAL_DAMAGE_TO_ROLE_RE, anchorPos, 'on-deal-damage');
+}
+
+// "to/against/targeting/damaging/attacking/hitting a <Role>" — the SAME enemy-class extraction
+// buildShipAbilities.ts's outgoing-damage-modifier branch already uses for Zeolite's "+30%
+// damage when hitting a Defender" gate (Wave 4). Reused here so both halves of Zeolite's
+// passive ("+30%… Defender" / "purges… Defender") read the role from one shared pattern.
+const ENEMY_ROLE_CLAUSE_RE =
+    /\b(?:to|against|targeting|damaging|attacking|hitting)\s+(?:an?\s+)?(defender|attacker|debuffer|supporter)s?\b/i;
+
+/**
+ * Extracts the `enemy-type` Condition from the sentence containing `anchorPos` (Zeolite's
+ * on-deal-damage purge, Task 12) — e.g. "when dealing damage to a Defender" → requiredEnemyType
+ * 'Defender'. Sentence-scoped on RAW text (mirrors detectRepairedThisRoundCondition). Undefined
+ * when no role phrase is present in that sentence.
+ */
+export function detectPurgeEnemyTypeCondition(
+    text: string | null | undefined,
+    anchorPos: number
+): Condition | undefined {
+    if (!text) return undefined;
+    const sentence = rawSentenceAround(text, anchorPos);
+    if (sentence === undefined) return undefined;
+    const m = ENEMY_ROLE_CLAUSE_RE.exec(sentence);
+    return m
+        ? { subject: 'enemy-type', derivable: true, requiredEnemyType: capType(m[1]) }
+        : undefined;
+}
+
 // "repaired this round" — Nayra's charged purge + its Stasis/Exposed inflicts. The
 // gate word ("if"/"when") is already verified by detectGrantConditions' conditional
 // guard / by rawSentenceAround's sentence scoping, so the phrase alone is enough.

--- a/src/utils/skillTextParser.ts
+++ b/src/utils/skillTextParser.ts
@@ -4617,18 +4617,22 @@ export type SkillSource = 'active' | 'charge' | 'passive1' | 'passive2' | 'passi
 export interface SkillEffect {
     buffName: string;
     // Player-side granularity (team-walk ally-scope): 'self' = caster only, 'ally' = a single
-    // chosen ally, 'all-allies' = every player actor. 'enemy' = single-target enemy debuff,
-    // 'all-enemies' = enemy debuff scoped to the whole opposing team (detectEnemyGrantScope).
-    // 'adjacent-enemies' / 'target-and-adjacent-enemies' = enemy debuff scoped to the anchor's
-    // neighbours (excluded/included respectively) — see detectAdjacentEnemyScope. Engine fan-out
-    // for these two is a later task; this file only resolves the scope.
-    // The combat engine routes 'ally'/'all-allies' grants from a walked team ship onto the right
-    // actors, and fans an 'all-enemies' debuff over aoeVictimIds generically; for the attacker's
-    // own sim 'self' and 'all-allies' both fold onto its side (zero churn).
+    // chosen ally, 'all-allies' = every player actor, 'adjacent-allies' = board-adjacent player
+    // actors only (Lionheart's crit-buff grants — ship-kit W8 Task 1; see detectGrantScope).
+    // 'enemy' = single-target enemy debuff, 'all-enemies' = enemy debuff scoped to the whole
+    // opposing team (detectEnemyGrantScope). 'adjacent-enemies' / 'target-and-adjacent-enemies' =
+    // enemy debuff scoped to the anchor's neighbours (excluded/included respectively) — see
+    // detectAdjacentEnemyScope. Engine fan-out for these two is a later task; this file only
+    // resolves the scope.
+    // The combat engine routes 'ally'/'all-allies'/'adjacent-allies' grants from a walked team
+    // ship onto the right actors, and fans an 'all-enemies' debuff over aoeVictimIds generically;
+    // for the attacker's own sim 'self'/'all-allies'/'adjacent-allies' all fold onto its side
+    // (zero churn).
     target:
         | 'self'
         | 'ally'
         | 'all-allies'
+        | 'adjacent-allies'
         | 'enemy'
         | 'all-enemies'
         | 'adjacent-enemies'
@@ -4940,6 +4944,13 @@ const SINGLE_ALLY_RE =
 // Ally-scoped (team-wide) grant phrasings: bare plural "allies" (subsumes "all allies"), "friendly …".
 // Note: bare "allies" subsumes "all allies", so the explicit "all allies" alternative is omitted.
 const ALL_ALLIES_RE = /friendly|allies/i;
+// Ship-kit W8 Task 1 (Lionheart): a receiver naming "(all) adjacent allies" bare — the crit-buff
+// grant "grants Attack Up II to all adjacent allies for 1 turn." — is board-adjacency scoped, not
+// team-wide. Tested BEFORE ALL_ALLIES_RE (which would otherwise match the "allies" substring and
+// swallow it as all-allies) but ONLY when the receiver is adjacency-ONLY: Tormenter's combined
+// "grants X to itself and all adjacent allies" receiver still routes all-allies (self + adjacent
+// together is broader than adjacency alone) — see the SELF_RECEIVER_RE co-check at the call site.
+const ADJACENT_ALLIES_RE = /\badjacent allies\b/i;
 // A grant whose receiver is explicitly the caster ("grants itself X").
 const SELF_RECEIVER_RE = /\bitself\b/i;
 // Granting (bestowing) verbs — the caster confers the buff on a (possibly explicit) receiver.
@@ -5023,6 +5034,7 @@ function buffGrantSpan(
  *      · This-Unit / no subject ("This Unit gains X")                        → 'self'
  *  - BESTOWING verb ("grants") — the OBJECT (receiver) takes the buff:
  *      · explicit self receiver ("grants itself X")                          → 'self'
+ *      · bare adjacency receiver ("grants X to all adjacent allies")         → 'adjacent-allies'
  *      · team receiver ("grants all allies X" / "grants X to all allies")    → 'all-allies'
  *      · single-ally receiver ("grants the/an/that ally X", "grants them X") → 'ally'
  *      · NO explicit receiver ("This Unit grants X")                         → 'all-allies'
@@ -5034,7 +5046,10 @@ function buffGrantSpan(
  * For the attacker's own sim 'self' and 'all-allies' are equivalent (both fold onto the
  * attacker's side); the distinction only matters when the engine walks a team ship's grants.
  */
-function detectGrantScope(skillText: string, buffName: string): 'self' | 'ally' | 'all-allies' {
+function detectGrantScope(
+    skillText: string,
+    buffName: string
+): 'self' | 'ally' | 'all-allies' | 'adjacent-allies' {
     const resolved = resolveBuffClause(skillText, buffName).toLowerCase();
     // Strip trigger/condition sub-clauses so an ally mentioned only as the TRIGGER ("after an
     // ally is critically repaired") doesn't leak ally-scope onto a buff the caster grants itself.
@@ -5052,11 +5067,17 @@ function detectGrantScope(skillText: string, buffName: string): 'self' | 'ally' 
         return 'self';
     }
 
-    // Bestowing verb (grants) → route by the OBJECT (the receiver of the grant). Team and ally
-    // receivers are tested BEFORE the self ("itself") receiver so a combined receiver like
-    // "grants Out. Damage Up I to itself and all adjacent allies" (Tormenter) routes all-allies,
-    // not self — "itself" only pins to self when it is the SOLE receiver (Nuqtu's "grants itself").
+    // Bestowing verb (grants) → route by the OBJECT (the receiver of the grant). Adjacency-ONLY
+    // and team receivers are tested BEFORE the self ("itself") receiver so a combined receiver
+    // like "grants Out. Damage Up I to itself and all adjacent allies" (Tormenter) still routes
+    // all-allies, not self — "itself" only pins to self when it is the SOLE receiver (Nuqtu's
+    // "grants itself"). Ship-kit W8 Task 1 (Lionheart): the adjacency check is co-guarded on the
+    // ABSENCE of "itself" so Tormenter's combined receiver (broader than adjacency alone) falls
+    // through to the plain all-allies branch below instead of being caught here.
     if (verb !== null && GRANT_VERB_RE.test(verb)) {
+        if (ADJACENT_ALLIES_RE.test(object) && !SELF_RECEIVER_RE.test(object)) {
+            return 'adjacent-allies';
+        }
         if (ALL_ALLIES_RE.test(object)) return 'all-allies';
         if (SINGLE_ALLY_RE.test(object)) return 'ally';
         if (SELF_RECEIVER_RE.test(object)) return 'self';
@@ -5066,6 +5087,9 @@ function detectGrantScope(skillText: string, buffName: string): 'self' | 'ally' 
 
     // No identifiable verb (defensive): fall back to the prior phrasing-only heuristic.
     if (SINGLE_ALLY_RE.test(clause)) return 'ally';
+    if (ADJACENT_ALLIES_RE.test(clause) && !SELF_RECEIVER_RE.test(clause)) {
+        return 'adjacent-allies';
+    }
     if (ALL_ALLIES_RE.test(clause)) return 'all-allies';
     return 'self';
 }


### PR DESCRIPTION
Final mop-up wave of the ship-kit correctness audit (`docs/ship-kit-correctness-ledger.md`). Closes the last **14 confirmed findings**, all re-traced against `main` (post Waves 1–7 and the #268 audit-security recalibration). Almost entirely parser-layer; two add a reactive-engine seam. **No new `AbilityType`/`AbilityTarget`/`ModifierChannel`** — every fix reuses an existing surface.

### Parser fidelity fixes
- **Lionheart** — on-crit Attack Up II/III now buff `adjacent-allies`, not the whole team (`detectGrantScope` gained an `adjacent-allies` branch).
- **Centurion** — charged skill now also grants adjacent allies 2 stacks of Core Charge I (occurrence-aware scope; the self ×4 grant no longer collapses the ally ×2 grant).
- **Lev** — charged Crit Power Up II now gated on `self-crit` ("If a critical hit occurs"), not every cast.
- **Chimei** — low-HP Stealth grant now fires `end-of-round`, not on-cast.
- **Selenite** — start-of-round Concentrate Fire now targets `enemy-highest-attack` (also widened the shared `isEnemyTarget` classifier so the debuff isn't mis-bucketed as a self-buff in the DPS preview).
- **Quixilver** — Barrier now granted to `all-allies` (receiver-aware condition-strip; the lossy trailing-`if` strip no longer eats the receiver clause).
- **Xcellence** — active now inflicts the untagged **Stasis**; passive now deals **on-resist shield-basis** reactive damage (115% of current shield, inflictor-scoped `on-own-debuff-resisted`; added a `shieldBasisPct` path to `applyReactiveDamage`).
- **Madax** — adjacent-Supporter Defense grant (was mis-parsed as a self-heal); the 13% on-kill self-heal is untouched.
- **Wisteria** — self-crit "after applying Corrosion, inflict Inferno II" now modeled (new `on-self-crit-dot` trigger, self-scoped).
- **Wusheng** — now loses Stealth when directly damaged while Stealthed.
- **Lingshe** — detonation damage now scales with crit power (1% per 10%), via the already-consumed `detonationDamage` channel.

### Reactive-engine seams (team-symmetric, integration-tested)
- **Zeolite** — purges 1 buff when it deals damage to a **Defender** (via the existing `on-deal-damage` event + `IntentExecContext.roleOf` from the existing side-agnostic role map; no new event).
- **Meiying** — Stasis-on-kill now gated on the **slain enemy carrying a debuff** (new `killed-enemy-had-debuff` condition + `LIVE_SUBJECTS` entry; also added the reactive-debuff `adjacent-enemies` fan-out the on-cast path already had — Meiying is the corpus's only reactive adjacent-enemies debuff).

### Resolved without code
- **Hemlock Toxic Overflow** — **false positive**: already shipped in Wave 3 (`toxicOverflow.ts` + end-of-round spread + rider heal).
- **Meatshield Protection buff-steal** — **deferred** (corpus-inert; named stacking buff with no source to steal from in the sim).

### Verification
- Full suite green: **413 files / 4768 tests**; lint 0 warnings.
- Subagent-driven: per-task spec+quality reviews + an Opus final whole-branch review. The final review's one Important finding (Madax `adjacent-allies` pre-combat grant over-granting to non-Supporter neighbours — inherited engine behaviour newly exposed) was fixed with a per-recipient role filter + non-vacuous test.
- Each new trigger/condition (`on-self-crit-dot`, `on-own-debuff-resisted` damage path, `killed-enemy-had-debuff`, `shieldBasisPct`) verified dispatched (not inert); engine seams mutation-verified non-vacuous and team-symmetric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Kh47NRsdbAY1A3BuTvwdG
