### PR TITLE
test(sim): real-kit behaviour fingerprints — the golden suite's first real-ship coverage

### DIFF
--- a/scripts/reportThinKitFingerprints.ts
+++ b/scripts/reportThinKitFingerprints.ts
@@ -1,0 +1,26 @@
+/**
+ * Reports which corpus ships fingerprint THIN — few distinct behaviour tokens across all three
+ * real-kit scenarios. Diagnostic only, run by hand:
+ *
+ *   npx tsx scripts/reportThinKitFingerprints.ts
+ *
+ * A thin ship is a candidate for the deferred fourth (status-seeded) scenario: its kit may be
+ * gated on enemy buffs/debuffs, which v1 does not seed. Deliberately NOT a test — it gates
+ * nothing, and the spec defers the fourth-scenario decision until these numbers exist.
+ */
+/* eslint-disable no-console */
+import { SCENARIOS, fingerprintShip, corpusNames } from '../src/utils/combat/audit/kitFingerprintScenarios';
+import { buildTraceShip } from './lib/traceShipFactory';
+
+const THIN_THRESHOLD = 3;
+
+const thin: string[] = [];
+for (const name of corpusNames()) {
+    const ship = buildTraceShip(name);
+    if (!ship) continue;
+    const fp = fingerprintShip(ship);
+    const distinct = new Set(SCENARIOS.flatMap((s) => fp[s]));
+    if (distinct.size <= THIN_THRESHOLD) thin.push(`${name}(${[...distinct].join(',')})`);
+}
+console.log(`thin ships (${thin.length} of ${corpusNames().length}):`);
+for (const line of thin) console.log(`  ${line}`);

--- a/src/utils/calculators/__tests__/__snapshots__/realKitFingerprints.test.ts.snap
+++ b/src/utils/calculators/__tests__/__snapshots__/realKitFingerprints.test.ts.snap
@@ -2,13 +2,6 @@
 
 exports[`kit fingerprints > AEGIS 1`] = `
 {
-  "hurtAllies": [
-    "buff",
-    "buff-expired",
-    "buff:active",
-    "charge-changed",
-    "shield",
-  ],
   "plain": [
     "buff",
     "buff-expired",
@@ -17,6 +10,13 @@ exports[`kit fingerprints > AEGIS 1`] = `
     "shield",
   ],
   "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "shield",
