### PR TITLE
fix: Insidiousness rolls once per attack and hits every debuffed enemy

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -6,6 +6,7 @@ export const CURRENT_VERSION = '1.64.0';
 // CHANGELOG (with the new version + today's date), clear this array back to [],
 // and bump CURRENT_VERSION. All three steps must happen together.
 export const UNRELEASED_CHANGES: string[] = [
+    'Combat sim: the Insidiousness implant now rolls its damage proc once per attack instead of once per debuff applied, and on a proc it hits every enemy that attack actually debuffed — exactly once each. Previously an area-of-effect debuffer got a separate roll for every debuff on every target (a two-debuff attack on two enemies rolled four times), and all of that damage landed on the first enemy regardless of which one the debuff reached.',
     'Combat log: a resisted damage-over-time effect (e.g. Incinerator inflicting Inferno) now shows a "resisted" line, the same as a resisted stat debuff — previously a resisted DoT produced no log line at all.',
     "Combat sim: a hit that Voron converts into a Damage over Time effect no longer counts as direct damage — so ally reactions that trigger on an ally being directly damaged (e.g. Cultivator's repair) correctly do NOT fire on Voron's converted hits. When Voron is in Stasis or Disabled the conversion doesn't happen, so the hit lands as direct damage and those reactions fire normally.",
     'Combat sim: reactive-damage skills that hit "an enemy" without a specific triggering target (e.g. start/end-of-round procs and some gear-set effects) now strike a real enemy instead of a phantom "enemy" placeholder that could appear when your team included a healer.',

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -1073,6 +1073,13 @@ export interface Ability {
      *  ability) RateGate (deterministic accumulator, like crit/landing). Absent or out of (0,1)
      *  → fires on every qualifying trigger. */
     procChance?: number;
+    /** Proc-roll granularity for a probabilistic reactive ability. `'per-attack'` draws the
+     *  gate ONCE per actor turn and reuses that verdict for every qualifying trigger event in
+     *  the same attack, via IntentExecContext.procDecisionThisAttack — so Insidiousness either
+     *  damages EVERY enemy its attack debuffed or none of them, matching the game. Absent →
+     *  per-event draws, the historical behaviour of every other procChance ability (Adaptive
+     *  Plating, Smokescreen, Ambush, Bloodthirst, Reactive Ward, Tenacity, Bulwark). */
+    procScope?: 'per-attack';
     /** Reactive event-frequency gate: fire this ability only every Nth qualifying trigger
      *  event, counted per SOURCE (the triggering actor). N=2 → every second event. Gated
      *  executor-side via IntentExecContext.repairCountBySource, keyed

--- a/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
+++ b/src/utils/abilities/__tests__/buildEquipmentAbilities.test.ts
@@ -447,6 +447,14 @@ describe('Insidiousness implant', () => {
         }
     });
 
+    it("carries procScope 'per-attack' (one roll per attack, all debuffed enemies)", () => {
+        const ab = buildForImplant('INSIDIOUSNESS', 'legendary')[0];
+        expect(ab.procScope).toBe('per-attack');
+        expect(ab.procChance).toBeCloseTo(0.21, 5);
+        expect(ab.trigger).toBe('on-debuff-inflicted');
+        expect(ab.config).toMatchObject({ type: 'damage', multiplier: 100, hits: 1 });
+    });
+
     it('common → multiplier 60, procChance ≈ 0.10', () => {
         const ab = buildForImplant('INSIDIOUSNESS', 'common')[0];
         expect(ab.procChance).toBeCloseTo(0.1);

--- a/src/utils/abilities/buildEquipmentAbilities.ts
+++ b/src/utils/abilities/buildEquipmentAbilities.ts
@@ -736,7 +736,10 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
         };
     },
     // D-PR4: reactive-damage-on-debuff implants
-    // Insidiousness: X% chance to deal Y% damage when debuffing an enemy.
+    // Insidiousness: X% chance to deal Y% damage when debuffing an enemy. In game the roll
+    // happens ONCE per attack and then applies to every enemy that attack debuffed (all or
+    // none) — `procScope:'per-attack'` gives exactly that, and the on-debuff-inflicted
+    // listener's `debuffVictimId` stamp puts each hit on its own debuffed enemy.
     INSIDIOUSNESS: (rarity) => {
         const m = INSIDIOUSNESS_MULT[rarity];
         const pc = INSIDIOUSNESS_PROC[rarity];
@@ -747,6 +750,7 @@ const IMPLANT_ABILITIES: Partial<Record<string, ImplantAbilityBuilder>> = {
             trigger: 'on-debuff-inflicted',
             conditions: [],
             procChance: pc,
+            procScope: 'per-attack',
             config: { type: 'damage', multiplier: m, hits: 1 },
             autoFilled: true,
         };

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -6195,6 +6195,37 @@ describe('Insidiousness integration — per-attack roll, all debuffed enemies', 
     const victimsOf = (result: ReturnType<typeof simulateBattle>): string[] =>
         insidiousnessProcs(result).map((r) => r.victim);
 
+    /** EVERY reactive `attack` row attributed to the carrier, whatever its target arity. The
+     *  negative tests assert on this rather than on `insidiousnessProcs`, whose
+     *  `targets.length === 1` discriminator is load-bearing for the positive test: a regression
+     *  that bundled both victims into ONE two-target reactive row would be filtered out and make
+     *  "no reactive damage" pass vacuously. */
+    function reactiveAttackRowCount(result: ReturnType<typeof simulateBattle>): number {
+        const carrierId = result.roster.find((r) => r.side === 'player')!.actorId;
+        let n = 0;
+        for (const round of result.combatLog) {
+            for (const turn of round.turns) {
+                for (const entry of turn.entries) {
+                    for (const re of entry.reactions) {
+                        if (re.kind === 'attack' && re.actorId === carrierId) n++;
+                    }
+                }
+            }
+        }
+        return n;
+    }
+
+    /** The OTHER vacuity path a "zero reactive damage" assertion has: the scenario never ran at
+     *  all (fixture drift stops debuffs landing, or the carrier never takes a turn), which would
+     *  make zero procs trivially true no matter what the implant does. Counts the carrier's landed
+     *  debuff rows so each negative test can prove its own premise. */
+    function landedDebuffCount(result: ReturnType<typeof simulateBattle>): number {
+        const carrierId = result.roster.find((r) => r.side === 'player')!.actorId;
+        return flattenCombatLog(result).filter(
+            (e) => e.kind === 'debuff' && e.actorId === carrierId
+        ).length;
+    }
+
     afterEach(() => resetRateGateRng());
 
     it('proc passes → EVERY debuffed enemy takes exactly one Insidiousness hit per attack', () => {
@@ -6222,7 +6253,12 @@ describe('Insidiousness integration — per-attack roll, all debuffed enemies', 
 
     it('proc fails → NO enemy takes Insidiousness damage', () => {
         setKeyedRng(() => 0.99); // 0.99 > 0.21 → the proc fails; landing (clamped to 1) still passes
-        expect(victimsOf(run(true, [0, 0]))).toEqual([]);
+        const result = run(true, [0, 0]);
+        // Premise: the attack ran and its debuffs landed — otherwise "no procs" proves nothing.
+        expect(landedDebuffCount(result)).toBeGreaterThan(0);
+        expect(victimsOf(result)).toEqual([]);
+        // Arity-agnostic: not even a bundled multi-victim reactive row.
+        expect(reactiveAttackRowCount(result)).toBe(0);
     });
 
     it('an enemy that resisted the debuff takes no Insidiousness damage', () => {
@@ -6234,10 +6270,18 @@ describe('Insidiousness integration — per-attack roll, all debuffed enemies', 
         const victims = victimsOf(result);
         expect(victims.length).toBeGreaterThan(0);
         expect(victims).not.toContain(foeB);
+        // No bundled multi-victim row could be hiding a hit on foe-b: every reactive row the
+        // carrier emitted is accounted for by the single-target rows inspected above.
+        expect(reactiveAttackRowCount(result)).toBe(victims.length);
     });
 
     it('no implant → no reactive damage at all (control)', () => {
         setKeyedRng(() => 0);
-        expect(victimsOf(run(false, [0, 0]))).toEqual([]);
+        const result = run(false, [0, 0]);
+        // Same premise guard: the carrier still cast and still debuffed both enemies — the ONLY
+        // difference from the passing case is the absent implant.
+        expect(landedDebuffCount(result)).toBeGreaterThan(0);
+        expect(victimsOf(result)).toEqual([]);
+        expect(reactiveAttackRowCount(result)).toBe(0);
     });
 });

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -6049,3 +6049,195 @@ describe('Tasks 1.5 + 3.3 — Voidfire Catalyst: detonationDamage + bombSplashDa
         });
     });
 });
