### PR TITLE
fix(sim): buff log entries attribute to the granter, making ally-directed kit visible

### DIFF
--- a/scripts/auditInteractions.ts
+++ b/scripts/auditInteractions.ts
@@ -97,9 +97,17 @@ function rosterPosition(result: BattleResult, actorId: string | undefined): Posi
 // buildStandardScenario opponents and composeBattle's real random-corpus opponents), not this
 // ship's own kit logic:
 //   - 'death'/'cheat-death'   — whether incoming damage was lethal this run (opponent power)
-//   - 'buff'/'buff-expired'   — buff-applied's actorId is the RECIPIENT (types/abilities.ts:
+//   - 'buff-expired'          — buff-applied's actorId is the RECIPIENT (types/abilities.ts:
 //                               "opposing-scoped on actorId — the buff RECIPIENT"), so this
 //                               fires whenever ANY other unit buffs/heals this one
+//   - 'buff'                  — as of the granter-attribution change, `buff` LOG ENTRIES book to
+//                               the GRANTER (buildCombatLog.ts), with the recipient carried only
+//                               in `targets` — the types/abilities.ts line above still describes
+//                               the underlying EVENT (unchanged, still recipient-scoped), but not
+//                               the log entry this script diffs. A `buff` token is therefore
+//                               self-kit signal now, not opponent noise. Kept in this set anyway,
+//                               pending a real-corpus recalibration run (dropping it is separate
+//                               work) — NOT because the opponent-driven rationale still applies.
 //   - 'debuff-resisted'       — actorId = e.sourceId ?? e.targetId; even when this ship is the
 //                               caster, "resisted or not" hinges on the TARGET's security stat,
 //                               which varies hugely between canned (security 20) and real corpus
@@ -117,8 +125,12 @@ function rosterPosition(result: BattleResult, actorId: string | undefined): Posi
 // (not the inert-only calibration battery), forcing this set empty and re-running the
 // differential oracle at seed 1/count 5 produces 3 additional opponent-noise differentials that
 // the guard does NOT catch (Aegis dot-ticked+detonation, Yuyan debuff-resisted, Quixilver
-// buff+buff-expired — verified empirically). Both fixes are necessary; neither subsumes the
-// other. Excluding these kinds trades away differential-oracle coverage for them audit-wide —
+// buff+buff-expired — verified empirically). NOTE: that Quixilver result predates the
+// granter-attribution change above — it was measured while `buff` was still recipient-attributed,
+// same as `buff-expired`. Post-change, `buff` books to the granter while `buff-expired` stays
+// recipient-attributed, so the two no longer share a rationale and cannot be re-assessed jointly;
+// this old joint result does not transfer to a future recalibration. Both fixes are necessary;
+// neither subsumes the other. Excluding these kinds trades away differential-oracle coverage for them audit-wide —
 // the ablation oracle is unaffected and remains the live signal for bugs in these areas (see the
 // Task 10 report's "Differential sensitivity trade-off" concern).
 //

--- a/src/components/simulator/RoundEventLog.tsx
+++ b/src/components/simulator/RoundEventLog.tsx
@@ -142,7 +142,11 @@ const formatters: Record<
     },
     heal: (entry, ctx) => renderTargets(entry, ctx, `${ctx.nameOf(entry.actorId)} heals`),
     shield: (entry, ctx) => renderTargets(entry, ctx, `${ctx.nameOf(entry.actorId)} shields`),
