### PR TITLE
fix(ci): repair the dependency audit gate and clear the advisories it was hiding

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,20 +1,25 @@
 name: Security
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
 
 jobs:
-  audit:
-    name: npm audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-      - run: npm ci
-      - run: npm audit --omit=dev --audit-level=high
+    audit:
+        name: npm audit
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: npm
+            - run: npm ci
+            # Equivalent to `npm audit --omit=dev --audit-level=high`, which cannot be used right now:
+            # the registry's bulk-advisory endpoint returns a gzip body with no `content-encoding`
+            # header, so every npm client fails to parse it, falls back to the retired quick endpoint
+            # and dies on a misleading "Invalid package tree" 400. See scripts/audit.mjs for the full
+            # write-up; swap this back for plain `npm audit` once upstream is fixed.
+            - run: npm run audit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,7 @@ Always dispatch `app:migration:end` even on error.
 - **RLS helper:** `public.has_profile_access(user_id uuid)` — use this on all user-data table policies (handles both main accounts and alt accounts).
 - **Import validation:** `validateExportedPlayData()` in `src/schemas/exportedPlayData.ts` — extend this schema if new fields are added to the import format.
 - **Security headers:** Set in `netlify.toml` under `[[headers]]`. CSP, HSTS, X-Frame-Options, nosniff, Referrer-Policy are all live. Update the CSP `connect-src` if new external API domains are added.
-- **Dependency hygiene:** `npm audit --omit=dev --audit-level=high` runs on every PR via `.github/workflows/security.yml`. Dependabot opens weekly PRs for outdated packages.
+- **Dependency hygiene:** `npm run audit` (`scripts/audit.mjs`) runs on every PR via `.github/workflows/security.yml` — it is a drop-in equivalent of `npm audit --omit=dev --audit-level=high` (production deps only, fails on high/critical). It exists because `npm audit` itself is broken against the registry: the bulk-advisory endpoint returns a gzip body with no `content-encoding` header, so npm cannot parse it, falls back to the retired quick endpoint, and reports a misleading `400 Invalid package tree`. Revert to plain `npm audit` once upstream is fixed. Accepted-risk advisories go in the script's `ALLOWLIST` (empty by default — each entry is a vulnerability we knowingly ship). Dependabot opens weekly PRs for outdated packages.
 
 ## Common Pitfalls
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-helmet-async": "^2.0.5",
-                "react-router-dom": "^7.12.0",
+                "react-router-dom": "^7.18.1",
                 "recharts": "^2.15.1",
                 "uuid": "^14.0.0",
                 "vite": "^6.4.2",
@@ -59,6 +59,7 @@
                 "postcss": "^8.5.10",
                 "prettier": "^3.4.2",
                 "puppeteer": "^24.40.0",
+                "semver": "^7.6.3",
                 "supabase": "^2.95.1",
                 "tailwindcss": "^3.4.15",
                 "tsx": "^4.19.3",
@@ -154,6 +155,15 @@
                 "url": "https://opencollective.com/babel"
             }
         },
+        "node_modules/@babel/core/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/@babel/generator": {
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
@@ -199,6 +209,15 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/@babel/helper-create-class-features-plugin": {
             "version": "7.28.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
@@ -221,6 +240,16 @@
                 "@babel/core": "^7.0.0"
             }
         },
+        "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/@babel/helper-create-regexp-features-plugin": {
             "version": "7.28.5",
             "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
@@ -237,6 +266,16 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-define-polyfill-provider": {
@@ -1537,6 +1576,16 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/preset-env/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/preset-modules": {
@@ -3302,19 +3351,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@puppeteer/browsers/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@rollup/plugin-node-resolve": {
             "version": "15.3.1",
             "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
@@ -4868,19 +4904,6 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@typescript-eslint/utils": {
             "version": "7.18.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
@@ -5870,6 +5893,16 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+            }
+        },
+        "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/babel-plugin-polyfill-corejs3": {
@@ -7823,6 +7856,16 @@
                 "node": "*"
             }
         },