+
+// ---------------------------------------------------------------------------
+// Insidiousness: one roll per attack, applied to every debuffed enemy (all-or-none)
+// ---------------------------------------------------------------------------
+//
+// A Curator-shaped carrier (AoE damage + two inflicted debuffs, `all` / Pattern-All) wearing
+// legendary Insidiousness attacks two enemies. Four debuff applications per turn used to mean
+// four 21% rolls that all landed on enemy slot 1; now it is ONE roll whose hit lands on each
+// enemy the debuff actually reached.
+describe('Insidiousness integration — per-attack roll, all debuffed enemies', () => {
+    const IMPLANT_ID = 'insid-legendary';
+
+    const insidPiece = makePiece({
+        id: IMPLANT_ID,
+        slot: 'implant_major',
+        rarity: 'legendary',
+        setBonus: 'INSIDIOUSNESS',
+    });
+    const getGearPiece = makeGetGearPiece({ [IMPLANT_ID]: insidPiece });
+
+    /** Curator-shaped AoE debuffer. `withImplant` toggles the Insidiousness major implant. */
+    function makeCarrier(withImplant: boolean): Ship {
+        return makeShip({
+            id: 'carrier',
+            name: 'Carrier',
+            type: 'Debuffer',
+            baseStats: {
+                hp: 0,
+                attack: 0,
+                defence: 0,
+                hacking: 200,
+                security: 100,
+                crit: 0,
+                critDamage: 0,
+                speed: 100,
+            } as Ship['baseStats'],
+            equipment: {},
+            implants: withImplant ? { implant_major: IMPLANT_ID } : {},
+            refits: [],
+            affinity: 'antimatter',
+            activeSkillText:
+                'This Unit deals <unit-damage>60% damage</unit-damage> to all enemies, and ' +
+                'inflicts <unit-skill>Attack Down III</unit-skill> and ' +
+                '<unit-skill>Crit Power Down III</unit-skill> for 2 turns.',
+            chargeSkillCharge: 0,
+            activeTarget: 'all',
+            activePattern: 'Pattern-All',
+        } as Partial<Ship>);
+    }
+
+    /** Inert enemy: no active damage, high HP so nothing dies mid-test. `security` decides
+     *  whether the carrier's inflicted debuffs land on it. */
+    function makeEnemy(id: string): Ship {
+        return makeShip({
+            id,
+            name: id,
+            type: 'Attacker',
+            baseStats: {
+                hp: 0,
+                attack: 0,
+                defence: 0,
+                hacking: 0,
+                security: 0,
+                crit: 0,
+                critDamage: 0,
+                speed: 1,
+            } as Ship['baseStats'],
+            equipment: {},
+            implants: {},
+            refits: [],
+            affinity: 'antimatter',
+            activeSkillText: 'This Unit deals <unit-damage>0% damage</unit-damage> to one enemy.',
+            chargeSkillCharge: 0,
+            activeTarget: 'front',
+            activePattern: 'Pattern-Base',
+        } as Partial<Ship>);
+    }
+
+    const place = (ship: Ship, position: Position, security: number): BattlePlacement => ({
+        ship,
+        position,
+        statOverrides: {
+            attack: 5_000,
+            crit: 0,
+            critDamage: 0,
+            defensePenetration: 0,
+            hacking: 200,
+            security,
+            defence: 0,
+            hp: 1_000_000_000,
+        },
+    });
+
+    /** Run 3 rounds: carrier (M4 player) vs two enemies at M4/M3. */
+    function run(withImplant: boolean, enemySecurity: [number, number]) {
+        return simulateBattle(
+            {
+                playerTeam: [place(makeCarrier(withImplant), 'M4', 100)],
+                enemyTeam: [
+                    place(makeEnemy('foe-a'), 'M4', enemySecurity[0]),
+                    place(makeEnemy('foe-b'), 'M3', enemySecurity[1]),
+                ],
+                rounds: 3,
+            },
+            getGearPiece
+        );
+    }
+
+    /** One row per Insidiousness proc: a reactive `attack` entry attributed to the carrier with a
+     *  single target, paired with the cast damage the SAME attack dealt that victim (so the test
+     *  can prove the row really is the 100%-multiplier implant hit and not a stray cast row). The
+     *  carrier's own AoE cast is a NON-reactive entry carrying both victims, so it never matches. */
+    type ProcRow = { victim: string; amount: number; castAmount: number; turnIndex: number };
+
+    function insidiousnessProcs(result: ReturnType<typeof simulateBattle>): ProcRow[] {
+        const carrierId = result.roster.find((r) => r.side === 'player')!.actorId;
+        const rows: ProcRow[] = [];
+        let turnIndex = 0;
+        for (const round of result.combatLog) {
+            for (const turn of round.turns) {
+                if (turn.actorId !== carrierId) continue;
+                turnIndex++;
+                for (const entry of turn.entries) {
+                    for (const re of entry.reactions) {
+                        if (re.kind !== 'attack' || re.actorId !== carrierId) continue;
+                        if (re.targets.length !== 1) continue;
+                        const amount = re.targets[0].amount ?? 0;
+                        if (amount <= 0) continue;
+                        const victim = re.targets[0].targetId;
+                        const cast = entry.targets.find((t) => t.targetId === victim);
+                        rows.push({
+                            victim,
+                            amount,
+                            castAmount: cast?.amount ?? 0,
+                            turnIndex,
+                        });
+                    }
+                }
+            }
+        }
+        return rows;
+    }
+
+    const victimsOf = (result: ReturnType<typeof simulateBattle>): string[] =>
+        insidiousnessProcs(result).map((r) => r.victim);
+
+    afterEach(() => resetRateGateRng());
+
+    it('proc passes → EVERY debuffed enemy takes exactly one Insidiousness hit per attack', () => {
+        setKeyedRng(() => 0); // every keyed gate fires: debuffs land, the 21% proc passes
+        const procs = insidiousnessProcs(run(true, [0, 0]));
+
+        // 3 rounds → 3 carrier attacks → BOTH enemies hit on each = 6 rows. Before the fix this
+        // was 4 rolls/attack all routed to enemy slot 1, so enemy 2 never appeared here.
+        expect(procs).toHaveLength(6);
+        const perTurn = [1, 2, 3].map((t) => procs.filter((r) => r.turnIndex === t));
+        for (const turnRows of perTurn) {
+            // All-or-none within one attack: two victims, each hit exactly once — never a subset,
+            // and never twice (the two debuffs on one enemy share a single verdict AND a single hit).
+            expect(turnRows).toHaveLength(2);
+            expect(new Set(turnRows.map((r) => r.victim)).size).toBe(2);
+        }
+
+        // Each row really is the 100%-multiplier implant hit: the cast is 60%, so the proc must be
+        // exactly 100/60 of the cast damage on the same victim in the same attack.
+        for (const row of procs) {
+            expect(row.castAmount).toBeGreaterThan(0);
+            expect(row.amount / row.castAmount).toBeCloseTo(100 / 60, 5);
+        }
+    });
+
+    it('proc fails → NO enemy takes Insidiousness damage', () => {
+        setKeyedRng(() => 0.99); // 0.99 > 0.21 → the proc fails; landing (clamped to 1) still passes
+        expect(victimsOf(run(true, [0, 0]))).toEqual([]);
+    });
+
+    it('an enemy that resisted the debuff takes no Insidiousness damage', () => {
+        setKeyedRng(() => 0);
+        // foe-b's security dwarfs the carrier's hacking → 0% landing chance → no debuff-applied
+        // for it → no Insidiousness proc against it, while foe-a is still debuffed and hit.
+        const result = run(true, [0, 1_000_000]);
+        const foeB = result.roster.find((r) => r.side === 'enemy' && r.name === 'foe-b')!.actorId;
+        const victims = victimsOf(result);
+        expect(victims.length).toBeGreaterThan(0);
+        expect(victims).not.toContain(foeB);
+    });
+
+    it('no implant → no reactive damage at all (control)', () => {
+        setKeyedRng(() => 0);
+        expect(victimsOf(run(false, [0, 0]))).toEqual([]);
+    });
+});

