### PR TITLE
feat: combat-log readability — CF source→target, killer names, DoT tier

### DIFF
--- a/src/components/simulator/RoundEventLog.tsx
+++ b/src/components/simulator/RoundEventLog.tsx
@@ -110,6 +110,23 @@ const noteLine = (entry: CombatLogEntry, ctx: FormatterCtx): React.ReactNode => 
 };
 
 /**
+ * A note line that surfaces the recipient: "{src} → {tgt}: {note}" when the entry carries a target
+ * distinct from the acting ship (an enemy debuff / applied DoT — so the log shows WHO it landed on),
+ * collapsing to the plain "{src}: {note}" line when there is no target or it is the actor itself
+ * (self-buff/debuff). Used by the `debuff` and `dot-applied` formatters.
+ */
+const sourceTargetNoteLine = (entry: CombatLogEntry, ctx: FormatterCtx): React.ReactNode => {
+    const src = ctx.nameOf(entry.actorId);
+    const targetId = entry.targets[0]?.targetId;
+    const label = entry.note ?? '';
+    if (targetId !== undefined && targetId !== entry.actorId) {
+        const tgt = ctx.nameOf(targetId);
+        return label ? `${src} → ${tgt}: ${label}` : `${src} → ${tgt}`;
+    }
+    return label ? `${src}: ${label}` : src;
+};
+
+/**
  * Per-kind formatter map. Every kind resolves to a renderable node; unmapped/future kinds
  * fall through to the neutral `noteLine` fallback (never throws — forward-compatible).
  */
@@ -126,8 +143,8 @@ const formatters: Record<
     heal: (entry, ctx) => renderTargets(entry, ctx, `${ctx.nameOf(entry.actorId)} heals`),
     shield: (entry, ctx) => renderTargets(entry, ctx, `${ctx.nameOf(entry.actorId)} shields`),
     buff: noteLine,
-    debuff: noteLine,
-    'dot-applied': noteLine,
+    debuff: sourceTargetNoteLine,
+    'dot-applied': sourceTargetNoteLine,
     'dot-ticked': (entry, ctx) => {
         const t = entry.targets[0];
         const who = ctx.nameOf(entry.actorId);
@@ -153,7 +170,15 @@ const formatters: Record<
     },
     'shield-destroyed': (entry, ctx) => `${ctx.nameOf(entry.actorId)}'s shield destroyed`,
     'cheat-death': (entry, ctx) => `${ctx.nameOf(entry.actorId)} cheats death!`,
