### PR TITLE
fix(dev): apply the browser target to optimizeDeps so `npm start` survives a cold dep cache

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,13 @@ import { VitePWA } from 'vite-plugin-pwa';
 import PrerenderPlugin from '@prerenderer/rollup-plugin';
 import PuppeteerRenderer from '@prerenderer/renderer-puppeteer';
 
+// Matches Vite's default 'modules' target but raises the Safari floor 14 -> 15.
+// esbuild 0.28+ refuses to emit destructuring for Safari 14 (known browser bug),
+// which breaks both minification (build) and dependency prebundling (dev server).
+// Must be applied to build.target AND optimizeDeps — the latter does not inherit
+// build.target, it always uses Vite's own default list.
+const BROWSER_TARGET = ['es2020', 'edge88', 'firefox78', 'chrome87', 'safari15'];
+
 // https://vitejs.dev/config/
 export default defineConfig({
     base: '/',
@@ -395,11 +402,13 @@ export default defineConfig({
             exclude: [...(configDefaults.coverage.exclude ?? [])],
         },
     },
+    optimizeDeps: {
+        esbuildOptions: {
+            target: BROWSER_TARGET,
+        },
+    },
     build: {
-        // Matches Vite's default 'modules' target but raises the Safari floor 14 -> 15.
-        // esbuild 0.28+ refuses to emit destructuring for Safari 14 (known browser bug),
-        // which breaks minification under the default target.
-        target: ['es2020', 'edge88', 'firefox78', 'chrome87', 'safari15'],
+        target: BROWSER_TARGET,
         rollupOptions: {
             output: {
                 manualChunks: {


### PR DESCRIPTION
This change has been sitting uncommitted in a local working tree since 2026-07-24. It's a real fix, so it belongs in the repo.

## The bug

`optimizeDeps` does **not** inherit `build.target` — it always uses Vite's own default `modules` list, which includes `safari14`. esbuild 0.28+ deliberately refuses to emit destructuring for Safari 14 (a known browser bug), so dependency pre-bundling hard-errors:

```
node_modules/@cloudinary/react/index.js:2021:14: ERROR: Transforming destructuring to the
configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari14"
+ 2 overrides) is not supported yet
```

~700 of them, across `@cloudinary/react`, `@supabase/supabase-js` and `html-to-image`. `npm start` dies.

## Why it hid for so long

- The June 2026 esbuild-advisory override (`616ffd9e`) raised `safari14` → `safari15` on **`build.target` only**. The dev server is the only thing that reads the optimizeDeps target, so production builds, tests, `tsc` and lint were never affected — CI stayed green throughout.
- It also looks intermittent: the failure only surfaces when `node_modules/.vite/deps` is absent or invalidated. A warm cache skips the optimize step entirely. So it hit fresh worktrees first, then the main checkout the moment an `npm install` wiped the cache.

## The fix

Hoist a shared `BROWSER_TARGET` const and apply it to **both** `build.target` and `optimizeDeps.esbuildOptions.target`, so the two can't drift again. Any future target change now has to go through the one const — that's the point of hoisting it rather than duplicating the array.

## Verification

Both directions, on esbuild 0.28.1 with a wiped cache (`rm -rf node_modules/.vite`):

| config | `npx vite optimize --force` |
|---|---|
| committed `main` | fails, 700 errors, `safari14` in the target list |
| this branch | succeeds, 17 deps optimized |

`npm run build` succeeds and 4903 tests pass.

No changelog entry — internal tooling, not user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015skAFQQpWk93zYTU5w8dkz