--- a/src/utils/combat/__tests__/triggers.test.ts
+++ b/src/utils/combat/__tests__/triggers.test.ts
@@ -4013,3 +4013,75 @@ describe('on-debuff-resisted damage branch (hpBasisPct)', () => {
         expect(calls).toHaveLength(2);
     });
 });
+
+// ----------------------------------------------------------------------
+// Insidiousness routing: an on-debuff-inflicted DAMAGE proc must land on the enemy
+// that was actually debuffed (eventCtx.debuffVictimId), not the first living opposing
+// actor. The listener stamps the field; this covers the executor side.
+// ----------------------------------------------------------------------
+describe('on-debuff-inflicted damage branch (debuffVictimId routing)', () => {
+    type Call = { owner: string; victim: string; mult: number };
+
+    const ownerRuntime = (): PlayerActorRuntime =>
+        ({ actor: { id: 'owner' } as CombatActor }) as unknown as PlayerActorRuntime;
+
+    const makeCtx = (over: Partial<IntentExecContext> = {}) => {
+        const calls: Call[] = [];
+        const ctx = {
+            round: 1,
+            enemy: { id: 'dummy' } as CombatActor,
+            enemyId: 'dummy',
+            statusEngine: createStatusEngine({ selfBuffs: [], enemyDebuffs: [] }),
+            bus: createEventBus(),
+            corrosionEntries: [],
+            infernoEntries: [],
+            pendingBombs: [],
+            runtimes: new Map([['owner', ownerRuntime()]]),
+            grantAllyCharges: () => {},
+            removeEnemyCharges: () => {},
+            removeChargesFrom: () => {},
+            grantExtraAction: () => {},
+            playerIds: ['owner'],
+            lastTurnCtxByActor: new Map(),
+            enemyHp: 100000,
+            cumulativeDamage: 0,
+            recordResisted: () => {},
+            oncePerRoundConsumed: new Set<string>(),
+            livingOpposingActorIds: () => ['enemy1', 'enemy2'],
+            applyReactiveDamage: (owner: string, victim: string, _id: string, mult: number) =>
+                calls.push({ owner, victim, mult }),
+            ...over,
+        } as unknown as IntentExecContext;
+        return { ctx, calls };
+    };
+
+    const intent = (debuffVictimId?: string): Intent => ({
+        ownerId: 'owner',
+        sourceSlot: 'passive',
+        ability: {
+            id: 'equip-implant-INSIDIOUSNESS',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-debuff-inflicted',
+            conditions: [],
+            config: { type: 'damage', multiplier: 70, hits: 1 },
+        },
+        ...(debuffVictimId ? { eventCtx: { debuffVictimId } } : {}),
+    });
+
+    it('routes to the debuffed enemy, NOT the first living opposing actor', () => {
+        const { ctx, calls } = makeCtx();
+        executeIntent(intent('enemy2'), ctx);
+        expect(calls).toHaveLength(1);
+        expect(calls[0]).toMatchObject({ owner: 'owner', victim: 'enemy2', mult: 70 });
+    });
+
+    it('keeps the first-living-opposing fallback when no debuff victim was stamped', () => {
+        // Start/end-of-round damage passives (Judge/Chakara) have no triggering counterparty
+        // and must keep routing to opposing[0] — this guards that fallback.
+        const { ctx, calls } = makeCtx();
+        executeIntent(intent(undefined), ctx);
+        expect(calls).toHaveLength(1);
+        expect(calls[0].victim).toBe('enemy1');
+    });
+});

