### PR TITLE
fix(sim): Rogue's Liberty lets allies ignore Taunt and Provoke

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -17,6 +17,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat simulator: Exposed now does something. It used to be a name in the debuff list with no effect at all — it now increases the next direct hit on that ship by 100% per stack (so Amartya's 2 stacks mean +200%) and is used up by that hit. Applies to both sides, so an enemy Exposed makes your ship take the extra damage too.",
     'Combat simulator: Warden\'s "when this Unit inflicts a Debuff" reaction now applies Out. Damage Down to the enemy it just debuffed. It was landing on nothing.',
     'Combat simulator: a skill\'s clauses now resolve in the order they are written. A skill that "deals damage and inflicts Defense Down" no longer gets to benefit from its own Defense Down — the hit lands first, then the debuff. Written the other way round ("inflicts Defense Down and deals damage") it still applies first and does help that hit. This lowers the reported damage of Amartya, Bizon, Kafa, Kinetik, Larkspur, Nayra, Prospect, Valkyrie, Yuyan and Zosimos on the cast that applies the debuff; every following hit is unchanged.',
+    "Combat simulator: Rogue's Liberty now works. Chimei grants it to allies, letting them ignore Taunt and Provoke for its duration and hit the target they would normally pick. It previously had no effect. As before, it does not let them ignore Concentrate Fire.",
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/combat/__tests__/rogueLiberty.integration.test.ts
+++ b/src/utils/combat/__tests__/rogueLiberty.integration.test.ts
@@ -1,0 +1,415 @@
+/**
+ * `Rogue's Liberty` ("Ignores Taunt and Provoke.") — Chimei grants it to all allies for 2 turns.
+ * It built as a name-only buff (empty `parsedEffects`) and nothing read it, so it did nothing.
+ *
+ * `ignoresForcedTargeting` already existed and was production-wired, but only as a STATIC
+ * construction-time actor flag derived from a ship's OWN skill text (nine ships). This makes it
+ * dynamic: a timed, ally-granted buff now sets it for its duration.
+ *
+ * Positional mode only — forced targeting is a positional concept; aggregate mode has no
+ * per-target selection to override. Semantics match the static flag exactly, including that it
+ * does NOT bypass Concentrate Fire (state.ts's flag docs; positionalBinding keeps CF above Taunt).
+ *
+ * Drives production targeting through `runCombat`. A `resolvePositionalTarget` unit test would
+ * pass without the engine ever reading the buff — positionalBinding.test.ts already covers the
+ * resolver itself.
+ *
+ * BOARD GEOMETRY (board.ts: column 4 = front, nearest the enemy; `front` selection anchors on the
+ * highest occupied column of the first row in scan order). So the natural `front` anchor sits at
+ * M4 and the forcing actor sits at M1 (back) — Taunt/CF is then what drags the hit backwards.
+ *
+ * TURN ORDER / ROUND CHOICE. Every assertion reads ROUND 2, because both of the engine's
+ * forced-targeting read sites run at cast time:
+ *   - `selectTurnTarget` resolves the anchor BEFORE `runPlayerTurn` executes the cast, so a
+ *     self-buff granted on-cast within that same cast cannot be up yet for its own selection.
+ *   - the buff models an ALLY grant (Chimei buffs the team; the ally attacks on a later turn),
+ *     so "up before the holder's turn" is the faithful shape anyway.
+ * Round 1 therefore establishes the buff (and lets the opposing side raise its Taunt / lets the
+ * end-of-round Concentrate Fire applier land); round 2 is the round under test.
+ *
+ * TWO READ SITES, TWO OBSERVABLES. `perTargetDamage` is fed by the per-victim positional apply
+ * loop (`drivePositionalApply`, which re-resolves the anchor per hit) — it observes the apply-side
+ * read. The on-cast marker debuff's `debuff-applied` targetId is routed from `selectTurnTarget`'s
+ * `tgt` — it observes the selection-side read. Both are asserted so neither edit can be dropped.
+ */
+import { describe, it, expect } from 'vitest';
+import { runCombat, type CombatEngineInput } from '../engine';
+import { createEventBus, type CombatEvent } from '../events';
+import { createStatusEngine } from '../statusEngine';
+import { holdsRoguesLiberty } from '../rogueLiberty';
+import type { Ability } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+import type { SelectedGameBuff } from '../../../types/calculator';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
+
+// ---------------------------------------------------------------------------
+// Local harness (per-file scaffold, copied from transformIncomingToDot.test.ts)
+// ---------------------------------------------------------------------------
+
+const HP = 10_000_000; // large enough nothing ever dies.
+const DIRECT_HIT = 5000; // attack 5000 x 100% x 1 hit vs defence 0.
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+/** A 0-damage active so an actor takes a real turn (and fires its on-cast clauses) without
+ *  disturbing anyone's HP. */
+const noopDamage = (): Ability => ({
+    id: 'noop-dmg',
+    type: 'damage',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'damage', multiplier: 0 },
+});
+
+let basicAttackCounter = 0;
+const basicAttack = (): Ability => ({
+    id: `basic-${++basicAttackCounter}`,
+    type: 'damage',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'damage', multiplier: 100, hits: 1 },
+});
+
+const BASE_PLAYER_SIDE = (overrides: Partial<CombatEngineInput>): CombatEngineInput => ({
+    attack: 0,
+    crit: 0,
+    critDamage: 0,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [{ slot: 'active', abilities: [noopDamage()] }] },
+    enemyDefense: 0,
+    enemyHp: HP,
+    numRounds: 2,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    defence: 0,
+    hp: HP,
+    healTargetId: 'attacker',
+    ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Ability shapes
+// ---------------------------------------------------------------------------
+
+/** The buff under test, granted as an active-slot on-cast self-buff (the verified-working grant
+ *  shape in this harness). 99 turns == "up for the whole run". */
+const roguesLibertyBuff = (): Ability => ({
+    id: 'rogues-liberty',
+    type: 'buff',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: {
+        type: 'buff',
+        buffName: "Rogue's Liberty",
+        parsedEffects: {},
+        stacks: 1,
+        isStackable: false,
+        duration: 99,
+    },
+});
+
+const tauntSelfBuff = (): Ability => ({
+    id: 'taunt',
+    type: 'buff',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: {
+        type: 'buff',
+        buffName: 'Taunt',
+        parsedEffects: {},
+        stacks: 1,
+        isStackable: false,
+        duration: 99,
+    },
+});
+
+/** Concentrate Fire is a DEBUFF on the forced target, so it has to come from the opposing side.
+ *  Mirrors the Doomsayer applier cfProvokeAppliers.integration.test.ts exercises: end-of-round,
+ *  `enemy-highest-attack`, no proc gate. Landing at the end of round 1 makes it live for round 2. */
+const cfApplier = (): Ability => ({
+    id: 'cf-applier',
+    type: 'debuff',
+    target: 'enemy-highest-attack',
+    trigger: 'end-of-round',
+    conditions: [],
+    config: {
+        type: 'debuff',
+        buffName: 'Concentrate Fire',
+        parsedEffects: {},
+        stacks: 1,
+        isStackable: false,
+        application: 'apply',
+        duration: 99,
+    },
+});
+
+/** An inert on-cast debuff whose `debuff-applied` event names the actor `selectTurnTarget`
+ *  resolved — the observable for the SELECTION-side read of `ignoresForcedTargeting`.
+ *  `application: 'apply'` so it never rolls against hacking/resistance. */
+const MARKER_DEBUFF = 'Target Marker';
+
+const markerDebuff = (): Ability => ({
+    id: 'marker',
+    type: 'debuff',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: {
+        type: 'debuff',
+        buffName: MARKER_DEBUFF,
+        parsedEffects: {},
+        stacks: 1,
+        isStackable: false,
+        application: 'apply',
+        duration: 99,
+    },
+});
+
+// ---------------------------------------------------------------------------
+// Measurement
+// ---------------------------------------------------------------------------
+
+/** Damage credited to each victim in the given round. */
+function damageByTarget(input: CombatEngineInput, round: number): Record<string, number> {
+    const result = runCombat({ ...input, bus: createEventBus() });
+    return result.rounds.find((r) => r.round === round)?.perTargetDamage ?? {};
+}
+
+/** Victim ids the marker debuff landed on, in the given round. */
+function markedIn(input: CombatEngineInput, round: number): string[] {
+    const bus = createEventBus();
+    const out: string[] = [];
+    bus.on('debuff-applied', (e: Extract<CombatEvent, { type: 'debuff-applied' }>) => {
+        if (e.buffName === MARKER_DEBUFF && e.round === round) out.push(e.targetId);
+    });
+    runCombat({ ...input, bus });
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Module reader
+// ---------------------------------------------------------------------------
+
+const seedBuff = (buffName: string): SelectedGameBuff =>
+    ({
+        id: buffName,
+        buffName,
+        stacks: 1,
+        parsedEffects: {},
+        isStackable: false,
+        skillDuration: null,
+    }) as SelectedGameBuff;
+
+describe('holdsRoguesLiberty', () => {
+    it('is true when the actor carries the buff', () => {
+        const se = createStatusEngine({
+            selfBuffs: [seedBuff("Rogue's Liberty")],
+            enemyDebuffs: [],
+        });
+        se.beginRound(1);
+        expect(holdsRoguesLiberty(se, 'attacker')).toBe(true);
+    });
+
+    it('is false otherwise', () => {
+        const se = createStatusEngine({ selfBuffs: [], enemyDebuffs: [] });
+        se.beginRound(1);
+        expect(holdsRoguesLiberty(se, 'attacker')).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// PLAYER side: the focus attacker holds the buff
+// ---------------------------------------------------------------------------
+
+/** An enemy that self-casts the given abilities and never deals damage. `attack` only feeds the
+ *  `enemy-highest-attack` selector — the 0-multiplier active means it always deals 0. */
+const enemyWith = (
+    id: string,
+    position: Position,
+    abilities: Ability[],
+    attack = 0
+): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack, crit: 0, critDamage: 0, defence: 0, hp: HP, speed: 1000 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        shipSkills: { slots: [{ slot: 'active', abilities: [...abilities, noopDamage()] }] },
+    }) as EnemyAttacker;
+
+/** Focus attacker at M4, `front` selection, slowest on the board so every other actor's on-cast
+ *  self-buff is already up when it picks its target. */
+const FOCUS = (overrides: Partial<CombatEngineInput>): CombatEngineInput =>
+    BASE_PLAYER_SIDE({
+        attack: DIRECT_HIT,
+        speed: 1,
+        position: 'M4',
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        ...overrides,
+    });
+
+const TWO_ENEMIES = (backAbilities: Ability[], backAttack = 0): EnemyAttacker[] => [
+    enemyWith('front-enemy', 'M4', []),
+    enemyWith('back-enemy', 'M1', backAbilities, backAttack),
+];
+
+describe("Rogue's Liberty lets the holder ignore Taunt — player side", () => {
+    it('without the buff, the taunting back enemy soaks the hit (baseline)', () => {
+        const dmg = damageByTarget(
+            FOCUS({
+                shipSkills: { slots: [{ slot: 'active', abilities: [basicAttack()] }] },
+                enemyAttackers: TWO_ENEMIES([tauntSelfBuff()]),
+            }),
+            2
+        );
+        expect(dmg['back-enemy'] ?? 0).toBeGreaterThan(0);
+        expect(dmg['front-enemy'] ?? 0).toBe(0);
+    });
+
+    it('with the buff, normal selection wins and the taunter is bypassed', () => {
+        const dmg = damageByTarget(
+            FOCUS({
+                shipSkills: {
+                    slots: [{ slot: 'active', abilities: [roguesLibertyBuff(), basicAttack()] }],
+                },
+                enemyAttackers: TWO_ENEMIES([tauntSelfBuff()]),
+            }),
+            2
+        );
+        expect(dmg['front-enemy'] ?? 0).toBeGreaterThan(0); // pre-fix: 0
+        expect(dmg['back-enemy'] ?? 0).toBe(0); // pre-fix: > 0
+    });
+
+    it("also shifts the cast's SELECTED target, not just where the damage lands", () => {
+        // The on-cast marker debuff routes to `selectTurnTarget`'s resolved `tgt`, so this pins
+        // the selection-side read independently of the per-victim apply loop.
+        const input = (abilities: Ability[]) =>
+            FOCUS({
+                shipSkills: { slots: [{ slot: 'active', abilities }] },
+                enemyAttackers: TWO_ENEMIES([tauntSelfBuff()]),
+            });
+        expect(markedIn(input([markerDebuff(), basicAttack()]), 2)).toEqual(['back-enemy']);
+        expect(markedIn(input([roguesLibertyBuff(), markerDebuff(), basicAttack()]), 2)).toEqual([
+            'front-enemy',
+        ]);
+    });
+
+    it('does NOT bypass Concentrate Fire', () => {
+        // CF outranks both Taunt and the ignore flag (state.ts's flag docs; positionalBinding
+        // keeps CF above Taunt). The focus's own end-of-round applier marks the highest-attack
+        // enemy — the back one — so in round 2 that enemy is still forced despite the buff.
+        const dmg = damageByTarget(
+            FOCUS({
+                shipSkills: {
+                    slots: [
+                        { slot: 'active', abilities: [roguesLibertyBuff(), basicAttack()] },
+                        { slot: 'passive', abilities: [cfApplier()] },
+                    ],
+                },
+                enemyAttackers: TWO_ENEMIES([], 10),
+            }),
+            2
+        );
+        expect(dmg['back-enemy'] ?? 0).toBeGreaterThan(0);
+        expect(dmg['front-enemy'] ?? 0).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ENEMY side: the SAME buff on an enemy attacker must behave identically
+// (team symmetry — never compare damage ACROSS sides; the RNG is keyed by ownerId)
+// ---------------------------------------------------------------------------
+
+/** A positioned player team actor that self-casts the given abilities and deals no damage. */
+const teamActorWith = (id: string, position: Position, abilities: Ability[]): TeamActor =>
+    ({
+        id,
+        speed: 1000, // acts before the enemy attacker, so its Taunt is up first
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        walk: {
+            shipSkills: { slots: [{ slot: 'active', abilities: [...abilities, noopDamage()] }] },
+            stats: {
+                attack: 0,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp: HP,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    }) as TeamActor;
+
+/** The mirror setup: an ENEMY attacker at M4 with `front` selection against two positioned team
+ *  actors; the taunter sits at the back (M1). The focus attacker is left POSITIONLESS so it stays
+ *  out of the positional candidate set and cannot soak the hit. */
+const MIRROR = (enemyAbilities: Ability[]): CombatEngineInput =>
+    BASE_PLAYER_SIDE({
+        speed: 1,
+        teamActors: [
+            teamActorWith('team-front', 'M4', []),
+            teamActorWith('team-back', 'M1', [tauntSelfBuff()]),
+        ],
+        enemyAttackers: [
+            {
+                id: 'enemy-rogue',
+                stats: { attack: DIRECT_HIT, crit: 0, critDamage: 0, defence: 0, hp: HP, speed: 1 },
+                chargeCount: 0,
+                startCharged: false,
+                position: 'M4',
+                target: parsedTarget('front'),
+                pattern: basePattern(),
+                shipSkills: {
+                    slots: [{ slot: 'active', abilities: [...enemyAbilities, basicAttack()] }],
+                },
+            } as EnemyAttacker,
+        ],
+    });
+
+describe("Rogue's Liberty is team-symmetric — an ENEMY holder ignores the player team's Taunt", () => {
+    it('without the buff, the taunting back team actor soaks the hit (baseline)', () => {
+        const dmg = damageByTarget(MIRROR([]), 2);
+        expect(dmg['team-back'] ?? 0).toBeGreaterThan(0);
+        expect(dmg['team-front'] ?? 0).toBe(0);
+    });
+
+    it('with the buff, normal selection wins and the taunter is bypassed', () => {
+        const dmg = damageByTarget(MIRROR([roguesLibertyBuff()]), 2);
+        expect(dmg['team-front'] ?? 0).toBeGreaterThan(0); // pre-fix: 0
+        expect(dmg['team-back'] ?? 0).toBe(0); // pre-fix: > 0
+    });
+});

--- a/src/utils/combat/__tests__/rogueLiberty.integration.test.ts
+++ b/src/utils/combat/__tests__/rogueLiberty.integration.test.ts
@@ -70,9 +70,12 @@ const noopDamage = (): Ability => ({
     config: { type: 'damage', multiplier: 0 },
 });
 
-let basicAttackCounter = 0;
+/** A real damaging active. Fixed id is safe here: every engine map keyed by ability id is
+ *  namespaced `${ownerId}:${abilityId}` (see triggers.ts's proc/once-per-attack gates), so a
+ *  literal id shared across different actors never collides — and no test in this file ever
+ *  puts two of these on the SAME actor's ability list. Ids are never asserted in this file. */
 const basicAttack = (): Ability => ({
-    id: `basic-${++basicAttackCounter}`,
+    id: 'basic-atk',
     type: 'damage',
     target: 'enemy',
     trigger: 'on-cast',

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -475,7 +475,8 @@ export interface EnemyActorInput {
     affinityCritCap?: number;
     /** Pre-resolved crit penalty (from computeAffinityModifiers). Default 0 (neutral). */
     affinityCritPenalty?: number;
-    /** Board position of this enemy (positional plumbing — set but not yet consumed). */
+    /** Board position of this enemy. Consumed by isPositional/resolvePositionalTarget at the
+     *  enemy-turn positional target-selection and footprint-apply sites. */
     position?: Position;
     /** Attacker ignores Taunt/Provoke forced targeting (not Concentrate Fire). Populated from the
      *  ship's own skill text via buildShipAbilities/detectIgnoresForcedTargeting; ORed at the read
@@ -489,9 +490,12 @@ export interface EnemyActorInput {
     /** Attacker is immune to charge loss effects (Lev). Enemy-sourced charge removal is a
      *  no-op against actors with this flag set (Phase 0 Task 7). Optional — undefined = false. */
     chargeLossImmune?: boolean;
-    /** Pre-parsed targeting preference for this enemy (positional plumbing — set but not yet consumed). */
+    /** Pre-parsed targeting preference for this enemy. Consumed by the enemy-turn positional
+     *  target selection AND the positional apply at the enemy damage site (threaded via
+     *  enemyTargetById). */
     target?: ParsedTarget;
-    /** Pre-parsed positional pattern for this enemy (positional plumbing — set but not yet consumed by apply). */
+    /** Pre-parsed positional pattern for this enemy. Consumed by the positional apply at the
+     *  enemy damage site (origin/covered footprint expansion; threaded via enemyPatternById). */
     pattern?: ParsedPattern;
     /** Pre-parsed charged-skill pattern when it differs from active; falls back to `pattern`. */
     chargedPattern?: ParsedPattern;
@@ -500,9 +504,11 @@ export interface EnemyActorInput {
      *  charge-firing turn (mirrors `chargedPattern`'s contract). */
     chargedTarget?: ParsedTarget;
     /** RAW affinity of this enemy attacker — the SAME affinity the adapter fed to
-     *  computeAffinityModifiers to produce `affinityDamageModifier` above (positional plumbing —
-     *  set but not yet consumed by apply). Threaded onto the runtime's attackerAffinity + the
-     *  CombatActor.affinity. Absent → neutral default ('antimatter') downstream. */
+     *  computeAffinityModifiers to produce `affinityDamageModifier` above. Threaded onto the
+     *  runtime's attackerAffinity (consumed by the positional apply path via
+     *  positionalScalars.attackerAffinity → victimHitDamage's per-victim matchup recompute) +
+     *  the CombatActor.affinity (consumed wherever a victim's own affinity is read). Absent →
+     *  neutral default ('antimatter') downstream. */
     affinity?: AffinityName;
     /** Pre-fight combat-modifier baseline (sub-project F, PR F3) — squad-leader modifier
      *  channels for this enemy attacker. Absent → all folds inert (byte-identical). */
@@ -1019,12 +1025,15 @@ export type TeamActorEngineInput = TeamActorInput & {
         healModifier?: number;
         /** RAW affinity of this team actor — the SAME affinity (TeamActorInput.affinity) the
          *  adapter fed to computeAffinityModifiers to produce `affinityDamageModifier` in this
-         *  bundle, so the two never disagree. Positional plumbing — set but not yet consumed by
-         *  apply (threaded onto the runtime's attackerAffinity + the CombatActor.affinity).
-         *  Absent → neutral default ('antimatter') downstream. */
+         *  bundle, so the two never disagree. Threaded onto the runtime's attackerAffinity
+         *  (consumed by the positional apply path via positionalScalars.attackerAffinity →
+         *  victimHitDamage's per-victim matchup recompute) + the CombatActor.affinity (consumed
+         *  wherever a victim's own affinity is read). Absent → neutral default ('antimatter')
+         *  downstream. */
         affinity?: AffinityName;
     };
-    /** Board position of this team actor (positional plumbing — set but not yet consumed). */
+    /** Board position of this team actor. Consumed by isPositional/resolvePositionalTarget at
+     *  the walked-team positional target-selection and footprint-apply sites. */
     position?: Position;
     /** Attacker ignores Taunt/Provoke forced targeting (not Concentrate Fire). Populated from the
      *  ship's own skill text via buildShipAbilities/detectIgnoresForcedTargeting; ORed at the read
@@ -1165,7 +1174,8 @@ export interface CombatEngineInput {
         affinityCritCap?: number;
         /** Pre-resolved crit penalty vs the heal target. Default 0 (neutral). */
         affinityCritPenalty?: number;
-        /** Board position of this enemy attacker (positional plumbing — set but not yet consumed). */
+        /** Board position of this enemy attacker. Consumed by isPositional/resolvePositionalTarget
+         *  at the enemy-turn positional target-selection and footprint-apply sites. */
         position?: Position;
         /** Attacker ignores Taunt/Provoke forced targeting (not Concentrate Fire). Populated from the
          *  ship's own skill text via buildShipAbilities/detectIgnoresForcedTargeting; ORed at the read
@@ -1179,9 +1189,13 @@ export interface CombatEngineInput {
         /** Attacker is immune to charge loss effects (Lev). Enemy-sourced charge removal is a
          *  no-op against actors with this flag set (Phase 0 Task 7). Optional — undefined = false. */
         chargeLossImmune?: boolean;
-        /** Pre-parsed targeting preference for this enemy attacker (positional plumbing — set but not yet consumed). */
+        /** Pre-parsed targeting preference for this enemy attacker. Consumed by the enemy-turn
+         *  positional target selection AND the positional apply at the enemy damage site
+         *  (threaded via enemyTargetById). */
         target?: ParsedTarget;
-        /** Pre-parsed positional pattern for this enemy attacker (positional plumbing — set but not yet consumed by apply). */
+        /** Pre-parsed positional pattern for this enemy attacker. Consumed by the positional
+         *  apply at the enemy damage site (origin/covered footprint expansion; threaded via
+         *  enemyPatternById). */
         pattern?: ParsedPattern;
         /** Pre-parsed charged-skill pattern when it differs from active; falls back to `pattern`. */
         chargedPattern?: ParsedPattern;
@@ -1190,8 +1204,10 @@ export interface CombatEngineInput {
          *  charge-firing turn (mirrors `chargedPattern`'s contract). */
         chargedTarget?: ParsedTarget;
         /** RAW affinity of this enemy attacker — the SAME affinity the adapter fed to
-         *  computeAffinityModifiers for `affinityDamageModifier` above (positional plumbing —
-         *  set but not yet consumed by apply). Absent → neutral default ('antimatter') downstream. */
+         *  computeAffinityModifiers for `affinityDamageModifier` above. Threaded onto the
+         *  runtime's attackerAffinity, consumed by the positional apply path via
+         *  positionalScalars.attackerAffinity → victimHitDamage's per-victim matchup recompute.
+         *  Absent → neutral default ('antimatter') downstream. */
         affinity?: AffinityName;
         /** Pre-fight combat-modifier baseline (sub-project F, PR F3) — squad-leader modifier
          *  channels for this enemy attacker. Absent → all folds inert (byte-identical). */
@@ -1206,7 +1222,8 @@ export interface CombatEngineInput {
     }[];
     /** Emit-only event tap. Listeners must not read or mutate combat state. */
     bus?: CombatEventBus;
-    /** Board position of the focus attacker (positional plumbing — set but not yet consumed). */
+    /** Board position of the focus attacker. Consumed by isPositional/resolvePositionalTarget at
+     *  the focus positional target-selection and footprint-apply sites. */
     position?: Position;
     /** Attacker ignores Taunt/Provoke forced targeting (not Concentrate Fire). Populated from the
      *  ship's own skill text via buildShipAbilities/detectIgnoresForcedTargeting; ORed at the read
@@ -1233,9 +1250,11 @@ export interface CombatEngineInput {
      *  charge-firing turn (mirrors `chargedPattern`'s contract). */
     chargedTarget?: ParsedTarget;
     /** RAW affinity of the focus attacker — the SAME affinity matchup the page resolved into the
-     *  pre-resolved `affinityDamageModifier` above, so the two never disagree (positional plumbing
-     *  — set but not yet consumed by apply). Threaded onto the attacker runtime's attackerAffinity
-     *  + the CombatActor.affinity. Absent → neutral default ('antimatter') downstream. */
+     *  pre-resolved `affinityDamageModifier` above, so the two never disagree. Threaded onto the
+     *  attacker runtime's attackerAffinity (consumed by the positional apply path via
+     *  positionalScalars.attackerAffinity → victimHitDamage's per-victim matchup recompute) + the
+     *  CombatActor.affinity (consumed wherever a victim's own affinity is read). Absent → neutral
+     *  default ('antimatter') downstream. */
     affinity?: AffinityName;
     /** Pre-fight combat-modifier baseline (sub-project F, PR F3) — squad-leader modifier
      *  channels for the focus attacker. Absent → all folds inert (byte-identical). */

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -105,6 +105,7 @@ import {
 } from './triggers';
 import { adjacentAllyIds } from './adjacency';
 import { consumeExposed, exposedIncomingPct } from './exposedStatus';
+import { holdsRoguesLiberty } from './rogueLiberty';
 import { supportFootprintAllyIds } from './supportFootprint';
 import type { PreFightCombatModifiers } from './preFight/types';
 import { protectionCascade } from './protectionTransfer';
@@ -476,7 +477,9 @@ export interface EnemyActorInput {
     affinityCritPenalty?: number;
     /** Board position of this enemy (positional plumbing — set but not yet consumed). */
     position?: Position;
-    /** Attacker ignores Taunt/Provoke (positional plumbing — not yet populated by a production caller). */
+    /** Attacker ignores Taunt/Provoke forced targeting (not Concentrate Fire). Populated from the
+     *  ship's own skill text via buildShipAbilities/detectIgnoresForcedTargeting; ORed at the read
+     *  sites with the timed `Rogue's Liberty` buff (rogueLiberty.ts). */
     ignoresForcedTargeting?: boolean;
     /** W6: ship-wide stealth-targeting bypass. */
     ignoresStealth?: boolean;
@@ -1023,7 +1026,9 @@ export type TeamActorEngineInput = TeamActorInput & {
     };
     /** Board position of this team actor (positional plumbing — set but not yet consumed). */
     position?: Position;
-    /** Attacker ignores Taunt/Provoke (positional plumbing — not yet populated by a production caller). */
+    /** Attacker ignores Taunt/Provoke forced targeting (not Concentrate Fire). Populated from the
+     *  ship's own skill text via buildShipAbilities/detectIgnoresForcedTargeting; ORed at the read
+     *  sites with the timed `Rogue's Liberty` buff (rogueLiberty.ts). */
     ignoresForcedTargeting?: boolean;
     /** W6: ship-wide stealth-targeting bypass. */
     ignoresStealth?: boolean;
@@ -1162,7 +1167,9 @@ export interface CombatEngineInput {
         affinityCritPenalty?: number;
         /** Board position of this enemy attacker (positional plumbing — set but not yet consumed). */
         position?: Position;
-        /** Attacker ignores Taunt/Provoke (positional plumbing — not yet populated by a production caller). */
+        /** Attacker ignores Taunt/Provoke forced targeting (not Concentrate Fire). Populated from the
+         *  ship's own skill text via buildShipAbilities/detectIgnoresForcedTargeting; ORed at the read
+         *  sites with the timed `Rogue's Liberty` buff (rogueLiberty.ts). */
         ignoresForcedTargeting?: boolean;
         /** W6: ship-wide stealth-targeting bypass. */
         ignoresStealth?: boolean;
@@ -1201,7 +1208,9 @@ export interface CombatEngineInput {
     bus?: CombatEventBus;
     /** Board position of the focus attacker (positional plumbing — set but not yet consumed). */
     position?: Position;
-    /** Attacker ignores Taunt/Provoke (positional plumbing — not yet populated by a production caller). */
+    /** Attacker ignores Taunt/Provoke forced targeting (not Concentrate Fire). Populated from the
+     *  ship's own skill text via buildShipAbilities/detectIgnoresForcedTargeting; ORed at the read
+     *  sites with the timed `Rogue's Liberty` buff (rogueLiberty.ts). */
     ignoresForcedTargeting?: boolean;
     /** W6: ship-wide stealth-targeting bypass. */
     ignoresStealth?: boolean;
@@ -5670,7 +5679,14 @@ export function runCombat(input: CombatEngineInput): {
                           tb.opposingRoster,
                           statusLookupFor(tb.opposingRoster),
                           {
-                              ignoresForcedTargeting: a.ignoresForcedTargeting,
+                              // The static per-ship flag OR the timed, ally-granted `Rogue's
+                              // Liberty` — read live here (not baked into the actor at
+                              // construction) precisely because the buff can come and go
+                              // mid-battle. Same treatment at the positional-apply site below,
+                              // which re-resolves the anchor per hit.
+                              ignoresForcedTargeting:
+                                  a.ignoresForcedTargeting ||
+                                  holdsRoguesLiberty(statusEngine, a.id),
                               ignoresStealth: a.ignoresStealth,
                               provokedBy: provokerOf(statusEngine, a.id),
                           }
@@ -5963,7 +5979,12 @@ export function runCombat(input: CombatEngineInput): {
                 pattern: sel.pattern,
                 target: sel.target,
                 actingPosition: actor.position!,
-                ignoresForcedTargeting: actor.ignoresForcedTargeting,
+                // Static per-ship flag OR the timed `Rogue's Liberty` (see selectTurnTarget).
+                // Both reads are needed: selectTurnTarget picks the cast's `tgt`, while this loop
+                // re-resolves the anchor for every hit — a buff read at only one of them would let
+                // the two disagree about which victim the cast is actually pointed at.
+                ignoresForcedTargeting:
+                    actor.ignoresForcedTargeting || holdsRoguesLiberty(statusEngine, actor.id),
                 ignoresStealth: actor.ignoresStealth,
                 actingId: actor.id,
                 opposingLiving: tb.opposingRoster,

--- a/src/utils/combat/rogueLiberty.ts
+++ b/src/utils/combat/rogueLiberty.ts
@@ -1,0 +1,29 @@
+import type { StatusEngine } from './statusEngine';
+import { selfBuffNamesForOwners } from './triggers';
+
+/**
+ * `Rogue's Liberty` — "Ignores Taunt and Provoke." (constants/buffs.ts). Granted by Chimei's
+ * charged skill to all allies for 2 turns.
+ *
+ * NAME-KEYED: this is a targeting-rule override, not a stat, so it has no `parsedEffects`
+ * channel to ride. It ORs into the existing `CombatActor.ignoresForcedTargeting` flag at the
+ * resolver's read sites, turning a static construction-time property into a dynamic one.
+ *
+ * Scope matches the static flag exactly: actor-wide while held (most of the nine ships that
+ * carry the static flag state the clause on a specific cast, yet it is modelled actor-wide),
+ * and it does NOT bypass Concentrate Fire — see state.ts's flag docs and positionalBinding's
+ * CF-over-Taunt priority.
+ */
+export const ROGUES_LIBERTY = "Rogue's Liberty";
+
+/**
+ * True when the actor currently carries Rogue's Liberty.
+ *
+ * Reads the BROAD self-buff union (scheduled + timed + aura/accum), unlike the one-shot statuses
+ * that must be narrowed to the single channel their consume call can spend: Rogue's Liberty is a
+ * standing effect for its whole duration and is never consumed, so every channel that can hold it
+ * is a legitimate source.
+ */
+export function holdsRoguesLiberty(statusEngine: StatusEngine, actorId: string): boolean {
+    return selfBuffNamesForOwners(statusEngine, [actorId]).includes(ROGUES_LIBERTY);
+}

--- a/src/utils/combat/state.ts
+++ b/src/utils/combat/state.ts
@@ -152,7 +152,9 @@ export interface CombatActor {
     /** Board position of this actor (positional plumbing — set at construction, not yet consumed). */
     position?: Position;
     /** Attacker ignores Taunt/Provoke forced targeting (not Concentrate Fire). Positional
-     *  plumbing — set at construction, consumed by resolvePositionalTarget. */
+     *  plumbing — set at construction, consumed by resolvePositionalTarget. ORed at the
+     *  engine.ts read sites with the timed `Rogue's Liberty` buff (rogueLiberty.ts) — this
+     *  field alone is no longer the resolver's effective input. */
     ignoresForcedTargeting?: boolean;
     /** Attacker ignores the Stealth targeting filter on ALL its casts (Lodolite's "ignores
      *  Stealth effects" passive). Positional plumbing — set at construction, consumed by

--- a/src/utils/combat/state.ts
+++ b/src/utils/combat/state.ts
@@ -149,7 +149,8 @@ export interface CombatActor {
     pendingAccumulators: PendingAccumulator[];
     /** Round this actor first reached 0 HP (set once via recordDestroyed). Undefined while alive. */
     destroyedRound?: number;
-    /** Board position of this actor (positional plumbing — set at construction, not yet consumed). */
+    /** Board position of this actor — set at construction and consumed by the positional path:
+     *  `isPositional` gates on it and `resolvePositionalTarget` reads it as the acting anchor. */
     position?: Position;
     /** Attacker ignores Taunt/Provoke forced targeting (not Concentrate Fire). Positional
      *  plumbing — set at construction, consumed by resolvePositionalTarget. ORed at the


### PR DESCRIPTION
Chimei's `Rogue's Liberty` built as a name-only buff and nothing read it. `ignoresForcedTargeting` already existed but only as a static per-ship flag; this ORs the timed buff in at the resolver's two read sites (`selectTurnTarget`, which picks the cast's target, and `drivePositionalApply`, which re-resolves the anchor per hit — both are covered by an independent assertion so neither can be dropped).

Also corrects four stale `not yet populated by a production caller` comments in `engine.ts` — the flag has been production-wired since the ship-kit audit, and those comments caused this gap to be mis-triaged.

Spec: `docs/superpowers/specs/2026-08-03-name-keyed-status-tranche-1-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSGWjgR1PAY61kCDSqFywz