+  ],
+  "wounded": [
     "buff",
     "buff-expired",
     "buff:active",
@@ -28,16 +28,6 @@ exports[`kit fingerprints > AEGIS 1`] = `
 
 exports[`kit fingerprints > APEX 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "control:charged",
-    "debuff",
-    "debuff-resisted",
-    "shield",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -49,6 +39,16 @@ exports[`kit fingerprints > APEX 1`] = `
     "shield",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+    "shield",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -63,17 +63,17 @@ exports[`kit fingerprints > APEX 1`] = `
 
 exports[`kit fingerprints > Akula 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
     "charge-changed",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -83,12 +83,6 @@ exports[`kit fingerprints > Akula 1`] = `
 
 exports[`kit fingerprints > Amartya 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -96,6 +90,12 @@ exports[`kit fingerprints > Amartya 1`] = `
     "debuff",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -106,17 +106,6 @@ exports[`kit fingerprints > Amartya 1`] = `
 
 exports[`kit fingerprints > Anemone 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-    "dot-applied:active",
-    "dot-applied:charged",
-    "heal",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -129,6 +118,17 @@ exports[`kit fingerprints > Anemone 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+    "heal",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -144,13 +144,6 @@ exports[`kit fingerprints > Anemone 1`] = `
 
 exports[`kit fingerprints > Anjian 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -159,6 +152,13 @@ exports[`kit fingerprints > Anjian 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -170,12 +170,6 @@ exports[`kit fingerprints > Anjian 1`] = `
 
 exports[`kit fingerprints > Arum 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -183,6 +177,12 @@ exports[`kit fingerprints > Arum 1`] = `
     "debuff",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -193,13 +193,6 @@ exports[`kit fingerprints > Arum 1`] = `
 
 exports[`kit fingerprints > Asphodel 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "buff-expired",
-    "buff:active",
-    "charge-changed",
-    "debuff:charged",
-  ],
   "plain": [
     "attack",
     "buff-expired",
@@ -208,6 +201,13 @@ exports[`kit fingerprints > Asphodel 1`] = `
     "debuff:charged",
   ],
   "richEnemy": [
+    "attack",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "debuff:charged",
+  ],
+  "wounded": [
     "attack",
     "buff-expired",
     "buff:active",
@@ -219,15 +219,6 @@ exports[`kit fingerprints > Asphodel 1`] = `
 
 exports[`kit fingerprints > Asphyxiator 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "charge-changed",
-    "control",
-    "debuff-resisted",
-    "debuff:active",
-    "debuff:charged",
-    "dot-applied",
-  ],
   "plain": [
     "attack",
     "charge-changed",
@@ -238,6 +229,15 @@ exports[`kit fingerprints > Asphyxiator 1`] = `
     "dot-applied",
   ],
   "richEnemy": [
+    "attack",
+    "charge-changed",
+    "control",
+    "debuff-resisted",
+    "debuff:active",
+    "debuff:charged",
+    "dot-applied",
+  ],
+  "wounded": [
     "attack",
     "charge-changed",
     "control",
@@ -251,13 +251,6 @@ exports[`kit fingerprints > Asphyxiator 1`] = `
 
 exports[`kit fingerprints > Bayah 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -266,6 +259,13 @@ exports[`kit fingerprints > Bayah 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -277,13 +277,13 @@ exports[`kit fingerprints > Bayah 1`] = `
 
 exports[`kit fingerprints > Bedrock 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-  ],
   "plain": [
     "attack:active",
   ],
   "richEnemy": [
+    "attack:active",
+  ],
+  "wounded": [
     "attack:active",
   ],
 }
@@ -291,12 +291,6 @@ exports[`kit fingerprints > Bedrock 1`] = `
 
 exports[`kit fingerprints > Belladonna 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "charge-changed",
-    "dot-applied:active",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "charge-changed",
@@ -304,6 +298,12 @@ exports[`kit fingerprints > Belladonna 1`] = `
     "dot-applied:charged",
   ],
   "richEnemy": [
+    "attack",
+    "charge-changed",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "wounded": [
     "attack",
     "charge-changed",
     "dot-applied:active",
@@ -314,17 +314,17 @@ exports[`kit fingerprints > Belladonna 1`] = `
 
 exports[`kit fingerprints > Berserker 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
     "charge-changed",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -334,19 +334,12 @@ exports[`kit fingerprints > Berserker 1`] = `
 
 exports[`kit fingerprints > Bizon 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "control:charged",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack",
     "attack:active",
     "attack:charged",
+    "buff",
+    "buff-expired",
     "charge-changed",
     "control:charged",
     "debuff",
@@ -356,6 +349,19 @@ exports[`kit fingerprints > Bizon 1`] = `
     "attack",
     "attack:active",
     "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
     "charge-changed",
     "control:charged",
     "debuff",
@@ -366,17 +372,6 @@ exports[`kit fingerprints > Bizon 1`] = `
 
 exports[`kit fingerprints > Butcher 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "buff",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-    "dot-applied:active",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -389,6 +384,17 @@ exports[`kit fingerprints > Butcher 1`] = `
     "dot-applied:charged",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -404,12 +410,6 @@ exports[`kit fingerprints > Butcher 1`] = `
 
 exports[`kit fingerprints > Carnation 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "charge-changed",
-    "dot-applied:active",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "charge-changed",
@@ -417,6 +417,12 @@ exports[`kit fingerprints > Carnation 1`] = `
     "dot-applied:charged",
   ],
   "richEnemy": [
+    "attack",
+    "charge-changed",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "wounded": [
     "attack",
     "charge-changed",
     "dot-applied:active",
@@ -427,12 +433,6 @@ exports[`kit fingerprints > Carnation 1`] = `
 
 exports[`kit fingerprints > Centurion 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -440,6 +440,12 @@ exports[`kit fingerprints > Centurion 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -450,12 +456,6 @@ exports[`kit fingerprints > Centurion 1`] = `
 
 exports[`kit fingerprints > Chakara 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -463,6 +463,12 @@ exports[`kit fingerprints > Chakara 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -473,14 +479,6 @@ exports[`kit fingerprints > Chakara 1`] = `
 
 exports[`kit fingerprints > Chimei 1`] = `
 {
-  "hurtAllies": [
-    "buff",
-    "buff-expired",
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-    "heal",
-  ],
   "plain": [
     "buff",
     "buff-expired",
@@ -490,6 +488,14 @@ exports[`kit fingerprints > Chimei 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "wounded": [
     "buff",
     "buff-expired",
     "buff:active",
@@ -502,13 +508,6 @@ exports[`kit fingerprints > Chimei 1`] = `
 
 exports[`kit fingerprints > Chisel 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -517,6 +516,13 @@ exports[`kit fingerprints > Chisel 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -528,14 +534,6 @@ exports[`kit fingerprints > Chisel 1`] = `
 
 exports[`kit fingerprints > Cinya 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-    "heal",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -545,6 +543,14 @@ exports[`kit fingerprints > Cinya 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "heal",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -557,11 +563,6 @@ exports[`kit fingerprints > Cinya 1`] = `
 
 exports[`kit fingerprints > Cobalt 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -574,6 +575,11 @@ exports[`kit fingerprints > Cobalt 1`] = `
     "attack:charged",
     "buff",
     "buff-expired",
+    "charge-changed",
+  ],
+  "wounded": [
+    "attack:active",
+    "attack:charged",
     "charge-changed",
   ],
 }
@@ -581,14 +587,6 @@ exports[`kit fingerprints > Cobalt 1`] = `
 
 exports[`kit fingerprints > Crocus 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff-resisted",
-    "dot-applied:active",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -598,6 +596,14 @@ exports[`kit fingerprints > Crocus 1`] = `
     "dot-applied:active",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -610,12 +616,6 @@ exports[`kit fingerprints > Crocus 1`] = `
 
 exports[`kit fingerprints > Crucialis 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "buff-expired",
-    "charge-changed",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -623,6 +623,12 @@ exports[`kit fingerprints > Crucialis 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "buff-expired",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "buff-expired",
@@ -633,13 +639,13 @@ exports[`kit fingerprints > Crucialis 1`] = `
 
 exports[`kit fingerprints > Crusher 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-  ],
   "plain": [
     "attack:active",
   ],
   "richEnemy": [
+    "attack:active",
+  ],
+  "wounded": [
     "attack:active",
   ],
 }
@@ -647,14 +653,6 @@ exports[`kit fingerprints > Crusher 1`] = `
 
 exports[`kit fingerprints > Cultivator 1`] = `
 {
-  "hurtAllies": [
-    "buff",
-    "buff-expired",
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-    "heal",
-  ],
   "plain": [
     "buff",
     "buff-expired",
@@ -670,19 +668,19 @@ exports[`kit fingerprints > Cultivator 1`] = `
     "buff:charged",
     "charge-changed",
     "heal",
+  ],
+  "wounded": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
   ],
 }
 `;
 
 exports[`kit fingerprints > Curator 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -691,6 +689,13 @@ exports[`kit fingerprints > Curator 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -702,13 +707,13 @@ exports[`kit fingerprints > Curator 1`] = `
 
 exports[`kit fingerprints > Custodian 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-  ],
   "plain": [
     "attack:active",
   ],
   "richEnemy": [
+    "attack:active",
+  ],
+  "wounded": [
     "attack:active",
   ],
 }
@@ -716,16 +721,6 @@ exports[`kit fingerprints > Custodian 1`] = `
 
 exports[`kit fingerprints > Defiant 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "control:charged",
-    "debuff",
-    "debuff-resisted",
-    "shield",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -737,6 +732,16 @@ exports[`kit fingerprints > Defiant 1`] = `
     "shield",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+    "shield",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -751,16 +756,6 @@ exports[`kit fingerprints > Defiant 1`] = `
 
 exports[`kit fingerprints > Demolisher 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "bomb",
-    "charge-changed",
-    "debuff-resisted",
-    "dot-applied:active",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -772,6 +767,16 @@ exports[`kit fingerprints > Demolisher 1`] = `
     "dot-applied:charged",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "bomb",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -786,12 +791,6 @@ exports[`kit fingerprints > Demolisher 1`] = `
 
 exports[`kit fingerprints > Enforcer 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -799,6 +798,12 @@ exports[`kit fingerprints > Enforcer 1`] = `
     "debuff",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -809,13 +814,13 @@ exports[`kit fingerprints > Enforcer 1`] = `
 
 exports[`kit fingerprints > Faust 1`] = `
 {
-  "hurtAllies": [
-    "charge-changed",
-  ],
   "plain": [
     "charge-changed",
   ],
   "richEnemy": [
+    "charge-changed",
+  ],
+  "wounded": [
     "charge-changed",
   ],
 }
@@ -823,22 +828,28 @@ exports[`kit fingerprints > Faust 1`] = `
 
 exports[`kit fingerprints > Flamel 1`] = `
 {
-  "hurtAllies": [
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-    "heal",
-  ],
   "plain": [
     "buff:active",
     "buff:charged",
     "charge-changed",
+    "debuff",
+    "debuff-resisted",
     "heal",
   ],
   "richEnemy": [
     "buff:active",
     "buff:charged",
     "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "heal",
+  ],
+  "wounded": [
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
     "heal",
   ],
 }
@@ -846,13 +857,13 @@ exports[`kit fingerprints > Flamel 1`] = `
 
 exports[`kit fingerprints > Forsythia 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-  ],
   "plain": [
     "attack:active",
   ],
   "richEnemy": [
+    "attack:active",
+  ],
+  "wounded": [
     "attack:active",
   ],
 }
@@ -860,26 +871,20 @@ exports[`kit fingerprints > Forsythia 1`] = `
 
 exports[`kit fingerprints > FrontLine 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "shield:active",
-    "shield:charged",
-  ],
   "plain": [
     "attack",
-    "attack:active",
-    "attack:charged",
     "charge-changed",
     "shield:active",
     "shield:charged",
   ],
   "richEnemy": [
     "attack",
-    "attack:active",
-    "attack:charged",
+    "charge-changed",
+    "shield:active",
+    "shield:charged",
+  ],
+  "wounded": [
+    "attack",
     "charge-changed",
     "shield:active",
     "shield:charged",
@@ -889,17 +894,17 @@ exports[`kit fingerprints > FrontLine 1`] = `
 
 exports[`kit fingerprints > Gallant 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
     "charge-changed",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -909,14 +914,6 @@ exports[`kit fingerprints > Gallant 1`] = `
 
 exports[`kit fingerprints > Graphite 1`] = `
 {
-  "hurtAllies": [
-    "buff",
-    "buff-expired",
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-    "shield",
-  ],
   "plain": [
     "buff",
     "buff-expired",
@@ -926,6 +923,14 @@ exports[`kit fingerprints > Graphite 1`] = `
     "shield",
   ],
   "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "shield",
+  ],
+  "wounded": [
     "buff",
     "buff-expired",
     "buff:active",
@@ -938,13 +943,6 @@ exports[`kit fingerprints > Graphite 1`] = `
 
 exports[`kit fingerprints > Grif 1`] = `
 {
-  "hurtAllies": [
-    "buff",
-    "buff-expired",
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-  ],
   "plain": [
     "buff",
     "buff-expired",
@@ -953,6 +951,13 @@ exports[`kit fingerprints > Grif 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "buff",
     "buff-expired",
     "buff:active",
@@ -964,16 +969,6 @@ exports[`kit fingerprints > Grif 1`] = `
 
 exports[`kit fingerprints > Guardian 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:charged",
-    "buff",
-    "buff-expired",
-    "charge-changed",
-    "control:active",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack",
     "attack:charged",
@@ -985,6 +980,16 @@ exports[`kit fingerprints > Guardian 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "control:active",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack",
     "attack:charged",
     "buff",
@@ -999,13 +1004,6 @@ exports[`kit fingerprints > Guardian 1`] = `
 
 exports[`kit fingerprints > Harvester 1`] = `
 {
-  "hurtAllies": [
-    "buff",
-    "buff-expired",
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-  ],
   "plain": [
     "buff",
     "buff-expired",
@@ -1014,6 +1012,13 @@ exports[`kit fingerprints > Harvester 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "buff",
     "buff-expired",
     "buff:active",
@@ -1025,13 +1030,6 @@ exports[`kit fingerprints > Harvester 1`] = `
 
 exports[`kit fingerprints > Hayyan 1`] = `
 {
-  "hurtAllies": [
-    "buff-expired",
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-    "heal",
-  ],
   "plain": [
     "buff-expired",
     "buff:active",
@@ -1040,6 +1038,13 @@ exports[`kit fingerprints > Hayyan 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "wounded": [
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -1051,19 +1056,13 @@ exports[`kit fingerprints > Hayyan 1`] = `
 
 exports[`kit fingerprints > Heliodor 1`] = `
 {
-  "hurtAllies": [
-    "buff",
-    "buff-expired",
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-  ],
   "plain": [
     "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
     "charge-changed",
+    "heal",
   ],
   "richEnemy": [
     "buff",
@@ -1071,20 +1070,21 @@ exports[`kit fingerprints > Heliodor 1`] = `
     "buff:active",
     "buff:charged",
     "charge-changed",
+    "heal",
+  ],
+  "wounded": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
   ],
 }
 `;
 
 exports[`kit fingerprints > Hemlock 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-    "dot-applied:active",
-    "heal",
-  ],
   "plain": [
     "attack",
     "attack:charged",
@@ -1094,6 +1094,14 @@ exports[`kit fingerprints > Hemlock 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "dot-applied:active",
+    "heal",
+  ],
+  "wounded": [
     "attack",
     "attack:charged",
     "charge-changed",
@@ -1106,12 +1114,6 @@ exports[`kit fingerprints > Hemlock 1`] = `
 
 exports[`kit fingerprints > Hermes 1`] = `
 {
-  "hurtAllies": [
-    "buff",
-    "buff-expired",
-    "charge-changed",
-    "heal",
-  ],
   "plain": [
     "buff",
     "buff-expired",
@@ -1119,6 +1121,12 @@ exports[`kit fingerprints > Hermes 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "heal",
+  ],
+  "wounded": [
     "buff",
     "buff-expired",
     "charge-changed",
@@ -1129,13 +1137,6 @@ exports[`kit fingerprints > Hermes 1`] = `
 
 exports[`kit fingerprints > Howler 1`] = `
 {
-  "hurtAllies": [
-    "buff-expired",
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-    "heal",
-  ],
   "plain": [
     "buff-expired",
     "buff:active",
@@ -1144,6 +1145,13 @@ exports[`kit fingerprints > Howler 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "wounded": [
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -1155,15 +1163,6 @@ exports[`kit fingerprints > Howler 1`] = `
 
 exports[`kit fingerprints > Huanying 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "bomb",
-    "charge-changed",
-    "control:charged",
-    "debuff",
-    "dot-applied",
-    "dot-applied:active",
-  ],
   "plain": [
     "attack",
     "bomb",
@@ -1174,6 +1173,15 @@ exports[`kit fingerprints > Huanying 1`] = `
     "dot-applied:active",
   ],
   "richEnemy": [
+    "attack",
+    "bomb",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "dot-applied",
+    "dot-applied:active",
+  ],
+  "wounded": [
     "attack",
     "bomb",
     "charge-changed",
@@ -1187,15 +1195,6 @@ exports[`kit fingerprints > Huanying 1`] = `
 
 exports[`kit fingerprints > Incinerator 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff-resisted",
-    "dot-applied:active",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -1206,6 +1205,15 @@ exports[`kit fingerprints > Incinerator 1`] = `
     "dot-applied:charged",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -1219,12 +1227,6 @@ exports[`kit fingerprints > Incinerator 1`] = `
 
 exports[`kit fingerprints > IonScorp 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "buff-expired",
-    "charge-changed",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -1232,6 +1234,12 @@ exports[`kit fingerprints > IonScorp 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "buff-expired",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "buff-expired",
@@ -1242,28 +1250,34 @@ exports[`kit fingerprints > IonScorp 1`] = `
 
 exports[`kit fingerprints > Iridium 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "buff-expired",
-    "charge-changed",
-    "control:charged",
-    "debuff",
-    "heal:active",
-  ],
   "plain": [
     "attack",
+    "attack:charged",
     "buff-expired",
     "charge-changed",
     "control:charged",
     "debuff",
+    "debuff-resisted",
     "heal:active",
   ],
   "richEnemy": [
     "attack",
+    "attack:charged",
     "buff-expired",
     "charge-changed",
     "control:charged",
     "debuff",
+    "debuff-resisted",
+    "heal:active",
+  ],
+  "wounded": [
+    "attack",
+    "attack:charged",
+    "buff-expired",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
     "heal:active",
   ],
 }
@@ -1271,16 +1285,6 @@ exports[`kit fingerprints > Iridium 1`] = `
 
 exports[`kit fingerprints > Isha 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:charged",
-    "buff",
-    "buff-expired",
-    "buff:active",
-    "charge-changed",
-    "control",
-    "heal",
-  ],
   "plain": [
     "attack",
     "attack:charged",
@@ -1292,6 +1296,16 @@ exports[`kit fingerprints > Isha 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "attack",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "control",
+    "heal",
+  ],
+  "wounded": [
     "attack",
     "attack:charged",
     "buff",
@@ -1306,13 +1320,13 @@ exports[`kit fingerprints > Isha 1`] = `
 
 exports[`kit fingerprints > Jempol 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-  ],
   "plain": [
     "attack:active",
   ],
   "richEnemy": [
+    "attack:active",
+  ],
+  "wounded": [
     "attack:active",
   ],
 }
@@ -1320,13 +1334,6 @@ exports[`kit fingerprints > Jempol 1`] = `
 
 exports[`kit fingerprints > Judge 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:charged",
-    "charge-changed",
-    "control:active",
-    "debuff",
-  ],
   "plain": [
     "attack",
     "attack:charged",
@@ -1335,6 +1342,13 @@ exports[`kit fingerprints > Judge 1`] = `
     "debuff",
   ],
   "richEnemy": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "control:active",
+    "debuff",
+  ],
+  "wounded": [
     "attack",
     "attack:charged",
     "charge-changed",
@@ -1346,16 +1360,6 @@ exports[`kit fingerprints > Judge 1`] = `
 
 exports[`kit fingerprints > Kafa 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "buff",
-    "buff-expired",
-    "charge-changed",
-    "control:charged",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -1365,6 +1369,14 @@ exports[`kit fingerprints > Kafa 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "charge-changed",
@@ -1377,14 +1389,6 @@ exports[`kit fingerprints > Kafa 1`] = `
 
 exports[`kit fingerprints > Kinetik 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-    "shield",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -1394,6 +1398,14 @@ exports[`kit fingerprints > Kinetik 1`] = `
     "shield",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "shield",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -1406,13 +1418,13 @@ exports[`kit fingerprints > Kinetik 1`] = `
 
 exports[`kit fingerprints > Krysa 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-  ],
   "plain": [
     "attack:active",
   ],
   "richEnemy": [
+    "attack:active",
+  ],
+  "wounded": [
     "attack:active",
   ],
 }
@@ -1420,14 +1432,6 @@ exports[`kit fingerprints > Krysa 1`] = `
 
 exports[`kit fingerprints > LUXX 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "buff-expired",
-    "buff:charged",
-    "charge-changed",
-    "shield",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -1437,6 +1441,14 @@ exports[`kit fingerprints > LUXX 1`] = `
     "shield",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "shield",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "buff-expired",
@@ -1449,11 +1461,6 @@ exports[`kit fingerprints > LUXX 1`] = `
 
 exports[`kit fingerprints > Laika 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -1465,18 +1472,16 @@ exports[`kit fingerprints > Laika 1`] = `
     "charge-changed",
     "shield",
   ],
+  "wounded": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
 }
 `;
 
 exports[`kit fingerprints > Larkspur 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -1485,6 +1490,13 @@ exports[`kit fingerprints > Larkspur 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -1496,13 +1508,6 @@ exports[`kit fingerprints > Larkspur 1`] = `
 
 exports[`kit fingerprints > Laska 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "charge-changed",
-    "control:charged",
-    "debuff",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -1511,6 +1516,13 @@ exports[`kit fingerprints > Laska 1`] = `
     "debuff",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "charge-changed",
@@ -1522,13 +1534,6 @@ exports[`kit fingerprints > Laska 1`] = `
 
 exports[`kit fingerprints > LeSabre 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -1537,6 +1542,13 @@ exports[`kit fingerprints > LeSabre 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -1548,13 +1560,6 @@ exports[`kit fingerprints > LeSabre 1`] = `
 
 exports[`kit fingerprints > Lev 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "buff-expired",
-    "buff:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -1563,6 +1568,13 @@ exports[`kit fingerprints > Lev 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "buff-expired",
@@ -1574,13 +1586,6 @@ exports[`kit fingerprints > Lev 1`] = `
 
 exports[`kit fingerprints > Liberator 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "buff-expired",
-    "buff:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -1589,6 +1594,13 @@ exports[`kit fingerprints > Liberator 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "buff-expired",
@@ -1600,22 +1612,25 @@ exports[`kit fingerprints > Liberator 1`] = `
 
 exports[`kit fingerprints > Lingshe 1`] = `
 {
-  "hurtAllies": [
-    "bomb",
-    "buff",
-    "charge-changed",
-    "dot-applied",
-  ],
   "plain": [
     "bomb",
     "buff",
     "charge-changed",
+    "debuff-resisted",
     "dot-applied",
   ],
   "richEnemy": [
     "bomb",
     "buff",
     "charge-changed",
+    "debuff-resisted",
+    "dot-applied",
+  ],
+  "wounded": [
+    "bomb",
+    "buff",
+    "charge-changed",
+    "debuff-resisted",
     "dot-applied",
   ],
 }
@@ -1623,15 +1638,6 @@ exports[`kit fingerprints > Lingshe 1`] = `
 
 exports[`kit fingerprints > Lionheart 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "buff",
-    "buff-expired",
-    "buff:active",
-    "charge-changed",
-    "control:charged",
-    "debuff",
-  ],
   "plain": [
     "attack",
     "buff",
@@ -1642,6 +1648,15 @@ exports[`kit fingerprints > Lionheart 1`] = `
     "debuff",
   ],
   "richEnemy": [
+    "attack",
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+  "wounded": [
     "attack",
     "buff",
     "buff-expired",
@@ -1655,17 +1670,17 @@ exports[`kit fingerprints > Lionheart 1`] = `
 
 exports[`kit fingerprints > Lodolite 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
     "charge-changed",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -1675,13 +1690,6 @@ exports[`kit fingerprints > Lodolite 1`] = `
 
 exports[`kit fingerprints > Los 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "buff-expired",
-    "buff:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -1690,6 +1698,13 @@ exports[`kit fingerprints > Los 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "buff-expired",
@@ -1701,14 +1716,6 @@ exports[`kit fingerprints > Los 1`] = `
 
 exports[`kit fingerprints > Madax 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "buff-expired",
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-    "control",
-  ],
   "plain": [
     "attack",
     "buff-expired",
@@ -1718,6 +1725,14 @@ exports[`kit fingerprints > Madax 1`] = `
     "control",
   ],
   "richEnemy": [
+    "attack",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "control",
+  ],
+  "wounded": [
     "attack",
     "buff-expired",
     "buff:active",
@@ -1730,15 +1745,6 @@ exports[`kit fingerprints > Madax 1`] = `
 
 exports[`kit fingerprints > Magnolia 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff-resisted",
-    "dot-applied:active",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -1749,6 +1755,15 @@ exports[`kit fingerprints > Magnolia 1`] = `
     "dot-applied:charged",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -1762,14 +1777,6 @@ exports[`kit fingerprints > Magnolia 1`] = `
 
 exports[`kit fingerprints > Makoli 1`] = `
 {
-  "hurtAllies": [
-    "buff",
-    "buff-expired",
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-    "heal",
-  ],
   "plain": [
     "buff",
     "buff-expired",
@@ -1779,6 +1786,14 @@ exports[`kit fingerprints > Makoli 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "wounded": [
     "buff",
     "buff-expired",
     "buff:active",
@@ -1791,38 +1806,32 @@ exports[`kit fingerprints > Makoli 1`] = `
 
 exports[`kit fingerprints > Malvex 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
     "charge-changed",
+    "shield-destroyed",
   ],
   "richEnemy": [
     "attack",
     "attack:active",
+    "attack:charged",
+    "buff-expired",
     "buff:charged",
     "charge-changed",
     "shield:active",
+  ],
+  "wounded": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "shield-destroyed",
   ],
 }
 `;
 
 exports[`kit fingerprints > Mangler 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "bomb",
-    "charge-changed",
-    "debuff-resisted",
-    "dot-applied:active",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -1834,6 +1843,16 @@ exports[`kit fingerprints > Mangler 1`] = `
     "dot-applied:charged",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "bomb",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -1848,12 +1867,6 @@ exports[`kit fingerprints > Mangler 1`] = `
 
 exports[`kit fingerprints > Meatshield 1`] = `
 {
-  "hurtAllies": [
-    "buff:active",
-    "charge-changed",
-    "dot-ticked",
-    "heal",
-  ],
   "plain": [
     "buff:active",
     "charge-changed",
@@ -1861,6 +1874,12 @@ exports[`kit fingerprints > Meatshield 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "buff:active",
+    "charge-changed",
+    "dot-ticked",
+    "heal",
+  ],
+  "wounded": [
     "buff:active",
     "charge-changed",
     "dot-ticked",
@@ -1871,15 +1890,6 @@ exports[`kit fingerprints > Meatshield 1`] = `
 
 exports[`kit fingerprints > Medved 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "control:charged",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -1890,6 +1900,15 @@ exports[`kit fingerprints > Medved 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -1903,14 +1922,6 @@ exports[`kit fingerprints > Medved 1`] = `
 
 exports[`kit fingerprints > Meiying 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "buff",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -1920,6 +1931,14 @@ exports[`kit fingerprints > Meiying 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "buff",
@@ -1932,13 +1951,13 @@ exports[`kit fingerprints > Meiying 1`] = `
 
 exports[`kit fingerprints > Mender 1`] = `
 {
-  "hurtAllies": [
-    "charge-changed",
-  ],
   "plain": [
     "charge-changed",
   ],
   "richEnemy": [
+    "charge-changed",
+  ],
+  "wounded": [
     "charge-changed",
   ],
 }
@@ -1946,13 +1965,6 @@ exports[`kit fingerprints > Mender 1`] = `
 
 exports[`kit fingerprints > Morao 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff-resisted",
-    "heal",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -1961,6 +1973,13 @@ exports[`kit fingerprints > Morao 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "heal",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -1972,16 +1991,6 @@ exports[`kit fingerprints > Morao 1`] = `
 
 exports[`kit fingerprints > Nayra 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "buff",
-    "buff-expired",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-    "debuff:active",
-    "debuff:charged",
-  ],
   "plain": [
     "attack",
     "buff",
@@ -1993,6 +2002,16 @@ exports[`kit fingerprints > Nayra 1`] = `
     "debuff:charged",
   ],
   "richEnemy": [
+    "attack",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "debuff:active",
+    "debuff:charged",
+  ],
+  "wounded": [
     "attack",
     "buff",
     "buff-expired",
@@ -2007,15 +2026,6 @@ exports[`kit fingerprints > Nayra 1`] = `
 
 exports[`kit fingerprints > Nemesis 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "buff-expired",
-    "buff:charged",
-    "charge-changed",
-    "debuff",
-    "shield",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -2026,6 +2036,15 @@ exports[`kit fingerprints > Nemesis 1`] = `
     "shield",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "debuff",
+    "shield",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "buff-expired",
@@ -2039,17 +2058,20 @@ exports[`kit fingerprints > Nemesis 1`] = `
 
 exports[`kit fingerprints > Nosorog 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-  ],
   "plain": [
+    "attack",
     "attack:active",
     "attack:charged",
     "charge-changed",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "wounded": [
+    "attack",
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -2059,17 +2081,17 @@ exports[`kit fingerprints > Nosorog 1`] = `
 
 exports[`kit fingerprints > Nuqtu 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
     "charge-changed",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -2079,14 +2101,8 @@ exports[`kit fingerprints > Nuqtu 1`] = `
 
 exports[`kit fingerprints > Nyxen 1`] = `
 {
-  "hurtAllies": [
-    "buff-expired",
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-    "shield",
-  ],
   "plain": [
+    "attack",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -2094,6 +2110,15 @@ exports[`kit fingerprints > Nyxen 1`] = `
     "shield",
   ],
   "richEnemy": [
+    "attack",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "shield",
+  ],
+  "wounded": [
+    "attack",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -2105,13 +2130,6 @@ exports[`kit fingerprints > Nyxen 1`] = `
 
 exports[`kit fingerprints > Obsidian 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "buff",
-    "buff-expired",
-    "charge-changed",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -2120,6 +2138,13 @@ exports[`kit fingerprints > Obsidian 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "buff",
@@ -2131,20 +2156,13 @@ exports[`kit fingerprints > Obsidian 1`] = `
 
 exports[`kit fingerprints > Oleander 1`] = `
 {
-  "hurtAllies": [
-    "buff",
-    "buff-expired",
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-    "heal",
-  ],
   "plain": [
     "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
     "charge-changed",
+    "dot-ticked",
     "heal",
   ],
   "richEnemy": [
@@ -2153,6 +2171,16 @@ exports[`kit fingerprints > Oleander 1`] = `
     "buff:active",
     "buff:charged",
     "charge-changed",
+    "dot-ticked",
+    "heal",
+  ],
+  "wounded": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "dot-ticked",
     "heal",
   ],
 }
@@ -2160,22 +2188,34 @@ exports[`kit fingerprints > Oleander 1`] = `
 
 exports[`kit fingerprints > Opal 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:charged",
-    "charge-changed",
-    "heal:active",
-  ],
   "plain": [
     "attack",
     "attack:charged",
+    "buff",
+    "buff-expired",
     "charge-changed",
+    "debuff",
+    "debuff-resisted",
     "heal:active",
   ],
   "richEnemy": [
     "attack",
     "attack:charged",
+    "buff",
+    "buff-expired",
     "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "heal:active",
+  ],
+  "wounded": [
+    "attack",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
     "heal:active",
   ],
 }
@@ -2183,17 +2223,6 @@ exports[`kit fingerprints > Opal 1`] = `
 
 exports[`kit fingerprints > Orel 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "buff-expired",
-    "buff:charged",
-    "charge-changed",
-    "control",
-    "control:active",
-    "death",
-    "debuff",
-    "dot-ticked",
-  ],
   "plain": [
     "attack",
     "buff-expired",
@@ -2205,6 +2234,16 @@ exports[`kit fingerprints > Orel 1`] = `
     "dot-ticked",
   ],
   "richEnemy": [
+    "attack",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "control",
+    "control:active",
+    "debuff",
+    "dot-ticked",
+  ],
+  "wounded": [
     "attack",
     "buff-expired",
     "buff:charged",
@@ -2219,13 +2258,6 @@ exports[`kit fingerprints > Orel 1`] = `
 
 exports[`kit fingerprints > Pallas 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:charged",
-    "buff-expired",
-    "charge-changed",
-    "heal:active",
-  ],
   "plain": [
     "attack",
     "attack:charged",
@@ -2234,6 +2266,13 @@ exports[`kit fingerprints > Pallas 1`] = `
     "heal:active",
   ],
   "richEnemy": [
+    "attack",
+    "attack:charged",
+    "buff-expired",
+    "charge-changed",
+    "heal:active",
+  ],
+  "wounded": [
     "attack",
     "attack:charged",
     "buff-expired",
@@ -2245,16 +2284,11 @@ exports[`kit fingerprints > Pallas 1`] = `
 
 exports[`kit fingerprints > Panguan 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "bomb",
-    "charge-changed",
-    "dot-applied:active",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "bomb",
+    "buff",
+    "buff-expired",
     "charge-changed",
     "dot-applied:active",
     "dot-applied:charged",
@@ -2262,6 +2296,17 @@ exports[`kit fingerprints > Panguan 1`] = `
   "richEnemy": [
     "attack",
     "bomb",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "wounded": [
+    "attack",
+    "bomb",
+    "buff",
+    "buff-expired",
     "charge-changed",
     "dot-applied:active",
     "dot-applied:charged",
@@ -2271,13 +2316,6 @@ exports[`kit fingerprints > Panguan 1`] = `
 
 exports[`kit fingerprints > Panon 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:charged",
-    "buff-expired",
-    "buff:active",
-    "charge-changed",
-  ],
   "plain": [
     "attack",
     "attack:charged",
@@ -2286,6 +2324,13 @@ exports[`kit fingerprints > Panon 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "attack",
+    "attack:charged",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack",
     "attack:charged",
     "buff-expired",
@@ -2297,13 +2342,6 @@ exports[`kit fingerprints > Panon 1`] = `
 
 exports[`kit fingerprints > Paracelsus 1`] = `
 {
-  "hurtAllies": [
-    "buff",
-    "buff-expired",
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-  ],
   "plain": [
     "buff",
     "buff-expired",
@@ -2312,6 +2350,13 @@ exports[`kit fingerprints > Paracelsus 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "buff",
     "buff-expired",
     "buff:active",
@@ -2323,27 +2368,33 @@ exports[`kit fingerprints > Paracelsus 1`] = `
 
 exports[`kit fingerprints > Pestilence 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "buff-expired",
-    "buff:charged",
-    "charge-changed",
-    "dot-applied",
-    "dot-applied:active",
-  ],
   "plain": [
     "attack",
+    "attack:active",
     "buff-expired",
     "buff:charged",
     "charge-changed",
+    "debuff-resisted",
     "dot-applied",
     "dot-applied:active",
   ],
   "richEnemy": [
     "attack",
+    "attack:active",
     "buff-expired",
     "buff:charged",
     "charge-changed",
+    "debuff-resisted",
+    "dot-applied",
+    "dot-applied:active",
+  ],
+  "wounded": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "debuff-resisted",
     "dot-applied",
     "dot-applied:active",
   ],
@@ -2352,14 +2403,6 @@ exports[`kit fingerprints > Pestilence 1`] = `
 
 exports[`kit fingerprints > Prospect 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "buff",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -2369,6 +2412,14 @@ exports[`kit fingerprints > Prospect 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "buff",
@@ -2381,13 +2432,6 @@ exports[`kit fingerprints > Prospect 1`] = `
 
 exports[`kit fingerprints > Provider 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -2396,6 +2440,13 @@ exports[`kit fingerprints > Provider 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -2407,13 +2458,13 @@ exports[`kit fingerprints > Provider 1`] = `
 
 exports[`kit fingerprints > Purifier 1`] = `
 {
-  "hurtAllies": [
-    "charge-changed",
-  ],
   "plain": [
     "charge-changed",
   ],
   "richEnemy": [
+    "charge-changed",
+  ],
+  "wounded": [
     "charge-changed",
   ],
 }
@@ -2421,12 +2472,6 @@ exports[`kit fingerprints > Purifier 1`] = `
 
 exports[`kit fingerprints > Quixilver 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:charged",
-    "charge-changed",
-    "shield:active",
-  ],
   "plain": [
     "attack",
     "attack:charged",
@@ -2434,6 +2479,12 @@ exports[`kit fingerprints > Quixilver 1`] = `
     "shield:active",
   ],
   "richEnemy": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "shield:active",
+  ],
+  "wounded": [
     "attack",
     "attack:charged",
     "charge-changed",
@@ -2444,17 +2495,6 @@ exports[`kit fingerprints > Quixilver 1`] = `
 
 exports[`kit fingerprints > Ravager 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "buff",
-    "buff-expired",
-    "charge-changed",
-    "debuff-resisted",
-    "dot-applied:active",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -2467,6 +2507,17 @@ exports[`kit fingerprints > Ravager 1`] = `
     "dot-applied:charged",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -2482,13 +2533,6 @@ exports[`kit fingerprints > Ravager 1`] = `
 
 exports[`kit fingerprints > Razi 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "charge-changed",
-    "control:charged",
-    "debuff",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -2497,6 +2541,13 @@ exports[`kit fingerprints > Razi 1`] = `
     "debuff",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "charge-changed",
@@ -2508,14 +2559,6 @@ exports[`kit fingerprints > Razi 1`] = `
 
 exports[`kit fingerprints > Redeemer 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "buff-expired",
-    "buff:charged",
-    "charge-changed",
-    "shield",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -2525,6 +2568,14 @@ exports[`kit fingerprints > Redeemer 1`] = `
     "shield",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "shield",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "buff-expired",
@@ -2537,13 +2588,13 @@ exports[`kit fingerprints > Redeemer 1`] = `
 
 exports[`kit fingerprints > Refine 1`] = `
 {
-  "hurtAllies": [
-    "charge-changed",
-  ],
   "plain": [
     "charge-changed",
   ],
   "richEnemy": [
+    "charge-changed",
+  ],
+  "wounded": [
     "charge-changed",
   ],
 }
@@ -2551,17 +2602,17 @@ exports[`kit fingerprints > Refine 1`] = `
 
 exports[`kit fingerprints > Rhodium 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
     "charge-changed",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -2571,13 +2622,6 @@ exports[`kit fingerprints > Rhodium 1`] = `
 
 exports[`kit fingerprints > Rikra 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "buff-expired",
-    "buff:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -2586,6 +2630,13 @@ exports[`kit fingerprints > Rikra 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "buff-expired",
@@ -2597,13 +2648,6 @@ exports[`kit fingerprints > Rikra 1`] = `
 
 exports[`kit fingerprints > Ripper 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -2612,6 +2656,13 @@ exports[`kit fingerprints > Ripper 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -2623,13 +2674,13 @@ exports[`kit fingerprints > Ripper 1`] = `
 
 exports[`kit fingerprints > Rookie 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-  ],
   "plain": [
     "attack:active",
   ],
   "richEnemy": [
+    "attack:active",
+  ],
+  "wounded": [
     "attack:active",
   ],
 }
@@ -2637,16 +2688,6 @@ exports[`kit fingerprints > Rookie 1`] = `
 
 exports[`kit fingerprints > Ruiner 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-    "dot-applied:active",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -2658,6 +2699,16 @@ exports[`kit fingerprints > Ruiner 1`] = `
     "dot-applied:charged",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -2672,15 +2723,6 @@ exports[`kit fingerprints > Ruiner 1`] = `
 
 exports[`kit fingerprints > Rys 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "buff-expired",
-    "buff:charged",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -2691,6 +2733,15 @@ exports[`kit fingerprints > Rys 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "buff-expired",
@@ -2704,13 +2755,6 @@ exports[`kit fingerprints > Rys 1`] = `
 
 exports[`kit fingerprints > Salvation 1`] = `
 {
-  "hurtAllies": [
-    "buff-expired",
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-    "heal",
-  ],
   "plain": [
     "buff-expired",
     "buff:active",
@@ -2719,6 +2763,13 @@ exports[`kit fingerprints > Salvation 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "wounded": [
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -2730,17 +2781,6 @@ exports[`kit fingerprints > Salvation 1`] = `
 
 exports[`kit fingerprints > Sansi 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "buff",
-    "buff-expired",
-    "buff:charged",
-    "charge-changed",
-    "control",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -2753,6 +2793,17 @@ exports[`kit fingerprints > Sansi 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "control",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "buff",
@@ -2768,17 +2819,17 @@ exports[`kit fingerprints > Sansi 1`] = `
 
 exports[`kit fingerprints > Sefuba 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
     "charge-changed",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -2788,12 +2839,6 @@ exports[`kit fingerprints > Sefuba 1`] = `
 
 exports[`kit fingerprints > Selenite 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -2801,6 +2846,12 @@ exports[`kit fingerprints > Selenite 1`] = `
     "debuff",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -2811,15 +2862,6 @@ exports[`kit fingerprints > Selenite 1`] = `
 
 exports[`kit fingerprints > Sentinel 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "buff",
-    "buff-expired",
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-    "heal",
-  ],
   "plain": [
     "attack",
     "buff",
@@ -2830,6 +2872,15 @@ exports[`kit fingerprints > Sentinel 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "attack",
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "wounded": [
     "attack",
     "buff",
     "buff-expired",
@@ -2843,15 +2894,6 @@ exports[`kit fingerprints > Sentinel 1`] = `
 
 exports[`kit fingerprints > Sha Xing 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "bomb",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-    "dot-applied:active",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "bomb",
@@ -2862,6 +2904,15 @@ exports[`kit fingerprints > Sha Xing 1`] = `
     "dot-applied:charged",
   ],
   "richEnemy": [
+    "attack",
+    "bomb",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "wounded": [
     "attack",
     "bomb",
     "charge-changed",
@@ -2875,13 +2926,6 @@ exports[`kit fingerprints > Sha Xing 1`] = `
 
 exports[`kit fingerprints > Shashou 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -2890,6 +2934,13 @@ exports[`kit fingerprints > Shashou 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -2901,13 +2952,6 @@ exports[`kit fingerprints > Shashou 1`] = `
 
 exports[`kit fingerprints > Shelter 1`] = `
 {
-  "hurtAllies": [
-    "buff-expired",
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-    "heal",
-  ],
   "plain": [
     "buff-expired",
     "buff:active",
@@ -2916,6 +2960,13 @@ exports[`kit fingerprints > Shelter 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "wounded": [
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -2927,21 +2978,30 @@ exports[`kit fingerprints > Shelter 1`] = `
 
 exports[`kit fingerprints > Shepherd 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "charge-changed",
-    "heal:active",
-    "heal:charged",
-  ],
   "plain": [
     "attack",
     "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied",
     "heal:active",
     "heal:charged",
   ],
   "richEnemy": [
     "attack",
     "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied",
+    "heal:active",
+    "heal:charged",
+  ],
+  "wounded": [
+    "attack",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied",
     "heal:active",
     "heal:charged",
   ],
@@ -2950,15 +3010,6 @@ exports[`kit fingerprints > Shepherd 1`] = `
 
 exports[`kit fingerprints > Snakeroot 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff-resisted",
-    "dot-applied:active",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -2969,6 +3020,15 @@ exports[`kit fingerprints > Snakeroot 1`] = `
     "dot-applied:charged",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -2982,15 +3042,6 @@ exports[`kit fingerprints > Snakeroot 1`] = `
 
 exports[`kit fingerprints > Snapdragon 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff-resisted",
-    "debuff:active",
-    "debuff:charged",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -3001,6 +3052,15 @@ exports[`kit fingerprints > Snapdragon 1`] = `
     "debuff:charged",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "debuff:active",
+    "debuff:charged",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -3014,17 +3074,17 @@ exports[`kit fingerprints > Snapdragon 1`] = `
 
 exports[`kit fingerprints > Sokol 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
     "charge-changed",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -3034,17 +3094,9 @@ exports[`kit fingerprints > Sokol 1`] = `
 
 exports[`kit fingerprints > Stalwart 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "buff-expired",
-    "buff:charged",
-    "charge-changed",
-    "control:active",
-    "debuff",
-  ],
   "plain": [
     "attack",
-    "buff-expired",
+    "buff",
     "buff:charged",
     "charge-changed",
     "control:active",
@@ -3052,7 +3104,15 @@ exports[`kit fingerprints > Stalwart 1`] = `
   ],
   "richEnemy": [
     "attack",
-    "buff-expired",
+    "buff",
+    "buff:charged",
+    "charge-changed",
+    "control:active",
+    "debuff",
+  ],
+  "wounded": [
+    "attack",
+    "buff",
     "buff:charged",
     "charge-changed",
     "control:active",
@@ -3063,13 +3123,6 @@ exports[`kit fingerprints > Stalwart 1`] = `
 
 exports[`kit fingerprints > Suku 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "charge-changed",
-    "control:charged",
-    "debuff",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -3078,6 +3131,13 @@ exports[`kit fingerprints > Suku 1`] = `
     "debuff",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "charge-changed",
@@ -3089,13 +3149,6 @@ exports[`kit fingerprints > Suku 1`] = `
 
 exports[`kit fingerprints > Sustainer 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "buff",
-    "buff-expired",
-    "charge-changed",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -3104,6 +3157,13 @@ exports[`kit fingerprints > Sustainer 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "buff",
@@ -3115,13 +3175,6 @@ exports[`kit fingerprints > Sustainer 1`] = `
 
 exports[`kit fingerprints > Thresh 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:charged",
-    "buff-expired",
-    "buff:active",
-    "charge-changed",
-  ],
   "plain": [
     "attack",
     "attack:charged",
@@ -3130,6 +3183,13 @@ exports[`kit fingerprints > Thresh 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "attack",
+    "attack:charged",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack",
     "attack:charged",
     "buff-expired",
@@ -3141,12 +3201,6 @@ exports[`kit fingerprints > Thresh 1`] = `
 
 exports[`kit fingerprints > Tithonus 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:charged",
-    "charge-changed",
-    "heal:active",
-  ],
   "plain": [
     "attack",
     "attack:charged",
@@ -3154,6 +3208,12 @@ exports[`kit fingerprints > Tithonus 1`] = `
     "heal:active",
   ],
   "richEnemy": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "heal:active",
+  ],
+  "wounded": [
     "attack",
     "attack:charged",
     "charge-changed",
@@ -3164,14 +3224,6 @@ exports[`kit fingerprints > Tithonus 1`] = `
 
 exports[`kit fingerprints > Torcher 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "buff",
-    "charge-changed",
-    "debuff",
-    "dot-applied:active",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "buff",
@@ -3181,6 +3233,14 @@ exports[`kit fingerprints > Torcher 1`] = `
     "dot-applied:charged",
   ],
   "richEnemy": [
+    "attack",
+    "buff",
+    "charge-changed",
+    "debuff",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "wounded": [
     "attack",
     "buff",
     "charge-changed",
@@ -3193,13 +3253,6 @@ exports[`kit fingerprints > Torcher 1`] = `
 
 exports[`kit fingerprints > Tormenter 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:charged",
-    "buff-expired",
-    "buff:active",
-    "charge-changed",
-  ],
   "plain": [
     "attack",
     "attack:charged",
@@ -3208,6 +3261,13 @@ exports[`kit fingerprints > Tormenter 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "attack",
+    "attack:charged",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack",
     "attack:charged",
     "buff-expired",
@@ -3219,13 +3279,13 @@ exports[`kit fingerprints > Tormenter 1`] = `
 
 exports[`kit fingerprints > Trydent 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-  ],
   "plain": [
     "attack:active",
   ],
   "richEnemy": [
+    "attack:active",
+  ],
+  "wounded": [
     "attack:active",
   ],
 }
@@ -3233,13 +3293,6 @@ exports[`kit fingerprints > Trydent 1`] = `
 
 exports[`kit fingerprints > Tycho 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "buff-expired",
-    "charge-changed",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -3250,6 +3303,14 @@ exports[`kit fingerprints > Tycho 1`] = `
   "richEnemy": [
     "attack:active",
     "attack:charged",
+    "buff-expired",
+    "charge-changed",
+    "debuff-resisted",
+  ],
+  "wounded": [
+    "attack:active",
+    "attack:charged",
+    "buff",
     "buff-expired",
     "charge-changed",
     "debuff-resisted",
@@ -3259,16 +3320,6 @@ exports[`kit fingerprints > Tycho 1`] = `
 
 exports[`kit fingerprints > Tygr 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "control",
-    "debuff",
-    "debuff-resisted",
-    "debuff:charged",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -3280,6 +3331,16 @@ exports[`kit fingerprints > Tygr 1`] = `
     "debuff:charged",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control",
+    "debuff",
+    "debuff-resisted",
+    "debuff:charged",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -3294,13 +3355,13 @@ exports[`kit fingerprints > Tygr 1`] = `
 
 exports[`kit fingerprints > Umayl 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-  ],
   "plain": [
     "attack:active",
   ],
   "richEnemy": [
+    "attack:active",
+  ],
+  "wounded": [
     "attack:active",
   ],
 }
@@ -3308,12 +3369,6 @@ exports[`kit fingerprints > Umayl 1`] = `
 
 exports[`kit fingerprints > Valerian 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "charge-changed",
-    "dot-applied:active",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "charge-changed",
@@ -3321,6 +3376,12 @@ exports[`kit fingerprints > Valerian 1`] = `
     "dot-applied:charged",
   ],
   "richEnemy": [
+    "attack",
+    "charge-changed",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "wounded": [
     "attack",
     "charge-changed",
     "dot-applied:active",
@@ -3331,13 +3392,6 @@ exports[`kit fingerprints > Valerian 1`] = `
 
 exports[`kit fingerprints > Valiant 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "buff-expired",
-    "buff:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -3346,6 +3400,13 @@ exports[`kit fingerprints > Valiant 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "buff-expired",
@@ -3357,15 +3418,6 @@ exports[`kit fingerprints > Valiant 1`] = `
 
 exports[`kit fingerprints > Valkyrie 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "buff",
-    "buff-expired",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -3376,6 +3428,15 @@ exports[`kit fingerprints > Valkyrie 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "buff",
@@ -3389,12 +3450,6 @@ exports[`kit fingerprints > Valkyrie 1`] = `
 
 exports[`kit fingerprints > Vanguard 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -3402,6 +3457,12 @@ exports[`kit fingerprints > Vanguard 1`] = `
     "debuff-resisted",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -3412,15 +3473,6 @@ exports[`kit fingerprints > Vanguard 1`] = `
 
 exports[`kit fingerprints > Vindicator 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:charged",
-    "charge-changed",
-    "control:active",
-    "debuff",
-    "debuff-resisted",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "attack:charged",
@@ -3431,6 +3483,15 @@ exports[`kit fingerprints > Vindicator 1`] = `
     "dot-applied:charged",
   ],
   "richEnemy": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "control:active",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:charged",
+  ],
+  "wounded": [
     "attack",
     "attack:charged",
     "charge-changed",
@@ -3444,14 +3505,6 @@ exports[`kit fingerprints > Vindicator 1`] = `
 
 exports[`kit fingerprints > Volk 1`] = `
 {
-  "hurtAllies": [
-    "buff",
-    "buff-expired",
-    "buff:active",
-    "buff:charged",
-    "charge-changed",
-    "heal",
-  ],
   "plain": [
     "buff",
     "buff-expired",
@@ -3461,6 +3514,14 @@ exports[`kit fingerprints > Volk 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "wounded": [
     "buff",
     "buff-expired",
     "buff:active",
@@ -3473,38 +3534,32 @@ exports[`kit fingerprints > Volk 1`] = `
 
 exports[`kit fingerprints > Voron 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
     "charge-changed",
     "debuff",
+    "dot-ticked",
   ],
   "richEnemy": [
     "attack:active",
     "attack:charged",
     "charge-changed",
     "debuff",
+    "dot-ticked",
+  ],
+  "wounded": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "dot-ticked",
   ],
 }
 `;
 
 exports[`kit fingerprints > Warden 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -3512,7 +3567,9 @@ exports[`kit fingerprints > Warden 1`] = `
     "charge-changed",
     "debuff",
     "debuff-resisted",
+    "dot-applied",
     "dot-applied:charged",
+    "heal",
   ],
   "richEnemy": [
     "attack",
@@ -3521,20 +3578,26 @@ exports[`kit fingerprints > Warden 1`] = `
     "charge-changed",
     "debuff",
     "debuff-resisted",
+    "dot-applied",
     "dot-applied:charged",
+    "heal",
+  ],
+  "wounded": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied",
+    "dot-applied:charged",
+    "heal",
   ],
 }
 `;
 
 exports[`kit fingerprints > Wildfire 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "charge-changed",
-    "debuff:active",
-    "debuff:charged",
-    "dot-applied",
-  ],
   "plain": [
     "attack",
     "charge-changed",
@@ -3543,6 +3606,13 @@ exports[`kit fingerprints > Wildfire 1`] = `
     "dot-applied",
   ],
   "richEnemy": [
+    "attack",
+    "charge-changed",
+    "debuff:active",
+    "debuff:charged",
+    "dot-applied",
+  ],
+  "wounded": [
     "attack",
     "charge-changed",
     "debuff:active",
@@ -3554,13 +3624,6 @@ exports[`kit fingerprints > Wildfire 1`] = `
 
 exports[`kit fingerprints > Wisteria 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "charge-changed",
-    "dot-applied",
-    "dot-applied:active",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "charge-changed",
@@ -3569,6 +3632,13 @@ exports[`kit fingerprints > Wisteria 1`] = `
     "dot-applied:charged",
   ],
   "richEnemy": [
+    "attack",
+    "charge-changed",
+    "dot-applied",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "wounded": [
     "attack",
     "charge-changed",
     "dot-applied",
@@ -3580,17 +3650,17 @@ exports[`kit fingerprints > Wisteria 1`] = `
 
 exports[`kit fingerprints > Wrecker 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
     "charge-changed",
   ],
   "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack:active",
     "attack:charged",
     "charge-changed",
@@ -3600,15 +3670,6 @@ exports[`kit fingerprints > Wrecker 1`] = `
 
 exports[`kit fingerprints > Wusheng 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "buff",
-    "buff-expired",
-    "buff:active",
-    "charge-changed",
-    "control:charged",
-    "debuff",
-  ],
   "plain": [
     "attack",
     "buff",
@@ -3619,6 +3680,15 @@ exports[`kit fingerprints > Wusheng 1`] = `
     "debuff",
   ],
   "richEnemy": [
+    "attack",
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+  "wounded": [
     "attack",
     "buff",
     "buff-expired",
@@ -3632,17 +3702,6 @@ exports[`kit fingerprints > Wusheng 1`] = `
 
 exports[`kit fingerprints > Xcellence 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "control:active",
-    "control:charged",
-    "debuff",
-    "debuff-resisted",
-    "shield",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -3655,6 +3714,17 @@ exports[`kit fingerprints > Xcellence 1`] = `
     "shield",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:active",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+    "shield",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -3670,13 +3740,13 @@ exports[`kit fingerprints > Xcellence 1`] = `
 
 exports[`kit fingerprints > Xiaodao 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-  ],
   "plain": [
     "attack:active",
   ],
   "richEnemy": [
+    "attack:active",
+  ],
+  "wounded": [
     "attack:active",
   ],
 }
@@ -3684,14 +3754,6 @@ exports[`kit fingerprints > Xiaodao 1`] = `
 
 exports[`kit fingerprints > Yarrow 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:charged",
-    "charge-changed",
-    "debuff-resisted",
-    "dot-applied:active",
-    "dot-applied:charged",
-  ],
   "plain": [
     "attack",
     "attack:charged",
@@ -3701,6 +3763,14 @@ exports[`kit fingerprints > Yarrow 1`] = `
     "dot-applied:charged",
   ],
   "richEnemy": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "wounded": [
     "attack",
     "attack:charged",
     "charge-changed",
@@ -3713,13 +3783,6 @@ exports[`kit fingerprints > Yarrow 1`] = `
 
 exports[`kit fingerprints > Yazid 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "buff-expired",
-    "buff:charged",
-    "charge-changed",
-    "heal:active",
-  ],
   "plain": [
     "attack",
     "buff-expired",
@@ -3728,6 +3791,13 @@ exports[`kit fingerprints > Yazid 1`] = `
     "heal:active",
   ],
   "richEnemy": [
+    "attack",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "heal:active",
+  ],
+  "wounded": [
     "attack",
     "buff-expired",
     "buff:charged",
@@ -3739,13 +3809,6 @@ exports[`kit fingerprints > Yazid 1`] = `
 
 exports[`kit fingerprints > Yin Jian 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "buff-expired",
-    "buff:charged",
-    "charge-changed",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -3754,6 +3817,13 @@ exports[`kit fingerprints > Yin Jian 1`] = `
     "charge-changed",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "buff-expired",
@@ -3765,14 +3835,6 @@ exports[`kit fingerprints > Yin Jian 1`] = `
 
 exports[`kit fingerprints > Yuyan 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "buff",
-    "charge-changed",
-    "control:active",
-    "control:charged",
-    "debuff",
-  ],
   "plain": [
     "attack",
     "buff",
@@ -3782,6 +3844,14 @@ exports[`kit fingerprints > Yuyan 1`] = `
     "debuff",
   ],
   "richEnemy": [
+    "attack",
+    "buff",
+    "charge-changed",
+    "control:active",
+    "control:charged",
+    "debuff",
+  ],
+  "wounded": [
     "attack",
     "buff",
     "charge-changed",
@@ -3794,15 +3864,6 @@ exports[`kit fingerprints > Yuyan 1`] = `
 
 exports[`kit fingerprints > Zeolite 1`] = `
 {
-  "hurtAllies": [
-    "attack",
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff-resisted",
-    "debuff:active",
-    "debuff:charged",
-  ],
   "plain": [
     "attack",
     "attack:active",
@@ -3813,6 +3874,15 @@ exports[`kit fingerprints > Zeolite 1`] = `
     "debuff:charged",
   ],
   "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "debuff:active",
+    "debuff:charged",
+  ],
+  "wounded": [
     "attack",
     "attack:active",
     "attack:charged",
@@ -3826,13 +3896,6 @@ exports[`kit fingerprints > Zeolite 1`] = `
 
 exports[`kit fingerprints > Zosimos 1`] = `
 {
-  "hurtAllies": [
-    "attack:active",
-    "attack:charged",
-    "charge-changed",
-    "debuff",
-    "debuff-resisted",
-  ],
   "plain": [
     "attack:active",
     "attack:charged",
@@ -3847,12 +3910,19 @@ exports[`kit fingerprints > Zosimos 1`] = `
     "debuff",
     "debuff-resisted",
   ],
+  "wounded": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
 }
 `;
 
 exports[`suite health > pins the corpus shape so a data refresh announces itself in ONE diff 1`] = `
 {
-  "digest": -1054457784,
+  "digest": -1538500136,
   "shipCount": 147,
 }
 `;

--- a/src/utils/calculators/__tests__/__snapshots__/realKitFingerprints.test.ts.snap
+++ b/src/utils/calculators/__tests__/__snapshots__/realKitFingerprints.test.ts.snap
@@ -3849,3 +3849,10 @@ exports[`kit fingerprints > Zosimos 1`] = `
   ],
 }
 `;
+
+exports[`suite health > pins the corpus shape so a data refresh announces itself in ONE diff 1`] = `
+{
+  "digest": -1054457784,
+  "shipCount": 147,
+}
+`;

--- a/src/utils/calculators/__tests__/__snapshots__/realKitFingerprints.test.ts.snap
+++ b/src/utils/calculators/__tests__/__snapshots__/realKitFingerprints.test.ts.snap
@@ -1,0 +1,3851 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`kit fingerprints > AEGIS 1`] = `
+{
+  "hurtAllies": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "shield",
+  ],
+  "plain": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "shield",
+  ],
+  "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "shield",
+  ],
+}
+`;
+
+exports[`kit fingerprints > APEX 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+    "shield",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+    "shield",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+    "shield",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Akula 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Amartya 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Anemone 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+    "heal",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+    "heal",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Anjian 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Arum 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Asphodel 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "debuff:charged",
+  ],
+  "plain": [
+    "attack",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "debuff:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "debuff:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Asphyxiator 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "charge-changed",
+    "control",
+    "debuff-resisted",
+    "debuff:active",
+    "debuff:charged",
+    "dot-applied",
+  ],
+  "plain": [
+    "attack",
+    "charge-changed",
+    "control",
+    "debuff-resisted",
+    "debuff:active",
+    "debuff:charged",
+    "dot-applied",
+  ],
+  "richEnemy": [
+    "attack",
+    "charge-changed",
+    "control",
+    "debuff-resisted",
+    "debuff:active",
+    "debuff:charged",
+    "dot-applied",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Bayah 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Bedrock 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+  ],
+  "plain": [
+    "attack:active",
+  ],
+  "richEnemy": [
+    "attack:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Belladonna 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "charge-changed",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "charge-changed",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "charge-changed",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Berserker 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Bizon 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Butcher 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Carnation 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "charge-changed",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "charge-changed",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "charge-changed",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Centurion 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Chakara 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Chimei 1`] = `
+{
+  "hurtAllies": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "plain": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Chisel 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Cinya 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "heal",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "heal",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Cobalt 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Crocus 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Crucialis 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "buff-expired",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "buff-expired",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "buff-expired",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Crusher 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+  ],
+  "plain": [
+    "attack:active",
+  ],
+  "richEnemy": [
+    "attack:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Cultivator 1`] = `
+{
+  "hurtAllies": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "plain": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Curator 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Custodian 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+  ],
+  "plain": [
+    "attack:active",
+  ],
+  "richEnemy": [
+    "attack:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Defiant 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+    "shield",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+    "shield",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+    "shield",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Demolisher 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "bomb",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "bomb",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "bomb",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Enforcer 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Faust 1`] = `
+{
+  "hurtAllies": [
+    "charge-changed",
+  ],
+  "plain": [
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Flamel 1`] = `
+{
+  "hurtAllies": [
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "plain": [
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "richEnemy": [
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Forsythia 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+  ],
+  "plain": [
+    "attack:active",
+  ],
+  "richEnemy": [
+    "attack:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > FrontLine 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "shield:active",
+    "shield:charged",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "shield:active",
+    "shield:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "shield:active",
+    "shield:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Gallant 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Graphite 1`] = `
+{
+  "hurtAllies": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "shield",
+  ],
+  "plain": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "shield",
+  ],
+  "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "shield",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Grif 1`] = `
+{
+  "hurtAllies": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Guardian 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "control:active",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "control:active",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "control:active",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Harvester 1`] = `
+{
+  "hurtAllies": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Hayyan 1`] = `
+{
+  "hurtAllies": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "plain": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "richEnemy": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Heliodor 1`] = `
+{
+  "hurtAllies": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Hemlock 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "dot-applied:active",
+    "heal",
+  ],
+  "plain": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "dot-applied:active",
+    "heal",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "dot-applied:active",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Hermes 1`] = `
+{
+  "hurtAllies": [
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "heal",
+  ],
+  "plain": [
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "heal",
+  ],
+  "richEnemy": [
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Howler 1`] = `
+{
+  "hurtAllies": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "plain": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "richEnemy": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Huanying 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "bomb",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "dot-applied",
+    "dot-applied:active",
+  ],
+  "plain": [
+    "attack",
+    "bomb",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "dot-applied",
+    "dot-applied:active",
+  ],
+  "richEnemy": [
+    "attack",
+    "bomb",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "dot-applied",
+    "dot-applied:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Incinerator 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > IonScorp 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "buff-expired",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "buff-expired",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "buff-expired",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Iridium 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "buff-expired",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "heal:active",
+  ],
+  "plain": [
+    "attack",
+    "buff-expired",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "heal:active",
+  ],
+  "richEnemy": [
+    "attack",
+    "buff-expired",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "heal:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Isha 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "control",
+    "heal",
+  ],
+  "plain": [
+    "attack",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "control",
+    "heal",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "control",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Jempol 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+  ],
+  "plain": [
+    "attack:active",
+  ],
+  "richEnemy": [
+    "attack:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Judge 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "control:active",
+    "debuff",
+  ],
+  "plain": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "control:active",
+    "debuff",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "control:active",
+    "debuff",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Kafa 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Kinetik 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "shield",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "shield",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "shield",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Krysa 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+  ],
+  "plain": [
+    "attack:active",
+  ],
+  "richEnemy": [
+    "attack:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > LUXX 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "shield",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "shield",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "shield",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Laika 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "shield",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Larkspur 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Laska 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+}
+`;
+
+exports[`kit fingerprints > LeSabre 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Lev 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Liberator 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Lingshe 1`] = `
+{
+  "hurtAllies": [
+    "bomb",
+    "buff",
+    "charge-changed",
+    "dot-applied",
+  ],
+  "plain": [
+    "bomb",
+    "buff",
+    "charge-changed",
+    "dot-applied",
+  ],
+  "richEnemy": [
+    "bomb",
+    "buff",
+    "charge-changed",
+    "dot-applied",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Lionheart 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+  "plain": [
+    "attack",
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+  "richEnemy": [
+    "attack",
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Lodolite 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Los 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Madax 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "control",
+  ],
+  "plain": [
+    "attack",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "control",
+  ],
+  "richEnemy": [
+    "attack",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "control",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Magnolia 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Makoli 1`] = `
+{
+  "hurtAllies": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "plain": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Malvex 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff:charged",
+    "charge-changed",
+    "shield:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Mangler 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "bomb",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "bomb",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "bomb",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Meatshield 1`] = `
+{
+  "hurtAllies": [
+    "buff:active",
+    "charge-changed",
+    "dot-ticked",
+    "heal",
+  ],
+  "plain": [
+    "buff:active",
+    "charge-changed",
+    "dot-ticked",
+    "heal",
+  ],
+  "richEnemy": [
+    "buff:active",
+    "charge-changed",
+    "dot-ticked",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Medved 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Meiying 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Mender 1`] = `
+{
+  "hurtAllies": [
+    "charge-changed",
+  ],
+  "plain": [
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Morao 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "heal",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "heal",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Nayra 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "debuff:active",
+    "debuff:charged",
+  ],
+  "plain": [
+    "attack",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "debuff:active",
+    "debuff:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "debuff:active",
+    "debuff:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Nemesis 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "debuff",
+    "shield",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "debuff",
+    "shield",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "debuff",
+    "shield",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Nosorog 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Nuqtu 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Nyxen 1`] = `
+{
+  "hurtAllies": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "shield",
+  ],
+  "plain": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "shield",
+  ],
+  "richEnemy": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "shield",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Obsidian 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Oleander 1`] = `
+{
+  "hurtAllies": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "plain": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Opal 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "heal:active",
+  ],
+  "plain": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "heal:active",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "heal:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Orel 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "control",
+    "control:active",
+    "death",
+    "debuff",
+    "dot-ticked",
+  ],
+  "plain": [
+    "attack",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "control",
+    "control:active",
+    "debuff",
+    "dot-ticked",
+  ],
+  "richEnemy": [
+    "attack",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "control",
+    "control:active",
+    "debuff",
+    "dot-ticked",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Pallas 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:charged",
+    "buff-expired",
+    "charge-changed",
+    "heal:active",
+  ],
+  "plain": [
+    "attack",
+    "attack:charged",
+    "buff-expired",
+    "charge-changed",
+    "heal:active",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:charged",
+    "buff-expired",
+    "charge-changed",
+    "heal:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Panguan 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "bomb",
+    "charge-changed",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "bomb",
+    "charge-changed",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "bomb",
+    "charge-changed",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Panon 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:charged",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack",
+    "attack:charged",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:charged",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Paracelsus 1`] = `
+{
+  "hurtAllies": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Pestilence 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "dot-applied",
+    "dot-applied:active",
+  ],
+  "plain": [
+    "attack",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "dot-applied",
+    "dot-applied:active",
+  ],
+  "richEnemy": [
+    "attack",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "dot-applied",
+    "dot-applied:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Prospect 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Provider 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Purifier 1`] = `
+{
+  "hurtAllies": [
+    "charge-changed",
+  ],
+  "plain": [
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Quixilver 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "shield:active",
+  ],
+  "plain": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "shield:active",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "shield:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Ravager 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Razi 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Redeemer 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "shield",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "shield",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "shield",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Refine 1`] = `
+{
+  "hurtAllies": [
+    "charge-changed",
+  ],
+  "plain": [
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Rhodium 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Rikra 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Ripper 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Rookie 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+  ],
+  "plain": [
+    "attack:active",
+  ],
+  "richEnemy": [
+    "attack:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Ruiner 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Rys 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Salvation 1`] = `
+{
+  "hurtAllies": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "plain": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "richEnemy": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Sansi 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "buff",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "control",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "buff",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "control",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "control",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Sefuba 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Selenite 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Sentinel 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "plain": [
+    "attack",
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "richEnemy": [
+    "attack",
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Sha Xing 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "bomb",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "bomb",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "bomb",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Shashou 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Shelter 1`] = `
+{
+  "hurtAllies": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "plain": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "richEnemy": [
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Shepherd 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "charge-changed",
+    "heal:active",
+    "heal:charged",
+  ],
+  "plain": [
+    "attack",
+    "charge-changed",
+    "heal:active",
+    "heal:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "charge-changed",
+    "heal:active",
+    "heal:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Snakeroot 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Snapdragon 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "debuff:active",
+    "debuff:charged",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "debuff:active",
+    "debuff:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "debuff:active",
+    "debuff:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Sokol 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Stalwart 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "control:active",
+    "debuff",
+  ],
+  "plain": [
+    "attack",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "control:active",
+    "debuff",
+  ],
+  "richEnemy": [
+    "attack",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "control:active",
+    "debuff",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Suku 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Sustainer 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Thresh 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:charged",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack",
+    "attack:charged",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:charged",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Tithonus 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "heal:active",
+  ],
+  "plain": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "heal:active",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "heal:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Torcher 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "buff",
+    "charge-changed",
+    "debuff",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "buff",
+    "charge-changed",
+    "debuff",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "buff",
+    "charge-changed",
+    "debuff",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Tormenter 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:charged",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack",
+    "attack:charged",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:charged",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Trydent 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+  ],
+  "plain": [
+    "attack:active",
+  ],
+  "richEnemy": [
+    "attack:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Tycho 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "buff-expired",
+    "charge-changed",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "buff-expired",
+    "charge-changed",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "buff-expired",
+    "charge-changed",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Tygr 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control",
+    "debuff",
+    "debuff-resisted",
+    "debuff:charged",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control",
+    "debuff",
+    "debuff-resisted",
+    "debuff:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control",
+    "debuff",
+    "debuff-resisted",
+    "debuff:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Umayl 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+  ],
+  "plain": [
+    "attack:active",
+  ],
+  "richEnemy": [
+    "attack:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Valerian 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "charge-changed",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "charge-changed",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "charge-changed",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Valiant 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Valkyrie 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "buff",
+    "buff-expired",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Vanguard 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Vindicator 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "control:active",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "control:active",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "control:active",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Volk 1`] = `
+{
+  "hurtAllies": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "plain": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+  "richEnemy": [
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Voron 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Warden 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Wildfire 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "charge-changed",
+    "debuff:active",
+    "debuff:charged",
+    "dot-applied",
+  ],
+  "plain": [
+    "attack",
+    "charge-changed",
+    "debuff:active",
+    "debuff:charged",
+    "dot-applied",
+  ],
+  "richEnemy": [
+    "attack",
+    "charge-changed",
+    "debuff:active",
+    "debuff:charged",
+    "dot-applied",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Wisteria 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "charge-changed",
+    "dot-applied",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "charge-changed",
+    "dot-applied",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "charge-changed",
+    "dot-applied",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Wrecker 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Wusheng 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+  "plain": [
+    "attack",
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+  "richEnemy": [
+    "attack",
+    "buff",
+    "buff-expired",
+    "buff:active",
+    "charge-changed",
+    "control:charged",
+    "debuff",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Xcellence 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:active",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+    "shield",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:active",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+    "shield",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "control:active",
+    "control:charged",
+    "debuff",
+    "debuff-resisted",
+    "shield",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Xiaodao 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+  ],
+  "plain": [
+    "attack:active",
+  ],
+  "richEnemy": [
+    "attack:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Yarrow 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "plain": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "dot-applied:active",
+    "dot-applied:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Yazid 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "heal:active",
+  ],
+  "plain": [
+    "attack",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "heal:active",
+  ],
+  "richEnemy": [
+    "attack",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+    "heal:active",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Yin Jian 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "buff-expired",
+    "buff:charged",
+    "charge-changed",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Yuyan 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "buff",
+    "charge-changed",
+    "control:active",
+    "control:charged",
+    "debuff",
+  ],
+  "plain": [
+    "attack",
+    "buff",
+    "charge-changed",
+    "control:active",
+    "control:charged",
+    "debuff",
+  ],
+  "richEnemy": [
+    "attack",
+    "buff",
+    "charge-changed",
+    "control:active",
+    "control:charged",
+    "debuff",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Zeolite 1`] = `
+{
+  "hurtAllies": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "debuff:active",
+    "debuff:charged",
+  ],
+  "plain": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "debuff:active",
+    "debuff:charged",
+  ],
+  "richEnemy": [
+    "attack",
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff-resisted",
+    "debuff:active",
+    "debuff:charged",
+  ],
+}
+`;
+
+exports[`kit fingerprints > Zosimos 1`] = `
+{
+  "hurtAllies": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "plain": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+  "richEnemy": [
+    "attack:active",
+    "attack:charged",
+    "charge-changed",
+    "debuff",
+    "debuff-resisted",
+  ],
+}
+`;

--- a/src/utils/calculators/__tests__/battleSimulatorTestTap.test.ts
+++ b/src/utils/calculators/__tests__/battleSimulatorTestTap.test.ts
@@ -1,0 +1,94 @@
+/**
+ * `BattleSimulationInput.__testTapActors` — the test-only seam that lets a fixture set initial
+ * actor state (`shieldPool`, `currentHp`) that BattlePlacement/statOverrides cannot express.
+ * Forwarded verbatim to the engine's own tap; consumed by the real-kit fingerprint scenarios.
+ */
+import { describe, it, expect } from 'vitest';
+import { simulateBattle, type BattlePlacement } from '../battleSimulator';
+import type { Ship } from '../../../types/ship';
+import type { Position } from '../../../types/encounters';
+import type { CombatActor } from '../../combat/state';
+
+const ship = (id: string): Ship =>
+    ({
+        id,
+        name: id,
+        type: 'ATTACKER',
+        refits: [],
+        activeSkillText: 'This Unit deals <unit-damage>90% damage</unit-damage>.',
+        activeTarget: 'front',
+        activePattern: 'Pattern-Base',
+        baseStats: {
+            hp: 100_000,
+            attack: 1000,
+            defence: 0,
+            hacking: 200,
+            security: 100,
+            crit: 0,
+            critDamage: 150,
+            speed: 100,
+        },
+    }) as unknown as Ship;
+
+const placement = (s: Ship, position: Position): BattlePlacement => ({
+    ship: s,
+    position,
+    statOverrides: {
+        attack: s.baseStats.attack,
+        crit: s.baseStats.crit,
+        critDamage: s.baseStats.critDamage,
+        defensePenetration: 0,
+        hacking: s.baseStats.hacking,
+        security: s.baseStats.security,
+        defence: s.baseStats.defence,
+        hp: s.baseStats.hp,
+        speed: s.baseStats.speed,
+    },
+});
+
+const input = (tap?: (actors: CombatActor[]) => void) => ({
+    playerTeam: [placement(ship('p1'), 'M4' as Position)],
+    enemyTeam: [placement(ship('e1'), 'M1' as Position)],
+    rounds: 1,
+    ...(tap ? { __testTapActors: tap } : {}),
+});
+
+describe('simulateBattle __testTapActors forwarding', () => {
+    it('hands the full roster to the tap exactly once', () => {
+        let calls = 0;
+        let ids: string[] = [];
+        simulateBattle(
+            input((actors) => {
+                calls += 1;
+                ids = actors.map((a) => a.id);
+            })
+        );
+        expect(calls).toBe(1);
+        // The roster is [team…, attacker, dummy enemy, enemy attackers…] (engine.ts allActors).
+        expect(ids.length).toBeGreaterThanOrEqual(2);
+        expect(ids).toContain('attacker');
+    });
+
+    it('seeds shieldPool that the battle then honours (the tap is not a no-op copy)', () => {
+        // Proves the tap mutates the LIVE actors, not a detached array: a seeded pool must show up
+        // as shield absorption when the enemy is hit. Without forwarding, this is 0.
+        // NOTE vs. brief: `BattleResult.rounds` has no `perActorShield` map — that name belongs to
+        // the engine's internal `RoundData` (consumed inside simulateBattle to build the per-actor
+        // `shieldsAbsorbed`/`shieldGranted`/`currentShieldPool` fields on `ShipRoundState`, see
+        // battleSimulator.ts's `BattleRound` / `ShipRoundState`). Reading the actual public shape
+        // (`ships[].shieldsAbsorbed`) instead — same assertion intent, correct accessor.
+        const seeded = simulateBattle(
+            input((actors) => {
+                for (const a of actors) if (a.side === 'enemy') a.shieldPool = 50_000;
+            })
+        );
+        const absorbed = seeded.rounds
+            .flatMap((r) => r.ships)
+            .reduce((sum, s) => sum + s.shieldsAbsorbed, 0);
+        expect(absorbed).toBeGreaterThan(0);
+    });
+
+    it('is inert when absent (production callers pass nothing)', () => {
+        expect(() => simulateBattle(input())).not.toThrow();
+    });
+});

--- a/src/utils/calculators/__tests__/battleSimulatorTestTap.test.ts
+++ b/src/utils/calculators/__tests__/battleSimulatorTestTap.test.ts
@@ -4,7 +4,8 @@
  * Forwarded verbatim to the engine's own tap; consumed by the real-kit fingerprint scenarios.
  */
 import { describe, it, expect } from 'vitest';
-import { simulateBattle, type BattlePlacement } from '../battleSimulator';
+import { simulateBattle, type BattlePlacement, type BattleResult } from '../battleSimulator';
+import { runSeededBattle } from '../../combat/audit/seededBattle';
 import type { Ship } from '../../../types/ship';
 import type { Position } from '../../../types/encounters';
 import type { CombatActor } from '../../combat/state';
@@ -46,10 +47,10 @@ const placement = (s: Ship, position: Position): BattlePlacement => ({
     },
 });
 
-const input = (tap?: (actors: CombatActor[]) => void) => ({
+const input = (tap?: (actors: CombatActor[]) => void, rounds = 1) => ({
     playerTeam: [placement(ship('p1'), 'M4' as Position)],
     enemyTeam: [placement(ship('e1'), 'M1' as Position)],
-    rounds: 1,
+    rounds,
     ...(tap ? { __testTapActors: tap } : {}),
 });
 
@@ -88,7 +89,43 @@ describe('simulateBattle __testTapActors forwarding', () => {
         expect(absorbed).toBeGreaterThan(0);
     });
 
-    it('is inert when absent (production callers pass nothing)', () => {
-        expect(() => simulateBattle(input())).not.toThrow();
+    it('seeds currentHp that the battle then honours (proves the OTHER seeded field is live)', () => {
+        // `shieldPool` seeding is proven above; the fingerprint scenarios also seed `currentHp`,
+        // and nothing proved THAT reaches live combat — a tap that set a field the engine
+        // recomputed at first use would leave the `wounded` scenario silently identical to `plain`.
+        // Proof by lethality: the same 3-round battle the enemy comfortably survives at full HP
+        // ends with it dead when the tap starts it at 1% HP.
+        const control = runSeededBattle(input(undefined, 3), 4242);
+        const seeded = runSeededBattle(
+            input((actors) => {
+                for (const a of actors) if (a.side === 'enemy') a.currentHp = a.stats.hp * 0.01;
+            }, 3),
+            4242
+        );
+        const enemyAlive = (r: BattleResult): boolean => {
+            const last = r.rounds[r.rounds.length - 1];
+            return last.ships.filter((s) => s.side === 'enemy').every((s) => s.alive);
+        };
+        expect(enemyAlive(control)).toBe(true);
+        expect(enemyAlive(seeded)).toBe(false);
+        expect(seeded.outcome.winner).toBe('player');
+        // ...and the kill is EARLIER than the round cap, i.e. the seed shortened the fight rather
+        // than the enemy dying anyway on the last round.
+        expect(seeded.outcome.lastRound).toBeLessThan(control.outcome.lastRound);
+    });
+
+    it('is inert when absent: a no-op tap produces a byte-identical battle', () => {
+        // `not.toThrow()` was near-tautological. The real claim is that the seam has no effect of
+        // its own — every production caller omits it, so the tapped and untapped engines must agree
+        // exactly. Both runs go through runSeededBattle under one seed so any difference is the
+        // tap's, not the RNG's.
+        const withoutTap = runSeededBattle(input(undefined, 3), 99);
+        const withNoopTap = runSeededBattle(
+            input(() => {
+                /* no-op: read nothing, mutate nothing */
+            }, 3),
+            99
+        );
+        expect(withNoopTap).toEqual(withoutTap);
     });
 });

--- a/src/utils/calculators/__tests__/realKitFingerprints.test.ts
+++ b/src/utils/calculators/__tests__/realKitFingerprints.test.ts
@@ -182,6 +182,31 @@ describe('suite health', () => {
         );
     });
 
+    it('every KNOWN_ZERO_DAMAGE exemption is STILL warranted (a kit/board fix must remove the ship, not leave a stale exemption)', () => {
+        // The sibling suite (kitFingerprintScenarios.test.ts's "every allow-listed ship is STILL
+        // unreachable") solves the same problem for KNOWN_UNREACHABLE; this is the equivalent
+        // guard for KNOWN_ZERO_DAMAGE. Without it, a kit or board change that makes Meiying or
+        // Voron take real damage would pass silently — the exemption would keep suppressing a
+        // failure that no longer exists to suppress.
+        //
+        // `some`, not `every`: the exemption asserts "this ship takes no damage", a claim `some`
+        // falsifies on the first counterexample. `every` would only flag a ship once it takes
+        // damage in ALL three scenarios, staying silent indefinitely if a fix only partially
+        // restores damage (e.g. two scenarios fixed, one still silently zero) — exactly the kind
+        // of half-fixed state this suite exists to catch, not wave through.
+        const stale = KNOWN_ZERO_DAMAGE.filter((name) => {
+            const inv = observedInvariants.get(name);
+            return !!inv && SCENARIOS.some((scenario) => inv[scenario].taken > 0);
+        });
+        expect(
+            stale,
+            `KNOWN_ZERO_DAMAGE exemption(s) that now take real damage in at least one scenario: ` +
+                `${stale.join(', ')} — the ship's kit or the board changed; remove it from ` +
+                'KNOWN_ZERO_DAMAGE (or re-document the reasoning for the scenarios still zero) ' +
+                'rather than leaving a stale exemption.'
+        ).toEqual([]);
+    });
+
     /** The coverage LEDGER. Every kind listed here is produced by at least one corpus ship today;
      *  losing any one of them is a coverage regression that must be explained, not re-blessed.
      *

--- a/src/utils/calculators/__tests__/realKitFingerprints.test.ts
+++ b/src/utils/calculators/__tests__/realKitFingerprints.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Real-kit behaviour fingerprints — the golden suite's ONLY real-ship coverage.
+ *
+ * Every other golden fixture in this directory is synthetic (see simGoldenFixtures.ts's header:
+ * the author had no local corpus), which is why 22 commits of real ship-behaviour change in #296
+ * and the Malvex gate fix in #297 moved zero snapshots.
+ *
+ * Each of the 147 corpus ships is run through three fixed scenarios and reduced to the SET of
+ * `kind[:slot]` behaviour tokens it produced. A diff means that ship's behaviour changed. The
+ * suite is deliberately STRUCTURAL, not numeric: it answers "does this clause still fire", which
+ * is the dominant defect class in the changelog ("now does something", "was a name in the buff
+ * list with no effect", "the condition was not being read at all"). Numeric drift is
+ * dpsGoldenParity / healingGoldenParity's job.
+ *
+ * `vitest -u` on this file is FORBIDDEN except as a deliberate, audited behaviour move. A moved
+ * snapshot is a real behaviour change and must be explained in the commit that moves it.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { runSeededBattle } from '../../combat/audit/seededBattle';
+import { fingerprintActorTokens } from '../../combat/audit/fingerprint';
+import {
+    buildScenarioBattle,
+    SCENARIOS,
+    SEED,
+    type ScenarioName,
+} from '../../combat/audit/kitFingerprintScenarios';
+import { buildTraceShip } from '../../../../scripts/lib/traceShipFactory';
+import { csvAvailable, loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
+import { shipDataAvailable } from '../../../../scripts/lib/shipDataSnapshot';
+import type { Ship } from '../../../types/ship';
+
+function requireReferenceData(): void {
+    if (!csvAvailable() || !shipDataAvailable()) {
+        throw new Error(
+            'docs/ship-skills.csv and/or docs/ship-data.json are missing from this worktree ' +
+                '(gitignored reference data) — tests need them to resolve real ship skill text/stats.'
+        );
+    }
+}
+
+/** The focus ship is always the first player placement, and simulateBattle mints the first player
+ *  actor with the reserved id 'attacker' (battleSimulator's minting scheme; the rest are
+ *  `p:<shipId>:<idx>`). So the focus actor id is fixed. */
+const FOCUS_ACTOR_ID = 'attacker';
+
+/** Fingerprint one ship across all three scenarios. Every battle goes through runSeededBattle —
+ *  its `finally` restores Math.random rather than any ambient seed, so a raw simulateBattle call
+ *  afterwards would be nondeterministic. */
+export function fingerprintShip(ship: Ship): Record<ScenarioName, string[]> {
+    const out = {} as Record<ScenarioName, string[]>;
+    for (const scenario of SCENARIOS) {
+        const result = runSeededBattle(buildScenarioBattle(ship, scenario), SEED);
+        out[scenario] = fingerprintActorTokens(result, FOCUS_ACTOR_ID);
+    }
+    return out;
+}
+
+/** Corpus ship names, sorted for a stable it.each order (CSV row order is not guaranteed). */
+function corpusNames(): string[] {
+    return loadShipSkillRecords()
+        .map((r) => r.name)
+        .sort((a, b) => a.localeCompare(b));
+}
+
+describe('kit fingerprints', () => {
+    beforeAll(requireReferenceData);
+
+    it.each(corpusNames().map((n) => [n] as const))('%s', (name) => {
+        const ship = buildTraceShip(name);
+        expect(ship, `${name} did not resolve from the corpus`).not.toBeNull();
+        expect(fingerprintShip(ship!)).toMatchSnapshot();
+    });
+});

--- a/src/utils/calculators/__tests__/realKitFingerprints.test.ts
+++ b/src/utils/calculators/__tests__/realKitFingerprints.test.ts
@@ -16,18 +16,14 @@
  * snapshot is a real behaviour change and must be explained in the commit that moves it.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import { runSeededBattle } from '../../combat/audit/seededBattle';
-import { fingerprintActorTokens } from '../../combat/audit/fingerprint';
 import {
-    buildScenarioBattle,
     SCENARIOS,
-    SEED,
-    type ScenarioName,
+    fingerprintShip,
+    corpusNames,
 } from '../../combat/audit/kitFingerprintScenarios';
 import { buildTraceShip } from '../../../../scripts/lib/traceShipFactory';
 import { csvAvailable, loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
 import { shipDataAvailable } from '../../../../scripts/lib/shipDataSnapshot';
-import type { Ship } from '../../../types/ship';
 
 function requireReferenceData(): void {
     if (!csvAvailable() || !shipDataAvailable()) {
@@ -36,30 +32,6 @@ function requireReferenceData(): void {
                 '(gitignored reference data) — tests need them to resolve real ship skill text/stats.'
         );
     }
-}
-
-/** The focus ship is always the first player placement, and simulateBattle mints the first player
- *  actor with the reserved id 'attacker' (battleSimulator's minting scheme; the rest are
- *  `p:<shipId>:<idx>`). So the focus actor id is fixed. */
-const FOCUS_ACTOR_ID = 'attacker';
-
-/** Fingerprint one ship across all three scenarios. Every battle goes through runSeededBattle —
- *  its `finally` restores Math.random rather than any ambient seed, so a raw simulateBattle call
- *  afterwards would be nondeterministic. */
-export function fingerprintShip(ship: Ship): Record<ScenarioName, string[]> {
-    const out = {} as Record<ScenarioName, string[]>;
-    for (const scenario of SCENARIOS) {
-        const result = runSeededBattle(buildScenarioBattle(ship, scenario), SEED);
-        out[scenario] = fingerprintActorTokens(result, FOCUS_ACTOR_ID);
-    }
-    return out;
-}
-
-/** Corpus ship names, sorted for a stable it.each order (CSV row order is not guaranteed). */
-function corpusNames(): string[] {
-    return loadShipSkillRecords()
-        .map((r) => r.name)
-        .sort((a, b) => a.localeCompare(b));
 }
 
 describe('kit fingerprints', () => {
@@ -92,5 +64,55 @@ describe('pinned regression: Malvex target-shield gates (#296, #297)', () => {
         expect(fp.richEnemy).toContain('buff:charged');
         expect(fp.plain).not.toContain('buff:charged');
         expect(fp.hurtAllies).not.toContain('buff:charged');
+    });
+});
+
+describe('suite health', () => {
+    beforeAll(requireReferenceData);
+
+    it('is non-vacuous: every ship produces tokens, and the roster covers many kinds', () => {
+        // Without this, a harness bug that fingerprints nothing yields 147 empty snapshots and
+        // reads as passing.
+        const all = new Set<string>();
+        const empty: string[] = [];
+        for (const name of corpusNames()) {
+            const ship = buildTraceShip(name);
+            if (!ship) continue;
+            const fp = fingerprintShip(ship);
+            const tokens = SCENARIOS.flatMap((s) => fp[s]);
+            if (tokens.length === 0) empty.push(name);
+            for (const t of tokens) all.add(t);
+        }
+        expect(empty, `ships producing NO tokens in any scenario: ${empty.join(', ')}`).toEqual([]);
+        // 18 kinds exist; the roster should exercise a broad share of them.
+        expect(new Set([...all].map((t) => t.split(':')[0])).size).toBeGreaterThanOrEqual(10);
+    }, 20_000);
+    // ^ Re-fingerprints all 147 ships (441 battles) on top of the it.each block above already
+    // having done so — the default 5s vitest timeout is comfortable in isolation (~4s) but gets
+    // squeezed under full-suite worker contention. 20s is a generous margin, not a tuned value.
+
+    it('is deterministic: fingerprinting the same ship twice gives identical tokens', () => {
+        // Guards against RNG leaking across scenarios — runSeededBattle restores Math.random in
+        // its finally, so a battle run outside it would drift between calls.
+        const ship = buildTraceShip('Malvex');
+        expect(ship).not.toBeNull();
+        expect(fingerprintShip(ship!)).toEqual(fingerprintShip(ship!));
+    });
+
+    it('pins the corpus shape so a data refresh announces itself in ONE diff', () => {
+        // 147 snapshots derived from gitignored data would otherwise churn with no explanation.
+        // This entry moving ALONGSIDE many ship entries means "the corpus changed"; ship entries
+        // moving while this one holds still means "the engine changed".
+        const rows = loadShipSkillRecords();
+        const digest = rows
+            .map(
+                (r) =>
+                    `${r.name}|${r.active.length}|${r.charge.length}|${r.passives.join('').length}`
+            )
+            .sort()
+            .join('\n');
+        let hash = 0;
+        for (let i = 0; i < digest.length; i++) hash = (hash * 31 + digest.charCodeAt(i)) | 0;
+        expect({ shipCount: rows.length, digest: hash }).toMatchSnapshot();
     });
 });

--- a/src/utils/calculators/__tests__/realKitFingerprints.test.ts
+++ b/src/utils/calculators/__tests__/realKitFingerprints.test.ts
@@ -20,8 +20,14 @@ import {
     SCENARIOS,
     fingerprintShip,
     corpusNames,
+    buildScenarioBattle,
+    FOCUS_ACTOR_ID,
+    ROUNDS,
+    SEED,
     type ScenarioName,
 } from '../../combat/audit/kitFingerprintScenarios';
+import { runSeededBattle } from '../../combat/audit/seededBattle';
+import { fingerprintActorTokens } from '../../combat/audit/fingerprint';
 import { buildTraceShip } from '../../../../scripts/lib/traceShipFactory';
 import { csvAvailable, loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
 import { shipDataAvailable } from '../../../../scripts/lib/shipDataSnapshot';
@@ -41,14 +47,43 @@ function requireReferenceData(): void {
  *  vitest runs describes in declaration order. */
 const observed = new Map<string, Record<ScenarioName, string[]>>();
 
+/** The two LIVE invariants every fingerprint rests on (see `kitFingerprintScenarios.test.ts`'s
+ *  "live battle invariants" describe, which spot-checks only Xiaodao/Malvex): the focus must take
+ *  real incoming damage, or all on-damaged kit is silent; and it must survive to round `ROUNDS`,
+ *  or its fingerprint is truncated at an arbitrary round. Captured here, corpus-wide, from the SAME
+ *  441 battle results the snapshot pass below already runs — reading a couple more fields off a
+ *  result that's already sitting in memory, not an extra battle run. Consumed by `suite health`. */
+interface LiveInvariant {
+    taken: number;
+    alive: boolean;
+    lastRound: number;
+}
+const observedInvariants = new Map<string, Record<ScenarioName, LiveInvariant>>();
+
 describe('kit fingerprints', () => {
     beforeAll(requireReferenceData);
 
     it.each(corpusNames().map((n) => [n] as const))('%s', (name) => {
         const ship = buildTraceShip(name);
         expect(ship, `${name} did not resolve from the corpus`).not.toBeNull();
-        const fp = fingerprintShip(ship!);
+        // Inlines fingerprintShip's own loop (rather than calling it) so the invariant fields can
+        // be read off the same BattleResult instead of running each of the 441 battles twice.
+        const fp = {} as Record<ScenarioName, string[]>;
+        const invariants = {} as Record<ScenarioName, LiveInvariant>;
+        for (const scenario of SCENARIOS) {
+            const result = runSeededBattle(buildScenarioBattle(ship!, scenario), SEED);
+            fp[scenario] = fingerprintActorTokens(result, FOCUS_ACTOR_ID);
+            const rows = result.rounds
+                .flatMap((r) => r.ships)
+                .filter((s) => s.actorId === FOCUS_ACTOR_ID);
+            invariants[scenario] = {
+                taken: rows.reduce((sum, s) => sum + s.damageTaken, 0),
+                alive: rows.every((s) => s.alive),
+                lastRound: result.outcome.lastRound,
+            };
+        }
         observed.set(name, fp);
+        observedInvariants.set(name, invariants);
         expect(fp).toMatchSnapshot();
     });
 });
@@ -98,6 +133,53 @@ describe('suite health', () => {
                     `${corpusNames().length} ships — run the whole file (no -t filter).`
             );
         }
+        if (observedInvariants.size !== corpusNames().length) {
+            throw new Error(
+                `suite health consumes the snapshot pass, which recorded live invariants for ` +
+                    `${observedInvariants.size} of ${corpusNames().length} ships — run the whole ` +
+                    'file (no -t filter).'
+            );
+        }
+    });
+
+    // Two corpus ships are documented, kit-explained exceptions to "the focus takes real incoming
+    // damage" — not a fixture failure (see final-fix-report.md's "before → after measurements"):
+    // Meiying gains Stealth "at the start of combat and every turn", so it is permanently
+    // untargetable; Voron "transforms the damage into a Damage over Time effect", so its intake
+    // books 0 at the instant of the hit even though it demonstrably IS being hit (it carries a
+    // `dot-ticked` token it would not otherwise have).
+    const KNOWN_ZERO_DAMAGE: readonly string[] = ['Meiying', 'Voron'];
+
+    it('every corpus ship takes real incoming damage and survives all 20 rounds, in every scenario', () => {
+        // The corpus-wide version of the two-ship spot-check in kitFingerprintScenarios.test.ts's
+        // "live battle invariants" (Xiaodao/Malvex) — cheap here because observedInvariants was
+        // collected as a side effect of the snapshot pass's own 441 battles, not by re-running them.
+        const noDamage: string[] = [];
+        const died: string[] = [];
+        const truncated: string[] = [];
+        for (const [name, byScenario] of observedInvariants) {
+            for (const scenario of SCENARIOS) {
+                const inv = byScenario[scenario];
+                if (inv.taken <= 0 && !KNOWN_ZERO_DAMAGE.includes(name)) {
+                    noDamage.push(`${name}/${scenario}`);
+                }
+                if (!inv.alive) died.push(`${name}/${scenario}`);
+                if (inv.lastRound !== ROUNDS) truncated.push(`${name}/${scenario}`);
+            }
+        }
+        expect(
+            noDamage,
+            'ship/scenario pairs where the focus took NO damage — the enemies are not resolving ' +
+                'onto it, so every on-damaged clause is silent there'
+        ).toEqual([]);
+        expect(
+            died,
+            'ship/scenario pairs where the focus died — its fingerprint is truncated at the round ' +
+                'it fell, so kill timing leaks into the snapshot'
+        ).toEqual([]);
+        expect(truncated, `ship/scenario pairs whose battle ended before round ${ROUNDS}`).toEqual(
+            []
+        );
     });
 
     /** The coverage LEDGER. Every kind listed here is produced by at least one corpus ship today;

--- a/src/utils/calculators/__tests__/realKitFingerprints.test.ts
+++ b/src/utils/calculators/__tests__/realKitFingerprints.test.ts
@@ -71,3 +71,26 @@ describe('kit fingerprints', () => {
         expect(fingerprintShip(ship!)).toMatchSnapshot();
     });
 });
+
+describe('pinned regression: Malvex target-shield gates (#296, #297)', () => {
+    beforeAll(requireReferenceData);
+
+    it('gates BOTH the active self-shield and the charged Barrier on a shielded target', () => {
+        // The case the whole suite exists for. Pre-#297 the active self-shield fired on every cast
+        // regardless of target, and pre-#296 the charged Barrier did too — so both tokens sat in
+        // all three scenarios. They must now appear ONLY where the target actually carries a
+        // Shield. Note bare `shield` (Malvex's passive on-damaged grant) is expected EVERYWHERE and
+        // is exactly why a bare-`kind` fingerprint could not have caught this.
+        const malvex = buildTraceShip('Malvex');
+        expect(malvex).not.toBeNull();
+        const fp = fingerprintShip(malvex!);
+
+        expect(fp.richEnemy).toContain('shield:active');
+        expect(fp.plain).not.toContain('shield:active');
+        expect(fp.hurtAllies).not.toContain('shield:active');
+
+        expect(fp.richEnemy).toContain('buff:charged');
+        expect(fp.plain).not.toContain('buff:charged');
+        expect(fp.hurtAllies).not.toContain('buff:charged');
+    });
+});

--- a/src/utils/calculators/__tests__/realKitFingerprints.test.ts
+++ b/src/utils/calculators/__tests__/realKitFingerprints.test.ts
@@ -20,6 +20,7 @@ import {
     SCENARIOS,
     fingerprintShip,
     corpusNames,
+    type ScenarioName,
 } from '../../combat/audit/kitFingerprintScenarios';
 import { buildTraceShip } from '../../../../scripts/lib/traceShipFactory';
 import { csvAvailable, loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
@@ -34,13 +35,21 @@ function requireReferenceData(): void {
     }
 }
 
+/** Filled by the snapshot pass below and consumed by `suite health` — 441 battles are expensive
+ *  (~7s), so the health assertions read what the snapshot pass already computed instead of
+ *  re-running the whole roster. `suite health` is declared AFTER the snapshot describe on purpose:
+ *  vitest runs describes in declaration order. */
+const observed = new Map<string, Record<ScenarioName, string[]>>();
+
 describe('kit fingerprints', () => {
     beforeAll(requireReferenceData);
 
     it.each(corpusNames().map((n) => [n] as const))('%s', (name) => {
         const ship = buildTraceShip(name);
         expect(ship, `${name} did not resolve from the corpus`).not.toBeNull();
-        expect(fingerprintShip(ship!)).toMatchSnapshot();
+        const fp = fingerprintShip(ship!);
+        observed.set(name, fp);
+        expect(fp).toMatchSnapshot();
     });
 });
 
@@ -51,45 +60,112 @@ describe('pinned regression: Malvex target-shield gates (#296, #297)', () => {
         // The case the whole suite exists for. Pre-#297 the active self-shield fired on every cast
         // regardless of target, and pre-#296 the charged Barrier did too — so both tokens sat in
         // all three scenarios. They must now appear ONLY where the target actually carries a
-        // Shield. Note bare `shield` (Malvex's passive on-damaged grant) is expected EVERYWHERE and
-        // is exactly why a bare-`kind` fingerprint could not have caught this.
+        // Shield.
+        //
+        // Malvex ALSO has an on-damaged passive self-shield ("gains Shield equal to 15% of the
+        // damage dealt to them"), and the focus is now genuinely under fire in every scenario, so
+        // that passive fires everywhere. It is still not visible as a bare `shield` token: the
+        // reactive grant emits no shield log entry, only its later destruction does — which is why
+        // `shield-destroyed` sits in plain/wounded while `shield` does not. So a bare-`kind`
+        // fingerprint WOULD also have caught #296/#297 here (bare `shield` is richEnemy-only). The
+        // `:slot` suffix's value is narrower than "it caught this": it separates two same-kind
+        // entries when both are logged, and it names WHICH slot regressed in the diff.
         const malvex = buildTraceShip('Malvex');
         expect(malvex).not.toBeNull();
         const fp = fingerprintShip(malvex!);
 
         expect(fp.richEnemy).toContain('shield:active');
         expect(fp.plain).not.toContain('shield:active');
-        expect(fp.hurtAllies).not.toContain('shield:active');
+        expect(fp.wounded).not.toContain('shield:active');
 
         expect(fp.richEnemy).toContain('buff:charged');
         expect(fp.plain).not.toContain('buff:charged');
-        expect(fp.hurtAllies).not.toContain('buff:charged');
+        expect(fp.wounded).not.toContain('buff:charged');
+
+        // The on-damaged passive really is live in the un-shielded scenarios (see above): a pool
+        // it never granted could not be destroyed.
+        expect(fp.plain).toContain('shield-destroyed');
+        expect(fp.wounded).toContain('shield-destroyed');
     });
 });
 
 describe('suite health', () => {
-    beforeAll(requireReferenceData);
+    beforeAll(() => {
+        requireReferenceData();
+        if (observed.size !== corpusNames().length) {
+            throw new Error(
+                `suite health consumes the snapshot pass, which recorded ${observed.size} of ` +
+                    `${corpusNames().length} ships — run the whole file (no -t filter).`
+            );
+        }
+    });
 
-    it('is non-vacuous: every ship produces tokens, and the roster covers many kinds', () => {
+    /** The coverage LEDGER. Every kind listed here is produced by at least one corpus ship today;
+     *  losing any one of them is a coverage regression that must be explained, not re-blessed.
+     *
+     *  The five `CombatLogEntryKind`s NOT here, and why none is a tuning failure:
+     *   - `cleanse` / `purge`: need a debuff on the player side / a buff on the enemy side to
+     *     remove. The filler ships apply neither, and status seeding is the deliberately deferred
+     *     fourth scenario. 21 corpus ships cleanse and 15 purge, so this is the single biggest
+     *     remaining hole.
+     *   - `detonation`: `buildCombatLog` books that entry to the bomb's VICTIM, not to the actor
+     *     that detonated it, so it can never appear in a focus-actor fingerprint unless the focus
+     *     is itself bombed — which needs an enemy that plants bombs, i.e. non-inert filler.
+     *   - `death`: booked to the actor that died. The focus surviving all 20 rounds is a hard
+     *     requirement (its death truncates its own fingerprint), so this one is unreachable by
+     *     construction.
+     *   - `cheat-death`: booked to the actor whose death was prevented, i.e. it needs the focus to
+     *     take LETHAL damage. Same conflict as `death`. Only 4 corpus ships carry Cheat Death
+     *     (Hayyan, Hermes, Tycho, Yazid) and an ally's cheat-death books to the ally. */
+    const EXPECTED_KINDS = [
+        'attack',
+        'bomb',
+        'buff',
+        'buff-expired',
+        'charge-changed',
+        'control',
+        'debuff',
+        'debuff-resisted',
+        'dot-applied',
+        'dot-ticked',
+        'heal',
+        'shield',
+        'shield-destroyed',
+    ] as const;
+
+    it('is non-vacuous: every ship produces tokens', () => {
         // Without this, a harness bug that fingerprints nothing yields 147 empty snapshots and
         // reads as passing.
-        const all = new Set<string>();
-        const empty: string[] = [];
-        for (const name of corpusNames()) {
-            const ship = buildTraceShip(name);
-            if (!ship) continue;
-            const fp = fingerprintShip(ship);
-            const tokens = SCENARIOS.flatMap((s) => fp[s]);
-            if (tokens.length === 0) empty.push(name);
-            for (const t of tokens) all.add(t);
-        }
+        const empty = [...observed.entries()]
+            .filter(([, fp]) => SCENARIOS.every((s) => fp[s].length === 0))
+            .map(([name]) => name);
         expect(empty, `ships producing NO tokens in any scenario: ${empty.join(', ')}`).toEqual([]);
-        // 18 kinds exist; the roster should exercise a broad share of them.
-        expect(new Set([...all].map((t) => t.split(':')[0])).size).toBeGreaterThanOrEqual(10);
-    }, 20_000);
-    // ^ Re-fingerprints all 147 ships (441 battles) on top of the it.each block above already
-    // having done so — the default 5s vitest timeout is comfortable in isolation (~4s) but gets
-    // squeezed under full-suite worker contention. 20s is a generous margin, not a tuned value.
+    });
+
+    it('covers every log kind the roster is expected to reach', () => {
+        const kinds = new Set<string>();
+        for (const fp of observed.values()) {
+            for (const scenario of SCENARIOS) {
+                for (const token of fp[scenario]) kinds.add(token.split(':')[0]);
+            }
+        }
+        const missing = EXPECTED_KINDS.filter((k) => !kinds.has(k));
+        expect(
+            missing,
+            `log kinds that stopped appearing anywhere in the roster: ${missing.join(', ')} — ` +
+                'a whole behaviour family went silent, or the scenarios stopped putting the board ' +
+                'in the state it needs (see EXPECTED_KINDS for what each one requires).'
+        ).toEqual([]);
+        // The other direction: a NEW kind showing up is also news — it means the roster reached a
+        // state the ledger does not describe. Update EXPECTED_KINDS and say why.
+        const unexpected = [...kinds].filter(
+            (k) => !(EXPECTED_KINDS as readonly string[]).includes(k)
+        );
+        expect(
+            unexpected,
+            `log kinds appearing that the ledger does not list: ${unexpected.join(', ')}`
+        ).toEqual([]);
+    });
 
     it('is deterministic: fingerprinting the same ship twice gives identical tokens', () => {
         // Guards against RNG leaking across scenarios — runSeededBattle restores Math.random in
@@ -103,12 +179,13 @@ describe('suite health', () => {
         // 147 snapshots derived from gitignored data would otherwise churn with no explanation.
         // This entry moving ALONGSIDE many ship entries means "the corpus changed"; ship entries
         // moving while this one holds still means "the engine changed".
+        //
+        // Hashes the raw skill TEXT, not its length: a same-length edit ("40%" -> "50%") is a real
+        // behaviour change and must move this digest, or the ship's own moved fingerprint would be
+        // misread as an engine change.
         const rows = loadShipSkillRecords();
         const digest = rows
-            .map(
-                (r) =>
-                    `${r.name}|${r.active.length}|${r.charge.length}|${r.passives.join('').length}`
-            )
+            .map((r) => `${r.name} ${r.active} ${r.charge} ${r.passives.join('')}`)
             .sort()
             .join('\n');
         let hash = 0;

--- a/src/utils/calculators/battleSimulator.ts
+++ b/src/utils/calculators/battleSimulator.ts
@@ -39,6 +39,7 @@
  * `simulateBattle` (the runCombat wrapper that produces these inputs) is Task 3 — NOT here.
  */
 import type { CombatEvent } from '../combat/events';
+import type { CombatActor } from '../combat/state';
 import type { Position } from '../../types/encounters';
 import type { Ship, AffinityName } from '../../types/ship';
 import type { CombatStatBlock, DoTType } from '../../types/calculator';
@@ -582,6 +583,12 @@ export interface BattleSimulationInput {
     playerSquadLeader?: SquadLeaderSelection;
     /** Enemy-side squad leader (pre-fight faction aura). Absent → no pre-fight change. */
     enemySquadLeader?: SquadLeaderSelection;
+    /** TEST-ONLY: forwarded verbatim to the engine's `__testTapActors` (engine.ts:1363, fired once
+     *  at actor construction). Lets a fixture seed initial actor state — `shieldPool`, `currentHp`
+     *  — that `BattlePlacement`/`statOverrides` cannot express, which is what the real-kit
+     *  fingerprint scenarios (richEnemy / hurtAllies) need. Never set by production callers.
+     *  Mutates the LIVE roster; the engine hands out `allActors` itself, not a copy. */
+    __testTapActors?: (actors: CombatActor[]) => void;
 }
 
 /** The combat stats simulateBattle resolves per placement. Derived from the ship's
@@ -1070,6 +1077,7 @@ export function simulateBattle(
         positionalTeamBattle: true,
         teamActors,
         enemyAttackers,
+        __testTapActors: input.__testTapActors,
         bus,
     });
 

--- a/src/utils/combat/audit/__tests__/fingerprint.test.ts
+++ b/src/utils/combat/audit/__tests__/fingerprint.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { fingerprintActor, diffFingerprints, runDifferential } from '../fingerprint';
+import {
+    fingerprintActor,
+    diffFingerprints,
+    runDifferential,
+    fingerprintActorTokens,
+} from '../fingerprint';
 import type { BattleResult } from '../../../calculators/battleSimulator';
+import type { CombatLogEntry } from '../../log/types';
 
 const fakeResult = (kindsByActor: Record<string, string[]>): BattleResult =>
     ({
@@ -69,5 +75,87 @@ describe('runDifferential', () => {
         expect(
             runDifferential(soloResult, compResult, 'ShipA', 'p1_ship', 'comp_actor_3')
         ).toBeNull();
+    });
+});
+
+/** Minimal BattleResult carrying only the combatLog shape fingerprinting walks. */
+const resultWith = (entries: CombatLogEntry[]): BattleResult =>
+    ({
+        combatLog: [{ round: 1, startOfRound: [], turns: [{ entries }], endOfRound: [] }],
+    }) as unknown as BattleResult;
+
+const entry = (over: Partial<CombatLogEntry>): CombatLogEntry => ({
+    kind: 'attack',
+    actorId: 'a',
+    targets: [],
+    reactions: [],
+    ...over,
+});
+
+describe('fingerprintActorTokens', () => {
+    it('suffixes a cast-sourced entry with its slot and leaves a passive entry bare', () => {
+        // The Malvex case: an active-slot shield grant and a passive on-damaged shield grant are
+        // the SAME kind. Bare-kind fingerprinting cannot tell them apart, so a bug that ungates
+        // the active one is invisible. The slot suffix is what separates them.
+        const tokens = fingerprintActorTokens(
+            resultWith([
+                entry({ kind: 'shield', slot: 'active', skillName: 'Shield Surge' }),
+                entry({ kind: 'shield' }),
+            ]),
+            'a'
+        );
+        expect(tokens).toEqual(['shield', 'shield:active']);
+    });
+
+    it('is sorted and de-duplicated so entry order can never churn a snapshot', () => {
+        const tokens = fingerprintActorTokens(
+            resultWith([
+                entry({ kind: 'heal', slot: 'charged' }),
+                entry({ kind: 'attack', slot: 'active' }),
+                entry({ kind: 'attack', slot: 'active' }),
+            ]),
+            'a'
+        );
+        expect(tokens).toEqual(['attack:active', 'heal:charged']);
+    });
+
+    it('walks nested reactions and ignores other actors', () => {
+        const tokens = fingerprintActorTokens(
+            resultWith([
+                entry({
+                    kind: 'attack',
+                    actorId: 'other',
+                    reactions: [entry({ kind: 'heal', actorId: 'a' })],
+                }),
+            ]),
+            'a'
+        );
+        expect(tokens).toEqual(['heal']);
+    });
+
+    it('excludes skillName from the token (a rename must not move a snapshot)', () => {
+        const a = fingerprintActorTokens(
+            resultWith([entry({ kind: 'attack', slot: 'active', skillName: 'Old Name' })]),
+            'a'
+        );
+        const b = fingerprintActorTokens(
+            resultWith([entry({ kind: 'attack', slot: 'active', skillName: 'New Name' })]),
+            'a'
+        );
+        expect(a).toEqual(b);
+    });
+
+    it('walks startOfRound and endOfRound, not just turn entries', () => {
+        const result = {
+            combatLog: [
+                {
+                    round: 1,
+                    startOfRound: [entry({ kind: 'dot-ticked' })],
+                    turns: [],
+                    endOfRound: [entry({ kind: 'buff-expired' })],
+                },
+            ],
+        } as unknown as BattleResult;
+        expect(fingerprintActorTokens(result, 'a')).toEqual(['buff-expired', 'dot-ticked']);
     });
 });

--- a/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
+++ b/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
@@ -126,7 +126,12 @@ describe('filler inertness guard', () => {
                 row!.charge.trim(),
                 `filler ship "${name}" gained a charge skill — same remedy as a new passive.`
             ).toBe('');
-            expect(row!.active.trim()).toMatch(BARE_DAMAGE);
+            expect(
+                row!.active.trim(),
+                `filler ship "${name}" gained a non-bare active skill — it can no longer be inert ` +
+                    'scaffolding. Swap it for another inert ship (Trydent, Umayl, Xiaodao are spare) ' +
+                    'and expect the fingerprint snapshots to move.'
+            ).toMatch(BARE_DAMAGE);
         }
     );
 });

--- a/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
+++ b/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import {
     buildScenarioBattle,
+    corpusNames,
     FILLER_NAMES,
     FOCUS_ACTOR_ID,
     FOCUS_POSITION,
@@ -18,6 +19,8 @@ import { runSeededBattle } from '../seededBattle';
 import { buildTraceShip } from '../../../../../scripts/lib/traceShipFactory';
 import { csvAvailable, loadShipSkillRecords } from '../../../../../scripts/lib/shipSkillCsv';
 import { shipDataAvailable } from '../../../../../scripts/lib/shipDataSnapshot';
+import { parseShipTargeting } from '../../../targetingParser';
+import { resolveCells } from '../../../targeting/resolvePattern';
 import type { Ship } from '../../../../types/ship';
 import type { CombatActor } from '../../state';
 
@@ -240,4 +243,77 @@ describe('filler inertness guard', () => {
             ).toMatch(BARE_DAMAGE);
         }
     );
+});
+
+describe('active pattern reachability from FOCUS_POSITION', () => {
+    // FOCUS_POSITION ('M4') is the FRONT column of its row (see that constant's docstring for the
+    // whole board rationale), and Line-Support patterns extend FORWARD from the caster. A caster
+    // anchored at the front has no cells ahead of it, so those patterns resolve to zero cells —
+    // their active skill can never fire from here. This is a FIXTURE limitation (one anchor cell
+    // cannot reach every pattern geometry), not an engine bug: measured precisely, it affects
+    // exactly these 3 of 147 corpus ships, all Line-Support at different ranges, and all 3 would
+    // resolve fine from M2 (one column back). Moving FOCUS_POSITION was considered and rejected
+    // (see FOCUS_POSITION's docstring) — it would regenerate all 147 snapshots a third time,
+    // risking the hard-won on-damaged tuning (145/147 fixtures), to reach 3 ships.
+    const KNOWN_UNREACHABLE: readonly string[] = ['Faust', 'Mender', 'Refine'];
+
+    beforeAll(requireReferenceData);
+
+    /** Occupied cells DERIVED from the real scenario board (not hard-coded), so this guard follows
+     *  the layout automatically if it ever changes. Positions don't depend on which ship is the
+     *  focus, so any resolvable corpus ship works to build the board. */
+    function occupiedCells(): Set<string> {
+        const focus = buildTraceShip('Malvex');
+        if (!focus) throw new Error('Malvex did not resolve from the corpus');
+        const battle = buildScenarioBattle(focus, 'plain');
+        return new Set([...battle.playerTeam, ...battle.enemyTeam].map((p) => p.position));
+    }
+
+    /** Names of every corpus ship whose ACTIVE targeting pattern, anchored at FOCUS_POSITION,
+     *  resolves to zero cells that are actually occupied on the scenario board. Ships whose
+     *  targeting can't be parsed/resolved at all (parseShipTargeting/resolveCells can throw for
+     *  unrecognized text) are skipped rather than counted either way — this guard is about
+     *  geometry reachability, not targeting-text coverage. */
+    function unreachableShips(): string[] {
+        const occupied = occupiedCells();
+        const out: string[] = [];
+        for (const name of corpusNames()) {
+            const ship = buildTraceShip(name);
+            if (!ship) continue;
+            let pattern;
+            try {
+                pattern = parseShipTargeting(ship)?.active?.pattern;
+                if (!pattern) continue;
+                const cells = resolveCells(pattern, FOCUS_POSITION);
+                if (!cells.some((c) => occupied.has(c.position))) out.push(name);
+            } catch {
+                continue;
+            }
+        }
+        return out;
+    }
+
+    it('no ship outside the allow-list resolves its active pattern to zero occupied cells', () => {
+        const unexpected = unreachableShips().filter((n) => !KNOWN_UNREACHABLE.includes(n));
+        expect(
+            unexpected,
+            `ship(s) whose active pattern resolves to ZERO occupied cells from FOCUS_POSITION and ` +
+                `are not on the allow-list: ${unexpected.join(', ')} — either a board change made ` +
+                'a previously-reachable ship go dark, or a new/changed corpus ship has an ' +
+                'unreachable pattern. If genuinely unreachable given the front-column geometry, ' +
+                'add it to KNOWN_UNREACHABLE with the same reasoning as Faust/Mender/Refine.'
+        ).toEqual([]);
+    });
+
+    it('every allow-listed ship is STILL unreachable (a board fix must shrink this list, not leave a stale exemption)', () => {
+        const unreachable = new Set(unreachableShips());
+        const stale = KNOWN_UNREACHABLE.filter((n) => !unreachable.has(n));
+        expect(
+            stale,
+            `allow-listed ship(s) that now resolve to a NON-empty set of occupied cells: ` +
+                `${stale.join(', ')} — the board (or this ship's pattern) changed and they are ` +
+                'reachable again. Remove them from KNOWN_UNREACHABLE rather than leaving a stale ' +
+                'exemption.'
+        ).toEqual([]);
+    });
 });

--- a/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
+++ b/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
@@ -1,19 +1,25 @@
 /**
  * The three real-kit fingerprint scenarios. These tests pin the SHAPE of each battle (roster,
- * positions, seeded state) — the fingerprint snapshots themselves live in
- * src/utils/calculators/__tests__/realKitFingerprints.test.ts.
+ * positions, seeded state) AND the two live invariants the fingerprints depend on — the focus ship
+ * is the one being attacked, and it survives all 20 rounds. The fingerprint snapshots themselves
+ * live in src/utils/calculators/__tests__/realKitFingerprints.test.ts.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import {
     buildScenarioBattle,
     FILLER_NAMES,
+    FOCUS_ACTOR_ID,
     FOCUS_POSITION,
+    ROUNDS,
     SCENARIOS,
+    SEED,
 } from '../kitFingerprintScenarios';
+import { runSeededBattle } from '../seededBattle';
 import { buildTraceShip } from '../../../../../scripts/lib/traceShipFactory';
 import { csvAvailable, loadShipSkillRecords } from '../../../../../scripts/lib/shipSkillCsv';
 import { shipDataAvailable } from '../../../../../scripts/lib/shipDataSnapshot';
 import type { Ship } from '../../../../types/ship';
+import type { CombatActor } from '../../state';
 
 function requireReferenceData(): void {
     if (!csvAvailable() || !shipDataAvailable()) {
@@ -23,6 +29,16 @@ function requireReferenceData(): void {
         );
     }
 }
+
+/** A stand-in roster for the seeding taps: two max-HP sizes per side so a FRACTION-of-max-HP
+ *  seed and an ABSOLUTE seed can be told apart. */
+const fakeRoster = () =>
+    [
+        { id: FOCUS_ACTOR_ID, side: 'player', shieldPool: 0, currentHp: 1000, stats: { hp: 1000 } },
+        { id: 'p:ally', side: 'player', shieldPool: 0, currentHp: 4000, stats: { hp: 4000 } },
+        { id: 'e:small', side: 'enemy', shieldPool: 0, currentHp: 1000, stats: { hp: 1000 } },
+        { id: 'e:big', side: 'enemy', shieldPool: 0, currentHp: 4000, stats: { hp: 4000 } },
+    ] as unknown as CombatActor[];
 
 describe('buildScenarioBattle', () => {
     let focus: Ship;
@@ -35,7 +51,7 @@ describe('buildScenarioBattle', () => {
     });
 
     it('exposes exactly three scenarios', () => {
-        expect([...SCENARIOS]).toEqual(['plain', 'richEnemy', 'hurtAllies']);
+        expect([...SCENARIOS]).toEqual(['plain', 'richEnemy', 'wounded']);
     });
 
     it('puts the focus ship first on the player side at the focus position', () => {
@@ -59,33 +75,68 @@ describe('buildScenarioBattle', () => {
         expect(new Set(positions).size).toBe(positions.length);
     });
 
+    it('puts three enemies in the focus row, behind the focus (the targeting contract)', () => {
+        // The whole layout rationale (see FOCUS_POSITION's docstring): selectTargets scans from the
+        // caster's own row and takes the front-most column, so enemies sharing the focus's row and
+        // sitting behind it resolve onto the FOCUS. Break this and the focus stops taking damage —
+        // which is exactly the hole this suite was found to have.
+        const battle = buildScenarioBattle(focus, 'plain');
+        const row = (p: string) => p[0];
+        const col = (p: string) => Number(p.slice(1));
+        const focusRow = row(FOCUS_POSITION);
+        const sameRow = battle.enemyTeam.filter((p) => row(p.position) === focusRow);
+        expect(sameRow).toHaveLength(3);
+        for (const p of sameRow) expect(col(p.position)).toBeLessThan(col(FOCUS_POSITION));
+        // ...and the odd enemy out shares a row with an ALLY, so an ally can be attacked (and the
+        // fragile one killed) without stealing the focus's incoming damage.
+        const offRow = battle.enemyTeam.filter((p) => row(p.position) !== focusRow);
+        expect(offRow).toHaveLength(1);
+        const allyRows = battle.playerTeam.slice(1).map((p) => row(p.position));
+        expect(allyRows).toContain(row(offRow[0].position));
+    });
+
+    it('scales filler attack to the focus ship rather than using one constant', () => {
+        // A fixed attack value either leaves 4047-defence tanks untouched or kills 7.3k-HP
+        // attackers; the derivation is what lets every fingerprint be taken at equal pressure.
+        const squishy = buildTraceShip('Xiaodao');
+        const tank = buildTraceShip('Lionheart');
+        expect(squishy).not.toBeNull();
+        expect(tank).not.toBeNull();
+        const attackOf = (s: Ship) =>
+            buildScenarioBattle(s, 'plain').enemyTeam[0].statOverrides!.attack!;
+        expect(attackOf(tank!)).toBeGreaterThan(attackOf(squishy!));
+    });
+
     it('plain seeds nothing at all (no tap — the baseline scenario)', () => {
         // plain must leave initial state untouched: it is the scenario where a wrongly-ungated
         // clause shows up, so any seeding here would mask exactly what it exists to reveal.
         expect(buildScenarioBattle(focus, 'plain').__testTapActors).toBeUndefined();
     });
 
-    it('richEnemy seeds a positive shield pool on enemy actors only', () => {
-        const battle = buildScenarioBattle(focus, 'richEnemy');
-        const actors = [
-            { id: 'e', side: 'enemy', shieldPool: 0, currentHp: 1000, stats: { hp: 1000 } },
-            { id: 'p', side: 'player', shieldPool: 0, currentHp: 1000, stats: { hp: 1000 } },
-        ];
-        battle.__testTapActors?.(actors as never);
-        expect(actors[0].shieldPool).toBeGreaterThan(0);
-        expect(actors[1].shieldPool).toBe(0);
+    it('richEnemy seeds an ABSOLUTE, depletable shield pool on enemy actors only', () => {
+        const actors = fakeRoster();
+        buildScenarioBattle(focus, 'richEnemy').__testTapActors?.(actors);
+        const [, ally, small, big] = actors;
+        expect(small.shieldPool).toBeGreaterThan(0);
+        expect(actors[0].shieldPool).toBe(0);
+        expect(ally.shieldPool).toBe(0);
+        // Absolute, not a fraction of max HP: the fraction version was 100M against ~1.2k hits and
+        // never depleted, so no shield-gated clause ever saw the pool run out.
+        expect(big.shieldPool).toBe(small.shieldPool);
+        // Small enough to be spent by the focus's own casts (a few hits' worth of its attack).
+        expect(small.shieldPool).toBeLessThan(10 * focus.baseStats.attack);
     });
 
-    it('hurtAllies damages player actors and leaves enemies at full HP', () => {
-        const battle = buildScenarioBattle(focus, 'hurtAllies');
-        const actors = [
-            { id: 'p', side: 'player', shieldPool: 0, currentHp: 1000, stats: { hp: 1000 } },
-            { id: 'e', side: 'enemy', shieldPool: 0, currentHp: 1000, stats: { hp: 1000 } },
-        ];
-        battle.__testTapActors?.(actors as never);
-        expect(actors[0].currentHp).toBeLessThan(1000);
-        expect(actors[0].currentHp).toBeGreaterThan(0);
-        expect(actors[1].currentHp).toBe(1000);
+    it('wounded hurts both sides, and hurts the focus least (it is the one under fire)', () => {
+        const actors = fakeRoster();
+        buildScenarioBattle(focus, 'wounded').__testTapActors?.(actors);
+        for (const a of actors) {
+            const pct = (100 * a.currentHp) / a.stats.hp;
+            expect(pct).toBeGreaterThan(30);
+            expect(pct).toBeLessThan(70);
+        }
+        const pctOf = (a: CombatActor) => (100 * a.currentHp) / a.stats.hp;
+        expect(pctOf(actors[0])).toBeGreaterThan(pctOf(actors[1]));
     });
 
     it('gives filler enough HP to survive, so kill timing cannot churn fingerprints', () => {
@@ -98,6 +149,61 @@ describe('buildScenarioBattle', () => {
     it('names 7 filler ships, all resolvable from the corpus', () => {
         expect(FILLER_NAMES).toHaveLength(7);
         for (const name of FILLER_NAMES) expect(buildTraceShip(name)).not.toBeNull();
+    });
+});
+
+describe('live battle invariants', () => {
+    // These run real battles, because the two properties every fingerprint rests on are dynamic:
+    // the focus must be HIT (or all on-damaged kit is silent) and must SURVIVE (or its fingerprint
+    // is truncated at an arbitrary round). Two focus ships: the corpus's thinnest-HP/lowest-defence
+    // ship, which is the survival edge case, and a mid-weight one.
+    beforeAll(requireReferenceData);
+
+    it.each(['Xiaodao', 'Malvex'])(
+        '%s takes real incoming damage and survives all 20 rounds in every scenario',
+        (name) => {
+            const ship = buildTraceShip(name);
+            expect(ship).not.toBeNull();
+            for (const scenario of SCENARIOS) {
+                const result = runSeededBattle(buildScenarioBattle(ship!, scenario), SEED);
+                const rows = result.rounds
+                    .flatMap((r) => r.ships)
+                    .filter((s) => s.actorId === FOCUS_ACTOR_ID);
+                const taken = rows.reduce((sum, s) => sum + s.damageTaken, 0);
+                expect(
+                    taken,
+                    `${name}/${scenario}: focus took no damage — the enemies are not resolving ` +
+                        'onto it, so every on-damaged clause in the corpus is silent'
+                ).toBeGreaterThan(0);
+                expect(
+                    rows.every((s) => s.alive),
+                    `${name}/${scenario}: focus died — its fingerprint is truncated at the round ` +
+                        'it fell, so kill timing now leaks into the snapshot'
+                ).toBe(true);
+                expect(result.outcome.lastRound).toBe(ROUNDS);
+            }
+        }
+    );
+
+    it('kills the fragile ally in wounded, and nothing else, in any scenario', () => {
+        const ship = buildTraceShip('Malvex');
+        expect(ship).not.toBeNull();
+        for (const scenario of SCENARIOS) {
+            const result = runSeededBattle(buildScenarioBattle(ship!, scenario), SEED);
+            const last = result.rounds[result.rounds.length - 1];
+            const dead = last.ships.filter((s) => !s.alive).map((s) => s.actorId);
+            if (scenario === 'wounded') {
+                // Exactly one death, and it is the T4 ally (the first filler ally placement).
+                expect(dead).toHaveLength(1);
+                expect(dead[0]).not.toBe(FOCUS_ACTOR_ID);
+                expect(
+                    result.roster.find((r) => r.actorId === dead[0])?.position,
+                    'the fragile ally must be the one that dies'
+                ).toBe('T4');
+            } else {
+                expect(dead, `${scenario}: nothing may die outside wounded`).toEqual([]);
+            }
+        }
     });
 });
 

--- a/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
+++ b/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The three real-kit fingerprint scenarios. These tests pin the SHAPE of each battle (roster,
+ * positions, seeded state) — the fingerprint snapshots themselves live in
+ * src/utils/calculators/__tests__/realKitFingerprints.test.ts.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+    buildScenarioBattle,
+    FILLER_NAMES,
+    FOCUS_POSITION,
+    SCENARIOS,
+} from '../kitFingerprintScenarios';
+import { buildTraceShip } from '../../../../../scripts/lib/traceShipFactory';
+import { csvAvailable } from '../../../../../scripts/lib/shipSkillCsv';
+import { shipDataAvailable } from '../../../../../scripts/lib/shipDataSnapshot';
+import type { Ship } from '../../../../types/ship';
+
+function requireReferenceData(): void {
+    if (!csvAvailable() || !shipDataAvailable()) {
+        throw new Error(
+            'docs/ship-skills.csv and/or docs/ship-data.json are missing from this worktree ' +
+                '(gitignored reference data) — tests need them to resolve real ship skill text/stats.'
+        );
+    }
+}
+
+describe('buildScenarioBattle', () => {
+    let focus: Ship;
+
+    beforeAll(() => {
+        requireReferenceData();
+        const m = buildTraceShip('Malvex');
+        if (!m) throw new Error('Malvex did not resolve from the corpus');
+        focus = m;
+    });
+
+    it('exposes exactly three scenarios', () => {
+        expect([...SCENARIOS]).toEqual(['plain', 'richEnemy', 'hurtAllies']);
+    });
+
+    it('puts the focus ship first on the player side at the focus position', () => {
+        const battle = buildScenarioBattle(focus, 'plain');
+        expect(battle.playerTeam[0].ship.name).toBe('Malvex');
+        expect(battle.playerTeam[0].position).toBe(FOCUS_POSITION);
+    });
+
+    it('builds a 4v4 of distinct ships within each side (a repeat is an illegal game state)', () => {
+        const battle = buildScenarioBattle(focus, 'plain');
+        expect(battle.playerTeam).toHaveLength(4);
+        expect(battle.enemyTeam).toHaveLength(4);
+        const ids = (side: typeof battle.playerTeam) => side.map((p) => p.ship.id);
+        expect(new Set(ids(battle.playerTeam)).size).toBe(4);
+        expect(new Set(ids(battle.enemyTeam)).size).toBe(4);
+    });
+
+    it('uses distinct board positions across the whole battle', () => {
+        const battle = buildScenarioBattle(focus, 'plain');
+        const positions = [...battle.playerTeam, ...battle.enemyTeam].map((p) => p.position);
+        expect(new Set(positions).size).toBe(positions.length);
+    });
+
+    it('plain seeds nothing at all (no tap — the baseline scenario)', () => {
+        // plain must leave initial state untouched: it is the scenario where a wrongly-ungated
+        // clause shows up, so any seeding here would mask exactly what it exists to reveal.
+        expect(buildScenarioBattle(focus, 'plain').__testTapActors).toBeUndefined();
+    });
+
+    it('richEnemy seeds a positive shield pool on enemy actors only', () => {
+        const battle = buildScenarioBattle(focus, 'richEnemy');
+        const actors = [
+            { id: 'e', side: 'enemy', shieldPool: 0, currentHp: 1000, stats: { hp: 1000 } },
+            { id: 'p', side: 'player', shieldPool: 0, currentHp: 1000, stats: { hp: 1000 } },
+        ];
+        battle.__testTapActors?.(actors as never);
+        expect(actors[0].shieldPool).toBeGreaterThan(0);
+        expect(actors[1].shieldPool).toBe(0);
+    });
+
+    it('hurtAllies damages player actors and leaves enemies at full HP', () => {
+        const battle = buildScenarioBattle(focus, 'hurtAllies');
+        const actors = [
+            { id: 'p', side: 'player', shieldPool: 0, currentHp: 1000, stats: { hp: 1000 } },
+            { id: 'e', side: 'enemy', shieldPool: 0, currentHp: 1000, stats: { hp: 1000 } },
+        ];
+        battle.__testTapActors?.(actors as never);
+        expect(actors[0].currentHp).toBeLessThan(1000);
+        expect(actors[0].currentHp).toBeGreaterThan(0);
+        expect(actors[1].currentHp).toBe(1000);
+    });
+
+    it('gives filler enough HP to survive, so kill timing cannot churn fingerprints', () => {
+        const battle = buildScenarioBattle(focus, 'plain');
+        for (const p of battle.enemyTeam) {
+            expect(p.statOverrides?.hp).toBeGreaterThan(p.ship.baseStats.hp);
+        }
+    });
+
+    it('names 7 filler ships, all resolvable from the corpus', () => {
+        expect(FILLER_NAMES).toHaveLength(7);
+        for (const name of FILLER_NAMES) expect(buildTraceShip(name)).not.toBeNull();
+    });
+});

--- a/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
+++ b/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
@@ -293,8 +293,18 @@ describe('active pattern reachability from FOCUS_POSITION', () => {
         return out;
     }
 
+    // Both tests below call unreachableShips(), which rebuilds all 147 corpus ships and re-runs
+    // parseShipTargeting/resolveCells for each — computed once here (registered AFTER the
+    // requireReferenceData beforeAll above, so reference data is guaranteed present first) rather
+    // than once per test.
+    let unreachable: string[];
+
+    beforeAll(() => {
+        unreachable = unreachableShips();
+    });
+
     it('no ship outside the allow-list resolves its active pattern to zero occupied cells', () => {
-        const unexpected = unreachableShips().filter((n) => !KNOWN_UNREACHABLE.includes(n));
+        const unexpected = unreachable.filter((n) => !KNOWN_UNREACHABLE.includes(n));
         expect(
             unexpected,
             `ship(s) whose active pattern resolves to ZERO occupied cells from FOCUS_POSITION and ` +
@@ -306,8 +316,8 @@ describe('active pattern reachability from FOCUS_POSITION', () => {
     });
 
     it('every allow-listed ship is STILL unreachable (a board fix must shrink this list, not leave a stale exemption)', () => {
-        const unreachable = new Set(unreachableShips());
-        const stale = KNOWN_UNREACHABLE.filter((n) => !unreachable.has(n));
+        const unreachableSet = new Set(unreachable);
+        const stale = KNOWN_UNREACHABLE.filter((n) => !unreachableSet.has(n));
         expect(
             stale,
             `allow-listed ship(s) that now resolve to a NON-empty set of occupied cells: ` +

--- a/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
+++ b/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
@@ -11,7 +11,7 @@ import {
     SCENARIOS,
 } from '../kitFingerprintScenarios';
 import { buildTraceShip } from '../../../../../scripts/lib/traceShipFactory';
-import { csvAvailable } from '../../../../../scripts/lib/shipSkillCsv';
+import { csvAvailable, loadShipSkillRecords } from '../../../../../scripts/lib/shipSkillCsv';
 import { shipDataAvailable } from '../../../../../scripts/lib/shipDataSnapshot';
 import type { Ship } from '../../../../types/ship';
 
@@ -99,4 +99,34 @@ describe('buildScenarioBattle', () => {
         expect(FILLER_NAMES).toHaveLength(7);
         for (const name of FILLER_NAMES) expect(buildTraceShip(name)).not.toBeNull();
     });
+});
+
+describe('filler inertness guard', () => {
+    // Every one of the 147 fingerprint snapshots assumes the filler ships contribute NOTHING. If a
+    // data refresh gives one a passive or a charge skill, that assumption breaks and every snapshot
+    // moves at once. This test makes that a single, named, explained failure instead.
+    const BARE_DAMAGE = /^This Unit deals <unit-damage>\d+% damage<\/unit-damage>\.?$/;
+
+    beforeAll(requireReferenceData);
+
+    it.each(FILLER_NAMES.map((n) => [n] as const))(
+        '%s is still inert: no passives, no charge skill, bare damage active',
+        (name) => {
+            const row = loadShipSkillRecords().find(
+                (r) => r.name.toUpperCase() === name.toUpperCase()
+            );
+            expect(row, `filler ship "${name}" is no longer in the corpus`).toBeDefined();
+            expect(
+                row!.passives.filter((p) => p && p.trim() !== ''),
+                `filler ship "${name}" gained a passive — it can no longer be inert scaffolding. ` +
+                    'Swap it for another inert ship (Trydent, Umayl, Xiaodao are spare) and expect ' +
+                    'the fingerprint snapshots to move.'
+            ).toEqual([]);
+            expect(
+                row!.charge.trim(),
+                `filler ship "${name}" gained a charge skill — same remedy as a new passive.`
+            ).toBe('');
+            expect(row!.active.trim()).toMatch(BARE_DAMAGE);
+        }
+    );
 });

--- a/src/utils/combat/audit/fingerprint.ts
+++ b/src/utils/combat/audit/fingerprint.ts
@@ -55,6 +55,38 @@ export function diffFingerprints(
  * divergence, not real interference. Diagnostic's `actorId` is the composition-side id, since
  * that's where a reported ship must be located to reproduce/inspect the finding.
  */
+/** Recurse into an entry list AND every entry's nested `reactions`, collecting the `kind[:slot]`
+ *  token of every entry whose `actorId` matches. The slot half is what distinguishes a
+ *  CAST-sourced effect from a passive/reactive one: `buildCombatLog` spreads
+ *  `ctx.consumePendingSkill()` (which carries `{skillName, slot}`) onto cast entries only, so a
+ *  passive entry has no `slot`. Without that split, a ship with two sources for the same kind
+ *  (Malvex: an active-slot shield grant AND a passive on-damaged shield grant) fingerprints
+ *  identically whether or not the active one is correctly gated. `skillName` is deliberately NOT
+ *  part of the token — it is the ship's own skill name, so it carries nothing the ship key doesn't,
+ *  and including it would churn snapshots on a cosmetic rename. */
+function walkEntryTokens(entries: CombatLogEntry[], actorId: string, acc: Set<string>): void {
+    for (const e of entries) {
+        if (e.actorId === actorId) acc.add(e.slot ? `${e.kind}:${e.slot}` : e.kind);
+        if (e.reactions?.length) walkEntryTokens(e.reactions, actorId, acc);
+    }
+}
+
+/** The behaviour fingerprint of one actor across a whole battle, as a SORTED array of
+ *  `kind[:slot]` tokens. Sorted so entry order can never churn a snapshot; de-duplicated because
+ *  it is a set of behaviours, not a count. Pure over an already-run `BattleResult`.
+ *
+ *  A REFINEMENT of `fingerprintActor`, not a replacement — that function is consumed by
+ *  `ablation.ts`'s differential oracle, which compares bare kind-sets, so it stays as-is. */
+export function fingerprintActorTokens(result: BattleResult, actorId: string): string[] {
+    const acc = new Set<string>();
+    for (const round of result.combatLog) {
+        walkEntryTokens(round.startOfRound, actorId, acc);
+        for (const turn of round.turns) walkEntryTokens(turn.entries, actorId, acc);
+        walkEntryTokens(round.endOfRound, actorId, acc);
+    }
+    return [...acc].sort();
+}
+
 export function runDifferential(
     soloResult: BattleResult,
     compResult: BattleResult,

--- a/src/utils/combat/audit/fingerprint.ts
+++ b/src/utils/combat/audit/fingerprint.ts
@@ -45,25 +45,29 @@ export function diffFingerprints(
     return { actorId, shipName, missingInComposition: missing, extraInComposition: extra };
 }
 
-/**
- * Consumer-facing differential entry point (Task 10 calls this). Fingerprints `shipName` in
- * each already-run `BattleResult` — via its OWN actorId in that result, since a ship's actorId
- * in a composition run need not match its solo-run actorId (roster-assigned) — and diffs them.
- *
- * PURE: does not run battles. The caller is responsible for producing `soloResult` and
- * `compResult` via `runSeededBattle(_, seed)` under the SAME seed; otherwise this compares RNG
- * divergence, not real interference. Diagnostic's `actorId` is the composition-side id, since
- * that's where a reported ship must be located to reproduce/inspect the finding.
- */
 /** Recurse into an entry list AND every entry's nested `reactions`, collecting the `kind[:slot]`
- *  token of every entry whose `actorId` matches. The slot half is what distinguishes a
- *  CAST-sourced effect from a passive/reactive one: `buildCombatLog` spreads
- *  `ctx.consumePendingSkill()` (which carries `{skillName, slot}`) onto cast entries only, so a
- *  passive entry has no `slot`. Without that split, a ship with two sources for the same kind
- *  (Malvex: an active-slot shield grant AND a passive on-damaged shield grant) fingerprints
- *  identically whether or not the active one is correctly gated. `skillName` is deliberately NOT
- *  part of the token — it is the ship's own skill name, so it carries nothing the ship key doesn't,
- *  and including it would churn snapshots on a cosmetic rename. */
+ *  token of every entry whose `actorId` matches.
+ *
+ *  The `:slot` suffix is NOT a reliable CAST-vs-passive/reactive marker, despite appearances.
+ *  `ctx.pendingSkill` (`{skillName, slot}`) is set exactly once per cast — from the single
+ *  `skill-fired` event emitted before any of its clauses resolve (`playerTurn.ts`) — and several
+ *  log-entry handlers in `buildCombatLog.ts` each spread `...(ctx.consumePendingSkill() ?? {})`,
+ *  which reads-and-clears it. So the tag is single-use FOR THE WHOLE CAST: whichever handler runs
+ *  first wins `:slot`, and every later entry from that same cast lands BARE. A bare token can
+ *  therefore be a genuine cast entry that simply lost the race, not a passive/reactive one.
+ *  Concretely, Malvex's charged cast grants Barrier via a named buff routed through the
+ *  `timedSelfBySlot` loop, which runs BEFORE the attack's `ability-performed` emission — so
+ *  `buff-applied` consumes the tag (`buff:charged`) and the charged attack itself lands as a bare
+ *  `attack`, not `attack:charged` (see the committed `richEnemy` snapshot for Malvex). Which entry
+ *  carries the slot is therefore a function of emission ORDER in `playerTurn.ts`; a pure refactor
+ *  that reorders emission (no behaviour change) can flip which entry gets tagged.
+ *
+ *  What IS still true, and the reason this token is richer than bare `kind`: within a single actor,
+ *  the suffix lets two same-kind entries from genuinely different sources be told apart in
+ *  practice — e.g. Malvex's gated active-slot shield (`shield:active`) versus its passive
+ *  on-damaged shield grant (bare `shield`). `skillName` is deliberately NOT part of the token — it
+ *  is the ship's own skill name, so it carries nothing the ship key doesn't, and including it
+ *  would churn snapshots on a cosmetic rename. */
 function walkEntryTokens(entries: CombatLogEntry[], actorId: string, acc: Set<string>): void {
     for (const e of entries) {
         if (e.actorId === actorId) acc.add(e.slot ? `${e.kind}:${e.slot}` : e.kind);
@@ -87,6 +91,16 @@ export function fingerprintActorTokens(result: BattleResult, actorId: string): s
     return [...acc].sort();
 }
 
+/**
+ * Consumer-facing differential entry point (Task 10 calls this). Fingerprints `shipName` in
+ * each already-run `BattleResult` — via its OWN actorId in that result, since a ship's actorId
+ * in a composition run need not match its solo-run actorId (roster-assigned) — and diffs them.
+ *
+ * PURE: does not run battles. The caller is responsible for producing `soloResult` and
+ * `compResult` via `runSeededBattle(_, seed)` under the SAME seed; otherwise this compares RNG
+ * divergence, not real interference. Diagnostic's `actorId` is the composition-side id, since
+ * that's where a reported ship must be located to reproduce/inspect the finding.
+ */
 export function runDifferential(
     soloResult: BattleResult,
     compResult: BattleResult,

--- a/src/utils/combat/audit/fingerprint.ts
+++ b/src/utils/combat/audit/fingerprint.ts
@@ -57,17 +57,22 @@ export function diffFingerprints(
  *  therefore be a genuine cast entry that simply lost the race, not a passive/reactive one.
  *  Concretely, Malvex's charged cast grants Barrier via a named buff routed through the
  *  `timedSelfBySlot` loop, which runs BEFORE the attack's `ability-performed` emission — so
- *  `buff-applied` consumes the tag (`buff:charged`) and the charged attack itself lands as a bare
- *  `attack`, not `attack:charged` (see the committed `richEnemy` snapshot for Malvex). Which entry
- *  carries the slot is therefore a function of emission ORDER in `playerTurn.ts`; a pure refactor
- *  that reorders emission (no behaviour change) can flip which entry gets tagged.
+ *  `buff-applied` consumes the tag (`buff:charged`) and THAT cast's attack lands as a bare
+ *  `attack`. Its committed `richEnemy` snapshot carries both `attack` and `attack:charged` for
+ *  exactly this reason: once the seeded enemy shield is spent, later charged casts grant no Barrier
+ *  and so keep their own tag. Which entry carries the slot is therefore a function of emission
+ *  ORDER in `playerTurn.ts`; a pure refactor that reorders emission (no behaviour change) can flip
+ *  which entry gets tagged.
  *
- *  What IS still true, and the reason this token is richer than bare `kind`: within a single actor,
- *  the suffix lets two same-kind entries from genuinely different sources be told apart in
- *  practice — e.g. Malvex's gated active-slot shield (`shield:active`) versus its passive
- *  on-damaged shield grant (bare `shield`). `skillName` is deliberately NOT part of the token — it
- *  is the ship's own skill name, so it carries nothing the ship key doesn't, and including it
- *  would churn snapshots on a cosmetic rename. */
+ *  So what does the suffix buy over a bare `kind`? Less than it looks, and it is worth being precise
+ *  because the cost above is real. It does NOT earn its keep by separating a cast entry from a
+ *  passive/reactive one of the same kind: on the current corpus that case does not arise, because
+ *  reactive grants tend not to log at all (Malvex's on-damaged shield passive fires in every
+ *  scenario, yet logs no `shield` entry — only its later `shield-destroyed` proves the pool
+ *  existed). What it does buy is NAMING the slot in a diff: `shield:active` disappearing says which
+ *  half of the kit regressed, where a vanished bare `shield` would not. `skillName` is deliberately
+ *  NOT part of the token — it is the ship's own skill name, so it carries nothing the ship key
+ *  doesn't, and including it would churn snapshots on a cosmetic rename. */
 function walkEntryTokens(entries: CombatLogEntry[], actorId: string, acc: Set<string>): void {
     for (const e of entries) {
         if (e.actorId === actorId) acc.add(e.slot ? `${e.kind}:${e.slot}` : e.kind);

--- a/src/utils/combat/audit/kitFingerprintScenarios.ts
+++ b/src/utils/combat/audit/kitFingerprintScenarios.ts
@@ -1,0 +1,137 @@
+import type { Ship } from '../../../types/ship';
+import type { Position } from '../../../types/encounters';
+import type { CombatActor } from '../state';
+import type { BattlePlacement, BattleSimulationInput } from '../../calculators/battleSimulator';
+import { buildTraceShip } from '../../../../scripts/lib/traceShipFactory';
+import { canonicalPlacement } from './fixtures';
+
+export type ScenarioName = 'plain' | 'richEnemy' | 'hurtAllies';
+
+/** Fixed scenario order — also the snapshot key order. */
+export const SCENARIOS: readonly ScenarioName[] = ['plain', 'richEnemy', 'hurtAllies'] as const;
+
+/** Pinned RNG seed for every scenario battle. One seed for all of them: the scenarios are meant
+ *  to differ by initial STATE, not by RNG stream. */
+export const SEED = 20260805;
+
+/** 20 rounds, matching the ablation harness — long enough for charge skills to fire, DoTs to
+ *  tick more than once, and cooldown-gated grants to re-arm. */
+export const ROUNDS = 20;
+
+/** Column 4 is the FRONT of the board (columns run 1 = back → 4 = front). The focus ship takes a
+ *  front-row slot so it is reachable by enemy targeting and resolves enemies itself. */
+export const FOCUS_POSITION: Position = 'M4';
+
+const ALLY_POSITIONS: Position[] = ['T4', 'T3', 'M3'];
+const ENEMY_POSITIONS: Position[] = ['B4', 'B3', 'B2', 'B1'];
+
+/** Seven corpus ships verified inert: no passives, no charge skill, and a bare
+ *  "This Unit deals 90% damage" active (see the inertness guard test, which fails loudly if a data
+ *  refresh changes that). Because they carry no kit, a focus ship's fingerprint is a function of
+ *  its OWN kit plus the engine — nothing here can perturb it.
+ *
+ *  First 4 are the enemy side, last 3 the ally side. Distinct WITHIN each side because a repeated
+ *  ship on one side is an illegal in-game state (compose.ts's pickDistinctShip); repeats across
+ *  sides would be legal but are unnecessary given 10 candidates exist. */
+export const FILLER_NAMES: readonly string[] = [
+    'Bedrock',
+    'Crusher',
+    'Custodian',
+    'Forsythia',
+    'Jempol',
+    'Krysa',
+    'Rookie',
+] as const;
+
+/** Filler survive the whole window: without this, a damage-formula change shifts kill timing,
+ *  which shifts which clauses get to fire — numeric sensitivity leaking into a structural suite. */
+const FILLER_HP = 500_000_000;
+/** ...and hit softly enough that the focus ship also survives all 20 rounds. */
+const FILLER_ATTACK = 500;
+
+/** The fragile ally: dies early and deterministically so on-ally-destroyed / revive / cheat-death
+ *  clauses fire. The ONE intentional exception to filler survival. Verified (traceShipFactory +
+ *  battleSimulator.resolveStats pass overrides straight through with no scaling) that hp: 1
+ *  resolves to stats.hp = 1 and currentHp = 1 at actor construction — the ally starts ALIVE, then
+ *  dies to the very first hit it takes (filler attack is 500). No need to raise it. */
+const FRAGILE_ALLY_HP = 1;
+
+let cache: Map<string, Ship> | null = null;
+
+function fillerShip(name: string): Ship {
+    if (!cache) cache = new Map();
+    const hit = cache.get(name);
+    if (hit) return hit;
+    const ship = buildTraceShip(name);
+    if (!ship) {
+        throw new Error(
+            `kitFingerprintScenarios: filler ship "${name}" did not resolve — ` +
+                'docs/ship-skills.csv / docs/ship-data.json are gitignored reference data ' +
+                'expected on dev machines (see CLAUDE.md).'
+        );
+    }
+    cache.set(name, ship);
+    return ship;
+}
+
+/** A filler placement: canonical base stats, then HP and attack overridden for survivability. */
+function fillerPlacement(name: string, position: Position, hp = FILLER_HP): BattlePlacement {
+    const base = canonicalPlacement(fillerShip(name), position);
+    return { ...base, statOverrides: { ...base.statOverrides, hp, attack: FILLER_ATTACK } };
+}
+
+/** 20% of max HP as a starting shield pool — any positive pool satisfies `enemy-shield`, which is
+ *  a boolean gate, and 20% is small enough that it drains during the battle so shield-destroyed
+ *  and punch-through clauses also get to fire. */
+const SHIELD_FRACTION = 0.2;
+/** Allies start at 50% HP: below every corpus hp-threshold gate worth exercising, and low enough
+ *  that heals have real headroom to land rather than clipping entirely to overheal. */
+const HURT_FRACTION = 0.5;
+
+const maxHpOf = (a: CombatActor): number => a.stats.hp;
+
+function seedFor(scenario: ScenarioName): ((actors: CombatActor[]) => void) | undefined {
+    switch (scenario) {
+        case 'plain':
+            return undefined;
+        case 'richEnemy':
+            return (actors) => {
+                for (const a of actors) {
+                    if (a.side === 'enemy') a.shieldPool = maxHpOf(a) * SHIELD_FRACTION;
+                }
+            };
+        case 'hurtAllies':
+            return (actors) => {
+                for (const a of actors) {
+                    if (a.side === 'player') a.currentHp = maxHpOf(a) * HURT_FRACTION;
+                }
+            };
+    }
+}
+
+/**
+ * The scenario battle for one focus ship: the focus at FOCUS_POSITION on the player side with 3
+ * inert filler allies, against 4 inert filler enemies. Only the seeded initial state varies by
+ * scenario. The focus ship keeps `canonicalPlacement`'s un-modified level-60 base stats — no gear,
+ * no refits, no engineering — so its fingerprint reflects its kit, not a gearing choice.
+ */
+export function buildScenarioBattle(focus: Ship, scenario: ScenarioName): BattleSimulationInput {
+    const enemyNames = FILLER_NAMES.slice(0, 4);
+    const allyNames = FILLER_NAMES.slice(4, 7);
+    const tap = seedFor(scenario);
+    return {
+        playerTeam: [
+            canonicalPlacement(focus, FOCUS_POSITION),
+            ...allyNames.map((name, i) =>
+                fillerPlacement(
+                    name,
+                    ALLY_POSITIONS[i],
+                    scenario === 'hurtAllies' && i === 0 ? FRAGILE_ALLY_HP : FILLER_HP
+                )
+            ),
+        ],
+        enemyTeam: enemyNames.map((name, i) => fillerPlacement(name, ENEMY_POSITIONS[i])),
+        rounds: ROUNDS,
+        ...(tap ? { __testTapActors: tap } : {}),
+    };
+}

--- a/src/utils/combat/audit/kitFingerprintScenarios.ts
+++ b/src/utils/combat/audit/kitFingerprintScenarios.ts
@@ -106,7 +106,12 @@ const INCOMING_FRACTION = 0.2;
  *
  *  An ESTIMATE, not a guarantee: the focus's own defence buffs/debuffs, incoming-damage modifiers,
  *  shields, dodges and self-heals all move the realised total. It only has to land in the band
- *  "clearly nonzero, comfortably survivable", which the scenario tests assert directly. */
+ *  "clearly nonzero, comfortably survivable", which the scenario tests assert directly.
+ *
+ *  Because this inverts the engine's OWN `calculateDamageReduction`, a change to the mitigation
+ *  formula is COMPENSATED here rather than surfaced — this suite is deliberately blind to
+ *  mitigation-formula changes, consistent with it being a structural (does-this-clause-fire) suite,
+ *  not a numeric one (that's dpsGoldenParity / healingGoldenParity's job). */
 function fillerAttackFor(focus: Ship): number {
     const defence = focus.baseStats.defence;
     const mitigation = defence > 0 ? calculateDamageReduction(defence) : 0;

--- a/src/utils/combat/audit/kitFingerprintScenarios.ts
+++ b/src/utils/combat/audit/kitFingerprintScenarios.ts
@@ -212,6 +212,14 @@ function seedFor(
                     a.currentHp = maxHpOf(a) * fraction;
                 }
             };
+        default: {
+            // Exhaustiveness guard: `undefined` is a legitimate return for 'plain', so a fourth
+            // ScenarioName falling through the switch would silently run unseeded and still
+            // produce a plausible-looking (but vacuous) snapshot. Force a compile error instead —
+            // the spec DEFERS a status-seeded scenario, it does not cancel it.
+            const exhaustive: never = scenario;
+            throw new Error(`kitFingerprintScenarios: unhandled scenario ${String(exhaustive)}`);
+        }
     }
 }
 

--- a/src/utils/combat/audit/kitFingerprintScenarios.ts
+++ b/src/utils/combat/audit/kitFingerprintScenarios.ts
@@ -4,14 +4,15 @@ import type { CombatActor } from '../state';
 import type { BattlePlacement, BattleSimulationInput } from '../../calculators/battleSimulator';
 import { buildTraceShip } from '../../../../scripts/lib/traceShipFactory';
 import { loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
+import { calculateDamageReduction } from '../../autogear/priorityScore';
 import { canonicalPlacement } from './fixtures';
 import { runSeededBattle } from './seededBattle';
 import { fingerprintActorTokens } from './fingerprint';
 
-export type ScenarioName = 'plain' | 'richEnemy' | 'hurtAllies';
+export type ScenarioName = 'plain' | 'richEnemy' | 'wounded';
 
 /** Fixed scenario order — also the snapshot key order. */
-export const SCENARIOS: readonly ScenarioName[] = ['plain', 'richEnemy', 'hurtAllies'] as const;
+export const SCENARIOS: readonly ScenarioName[] = ['plain', 'richEnemy', 'wounded'] as const;
 
 /** Pinned RNG seed for every scenario battle. One seed for all of them: the scenarios are meant
  *  to differ by initial STATE, not by RNG stream. */
@@ -21,12 +22,42 @@ export const SEED = 20260805;
  *  tick more than once, and cooldown-gated grants to re-arm. */
 export const ROUNDS = 20;
 
-/** Column 4 is the FRONT of the board (columns run 1 = back → 4 = front). The focus ship takes a
- *  front-row slot so it is reachable by enemy targeting and resolves enemies itself. */
+/**
+ * BOARD LAYOUT — the single most load-bearing choice in this fixture, because it decides whether
+ * the focus ship is ever ATTACKED. `selectTargets` scans rows starting at the CASTER's own row
+ * (`rowScanOrder`: caster row → next → wrap) and takes the front-most occupied column (col 4 =
+ * front) of the first row that holds a target. Consequences that drive the numbers below:
+ *
+ *  - Three enemies share the focus's OWN row (M3/M2/M1 against the focus at M4). Their scan starts
+ *    at row M, finds exactly one player there — the focus, front-most at col 4 — so all three
+ *    single-target attacks land on the focus, every round. That is what makes on-damaged kit
+ *    (counterattack, reflect, revenge, on-damaged grants, Barrier hit-counting) observable at all:
+ *    the previous layout parked the focus behind an ally in another row and it took ZERO incoming
+ *    damage in 136 of 147 fingerprints.
+ *  - Sharing the row also keeps the focus's OWN offence multi-target: scanning from M it finds
+ *    M3/M2/M1 front-to-back, so front/back/skip/adjacent patterns still differentiate, and `all`
+ *    still reaches four enemies (row M, then T3).
+ *  - The fourth enemy sits at T3, whose scan starts at row T where the front-most player is the
+ *    ALLY at T4 — the slot the fragile ally occupies in `wounded`. That is the only way an ally
+ *    can be attacked (and so die) while the focus is itself front-most in its own row.
+ *  - The third ally at T2 backs up T4: when the fragile ally dies, the T3 enemy retargets to T2
+ *    rather than joining the three already hitting the focus, so the focus's incoming-damage
+ *    budget is the same in all three scenarios.
+ *  - Allies at T4/B4 flank the focus's column-4 cell, so column/adjacency support footprints
+ *    reach real allies.
+ *
+ * All eight cells are distinct: an ally and an enemy on the same cell would be
+ * indistinguishable in position-keyed engine state.
+ */
 export const FOCUS_POSITION: Position = 'M4';
 
-const ALLY_POSITIONS: Position[] = ['T4', 'T3', 'M3'];
-const ENEMY_POSITIONS: Position[] = ['B4', 'B3', 'B2', 'B1'];
+const ALLY_POSITIONS: Position[] = ['T4', 'T2', 'B4'];
+const ENEMY_POSITIONS: Position[] = ['M3', 'M2', 'M1', 'T3'];
+
+/** How many enemies resolve onto the focus each round under the layout above (M3/M2/M1). Drives
+ *  the incoming-damage budget in `fillerAttackFor`; verified by the "focus is the one being
+ *  attacked" scenario test. */
+const ATTACKERS_ON_FOCUS = 3;
 
 /** Seven corpus ships verified inert: no passives, no charge skill, and a bare
  *  "This Unit deals 90% damage" active (see the inertness guard test, which fails loudly if a data
@@ -47,16 +78,52 @@ export const FILLER_NAMES: readonly string[] = [
 ] as const;
 
 /** Filler survive the whole window: without this, a damage-formula change shifts kill timing,
- *  which shifts which clauses get to fire — numeric sensitivity leaking into a structural suite. */
+ *  which shifts which clauses get to fire — numeric sensitivity leaking into a structural suite.
+ *  Deliberately absurd rather than merely large: the corpus's per-battle damage output spans more
+ *  than an order of magnitude, so no single finite HP value both keeps the hardest hitter from
+ *  killing and lets the softest one dent anything. HP% STATE is therefore seeded directly (see
+ *  HURT_FRACTION) instead of being produced by damage — that decouples "which hp-threshold gates
+ *  can read true" from "how hard this particular focus ship hits". */
 const FILLER_HP = 500_000_000;
-/** ...and hit softly enough that the focus ship also survives all 20 rounds. */
-const FILLER_ATTACK = 500;
+
+/** Share of the focus ship's MAX HP that the whole 20-round battle should take off it.
+ *
+ *  Absolute filler attack cannot work here: the corpus spans 7.3k–23.9k HP and 972–4047 defence
+ *  (22%–53% mitigation), so one attack value either leaves the tanks untouched or kills the
+ *  squishies. `fillerAttackFor` inverts the damage formula per focus ship instead, so every
+ *  fingerprint is taken at the same RELATIVE pressure.
+ *
+ *  0.2 is chosen against the `wounded` scenario, the binding constraint: the focus starts there at
+ *  FOCUS_HURT_FRACTION (45%) and must still be alive at round 20, since its death would truncate
+ *  its own fingerprint. Measured worst case across the corpus is a 22.4% HP decline (Isha), so the
+ *  thinnest survivor still ends around 23% — real, sustained incoming damage with a genuine margin,
+ *  and enough of a decline to cross 40%-HP self-gates part-way through the battle. */
+const INCOMING_FRACTION = 0.2;
+
+/** The filler active is a bare single-hit "deals 90% damage", so one filler attack point yields
+ *  `0.9 × (1 − mitigation)` damage per hit against this focus ship. Invert that over the whole
+ *  battle's hit count to hit INCOMING_FRACTION of its max HP.
+ *
+ *  An ESTIMATE, not a guarantee: the focus's own defence buffs/debuffs, incoming-damage modifiers,
+ *  shields, dodges and self-heals all move the realised total. It only has to land in the band
+ *  "clearly nonzero, comfortably survivable", which the scenario tests assert directly. */
+function fillerAttackFor(focus: Ship): number {
+    const defence = focus.baseStats.defence;
+    const mitigation = defence > 0 ? calculateDamageReduction(defence) : 0;
+    const perHitPerAttackPoint = 0.9 * (1 - mitigation / 100);
+    const hits = ROUNDS * ATTACKERS_ON_FOCUS;
+    return Math.max(
+        1,
+        Math.round((INCOMING_FRACTION * focus.baseStats.hp) / (perHitPerAttackPoint * hits))
+    );
+}
 
 /** The fragile ally: dies early and deterministically so on-ally-destroyed / revive / cheat-death
  *  clauses fire. The ONE intentional exception to filler survival. Verified (traceShipFactory +
  *  battleSimulator.resolveStats pass overrides straight through with no scaling) that hp: 1
  *  resolves to stats.hp = 1 and currentHp = 1 at actor construction — the ally starts ALIVE, then
- *  dies to the very first hit it takes (filler attack is 500). No need to raise it. */
+ *  dies to the very first hit it takes. It sits at T4, the only ally cell an enemy resolves onto,
+ *  and 1 HP makes the kill timing immune to any damage-formula change: ANY hit is lethal. */
 const FRAGILE_ALLY_HP = 1;
 
 let cache: Map<string, Ship> | null = null;
@@ -77,36 +144,67 @@ function fillerShip(name: string): Ship {
     return ship;
 }
 
-/** A filler placement: canonical base stats, then HP and attack overridden for survivability. */
-function fillerPlacement(name: string, position: Position, hp = FILLER_HP): BattlePlacement {
+/** A filler placement: canonical base stats, then HP and attack overridden. Attack is per-battle
+ *  (derived from the focus ship), not a constant — see `fillerAttackFor`. */
+function fillerPlacement(
+    name: string,
+    position: Position,
+    attack: number,
+    hp = FILLER_HP
+): BattlePlacement {
     const base = canonicalPlacement(fillerShip(name), position);
-    return { ...base, statOverrides: { ...base.statOverrides, hp, attack: FILLER_ATTACK } };
+    return { ...base, statOverrides: { ...base.statOverrides, hp, attack } };
 }
 
-/** 20% of max HP as a starting shield pool — any positive pool satisfies `enemy-shield`, which is
- *  a boolean gate, and 20% is small enough that it drains during the battle so shield-destroyed
- *  and punch-through clauses also get to fire. */
-const SHIELD_FRACTION = 0.2;
-/** Allies start at 50% HP: below every corpus hp-threshold gate worth exercising, and low enough
- *  that heals have real headroom to land rather than clipping entirely to overheal. */
-const HURT_FRACTION = 0.5;
+/** `richEnemy`'s seeded enemy shield, as a multiple of the focus ship's base attack — an ABSOLUTE
+ *  pool, not a fraction of the filler's (absurd) max HP. A fraction was the original choice and it
+ *  was inert: 20% of 500M is 100M against ~1.2k hits, so `enemy-shield` gates read true for the
+ *  entire battle and nothing ever punched through. Three attack points' worth survives the first
+ *  cast or two — long enough for a shield-gated clause to fire at least once — then depletes, so
+ *  shield-removal and punch-through clauses see the other side of the gate too. */
+const SHIELD_POOL_HITS = 3;
+
+/** `wounded` seeds every filler on BOTH sides to 35% HP: under the corpus's 40%- and 50%-HP gates
+ *  (ally-repair triggers, execute/threshold damage, Stealth-below-40 grants) while still inside the
+ *  30–70% band, i.e. hurt enough to read as hurt and far enough from 0 that nothing dies to a
+ *  rounding-level change. Seeding the ENEMY side too moved zero fingerprints on today's corpus
+ *  (measured) — it is kept because the scenario's whole purpose is to put the board in the state
+ *  its name claims, and the next kit with an enemy-HP gate is then covered for free. */
+const HURT_FRACTION = 0.35;
+
+/** ...but the FOCUS starts higher than its allies, because it is the only actor under sustained
+ *  attack: 45% leaves INCOMING_FRACTION's worth of decline plus margin, and it means the focus
+ *  CROSSES the 40% line mid-battle rather than starting below it — a transition that "when HP
+ *  drops below 40%" clauses (Tycho) require and a static low start would never produce. */
+const FOCUS_HURT_FRACTION = 0.45;
+
+/** The focus ship is always the first player placement, and simulateBattle mints the first player
+ *  actor with the reserved id 'attacker' (battleSimulator's minting scheme; the rest are
+ *  `p:<shipId>:<idx>`). So the focus actor id is fixed. */
+export const FOCUS_ACTOR_ID = 'attacker';
 
 const maxHpOf = (a: CombatActor): number => a.stats.hp;
 
-function seedFor(scenario: ScenarioName): ((actors: CombatActor[]) => void) | undefined {
+function seedFor(
+    focus: Ship,
+    scenario: ScenarioName
+): ((actors: CombatActor[]) => void) | undefined {
     switch (scenario) {
         case 'plain':
             return undefined;
-        case 'richEnemy':
+        case 'richEnemy': {
+            const pool = SHIELD_POOL_HITS * focus.baseStats.attack;
             return (actors) => {
                 for (const a of actors) {
-                    if (a.side === 'enemy') a.shieldPool = maxHpOf(a) * SHIELD_FRACTION;
+                    if (a.side === 'enemy') a.shieldPool = pool;
                 }
             };
-        case 'hurtAllies':
+        }
+        case 'wounded':
             return (actors) => {
                 for (const a of actors) {
-                    if (a.side === 'player') a.currentHp = maxHpOf(a) * HURT_FRACTION;
+                    const fraction = a.id === FOCUS_ACTOR_ID ? FOCUS_HURT_FRACTION : HURT_FRACTION;
+                    a.currentHp = maxHpOf(a) * fraction;
                 }
             };
     }
@@ -114,14 +212,17 @@ function seedFor(scenario: ScenarioName): ((actors: CombatActor[]) => void) | un
 
 /**
  * The scenario battle for one focus ship: the focus at FOCUS_POSITION on the player side with 3
- * inert filler allies, against 4 inert filler enemies. Only the seeded initial state varies by
- * scenario. The focus ship keeps `canonicalPlacement`'s un-modified level-60 base stats — no gear,
- * no refits, no engineering — so its fingerprint reflects its kit, not a gearing choice.
+ * inert filler allies, against 4 inert filler enemies (see FOCUS_POSITION for why those cells).
+ * Only the seeded initial state varies by scenario. The focus ship keeps `canonicalPlacement`'s
+ * un-modified level-60 base stats — no gear, no refits, no engineering — so its fingerprint
+ * reflects its kit, not a gearing choice. The FILLER stats, by contrast, are tuned (HP, attack)
+ * and are the only lever this fixture pulls on how hard the battle presses.
  */
 export function buildScenarioBattle(focus: Ship, scenario: ScenarioName): BattleSimulationInput {
     const enemyNames = FILLER_NAMES.slice(0, 4);
     const allyNames = FILLER_NAMES.slice(4, 7);
-    const tap = seedFor(scenario);
+    const tap = seedFor(focus, scenario);
+    const attack = fillerAttackFor(focus);
     return {
         playerTeam: [
             canonicalPlacement(focus, FOCUS_POSITION),
@@ -129,20 +230,16 @@ export function buildScenarioBattle(focus: Ship, scenario: ScenarioName): Battle
                 fillerPlacement(
                     name,
                     ALLY_POSITIONS[i],
-                    scenario === 'hurtAllies' && i === 0 ? FRAGILE_ALLY_HP : FILLER_HP
+                    attack,
+                    scenario === 'wounded' && i === 0 ? FRAGILE_ALLY_HP : FILLER_HP
                 )
             ),
         ],
-        enemyTeam: enemyNames.map((name, i) => fillerPlacement(name, ENEMY_POSITIONS[i])),
+        enemyTeam: enemyNames.map((name, i) => fillerPlacement(name, ENEMY_POSITIONS[i], attack)),
         rounds: ROUNDS,
         ...(tap ? { __testTapActors: tap } : {}),
     };
 }
-
-/** The focus ship is always the first player placement, and simulateBattle mints the first player
- *  actor with the reserved id 'attacker' (battleSimulator's minting scheme; the rest are
- *  `p:<shipId>:<idx>`). So the focus actor id is fixed. */
-const FOCUS_ACTOR_ID = 'attacker';
 
 /** Fingerprint one ship across all three scenarios. Every battle goes through runSeededBattle —
  *  its `finally` restores Math.random rather than any ambient seed, so a raw simulateBattle call

--- a/src/utils/combat/audit/kitFingerprintScenarios.ts
+++ b/src/utils/combat/audit/kitFingerprintScenarios.ts
@@ -3,7 +3,10 @@ import type { Position } from '../../../types/encounters';
 import type { CombatActor } from '../state';
 import type { BattlePlacement, BattleSimulationInput } from '../../calculators/battleSimulator';
 import { buildTraceShip } from '../../../../scripts/lib/traceShipFactory';
+import { loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
 import { canonicalPlacement } from './fixtures';
+import { runSeededBattle } from './seededBattle';
+import { fingerprintActorTokens } from './fingerprint';
 
 export type ScenarioName = 'plain' | 'richEnemy' | 'hurtAllies';
 
@@ -134,4 +137,32 @@ export function buildScenarioBattle(focus: Ship, scenario: ScenarioName): Battle
         rounds: ROUNDS,
         ...(tap ? { __testTapActors: tap } : {}),
     };
+}
+
+/** The focus ship is always the first player placement, and simulateBattle mints the first player
+ *  actor with the reserved id 'attacker' (battleSimulator's minting scheme; the rest are
+ *  `p:<shipId>:<idx>`). So the focus actor id is fixed. */
+const FOCUS_ACTOR_ID = 'attacker';
+
+/** Fingerprint one ship across all three scenarios. Every battle goes through runSeededBattle —
+ *  its `finally` restores Math.random rather than any ambient seed, so a raw simulateBattle call
+ *  afterwards would be nondeterministic.
+ *
+ *  Lives here (rather than in the `.test.ts` file that consumes it) so both the vitest suite and
+ *  `scripts/reportThinKitFingerprints.ts` (run under plain `tsx`, no vitest globals) can import it
+ *  without importing a `.test.ts` module. */
+export function fingerprintShip(ship: Ship): Record<ScenarioName, string[]> {
+    const out = {} as Record<ScenarioName, string[]>;
+    for (const scenario of SCENARIOS) {
+        const result = runSeededBattle(buildScenarioBattle(ship, scenario), SEED);
+        out[scenario] = fingerprintActorTokens(result, FOCUS_ACTOR_ID);
+    }
+    return out;
+}
+
+/** Corpus ship names, sorted for a stable order (CSV row order is not guaranteed). */
+export function corpusNames(): string[] {
+    return loadShipSkillRecords()
+        .map((r) => r.name)
+        .sort((a, b) => a.localeCompare(b));
 }


### PR DESCRIPTION
The golden combat-sim suite covered **zero real ship kits**. Every fixture in `simGoldenFixtures.ts` is synthetic — the header records why: *"this repo has no local docs/ship-skills.csv to grep, per the task brief"*. The author had no corpus.

That is why 22 commits of real ship-behaviour change in #296, and the Malvex gate fix in #297, moved **no snapshots at all**.

This adds the suite's first real-ship coverage: each of the 147 corpus ships is run through three fixed scenarios and reduced to a sorted set of `kind[:slot]` behaviour tokens, snapshotted per ship name.

## Shape

| scenario | environment | unlocks |
|---|---|---|
| `plain` | untouched inert filler | the baseline — where a broken gate leaks |
| `richEnemy` | enemies seeded with a depletable Shield pool | `enemy-shield` gates, shield punch-through |
| `wounded` | both sides pre-damaged, one fragile ally | heals, hp-threshold gates, `on-ally-destroyed` |

Deliberately **structural** ("does this clause still fire"), not numeric — that stays `dpsGoldenParity` / `healingGoldenParity`'s job. It targets the dominant defect class in the changelog: *"now does something"*, *"was a name in the buff list with no effect"*, *"the condition was not being read at all"*.

Per-ship keys mean a change to one ship moves one entry. Filler are 7 corpus ships verified inert (no passives, no charge, bare 90% damage), guarded by a test so a data refresh can't silently churn 147 snapshots.

## The test that justifies it

`shield:active` (#297) and `buff:charged` (#296) appear **only** in `richEnemy` — both gated on the target carrying a Shield. Asserted explicitly, not just via snapshot, since an explicit assertion survives a careless `-u`.

**Negative-verified:** with #297's `detectTargetShieldGate` block commented out, the test fails on `expect(fp.plain).not.toContain('shield:active')`. A guard never seen failing isn't known to guard anything.

## Review found real problems — three changed the deliverable

- **The `:slot` token's stated justification was false.** Malvex's passive shield never fired, so a bare-`kind` fingerprint *would* have caught #297. Comment corrected; the token is kept for the reachability it genuinely adds, with its emission-order caveat documented (`consumePendingSkill` is single-use per cast, so a bare token does **not** reliably mean "passive").
- **The focus ship took zero incoming damage in 136/147 fixtures.** Root cause was the board, not the attack constant: `selectTargets` scans from the caster's own row, so with all enemies in row B every enemy attack resolved onto an ally. Retuned: **145/147** now take damage, zero focus deaths, zero truncated battles, `shield-destroyed` lit.
- **3 ships' actives are unreachable** from the front-column anchor (Line-Support extends forward). Measured as exactly 3 of 147, so guarded both directions rather than retuning the board a third time.

## Known gaps, recorded in the spec

- `cleanse` / `purge` never fire — needs the deferred status seeding (~21 and ~15 ships). **The biggest remaining hole.**
- `detonation` books to the bomb's victim, structurally unreachable in a focus fingerprint.
- `death` / `cheat-death` need the focus to die, which the survival invariant forbids by design.
- Only 5 of 147 ships differ across scenarios — the corpus has just 9 HP-gate clauses, 1 target-shield gate, 1 full-HP gate. A shield-seeding variant showing 131 was measured and **rejected as uniform fixture-caused inflation**.
- `Faust` / `Mender` / `Refine` actives unreachable from `FOCUS_POSITION` (guarded).

## It already found a suspected engine bug

`Purifier`'s `Wings-Support-Not-Self-Range-2` covers occupied ally cells from M4, yet no ally is buffed across 20 rounds. Not fixed here — but that is precisely what this suite exists to surface.

## Production impact

One change: `BattleSimulationInput.__testTapActors` (+8 lines), forwarded to the tap `CombatEngineInput` has carried since A2 Task 2 and 44 test files already use. Optional, function-typed, inert when absent.

Full suite **468 files / 5306 tests green in ~26.7s** — faster than the 27s baseline. `tsc --noEmit` clean. No pre-existing snapshot moved; the branch is additive but for one deleted line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSGWjgR1PAY61kCDSqFywz