+        "node_modules/eslint-plugin-import/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/eslint-plugin-react": {
             "version": "7.37.3",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.3.tgz",
@@ -7932,6 +7975,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/eslint-plugin-react/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/eslint-scope": {
@@ -9487,19 +9540,6 @@
                 "semver": "^7.7.1"
             }
         },
-        "node_modules/is-bun-module/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/is-callable": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -10035,9 +10075,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "funding": [
                 {
                     "type": "github",
@@ -10618,19 +10658,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/make-dir/node_modules/semver": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -10849,9 +10876,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "funding": [
                 {
                     "type": "github",
@@ -11597,9 +11624,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.10",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-            "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+            "version": "8.5.23",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+            "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -11616,7 +11643,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -12131,9 +12158,9 @@
             "peer": true
         },
         "node_modules/react-router": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-            "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+            "version": "7.18.1",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+            "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
             "license": "MIT",
             "dependencies": {
                 "cookie": "^1.0.1",
@@ -12153,12 +12180,12 @@
             }
         },
         "node_modules/react-router-dom": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-            "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+            "version": "7.18.1",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+            "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
             "license": "MIT",
             "dependencies": {
-                "react-router": "7.16.0"
+                "react-router": "7.18.1"
             },
             "engines": {
                 "node": ">=20.0.0"
@@ -12821,12 +12848,16 @@
             "license": "MIT"
         },
         "node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/send": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet-async": "^2.0.5",
-        "react-router-dom": "^7.12.0",
+        "react-router-dom": "^7.18.1",
         "recharts": "^2.15.1",
         "uuid": "^14.0.0",
         "vite": "^6.4.2",
@@ -56,7 +56,8 @@
         "audit:kit-ledger": "tsx scripts/writeKitLedger.ts",
         "audit:interactions": "tsx scripts/auditInteractions.ts",
         "fetch:ship-skills": "tsx scripts/fetch-ship-skills.ts",
-        "fetch:ship-data": "tsx scripts/fetch-ship-data.ts"
+        "fetch:ship-data": "tsx scripts/fetch-ship-data.ts",
+        "audit": "node scripts/audit.mjs"
     },
     "browserslist": {
         "production": [
@@ -97,6 +98,7 @@
         "postcss": "^8.5.10",
         "prettier": "^3.4.2",
         "puppeteer": "^24.40.0",
+        "semver": "^7.6.3",
         "supabase": "^2.95.1",
         "tailwindcss": "^3.4.15",
         "tsx": "^4.19.3",

--- a/scripts/audit.mjs
+++ b/scripts/audit.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/**
+ * Dependency vulnerability gate — a drop-in replacement for
+ * `npm audit --omit=dev --audit-level=high`.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `npm audit` is currently broken against the public registry, for every npm client:
+ * `POST /-/npm/v1/security/advisories/bulk` returns a **gzip-compressed body with no
+ * `content-encoding: gzip` header**, so the client cannot decode it. npm's own fetch throws a
+ * JSON parse error, falls back to the retired `/security/audits/quick` endpoint, and that
+ * answers `400 Invalid package tree, run npm install to rebuild your package-lock.json` —
+ * a red herring that has nothing to do with the lockfile. Reproduced on npm 10.8.2 and 11,
+ * with a one-package payload, and with `accept-encoding: identity`.
+ *
+ * This script talks to the SAME advisory endpoint with the SAME request shape npm uses, and
+ * simply gunzips the response when it arrives compressed. It is deliberately forward-compatible:
+ * if the registry starts sending correct headers (or uncompressed JSON) it keeps working, so
+ * this can be swapped back for plain `npm audit` whenever upstream is fixed.
+ *
+ * SEMANTICS (matched to the npm command it replaces)
+ * --------------------------------------------------
+ *  - Scope: production dependencies only — entries flagged `dev`/`devOptional` in the lockfile
+ *    are skipped, exactly as `--omit=dev` does.
+ *  - Threshold: fails on `high` and `critical` by default (`--audit-level`).
+ *  - Version matching: an advisory counts only when an INSTALLED version satisfies its
+ *    `vulnerable_versions` range.
+ *
+ * It never fails open: any transport error, non-200, or unparseable body exits non-zero with a
+ * clear message, so a genuinely broken endpoint is loud rather than silently "green".
+ *
+ * Usage: node scripts/audit.mjs [--audit-level=high] [--include-dev]
+ */
+import fs from 'node:fs';
+import zlib from 'node:zlib';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import semver from 'semver';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const REGISTRY = process.env.npm_config_registry ?? 'https://registry.npmjs.org';
+const BULK_ENDPOINT = `${REGISTRY.replace(/\/$/, '')}/-/npm/v1/security/advisories/bulk`;
+
+const SEVERITY_ORDER = ['info', 'low', 'moderate', 'high', 'critical'];
+
+/**
+ * Advisories that are known, reviewed, and accepted for now. Keep this EMPTY unless there is a
+ * deliberate decision behind an entry — each one is a vulnerability we are shipping. Every entry
+ * needs an owner-visible reason and, ideally, the condition that will let us drop it again.
+ * Matched on the advisory `id` (GHSA), scoped to a package name so an id can never silently
+ * suppress a finding elsewhere.
+ *
+ * @type {{ package: string, id: string, reason: string }[]}
+ */
+const ALLOWLIST = [
+    {
+        package: 'react-router',
+        id: '1124282', // GHSA-qwww-vcr4-c8h2
+        reason:
+            'RSC Mode CSRF Bypass — requires React Router RSC mode, which this app does not use. ' +
+            'It is a client-only Vite SPA: BrowserRouter only, no server request handler, no SSR, ' +
+            'and no react-router/rsc, matchRSCServerRequest, unstable_RSC or createStaticHandler ' +
+            'anywhere in src. Range >=7.12.0 <8.3.0 has no 7.x fix and react-router-dom publishes ' +
+            'no 8.x, so clearing it means migrating off react-router-dom to react-router@8. ' +
+            'DROP THIS ENTRY once that migration lands.',
+    },
+];
+
+const args = process.argv.slice(2);
+const levelArg = args.find((a) => a.startsWith('--audit-level='))?.split('=')[1] ?? 'high';
+const includeDev = args.includes('--include-dev');
+const threshold = SEVERITY_ORDER.indexOf(levelArg);
+if (threshold === -1) {
+    console.error(
+        `audit: unknown --audit-level "${levelArg}" (expected one of ${SEVERITY_ORDER.join(', ')})`
+    );
+    process.exit(2);
+}
+
+/** Build npm's bulk payload — `{ packageName: [installedVersions] }` — from the lockfile. */
+function buildPayload() {
+    const lockPath = path.join(ROOT, 'package-lock.json');
+    if (!fs.existsSync(lockPath)) {
+        console.error('audit: package-lock.json not found — run `npm install` first');
+        process.exit(2);
+    }
+    const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+    const byName = new Map();
+    for (const [treePath, meta] of Object.entries(lock.packages ?? {})) {
+        if (!treePath || !meta.version) continue; // '' is the root project itself
+        if (!includeDev && (meta.dev || meta.devOptional)) continue; // mirrors --omit=dev
+        const name = meta.name ?? treePath.split('node_modules/').pop();
+        if (!byName.has(name)) byName.set(name, new Set());
+        byName.get(name).add(meta.version);
+    }
+    return Object.fromEntries([...byName].map(([name, versions]) => [name, [...versions]]));
+}
+
+/** POST the payload and decode the reply, gunzipping when the registry omits content-encoding. */
+async function fetchAdvisories(payload) {
+    let res;
+    try {
+        res = await fetch(BULK_ENDPOINT, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+    } catch (err) {
+        console.error(`audit: could not reach ${BULK_ENDPOINT} — ${err.message}`);
+        process.exit(2);
+    }
+    if (!res.ok) {
+        console.error(`audit: advisory endpoint returned ${res.status} ${res.statusText}`);
+        process.exit(2);
+    }
+    const buf = Buffer.from(await res.arrayBuffer());
+    // 1f 8b = gzip magic. The registry currently sends gzip WITHOUT declaring it, so sniff the
+    // bytes rather than trusting the header; both shapes are handled.
+    const isGzip = buf.length > 2 && buf[0] === 0x1f && buf[1] === 0x8b;
+    let text;
+    try {
+        text = isGzip ? zlib.gunzipSync(buf).toString('utf8') : buf.toString('utf8');
+    } catch (err) {
+        console.error(`audit: could not decompress the advisory response — ${err.message}`);
+        process.exit(2);
+    }
+    try {
+        return JSON.parse(text);
+    } catch (err) {
+        console.error(`audit: advisory response was not valid JSON — ${err.message}`);
+        process.exit(2);
+    }
+}
+
+const payload = buildPayload();
+const advisories = await fetchAdvisories(payload);
+
+const findings = [];
+for (const [name, list] of Object.entries(advisories)) {
+    for (const advisory of list ?? []) {
+        const affected = (payload[name] ?? []).filter((v) =>
+            semver.satisfies(v, advisory.vulnerable_versions, { includePrerelease: true })
+        );
+        if (!affected.length) continue;
+        // The endpoint sends `id` as a NUMBER; compare as strings so an allowlist entry written
+        // either way matches.
+        const allowed = ALLOWLIST.find(
+            (a) => a.package === name && String(a.id) === String(advisory.id)
+        );
+        findings.push({
+            name,
+            versions: affected,
+            severity: advisory.severity,
+            title: advisory.title,
+            url: advisory.url,
+            id: advisory.id,
+            allowed,
+        });
+    }
+}
+
+const scope = includeDev ? 'all dependencies' : 'production dependencies';
+const atOrAboveThreshold = findings.filter((f) => SEVERITY_ORDER.indexOf(f.severity) >= threshold);
+const blocking = atOrAboveThreshold.filter((f) => !f.allowed);
+const accepted = atOrAboveThreshold.filter((f) => f.allowed);
+
+console.log(
+    `audit: scanned ${Object.keys(payload).length} ${scope} — ` +
+        `${findings.length} advisories matched, ${atOrAboveThreshold.length} at or above "${levelArg}"`
+);
+
+for (const f of accepted) {
+    console.log(`  ACCEPTED  [${f.severity}] ${f.name} ${f.versions.join(', ')} — ${f.title}`);
+    console.log(`            ${f.id} · reason: ${f.allowed.reason}`);
+}
+for (const f of blocking) {
+    console.log(`  ${f.severity.toUpperCase()}  ${f.name} ${f.versions.join(', ')} — ${f.title}`);
+    console.log(`            ${f.id} · ${f.url}`);
+}
+
+if (blocking.length) {
+    console.error(
+        `\naudit: FAILED — ${blocking.length} unresolved advisory(ies) at or above "${levelArg}" in ${scope}.`
+    );
+    process.exit(1);
+}
+console.log(`audit: OK — no unresolved advisories at or above "${levelArg}" in ${scope}.`);


### PR DESCRIPTION
The Security job has been failing on every PR and on `main`. It was **not** a lockfile problem, and it was **not** only the postcss/react-router advisories we'd assumed.

## Root cause (upstream, affects every npm client)

`POST /-/npm/v1/security/advisories/bulk` returns a **gzip-compressed body with no `content-encoding: gzip` header**. npm can't decode it, so `res.json()` throws a `SyntaxError`; npm then silently falls back to the **retired** `/security/audits/quick` endpoint, which answers:

```
400 Invalid package tree, run  npm install  to rebuild your package-lock.json
```

That message is a red herring — it points at the lockfile, which is fine.

Evidence:

- Reproduced on npm **10.8.2** and npm **11**, with a **one-package** payload, and with `accept-encoding: identity`.
- The response body starts with the gzip magic `1f 8b 08` and gunzips to valid JSON.
- npm 11 says it outright: `invalid json response body ... reason: Unexpected token '^_'` (`^_` = `0x1f`).
- Our lockfile is clean: lockfileVersion 3, 1134 packages, **zero** non-registry resolutions.
- `main` fails identically and this branch touches no dependency resolution logic, so nothing is repo-specific.

`npm audit` tries bulk first and falls back to quick only when bulk throws (`@npmcli/arborist/lib/audit-report.js`), which is why the visible error is from the retired endpoint rather than the real one.

## The fix

`scripts/audit.mjs`, wired as `npm run audit`, is a drop-in equivalent of `npm audit --omit=dev --audit-level=high`:

- **Same endpoint, same request shape** npm uses (`{ name: [versions] }` from the lockfile).
- **Same scope** — production only, skipping `dev`/`devOptional` entries, exactly like `--omit=dev`.
- **Same threshold** — fails on high/critical, configurable via `--audit-level`.
- Sniffs the gzip magic and decompresses when the header is missing, and handles plain JSON too — so it keeps working once upstream is fixed, and can then be swapped straight back for `npm audit`.
- **Never fails open**: transport errors, non-200s and unparseable bodies all exit non-zero with a clear message.

## What the broken gate was hiding

Five real high-severity advisories in production dependencies. All now resolved:

| package | before | after | advisory |
|---|---|---|---|
| js-yaml | 4.2.0 | **4.3.0** | quadratic-CPU YAML merge keys |
| postcss | 8.5.10 | **8.5.23** | 2× `sourceMappingURL` arbitrary file read / path traversal |
| react-router | 7.16.0 | **7.18.1** | unauthenticated DoS via inefficient route matching |

js-yaml and postcss were plain `npm update` bumps; react-router came via `react-router-dom` `^7.12.0` → `^7.18.1`.

## The one accepted advisory

`GHSA-qwww-vcr4-c8h2` (React Router **RSC Mode CSRF Bypass**, range `>=7.12.0 <8.3.0`) has no 7.x fix, and `react-router-dom` publishes no 8.x — so clearing it properly means migrating off `react-router-dom` to `react-router@8` across 31 files.

It is allowlisted as **not applicable**: the advisory requires React Router RSC mode, and this is a client-only Vite SPA — `BrowserRouter` only, no SSR, no server request handler, and no `react-router/rsc`, `matchRSCServerRequest`, `unstable_RSC` or `createStaticHandler` anywhere in `src` (verified). The entry carries that reasoning and the condition to drop it.

Accepted advisories are **printed on every run**, so they stay visible rather than being silently suppressed:

```
ACCEPTED  [high] react-router 7.18.1 — React Router: RSC Mode CSRF Bypass ...
          1124282 · reason: ... DROP THIS ENTRY once that migration lands.
audit: OK — no unresolved advisories at or above "high" in production dependencies.
```

## Verification

- `npm run audit` exits **0**; deleting the allowlist entry makes it exit **1** again (checked both ways).
- **4903 tests pass**, `npm run lint` clean, `tsc --noEmit` clean.
- `npm run build` succeeds with the react-router bump; `BrowserRouter` is the only router surface in use.

## Follow-up (not in this PR)

`vite`, `vite-plugin-svgr`, `vite-tsconfig-paths`, `@vitejs/plugin-react-swc` and the `@types/*` packages sit in `dependencies` rather than `devDependencies`. They're build-time only, and that misclassification is why postcss and js-yaml were in production audit scope at all. Worth fixing separately — moving them affects what Netlify installs, so it deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015skAFQQpWk93zYTU5w8dkz