-    death: noteLine,
+    death: (entry, ctx) => {
+        const actor = ctx.nameOf(entry.actorId);
+        // The killer (when known) is carried as the entry's single target so we resolve it to a
+        // ship name here rather than showing a raw actor id.
+        const killerId = entry.targets[0]?.targetId;
+        return killerId !== undefined
+            ? `${actor}: destroyed by ${ctx.nameOf(killerId)}`
+            : `${actor}: destroyed`;
+    },
     detonation: (entry, ctx) => {
         const amount = entry.targets[0]?.amount;
         const head = noteLine(entry, ctx) as string;

--- a/src/components/simulator/__tests__/RoundEventLog.test.tsx
+++ b/src/components/simulator/__tests__/RoundEventLog.test.tsx
@@ -202,6 +202,96 @@ describe('RoundEventLog', () => {
         expect(screen.getByText('No events this round.')).toBeInTheDocument();
     });
 
+    // Helper: a single-turn round carrying one entry, for the per-kind formatter tests below.
+    const oneEntryRound = (
+        entry: CombatLogRound['turns'][number]['entries'][number]
+    ): CombatLogRound => ({
+        round: 1,
+        startOfRound: [],
+        endOfRound: [],
+        turns: [
+            { actorId: entry.actorId ?? 'nova', chargeBefore: 0, chargeMax: 0, entries: [entry] },
+        ],
+    });
+
+    it('death: resolves the killer id to a ship name', () => {
+        render(
+            <RoundEventLog
+                round={oneEntryRound({
+                    kind: 'death',
+                    actorId: 'graphite',
+                    targets: [{ targetId: 'hexa' }],
+                    reactions: [],
+                })}
+                roster={roster}
+            />
+        );
+        expect(screen.getByText(/Graphite: destroyed by Enemy Hexa/)).toBeInTheDocument();
+    });
+
+    it('death: renders plain "destroyed" when there is no killer', () => {
+        render(
+            <RoundEventLog
+                round={oneEntryRound({
+                    kind: 'death',
+                    actorId: 'graphite',
+                    targets: [],
+                    reactions: [],
+                })}
+                roster={roster}
+            />
+        );
+        expect(screen.getByText(/Graphite: destroyed$/)).toBeInTheDocument();
+    });
+
+    it('debuff: shows attacker → target when the debuff lands on another ship', () => {
+        render(
+            <RoundEventLog
+                round={oneEntryRound({
+                    kind: 'debuff',
+                    actorId: 'selenite',
+                    targets: [{ targetId: 'nova' }],
+                    reactions: [],
+                    note: 'Concentrate Fire',
+                })}
+                roster={roster}
+            />
+        );
+        expect(screen.getByText(/Enemy Selenite → Nova: Concentrate Fire/)).toBeInTheDocument();
+    });
+
+    it('dot-applied: shows attacker → target with the tiered note', () => {
+        render(
+            <RoundEventLog
+                round={oneEntryRound({
+                    kind: 'dot-applied',
+                    actorId: 'nova',
+                    targets: [{ targetId: 'hexa' }],
+                    reactions: [],
+                    note: 'corrosion III ×2',
+                })}
+                roster={roster}
+            />
+        );
+        expect(screen.getByText(/Nova → Enemy Hexa: corrosion III ×2/)).toBeInTheDocument();
+    });
+
+    it('debuff: collapses to just the actor when the target is itself (self-debuff)', () => {
+        render(
+            <RoundEventLog
+                round={oneEntryRound({
+                    kind: 'debuff',
+                    actorId: 'nova',
+                    targets: [{ targetId: 'nova' }],
+                    reactions: [],
+                    note: 'Overload',
+                })}
+                roster={roster}
+            />
+        );
+        expect(screen.getByText(/^Nova: Overload$/)).toBeInTheDocument();
+    });
+
     it('shows a collapsed stats summary under a turn and expands to the full block', async () => {
         const round: CombatLogRound = {
             round: 1,

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -6,6 +6,7 @@ export const CURRENT_VERSION = '1.64.0';
 // CHANGELOG (with the new version + today's date), clear this array back to [],
 // and bump CURRENT_VERSION. All three steps must happen together.
 export const UNRELEASED_CHANGES: string[] = [
+    'Combat log readability: debuff and DoT lines now show who they came from and who they landed on (e.g. "Enemy Selenite → Nova: Concentrate Fire"); death lines name the destroyer instead of a raw id ("Judge: destroyed by Enemy Vanguard"); and Corrosion/Inferno lines show their tier (I/II/III), with a mix of tiers on one target split onto separate lines.',
     "Combat sim: fixed a crash when Lingshe's Bomb-countdown reduction detonated a Bomb that killed an enemy still carrying other Bombs (e.g. paired with a Bomb planter like Sha Xing or Panguan). All of that enemy's due Bombs now detonate correctly instead of aborting the simulation.",
     'Combat sim: Zeolite now purges 1 buff from an enemy Defender whenever it deals damage to one, matching its passive — previously this follow-up purge never applied at all.',
     'Combat sim: Lingshe now gains Stealth only when she herself detonates a Bomb (her charged skill), instead of gaining it from any Bomb bursting anywhere in the battle — including bombs that simply expire on their own or that another ship detonates.',

--- a/src/utils/combat/__tests__/blockDebuff.test.ts
+++ b/src/utils/combat/__tests__/blockDebuff.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { dotResistLabel, isBlockDebuff, controlEffectLabel } from '../debuffImmunity';
+import {
+    dotResistLabel,
+    dotTierNumeral,
+    isBlockDebuff,
+    controlEffectLabel,
+} from '../debuffImmunity';
 import { runCombat, CombatEngineInput } from '../engine';
 import { ShipSkills, Ability } from '../../../types/abilities';
 import { executeIntent, Intent, IntentExecContext } from '../triggers';
@@ -20,17 +25,51 @@ describe('debuffImmunity helpers', () => {
         });
     });
 
-    describe('dotResistLabel', () => {
-        it('formats inferno with roman numeral tier', () => {
-            expect(dotResistLabel('inferno', 3)).toBe('Inferno III');
+    describe('dotTierNumeral', () => {
+        // `tier` is a MAGNITUDE (corrosion 3/6/9, inferno 15/30/45, bomb 100/200/300) — the same
+        // value tickDoTs divides by 100. dotTierNumeral maps that magnitude to its display level.
+        it('maps corrosion magnitudes to I/II/III (base 3)', () => {
+            expect(dotTierNumeral('corrosion', 3)).toBe('I');
+            expect(dotTierNumeral('corrosion', 6)).toBe('II');
+            expect(dotTierNumeral('corrosion', 9)).toBe('III');
         });
 
-        it('formats corrosion with roman numeral tier', () => {
-            expect(dotResistLabel('corrosion', 2)).toBe('Corrosion II');
+        it('maps inferno magnitudes to I/II/III (base 15)', () => {
+            expect(dotTierNumeral('inferno', 15)).toBe('I');
+            expect(dotTierNumeral('inferno', 30)).toBe('II');
+            expect(dotTierNumeral('inferno', 45)).toBe('III');
+        });
+
+        it('returns "" for bomb and generic (untiered display)', () => {
+            expect(dotTierNumeral('bomb', 100)).toBe('');
+            expect(dotTierNumeral('generic', 5)).toBe('');
+        });
+
+        it('returns "" for a magnitude that is not an exact tier multiple', () => {
+            expect(dotTierNumeral('corrosion', 5)).toBe('');
+            expect(dotTierNumeral('inferno', 8)).toBe('');
+        });
+    });
+
+    describe('dotResistLabel', () => {
+        it('formats inferno from its magnitude (45 → III)', () => {
+            expect(dotResistLabel('inferno', 45)).toBe('Inferno III');
+        });
+
+        it('formats corrosion from its magnitude (6 → II)', () => {
+            expect(dotResistLabel('corrosion', 6)).toBe('Corrosion II');
+        });
+
+        it('formats corrosion tier I from its magnitude (3 → I)', () => {
+            expect(dotResistLabel('corrosion', 3)).toBe('Corrosion I');
         });
 
         it('formats bomb with no tier suffix', () => {
-            expect(dotResistLabel('bomb', 0)).toBe('Bomb');
+            expect(dotResistLabel('bomb', 100)).toBe('Bomb');
+        });
+
+        it('formats generic as the plain untiered label', () => {
+            expect(dotResistLabel('generic', 5)).toBe('Damage over Time');
         });
     });
 
@@ -251,7 +290,9 @@ const infernoIIIEnemy = (): EnemyAttacker =>
                             config: {
                                 type: 'dot',
                                 dotType: 'inferno',
-                                tier: 3,
+                                // Inferno III MAGNITUDE (15/30/45 = I/II/III) — the value the tick
+                                // math and dotResistLabel both consume; 45 → 'Inferno III'.
+                                tier: 45,
                                 stacks: 2,
                                 duration: 3,
                             },
@@ -295,7 +336,7 @@ describe('Block Debuff — cast-side DoT block + resist event (engine)', () => {
         const entry = e1Effects(result);
         expect(entry).toBeDefined();
         expect(entry!.dots).toHaveLength(0);
-        expect(entry!.resistedDots).toEqual([{ type: 'inferno', tier: 3, stacks: 2 }]);
+        expect(entry!.resistedDots).toEqual([{ type: 'inferno', tier: 45, stacks: 2 }]);
     });
 
     it('control: WITHOUT Block Debuff the same DoT lands (dot-applied, NO resist event)', () => {
@@ -488,6 +529,51 @@ describe('Block Debuff — reactive timed-debuff fold (engine)', () => {
         expect(events.some((e) => e.type === 'debuff-applied')).toBe(false);
     });
 
+    it('a RESISTED reactive timed debuff reports the RESOLVED target id (not the dummy sink)', () => {
+        // Combat-log fidelity (#1): the reactive resist emit must name the ship the debuff was
+        // aimed at (the counter target), not the fixed `ctx.enemy.id` dummy sink — so the log can
+        // render "src → <that ship>: X resisted" instead of "src → enemy".
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        se.beginRound(1);
+        const events: CombatEvent[] = [];
+        const bus = createEventBus();
+        bus.on('debuff-resisted', (e) => events.push(e as CombatEvent));
+        const ctx: IntentExecContext = {
+            round: 1,
+            enemy: { id: 'enemy-default' } as CombatActor,
+            enemyId: 'enemy-default',
+            statusEngine: se,
+            bus,
+            corrosionEntries: [],
+            infernoEntries: [],
+            pendingBombs: [],
+            runtimes: new Map([
+                [
+                    'attacker',
+                    {
+                        actor: { id: 'attacker' } as CombatActor,
+                        // Never lands → the resist branch fires.
+                        landsTimedEnemyApplication: () => false,
+                        debuffLandingGate: () => true,
+                    } as unknown as PlayerActorRuntime,
+                ],
+            ]),
+            grantAllyCharges: () => {},
+            grantExtraAction: () => {},
+            playerIds: ['attacker'],
+            lastTurnCtxByActor: new Map(),
+            enemyHp: 100000,
+            cumulativeDamage: 0,
+            recordResisted: () => {},
+        } as unknown as IntentExecContext;
+
+        executeIntent(makeReactiveDebuffIntent('enemy-1'), ctx);
+
+        const resisted = events.filter((e) => e.type === 'debuff-resisted');
+        expect(resisted).toHaveLength(1);
+        expect(resisted[0].type === 'debuff-resisted' && resisted[0].targetId).toBe('enemy-1');
+    });
+
     it('control: WITHOUT Block Debuff the same reactive TIMED debuff lands (non-vacuity)', () => {
         const { ctx, resisted } = buildCtx(); // no immunity seeded
         const events: CombatEvent[] = [];
@@ -540,7 +626,8 @@ describe('Block Debuff — reactive DoT block + resist event (engine)', () => {
             config: {
                 type: 'dot',
                 dotType: 'inferno',
-                tier: 3,
+                // Inferno III magnitude (see dotTierNumeral: 45 → 'Inferno III').
+                tier: 45,
                 stacks: 2,
                 duration: 3,
             },

--- a/src/utils/combat/__tests__/genericDot.test.ts
+++ b/src/utils/combat/__tests__/genericDot.test.ts
@@ -164,4 +164,52 @@ describe('generic DoT', () => {
         // 2 (applier-a) + 1 (applier-b) = 3; the no-ctx entry's 5 stacks are excluded.
         expect(tickedStacks).toBe(3);
     });
+
+    // Combat-log fidelity: distinct tiers of the SAME dotType must NOT be summed into one tick
+    // line — tickDoTs emits one `emitTicked(dotType, damage, stacks, tier)` per (dotType, tier)
+    // group so the log can show "corrosion I ×n" and "corrosion III ×m" separately. Same-tier
+    // entries still coalesce, and the total credited damage is unchanged.
+    it('emits one tick per (dotType, tier) group; same-tier entries coalesce', () => {
+        const ctx = {
+            effectiveAttack: 100,
+            dotMult: 1,
+            affinityMult: 1,
+            effectiveDefence: 0,
+            effectiveMaxHp: 0,
+            outgoingHealPct: 0,
+            incomingHealPct: 0,
+        };
+        const corrosion: ActiveDoTStack[] = [
+            { stacks: 1, tier: 3, remainingRounds: 2, sourceId: 'a' }, // Corrosion I
+            { stacks: 2, tier: 9, remainingRounds: 2, sourceId: 'a' }, // Corrosion III
+            { stacks: 1, tier: 3, remainingRounds: 2, sourceId: 'b' }, // another Corrosion I → coalesces
+        ];
+        const ticks: Array<{ dotType: string; damage: number; stacks: number; tier: number }> = [];
+        let credited = 0;
+        tickDoTs({
+            corrosionEntries: corrosion,
+            infernoEntries: [],
+            genericDoTEntries: [],
+            enemyHp: 1_000, // corrosionBaseHp = 1000 → tier/100 * 1000 = 10 * tier% per stack
+            ctxFor: () => ctx,
+            emitTicked: (dotType, damage, stacks, tier) => {
+                ticks.push({ dotType, damage, stacks, tier });
+            },
+            credit: (_s, dotType, damage) => {
+                if (dotType === 'corrosion') credited += damage;
+            },
+        });
+
+        const corrosionTicks = ticks.filter((t) => t.dotType === 'corrosion');
+        // Two groups: tier 3 (I) and tier 9 (III) — NOT one summed line.
+        expect(corrosionTicks).toHaveLength(2);
+        const t1 = corrosionTicks.find((t) => t.tier === 3);
+        const t3 = corrosionTicks.find((t) => t.tier === 9);
+        // tier 3: two stacks total (a:1 + b:1), damage = 2 * 0.03 * 1000 = 60.
+        expect(t1).toMatchObject({ stacks: 2, damage: 60 });
+        // tier 9: two stacks (a:2), damage = 2 * 0.09 * 1000 = 180.
+        expect(t3).toMatchObject({ stacks: 2, damage: 180 });
+        // Total credited is unchanged by the split.
+        expect(credited).toBe(240);
+    });
 });

--- a/src/utils/combat/__tests__/triggers.test.ts
+++ b/src/utils/combat/__tests__/triggers.test.ts
@@ -2818,15 +2818,14 @@ describe('Phase 4c Task 6: live drain-time selfHpPct', () => {
 });
 
 // ----------------------------------------------------------------------
-// Phase 4c Task 6 (incidental cleanup — Task 5 code review):
-//
-// A debuff intent WITH eventCtx.counterTargetId whose owner's
-// landsTimedEnemyApplication returns false must emit `debuff-resisted`
-// with targetId === ctx.enemy.id (locks the deliberate resisted-path
-// asymmetry: the resisted path always uses the default ctx.enemy.id,
-// not counterTargetId).
+// Combat-log fidelity (#1): a RESISTED reactive debuff reports the RESOLVED
+// target it was aimed at (eventCtx.counterTargetId / enemy-highest-attack),
+// falling back to ctx.enemy.id only when no specific victim resolved — so the
+// log names the ship that resisted instead of the dummy sink. (This SUPERSEDES
+// the earlier Task-5 "always ctx.enemy.id" lock: the resisted target is now the
+// same debuffTargetId the applied path uses.)
 // ----------------------------------------------------------------------
-describe('Phase 4c Task 6: debuff-resisted always targets ctx.enemy.id (Task 5 cleanup lock)', () => {
+describe('debuff-resisted reports the resolved counter target (combat-log fidelity)', () => {
     const makeResistableDebuffIntent = (counterTargetId: string): Intent => ({
         ownerId: 'attacker',
         sourceSlot: 'passive',
@@ -2849,7 +2848,7 @@ describe('Phase 4c Task 6: debuff-resisted always targets ctx.enemy.id (Task 5 c
         eventCtx: { counterTargetId },
     });
 
-    it('debuff-resisted emits with targetId === ctx.enemy.id even when counterTargetId is set', () => {
+    it('debuff-resisted emits with targetId === the resolved counterTargetId when set', () => {
         const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
         se.beginRound(1);
         const emitted: Array<{ type: string; targetId?: string }> = [];
@@ -2889,9 +2888,10 @@ describe('Phase 4c Task 6: debuff-resisted always targets ctx.enemy.id (Task 5 c
 
         executeIntent(makeResistableDebuffIntent('enemy-attacker-99'), ctx);
 
-        // debuff-resisted must point at ctx.enemy.id, not the counterTargetId.
+        // debuff-resisted now points at the RESOLVED counter target (the ship it was aimed at),
+        // so the combat log can name it — not the default ctx.enemy.id dummy sink.
         expect(emitted).toHaveLength(1);
-        expect(emitted[0].targetId).toBe('enemy-default');
+        expect(emitted[0].targetId).toBe('enemy-attacker-99');
     });
 });
 

--- a/src/utils/combat/debuffImmunity.ts
+++ b/src/utils/combat/debuffImmunity.ts
@@ -20,15 +20,42 @@ export function targetCarriesBlockDebuff(statusEngine: StatusEngine, targetId: s
 }
 
 const ROMAN = ['', 'I', 'II', 'III', 'IV', 'V'];
+
+/** Per-DoT-type magnitude of the tier-I stack — the unit `ActiveDoTStack.tier` (and the parsed
+ *  DoT config `tier`) is measured in. Corrosion I = 3, Inferno I = 15, Bomb I = 100; tier II/III
+ *  are the 2×/3× multiples. `generic` DoTs are absolute-per-tick and carry no tier scale. */
+const DOT_TIER_BASE: Record<DoTType, number> = {
+    corrosion: 3,
+    inferno: 15,
+    bomb: 100,
+    generic: 0,
+};
+
+/**
+ * Map a DoT tier MAGNITUDE (e.g. Corrosion III = 9, Inferno II = 30) to its display numeral
+ * ('I'|'II'|'III'|…). Returns '' when the type is untiered for display (bomb/generic) or when the
+ * magnitude is not an exact multiple of the type's base tier (so arbitrary/synthetic magnitudes
+ * never surface a misleading numeral — only the canonical I/II/III magnitudes do).
+ */
+export function dotTierNumeral(dotType: DoTType, magnitude: number): string {
+    if (dotType === 'bomb' || dotType === 'generic') return '';
+    const base = DOT_TIER_BASE[dotType];
+    if (base <= 0 || magnitude <= 0 || magnitude % base !== 0) return '';
+    const level = magnitude / base;
+    return level < ROMAN.length ? ROMAN[level] : '';
+}
+
 /** Single source of truth for the resisted-debuff label of a blocked DoT, so the emit site and
- *  the test assertion agree. e.g. ('inferno', 3) -> 'Inferno III'; ('bomb', 0) -> 'Bomb'.
- *  SP-E: 'generic' is an absolute per-tick DoT, not tiered, so it always renders as the plain
- *  'Damage over Time' label (no numeral) regardless of tier. */
+ *  the test assertion agree. `tier` is the MAGNITUDE (corrosion 3/6/9, inferno 15/30/45) — the
+ *  same value tickDoTs divides by 100 — NOT a 1/2/3 level. e.g. ('inferno', 45) -> 'Inferno III';
+ *  ('bomb', 100) -> 'Bomb'. SP-E: 'generic' is an absolute per-tick DoT, not tiered, so it always
+ *  renders as the plain 'Damage over Time' label (no numeral) regardless of tier. */
 export function dotResistLabel(dotType: DoTType, tier: number): string {
     if (dotType === 'generic') return 'Damage over Time';
     const kind = dotType.charAt(0).toUpperCase() + dotType.slice(1);
-    const numeral = tier > 0 && tier < ROMAN.length ? ` ${ROMAN[tier]}` : '';
-    return dotType === 'bomb' ? kind : `${kind}${numeral}`;
+    if (dotType === 'bomb') return kind;
+    const numeral = dotTierNumeral(dotType, tier);
+    return numeral ? `${kind} ${numeral}` : kind;
 }
 
 /** Resisted-debuff label for a blocked control infliction, matching the named-debuff buff names

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -869,11 +869,12 @@ export function tickDoTs(args: {
     genericDoTEntries: ActiveDoTStack[];
     enemyHp: number;
     ctxFor: (sourceId: string) => PlayerRoundCtx | undefined;
-    /** `stacks` = the per-dotType SUMMED TICKING stacks (only entries that actually tick this
-     *  call — i.e. have a resolvable applier ctx for corrosion/inferno — are counted; generic
-     *  has no ctx gate so all its entries count). Combat-log fidelity: lets the `dot-ticked`
-     *  event/log line show "{dotType} ×{stacks}" alongside the damage. */
-    emitTicked: (dotType: TickableDoTType, damage: number, stacks: number) => void;
+    /** Called ONCE PER (dotType, tier) GROUP that ticked (corrosion/inferno split by tier so the
+     *  combat log shows "corrosion I ×n" and "corrosion III ×m" on separate lines; generic emits a
+     *  single tier-0 call). `stacks` = the summed ticking stacks for that group (only entries with a
+     *  resolvable applier ctx are counted for corrosion/inferno; generic counts all). `tier` = the
+     *  group's tier MAGNITUDE (corrosion 3/6/9, inferno 15/30/45; 0 for generic). */
+    emitTicked: (dotType: TickableDoTType, damage: number, stacks: number, tier: number) => void;
     credit: (sourceId: string, dotType: TickableDoTType, damage: number) => void;
     /** D-PR3 (Vortex Veil): % reduction applied to this carrier's DoT ticks of the given type.
      *  Absent → 0 → byte-identical. */
@@ -886,46 +887,70 @@ export function tickDoTs(args: {
     dotMultFor?: (ctx: PlayerRoundCtx) => number;
 }): void {
     const dotMultFor = args.dotMultFor ?? ((ctx: PlayerRoundCtx) => ctx.dotMult);
+    // Per-(dotType,tier) tick group — the combat log shows each tier on its own line, so a mix of
+    // e.g. Corrosion I and Corrosion III does not collapse into one summed line. `credits` keeps
+    // the per-entry credit list IN ENTRY ORDER so crediting is byte-identical to the pre-grouping
+    // single-loop behaviour; only the log-facing `emitTicked` granularity changes.
+    interface TickGroup {
+        sum: number;
+        stacks: number;
+        credits: Array<{ sourceId: string; d: number }>;
+    }
+    // Sum-then-emit for a whole DoT type, split by tier. Emits per tier ASCENDING (deterministic
+    // log order, independent of entry order). Credits run in entry order across all tiers, exactly
+    // as before, so total credited damage and RNG-free credit order are unchanged.
+    const tickByTier = (
+        dotType: 'corrosion' | 'inferno',
+        entries: ActiveDoTStack[],
+        damageOf: (e: ActiveDoTStack, ctx: PlayerRoundCtx) => number
+    ): void => {
+        const byTier = new Map<number, TickGroup>();
+        const creditOrder: Array<{
+            sourceId: string;
+            dotType: 'corrosion' | 'inferno';
+            d: number;
+        }> = [];
+        let total = 0;
+        for (const e of entries) {
+            const ctx = args.ctxFor(e.sourceId);
+            if (!ctx) continue; // applier has not acted yet this run (faster-enemy round 1)
+            const d = damageOf(e, ctx);
+            let g = byTier.get(e.tier);
+            if (!g) {
+                g = { sum: 0, stacks: 0, credits: [] };
+                byTier.set(e.tier, g);
+            }
+            g.sum += d;
+            g.stacks += e.stacks;
+            creditOrder.push({ sourceId: e.sourceId, dotType, d });
+            total += d;
+        }
+        if (total <= 0) return;
+        const reductionPct = args.incomingDotReductionPct?.(dotType) ?? 0;
+        const factor = 1 - reductionPct / 100;
+        for (const { sourceId, d } of creditOrder) args.credit(sourceId, dotType, d * factor);
+        for (const tier of [...byTier.keys()].sort((a, b) => a - b)) {
+            const g = byTier.get(tier)!;
+            if (g.sum <= 0) continue;
+            args.emitTicked(dotType, g.sum * factor, g.stacks, tier);
+        }
+    };
+
     // Step 4: Tick corrosion (scales with enemy HP, capped at 5000 dmg per 1%)
     const corrosionBaseHp = Math.min(args.enemyHp, 500_000);
-    const corrosionCredits: Array<{ sourceId: string; d: number }> = [];
-    let corrosionSum = 0;
-    let corrosionStacks = 0;
-    for (const e of args.corrosionEntries) {
-        const ctx = args.ctxFor(e.sourceId);
-        if (!ctx) continue; // applier has not acted yet this run (faster-enemy round 1)
-        const d = e.stacks * (e.tier / 100) * corrosionBaseHp * dotMultFor(ctx) * ctx.affinityMult;
-        corrosionCredits.push({ sourceId: e.sourceId, d });
-        corrosionSum += d;
-        corrosionStacks += e.stacks;
-    }
-    if (corrosionSum > 0) {
-        const reductionPct = args.incomingDotReductionPct?.('corrosion') ?? 0;
-        const factor = 1 - reductionPct / 100;
-        for (const { sourceId, d } of corrosionCredits)
-            args.credit(sourceId, 'corrosion', d * factor);
-        args.emitTicked('corrosion', corrosionSum * factor, corrosionStacks);
-    }
+    tickByTier(
+        'corrosion',
+        args.corrosionEntries,
+        (e, ctx) => e.stacks * (e.tier / 100) * corrosionBaseHp * dotMultFor(ctx) * ctx.affinityMult
+    );
 
     // Step 5: Tick inferno (scales with the applier's effective attack, no outgoing buff)
-    const infernoCredits: Array<{ sourceId: string; d: number }> = [];
-    let infernoSum = 0;
-    let infernoStacks = 0;
-    for (const e of args.infernoEntries) {
-        const ctx = args.ctxFor(e.sourceId);
-        if (!ctx) continue;
-        const d =
-            e.stacks * (e.tier / 100) * ctx.effectiveAttack * dotMultFor(ctx) * ctx.affinityMult;
-        infernoCredits.push({ sourceId: e.sourceId, d });
-        infernoSum += d;
-        infernoStacks += e.stacks;
-    }
-    if (infernoSum > 0) {
-        const reductionPct = args.incomingDotReductionPct?.('inferno') ?? 0;
-        const factor = 1 - reductionPct / 100;
-        for (const { sourceId, d } of infernoCredits) args.credit(sourceId, 'inferno', d * factor);
-        args.emitTicked('inferno', infernoSum * factor, infernoStacks);
-    }
+    tickByTier(
+        'inferno',
+        args.infernoEntries,
+        (e, ctx) =>
+            e.stacks * (e.tier / 100) * ctx.effectiveAttack * dotMultFor(ctx) * ctx.affinityMult
+    );
 
     // SP-E: Tick generic DoTs — an ABSOLUTE per-tick amount, independent of stats/HP (no ctxFor
     // gate: unlike corrosion/inferno, a generic tick doesn't need the applier's effective attack
@@ -943,7 +968,8 @@ export function tickDoTs(args: {
         const reductionPct = args.incomingDotReductionPct?.('generic') ?? 0;
         const factor = 1 - reductionPct / 100;
         for (const { sourceId, d } of genericCredits) args.credit(sourceId, 'generic', d * factor);
-        args.emitTicked('generic', genericSum * factor, genericStacks);
+        // Generic DoTs are untiered (absolute per-tick) → single tier-0 group.
+        args.emitTicked('generic', genericSum * factor, genericStacks, 0);
     }
 
     // Expire DoT stacks after ticking
@@ -6737,7 +6763,7 @@ export function runCombat(input: CombatEngineInput): {
                             // Corrosion scales with the afflicted ship's HP — the tank's own max HP.
                             enemyHp: recipientMaxHp(healTarget.id),
                             ctxFor: (sourceId) => lastTurnCtxByActor.get(sourceId),
-                            emitTicked: (dotType, damage, stacks) =>
+                            emitTicked: (dotType, damage, stacks, tier) =>
                                 bus.emit({
                                     type: 'dot-ticked',
                                     targetId: healTarget.id,
@@ -6745,6 +6771,7 @@ export function runCombat(input: CombatEngineInput): {
                                     dotType,
                                     damage,
                                     stacks,
+                                    tier,
                                 }),
                             // Sum the ticked damage across all appliers; route it as INCOMING to the tank
                             // (NOT into a player damage row). expireStacks inside tickDoTs ages the entries.
@@ -6824,7 +6851,7 @@ export function runCombat(input: CombatEngineInput): {
                                 // Corrosion scales with the AFFLICTED ship's own max HP.
                                 enemyHp: recipientMaxHp(actor.id),
                                 ctxFor: (sourceId) => lastTurnCtxByActor.get(sourceId),
-                                emitTicked: (dotType, damage, stacks) =>
+                                emitTicked: (dotType, damage, stacks, tier) =>
                                     bus.emit({
                                         type: 'dot-ticked',
                                         targetId: actor.id,
@@ -6832,6 +6859,7 @@ export function runCombat(input: CombatEngineInput): {
                                         dotType,
                                         damage,
                                         stacks,
+                                        tier,
                                     }),
                                 credit: (sourceId, dotType, damage) => {
                                     total += damage;
@@ -7405,7 +7433,7 @@ export function runCombat(input: CombatEngineInput): {
                         genericDoTEntries,
                         enemyHp,
                         ctxFor: (sourceId) => lastTurnCtxByActor.get(sourceId),
-                        emitTicked: (dotType, damage, stacks) =>
+                        emitTicked: (dotType, damage, stacks, tier) =>
                             bus.emit({
                                 type: 'dot-ticked',
                                 targetId: enemy.id,
@@ -7413,6 +7441,7 @@ export function runCombat(input: CombatEngineInput): {
                                 dotType,
                                 damage,
                                 stacks,
+                                tier,
                             }),
                         credit: (sourceId, dotType, damage) =>
                             creditDamage(sourceId, dotType, damage),

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -126,6 +126,11 @@ export type CombatEvent =
           round: number;
           dotType: DoTType;
           stacks: number;
+          /** Tier MAGNITUDE of the applied DoT (corrosion 3/6/9, inferno 15/30/45, bomb
+           *  100/200/300 — the value tickDoTs divides by 100). Combat-log fidelity: lets the
+           *  applied line show the tier numeral (corrosion/inferno) via dotTierNumeral. Always set
+           *  by the engine; optional so hand-crafted test emits may omit it (→ no numeral shown). */
+          tier?: number;
           /** The applying cast had >= 1 critting hit (per-hit crits). Present only when
            *  true. Executor-applied dots omit it (drain-time has no crit outcome). */
           viaCrit?: boolean;
@@ -241,9 +246,14 @@ export type CombatEvent =
           // this event too. 'bomb' never appears here (bombs burst via 'bomb-detonated').
           dotType: DoTType;
           damage: number;
-          /** Combat-log fidelity: the per-dotType SUMMED TICKING stacks (see `tickDoTs`'s
-           *  `emitTicked` jsdoc) — lets the log line show "{dotType} ×{stacks}". */
+          /** Combat-log fidelity: the per-dotType-and-TIER SUMMED TICKING stacks (see `tickDoTs`'s
+           *  `emitTicked` jsdoc) — lets the log line show "{dotType} {numeral} ×{stacks}". */
           stacks: number;
+          /** Tier MAGNITUDE of this tick group (corrosion 3/6/9, inferno 15/30/45). tickDoTs emits
+           *  one event per (dotType, tier), so this is a single tier, not a mix. Feeds the numeral
+           *  via dotTierNumeral. Always set by the engine; optional so hand-crafted test emits may
+           *  omit it (→ no numeral shown). */
+          tier?: number;
       }
     | { type: 'dot-detonated'; targetId: string; round: number; damage: number }
     /** Emitted on each bomb burst, but the two paths are asymmetric:

--- a/src/utils/combat/log/__tests__/buildCombatLog.test.ts
+++ b/src/utils/combat/log/__tests__/buildCombatLog.test.ts
@@ -1062,7 +1062,7 @@ describe('buildCombatLog', () => {
         expect(entry.note).toBe('Defense Shred');
     });
 
-    it('dot-applied: sourceId → actorId (inflicter), targetId → targets, note has dotType', () => {
+    it('dot-applied: sourceId → actorId (inflicter), targetId → targets, note has dotType + tier', () => {
         const events: CombatEvent[] = [
             ev({ type: 'round-started', round: 1 }),
             ev({ type: 'turn-started', actorId: 'A', round: 1 }),
@@ -1073,6 +1073,7 @@ describe('buildCombatLog', () => {
                 round: 1,
                 dotType: 'corrosion',
                 stacks: 2,
+                tier: 6, // Corrosion II magnitude → 'II'
             }),
             ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
             ev({ type: 'round-ended', round: 1 }),
@@ -1085,7 +1086,28 @@ describe('buildCombatLog', () => {
         expect(entry.actorId).toBe('A'); // sourceId, inflicter
         expect(entry.targets).toHaveLength(1);
         expect(entry.targets[0].targetId).toBe('B');
-        expect(entry.note).toContain('corrosion');
+        expect(entry.note).toBe('corrosion II ×2');
+    });
+
+    it('dot-applied: bomb carries no tier numeral (untiered display)', () => {
+        const events: CombatEvent[] = [
+            ev({ type: 'round-started', round: 1 }),
+            ev({ type: 'turn-started', actorId: 'A', round: 1 }),
+            ev({
+                type: 'dot-applied',
+                sourceId: 'A',
+                targetId: 'B',
+                round: 1,
+                dotType: 'bomb',
+                stacks: 1,
+                tier: 200,
+            }),
+            ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
+            ev({ type: 'round-ended', round: 1 }),
+        ];
+        const log = buildCombatLog(events, roster, initialCharge);
+        const entry = log[0].turns[0].entries[0];
+        expect(entry.note).toBe('bomb ×1');
     });
 
     it('dot-ticked: targetId is both the actorId and target; amount is the damage; note is "{dotType} ×{stacks}"; no skill consumed', () => {
@@ -1107,6 +1129,7 @@ describe('buildCombatLog', () => {
                 dotType: 'corrosion',
                 damage: 1234,
                 stacks: 3,
+                tier: 9, // Corrosion III magnitude → 'III'
             }),
             ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
             ev({ type: 'round-ended', round: 1 }),
@@ -1121,7 +1144,7 @@ describe('buildCombatLog', () => {
         expect(dotEntry!.targets).toHaveLength(1);
         expect(dotEntry!.targets[0].targetId).toBe('B');
         expect(dotEntry!.targets[0].amount).toBe(1234);
-        expect(dotEntry!.note).toBe('corrosion ×3');
+        expect(dotEntry!.note).toBe('corrosion III ×3');
         // skill-fired must NOT have been consumed by dot-ticked
         expect(dotEntry!.skillName).toBeUndefined();
         expect(dotEntry!.slot).toBeUndefined();
@@ -1237,7 +1260,7 @@ describe('buildCombatLog', () => {
         expect(entry.note).toContain('3');
     });
 
-    it('ship-destroyed: actorId is the destroyed ship, killerId appears in note', () => {
+    it('ship-destroyed: actorId is the destroyed ship, killerId carried as a target (not baked into note)', () => {
         const events: CombatEvent[] = [
             ev({ type: 'round-started', round: 1 }),
             ev({ type: 'turn-started', actorId: 'A', round: 1 }),
@@ -1256,8 +1279,10 @@ describe('buildCombatLog', () => {
         const entry = entries[0];
         expect(entry.kind).toBe('death');
         expect(entry.actorId).toBe('B'); // the destroyed ship
-        expect(entry.targets).toEqual([]);
-        expect(entry.note).toContain('A'); // killerId in note
+        // Killer is carried as a target so the RENDERER can resolve it to a ship name via nameOf,
+        // instead of a raw id baked into the note string.
+        expect(entry.targets).toEqual([{ targetId: 'A' }]);
+        expect(entry.note).toBeUndefined();
     });
 
     // ─── Reaction nesting + endOfRound fallback ───────────────────────────────

--- a/src/utils/combat/log/buildCombatLog.ts
+++ b/src/utils/combat/log/buildCombatLog.ts
@@ -1,5 +1,15 @@
 import { CombatEvent, CombatEventType } from '../events';
+import { dotTierNumeral } from '../debuffImmunity';
+import type { DoTType } from '../../../types/calculator';
 import { CombatLogEntry, CombatLogRound, CombatLogTarget, CombatLogTurn } from './types';
+
+/** Combat-log note for a DoT apply/tick line: "{dotType} {numeral} ×{stacks}" (numeral omitted
+ *  for bomb/generic and non-canonical magnitudes). e.g. ('corrosion', 9, 3) → "corrosion III ×3";
+ *  ('bomb', 200, 1) → "bomb ×1". */
+const dotNote = (dotType: DoTType, tier: number | undefined, stacks: number): string => {
+    const numeral = tier === undefined ? '' : dotTierNumeral(dotType, tier);
+    return `${dotType}${numeral ? ` ${numeral}` : ''} ×${stacks}`;
+};
 
 export interface RosterEntry {
     actorId: string;
@@ -537,7 +547,7 @@ const handlers: Partial<{ [K in CombatEventType]: Handler<K> }> = {
             actorId: e.sourceId,
             targets: [{ targetId: e.targetId }],
             reactions: [],
-            note: `${e.dotType} ×${e.stacks}`,
+            note: dotNote(e.dotType, e.tier, e.stacks),
             ...(ctx.consumePendingSkill() ?? {}),
         };
         ctx.attachEntry(entry);
@@ -552,7 +562,7 @@ const handlers: Partial<{ [K in CombatEventType]: Handler<K> }> = {
             actorId: e.targetId,
             targets: [{ targetId: e.targetId, amount: e.damage }],
             reactions: [],
-            note: `${e.dotType} ×${e.stacks}`,
+            note: dotNote(e.dotType, e.tier, e.stacks),
         };
         ctx.attachEntry(entry);
     },
@@ -626,13 +636,13 @@ const handlers: Partial<{ [K in CombatEventType]: Handler<K> }> = {
 
     'ship-destroyed': (e, ctx) => {
         if (!ctx.currentTurn && !ctx.currentRound) return;
-        const note = e.killerId ? `destroyed by ${e.killerId}` : undefined;
+        // Carry the killer as a TARGET (not a raw id baked into the note) so the renderer's
+        // `death` formatter resolves it to a ship name via nameOf.
         const entry: CombatLogEntry = {
             kind: 'death',
             actorId: e.actorId,
-            targets: [],
+            targets: e.killerId ? [{ targetId: e.killerId }] : [],
             reactions: [],
-            ...(note !== undefined ? { note } : {}),
         };
         ctx.attachEntry(entry);
     },

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -791,7 +791,7 @@ function applyNewDoTs(args: {
      *  transform (Voron/Orel, E3) can share this one apply entry point. */
     genericDoTEntries: ActiveDoTStack[];
     pendingBombs: PendingBomb[];
-    emitDotApplied: (dotType: DoTType, stacks: number) => void;
+    emitDotApplied: (dotType: DoTType, stacks: number, tier: number) => void;
 }): void {
     for (const dot of args.dotsConfig) {
         if (dot.stacks <= 0 || dot.tier <= 0) continue;
@@ -802,7 +802,7 @@ function applyNewDoTs(args: {
                 remainingRounds: dot.duration,
                 sourceId: args.sourceId,
             });
-            args.emitDotApplied('corrosion', dot.stacks);
+            args.emitDotApplied('corrosion', dot.stacks, dot.tier);
         } else if (dot.type === 'inferno') {
             args.infernoEntries.push({
                 stacks: dot.stacks,
@@ -810,7 +810,7 @@ function applyNewDoTs(args: {
                 remainingRounds: dot.duration,
                 sourceId: args.sourceId,
             });
-            args.emitDotApplied('inferno', dot.stacks);
+            args.emitDotApplied('inferno', dot.stacks, dot.tier);
         } else if (dot.type === 'bomb') {
             args.pendingBombs.push({
                 countdown: Math.max(1, dot.duration),
@@ -822,7 +822,7 @@ function applyNewDoTs(args: {
                 detonationDamageModifier: args.detonationDamageModifier,
                 splashModifier: args.splashModifier,
             });
-            args.emitDotApplied('bomb', dot.stacks);
+            args.emitDotApplied('bomb', dot.stacks, dot.tier);
         } else if (dot.type === 'generic') {
             args.genericDoTEntries.push({
                 stacks: dot.stacks,
@@ -830,7 +830,7 @@ function applyNewDoTs(args: {
                 remainingRounds: dot.duration,
                 sourceId: args.sourceId,
             });
-            args.emitDotApplied('generic', dot.stacks);
+            args.emitDotApplied('generic', dot.stacks, dot.tier);
         }
     }
 }
@@ -2392,7 +2392,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 infernoEntries,
                 genericDoTEntries,
                 pendingBombs,
-                emitDotApplied: (dotType, stacks) =>
+                emitDotApplied: (dotType, stacks, tier) =>
                     bus.emit({
                         type: 'dot-applied',
                         sourceId: actor.id,
@@ -2400,6 +2400,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                         round: r,
                         dotType,
                         stacks,
+                        tier,
                         ...(critHits > 0 ? { viaCrit: true } : {}),
                     }),
             });
@@ -2457,7 +2458,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 infernoEntries: victim.infernoEntries,
                 genericDoTEntries: victim.genericDoTEntries,
                 pendingBombs: victim.pendingBombs,
-                emitDotApplied: (dotType, stacks) =>
+                emitDotApplied: (dotType, stacks, tier) =>
                     bus.emit({
                         type: 'dot-applied',
                         sourceId: actor.id,
@@ -2465,6 +2466,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                         round: r,
                         dotType,
                         stacks,
+                        tier,
                         ...(critHits > 0 ? { viaCrit: true } : {}),
                     }),
             });

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -2650,11 +2650,13 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                 ctx.bus.emit({
                     type: 'debuff-resisted',
                     // sourceId = the inflictor (PR-J) so an on-debuff-resisted reaction (Vindicator)
-                    // can route retaliation back at it; the round display ignores it.
+                    // can route retaliation back at it.
                     sourceId: intent.ownerId,
-                    // debuff-resisted feeds the round display only — no per-target counter
-                    // routing needed (unchanged even for the recipient-targeted fan-out above).
-                    targetId: ctx.enemy.id,
+                    // The RESOLVED target the debuff was aimed at (enemy-highest-attack /
+                    // counter-infliction route), falling back to the default enemy only when no
+                    // specific victim resolved — so the combat log names the ship that resisted
+                    // ("src → <that ship>: X resisted") instead of the dummy sink id.
+                    targetId: debuffTargetId,
                     round: ctx.round,
                     buffName: cfg.buffName,
                 });
@@ -2715,6 +2717,7 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                 round: ctx.round,
                 dotType: cfg.dotType,
                 stacks: cfg.stacks,
+                tier: cfg.tier,
             });
         };
 


### PR DESCRIPTION
Three combat-log tweaks reported from the simulator. All are display/emit-layer — no combat-model change.

## 1. Concentrate Fire (and every enemy debuff / applied DoT) shows source → target
- Renderer: the `debuff` and `dot-applied` formatters now surface `{src} → {tgt}: {note}` (collapsing to `{src}: {note}` for self-targeted). The entry already carried the resolved target id; it was being dropped by `noteLine`.
- Engine: the reactive resisted emit (`triggers.ts`) now reports the resolved target instead of the `enemy` dummy sink, so resisted lines also name the ship.
- The real target was already resolved by the engine (Wave-8 `enemy-highest-attack`, wired team-symmetrically); this only surfaces it.

Before: `Enemy Selenite → enemy: Concentrate Fire resisted` / `Selenite: Concentrate Fire`
After: `Enemy Selenite → Nova: Concentrate Fire resisted` / `Enemy Selenite → Nova: Concentrate Fire`

## 2. Death line names the killer
Killer id flows as a target and resolves through `nameOf` instead of a raw id baked into the note.

Before: `Judge: destroyed by e:faa2ca9a-…:1` — After: `Judge: destroyed by Enemy Vanguard`

## 3. DoT tier (I/II/III) on tick / apply / resist, one line per tier
- `tickDoTs` groups ticks by tier magnitude and emits one `dot-ticked` per `(dotType, tier)`, so a mix of tiers on one target splits onto separate lines. Credit order/amounts unchanged (credit is per-entry).
- New `dot-applied`/`dot-ticked` `tier` field (optional; engine always sets it), rendered via a new `dotTierNumeral` helper.
- **Latent bug fixed:** `dotResistLabel` indexed the tier *magnitude* (3/6/9…) as if it were a *level* (1/2/3), so Block-Debuff-resisted DoTs mislabeled ("Corrosion I"→"Corrosion III"; II/III lost the numeral). Its unit test only exercised the helper with level values, so it never caught the production magnitude inputs. Now derives the level from the magnitude.

Before: `Enemy Graphite: corrosion ×1 → 3,444` — After: `Enemy Graphite: corrosion III ×1 → 3,444`

## Testing
- New unit tests: `dotTierNumeral`/`dotResistLabel` (magnitude semantics), `tickDoTs` per-tier grouping, killer-as-target builder, and the four renderer formatters.
- The resisted-target fix is unit-tested at the executor; the applied-path `enemy-highest-attack` resolution is already proven end-to-end and team-symmetrically by the existing Doomsayer suite.
- Two tests that had locked the old placeholder/buggy behavior were updated to the corrected semantics.
- Full suite **4862 green**, lint (max-warnings 0) + tsc clean. Smoke-tested in the simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Kh47NRsdbAY1A3BuTvwdG