### PR TITLE
fix(sim): ally-crit routing, reaction-repair visibility, and combat-log order

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -5,7 +5,12 @@ export const CURRENT_VERSION = '1.65.0';
 // RELEASE CHECKLIST: move these strings into a new ChangelogEntry at the top of
 // CHANGELOG (with the new version + today's date), clear this array back to [],
 // and bump CURRENT_VERSION. All three steps must happen together.
-export const UNRELEASED_CHANGES: string[] = [];
+export const UNRELEASED_CHANGES: string[] = [
+    'Combat simulator: reactions to an ally\'s critical hit (Sentinel, Howler, Hermes) now fire once per attack instead of once per critting hit, and "deals damage to that enemy" riders land on the enemies that were actually crit rather than on the attack\'s main target.',
+    "Combat simulator: passives that punish an enemy for repairing (Ruiner's Bomb) now also see repairs that come from the enemy's own reactions, such as a healer repairing itself when damaged.",
+    'Combat simulator: the combat log now lists each turn as skill effects first, then charge, then the consequences (resists, deaths, expiries) — previously the attack line could appear after the kill it caused.',
+    'Combat simulator: debuff-duration reductions (Heliodor, Pestilence) are now shown in the combat log instead of happening silently.',
+];
 
 export const CHANGELOG: ChangelogEntry[] = [
     {

--- a/src/utils/combat/__tests__/healing.test.ts
+++ b/src/utils/combat/__tests__/healing.test.ts
@@ -1523,10 +1523,14 @@ describe('healing — Task 9: reactive listeners (on-ally-critically-repaired / 
         expect(enqueued).toHaveLength(1);
     });
 
-    it('on-ally-crit (non-charge rider): an ally crit enqueues once per critting hit; own/enemy/no-crit do not', () => {
+    it('on-ally-crit (non-charge rider): an ally crit enqueues once PER ATTACK; own/enemy/no-crit do not', () => {
         const handBus = makeHandBus();
         const enqueued: Intent[] = [];
-        // A NON-charge rider (Sentinel-style reactive damage) — these fire once per critting hit.
+        // A NON-charge rider (Sentinel-style reactive damage). Every on-ally-crit rider — not just
+        // the charge special-case — now enqueues once per critting ATTACK: the corpus clauses read
+        // "when an ally critically hits an enemy, this Unit <does X>", one reaction per attack.
+        // A multi-crit AoE fans out over the crit VICTIMS inside the executor (critVictimIds),
+        // not by re-enqueuing the intent once per critting hit.
         const ability: Ability = {
             id: 'ally-crit-damage',
             type: 'damage',
@@ -1549,25 +1553,69 @@ describe('healing — Task 9: reactive listeners (on-ally-critically-repaired / 
             abilityType: 'damage' as const,
         };
 
-        // Another player's cast with 2 critting hits → 2 enqueues.
+        // Another player's cast with 2 critting hits → ONE enqueue (per attack, not per hit).
         handBus.emit({ type: 'ability-performed', actorId: 'other', critHits: 2, ...base });
-        expect(enqueued).toHaveLength(2);
+        expect(enqueued).toHaveLength(1);
 
         // Own cast → excluded → 0 additional.
         handBus.emit({ type: 'ability-performed', actorId: 'attacker', critHits: 2, ...base });
-        expect(enqueued).toHaveLength(2);
+        expect(enqueued).toHaveLength(1);
 
         // Enemy cast → excluded → 0 additional.
         handBus.emit({ type: 'ability-performed', actorId: 'enemy', critHits: 2, ...base });
-        expect(enqueued).toHaveLength(2);
+        expect(enqueued).toHaveLength(1);
 
         // Another player's cast with NO crit (no critHits, didCrit false) → 0 additional.
         handBus.emit({ ...base, type: 'ability-performed', actorId: 'other', didCrit: false });
-        expect(enqueued).toHaveLength(2);
+        expect(enqueued).toHaveLength(1);
 
         // Another player's cast with didCrit binary only (no critHits field) → 1 enqueue.
         handBus.emit({ ...base, type: 'ability-performed', actorId: 'other', didCrit: true });
-        expect(enqueued).toHaveLength(3);
+        expect(enqueued).toHaveLength(2);
+
+        // Routing: with no critVictimIds on the event (single-target inline emit), the rider falls
+        // back to the cast's targetId — the only possible crit victim there.
+        expect(enqueued[1].eventCtx?.critVictimIds).toEqual(['enemy']);
+        expect(enqueued[1].eventCtx?.counterTargetId).toBe('enemy');
+    });
+
+    it('on-ally-crit: critVictimIds routes "that enemy" to the victims that CRIT, not the anchor', () => {
+        const handBus = makeHandBus();
+        const enqueued: Intent[] = [];
+        const ability: Ability = {
+            id: 'ally-crit-damage',
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-ally-crit',
+            conditions: [],
+            config: { type: 'damage', multiplier: 60, noCrit: true },
+        };
+        registerReactiveListeners({
+            bus: handBus,
+            perOwner: [
+                { ownerId: 'attacker', reactiveAbilities: [{ ability, sourceSlot: 'passive' }] },
+            ],
+            enqueue: (intent) => enqueued.push(intent),
+            isOpposing: (id) => id.startsWith('enemy'),
+        });
+
+        // The AoE's SELECTED target ('enemy-anchor') did not crit; two covered victims did.
+        handBus.emit({
+            type: 'ability-performed',
+            actorId: 'other',
+            targetId: 'enemy-anchor',
+            round: 1,
+            abilityType: 'damage',
+            didCrit: true,
+            critHits: 2,
+            critVictimIds: ['enemy-b', 'enemy-c'],
+        });
+
+        // ONE enqueue for the attack, carrying BOTH crit victims for the executor to fan over —
+        // the anchor (which never crit) must not appear anywhere in the routing.
+        expect(enqueued).toHaveLength(1);
+        expect(enqueued[0].eventCtx?.critVictimIds).toEqual(['enemy-b', 'enemy-c']);
+        expect(enqueued[0].eventCtx?.counterTargetId).toBe('enemy-b');
     });
 
     it('on-ally-crit (charge rider): charge gain is once PER ATTACK that crits, not per critting hit', () => {

--- a/src/utils/combat/__tests__/hermesOncePerAttack.integration.test.ts
+++ b/src/utils/combat/__tests__/hermesOncePerAttack.integration.test.ts
@@ -234,12 +234,23 @@ describe('Hermes Everliving Regeneration — once per attack, not per hit/victim
 });
 
 /**
- * Regression lock — the guard is NARROW: it collapses ONLY self-target riders. An ally-target
- * reactive buff on the SAME on-ally-crit trigger (the shape of Howler's Blast grant / Sentinel's
- * ally repair) MUST still fire once per critting hit, routed to the crediting ally per victim.
- * A hand-built ally-target buff is used here purely to exercise the `target !== 'self'` branch of
- * the guard in isolation (real Cultivator/Graphite/Sentinel/Howler ally goldens across the suite
- * are the broader lock).
+ * Regression lock — an ALLY-target rider on on-ally-crit (the shape of Howler's Blast grant /
+ * Sentinel's ally repair) also fires exactly ONCE per critting attack.
+ *
+ * This used to fire 3× for a 3-hit crit: the once-per-attack collapse lived in the executor and
+ * was deliberately narrowed to `target: 'self'`, so ally-routed riders kept re-applying per
+ * critting hit. That produced the user-reported "Sentinel heals → Ruiner: 1,152" twice for ONE
+ * Ruiner AoE. The collapse now lives in the LISTENER and covers the whole on-ally-crit trigger:
+ * "when an ally critically hits an enemy, this Unit <does X>" is one reaction per attack, whatever
+ * X targets. Per-ENEMY fan-out for "…to that enemy" riders happens inside the damage executor via
+ * eventCtx.critVictimIds, not by re-enqueuing.
+ *
+ * The executor's self-target guard is untouched and still load-bearing for the other per-hit
+ * triggers (on-attacked / on-ally-attacked), which genuinely fan one attack into many events.
+ *
+ * A hand-built ally-target buff is used here purely to exercise the `target !== 'self'` branch in
+ * isolation (real Cultivator/Graphite/Sentinel/Howler ally goldens across the suite are the
+ * broader lock).
  */
 function runAllyTargetRider() {
     const allyBuff: Ability = {
@@ -318,9 +329,9 @@ function runAllyTargetRider() {
     return blasts.length;
 }
 
-describe('ally-target on-ally-crit rider — still per critting hit (narrowness lock)', () => {
-    it('an ally-target buff fires once per critting hit, NOT collapsed to one', () => {
-        // The crediting ally landed 3 critting hits → the ally-routed buff applies 3×.
-        expect(runAllyTargetRider()).toBe(3);
+describe('ally-target on-ally-crit rider — once per attack', () => {
+    it('an ally-target buff fires once for a 3-hit critting attack, not three times', () => {
+        // The crediting ally landed 3 critting hits in ONE attack → one ally-routed grant.
+        expect(runAllyTargetRider()).toBe(1);
     });
 });

--- a/src/utils/combat/__tests__/positionalApplyPerVictimCrit.test.ts
+++ b/src/utils/combat/__tests__/positionalApplyPerVictimCrit.test.ts
@@ -146,9 +146,11 @@ describe('applyPositionalDamage — rollVictimCrit callback (per-victim crit sea
 
     /**
      * Return value: anchor no-crit, covered crits via rollVictimCrit.
-     * anyCrit must be true; critPairs must be 1.
+     * anyCrit must be true; critPairs must be 1; critVictimIds names ONLY the covered victim
+     * (the crit IDENTITY the on-ally-crit reactive routes "that enemy" off — the anchor did
+     * NOT crit, so routing off the cast's selected target would hit the wrong ship).
      */
-    it('returns { anyCrit: true, critPairs: 1 } when only the covered victim crits', () => {
+    it('returns { anyCrit: true, critPairs: 1, critVictimIds: [covered] } when only the covered victim crits', () => {
         const pattern = parsePattern('Pattern-Line-Range-1');
         const target = parseTarget('front');
         const anchorActor = actor('origin', 'M4');
@@ -170,7 +172,7 @@ describe('applyPositionalDamage — rollVictimCrit callback (per-victim crit sea
             rollVictimCrit: (v) => v.id === 'covered', // only covered crits
         });
 
-        expect(result).toEqual({ anyCrit: true, critPairs: 1 });
+        expect(result).toEqual({ anyCrit: true, critPairs: 1, critVictimIds: ['covered'] });
     });
 
     /**
@@ -199,7 +201,7 @@ describe('applyPositionalDamage — rollVictimCrit callback (per-victim crit sea
             // No rollVictimCrit → fallback to hitCrits[h]=false → nobody crits
         });
 
-        expect(result).toEqual({ anyCrit: false, critPairs: 0 });
+        expect(result).toEqual({ anyCrit: false, critPairs: 0, critVictimIds: [] });
     });
 
     /**
@@ -275,7 +277,13 @@ describe('applyPositionalDamage — rollVictimCrit callback (per-victim crit sea
             rollVictimCrit: (_v) => true, // covered crits on both hits too
         });
 
-        // 2 hits × 2 victims, all crit → 4 critting pairs.
-        expect(result).toEqual({ anyCrit: true, critPairs: 4 });
+        // 2 hits × 2 victims, all crit → 4 critting pairs, but only 2 DISTINCT crit victims:
+        // critVictimIds de-duplicates across hits ("deals X to that enemy" is per enemy, not per
+        // critting (hit, victim) pair), and lists them in first-crit order.
+        expect(result).toEqual({
+            anyCrit: true,
+            critPairs: 4,
+            critVictimIds: ['origin', 'covered'],
+        });
     });
 });

--- a/src/utils/combat/__tests__/reactiveRepairIsARepair.integration.test.ts
+++ b/src/utils/combat/__tests__/reactiveRepairIsARepair.integration.test.ts
@@ -1,0 +1,212 @@
+/**
+ * A REACTIVE repair is still "an enemy performing a repair" — and a reactive duration-shrink is
+ * visible in the log.
+ *
+ * USER-REPORTED (combat log): Ruiner's passive "inflicts Bomb II for 2 turns on any enemy
+ * performing a repair" never fired against the enemies that repair the MOST — the reaction-healers:
+ *
+ *     ↳ reacts: Enemy Heliodor heals → Enemy Heliodor: 4,297
+ *     ↳ reacts: Enemy Cultivator heals → Enemy Heliodor: 5,339
+ *     (no Bomb on either)
+ *
+ * ROOT CAUSE: `on-enemy-repaired` rides `heal-performed`. A drain-time REACTIVE heal deliberately
+ * emits NO `heal-performed` — that is the chain guard stopping a reactive repair from re-triggering
+ * the repairer's own on-repair listeners — and emits only the LOG-ONLY `reactive-heal-performed`,
+ * which nothing subscribed to. So every repair that arrives as a REACTION was invisible to Ruiner.
+ * Fixed by subscribing `on-enemy-repaired` to that event too; it cannot reopen the chain because
+ * no on-enemy-repaired rider in the corpus heals (Bomb debuff, Overload self-buff, charge removal,
+ * Defense Shred), and MAX_INTENT_GENERATIONS backstops any future one that does.
+ *
+ * SECOND FINDING (same log): Heliodor's "When directly damaged, this Unit reduces the duration of
+ * all active Debuffs on itself by 1 turn and repairs itself for 8%" showed the repair but never the
+ * shrink. The reduce-duration executor branch emitted no event at ALL (unlike `remove` mode, which
+ * emits reactive-cleanse-performed), so a working mechanic was indistinguishable from a missing
+ * one. It now emits the same log-only event flagged `mode: 'reduce-duration'`.
+ *
+ * Both ships run through the REAL production path — verbatim skill text from docs/ship-skills.csv
+ * through buildShipAbilities, driven by runCombat.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import { Ship } from '../../../types/ship';
+import { Ability } from '../../../types/abilities';
+import { parsePattern, parseTarget } from '../../targetingParser';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+function ship(over: Partial<Ship>): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}], ...over } as Ship;
+}
+
+/** Ruiner's R2 passive, verbatim from docs/ship-skills.csv (second passive column). */
+const RUINER_R2 =
+    'This Unit inflicts <unit-skill>Bomb II</unit-skill> for 2 turns on any enemy performing a ' +
+    '<unit-aid>repair</unit-aid>, once per round per enemy.<br /><br />This Unit gains 1 stack of ' +
+    '<unit-skill>Overload</unit-skill> when an enemy performs a <unit-aid>repair</unit-aid>, upon ' +
+    'killing an enemy, this Unit removes <unit-skill>Overload</unit-skill>.';
+
+/** Heliodor's R2 passive, verbatim from docs/ship-skills.csv (second passive column). */
+const HELIODOR_R2 =
+    'When directly damaged, this Unit reduces the duration of all active <unit-aid>Debuffs</unit-aid> ' +
+    'on itself by 1 turn and <unit-damage>repairs itself for 8%</unit-damage> of its Max HP.';
+
+const passiveAbilitiesOf = (text: string): Ability[] =>
+    buildShipAbilities(ship({ secondPassiveSkillText: text })).slots.find(
+        (s) => s.slot === 'passive'
+    )?.abilities ?? [];
+
+describe('extracted shapes (mutation guard)', () => {
+    it('Ruiner R2 inflicts a Bomb on on-enemy-repaired', () => {
+        const bomb = passiveAbilitiesOf(RUINER_R2).find(
+            (a) => a.config.type === 'debuff' && /Bomb/.test(a.config.buffName)
+        );
+        if (!bomb) throw new Error('mutation guard: Ruiner Bomb rider not found');
+        expect(bomb.trigger).toBe('on-enemy-repaired');
+        expect(bomb.target).toBe('enemy');
+        // The corpus cap that keeps this from firing on every reaction-heal in a round.
+        expect(bomb.oncePerRoundPerEnemy).toBe(true);
+    });
+
+    it('Heliodor R2 shrinks debuff durations and repairs, both on on-attacked', () => {
+        const abilities = passiveAbilitiesOf(HELIODOR_R2);
+        const shrink = abilities.find(
+            (a) => a.config.type === 'cleanse' && a.config.mode === 'reduce-duration'
+        );
+        const heal = abilities.find((a) => a.config.type === 'heal');
+        if (!shrink || !heal) throw new Error('mutation guard: Heliodor R2 riders not found');
+        expect(shrink.trigger).toBe('on-attacked');
+        expect(heal.trigger).toBe('on-attacked');
+    });
+});
+
+/** Heliodor as the sole enemy: reaction-heals and duration-shrinks whenever directly damaged. */
+const heliodor = (): EnemyAttacker =>
+    ({
+        id: 'heliodor',
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 500_000, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position: 'M4',
+        target: parseTarget('front'),
+        pattern: parsePattern('Pattern-Base'),
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'noop',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 0 },
+                        },
+                    ],
+                },
+                { slot: 'passive', abilities: passiveAbilitiesOf(HELIODOR_R2) },
+            ],
+        },
+    }) as EnemyAttacker;
+
+/** Ruiner attacks Heliodor. The hit is DIRECT damage, so Heliodor's on-attacked passive fires:
+ *  it repairs itself (a REACTIVE heal) and shrinks its own debuff durations. Ruiner should see
+ *  that repair and bomb it. */
+function runRuinerVsHeliodor() {
+    const input: CombatEngineInput = {
+        attack: 4000,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'ruiner-active',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 160 },
+                        },
+                    ],
+                },
+                { slot: 'passive', abilities: passiveAbilitiesOf(RUINER_R2) },
+            ],
+        },
+        enemyDefense: 0,
+        enemyHp: 500_000,
+        numRounds: 2,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 500,
+        hacking: 100_000, // debuff landing is not what this test is about — never resist
+        healTargetId: 'attacker', // healing mode on, so reactive repairs actually resolve
+        position: 'M1',
+        target: parseTarget('front'),
+        pattern: parsePattern('Pattern-Base'),
+        enemyAttackers: [heliodor()],
+    };
+
+    const bus = createEventBus();
+    const events: CombatEvent[] = [];
+    bus.on('debuff-applied', (e) => events.push(e));
+    bus.on('reactive-heal-performed', (e) => events.push(e));
+    bus.on('reactive-cleanse-performed', (e) => events.push(e));
+    runCombat({ ...input, bus });
+    return events;
+}
+
+describe('on-enemy-repaired sees REACTIVE repairs', () => {
+    it('Ruiner bombs Heliodor for its on-damaged self-repair, capped once per round per enemy', () => {
+        const events = runRuinerVsHeliodor();
+
+        // The reaction-heal must actually have happened, or the rest proves nothing.
+        const heals = events.filter((e) => e.type === 'reactive-heal-performed');
+        expect(heals.length).toBeGreaterThan(0);
+        expect(heals.every((e) => e.casterId === 'heliodor')).toBe(true);
+
+        // Pre-fix: zero Bombs — the repair arrived only as reactive-heal-performed, which
+        // on-enemy-repaired did not listen to.
+        const bombs = events.filter(
+            (e) =>
+                e.type === 'debuff-applied' && /Bomb/.test(e.buffName) && e.targetId === 'heliodor'
+        );
+        expect(bombs.length).toBeGreaterThan(0);
+        // `oncePerRoundPerEnemy` holds: at most one Bomb per round across 2 rounds, even though
+        // Heliodor reaction-heals off every hit it takes.
+        expect(bombs.length).toBeLessThanOrEqual(2);
+    });
+
+    it("Heliodor's debuff-duration shrink emits a log-visible reactive-cleanse-performed", () => {
+        const events = runRuinerVsHeliodor();
+        const shrinks = events.filter(
+            (e): e is Extract<CombatEvent, { type: 'reactive-cleanse-performed' }> =>
+                e.type === 'reactive-cleanse-performed' && e.mode === 'reduce-duration'
+        );
+        // Pre-fix: the reduce-duration branch emitted nothing, so a working mechanic was
+        // invisible in the log. Heliodor is carrying Ruiner's Bomb, so there IS something to shrink.
+        expect(shrinks.length).toBeGreaterThan(0);
+        expect(shrinks[0]).toMatchObject({
+            casterId: 'heliodor',
+            mode: 'reduce-duration',
+            durationTurns: 1,
+        });
+        expect(shrinks[0].perTarget.map((pt) => pt.targetId)).toEqual(['heliodor']);
+    });
+});

--- a/src/utils/combat/__tests__/sentinelAllyCritRouting.integration.test.ts
+++ b/src/utils/combat/__tests__/sentinelAllyCritRouting.integration.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Sentinel's on-ally-crit passive — once per ATTACK, routed to the enemies that actually CRIT.
+ *
+ * USER-REPORTED BUG (combat log, Ruiner's turn — a 3-victim AoE where the SELECTED target
+ * Heliodor did not crit but Hermes and Cultivator did):
+ *
+ *     Ruiner [active]
+ *     Enemy Heliodor: 13,985 → 76%
+ *     Enemy Hermes: 9,888 (crit)
+ *     Enemy Cultivator: 11,664 (crit)
+ *     ↳ reacts: Sentinel heals → Ruiner: 1,152     <- twice: one per critting hit
+ *     ↳ reacts: Sentinel heals → Ruiner: 1,152
+ *     ↳ reacts: Sentinel → Enemy Heliodor: 1,588   <- both on the ANCHOR, which never crit
+ *     ↳ reacts: Sentinel → Enemy Heliodor: 1,588
+ *
+ * TWO root causes, both in the `on-ally-crit` listener (triggers.ts):
+ *   1. It enqueued the intent `critHits` times — once per critting (hit, victim) pair — so the
+ *      ally repair landed once per crit instead of once per attack. "When an ally critically hits
+ *      an enemy, this Unit repairs the ally" is ONE reaction to ONE attack.
+ *   2. It stamped `counterTargetId: e.targetId`. `ability-performed.targetId` is the cast's
+ *      SELECTED anchor, and `critHits` is a bare COUNT — the crit IDENTITY resolved per victim in
+ *      positionalApply was discarded. So "deals 60% damage to that enemy" dumped every proc on the
+ *      anchor, which in an AoE is frequently a victim that never crit.
+ *
+ * Fixed by carrying `critVictimIds` (the DISTINCT crit victims) on `ability-performed` and
+ * enqueuing ONCE per critting attack, with the damage executor fanning out over that set.
+ *
+ * Everything runs through the REAL production path — Sentinel's verbatim R2 passive text from
+ * docs/ship-skills.csv through buildShipAbilities, driven by runCombat.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { buildShipAbilities } from '../../abilities/buildShipAbilities';
+import { setRateGateRng, setupKeyedTestRng } from '../../calculators/rateAccumulator';
+import { Ship, AffinityName } from '../../../types/ship';
+import { Ability } from '../../../types/abilities';
+import { parsePattern, parseTarget } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+function ship(over: Partial<Ship>): Ship {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { ...({} as any), refits: [{}, {}], ...over } as Ship;
+}
+
+/** Sentinel's R2 (refit-active at 2 refits) passive, verbatim from docs/ship-skills.csv. */
+const SENTINEL_R2 =
+    'When an ally critically hits an enemy, this Unit ' +
+    "<unit-damage>repairs the ally for 5%</unit-damage> of this Unit's Max HP and deals " +
+    '<unit-damage>60% damage</unit-damage> to that enemy.<br />This attack cannot critically hit.';
+
+function sentinelPassiveAbilities(): Ability[] {
+    return (
+        buildShipAbilities(ship({ secondPassiveSkillText: SENTINEL_R2 })).slots.find(
+            (s) => s.slot === 'passive'
+        )?.abilities ?? []
+    );
+}
+
+describe('Sentinel R2 riders — extracted shape (mutation guard)', () => {
+    it('an ally-targeted heal and an enemy-targeted damage both ride on-ally-crit', () => {
+        const abilities = sentinelPassiveAbilities();
+        const heal = abilities.find((a) => a.config.type === 'heal');
+        const damage = abilities.find((a) => a.config.type === 'damage');
+        if (!heal || !damage) throw new Error('mutation guard: Sentinel R2 riders not found');
+        expect(heal.trigger).toBe('on-ally-crit');
+        expect(heal.target).toBe('ally');
+        expect(damage.trigger).toBe('on-ally-crit');
+        expect(damage.target).toBe('enemy');
+    });
+});
+
+const SENTINEL_MAX_HP = 20_000;
+
+/** Sentinel as a team actor: carries only its real passive; acts last (speed 1) so the ally's
+ *  crit precedes its own turn, and deals no damage of its own. */
+const sentinel = (position: Position): TeamActorEngineInput =>
+    ({
+        id: 'sentinel',
+        speed: 1,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        target: parseTarget('front'),
+        pattern: parsePattern('Pattern-Base'),
+        walk: {
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active',
+                        abilities: [
+                            {
+                                id: 'noop',
+                                type: 'damage',
+                                target: 'enemy',
+                                trigger: 'on-cast',
+                                conditions: [],
+                                config: { type: 'damage', multiplier: 0 },
+                            },
+                        ],
+                    },
+                    { slot: 'passive', abilities: sentinelPassiveAbilities() },
+                ],
+            },
+            stats: {
+                attack: 1000,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp: SENTINEL_MAX_HP,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    }) as TeamActorEngineInput;
+
+const dummyEnemy = (id: string, position: Position, affinity: AffinityName): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        affinity,
+        target: parseTarget('front'),
+        pattern: parsePattern('Pattern-Base'),
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'noop',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 0 },
+                        },
+                    ],
+                },
+            ],
+        },
+    }) as EnemyAttacker;
+
+/**
+ * The focus ally fires a single-hit AoE (Pattern-Line-Range-1) at 'front'. The anchor is
+ * `enemy-anchor` @ M4; `enemy-covered` @ M3 is the covered footprint victim.
+ *
+ * The split (anchor does NOT crit, covered victim DOES) is made deterministic by AFFINITY rather
+ * than by scripting draw order — the crit gate is a real random sample, so both victims would
+ * otherwise share one rate. The focus attacker is thermal at 25 crit:
+ *   - vs the ELECTRIC anchor it is at a disadvantage → cap 75, penalty 25 → rate max(0, 25-25) = 0
+ *     → `rng() < 0` is false for ANY rng value: the anchor can never crit.
+ *   - vs the ANTIMATTER covered victim the matchup is neutral → rate 0.25 → `rng() = 0` crits.
+ * With the RNG pinned at 0 both outcomes are forced, and this is exactly the reported shape:
+ * the cast's selected target did not crit while a splash victim did.
+ */
+function runAoE(anchorAffinity: AffinityName = 'electric'): {
+    reactiveDamage: Extract<CombatEvent, { type: 'reactive-damage-performed' }>[];
+    reactiveHeals: Extract<CombatEvent, { type: 'reactive-heal-performed' }>[];
+} {
+    setRateGateRng(() => 0);
+
+    const input: CombatEngineInput = {
+        attack: 1000,
+        crit: 25, // disadvantage penalty zeroes this vs the anchor; stays 25% vs the covered victim
+        critDamage: 100,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'aoe',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            config: { type: 'damage', multiplier: 100 },
+                        },
+                    ],
+                },
+            ],
+        },
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 500, // acts before Sentinel
+        affinity: 'thermal', // electric holds advantage over thermal → disadvantaged vs the anchor
+        healTargetId: 'sentinel',
+        position: 'M1',
+        target: parseTarget('front'),
+        pattern: parsePattern('Pattern-Line-Range-1'),
+        teamActors: [sentinel('M2')],
+        enemyAttackers: [
+            dummyEnemy('enemy-anchor', 'M4', anchorAffinity),
+            dummyEnemy('enemy-covered', 'M3', 'antimatter'),
+        ],
+    };
+
+    const bus = createEventBus();
+    const reactiveDamage: Extract<CombatEvent, { type: 'reactive-damage-performed' }>[] = [];
+    const reactiveHeals: Extract<CombatEvent, { type: 'reactive-heal-performed' }>[] = [];
+    bus.on('reactive-damage-performed', (e) => {
+        if (e.sourceId === 'sentinel') reactiveDamage.push(e);
+    });
+    bus.on('reactive-heal-performed', (e) => {
+        if (e.casterId === 'sentinel') reactiveHeals.push(e);
+    });
+    runCombat({ ...input, bus });
+    return { reactiveDamage, reactiveHeals };
+}
+
+describe('Sentinel on-ally-crit — attack-scoped repair, crit-victim-scoped damage', () => {
+    // src/setupTests.ts installs the seeded RNG per test; restore it after the scripted override.
+    afterEach(() => setupKeyedTestRng(12345));
+
+    it('repairs the critting ally ONCE for the whole attack, not once per critting hit', () => {
+        const { reactiveHeals } = runAoE();
+        expect(reactiveHeals).toHaveLength(1);
+        expect(reactiveHeals[0].perTarget.map((pt) => pt.targetId)).toEqual(['attacker']);
+    });
+
+    it('lands its 60% damage on the enemy that CRIT, never on the non-critting anchor', () => {
+        const { reactiveDamage } = runAoE();
+        expect(reactiveDamage.map((e) => e.targetId)).toEqual(['enemy-covered']);
+        // The reported bug: both procs landed on 'enemy-anchor', which never crit.
+        expect(reactiveDamage.some((e) => e.targetId === 'enemy-anchor')).toBe(false);
+    });
+
+    // The reported shape verbatim: ONE AoE crits TWO enemies. Making the anchor antimatter puts
+    // the attacker at a neutral matchup against both victims, so both crit off the pinned RNG.
+    it('with TWO crit victims: one repair for the attack, one 60% hit per crit victim', () => {
+        const { reactiveDamage, reactiveHeals } = runAoE('antimatter');
+        // Was 2 repairs (one per critting hit) — "Sentinel heals → Ruiner: 1,152" twice.
+        expect(reactiveHeals).toHaveLength(1);
+        // Was 2 hits BOTH on the anchor; now one hit per DISTINCT crit victim.
+        expect(reactiveDamage.map((e) => e.targetId).sort()).toEqual([
+            'enemy-anchor',
+            'enemy-covered',
+        ]);
+    });
+});

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -5116,7 +5116,7 @@ export function runCombat(input: CombatEngineInput): {
             // keyed by victim id. Required for a non-zero delta — see the causality note above
             // perVictimOutgoingDeltaPct. Unsupplied → delta stays 0 for every victim.
             preTurnVictimStatus?: Map<string, PreTurnVictimStatusSnapshot>;
-        }): { anyCrit: boolean; critPairs: number } => {
+        }): { anyCrit: boolean; critPairs: number; critVictimIds: string[] } => {
             // Task 3: this is the ONE deferred (positional) apply path — reflects fired here must
             // buffer their log row until emitDeferredAbilityPerformed creates the attack entry
             // (see the deferReflectLogs doc above applyVictimDamage). try/finally so the flag
@@ -5264,7 +5264,12 @@ export function runCombat(input: CombatEngineInput): {
         const emitDeferredAbilityPerformed = (
             dap: NonNullable<PlayerTurnResult['deferredAbilityPerformed']>,
             didCrit: boolean,
-            critHits: number
+            critHits: number,
+            // The DISTINCT enemies this cast critically hit (positionalApply's per-victim crit
+            // identity). Carried on the event so an `on-ally-crit` reactive can route "that enemy"
+            // to the enemies actually crit rather than the cast's SELECTED anchor (which may not
+            // have crit at all in an AoE). Empty on the 0-damage fallback path (no apply ran).
+            critVictimIds: string[]
         ) => {
             bus.emit({
                 type: 'ability-performed',
@@ -5275,6 +5280,7 @@ export function runCombat(input: CombatEngineInput): {
                 damage: dap.damage,
                 didCrit,
                 ...(critHits > 0 ? { critHits } : {}),
+                ...(critVictimIds.length > 0 ? { critVictimIds } : {}),
                 didHit: true,
             });
             // Task 3: the attack entry now exists — drain any reflect rows buffered during this
@@ -5865,7 +5871,7 @@ export function runCombat(input: CombatEngineInput): {
             ) => void,
             emitAttacked: (attackedSignals: PositionalAttackedSignals) => void
         ): {
-            critAgg: { anyCrit: boolean; critPairs: number };
+            critAgg: { anyCrit: boolean; critPairs: number; critVictimIds: string[] };
             attackedSignals: PositionalAttackedSignals;
         } => {
             // Aggregate EACH footprint victim's per-attack damage + OR its shield-hit flag across the
@@ -5946,7 +5952,8 @@ export function runCombat(input: CombatEngineInput): {
                 emitDeferredAbilityPerformed(
                     sel.deferredAbilityPerformed,
                     critAgg.anyCrit,
-                    critAgg.critPairs
+                    critAgg.critPairs,
+                    critAgg.critVictimIds
                 );
             }
             // Set the DEFERRED Stasis break for every covered victim (unconditional — covered victims
@@ -7759,7 +7766,9 @@ export function runCombat(input: CombatEngineInput): {
                             // actually ran; when the enemy turn is positional but deals 0 damage (apply
                             // skipped), the deferred emit below falls back to the anchor-based crit values
                             // (byte-identical to the pre-Task-5 inline emit for that 0-damage edge case).
-                            let enemyCritAgg: { anyCrit: boolean; critPairs: number } | undefined;
+                            let enemyCritAgg:
+                                | { anyCrit: boolean; critPairs: number; critVictimIds: string[] }
+                                | undefined;
                             // Task 5: predict enemy positional apply (mirror of focus/team) so runPlayerTurn
                             // defers its inline ability-performed emit. The opposing roster from the enemy's
                             // view is the PLAYER team (allPlayerActors).
@@ -8251,7 +8260,12 @@ export function runCombat(input: CombatEngineInput): {
                             // enemy is positional (deferred payload present) AND the apply was skipped.
                             if (enemyDeferredAbilityPerformed && !enemyCritAgg) {
                                 const dap = enemyDeferredAbilityPerformed;
-                                emitDeferredAbilityPerformed(dap, dap.didCrit, dap.critHits ?? 0);
+                                emitDeferredAbilityPerformed(
+                                    dap,
+                                    dap.didCrit,
+                                    dap.critHits ?? 0,
+                                    []
+                                );
                             }
                         } // end dead-after-burst guard (!burstDestroyedActor)
                     } else {

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -79,6 +79,14 @@ export type CombatEvent =
           /** Number of individual hits that crit this cast (per-hit crit checks).
            *  Present only when > 0; `didCrit` stays the any-hit binary. */
           critHits?: number;
+          /** The DISTINCT victims this cast critically hit, in first-crit order. Present only on
+           *  the POSITIONAL deferred emit (where the per-victim apply resolves crits per victim)
+           *  and only when non-empty; absent on the single-target inline emit, where `targetId`
+           *  IS the only possible crit victim. Consumers must fall back to `targetId` when it is
+           *  absent. Exists because `critHits` is a bare COUNT: for an AoE that crit two covered
+           *  victims but not the selected anchor, `targetId` names a victim that never crit, so a
+           *  "deals X to that enemy" reactive routed off `targetId` hits the wrong ship. */
+          critVictimIds?: string[];
           didHit?: boolean;
       } & ReactiveStamp)
     | ({
@@ -192,10 +200,16 @@ export type CombatEvent =
           amount: number;
           didCrit?: boolean;
       } & ReactiveStamp)
-    /** LOG-ONLY: a drain-time REACTIVE heal resolved (executeIntent heal branch). A reactive heal
-     *  credits `directHeal` but emits NO `heal-performed` (chain guard — it must not re-trigger
-     *  on-repair listeners). This event exists SOLELY for buildCombatLog: NO combat listener
-     *  subscribes to it. `casterId` = the reacting owner; `perTarget` = per-recipient raw repair. */
+    /** A drain-time REACTIVE heal resolved (executeIntent heal branch). A reactive heal credits
+     *  `directHeal` but emits NO `heal-performed` (chain guard — it must not re-trigger the
+     *  REPAIRER'S OWN on-repair listeners, which would loop). `casterId` = the reacting owner;
+     *  `perTarget` = per-recipient raw repair.
+     *
+     *  Primarily for buildCombatLog, but NOT log-only: `on-enemy-repaired` also subscribes, because
+     *  a reactive repair is still "an enemy performing a repair" (Ruiner's Bomb) and reaction-healers
+     *  repair almost exclusively through this event. That subscription is safe specifically because
+     *  no on-enemy-repaired rider heals, so it cannot re-enter this emit — any NEW subscriber must
+     *  re-establish that argument for itself rather than assume this event is inert. */
     | ({
           type: 'reactive-heal-performed';
           casterId: string;
@@ -216,6 +230,13 @@ export type CombatEvent =
           casterId: string;
           round: number;
           perTarget: { targetId: string; count: number }[];
+          /** Present ONLY for a duration-SHRINK reaction (Heliodor/Pestilence/Warpstrike's
+           *  "reduces the duration of all active Debuffs … by 1 turn"). Absent → the default
+           *  `remove` mode, where `count` is debuffs actually removed. When present, `count` is
+           *  instead the number of debuffs whose duration was SHRUNK, and `durationTurns` is by
+           *  how much — the log renders the two differently ("cleansed 2" vs "-1 turn on 2"). */
+          mode?: 'reduce-duration';
+          durationTurns?: number;
       } & ReactiveStamp)
     /** A cleanse cast resolved. `casterId` is the cleansing actor; `count` is the number of
      *  debuffs ACTUALLY removed. Team-symmetric (the enemy-cleanse-lift, #166-era): BOTH the

--- a/src/utils/combat/log/__tests__/buildCombatLog.test.ts
+++ b/src/utils/combat/log/__tests__/buildCombatLog.test.ts
@@ -2129,3 +2129,129 @@ describe('buildCombatLog — stats-snapshot (Task 6c)', () => {
         expect(all.some((e) => e.kind === 'cheat-death')).toBe(false);
     });
 });
+
+/**
+ * Turn-entry display order — USER-REPORTED: the attack line printed LAST, under its own
+ * consequences, because a positional cast's `ability-performed` is deliberately deferred until
+ * after the per-victim apply (so it can report the true per-victim crit outcome):
+ *
+ *     Butcher: charge 0→1
+ *     Butcher → Enemy Heliodor: Inferno II resisted
+ *     Enemy Heliodor: destroyed by Butcher          <- killed by an attack not yet printed
+ *     Butcher [active] → Enemy Heliodor: 64,450 (crit)
+ *     Butcher: Attack Up III expired
+ *
+ * The builder does no sorting of its own — entry order WAS emission order — so this is corrected
+ * at the presentation layer: what the skill did, then charge, then consequences. The engine's
+ * emission order is untouched (reaction nesting and the reflect-log flush depend on it).
+ */
+describe('buildCombatLog — turn entry display order', () => {
+    it('orders a turn skill-effects -> charge -> consequences, whatever the emission order', () => {
+        // Emitted in the exact order the engine produces for a positional killing blow.
+        const events: CombatEvent[] = [
+            ev({ type: 'round-started', round: 1 }),
+            ev({ type: 'turn-started', actorId: 'A', round: 1 }),
+            ev({
+                type: 'charge-changed',
+                actorId: 'A',
+                round: 1,
+                oldCharge: 0,
+                newCharge: 1,
+                reason: 'gen',
+            }),
+            ev({
+                type: 'debuff-resisted',
+                sourceId: 'A',
+                targetId: 'B',
+                round: 1,
+                buffName: 'Inferno II',
+            }),
+            ev({ type: 'ship-destroyed', actorId: 'B', round: 1, killerId: 'A' }),
+            ev({
+                type: 'ability-performed',
+                actorId: 'A',
+                targetId: 'B',
+                round: 1,
+                abilityType: 'damage',
+                damage: 64450,
+                didCrit: true,
+                critHits: 1,
+                didHit: true,
+            }),
+            ev({
+                type: 'attacked',
+                attackerId: 'A',
+                targetId: 'B',
+                round: 1,
+                damage: 64450,
+                didCrit: true,
+                isPrimaryTarget: true,
+            }),
+            ev({ type: 'buff-expired', actorId: 'A', round: 1, buffName: 'Attack Up III' }),
+            ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
+            ev({ type: 'round-ended', round: 1 }),
+        ];
+
+        const turn = buildCombatLog(events, roster, initialCharge)[0].turns[0];
+        expect(turn.entries.map((e) => e.kind)).toEqual([
+            'attack', // what the skill did
+            'charge-changed', // charge bookkeeping
+            'debuff-resisted', // consequences, in emission order among themselves
+            'death',
+            'buff-expired',
+        ]);
+    });
+
+    it('keeps reactions nested under their trigger when that trigger is reordered', () => {
+        const events: CombatEvent[] = [
+            ev({ type: 'round-started', round: 1 }),
+            ev({ type: 'turn-started', actorId: 'A', round: 1 }),
+            ev({
+                type: 'charge-changed',
+                actorId: 'A',
+                round: 1,
+                oldCharge: 0,
+                newCharge: 1,
+                reason: 'gen',
+            }),
+            ev({
+                type: 'ability-performed',
+                actorId: 'A',
+                targetId: 'B',
+                round: 1,
+                abilityType: 'damage',
+                damage: 1000,
+                didCrit: true,
+                critHits: 1,
+                didHit: true,
+            }),
+            ev({
+                type: 'attacked',
+                attackerId: 'A',
+                targetId: 'B',
+                round: 1,
+                damage: 1000,
+                didCrit: true,
+                isPrimaryTarget: true,
+            }),
+            // A reaction to that attack, stamped into A's turn.
+            ev({
+                type: 'reactive-damage-performed',
+                sourceId: 'B',
+                targetId: 'A',
+                round: 1,
+                amount: 620,
+                reactive: true,
+                duringTurnOf: 'A',
+            }),
+            ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
+            ev({ type: 'round-ended', round: 1 }),
+        ];
+
+        const turn = buildCombatLog(events, roster, initialCharge)[0].turns[0];
+        // The attack hoists above the charge row, carrying its reaction with it — the reaction is
+        // never promoted to a top-level entry by the sort.
+        expect(turn.entries.map((e) => e.kind)).toEqual(['attack', 'charge-changed']);
+        expect(turn.entries[0].reactions.map((r) => r.actorId)).toEqual(['B']);
+    });
+});

--- a/src/utils/combat/log/buildCombatLog.ts
+++ b/src/utils/combat/log/buildCombatLog.ts
@@ -1,7 +1,13 @@
 import { CombatEvent, CombatEventType } from '../events';
 import { dotTierNumeral } from '../debuffImmunity';
 import type { DoTType } from '../../../types/calculator';
-import { CombatLogEntry, CombatLogRound, CombatLogTarget, CombatLogTurn } from './types';
+import {
+    CombatLogEntry,
+    CombatLogEntryKind,
+    CombatLogRound,
+    CombatLogTarget,
+    CombatLogTurn,
+} from './types';
 
 /** Combat-log note for a DoT apply/tick line: "{dotType} {numeral} ×{stacks}" (numeral omitted
  *  for bomb/generic and non-canonical magnitudes). e.g. ('corrosion', 9, 3) → "corrosion III ×3";
@@ -9,6 +15,58 @@ import { CombatLogEntry, CombatLogRound, CombatLogTarget, CombatLogTurn } from '
 const dotNote = (dotType: DoTType, tier: number | undefined, stacks: number): string => {
     const numeral = tier === undefined ? '' : dotTierNumeral(dotType, tier);
     return `${dotType}${numeral ? ` ${numeral}` : ''} ×${stacks}`;
+};
+
+/**
+ * Display rank for a turn's top-level entries — what the SKILL did, then the charge bookkeeping,
+ * then everything that FOLLOWED from the skill.
+ *
+ * Why a display sort rather than reordering the engine's emissions: the log renders events in
+ * emission order, and for a POSITIONAL cast the engine deliberately defers its one aggregate
+ * `ability-performed` until AFTER the per-victim apply (engine.ts `emitDeferredAbilityPerformed`),
+ * so it can report the TRUE per-victim crit outcome instead of the anchor-only guess. That is why
+ * the attack line landed last, under its own consequences:
+ *
+ *     Butcher: charge 0→1
+ *     Butcher → Enemy Heliodor: Inferno II resisted
+ *     Enemy Heliodor: destroyed by Butcher          <- killed by an attack not yet printed
+ *     Butcher [active] → Enemy Heliodor: 64,450     <- the attack
+ *
+ * The emission order is load-bearing (reaction nesting keys off the most-recent non-reactive entry,
+ * and the reflect-log flush is sequenced against the attack entry), so it stays as-is and the
+ * ordering is corrected at the presentation layer instead.
+ *
+ * Sorting top-level entries is safe AFTER the fold: reactions already live inside their trigger's
+ * `.reactions[]` (they move with it) and `setHp` has already stamped its targets.
+ */
+const ENTRY_DISPLAY_RANK: Record<CombatLogEntryKind, number> = {
+    // 0 — what the skill did.
+    attack: 0,
+    heal: 0,
+    shield: 0,
+    buff: 0,
+    debuff: 0,
+    'dot-applied': 0,
+    control: 0,
+    cleanse: 0,
+    purge: 0,
+    bomb: 0,
+    // 1 — charge bookkeeping for the turn.
+    'charge-changed': 1,
+    // 2 — consequences: what the skill (or the round) caused.
+    'debuff-resisted': 2,
+    detonation: 2,
+    'dot-ticked': 2,
+    death: 2,
+    'shield-destroyed': 2,
+    'cheat-death': 2,
+    'buff-expired': 2,
+};
+
+/** Stable rank sort of one turn's top-level entries. Stable, so entries sharing a rank keep their
+ *  emission order (an unknown kind ranks 0 and stays where it was relative to other skill rows). */
+const sortTurnEntries = (entries: CombatLogEntry[]): void => {
+    entries.sort((a, b) => (ENTRY_DISPLAY_RANK[a.kind] ?? 0) - (ENTRY_DISPLAY_RANK[b.kind] ?? 0));
 };
 
 export interface RosterEntry {
@@ -549,7 +607,12 @@ const handlers: Partial<{ [K in CombatEventType]: Handler<K> }> = {
             actorId: e.casterId,
             targets: e.perTarget.map((pt) => ({ targetId: pt.targetId })),
             reactions: [],
-            note: `cleansed ${total}`,
+            // A duration SHRINK is not a removal — say so, or the reader counts debuffs that are
+            // still on the ship as gone. `count` means "debuffs shrunk" in that mode.
+            note:
+                e.mode === 'reduce-duration'
+                    ? `-${e.durationTurns ?? 1} turn on ${total} debuff${total === 1 ? '' : 's'}`
+                    : `cleansed ${total}`,
         };
         ctx.attachEntry(entry);
     },
@@ -721,6 +784,14 @@ export function buildCombatLog(
 
         // Clear the stamp so it never bleeds into the next event.
         ctx.currentStamp = undefined;
+    }
+
+    // Presentation pass — see ENTRY_DISPLAY_RANK. Runs once at the END rather than at each
+    // turn boundary because a reaction stamped `duringTurnOf` can still be appended to an
+    // already-closed turn (routeReaction's no-trigger fallback), so a turn is only truly
+    // complete when the whole stream has been folded.
+    for (const round of ctx.rounds) {
+        for (const turn of round.turns) sortTurnEntries(turn.entries);
     }
 
     return ctx.rounds;

--- a/src/utils/combat/positionalApply.ts
+++ b/src/utils/combat/positionalApply.ts
@@ -100,7 +100,11 @@ export function footprintVictims(
  * Task 8); this file imports no engine state.
  *
  * @returns `anyCrit` — true if at least one (hit, victim) pair critted this call;
- *          `critPairs` — the count of critting (hit, victim) pairs.
+ *          `critPairs` — the count of critting (hit, victim) pairs;
+ *          `critVictimIds` — the DISTINCT victims that took at least one critting hit, in
+ *          first-crit order. Carries the per-victim crit IDENTITY that `critPairs` (a bare
+ *          count) throws away, so an `on-ally-crit` reactive can route "that enemy" to the
+ *          enemies actually crit rather than the cast's selected anchor.
  */
 export function applyPositionalDamage(args: {
     hitCrits: boolean[];
@@ -156,7 +160,7 @@ export function applyPositionalDamage(args: {
      * Unsupplied → every victim uses hitCrits[h] → byte-identical.
      */
     rollVictimCrit?: (victim: CombatActor) => boolean;
-}): { anyCrit: boolean; critPairs: number } {
+}): { anyCrit: boolean; critPairs: number; critVictimIds: string[] } {
     const {
         hitCrits,
         scalars,
@@ -177,6 +181,9 @@ export function applyPositionalDamage(args: {
 
     let anyCrit = false;
     let critPairs = 0;
+    // Insertion-ordered DISTINCT crit victims. A multi-hit cast that crits the same victim twice
+    // lists it once — "deals X to that enemy" is per ENEMY, not per critting (hit, victim) pair.
+    const critVictims = new Set<string>();
 
     // Canonical hit count: derive the loop count from `scalars.hits` (the single source of
     // truth that victimHitDamage also reads), avoiding silent under/over-application from a
@@ -209,6 +216,7 @@ export function applyPositionalDamage(args: {
             if (didCrit) {
                 anyCrit = true;
                 critPairs += 1;
+                critVictims.add(victim.id);
             }
             const equipReductionPct = incomingReductionFor?.(victim, didCrit) ?? 0;
             const dmgBase = victimHitDamage(
@@ -227,5 +235,5 @@ export function applyPositionalDamage(args: {
             onVictimResolved?.(victim, dmg, outcome, didCrit);
         }
     }
-    return { anyCrit, critPairs };
+    return { anyCrit, critPairs, critVictimIds: [...critVictims] };
 }

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -162,6 +162,13 @@ export interface Intent {
          *  which fans out to EACH of these instead of routing to the repairer. Mirrors
          *  repairedAllyIds/shieldRecipientIds but for the OPPOSING side. */
         repairedEnemyIds?: string[];
+        /** The DISTINCT enemies an ally's crit-ing attack actually critically hit
+         *  (ability-performed.critVictimIds), stamped by the on-ally-crit listener. Read by the
+         *  reactive `damage` branch so a "deals X% damage to that enemy" rider (Sentinel) fans out
+         *  to EVERY enemy the ally crit rather than routing the whole proc onto the cast's
+         *  SELECTED anchor — which, in an AoE, is frequently a victim that never crit. Mirrors
+         *  repairedEnemyIds' fan-out shape. Never empty when present. */
+        critVictimIds?: string[];
         /** The clipped overheal (heal-performed.overheal) carried from an own-repair-to-ally
          *  event, read by an `overheal`-basis reactive shield to scale off the over-repaired
          *  amount rather than the owner's max HP (Abundant Renewal). Aggregate fallback used when
@@ -620,39 +627,43 @@ export function registerReactiveListeners(args: {
                     break;
                 case 'on-ally-crit':
                     bus.on('ability-performed', (e) => {
-                        // An ALLY's critting hits (mirrors on-crit with ally scoping):
-                        // fires once PER CRITTING HIT, own casts and every opposing actor
-                        // excluded — an opposing crit is NOT an ally crit, even though a
-                        // walked enemy now emits ability-performed.
+                        // An ALLY's critting attack (mirrors on-crit with ally scoping): own casts
+                        // and every opposing actor excluded — an opposing crit is NOT an ally crit,
+                        // even though a walked enemy now emits ability-performed.
                         if (!isSameSideAlly(e.actorId, ownerId)) return;
-                        // Charge gain is once PER ATTACK that crits (Hermes: "gains 1 charge"
-                        // per ally-crit event) — a multi-hit or AoE crit grants a single charge,
-                        // not one per critting (hit, victim) pair. Every other on-ally-crit rider
-                        // (Sentinel's reactive damage/heal, Howler's cleanse/Blast) stays
-                        // per-critting-hit via critHits.
-                        const n =
-                            intent.ability.config.type === 'charge'
-                                ? e.didCrit
-                                    ? 1
-                                    : 0
-                                : (e.critHits ?? (e.didCrit ? 1 : 0));
+                        // ONE enqueue per ATTACK that crit, NOT one per critting (hit, victim)
+                        // pair. The corpus clauses all read "when an ally critically hits an enemy,
+                        // this Unit <does X>" — X is a single reaction to the attack: Hermes gains
+                        // 1 charge, Howler cleanses 1 debuff from the ally, Sentinel repairs the
+                        // ally once. A 3-victim AoE that crits twice is still ONE ally crit.
+                        // (Charge was already collapsed this way by an explicit special-case; the
+                        // per-critHits loop for every other rider was the over-fire bug — Sentinel
+                        // healed Ruiner twice for one AoE.)
+                        if (!e.didCrit && (e.critHits ?? 0) === 0) return;
+                        // The enemies actually crit. `critVictimIds` is present only on the
+                        // POSITIONAL deferred emit; the single-target inline emit omits it, where
+                        // `targetId` IS the sole possible crit victim — hence the fallback.
+                        const critVictimIds =
+                            e.critVictimIds && e.critVictimIds.length > 0
+                                ? e.critVictimIds
+                                : [e.targetId];
                         // Stamp the crit-ing ally via damagedAllyId (Phase 3 PR-G, Howler) so an
                         // 'ally'-target reactive (cleanse/buff/heal — Sentinel's repair) lands on
                         // THAT ally, mirroring the on-ally-debuffed/on-ally-purged siblings. ALSO
-                        // stamp the crit-VICTIM enemy via counterTargetId (#2, Sentinel) so an
-                        // 'enemy'-target reactive damage hits "that enemy" (the one the ally crit)
-                        // rather than the ctx.enemy fallback. Zero-collateral for the pre-existing
-                        // riders (Hermes's charge + Everliving Regeneration buff are 'self'-target;
-                        // Howler's cleanse is 'ally'-target — none read counterTargetId).
-                        for (let i = 0; i < n; i++)
-                            enqueue({
-                                ...intent,
-                                eventCtx: {
-                                    ...intent.eventCtx,
-                                    damagedAllyId: e.actorId,
-                                    counterTargetId: e.targetId,
-                                },
-                            });
+                        // stamp the crit VICTIMS so an 'enemy'-target reactive damage hits "that
+                        // enemy" — every enemy the ally crit (Sentinel's 60% lands on each), NOT
+                        // the cast's selected anchor, which in an AoE may never have crit at all.
+                        // `counterTargetId` stays stamped (first crit victim) as the single-victim
+                        // channel every other consumer already reads.
+                        enqueue({
+                            ...intent,
+                            eventCtx: {
+                                ...intent.eventCtx,
+                                damagedAllyId: e.actorId,
+                                counterTargetId: critVictimIds[0],
+                                critVictimIds,
+                            },
+                        });
                     });
                     break;
                 case 'start-of-round':
@@ -941,28 +952,50 @@ export function registerReactiveListeners(args: {
                             });
                     });
                     break;
-                case 'on-enemy-repaired':
-                    bus.on('heal-performed', (e) => {
-                        // Opposing-scoped. Capture the repairer id so the charge branch can (a)
-                        // count repairs per source for an everyNthEvent gate and (b) target THAT
-                        // enemy. Harmless for Zosimos's self-gain intent (it ignores repairerId).
-                        // Phase 3 PR-F: ALSO stamp counterTargetId = the repairer (Ruiner's Bomb
-                        // routes here like every other "on that enemy" counter-infliction — the
-                        // debuff branch's existing `counterTargetId ?? ctx.enemy.id` fallback picks
-                        // this up for free) and repairedEnemyIds = e.targets (Amartya's "that
-                        // defender" Defense Shred fans out to every healed enemy instead).
-                        if (isOpposing(e.casterId))
-                            enqueue({
-                                ...intent,
-                                eventCtx: {
-                                    ...intent.eventCtx,
-                                    repairerId: e.casterId,
-                                    counterTargetId: e.casterId,
-                                    repairedEnemyIds: e.targets,
-                                },
-                            });
-                    });
+                case 'on-enemy-repaired': {
+                    // Opposing-scoped. Capture the repairer id so the charge branch can (a)
+                    // count repairs per source for an everyNthEvent gate and (b) target THAT
+                    // enemy. Harmless for Zosimos's self-gain intent (it ignores repairerId).
+                    // Phase 3 PR-F: ALSO stamp counterTargetId = the repairer (Ruiner's Bomb
+                    // routes here like every other "on that enemy" counter-infliction — the
+                    // debuff branch's existing `counterTargetId ?? ctx.enemy.id` fallback picks
+                    // this up for free) and repairedEnemyIds = the healed set (Amartya's "that
+                    // defender" Defense Shred fans out to every healed enemy instead).
+                    const onEnemyRepair = (casterId: string, targets: string[]) => {
+                        if (!isOpposing(casterId)) return;
+                        enqueue({
+                            ...intent,
+                            eventCtx: {
+                                ...intent.eventCtx,
+                                repairerId: casterId,
+                                counterTargetId: casterId,
+                                repairedEnemyIds: targets,
+                            },
+                        });
+                    };
+                    bus.on('heal-performed', (e) => onEnemyRepair(e.casterId, e.targets));
+                    // A REACTIVE repair is still "an enemy performing a repair" (Ruiner's Bomb).
+                    // Reactive heals deliberately emit NO `heal-performed` (chain guard — it would
+                    // re-trigger the caster's own on-repair listeners and loop), only the log-only
+                    // `reactive-heal-performed`; without this second subscription Ruiner was blind
+                    // to exactly the ships his passive is meant to punish — the reaction-healers
+                    // (Heliodor's on-damaged self-repair, Cultivator's on-ally-damaged repair),
+                    // which repair many times a round and never once via heal-performed.
+                    //
+                    // CHAIN SAFETY: this is a listener on a type documented as having none, so it
+                    // must not reopen the loop the chain guard closed. It cannot: the enqueued
+                    // intents are the on-enemy-repaired riders (Ruiner's Bomb debuff + Overload
+                    // self-buff, Zosimos's charge removal, Amartya's Defense Shred) — none of them
+                    // heal, so none can emit another reactive-heal-performed. The generic
+                    // MAX_INTENT_GENERATIONS backstop covers any future rider that could.
+                    bus.on('reactive-heal-performed', (e) =>
+                        onEnemyRepair(
+                            e.casterId,
+                            e.perTarget.map((pt) => pt.targetId)
+                        )
+                    );
                     break;
+                }
                 case 'on-enemy-dot-damage':
                     bus.on('dot-ticked', (e) => {
                         // Ship-kit W3 (Task 6, Anemone): opposing-scoped reaction to an ENEMY-side
@@ -2124,7 +2157,10 @@ const REACTIVE_STAMPED_EVENT_TYPES: ReadonlySet<CombatEventType> = new Set<Stamp
     // #2 log visibility: drain-time reactive damage/heal procs emit these LOG-ONLY events so the
     // combat log can surface them (they deliberately emit no ability-performed/heal-performed —
     // chain guard). Emitted through ctx.bus during a reactive intent → stamped duringTurnOf so
-    // they nest under the triggering turn. No combat listener subscribes → they never chain.
+    // they nest under the triggering turn. `-damage`/`-cleanse` have no combat subscriber at all;
+    // `-heal` has exactly one (on-enemy-repaired — a reactive repair is still an enemy repairing),
+    // which cannot chain because no on-enemy-repaired rider heals. See the events.ts note before
+    // adding another subscriber to any of the three.
     'reactive-damage-performed',
     'reactive-heal-performed',
     'reactive-cleanse-performed',
@@ -3038,7 +3074,7 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
         let shieldGrantedSum = 0;
         const shieldPerTarget: { targetId: string; amount: number }[] = [];
         // #2 log visibility: accumulate the reactive HEAL's per-recipient raw repair so we can emit
-        // ONE log-only reactive-heal-performed after the loop (the executor emits no heal-performed).
+        // ONE reactive-heal-performed after the loop (the executor emits no heal-performed).
         const healPerTarget: { targetId: string; amount: number }[] = [];
         let healSum = 0;
         for (const rid of recipients) {
@@ -3119,9 +3155,9 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                 perTarget: shieldPerTarget,
             });
         }
-        // #2 log visibility: a reactive HEAL emits the LOG-ONLY reactive-heal-performed (NOT
-        // heal-performed — that would re-trigger on-repair listeners). No combat listener
-        // subscribes to this type, so it can't chain; buildCombatLog surfaces it, stamped
+        // #2 log visibility: a reactive HEAL emits reactive-heal-performed (NOT heal-performed —
+        // that would re-trigger the REPAIRER'S OWN on-repair listeners and loop). Its only combat
+        // subscriber is on-enemy-repaired, whose riders never heal → still no chain. Stamped
         // duringTurnOf via ctx.bus so it nests under the triggering turn.
         if (cfg.type === 'heal' && healPerTarget.length > 0 && ctx.bus) {
             ctx.bus.emit({
@@ -3155,8 +3191,30 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                     ? ctx.statusEngine.reduceAllDebuffsDuration
                     : ctx.statusEngine.reduceNewestDebuffDuration;
             let affected = 0;
-            for (const rid of recipients) affected += reduceOne(rid, cfg.durationTurns ?? 1);
+            const reducePerTarget: { targetId: string; count: number }[] = [];
+            const durationTurns = cfg.durationTurns ?? 1;
+            for (const rid of recipients) {
+                const n = reduceOne(rid, durationTurns);
+                if (n > 0) reducePerTarget.push({ targetId: rid, count: n });
+                affected += n;
+            }
             ctx.healing?.credit(intent.ownerId, 'cleanseCount', affected);
+            // Log visibility: this branch previously emitted NOTHING, so Heliodor's "reduces the
+            // duration of all active Debuffs … by 1 turn" was invisible in the combat log even
+            // when it fired — indistinguishable from not being wired at all. Reuses the LOG-ONLY
+            // reactive-cleanse-performed (no combat listener subscribes → cannot chain), flagged
+            // `mode: 'reduce-duration'` so the renderer says "-N turn" rather than "cleansed N".
+            // Silent when nothing was shrunk (no debuffs present), matching the remove twin.
+            if (reducePerTarget.length > 0 && ctx.bus) {
+                ctx.bus.emit({
+                    type: 'reactive-cleanse-performed',
+                    casterId: intent.ownerId,
+                    round: ctx.round,
+                    perTarget: reducePerTarget,
+                    mode: 'reduce-duration',
+                    durationTurns,
+                });
+            }
             return;
         }
         // remove mode — keep the !ctx.healing return BEFORE the proc gate (gate-desync rule;
@@ -3335,9 +3393,16 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
             const anchorId = intent.eventCtx?.victimId;
             victimIds =
                 anchorId !== undefined ? (ctx.adjacentOpposingIdsFor?.(anchorId) ?? []) : [];
+        } else if (intent.eventCtx?.critVictimIds !== undefined) {
+            // Sentinel's on-ally-crit "deals 60% damage to that enemy": "that enemy" is EVERY
+            // enemy the ally critically hit, so fan out over the crit-victim set rather than
+            // taking the single counterTargetId below (which is only the FIRST of them). Checked
+            // before counterTargetId because the on-ally-crit listener stamps both — this clause
+            // is the more specific of the two and only that listener ever sets it.
+            victimIds = intent.eventCtx.critVictimIds;
         } else if (intent.eventCtx?.counterTargetId !== undefined) {
             // The trigger stamped the retaliation target (reflect/revenge, FrontLine's
-            // on-enemy-charged-cast, Sentinel's on-ally-crit, …) — route there directly.
+            // on-enemy-charged-cast, …) — route there directly.
             victimIds = [intent.eventCtx.counterTargetId];
         } else if (intent.eventCtx?.debuffVictimId !== undefined) {
             // Insidiousness (on-debuff-inflicted): route to the enemy this infliction actually


### PR DESCRIPTION
Four user-reported combat-simulator bugs, each red-verified before the fix.

## 1. Sentinel repaired twice for one AoE

`on-ally-crit` enqueued its intent `critHits` times — once per critting (hit, victim) pair — with an explicit special case collapsing only `charge` riders to one. So a two-victim crit produced two repairs.

Every rider on the trigger now enqueues **once per critting attack**. The corpus clauses all read "when an ally critically hits an enemy, this Unit `<does X>`" — one reaction to one attack. Charge already behaved this way via a hand-rolled special case; it's now the rule. Howler's cleanse/Blast collapse too (confirmed with @TheSusort).

The executor-side `oncePerAttackGuardKey` is now redundant for `on-ally-crit` but is left in place — it's still load-bearing for `on-attacked` / `on-ally-attacked`, which genuinely fan one attack into many events.

## 2. Reactive damage hit the wrong ship

The same listener stamped `counterTargetId: e.targetId` — the cast's **selected** anchor. `critHits` is a bare count, and the per-victim crit identity resolved in `positionalApply.ts` was discarded, so Sentinel's "deals 60% damage to that enemy" landed on a victim that never crit:

```
Ruiner [active]
Enemy Heliodor: 13,985 → 76%          <- selected target, did NOT crit
Enemy Hermes: 9,888 (crit)
Enemy Cultivator: 11,664 (crit)
  ↳ Sentinel heals → Ruiner: 1,152    <- twice
  ↳ Sentinel heals → Ruiner: 1,152
  ↳ Sentinel → Enemy Heliodor: 1,588  <- both on the non-critting anchor
  ↳ Sentinel → Enemy Heliodor: 1,588
```

`applyPositionalDamage` now returns `critVictimIds` (distinct victims, first-crit order), threaded through `drivePositionalApply` → `emitDeferredAbilityPerformed` onto `ability-performed`. The reactive damage executor fans out over it via a new `eventCtx.critVictimIds` branch placed before the `counterTargetId` branch.

`critVictimIds` is present **only** on the positional deferred emit; the single-target inline emit omits it, where `targetId` is the sole possible crit victim — so consumers fall back to `targetId`. Documented at the event definition.

## 3. Ruiner's Bomb was blind to reaction-healers

`on-enemy-repaired` rode `heal-performed`. A reactive repair deliberately emits none — that's the chain guard stopping a repair-reaction from re-triggering the repairer's own on-repair listeners — and emits only `reactive-heal-performed`, which nothing subscribed to. So "inflicts Bomb II on any enemy performing a repair" missed exactly the ships it targets: Heliodor's on-damaged self-repair, Cultivator's on-ally-damaged repair, which repair almost exclusively that way.

It now subscribes to both. **Chain safety:** no `on-enemy-repaired` rider heals (Bomb debuff, Overload self-buff, Zosimos charge removal, Amartya Defense Shred), so it cannot re-enter the emit; `MAX_INTENT_GENERATIONS` backstops any future one that could. That argument is recorded at the event definition so a new subscriber has to re-derive it rather than assume the event is inert. Ruiner's `oncePerRoundPerEnemy` cap is already modelled, so the Bomb doesn't fire on every reaction-heal.

## 4. Heliodor's debuff-duration shrink was invisible

The `cleanse` / `mode: 'reduce-duration'` branch emitted **no event at all** — unlike `remove` mode, which emits `reactive-cleanse-performed`. A working mechanic was indistinguishable from an unwired one. (It was firing; verified.)

It now emits the same log-only event flagged `mode: 'reduce-duration'`, rendering `-1 turn on N debuffs` rather than reusing `cleansed N`, which would read as removal — a shrink leaves the debuff on the ship.

## Log ordering

`buildCombatLog` did no sorting; entry order was raw emission order. A positional cast defers its `ability-performed` until after the per-victim apply (so it can report true per-victim crits instead of the anchor-only guess), which put the attack line *after* the death it caused:

```
Butcher: charge 0→1
Butcher → Enemy Heliodor: Inferno II resisted
Enemy Heliodor: destroyed by Butcher          <- killed by an attack not yet printed
Butcher [active] → Enemy Heliodor: 64,450 (crit)
```

Fixed at the presentation layer with a stable rank sort — skill effects → charge → consequences. Engine emission order is untouched: reaction nesting keys off the most-recent non-reactive entry, and the reflect-log flush is sequenced against the attack entry. The sort runs once at the end of the fold rather than per turn, because a reaction stamped `duringTurnOf` can still be appended to an already-closed turn via `routeReaction`'s fallback.

## Testing

- `sentinelAllyCritRouting.integration.test.ts` — the reported AoE shape, both the one-crit-victim and two-crit-victim cases.
- `reactiveRepairIsARepair.integration.test.ts` — Ruiner vs Heliodor; covers the Bomb and the shrink event.
- Ordering + reaction-nesting cases in `buildCombatLog.test.ts`.

Both new files drive the **real** production path — verbatim skill text from `docs/ship-skills.csv` through `buildShipAbilities`, run by `runCombat` — with mutation guards on the extracted ability shapes.

Forcing "anchor did not crit, covered victim did" deterministically is done by **affinity**, not by scripting draw order: the crit gate is a real random sample, so both victims would share one rate. A thermal attacker at 25 crit is at a disadvantage vs an electric anchor (cap 75, penalty 25) → rate `max(0, 25-25) = 0`, false for any RNG; vs an antimatter covered victim the matchup is neutral → rate 0.25, which a pinned `rng = 0` always passes.

Two existing tests asserted the old per-critting-hit behaviour and were rewritten to the new contract (`healing.test.ts`, `hermesOncePerAttack.integration.test.ts`).

Full suite green: 441 files / 4947 tests. Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSGWjgR1PAY61kCDSqFywz