--- a/src/utils/combat/__tests__/triggers.test.ts
+++ b/src/utils/combat/__tests__/triggers.test.ts
@@ -4129,6 +4129,7 @@ describe("procScope 'per-attack' verdict cache", () => {
             oncePerRoundConsumed: new Set<string>(),
             procChanceGates: new Map(),
             procDecisionThisAttack: new Map<string, boolean>(),
+            reactionFiredThisAttack: new Set<string>(),
             applyReactiveDamage: (_o: string, victim: string) => calls.push(victim),
             ...over,
         } as unknown as IntentExecContext;
@@ -4171,12 +4172,31 @@ describe("procScope 'per-attack' verdict cache", () => {
         expect(calls).toEqual([]);
     });
 
+    it('hits each victim ONCE per attack even when the cast inflicts two debuffs on it', () => {
+        // Curator applies Attack Down III AND Crit Power Down III to the same enemy → two
+        // debuff-applied events → two intents sharing one verdict. Without the per-victim
+        // dedupe the enemy would take the 100% hit twice (200% for a 100% implant).
+        pinKeyedRng(0.1);
+        const { ctx, calls } = makeCtx();
+        executeIntent(intent('enemy1', true), ctx);
+        executeIntent(intent('enemy1', true), ctx);
+        executeIntent(intent('enemy2', true), ctx);
+        executeIntent(intent('enemy2', true), ctx);
+        expect(calls).toEqual(['enemy1', 'enemy2']);
+    });
+
     it('draws again once the cache is cleared (next attack)', () => {
         const rng = pinKeyedRng(0.1);
         const cache = new Map<string, boolean>();
-        const { ctx, calls } = makeCtx({ procDecisionThisAttack: cache });
+        const fired = new Set<string>();
+        const { ctx, calls } = makeCtx({
+            procDecisionThisAttack: cache,
+            reactionFiredThisAttack: fired,
+        });
         executeIntent(intent('enemy1', true), ctx);
-        cache.clear(); // the engine does this at each actor turn-start
+        // The engine clears both at each actor turn-start.
+        cache.clear();
+        fired.clear();
         executeIntent(intent('enemy1', true), ctx);
         expect(rng.draws()).toBe(2);
         expect(calls).toEqual(['enemy1', 'enemy1']);

--- a/src/utils/combat/__tests__/triggers.test.ts
+++ b/src/utils/combat/__tests__/triggers.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setKeyedRng, resetRateGateRng } from '../../calculators/rateAccumulator';
 import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
 import { createEventBus, CombatEvent } from '../events';
 import {
@@ -4083,5 +4084,111 @@ describe('on-debuff-inflicted damage branch (debuffVictimId routing)', () => {
         executeIntent(intent(undefined), ctx);
         expect(calls).toHaveLength(1);
         expect(calls[0].victim).toBe('enemy1');
+    });
+});
+
+// ----------------------------------------------------------------------
+// procScope:'per-attack' — Insidiousness rolls ONCE per attack and every debuff event
+// in that attack reuses the verdict (all debuffed enemies take the hit, or none do).
+// ----------------------------------------------------------------------
+describe("procScope 'per-attack' verdict cache", () => {
+    const ownerRuntime = (): PlayerActorRuntime =>
+        ({ actor: { id: 'owner' } as CombatActor }) as unknown as PlayerActorRuntime;
+
+    /** Pin the keyed proc stream and count draws. `value` < procChance → pass. */
+    function pinKeyedRng(value: number): { draws: () => number } {
+        let n = 0;
+        setKeyedRng(() => {
+            n++;
+            return value;
+        });
+        return { draws: () => n };
+    }
+
+    const makeCtx = (over: Partial<IntentExecContext> = {}) => {
+        const calls: string[] = [];
+        const ctx = {
+            round: 1,
+            enemy: { id: 'dummy' } as CombatActor,
+            enemyId: 'dummy',
+            statusEngine: createStatusEngine({ selfBuffs: [], enemyDebuffs: [] }),
+            bus: createEventBus(),
+            corrosionEntries: [],
+            infernoEntries: [],
+            pendingBombs: [],
+            runtimes: new Map([['owner', ownerRuntime()]]),
+            grantAllyCharges: () => {},
+            removeEnemyCharges: () => {},
+            removeChargesFrom: () => {},
+            grantExtraAction: () => {},
+            playerIds: ['owner'],
+            lastTurnCtxByActor: new Map(),
+            enemyHp: 100000,
+            cumulativeDamage: 0,
+            recordResisted: () => {},
+            oncePerRoundConsumed: new Set<string>(),
+            procChanceGates: new Map(),
+            procDecisionThisAttack: new Map<string, boolean>(),
+            applyReactiveDamage: (_o: string, victim: string) => calls.push(victim),
+            ...over,
+        } as unknown as IntentExecContext;
+        return { ctx, calls };
+    };
+
+    const intent = (victim: string, perAttack: boolean): Intent => ({
+        ownerId: 'owner',
+        sourceSlot: 'passive',
+        ability: {
+            id: 'equip-implant-INSIDIOUSNESS',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-debuff-inflicted',
+            conditions: [],
+            procChance: 0.5,
+            ...(perAttack ? { procScope: 'per-attack' as const } : {}),
+            config: { type: 'damage', multiplier: 70, hits: 1 },
+        },
+        eventCtx: { debuffVictimId: victim },
+    });
+
+    afterEach(() => resetRateGateRng());
+
+    it('draws ONCE for two debuff events and applies to both victims on a pass', () => {
+        const rng = pinKeyedRng(0.1); // 0.1 < 0.5 → pass
+        const { ctx, calls } = makeCtx();
+        executeIntent(intent('enemy1', true), ctx);
+        executeIntent(intent('enemy2', true), ctx);
+        expect(rng.draws()).toBe(1);
+        expect(calls).toEqual(['enemy1', 'enemy2']);
+    });
+
+    it('draws ONCE for two debuff events and applies to NEITHER victim on a fail', () => {
+        const rng = pinKeyedRng(0.9); // 0.9 > 0.5 → fail
+        const { ctx, calls } = makeCtx();
+        executeIntent(intent('enemy1', true), ctx);
+        executeIntent(intent('enemy2', true), ctx);
+        expect(rng.draws()).toBe(1);
+        expect(calls).toEqual([]);
+    });
+
+    it('draws again once the cache is cleared (next attack)', () => {
+        const rng = pinKeyedRng(0.1);
+        const cache = new Map<string, boolean>();
+        const { ctx, calls } = makeCtx({ procDecisionThisAttack: cache });
+        executeIntent(intent('enemy1', true), ctx);
+        cache.clear(); // the engine does this at each actor turn-start
+        executeIntent(intent('enemy1', true), ctx);
+        expect(rng.draws()).toBe(2);
+        expect(calls).toEqual(['enemy1', 'enemy1']);
+    });
+
+    it('without procScope, every event draws its own verdict (regression guard)', () => {
+        // Adaptive Plating / Smokescreen / Bloodthirst et al. must keep per-event rolls.
+        const rng = pinKeyedRng(0.1);
+        const { ctx, calls } = makeCtx();
+        executeIntent(intent('enemy1', false), ctx);
+        executeIntent(intent('enemy2', false), ctx);
+        expect(rng.draws()).toBe(2);
+        expect(calls).toEqual(['enemy1', 'enemy2']);
     });
 });

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2665,6 +2665,10 @@ export function runCombat(input: CombatEngineInput): {
     // `${ownerId}:${abilityId}`; each gate is a RateGate that fires with the ability's
     // procChance probability on each draw (random, like the crit/landing gates).
     const procChanceGates = new Map<string, RateGate>();
+    // Per-actor-turn verdict cache for procScope:'per-attack' proc abilities (Insidiousness).
+    // Keyed `${ownerId}:${abilityId}`; cleared at each actor turn-start beside
+    // reactionFiredThisAttack so a later attack rolls afresh.
+    const procDecisionThisAttack = new Map<string, boolean>();
     // G PR1: dedicated crit-gate for counterattacks. A NEW map (NOT any existing per-actor
     // crit gate) so it only ever creates keys for counter-carriers → no draw, no perturbation
     // for every existing fixture → byte-identical.
@@ -6192,6 +6196,9 @@ export function runCombat(input: CombatEngineInput): {
                         // Combat-lifetime proc-chance gates (D-PR1): equipment reactive procs
                         // that carry a procChance fire at their stated rate via this accumulator.
                         procChanceGates,
+                        // Per-attack proc verdict cache (Insidiousness): one roll per attack,
+                        // replayed for every debuff event that attack inflicts.
+                        procDecisionThisAttack,
                         // Phase 4c PR 6: live lowest-speed-ally gate. UNCONDITIONAL (unlike the
                         // healing-only selfHpPctFor spread) — in DPS mode the set is {attacker}, so
                         // the lone attacker resolves true and DPS gating stays byte-identical.
@@ -6661,6 +6668,9 @@ export function runCombat(input: CombatEngineInput): {
                 // Task 5: reset the self-rider once-per-attack guard beside the counter guard so a
                 // later attack re-applies Hermes's Everliving Regeneration / charge.
                 reactionFiredThisAttack.clear();
+                // Insidiousness: drop the per-attack proc verdicts so this attack draws its own
+                // single roll (and every debuff it inflicts shares that one verdict).
+                procDecisionThisAttack.clear();
 
                 // Set the active carrier for the own-turn self-buff reprieve: a TIMED self-buff
                 // written during this actor's own turn is flagged appliedThisTurn so it survives

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -1385,6 +1385,13 @@ export interface IntentExecContext {
      *  (see oncePerAttackGuardKey + the heal branch). Absent → no guard (unit ctxs without the
      *  engine keep firing per intent, byte-identical). */
     reactionFiredThisAttack?: Set<string>;
+    /** Per-actor-turn verdict cache for `procScope:'per-attack'` abilities (Insidiousness).
+     *  Keyed `ownerId:abilityId` → the single roll's outcome, cleared at each actor turn-start
+     *  (engine) beside `reactionFiredThisAttack`. Distinct from that Set: this is not a
+     *  suppression guard but a memo, so EVERY qualifying event in the attack still executes
+     *  against its own victim under one shared pass/fail. Absent (unit ctxs) → per-event draws,
+     *  byte-identical. */
+    procDecisionThisAttack?: Map<string, boolean>;
     /** Resolve the opposing actor carrying the most buffs (Rhodium's enemy-most-buffs purge).
      *  Per-side: a player owner scans the enemy roster, an enemy owner scans the player roster.
      *  Returns undefined when no opposing actor exists (DPS dummy) → executor falls back to
@@ -1980,6 +1987,15 @@ function passesProcChanceGate(intent: Intent, ctx: IntentExecContext): boolean {
     const pc = intent.ability.procChance;
     if (pc === undefined || pc <= 0 || pc >= 1) return true;
     const gateKey = `${intent.ownerId}:${intent.ability.id}`;
+    // procScope:'per-attack' (Insidiousness): one roll for the whole attack. The verdict is
+    // memoized per (owner, ability) and replayed for every later event this attack, so an AoE
+    // debuffer's four debuff applications share ONE 21% roll and all-or-none holds across every
+    // debuffed enemy. Opt-in by design — this gate is shared with the heal/shield/buff/debuff
+    // branches, and memoizing unconditionally would silently convert every other proc ability
+    // (Adaptive Plating, Smokescreen, Ambush, Bloodthirst, Reactive Ward, Tenacity) to per-turn.
+    const memo = intent.ability.procScope === 'per-attack' ? ctx.procDecisionThisAttack : undefined;
+    const cached = memo?.get(gateKey);
+    if (cached !== undefined) return cached;
     let gate = ctx.procChanceGates?.get(gateKey);
     if (ctx.procChanceGates && !gate) {
         // Keyed by owner + purpose (SP-0 Task 3), NOT the finer-grained map key — every
@@ -1989,7 +2005,9 @@ function passesProcChanceGate(intent: Intent, ctx: IntentExecContext): boolean {
         gate = makeRateGate(`${intent.ownerId}:proc`);
         ctx.procChanceGates.set(gateKey, gate);
     }
-    return !gate || gate(pc);
+    const verdict = !gate || gate(pc);
+    memo?.set(gateKey, verdict);
+    return verdict;
 }
 
 /** D-PR14 once-per-round gate, shared by the damage/heal/shield executors (the debuff branch

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -3357,6 +3357,18 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                 : undefined;
         for (const victimId of victimIds) {
             if (victimId === undefined) continue;
+            // procScope:'per-attack' (Insidiousness): ONE hit per victim per attack. The trigger
+            // fires once per debuff APPLICATION, so a cast inflicting two debuffs on the same
+            // enemy (Curator's Attack Down III + Crit Power Down III) would otherwise hit that
+            // enemy twice under the single shared verdict — 200% damage for a 100% implant.
+            // Keyed with the victim so a DIFFERENT debuffed enemy still takes its own hit; rides
+            // `reactionFiredThisAttack`, which the engine clears at each actor turn-start beside
+            // the proc verdict cache. Absent set (unit ctxs) → no dedupe, byte-identical.
+            if (intent.ability.procScope === 'per-attack') {
+                const firedKey = `${intent.ownerId}:${intent.ability.id}:${victimId}`;
+                if (ctx.reactionFiredThisAttack?.has(firedKey)) continue;
+                ctx.reactionFiredThisAttack?.add(firedKey);
+            }
             const outcome = ctx.applyReactiveDamage?.(
                 intent.ownerId,
                 victimId,

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -214,6 +214,16 @@ export interface Intent {
          *  hitting a PLAYER actor. Absent for the debuff-applied branch of the same trigger
          *  (Oleander's buff grant doesn't need a victim — it routes via damagedAllyId only). */
         victimId?: string;
+        /** The debuffed enemy's actor id (debuff-applied.targetId / dot-applied.targetId),
+         *  stamped by the on-debuff-inflicted listener. Read ONLY by the reactive `damage`
+         *  branch (Insidiousness) so the proc lands on the enemy that was actually debuffed
+         *  instead of falling through to the first living opposing actor. A DEDICATED field
+         *  rather than reusing `victimId`: that one is the `adjacent-enemies` splash anchor
+         *  (on-bomb-detonated), and reusing it would newly re-anchor any adjacent-enemies
+         *  damage ability reached via this trigger. Every OTHER on-debuff-inflicted consumer
+         *  (Warden's debuff, APEX/Butcher/Torcher/Prospect/Yuyan self-riders, Hemlock's
+         *  charge, Pestilence's cleanse) ignores this field → unchanged. */
+        debuffVictimId?: string;
         /** SP-E, Task E4: the DoT type of the ally's application (dot-applied.dotType), captured
          *  alongside victimId. The convert-dot executor gates on this === cfg.fromDotType so an
          *  ally's Inferno (or any other DoT) never converts under a Corrosion-only ability. */
@@ -455,11 +465,22 @@ export function registerReactiveListeners(args: {
                         // Crit Shred feeding an on-debuff-inflicted charge — triggers.test scenario 10)
                         // still chain here as before. Existing consumers (Butcher/Pestilence/APEX)
                         // inflict their gating debuffs from non-on-debuff-inflicted paths, unaffected.
+                        // The debuffed enemy rides along as `debuffVictimId` so the reactive
+                        // damage branch (Insidiousness) hits the enemy this infliction actually
+                        // landed on rather than falling through to the first living opposing
+                        // actor. Every other consumer of this trigger ignores the field.
                         if (e.sourceId === ownerId && !e.viaDebuffInflictedReaction)
-                            enqueue(intent);
+                            enqueue({
+                                ...intent,
+                                eventCtx: { ...intent.eventCtx, debuffVictimId: e.targetId },
+                            });
                     });
                     bus.on('dot-applied', (e) => {
-                        if (e.sourceId === ownerId) enqueue(intent);
+                        if (e.sourceId === ownerId)
+                            enqueue({
+                                ...intent,
+                                eventCtx: { ...intent.eventCtx, debuffVictimId: e.targetId },
+                            });
                     });
                     break;
                 case 'on-ally-debuff-inflicted':
@@ -3288,9 +3309,14 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
             // The trigger stamped the retaliation target (reflect/revenge, FrontLine's
             // on-enemy-charged-cast, Sentinel's on-ally-crit, …) — route there directly.
             victimIds = [intent.eventCtx.counterTargetId];
+        } else if (intent.eventCtx?.debuffVictimId !== undefined) {
+            // Insidiousness (on-debuff-inflicted): route to the enemy this infliction actually
+            // landed on. Before this clause the trigger fell through to the fallback below and
+            // always hit opposing[0], so an AoE debuffer dumped every proc onto enemy slot 1.
+            victimIds = [intent.eventCtx.debuffVictimId];
         } else {
-            // No specific triggering enemy (start/end-of-round, on-deal-damage, on-debuff-
-            // inflicted with plain `target:'enemy'`). In a POSITIONAL battle route to a real
+            // No specific triggering enemy (start/end-of-round, on-deal-damage). In a
+            // POSITIONAL battle route to a real
             // living opposing actor — NEVER the vestigial DPS-dummy sink (ctx.enemy.id), which
             // stays alive whenever the team fields an ally-targeting ship (healer) and would
             // otherwise leak a phantom "→ enemy" line into the log (repeated once per fire).


### PR DESCRIPTION
## What

The Insidiousness implant fired far more often than it does in game, and always hit the wrong enemy.

Spotted from a combat log where Curator's 60%-multiplier AoE produced a `19,915 (crit)` reaction — exactly `11,949 × 100/60`, i.e. a legendary Insidiousness hit (100% multiplier, 21% proc, `on-debuff-inflicted`).

Three defects:

1. **Rolled per debuff application.** `debuff-applied` fires once per (debuff × enemy), so Curator's active (Attack Down III + Crit Power Down III × 2 enemies) drew **four** independent 21% rolls — ≈66% effective per turn.
2. **Always hit enemy slot 1.** The `on-debuff-inflicted` listener discarded which enemy was debuffed, so the reactive damage branch fell through to its "no triggering enemy" fallback and routed to `livingOpposingActorIds(owner)[0]`.
3. **Hit each enemy twice.** Found by the acceptance test during implementation: once the verdict was shared, the per-application trigger still produced one hit *per debuff type* — 200% damage per enemy for a 100% implant.

Confirmed in-game behaviour: the roll happens **once per attack**, and on a pass it triggers on **all** debuffed enemies or none — never a subset.

## How

- **`Ability.procScope?: 'per-attack'`** (new, opt-in). `passesProcChanceGate` memoizes the verdict per `(owner, ability)` in `IntentExecContext.procDecisionThisAttack`, which the engine clears at each actor turn-start beside `reactionFiredThisAttack`. A *memo*, not a suppression guard — every debuff event still executes against its own victim under one shared pass/fail.
  - Opt-in deliberately: that gate is shared by the damage/heal/shield/buff/debuff branches, so an unconditional memo would silently convert Adaptive Plating, Smokescreen, Ambush, Bloodthirst, Reactive Ward and Tenacity to per-turn rolls. A regression test pins their per-event behaviour.
- **`eventCtx.debuffVictimId`** stamped by the `on-debuff-inflicted` listener (both `debuff-applied` and `dot-applied`), consumed **only** by the reactive damage branch. Warden's debuff, the APEX/Butcher/Torcher/Prospect/Yuyan self-riders, Hemlock's charge and Pestilence's cleanse ignore the field, so they are unchanged. A dedicated field rather than reusing `victimId`, which is the `adjacent-enemies` splash anchor.
- **Per-victim dedupe** inside the attack via `reactionFiredThisAttack`, gated on `procScope === 'per-attack'`, so a two-debuff cast lands one hit per enemy.

Resists need no special handling: `debuff-applied` only fires on a landed debuff (resists emit `debuff-resisted`, silent landing-roll failures emit nothing), so "only enemies the debuff actually landed on" falls out of the event stream.

## Net effect

Curator's four debuff applications collapse to one 21% roll. On a pass, both debuffed enemies take one 100% hit each; on a fail, neither does. Effective rate ≈66%/turn → 21%/turn.

## Tests

- **Unit (routing):** routes to the debuffed enemy; the `opposing[0]` fallback still holds for start/end-of-round damage passives.
- **Unit (verdict cache):** one draw for two events on a pass and on a fail; one hit per victim even with two debuffs on it; a fresh draw after the turn-start clear; per-event draws without the flag.
- **Engine acceptance** (positional 2-enemy battle, pinned keyed RNG): pass → exactly 6 proc rows over 3 attacks, two per attack, distinct victims, each amount asserted at exactly `100/60` of that victim's cast hit; fail → zero; resisted enemy (security ≫ hacking) → not hit; no implant → no reactive damage.
- **Builder mutation guard** on the `INSIDIOUSNESS` shape.
- Pre-existing D-PR4 DPS-mode tests unchanged — one debuff application per turn there, so the recorded 13-of-20 proc count is unaffected.

430 files / 4883 tests green, `npm run lint` clean.

## Deferred (not in this PR)

Audited all 33 `procChance` equipment abilities: the proc gate is per-**event** engine-wide, and several triggers fire more than once per attack. Left alone pending in-game verification of whether the game is per-attack universally:

- **Class A** (same shape as Insidiousness): Firewall (`on-debuffed`, one roll per debuff received), Lockdown (`on-debuff-resisted`).
- **Class B** (per hit — `emitAttacked` emits one `attacked` per hit, so Adaptive Plating's "fires once per attack" comment is inaccurate): Smokescreen / Adaptive Plating / Bulwark roll per hit with the effect capped, so only the odds inflate; **Reactive Ward, Tenacity and Second Wind roll *and apply* per hit, uncapped** — a 3-hit attacker triggers three cleanses / three Buff Protection applications / three heals. Bloodthirst rolls per critting hit.
- Warden's `on-debuff-inflicted` debuff still routes to `opposing[0]`; `debuffVictimId` makes that a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015skAFQQpWk93zYTU5w8dkz