-    buff: noteLine,
+    // Same source→target shape as `debuff`/`dot-applied`: `buff` entries book to the GRANTER
+    // with the recipient in `targets`, so an ally grant reads "Purifier → Jempol: Hacking Up II".
+    // `sourceTargetNoteLine` collapses to the plain "{src}: {note}" line when the target is the
+    // actor itself, so self-buffs render exactly as they did before granter attribution.
+    buff: sourceTargetNoteLine,
     debuff: sourceTargetNoteLine,
     'dot-applied': sourceTargetNoteLine,
     'dot-ticked': (entry, ctx) => {

--- a/src/components/simulator/__tests__/RoundEventLog.test.tsx
+++ b/src/components/simulator/__tests__/RoundEventLog.test.tsx
@@ -292,6 +292,38 @@ describe('RoundEventLog', () => {
         expect(screen.getByText(/^Nova: Overload$/)).toBeInTheDocument();
     });
 
+    it('buff: shows granter → recipient when the buff lands on an ally', () => {
+        render(
+            <RoundEventLog
+                round={oneEntryRound({
+                    kind: 'buff',
+                    actorId: 'nova',
+                    targets: [{ targetId: 'graphite' }],
+                    reactions: [],
+                    note: 'Hacking Up II',
+                })}
+                roster={roster}
+            />
+        );
+        expect(screen.getByText(/Nova → Graphite: Hacking Up II/)).toBeInTheDocument();
+    });
+
+    it('buff: collapses to just the actor when the target is itself (self-buff)', () => {
+        render(
+            <RoundEventLog
+                round={oneEntryRound({
+                    kind: 'buff',
+                    actorId: 'nova',
+                    targets: [{ targetId: 'nova' }],
+                    reactions: [],
+                    note: 'Attack Up',
+                })}
+                roster={roster}
+            />
+        );
+        expect(screen.getByText(/^Nova: Attack Up$/)).toBeInTheDocument();
+    });
+
     it('shows a collapsed stats summary under a turn and expands to the full block', async () => {
         const round: CombatLogRound = {
             round: 1,

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -31,6 +31,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat simulator: Malvex's charged skill only grants itself a Barrier when the target it hits actually has a Shield, as its skill says. The condition was not being read at all, so Malvex gained full damage immunity on every charged cast regardless of the target.",
     "Combat simulator: Malvex's normal skill follows the same rule — it only shields itself for 15% of its max health when the target it hits has a Shield. It used to bank that Shield on every cast, which also fed the bonus damage its skills deal based on its own current Shield.",
     'Autogear: Defence and Crit Chance priorities are now weighted on the same scale as every other stat. Both were being compared against their raw values instead of a typical value for the stat, which made a Defence priority around 5000x too strong and a Crit Chance priority around 25x too strong — either one would swamp the priorities listed above it. If you have saved configurations that use Defence or Crit Chance as a priority, re-run autogear to get the corrected recommendation.',
+    'Combat log now shows which ship granted a buff to an ally, instead of only naming the ship that received it.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/pages/DocumentationPage.tsx
+++ b/src/pages/DocumentationPage.tsx
@@ -3308,6 +3308,13 @@ const DocumentationPage: React.FC = () => {
                                         shown rather than an even split.
                                     </li>
                                     <li>
+                                        <strong>Buff grants show who cast them:</strong> A buff
+                                        entry is attributed to the ship that granted it, with the
+                                        ally that received it listed as the target — so a support
+                                        ship&apos;s buffs to its allies are credited to that ship,
+                                        not just shown against the ally that gained the buff.
+                                    </li>
+                                    <li>
                                         <strong>Charge state and skill tags:</strong> Each turn
                                         shows the acting ship&apos;s current charge (e.g.
                                         &quot;charge 2/3&quot;) and whether it used its active or

--- a/src/utils/calculators/__tests__/__snapshots__/realKitFingerprints.test.ts.snap
+++ b/src/utils/calculators/__tests__/__snapshots__/realKitFingerprints.test.ts.snap
@@ -195,6 +195,7 @@ exports[`kit fingerprints > Asphodel 1`] = `
 {
   "plain": [
     "attack",
+    "buff",
     "buff-expired",
     "buff:active",
     "charge-changed",
@@ -202,6 +203,7 @@ exports[`kit fingerprints > Asphodel 1`] = `
   ],
   "richEnemy": [
     "attack",
+    "buff",
     "buff-expired",
     "buff:active",
     "charge-changed",
@@ -209,6 +211,7 @@ exports[`kit fingerprints > Asphodel 1`] = `
   ],
   "wounded": [
     "attack",
+    "buff",
     "buff-expired",
     "buff:active",
     "charge-changed",
@@ -829,6 +832,7 @@ exports[`kit fingerprints > Faust 1`] = `
 exports[`kit fingerprints > Flamel 1`] = `
 {
   "plain": [
+    "buff",
     "buff:active",
     "buff:charged",
     "charge-changed",
@@ -837,6 +841,7 @@ exports[`kit fingerprints > Flamel 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "buff",
     "buff:active",
     "buff:charged",
     "charge-changed",
@@ -845,6 +850,7 @@ exports[`kit fingerprints > Flamel 1`] = `
     "heal",
   ],
   "wounded": [
+    "buff",
     "buff:active",
     "buff:charged",
     "charge-changed",
@@ -1031,6 +1037,7 @@ exports[`kit fingerprints > Harvester 1`] = `
 exports[`kit fingerprints > Hayyan 1`] = `
 {
   "plain": [
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -1038,6 +1045,7 @@ exports[`kit fingerprints > Hayyan 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -1045,6 +1053,7 @@ exports[`kit fingerprints > Hayyan 1`] = `
     "heal",
   ],
   "wounded": [
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -1138,6 +1147,7 @@ exports[`kit fingerprints > Hermes 1`] = `
 exports[`kit fingerprints > Howler 1`] = `
 {
   "plain": [
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -1145,6 +1155,7 @@ exports[`kit fingerprints > Howler 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -1152,6 +1163,7 @@ exports[`kit fingerprints > Howler 1`] = `
     "heal",
   ],
   "wounded": [
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -1563,6 +1575,7 @@ exports[`kit fingerprints > Lev 1`] = `
   "plain": [
     "attack",
     "attack:active",
+    "buff",
     "buff-expired",
     "buff:charged",
     "charge-changed",
@@ -1570,6 +1583,7 @@ exports[`kit fingerprints > Lev 1`] = `
   "richEnemy": [
     "attack",
     "attack:active",
+    "buff",
     "buff-expired",
     "buff:charged",
     "charge-changed",
@@ -1577,6 +1591,7 @@ exports[`kit fingerprints > Lev 1`] = `
   "wounded": [
     "attack",
     "attack:active",
+    "buff",
     "buff-expired",
     "buff:charged",
     "charge-changed",
@@ -1589,6 +1604,7 @@ exports[`kit fingerprints > Liberator 1`] = `
   "plain": [
     "attack",
     "attack:active",
+    "buff",
     "buff-expired",
     "buff:charged",
     "charge-changed",
@@ -1596,6 +1612,7 @@ exports[`kit fingerprints > Liberator 1`] = `
   "richEnemy": [
     "attack",
     "attack:active",
+    "buff",
     "buff-expired",
     "buff:charged",
     "charge-changed",
@@ -1603,6 +1620,7 @@ exports[`kit fingerprints > Liberator 1`] = `
   "wounded": [
     "attack",
     "attack:active",
+    "buff",
     "buff-expired",
     "buff:charged",
     "charge-changed",
@@ -1693,6 +1711,7 @@ exports[`kit fingerprints > Los 1`] = `
   "plain": [
     "attack",
     "attack:active",
+    "buff",
     "buff-expired",
     "buff:charged",
     "charge-changed",
@@ -1700,6 +1719,7 @@ exports[`kit fingerprints > Los 1`] = `
   "richEnemy": [
     "attack",
     "attack:active",
+    "buff",
     "buff-expired",
     "buff:charged",
     "charge-changed",
@@ -1707,6 +1727,7 @@ exports[`kit fingerprints > Los 1`] = `
   "wounded": [
     "attack",
     "attack:active",
+    "buff",
     "buff-expired",
     "buff:charged",
     "charge-changed",
@@ -1718,6 +1739,7 @@ exports[`kit fingerprints > Madax 1`] = `
 {
   "plain": [
     "attack",
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -1726,6 +1748,7 @@ exports[`kit fingerprints > Madax 1`] = `
   ],
   "richEnemy": [
     "attack",
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -1734,6 +1757,7 @@ exports[`kit fingerprints > Madax 1`] = `
   ],
   "wounded": [
     "attack",
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -2103,6 +2127,7 @@ exports[`kit fingerprints > Nyxen 1`] = `
 {
   "plain": [
     "attack",
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -2111,6 +2136,7 @@ exports[`kit fingerprints > Nyxen 1`] = `
   ],
   "richEnemy": [
     "attack",
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -2119,6 +2145,7 @@ exports[`kit fingerprints > Nyxen 1`] = `
   ],
   "wounded": [
     "attack",
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -2225,6 +2252,7 @@ exports[`kit fingerprints > Orel 1`] = `
 {
   "plain": [
     "attack",
+    "buff",
     "buff-expired",
     "buff:charged",
     "charge-changed",
@@ -2235,6 +2263,7 @@ exports[`kit fingerprints > Orel 1`] = `
   ],
   "richEnemy": [
     "attack",
+    "buff",
     "buff-expired",
     "buff:charged",
     "charge-changed",
@@ -2245,6 +2274,7 @@ exports[`kit fingerprints > Orel 1`] = `
   ],
   "wounded": [
     "attack",
+    "buff",
     "buff-expired",
     "buff:charged",
     "charge-changed",
@@ -2319,6 +2349,7 @@ exports[`kit fingerprints > Panon 1`] = `
   "plain": [
     "attack",
     "attack:charged",
+    "buff",
     "buff-expired",
     "buff:active",
     "charge-changed",
@@ -2326,6 +2357,7 @@ exports[`kit fingerprints > Panon 1`] = `
   "richEnemy": [
     "attack",
     "attack:charged",
+    "buff",
     "buff-expired",
     "buff:active",
     "charge-changed",
@@ -2333,6 +2365,7 @@ exports[`kit fingerprints > Panon 1`] = `
   "wounded": [
     "attack",
     "attack:charged",
+    "buff",
     "buff-expired",
     "buff:active",
     "charge-changed",
@@ -2371,6 +2404,7 @@ exports[`kit fingerprints > Pestilence 1`] = `
   "plain": [
     "attack",
     "attack:active",
+    "buff",
     "buff-expired",
     "buff:charged",
     "charge-changed",
@@ -2381,6 +2415,7 @@ exports[`kit fingerprints > Pestilence 1`] = `
   "richEnemy": [
     "attack",
     "attack:active",
+    "buff",
     "buff-expired",
     "buff:charged",
     "charge-changed",
@@ -2391,6 +2426,7 @@ exports[`kit fingerprints > Pestilence 1`] = `
   "wounded": [
     "attack",
     "attack:active",
+    "buff",
     "buff-expired",
     "buff:charged",
     "charge-changed",
@@ -2459,12 +2495,21 @@ exports[`kit fingerprints > Provider 1`] = `
 exports[`kit fingerprints > Purifier 1`] = `
 {
   "plain": [
+    "buff",
+    "buff:active",
+    "buff:charged",
     "charge-changed",
   ],
   "richEnemy": [
+    "buff",
+    "buff:active",
+    "buff:charged",
     "charge-changed",
   ],
   "wounded": [
+    "buff",
+    "buff:active",
+    "buff:charged",
     "charge-changed",
   ],
 }
@@ -2589,12 +2634,15 @@ exports[`kit fingerprints > Redeemer 1`] = `
 exports[`kit fingerprints > Refine 1`] = `
 {
   "plain": [
+    "buff",
     "charge-changed",
   ],
   "richEnemy": [
+    "buff",
     "charge-changed",
   ],
   "wounded": [
+    "buff",
     "charge-changed",
   ],
 }
@@ -2756,6 +2804,7 @@ exports[`kit fingerprints > Rys 1`] = `
 exports[`kit fingerprints > Salvation 1`] = `
 {
   "plain": [
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -2763,6 +2812,7 @@ exports[`kit fingerprints > Salvation 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -2770,6 +2820,7 @@ exports[`kit fingerprints > Salvation 1`] = `
     "heal",
   ],
   "wounded": [
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -2953,6 +3004,7 @@ exports[`kit fingerprints > Shashou 1`] = `
 exports[`kit fingerprints > Shelter 1`] = `
 {
   "plain": [
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -2960,6 +3012,7 @@ exports[`kit fingerprints > Shelter 1`] = `
     "heal",
   ],
   "richEnemy": [
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -2967,6 +3020,7 @@ exports[`kit fingerprints > Shelter 1`] = `
     "heal",
   ],
   "wounded": [
+    "buff",
     "buff-expired",
     "buff:active",
     "buff:charged",
@@ -3256,6 +3310,7 @@ exports[`kit fingerprints > Tormenter 1`] = `
   "plain": [
     "attack",
     "attack:charged",
+    "buff",
     "buff-expired",
     "buff:active",
     "charge-changed",
@@ -3263,6 +3318,7 @@ exports[`kit fingerprints > Tormenter 1`] = `
   "richEnemy": [
     "attack",
     "attack:charged",
+    "buff",
     "buff-expired",
     "buff:active",
     "charge-changed",
@@ -3270,6 +3326,7 @@ exports[`kit fingerprints > Tormenter 1`] = `
   "wounded": [
     "attack",
     "attack:charged",
+    "buff",
     "buff-expired",
     "buff:active",
     "charge-changed",

--- a/src/utils/calculators/__tests__/realKitFingerprints.test.ts
+++ b/src/utils/calculators/__tests__/realKitFingerprints.test.ts
@@ -124,6 +124,25 @@ describe('pinned regression: Malvex target-shield gates (#296, #297)', () => {
     });
 });
 
+describe('pinned regression: ally-directed kit is visible (buff granter attribution)', () => {
+    beforeAll(requireReferenceData);
+
+    it("sees Purifier's ally grants, which booked to the RECEIVER before granter attribution", () => {
+        // Purifier's whole active is other-directed: it grants Hacking Up II + Binderburg
+        // Resilience II to allies covered by Pattern-Wings-Support-Not-Self-Range-2 and never
+        // touches itself. Because `buff` was the one grant-style log kind booked to its
+        // recipient, its entire fingerprint was `charge-changed` — correct code that looked
+        // dead. This pins the fix: an ally-only support kit must produce a `buff` token of its
+        // own. A bare snapshot would also catch it, but only this test says WHY it moved.
+        const purifier = buildTraceShip('Purifier');
+        expect(purifier).not.toBeNull();
+        const fp = fingerprintShip(purifier!);
+        for (const scenario of SCENARIOS) {
+            expect(fp[scenario], `${scenario} lost Purifier's ally grants`).toContain('buff');
+        }
+    });
+});
+
 describe('suite health', () => {
     beforeAll(() => {
         requireReferenceData();

--- a/src/utils/combat/__tests__/enemyReactiveSelfBuffs.test.ts
+++ b/src/utils/combat/__tests__/enemyReactiveSelfBuffs.test.ts
@@ -445,14 +445,18 @@ describe('D-PR9 team-agnostic mirror — enemy-side Spearhead + Font of Power', 
         },
     });
 
-    /** Every actorId that ever received a GRANT of `label` (hierarchical combatLog). */
+    /** Every actorId that ever received a GRANT of `label` (hierarchical combatLog).
+     *  `entry.actorId` on a 'buff' entry is the GRANTER (post-granter-attribution); the
+     *  recipient lives in `entry.targets`. */
     const buffedActors = (
         result: ReturnType<typeof simulateBattle>,
         label: string
     ): Set<string> => {
         const set = new Set<string>();
         for (const entry of flattenCombatLog(result)) {
-            if (entry.kind === 'buff' && entry.note === label) set.add(entry.actorId);
+            if (entry.kind === 'buff' && entry.note === label) {
+                for (const t of entry.targets) set.add(t.targetId);
+            }
         }
         return set;
     };

--- a/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
+++ b/src/utils/combat/__tests__/equipmentAbilities.integration.test.ts
@@ -2971,11 +2971,15 @@ describe('Font of Power — on-own-repair-to-ally Power Infused Nanobots', () =>
 
     const ROUNDS = 16; // carrier repairs each round → floor(16 × 0.16) = 2 proc fires
 
-    /** Collect every actorId that ever received a Power Infused Nanobots GRANT (combatLog). */
+    /** Collect every actorId that ever received a Power Infused Nanobots GRANT (combatLog).
+     *  `entry.actorId` on a 'buff' entry is the GRANTER (post-granter-attribution); the
+     *  recipient lives in `entry.targets`. */
     function buffedActors(result: ReturnType<typeof simulateBattle>): Set<string> {
         const set = new Set<string>();
         for (const entry of flattenCombatLog(result)) {
-            if (entry.kind === 'buff' && entry.note === NANOBOTS) set.add(entry.actorId);
+            if (entry.kind === 'buff' && entry.note === NANOBOTS) {
+                for (const t of entry.targets) set.add(t.targetId);
+            }
         }
         return set;
     }
@@ -3344,10 +3348,12 @@ describe('Spearhead — on-charged-cast all-allies Attack Up I', () => {
         // unreliable for the carrier here: the carrier grants the 1-turn buff on its OWN turn,
         // so it has already expired by the round-end snapshot — but the application still
         // happened (and folded into that turn's damage). The buff log captures every recipient.
+        // `e.actorId` is the GRANTER (post-granter-attribution); the recipient lives in
+        // `e.targets`.
         const buffedActors = new Set(
             flattenCombatLog(result)
                 .filter((e) => e.kind === 'buff' && e.note === ATTACK_UP_I)
-                .map((e) => e.actorId)
+                .flatMap((e) => e.targets.map((t) => t.targetId))
         );
 
         // Every player ally — including the carrier — got the buff at least once.

--- a/src/utils/combat/audit/kitFingerprintScenarios.ts
+++ b/src/utils/combat/audit/kitFingerprintScenarios.ts
@@ -84,7 +84,7 @@ export const FILLER_NAMES: readonly string[] = [
  *  killing and lets the softest one dent anything. HP% STATE is therefore seeded directly (see
  *  HURT_FRACTION) instead of being produced by damage — that decouples "which hp-threshold gates
  *  can read true" from "how hard this particular focus ship hits". */
-const FILLER_HP = 500_000_000;
+export const FILLER_HP = 500_000_000;
 
 /** Share of the focus ship's MAX HP that the whole 20-round battle should take off it.
  *

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -443,6 +443,7 @@ function seedPassiveTimedStatuses(
                 bus.emit({
                     type: 'buff-applied',
                     actorId: rid,
+                    granterId: status.casterId ?? rt.actor.id,
                     round,
                     buffName: status.payload.buffName,
                     duration: status.duration,

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -91,7 +91,15 @@ export type CombatEvent =
       } & ReactiveStamp)
     | ({
           type: 'buff-applied';
+          /** The actor that RECEIVED the buff. */
           actorId: string;
+          /** The actor that GRANTED it — `status.casterId` / `intent.ownerId` at the emission
+           *  site. Optional only so statusEngine unit fixtures need not restate it; read sites
+           *  fall back to `actorId` (self-grant), which is what every pre-2026-08 event meant.
+           *  Log attribution reads this so a ship whose kit only buffs OTHERS is still
+           *  attributable to itself — `buff` was the sole grant-style kind booked to its
+           *  recipient while heal/shield/control/debuff/dot all book to the source. */
+          granterId?: string;
           round: number;
           buffName: string;
           duration: number | 'recurring';

--- a/src/utils/combat/log/__tests__/buffGranterAttribution.integration.test.ts
+++ b/src/utils/combat/log/__tests__/buffGranterAttribution.integration.test.ts
@@ -1,0 +1,58 @@
+/**
+ * End-to-end proof that an ally-directed grant is attributed to the CASTER in the combat log.
+ *
+ * Purifier is the worked example from the design: its active
+ * ("This Unit grants Hacking Up II and Binderburg Resilience II for 1 turn") targets
+ * `other-allies` through `Pattern-Wings-Support-Not-Self-Range-2`, which from the focus cell M4
+ * covers {T3, T4, B3, B4} — so the allies at T4 and B4 receive it and the ally at T2 does not.
+ * The kit was always correct; before granter attribution every one of these entries booked to the
+ * RECEIVER, so Purifier's own fingerprint was empty but for `charge-changed`.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { buildScenarioBattle, SEED } from '../../audit/kitFingerprintScenarios';
+import { runSeededBattle } from '../../audit/seededBattle';
+import type { CombatLogEntry } from '../types';
+import { buildTraceShip } from '../../../../../scripts/lib/traceShipFactory';
+import { csvAvailable } from '../../../../../scripts/lib/shipSkillCsv';
+import { shipDataAvailable } from '../../../../../scripts/lib/shipDataSnapshot';
+
+function collect(entries: CombatLogEntry[], acc: CombatLogEntry[]): void {
+    for (const e of entries) {
+        acc.push(e);
+        if (e.reactions?.length) collect(e.reactions, acc);
+    }
+}
+
+describe('buff granter attribution (integration)', () => {
+    beforeAll(() => {
+        if (!csvAvailable() || !shipDataAvailable()) {
+            throw new Error(
+                'docs/ship-skills.csv and/or docs/ship-data.json are missing from this worktree ' +
+                    '(gitignored reference data).'
+            );
+        }
+    });
+
+    it("attributes Purifier's ally grants to Purifier, with the ally as the target", () => {
+        const purifier = buildTraceShip('Purifier');
+        expect(purifier).not.toBeNull();
+        const result = runSeededBattle(buildScenarioBattle(purifier!, 'plain'), SEED);
+
+        const all: CombatLogEntry[] = [];
+        for (const round of result.combatLog) {
+            collect(round.startOfRound, all);
+            for (const turn of round.turns) collect(turn.entries, all);
+            collect(round.endOfRound, all);
+        }
+
+        const grants = all.filter((e) => e.kind === 'buff' && e.note === 'Hacking Up II');
+        expect(grants.length).toBeGreaterThan(0);
+
+        // Every one books to the caster...
+        for (const g of grants) expect(g.actorId).toBe('attacker');
+        // ...and names an ally OTHER than the caster as its target (notSelf pattern).
+        const recipients = new Set(grants.map((g) => g.targets[0]?.targetId));
+        expect(recipients.has('attacker')).toBe(false);
+        expect(recipients.size).toBeGreaterThan(0);
+    });
+});

--- a/src/utils/combat/log/__tests__/buffGranterAttribution.integration.test.ts
+++ b/src/utils/combat/log/__tests__/buffGranterAttribution.integration.test.ts
@@ -9,12 +9,16 @@
  * RECEIVER, so Purifier's own fingerprint was empty but for `charge-changed`.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import { buildScenarioBattle, SEED } from '../../audit/kitFingerprintScenarios';
+import { buildScenarioBattle, FILLER_NAMES, SEED } from '../../audit/kitFingerprintScenarios';
 import { runSeededBattle } from '../../audit/seededBattle';
 import type { CombatLogEntry } from '../types';
 import { buildTraceShip } from '../../../../../scripts/lib/traceShipFactory';
 import { csvAvailable } from '../../../../../scripts/lib/shipSkillCsv';
 import { shipDataAvailable } from '../../../../../scripts/lib/shipDataSnapshot';
+import { canonicalPlacement } from '../../audit/fixtures';
+import type { Ship } from '../../../../types/ship';
+import type { Position } from '../../../../types/encounters';
+import type { BattlePlacement } from '../../../calculators/battleSimulator';
 
 function collect(entries: CombatLogEntry[], acc: CombatLogEntry[]): void {
     for (const e of entries) {
@@ -51,8 +55,79 @@ describe('buff granter attribution (integration)', () => {
         // Every one books to the caster...
         for (const g of grants) expect(g.actorId).toBe('attacker');
         // ...and names an ally OTHER than the caster as its target (notSelf pattern).
-        const recipients = new Set(grants.map((g) => g.targets[0]?.targetId));
+        // Each grant must have exactly one real (non-undefined) recipient — otherwise a set of
+        // {undefined} would satisfy both assertions below vacuously.
+        const rosterIds = new Set(result.roster.map((r) => r.actorId));
+        for (const g of grants) {
+            expect(g.targets.length).toBe(1);
+            expect(g.targets[0].targetId).toBeDefined();
+            expect(rosterIds.has(g.targets[0].targetId)).toBe(true);
+        }
+        const recipients = new Set(grants.map((g) => g.targets[0].targetId));
         expect(recipients.has('attacker')).toBe(false);
         expect(recipients.size).toBeGreaterThan(0);
+    });
+
+    it('attributes an ENEMY-side grant to the enemy granter, not the enemy receiver', () => {
+        // Team symmetry: enemies run the same per-recipient application loop as the player side
+        // (see playerTurn.ts's "covers BOTH sides" comment), so granter attribution must hold
+        // there too.
+        //
+        // The standard scenario board CANNOT show this — its enemy side is inert filler that
+        // grants nothing, so a loop over enemy buff entries would be vacuous. Put Purifier on the
+        // ENEMY team instead: at M4 its Wings-Support-Not-Self-Range-2 active covers the enemy
+        // allies at T4/B4 exactly as it does on the player side.
+        const purifier = buildTraceShip('Purifier');
+        expect(purifier).not.toBeNull();
+        const filler = FILLER_NAMES.map((n) => buildTraceShip(n)!);
+        const pl = (ship: Ship, position: Position): BattlePlacement => {
+            const base = canonicalPlacement(ship, position);
+            return {
+                ...base,
+                statOverrides: { ...base.statOverrides, hp: 500_000_000, attack: 400 },
+            };
+        };
+        const result = runSeededBattle(
+            {
+                playerTeam: [
+                    pl(filler[0], 'M4'),
+                    pl(filler[1], 'T4'),
+                    pl(filler[2], 'T2'),
+                    pl(filler[3], 'B4'),
+                ],
+                enemyTeam: [
+                    canonicalPlacement(purifier!, 'M4'),
+                    pl(filler[4], 'T4'),
+                    pl(filler[5], 'T2'),
+                    pl(filler[6], 'B4'),
+                ],
+                rounds: 5,
+            },
+            SEED
+        );
+
+        const all: CombatLogEntry[] = [];
+        for (const round of result.combatLog) {
+            collect(round.startOfRound, all);
+            for (const turn of round.turns) collect(turn.entries, all);
+            collect(round.endOfRound, all);
+        }
+
+        const enemyIds = new Set(
+            result.roster.filter((r) => r.side === 'enemy').map((r) => r.actorId)
+        );
+        const enemyBuffs = all.filter(
+            (e) => e.kind === 'buff' && e.targets.some((t) => enemyIds.has(t.targetId))
+        );
+        // Non-vacuity guard FIRST: an empty list would make every assertion below trivially true.
+        // The verified baseline for this board is 20 entries; assert loosely so a kit/data
+        // refresh does not churn the test, but never allow zero.
+        expect(enemyBuffs.length).toBeGreaterThan(0);
+
+        const purifierId = result.roster.find((r) => r.name === 'Purifier')!.actorId;
+        for (const b of enemyBuffs) {
+            expect(enemyIds.has(b.actorId)).toBe(true);
+            expect(b.actorId).toBe(purifierId);
+        }
     });
 });

--- a/src/utils/combat/log/__tests__/buffGranterAttribution.integration.test.ts
+++ b/src/utils/combat/log/__tests__/buffGranterAttribution.integration.test.ts
@@ -9,7 +9,12 @@
  * RECEIVER, so Purifier's own fingerprint was empty but for `charge-changed`.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import { buildScenarioBattle, FILLER_NAMES, SEED } from '../../audit/kitFingerprintScenarios';
+import {
+    buildScenarioBattle,
+    FILLER_HP,
+    FILLER_NAMES,
+    SEED,
+} from '../../audit/kitFingerprintScenarios';
 import { runSeededBattle } from '../../audit/seededBattle';
 import type { CombatLogEntry } from '../types';
 import { buildTraceShip } from '../../../../../scripts/lib/traceShipFactory';
@@ -80,11 +85,14 @@ describe('buff granter attribution (integration)', () => {
         const purifier = buildTraceShip('Purifier');
         expect(purifier).not.toBeNull();
         const filler = FILLER_NAMES.map((n) => buildTraceShip(n)!);
+        // Named assertion instead of letting a resolution failure crash opaquely inside
+        // canonicalPlacement below.
+        expect(filler.every(Boolean)).toBe(true);
         const pl = (ship: Ship, position: Position): BattlePlacement => {
             const base = canonicalPlacement(ship, position);
             return {
                 ...base,
-                statOverrides: { ...base.statOverrides, hp: 500_000_000, attack: 400 },
+                statOverrides: { ...base.statOverrides, hp: FILLER_HP, attack: 400 },
             };
         };
         const result = runSeededBattle(
@@ -126,6 +134,10 @@ describe('buff granter attribution (integration)', () => {
 
         const purifierId = result.roster.find((r) => r.name === 'Purifier')!.actorId;
         for (const b of enemyBuffs) {
+            // Pins the no-aggregation invariant itself (exactly one target per buff entry) rather
+            // than merely tolerating it — `some`/`every` above are equivalent today only because
+            // this holds.
+            expect(b.targets.length).toBe(1);
             expect(enemyIds.has(b.actorId)).toBe(true);
             expect(b.actorId).toBe(purifierId);
         }

--- a/src/utils/combat/log/__tests__/buildCombatLog.test.ts
+++ b/src/utils/combat/log/__tests__/buildCombatLog.test.ts
@@ -1018,11 +1018,18 @@ describe('buildCombatLog', () => {
         expect(entry.targets[0].targetId).toBe('B');
     });
 
-    it('buff-applied: self-buff — actorId is the buff receiver, targets is empty, note has buffName', () => {
+    it('buff-applied: self-buff — actorId is the granter (same as receiver), recipient in targets', () => {
         const events: CombatEvent[] = [
             ev({ type: 'round-started', round: 1 }),
             ev({ type: 'turn-started', actorId: 'A', round: 1 }),
-            ev({ type: 'buff-applied', actorId: 'A', round: 1, buffName: 'Inspire', duration: 2 }),
+            ev({
+                type: 'buff-applied',
+                actorId: 'A',
+                granterId: 'A',
+                round: 1,
+                buffName: 'Inspire',
+                duration: 2,
+            }),
             ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
             ev({ type: 'round-ended', round: 1 }),
         ];
@@ -1032,8 +1039,49 @@ describe('buildCombatLog', () => {
         const entry = entries[0];
         expect(entry.kind).toBe('buff');
         expect(entry.actorId).toBe('A');
-        expect(entry.targets).toEqual([]);
+        expect(entry.targets).toEqual([{ targetId: 'A' }]);
         expect(entry.note).toBe('Inspire');
+    });
+
+    it('buff-applied: ally grant — actorId is the GRANTER, not the receiver; receiver is the target', () => {
+        // The defect this whole change exists for: pre-change this entry booked to 'B' (the
+        // receiver), so a ship whose kit only ever buffs OTHERS produced no entries of its own
+        // and read as dead in an actor-scoped fingerprint.
+        const events: CombatEvent[] = [
+            ev({ type: 'round-started', round: 1 }),
+            ev({ type: 'turn-started', actorId: 'A', round: 1 }),
+            ev({
+                type: 'buff-applied',
+                actorId: 'B',
+                granterId: 'A',
+                round: 1,
+                buffName: 'Hacking Up II',
+                duration: 1,
+            }),
+            ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
+            ev({ type: 'round-ended', round: 1 }),
+        ];
+        const log = buildCombatLog(events, roster, initialCharge);
+        const entry = log[0].turns[0].entries[0];
+        expect(entry.actorId).toBe('A');
+        expect(entry.targets).toEqual([{ targetId: 'B' }]);
+        expect(entry.note).toBe('Hacking Up II');
+    });
+
+    it('buff-applied: no granterId — falls back to the receiver (fixture compatibility)', () => {
+        // granterId is optional so statusEngine unit fixtures need not restate it. An event
+        // without one must behave exactly as it did before this change.
+        const events: CombatEvent[] = [
+            ev({ type: 'round-started', round: 1 }),
+            ev({ type: 'turn-started', actorId: 'A', round: 1 }),
+            ev({ type: 'buff-applied', actorId: 'A', round: 1, buffName: 'Inspire', duration: 2 }),
+            ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
+            ev({ type: 'round-ended', round: 1 }),
+        ];
+        const log = buildCombatLog(events, roster, initialCharge);
+        const entry = log[0].turns[0].entries[0];
+        expect(entry.actorId).toBe('A');
+        expect(entry.targets).toEqual([{ targetId: 'A' }]);
     });
 
     it('debuff-applied: actorId is sourceId (the INFLICTER), not the victim; target contains victim', () => {

--- a/src/utils/combat/log/buildCombatLog.ts
+++ b/src/utils/combat/log/buildCombatLog.ts
@@ -551,6 +551,13 @@ const handlers: Partial<{ [K in CombatEventType]: Handler<K> }> = {
         // `dot-applied` (sourceId) already use. `buff` was the lone grant-style kind booked to
         // its recipient, which made an ally-only support kit invisible to any actor-scoped
         // reader. Falls back to the receiver when no granter is carried (self-grant).
+        //
+        // Giving this entry a non-empty `targets` puts it into setHp's reverse fallback scan for
+        // the first time (previously `targets: []` made it structurally invisible there).
+        // Currently harmless because in playerTurn.ts the buff-grant loop runs BEFORE
+        // shield-applied/heal-performed, so those more-recent entries win the reverse scan first —
+        // but reordering those emissions would silently let a buff entry's target get stamped with
+        // a stale resultingHpPct instead.
         const entry: CombatLogEntry = {
             kind: 'buff',
             actorId: e.granterId ?? e.actorId,

--- a/src/utils/combat/log/buildCombatLog.ts
+++ b/src/utils/combat/log/buildCombatLog.ts
@@ -546,10 +546,15 @@ const handlers: Partial<{ [K in CombatEventType]: Handler<K> }> = {
 
     'buff-applied': (e, ctx) => {
         if (!ctx.currentTurn && !ctx.currentRound) return;
+        // Books to the GRANTER, with the receiver in `targets` — the same shape `heal`
+        // (casterId), `shield-applied` (granterId), `control` (casterId), `debuff` and
+        // `dot-applied` (sourceId) already use. `buff` was the lone grant-style kind booked to
+        // its recipient, which made an ally-only support kit invisible to any actor-scoped
+        // reader. Falls back to the receiver when no granter is carried (self-grant).
         const entry: CombatLogEntry = {
             kind: 'buff',
-            actorId: e.actorId,
-            targets: [],
+            actorId: e.granterId ?? e.actorId,
+            targets: [{ targetId: e.actorId }],
             reactions: [],
             note: e.buffName,
             ...(ctx.consumePendingSkill() ?? {}),

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1794,6 +1794,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
             bus.emit({
                 type: 'buff-applied',
                 actorId: rid,
+                granterId: status.casterId ?? actor.id,
                 round: r,
                 buffName: status.payload.buffName,
                 duration: status.duration,

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1770,7 +1770,8 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         // is applied to EVERY recipient (Task 5): self → [caster]; ally/all-allies → all players.
         // The status lives on each recipient (decrements at the recipient's Post Turn; family +
         // persistent rules run per recipient side because applyTimedAbilityStatus threads
-        // recipientId). buff-applied emits ONCE PER RECIPIENT with the recipient's actorId.
+        // recipientId). buff-applied emits ONCE PER RECIPIENT with the recipient's actorId, with
+        // the granter riding alongside in `granterId`.
         if (!conditionsMet(status.conditions, postDebuffGateCtx)) continue;
         // recipients is set by the engine helper for every timed-by-slot status; default to
         // [actor.id] (self routing) for any caller that omitted it (statusEngine fixtures).

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -2648,6 +2648,7 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
             ctx.bus.emit({
                 type: 'buff-applied',
                 actorId: rid,
+                granterId: intent.ownerId,
                 round: ctx.round,
                 buffName: cfg.buffName,
                 duration,
@@ -2693,6 +2694,7 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
                 ctx.bus.emit({
                     type: 'buff-applied',
                     actorId: rid,
+                    granterId: intent.ownerId,
                     round: ctx.round,
                     buffName: extra.buffName,
                     duration: extra.duration,


### PR DESCRIPTION
## The bug that wasn't

Purifier's fingerprint was `charge-changed` and nothing else, across all three scenarios — which looked like the engine failing to apply its ally buffs. It isn't. Dumping the full battle log for every actor shows the active firing correctly on every round:

```
turn: attacker
  [buff:active] actor=p:trace:Jempol:1  note=Hacking Up II
  [buff]        actor=p:trace:Rookie:3  note=Hacking Up II
  [buff]        actor=p:trace:Jempol:1  note=Binderburg Resilience II
  [buff]        actor=p:trace:Rookie:3  note=Binderburg Resilience II
```

Jempol@T4 and Rookie@B4 are buffed, Krysa@T2 is not — exactly matching `Wings-Support-Not-Self-Range-2 @ M4 → {T3, T4, B3, B4}`. Correct code that the suite could not see.

## Root cause

`buff` was the **only** grant-style log kind attributed to its recipient. Every sibling books to the source:

| Handler | Attribution |
| --- | --- |
| `heal-performed` | `casterId` |
| `shield-applied` | `granterId` |
| `control-applied` | `casterId` |
| `cleanse` / `purge` | `casterId` |
| `debuff-applied` / `dot-applied` | `sourceId` |
| **`buff-applied`** | **`actorId` (recipient)** |

`fingerprintActorTokens` filters on `actorId`, so a ship whose kit acts entirely on allies produced no tokens of its own. A one-field inconsistency, not an architectural gap.

## The change

- `buff-applied` gains an optional `granterId`, populated at all four engine emission sites from the granter already in scope (`status.casterId` / `intent.ownerId`)
- The log entry books to `granterId ?? actorId` with the recipient moved into `targets` — the same shape `heal` and `shield` already use
- `RoundEventLog` switches `buff` to `sourceTargetNoteLine`, so an ally grant reads `Purifier → Jempol: Hacking Up II`. Self-buffs collapse to the old `{src}: {note}` line and render identically

`granterId` is optional and falls back to the recipient, so statusEngine fixtures that omit it behave exactly as before.

## Snapshot movement — additive only

17 ships gained a `buff` token; **zero lost any** (57 insertions, 0 deletions). Verified before the snapshot was written, not after. That was the design's prediction: in that fixture allies are verified-inert filler, the focus carries no gear, and enemies cannot grant player buffs — so no focus ship can receive a buff from anyone else.

Ships affected: Asphodel, Flamel, Hayyan, Howler, Lev, Liberator, Los, Madax, Nyxen, Orel, Panon, Pestilence, Purifier, Refine, Salvation, Shelter, Tormenter.

## Deliberate non-changes

- **`buff-expired` stays recipient-attributed.** No granter is tracked at expiry. Purifier gains `buff` but the ally keeps `buff-expired` — an accepted asymmetry.
- **No aggregation.** An N-recipient grant stays N entries with one target each, rather than collapsing into a `perTarget` list like `heal`.
- **`'buff'` stays in `auditInteractions.ts`'s `BASE_EXCLUDED_KINDS`.** Its justifying comment was stale and is corrected here, but dropping the exclusion needs a real-corpus recalibration run — and the recorded calibration result doesn't transfer, since `buff-expired` remains recipient-attributed. Follow-up, not bundled.

## Testing

Team symmetry is proven on a **bespoke board with Purifier on the enemy team**. The standard scenario board cannot show it: its enemy side is four inert filler ships that grant no buffs, so an assertion looping over enemy-booked entries would iterate an empty list and pass regardless of the code. The enemy board produces 20 real grants, with a non-vacuity guard ahead of the assertions.

Full suite: **469 files / 5314 tests passing**, `tsc --noEmit` clean, lint clean. Every commit was made with the husky pre-commit hook running in full — no `--no-verify`.

## Known gap, not addressed here

Three ships — Faust, Mender, Refine — have `Pattern-Line-Support-Not-Self-*` actives that resolve to **zero cells** from the focus cell M4, because Line-Support extends forward and M4 is the front-most column. Their actives fire and do nothing. That's a fixture *board* defect with a much larger blast radius (moving `FOCUS_POSITION` would churn all 147 snapshots, since three enemies sharing row M is what puts the focus under fire at all). It needs its own design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSGWjgR1PAY61kCDSqFywz
