### PR TITLE
test(sim): Faust, Mender and Refine fingerprint their support kit on a second board

### DIFF
--- a/scripts/reportThinKitFingerprints.ts
+++ b/scripts/reportThinKitFingerprints.ts
@@ -1,6 +1,7 @@
 /**
- * Reports which corpus ships fingerprint THIN — few distinct behaviour tokens across all three
- * real-kit scenarios. Diagnostic only, run by hand:
+ * Reports which corpus ships fingerprint THIN — few distinct behaviour tokens across every
+ * scenario the ship runs (three, or four for support-anchored ships). Diagnostic only, run by
+ * hand:
  *
  *   npx tsx scripts/reportThinKitFingerprints.ts
  *
@@ -9,7 +10,7 @@
  * nothing, and the spec defers the fourth-scenario decision until these numbers exist.
  */
 /* eslint-disable no-console */
-import { SCENARIOS, fingerprintShip, corpusNames } from '../src/utils/combat/audit/kitFingerprintScenarios';
+import { fingerprintShip, corpusNames } from '../src/utils/combat/audit/kitFingerprintScenarios';
 import { buildTraceShip } from './lib/traceShipFactory';
 
 const THIN_THRESHOLD = 3;
@@ -19,7 +20,7 @@ for (const name of corpusNames()) {
     const ship = buildTraceShip(name);
     if (!ship) continue;
     const fp = fingerprintShip(ship);
-    const distinct = new Set(SCENARIOS.flatMap((s) => fp[s]));
+    const distinct = new Set(Object.values(fp).flat());
     if (distinct.size <= THIN_THRESHOLD) thin.push(`${name}(${[...distinct].join(',')})`);
 }
 console.log(`thin ships (${thin.length} of ${corpusNames().length}):`);

--- a/src/utils/calculators/__tests__/__snapshots__/realKitFingerprints.test.ts.snap
+++ b/src/utils/calculators/__tests__/__snapshots__/realKitFingerprints.test.ts.snap
@@ -823,6 +823,13 @@ exports[`kit fingerprints > Faust 1`] = `
   "richEnemy": [
     "charge-changed",
   ],
+  "supportAnchor": [
+    "buff",
+    "buff:active",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
   "wounded": [
     "charge-changed",
   ],
@@ -1981,6 +1988,12 @@ exports[`kit fingerprints > Mender 1`] = `
   "richEnemy": [
     "charge-changed",
   ],
+  "supportAnchor": [
+    "buff",
+    "buff:charged",
+    "charge-changed",
+    "heal",
+  ],
   "wounded": [
     "charge-changed",
   ],
@@ -2639,6 +2652,12 @@ exports[`kit fingerprints > Refine 1`] = `
   ],
   "richEnemy": [
     "buff",
+    "charge-changed",
+  ],
+  "supportAnchor": [
+    "buff",
+    "buff:active",
+    "buff:charged",
     "charge-changed",
   ],
   "wounded": [

--- a/src/utils/calculators/__tests__/realKitFingerprints.test.ts
+++ b/src/utils/calculators/__tests__/realKitFingerprints.test.ts
@@ -24,7 +24,10 @@ import {
     FOCUS_ACTOR_ID,
     ROUNDS,
     SEED,
+    scenariosFor,
+    darkSlotsOnPrimaryBoard,
     type ScenarioName,
+    type FingerprintScenario,
 } from '../../combat/audit/kitFingerprintScenarios';
 import { runSeededBattle } from '../../combat/audit/seededBattle';
 import { fingerprintActorTokens } from '../../combat/audit/fingerprint';
@@ -45,7 +48,7 @@ function requireReferenceData(): void {
  *  (~7s), so the health assertions read what the snapshot pass already computed instead of
  *  re-running the whole roster. `suite health` is declared AFTER the snapshot describe on purpose:
  *  vitest runs describes in declaration order. */
-const observed = new Map<string, Record<ScenarioName, string[]>>();
+const observed = new Map<string, Partial<Record<FingerprintScenario, string[]>>>();
 
 /** The two LIVE invariants every fingerprint rests on (see `kitFingerprintScenarios.test.ts`'s
  *  "live battle invariants" describe, which spot-checks only Xiaodao/Malvex): the focus must take
@@ -68,11 +71,16 @@ describe('kit fingerprints', () => {
         expect(ship, `${name} did not resolve from the corpus`).not.toBeNull();
         // Inlines fingerprintShip's own loop (rather than calling it) so the invariant fields can
         // be read off the same BattleResult instead of running each of the 441 battles twice.
-        const fp = {} as Record<ScenarioName, string[]>;
+        const fp: Partial<Record<FingerprintScenario, string[]>> = {};
         const invariants = {} as Record<ScenarioName, LiveInvariant>;
-        for (const scenario of SCENARIOS) {
+        for (const scenario of scenariosFor(ship!)) {
             const result = runSeededBattle(buildScenarioBattle(ship!, scenario), SEED);
             fp[scenario] = fingerprintActorTokens(result, FOCUS_ACTOR_ID);
+            // The support-anchor board's focus takes zero incoming damage BY CONSTRUCTION (allies
+            // forward of it are front-most and absorb every attack), so it cannot satisfy the
+            // incoming-damage invariant and is deliberately excluded from it. Its own guard is
+            // "the previously-dark slot produced fresh tokens", asserted in `suite health`.
+            if (scenario === 'supportAnchor') continue;
             const rows = result.rounds
                 .flatMap((r) => r.ships)
                 .filter((s) => s.actorId === FOCUS_ACTOR_ID);
@@ -263,7 +271,7 @@ describe('suite health', () => {
         // Without this, a harness bug that fingerprints nothing yields 147 empty snapshots and
         // reads as passing.
         const empty = [...observed.entries()]
-            .filter(([, fp]) => SCENARIOS.every((s) => fp[s].length === 0))
+            .filter(([, fp]) => SCENARIOS.every((s) => (fp[s] ?? []).length === 0))
             .map(([name]) => name);
         expect(empty, `ships producing NO tokens in any scenario: ${empty.join(', ')}`).toEqual([]);
     });
@@ -271,8 +279,8 @@ describe('suite health', () => {
     it('covers every log kind the roster is expected to reach', () => {
         const kinds = new Set<string>();
         for (const fp of observed.values()) {
-            for (const scenario of SCENARIOS) {
-                for (const token of fp[scenario]) kinds.add(token.split(':')[0]);
+            for (const tokens of Object.values(fp)) {
+                for (const token of tokens) kinds.add(token.split(':')[0]);
             }
         }
         const missing = EXPECTED_KINDS.filter((k) => !kinds.has(k));
@@ -317,5 +325,54 @@ describe('suite health', () => {
         let hash = 0;
         for (let i = 0; i < digest.length; i++) hash = (hash * 31 + digest.charCodeAt(i)) | 0;
         expect({ shipCount: rows.length, digest: hash }).toMatchSnapshot();
+    });
+
+    it('every support-anchor ship produces behaviour there that the primary board never showed', () => {
+        // The #298 lesson, applied to the new board: a fixture that RUNS is not a fixture that
+        // OBSERVES. Without this, routing three ships onto a second board could snapshot three
+        // more vacuous entries and read as a fix.
+        //
+        // Compared against the UNION of all three primary scenarios, which controls for seeding:
+        // supportAnchor reuses `wounded`'s HP seeding, so anything the ship already does when
+        // wounded is not evidence that its support footprint reached anyone.
+        //
+        // `charge-changed` is excluded as evidence: it is emitted on cast regardless of whether
+        // the ability found any target, and it is exactly the token Faust and Mender's vacuous
+        // primary fingerprints already consisted of.
+        //
+        // Asserted per SHIP, not per slot, on purpose: `ctx.consumePendingSkill()` is single-use
+        // per cast, so only the first log entry of a cast carries `{skillName, slot}` and a
+        // later entry from the same cast legitimately lands bare. Per-slot evidence would be
+        // flaky for reasons unrelated to the kit. Per-SLOT geometry is guard 1's job, in
+        // kitFingerprintScenarios.test.ts.
+        const EVIDENCE_EXCLUDED = new Set(['charge-changed']);
+        const darkNames = [...new Set(darkSlotsOnPrimaryBoard().map((d) => d.name))].sort();
+        expect(
+            darkNames.length,
+            'the derivation found no dark ships — the sweep is broken'
+        ).toBeGreaterThan(0);
+
+        const barren: string[] = [];
+        for (const name of darkNames) {
+            const fp = observed.get(name);
+            expect(fp, `${name} was never fingerprinted`).toBeDefined();
+            expect(
+                fp!.supportAnchor,
+                `${name} is dark on the primary board but ran no supportAnchor scenario — ` +
+                    'scenariosFor did not route it'
+            ).toBeDefined();
+            const primary = new Set(SCENARIOS.flatMap((s) => fp![s] ?? []));
+            const fresh = (fp!.supportAnchor ?? []).filter(
+                (t) => !primary.has(t) && !EVIDENCE_EXCLUDED.has(t.split(':')[0])
+            );
+            if (fresh.length === 0) barren.push(name);
+        }
+        expect(
+            barren,
+            `ship(s) whose supportAnchor fingerprint adds NOTHING over their primary one: ` +
+                `${barren.join(', ')} — the second board reached their pattern geometrically ` +
+                '(guard 1 proves that) but their kit still produced no new behaviour. That is a ' +
+                'FINDING to investigate and report, not a reason to relax this assertion.'
+        ).toEqual([]);
     });
 });

--- a/src/utils/calculators/__tests__/realKitFingerprints.test.ts
+++ b/src/utils/calculators/__tests__/realKitFingerprints.test.ts
@@ -151,6 +151,58 @@ describe('pinned regression: ally-directed kit is visible (buff granter attribut
     });
 });
 
+describe('pinned regression: Line-Support kit reaches allies on the support-anchor board', () => {
+    beforeAll(requireReferenceData);
+
+    // Pattern-Line-Support-* extends FORWARD, so anchored on the primary board's front column it
+    // resolved to zero cells and these three ships' actives AND charges were structurally
+    // unobservable — Faust and Mender fingerprinted as a bare ['charge-changed']. The snapshot
+    // catches any future regression; this test says WHY those entries exist.
+    //
+    // Kinds, not kind:slot tokens — see the note above: the suffix tracks emission order, the kind
+    // tracks the kit. `charge-changed` is never valid evidence here: it is emitted on cast whether
+    // or not the ability found a target, which is exactly what made the old fingerprints look
+    // alive when they were not.
+    //
+    // Mender has no `:active`-suffixed token below, yet its active heal fires correctly every
+    // round — verified by tracing the raw combat log (two allies healed for 4,179.35 each, rounds
+    // 1-20, the only entry in Mender's own turn, so there is no competing handler to lose the
+    // `ctx.consumePendingSkill()` race to). That heal code path simply never calls
+    // `consumePendingSkill()`; it is a pre-existing engine tag-attribution characteristic, not a
+    // fixture defect. This is exactly why the assertions below are kind-level, not slot-level.
+    const EXPECTED_KINDS: Record<string, string[]> = {
+        Faust: ['heal', 'buff'],
+        Mender: ['heal'],
+        Refine: ['buff'],
+    };
+
+    it.each(Object.keys(EXPECTED_KINDS))('%s supports its allies from M1', (name) => {
+        const ship = buildTraceShip(name);
+        expect(ship).not.toBeNull();
+        const fp = fingerprintShip(ship!);
+        expect(fp.supportAnchor, `${name} ran no supportAnchor scenario`).toBeDefined();
+
+        const anchor = fp.supportAnchor ?? [];
+        const primary = new Set(SCENARIOS.flatMap((s) => fp[s]));
+        for (const kind of EXPECTED_KINDS[name]) {
+            const matching = anchor.filter((t) => t.split(':')[0] === kind);
+            expect(
+                matching,
+                `${name} produced no ${kind} entry on the support-anchor board — its support ` +
+                    'clause stopped reaching its allies'
+            ).not.toEqual([]);
+            // ...and it must be NEW. Without this, a kind the ship already emitted on the primary
+            // board (Refine's passive `buff`) would satisfy the test without the active firing.
+            expect(
+                matching.some((t) => !primary.has(t)),
+                `${name}'s ${kind} entries are all ones it already produced on the primary board ` +
+                    '— either the support-anchor board added nothing, or the primary board now ' +
+                    'sees this kit and the second board no longer earns its keep'
+            ).toBe(true);
+        }
+    });
+});
+
 describe('suite health', () => {
     beforeAll(() => {
         requireReferenceData();
@@ -210,10 +262,10 @@ describe('suite health', () => {
     });
 
     it('every KNOWN_ZERO_DAMAGE exemption is STILL warranted (a kit/board fix must remove the ship, not leave a stale exemption)', () => {
-        // The sibling suite (kitFingerprintScenarios.test.ts's "every allow-listed ship is STILL
-        // unreachable") solves the same problem for KNOWN_UNREACHABLE; this is the equivalent
-        // guard for KNOWN_ZERO_DAMAGE. Without it, a kit or board change that makes Meiying or
-        // Voron take real damage would pass silently — the exemption would keep suppressing a
+        // KNOWN_ZERO_DAMAGE is the last hand-maintained exemption list in this suite — its sibling,
+        // KNOWN_UNREACHABLE, was replaced by a derivation (see kitFingerprintScenarios.test.ts's
+        // 'pattern reachability'). Without this guard, a kit or board change that makes Meiying or
+        // Voron take real damage would pass silently: the exemption would keep suppressing a
         // failure that no longer exists to suppress.
         //
         // `some`, not `every`: the exemption asserts "this ship takes no damage", a claim `some`

--- a/src/utils/calculators/__tests__/realKitFingerprints.test.ts
+++ b/src/utils/calculators/__tests__/realKitFingerprints.test.ts
@@ -5,9 +5,12 @@
  * the author had no local corpus), which is why 22 commits of real ship-behaviour change in #296
  * and the Malvex gate fix in #297 moved zero snapshots.
  *
- * Each of the 147 corpus ships is run through three fixed scenarios and reduced to the SET of
- * `kind[:slot]` behaviour tokens it produced. A diff means that ship's behaviour changed. The
- * suite is deliberately STRUCTURAL, not numeric: it answers "does this clause still fire", which
+ * Each of the 147 corpus ships is run through the three universal scenarios (plain, richEnemy,
+ * wounded), plus a fourth — supportAnchor, on the second board geometry — for the handful whose
+ * targeting pattern the primary board's geometry cannot reach (see kitFingerprintScenarios.ts's
+ * darkSlotsOnPrimaryBoard). Every run is reduced to the SET of `kind[:slot]` behaviour tokens it
+ * produced. A diff means that ship's behaviour changed. The suite is deliberately STRUCTURAL, not
+ * numeric: it answers "does this clause still fire", which
  * is the dominant defect class in the changelog ("now does something", "was a name in the buff
  * list with no effect", "the condition was not being read at all"). Numeric drift is
  * dpsGoldenParity / healingGoldenParity's job.
@@ -170,13 +173,13 @@ describe('pinned regression: Line-Support kit reaches allies on the support-anch
     // `ctx.consumePendingSkill()` race to). That heal code path simply never calls
     // `consumePendingSkill()`; it is a pre-existing engine tag-attribution characteristic, not a
     // fixture defect. This is exactly why the assertions below are kind-level, not slot-level.
-    const EXPECTED_KINDS: Record<string, string[]> = {
+    const EXPECTED_SUPPORT_KINDS: Record<string, string[]> = {
         Faust: ['heal', 'buff'],
         Mender: ['heal'],
         Refine: ['buff'],
     };
 
-    it.each(Object.keys(EXPECTED_KINDS))('%s supports its allies from M1', (name) => {
+    it.each(Object.keys(EXPECTED_SUPPORT_KINDS))('%s supports its allies from M1', (name) => {
         const ship = buildTraceShip(name);
         expect(ship).not.toBeNull();
         const fp = fingerprintShip(ship!);
@@ -184,7 +187,7 @@ describe('pinned regression: Line-Support kit reaches allies on the support-anch
 
         const anchor = fp.supportAnchor ?? [];
         const primary = new Set(SCENARIOS.flatMap((s) => fp[s]));
-        for (const kind of EXPECTED_KINDS[name]) {
+        for (const kind of EXPECTED_SUPPORT_KINDS[name]) {
             const matching = anchor.filter((t) => t.split(':')[0] === kind);
             expect(
                 matching,
@@ -371,7 +374,7 @@ describe('suite health', () => {
         // misread as an engine change.
         const rows = loadShipSkillRecords();
         const digest = rows
-            .map((r) => `${r.name} ${r.active} ${r.charge} ${r.passives.join('')}`)
+            .map((r) => `${r.name}\0${r.active}\0${r.charge}\0${r.passives.join('\x01')}`)
             .sort()
             .join('\n');
         let hash = 0;

--- a/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
+++ b/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
@@ -327,3 +327,88 @@ describe('active pattern reachability from FOCUS_POSITION', () => {
         ).toEqual([]);
     });
 });
+
+describe('support-anchor board', () => {
+    // The second board geometry. Its ONLY job is to give a forward-extending support pattern
+    // (Pattern-Line-Support-*) allies to actually reach: those patterns extend toward column 4,
+    // so a caster anchored at the front column resolves to zero cells. Anchoring at M1 with allies
+    // at M2/M3/M4 covers ranges 1 through 3.
+    //
+    // The focus takes ZERO incoming damage here and that is unavoidable, not a tuning miss: for a
+    // Line-Support caster to have anyone to support, allies must sit forward of it in its own row,
+    // which makes one of THEM the front-most player that selectTargets resolves onto. The primary
+    // board keeps the on-damaged coverage for these same ships; this board answers only "does the
+    // support footprint reach anyone".
+    let focus: Ship;
+
+    beforeAll(() => {
+        requireReferenceData();
+        const m = buildTraceShip('Malvex');
+        if (!m) throw new Error('Malvex did not resolve from the corpus');
+        focus = m;
+    });
+
+    it('anchors the focus at the BACK of the middle row with three allies forward of it', () => {
+        const battle = buildScenarioBattle(focus, 'supportAnchor');
+        expect(battle.playerTeam[0].position).toBe('M1');
+        const allyPositions = battle.playerTeam.slice(1).map((p) => p.position);
+        expect(allyPositions).toEqual(['M2', 'M3', 'M4']);
+    });
+
+    it('keeps enemies out of the focus row so the support line is all allies', () => {
+        // Also keeps the focus's own enemy-directed kit live: its row scan is M -> B -> T, row M
+        // holds no enemies, so it finds B4 front-most and reaches all four under an `all` pattern.
+        const battle = buildScenarioBattle(focus, 'supportAnchor');
+        for (const p of battle.enemyTeam) expect(p.position[0]).not.toBe('M');
+        expect(battle.enemyTeam.map((p) => p.position)).toEqual(['B4', 'B3', 'B2', 'T4']);
+    });
+
+    it('uses eight distinct cells, like the primary board', () => {
+        // An ally and an enemy on the same cell are indistinguishable in position-keyed engine state.
+        const battle = buildScenarioBattle(focus, 'supportAnchor');
+        const positions = [...battle.playerTeam, ...battle.enemyTeam].map((p) => p.position);
+        expect(new Set(positions).size).toBe(positions.length);
+        expect(positions).toHaveLength(8);
+    });
+
+    it('has NO fragile ally — every support target must survive the window', () => {
+        // `wounded` drops ALLY_POSITIONS[0] to 1 HP so it dies and lights on-ally-destroyed
+        // clauses. Here a dying support target would make reach flaky, and on-ally-destroyed
+        // coverage for these ships already exists on the primary board.
+        const battle = buildScenarioBattle(focus, 'supportAnchor');
+        for (const p of battle.playerTeam.slice(1)) {
+            expect(p.statOverrides?.hp).toBeGreaterThan(p.ship.baseStats.hp);
+        }
+    });
+
+    it("reuses wounded's seeding verbatim, so ally repairs land instead of overhealing", () => {
+        // Load-bearing, not tidiness: Faust and Mender's actives REPAIR allies, and a repair aimed
+        // at a full-HP 500,000,000-HP filler is an overheal that may log nothing at all. A
+        // plain-seeded support-anchor board would be green, deterministic, and observing nothing.
+        const anchorActors = fakeRoster();
+        const woundedActors = fakeRoster();
+        buildScenarioBattle(focus, 'supportAnchor').__testTapActors?.(anchorActors);
+        buildScenarioBattle(focus, 'wounded').__testTapActors?.(woundedActors);
+        expect(anchorActors.map((a) => a.currentHp)).toEqual(woundedActors.map((a) => a.currentHp));
+    });
+
+    it('leaves the primary board untouched', () => {
+        // The whole approach rests on 144 snapshots not moving.
+        const battle = buildScenarioBattle(focus, 'plain');
+        expect(battle.playerTeam.map((p) => p.position)).toEqual(['M4', 'T4', 'T2', 'B4']);
+        expect(battle.enemyTeam.map((p) => p.position)).toEqual(['M3', 'M2', 'M1', 'T3']);
+    });
+
+    it('runs a full 20 rounds with nobody dying', () => {
+        // The live half of the board contract. Static position assertions cannot show that the
+        // battle actually completes: a death among the support targets would silently shrink the
+        // footprint mid-battle, and an early end would truncate the fingerprint at an arbitrary
+        // round. Note this asserts NOBODY dies, including the focus — there is no fragile ally
+        // here, unlike `wounded`.
+        const result = runSeededBattle(buildScenarioBattle(focus, 'supportAnchor'), SEED);
+        expect(result.outcome.lastRound).toBe(ROUNDS);
+        const last = result.rounds[result.rounds.length - 1];
+        const dead = last.ships.filter((s) => !s.alive).map((s) => s.actorId);
+        expect(dead, 'nothing may die on the support-anchor board').toEqual([]);
+    });
+});

--- a/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
+++ b/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
@@ -1,8 +1,10 @@
 /**
- * The three real-kit fingerprint scenarios. These tests pin the SHAPE of each battle (roster,
- * positions, seeded state) AND the two live invariants the fingerprints depend on — the focus ship
- * is the one being attacked, and it survives all 20 rounds. The fingerprint snapshots themselves
- * live in src/utils/calculators/__tests__/realKitFingerprints.test.ts.
+ * The real-kit fingerprint scenarios and the two board geometries they run on. These tests pin the
+ * SHAPE of each battle (roster, positions, seeded state), the live invariants the primary board's
+ * fingerprints depend on — the focus ship is the one being attacked, and it survives all 20 rounds
+ * — and the derivation that routes an unreachable ship onto the support-anchor board. The
+ * fingerprint snapshots themselves live in
+ * src/utils/calculators/__tests__/realKitFingerprints.test.ts.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import {
@@ -249,7 +251,7 @@ describe('filler inertness guard', () => {
 });
 
 describe('pattern reachability', () => {
-    // Replaces a hand-maintained KNOWN_UNREACHABLE allow-list. The set of unreachable ships is now
+    // Replaces a hand-maintained unreachable-ship allow-list. The set of unreachable ships is now
     // DERIVED, so a corpus refresh that makes a new ship unreachable routes it onto the
     // support-anchor board automatically instead of needing a human to notice and extend a list.
     //

--- a/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
+++ b/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
@@ -8,19 +8,22 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import {
     buildScenarioBattle,
     corpusNames,
+    darkSlotsOnPrimaryBoard,
     FILLER_NAMES,
     FOCUS_ACTOR_ID,
     FOCUS_POSITION,
+    occupiedCellCount,
+    PRIMARY_BOARD,
     ROUNDS,
     SCENARIOS,
     SEED,
+    SUPPORT_ANCHOR_BOARD,
 } from '../kitFingerprintScenarios';
 import { runSeededBattle } from '../seededBattle';
 import { buildTraceShip } from '../../../../../scripts/lib/traceShipFactory';
 import { csvAvailable, loadShipSkillRecords } from '../../../../../scripts/lib/shipSkillCsv';
 import { shipDataAvailable } from '../../../../../scripts/lib/shipDataSnapshot';
 import { parseShipTargeting } from '../../../targetingParser';
-import { resolveCells } from '../../../targeting/resolvePattern';
 import type { Ship } from '../../../../types/ship';
 import type { CombatActor } from '../../state';
 
@@ -245,85 +248,82 @@ describe('filler inertness guard', () => {
     );
 });
 
-describe('active pattern reachability from FOCUS_POSITION', () => {
-    // FOCUS_POSITION ('M4') is the FRONT column of its row (see that constant's docstring for the
-    // whole board rationale), and Line-Support patterns extend FORWARD from the caster. A caster
-    // anchored at the front has no cells ahead of it, so those patterns resolve to zero cells —
-    // their active skill can never fire from here. This is a FIXTURE limitation (one anchor cell
-    // cannot reach every pattern geometry), not an engine bug: measured precisely, it affects
-    // exactly these 3 of 147 corpus ships, all Line-Support at different ranges, and all 3 would
-    // resolve fine from M2 (one column back). Moving FOCUS_POSITION was considered and rejected
-    // (see FOCUS_POSITION's docstring) — it would regenerate all 147 snapshots a third time,
-    // risking the hard-won on-damaged tuning (145/147 fixtures), to reach 3 ships.
-    const KNOWN_UNREACHABLE: readonly string[] = ['Faust', 'Mender', 'Refine'];
-
+describe('pattern reachability', () => {
+    // Replaces a hand-maintained KNOWN_UNREACHABLE allow-list. The set of unreachable ships is now
+    // DERIVED, so a corpus refresh that makes a new ship unreachable routes it onto the
+    // support-anchor board automatically instead of needing a human to notice and extend a list.
+    //
+    // Both slots are swept, not just `active`. Charged targeting INHERITS active when both charged
+    // columns are blank (targetingParser.ts), and all three of today's dark ships have blank
+    // charged columns — so the old active-only guard under-reported by half.
     beforeAll(requireReferenceData);
 
-    /** Occupied cells DERIVED from the real scenario board (not hard-coded), so this guard follows
-     *  the layout automatically if it ever changes. Positions don't depend on which ship is the
-     *  focus, so any resolvable corpus ship works to build the board. */
-    function occupiedCells(): Set<string> {
-        const focus = buildTraceShip('Malvex');
-        if (!focus) throw new Error('Malvex did not resolve from the corpus');
-        const battle = buildScenarioBattle(focus, 'plain');
-        return new Set([...battle.playerTeam, ...battle.enemyTeam].map((p) => p.position));
-    }
-
-    /** Names of every corpus ship whose ACTIVE targeting pattern, anchored at FOCUS_POSITION,
-     *  resolves to zero cells that are actually occupied on the scenario board. Ships whose
-     *  targeting can't be parsed/resolved at all (parseShipTargeting/resolveCells can throw for
-     *  unrecognized text) are skipped rather than counted either way — this guard is about
-     *  geometry reachability, not targeting-text coverage. */
-    function unreachableShips(): string[] {
-        const occupied = occupiedCells();
-        const out: string[] = [];
-        for (const name of corpusNames()) {
-            const ship = buildTraceShip(name);
-            if (!ship) continue;
-            let pattern;
-            try {
-                pattern = parseShipTargeting(ship)?.active?.pattern;
-                if (!pattern) continue;
-                const cells = resolveCells(pattern, FOCUS_POSITION);
-                if (!cells.some((c) => occupied.has(c.position))) out.push(name);
-            } catch {
-                continue;
-            }
-        }
-        return out;
-    }
-
-    // Both tests below call unreachableShips(), which rebuilds all 147 corpus ships and re-runs
-    // parseShipTargeting/resolveCells for each — computed once here (registered AFTER the
-    // requireReferenceData beforeAll above, so reference data is guaranteed present first) rather
-    // than once per test.
-    let unreachable: string[];
-
-    beforeAll(() => {
-        unreachable = unreachableShips();
+    it('finds the dark slots the primary board cannot reach', () => {
+        // Not an allow-list: a pin on the CURRENT corpus, so a data refresh that changes this
+        // announces itself in one named diff rather than silently changing which ships run a
+        // fourth scenario. Widening it is fine; it must be a deliberate edit.
+        const dark = darkSlotsOnPrimaryBoard()
+            .map((d) => `${d.name}:${d.slot}`)
+            .sort();
+        expect(dark).toEqual([
+            'Faust:active',
+            'Faust:charged',
+            'Mender:active',
+            'Mender:charged',
+            'Refine:active',
+            'Refine:charged',
+        ]);
     });
 
-    it('no ship outside the allow-list resolves its active pattern to zero occupied cells', () => {
-        const unexpected = unreachable.filter((n) => !KNOWN_UNREACHABLE.includes(n));
+    it('every dark slot resolves to occupied cells on the support-anchor board', () => {
+        // The guard that makes the derivation safe. A ship dark on BOTH boards would silently run
+        // a fourth scenario that observes nothing; this names it instead.
+        const stranded: string[] = [];
+        for (const { name, slot } of darkSlotsOnPrimaryBoard()) {
+            const ship = buildTraceShip(name);
+            if (!ship) continue;
+            const pattern = parseShipTargeting(ship)?.[slot]?.pattern;
+            if (!pattern) continue;
+            if (occupiedCellCount(pattern, SUPPORT_ANCHOR_BOARD) === 0) {
+                stranded.push(`${name}:${slot}`);
+            }
+        }
         expect(
-            unexpected,
-            `ship(s) whose active pattern resolves to ZERO occupied cells from FOCUS_POSITION and ` +
-                `are not on the allow-list: ${unexpected.join(', ')} — either a board change made ` +
-                'a previously-reachable ship go dark, or a new/changed corpus ship has an ' +
-                'unreachable pattern. If genuinely unreachable given the front-column geometry, ' +
-                'add it to KNOWN_UNREACHABLE with the same reasoning as Faust/Mender/Refine.'
+            stranded,
+            `slot(s) that resolve to ZERO occupied cells on BOTH boards: ${stranded.join(', ')} — ` +
+                'the support-anchor geometry does not cover this pattern shape. Either extend that ' +
+                'board or add a third one; do NOT leave the ship running a scenario that observes ' +
+                'nothing.'
         ).toEqual([]);
     });
 
-    it('every allow-listed ship is STILL unreachable (a board fix must shrink this list, not leave a stale exemption)', () => {
-        const unreachableSet = new Set(unreachable);
-        const stale = KNOWN_UNREACHABLE.filter((n) => !unreachableSet.has(n));
+    it('no ship is dark on the support-anchor board that was reachable on the primary one', () => {
+        // The reverse direction: the second board must not go dark for a ship the first one
+        // handled, which would mean a future routing change could strand it.
+        const darkNames = new Set(darkSlotsOnPrimaryBoard().map((d) => d.name.toUpperCase()));
+        const regressed: string[] = [];
+        for (const name of corpusNames()) {
+            if (darkNames.has(name.toUpperCase())) continue;
+            const ship = buildTraceShip(name);
+            if (!ship) continue;
+            for (const slot of ['active', 'charged'] as const) {
+                let pattern;
+                try {
+                    pattern = parseShipTargeting(ship)?.[slot]?.pattern;
+                } catch {
+                    continue;
+                }
+                if (!pattern) continue;
+                if (occupiedCellCount(pattern, PRIMARY_BOARD) === 0) {
+                    regressed.push(`${name}:${slot}`);
+                }
+            }
+        }
         expect(
-            stale,
-            `allow-listed ship(s) that now resolve to a NON-empty set of occupied cells: ` +
-                `${stale.join(', ')} — the board (or this ship's pattern) changed and they are ` +
-                'reachable again. Remove them from KNOWN_UNREACHABLE rather than leaving a stale ' +
-                'exemption.'
+            regressed,
+            `slot(s) dark on the primary board but missing from the derivation: ` +
+                `${regressed.join(', ')} — darkSlotsOnPrimaryBoard() and this sweep disagree, so ` +
+                'the derivation is not seeing the whole corpus.'
         ).toEqual([]);
     });
 });

--- a/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
+++ b/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
@@ -9,13 +9,12 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import {
     buildScenarioBattle,
-    corpusNames,
     darkSlotsOnPrimaryBoard,
+    FILLER_HP,
     FILLER_NAMES,
     FOCUS_ACTOR_ID,
     FOCUS_POSITION,
     occupiedCellCount,
-    PRIMARY_BOARD,
     ROUNDS,
     SCENARIOS,
     SEED,
@@ -84,7 +83,7 @@ describe('buildScenarioBattle', () => {
     });
 
     it('puts three enemies in the focus row, behind the focus (the targeting contract)', () => {
-        // The whole layout rationale (see FOCUS_POSITION's docstring): selectTargets scans from the
+        // The whole layout rationale (see PRIMARY_BOARD's docstring): selectTargets scans from the
         // caster's own row and takes the front-most column, so enemies sharing the focus's row and
         // sitting behind it resolve onto the FOCUS. Break this and the focus stops taking damage —
         // which is exactly the hole this suite was found to have.
@@ -298,36 +297,6 @@ describe('pattern reachability', () => {
                 'nothing.'
         ).toEqual([]);
     });
-
-    it('no ship is dark on the support-anchor board that was reachable on the primary one', () => {
-        // The reverse direction: the second board must not go dark for a ship the first one
-        // handled, which would mean a future routing change could strand it.
-        const darkNames = new Set(darkSlotsOnPrimaryBoard().map((d) => d.name.toUpperCase()));
-        const regressed: string[] = [];
-        for (const name of corpusNames()) {
-            if (darkNames.has(name.toUpperCase())) continue;
-            const ship = buildTraceShip(name);
-            if (!ship) continue;
-            for (const slot of ['active', 'charged'] as const) {
-                let pattern;
-                try {
-                    pattern = parseShipTargeting(ship)?.[slot]?.pattern;
-                } catch {
-                    continue;
-                }
-                if (!pattern) continue;
-                if (occupiedCellCount(pattern, PRIMARY_BOARD) === 0) {
-                    regressed.push(`${name}:${slot}`);
-                }
-            }
-        }
-        expect(
-            regressed,
-            `slot(s) dark on the primary board but missing from the derivation: ` +
-                `${regressed.join(', ')} — darkSlotsOnPrimaryBoard() and this sweep disagree, so ` +
-                'the derivation is not seeing the whole corpus.'
-        ).toEqual([]);
-    });
 });
 
 describe('support-anchor board', () => {
@@ -379,7 +348,7 @@ describe('support-anchor board', () => {
         // coverage for these ships already exists on the primary board.
         const battle = buildScenarioBattle(focus, 'supportAnchor');
         for (const p of battle.playerTeam.slice(1)) {
-            expect(p.statOverrides?.hp).toBeGreaterThan(p.ship.baseStats.hp);
+            expect(p.statOverrides?.hp).toBe(FILLER_HP);
         }
     });
 

--- a/src/utils/combat/audit/kitFingerprintScenarios.ts
+++ b/src/utils/combat/audit/kitFingerprintScenarios.ts
@@ -11,8 +11,14 @@ import { fingerprintActorTokens } from './fingerprint';
 
 export type ScenarioName = 'plain' | 'richEnemy' | 'wounded';
 
-/** Fixed scenario order — also the snapshot key order. */
+/** The three scenarios EVERY corpus ship runs. Deliberately narrower than `FingerprintScenario`:
+ *  the corpus-wide live invariants (focus takes real damage, focus survives) are asserted over this
+ *  array, and the support-anchor board cannot satisfy the first one by construction. Keeping it out
+ *  of `SCENARIOS` excludes it from those invariants with no exemption list to go stale. */
 export const SCENARIOS: readonly ScenarioName[] = ['plain', 'richEnemy', 'wounded'] as const;
+
+/** Every scenario a ship MAY run. `supportAnchor` is conditional — see `scenariosFor`. */
+export type FingerprintScenario = ScenarioName | 'supportAnchor';
 
 /** Pinned RNG seed for every scenario battle. One seed for all of them: the scenarios are meant
  *  to differ by initial STATE, not by RNG stream. */
@@ -22,17 +28,24 @@ export const SEED = 20260805;
  *  tick more than once, and cooldown-gated grants to re-arm. */
 export const ROUNDS = 20;
 
+/** One board geometry: where the focus sits, and where its filler allies and enemies sit. */
+export interface BoardLayout {
+    focus: Position;
+    allies: readonly Position[];
+    enemies: readonly Position[];
+}
+
 /**
- * BOARD LAYOUT — the single most load-bearing choice in this fixture, because it decides whether
- * the focus ship is ever ATTACKED. `selectTargets` scans rows starting at the CASTER's own row
- * (`rowScanOrder`: caster row → next → wrap) and takes the front-most occupied column (col 4 =
- * front) of the first row that holds a target. Consequences that drive the numbers below:
+ * THE PRIMARY BOARD — the single most load-bearing choice in this fixture, because it decides
+ * whether the focus ship is ever ATTACKED. `selectTargets` scans rows starting at the CASTER's own
+ * row (`rowScanOrder`: caster row → next → wrap) and takes the front-most occupied column (col 4 =
+ * front) of the first row that holds a target. Consequences:
  *
  *  - Three enemies share the focus's OWN row (M3/M2/M1 against the focus at M4). Their scan starts
  *    at row M, finds exactly one player there — the focus, front-most at col 4 — so all three
  *    single-target attacks land on the focus, every round. That is what makes on-damaged kit
  *    (counterattack, reflect, revenge, on-damaged grants, Barrier hit-counting) observable at all:
- *    the previous layout parked the focus behind an ally in another row and it took ZERO incoming
+ *    an earlier layout parked the focus behind an ally in another row and it took ZERO incoming
  *    damage in 136 of 147 fingerprints.
  *  - Sharing the row also keeps the focus's OWN offence multi-target: scanning from M it finds
  *    M3/M2/M1 front-to-back, so front/back/skip/adjacent patterns still differentiate, and `all`
@@ -46,13 +59,52 @@ export const ROUNDS = 20;
  *  - Allies at T4/B4 flank the focus's column-4 cell, so column/adjacency support footprints
  *    reach real allies.
  *
- * All eight cells are distinct: an ally and an enemy on the same cell would be
- * indistinguishable in position-keyed engine state.
+ * All eight cells are distinct: an ally and an enemy on the same cell would be indistinguishable
+ * in position-keyed engine state.
+ *
+ * WHAT THIS BOARD CANNOT DO, and why there is a second one: anchoring at the FRONT column means a
+ * forward-extending support pattern (`Pattern-Line-Support-*`, which extends +q toward col 4) has
+ * no cells ahead of it and resolves to ZERO. Three corpus ships are affected, in BOTH their active
+ * and charged slots (charged targeting inherits active when the charged columns are blank —
+ * `targetingParser.ts`). It cannot be fixed by moving this anchor: for such a caster to have
+ * anyone to support, allies must sit forward of it in its own row, which makes one of THEM
+ * front-most and stops the focus being attacked. The two requirements are mutually exclusive on one
+ * board, so they get one board each. See SUPPORT_ANCHOR_BOARD.
  */
-export const FOCUS_POSITION: Position = 'M4';
+export const PRIMARY_BOARD: BoardLayout = {
+    focus: 'M4',
+    allies: ['T4', 'T2', 'B4'],
+    enemies: ['M3', 'M2', 'M1', 'T3'],
+};
 
-const ALLY_POSITIONS: Position[] = ['T4', 'T2', 'B4'];
-const ENEMY_POSITIONS: Position[] = ['M3', 'M2', 'M1', 'T3'];
+/**
+ * THE SUPPORT-ANCHOR BOARD — run only by ships the primary board cannot reach (see
+ * `scenariosFor`). The focus sits at the BACK of the middle row with three allies forward of it,
+ * giving forward-extending support patterns three occupied cells to cover (ranges 1 through 3).
+ *
+ * Enemies stay OUT of row M, so the support line is all allies. The focus's own row scan is
+ * M → B → T, so with row M holding no enemies it finds B4 front-most and still reaches all four
+ * under an `all` pattern — its enemy-directed kit stays live.
+ *
+ * ACCEPTED LIMITATION: the focus takes zero incoming damage here, because the allies forward of it
+ * are front-most and absorb every attack. Nothing is lost — the affected ships keep their full
+ * primary-board fingerprints, which is where their on-damaged coverage lives. This board answers
+ * one narrow question: does this ship's support footprint reach anyone, and what does it do when
+ * it does.
+ */
+export const SUPPORT_ANCHOR_BOARD: BoardLayout = {
+    focus: 'M1',
+    allies: ['M2', 'M3', 'M4'],
+    enemies: ['B4', 'B3', 'B2', 'T4'],
+};
+
+export function boardFor(scenario: FingerprintScenario): BoardLayout {
+    return scenario === 'supportAnchor' ? SUPPORT_ANCHOR_BOARD : PRIMARY_BOARD;
+}
+
+/** The primary board's focus cell. Kept as a named export because the reachability derivation and
+ *  several board tests read it directly. */
+export const FOCUS_POSITION: Position = PRIMARY_BOARD.focus;
 
 /** How many enemies resolve onto the focus each round under the layout above (M3/M2/M1). Drives
  *  the incoming-damage budget in `fillerAttackFor`; verified by the "focus is the one being
@@ -192,7 +244,7 @@ const maxHpOf = (a: CombatActor): number => a.stats.hp;
 
 function seedFor(
     focus: Ship,
-    scenario: ScenarioName
+    scenario: FingerprintScenario
 ): ((actors: CombatActor[]) => void) | undefined {
     switch (scenario) {
         case 'plain':
@@ -205,7 +257,11 @@ function seedFor(
                 }
             };
         }
+        // `supportAnchor` shares wounded's seeding VERBATIM — one new variable (geometry), not two.
+        // It is also load-bearing: the ships this board exists for repair their allies, and a
+        // repair aimed at a full-HP filler is an overheal that may log nothing at all.
         case 'wounded':
+        case 'supportAnchor':
             return (actors) => {
                 for (const a of actors) {
                     const fraction = a.id === FOCUS_ACTOR_ID ? FOCUS_HURT_FRACTION : HURT_FRACTION;
@@ -231,24 +287,31 @@ function seedFor(
  * reflects its kit, not a gearing choice. The FILLER stats, by contrast, are tuned (HP, attack)
  * and are the only lever this fixture pulls on how hard the battle presses.
  */
-export function buildScenarioBattle(focus: Ship, scenario: ScenarioName): BattleSimulationInput {
+export function buildScenarioBattle(
+    focus: Ship,
+    scenario: FingerprintScenario
+): BattleSimulationInput {
+    const board = boardFor(scenario);
     const enemyNames = FILLER_NAMES.slice(0, 4);
     const allyNames = FILLER_NAMES.slice(4, 7);
     const tap = seedFor(focus, scenario);
     const attack = fillerAttackFor(focus);
     return {
         playerTeam: [
-            canonicalPlacement(focus, FOCUS_POSITION),
+            canonicalPlacement(focus, board.focus),
             ...allyNames.map((name, i) =>
                 fillerPlacement(
                     name,
-                    ALLY_POSITIONS[i],
+                    board.allies[i],
                     attack,
+                    // Note `scenario === 'wounded'` and NOT the seeding branch: supportAnchor
+                    // reuses wounded's HP seeding but must NOT get its fragile ally, because a
+                    // dying support target would make reach flaky.
                     scenario === 'wounded' && i === 0 ? FRAGILE_ALLY_HP : FILLER_HP
                 )
             ),
         ],
-        enemyTeam: enemyNames.map((name, i) => fillerPlacement(name, ENEMY_POSITIONS[i], attack)),
+        enemyTeam: enemyNames.map((name, i) => fillerPlacement(name, board.enemies[i], attack)),
         rounds: ROUNDS,
         ...(tap ? { __testTapActors: tap } : {}),
     };

--- a/src/utils/combat/audit/kitFingerprintScenarios.ts
+++ b/src/utils/combat/audit/kitFingerprintScenarios.ts
@@ -104,8 +104,9 @@ export function boardFor(scenario: FingerprintScenario): BoardLayout {
     return scenario === 'supportAnchor' ? SUPPORT_ANCHOR_BOARD : PRIMARY_BOARD;
 }
 
-/** The primary board's focus cell. Kept as a named export because the reachability derivation and
- *  several board tests read it directly. */
+/** The primary board's focus cell. Kept as a named export because several board tests read it
+ *  directly. The reachability derivation does NOT read it — `darkSlotsOnPrimaryBoard` goes through
+ *  `occupiedCellCount`, which reads `PRIMARY_BOARD.focus` instead. */
 export const FOCUS_POSITION: Position = PRIMARY_BOARD.focus;
 
 /** How many enemies resolve onto the focus each round under PRIMARY_BOARD (M3/M2/M1). Drives
@@ -271,7 +272,7 @@ function seedFor(
                 }
             };
         default: {
-            // Exhaustiveness guard: `undefined` is a legitimate return for 'plain', so a fourth
+            // Exhaustiveness guard: `undefined` is a legitimate return for 'plain', so a fifth
             // ScenarioName falling through the switch would silently run unseeded and still
             // produce a plausible-looking (but vacuous) snapshot. Force a compile error instead —
             // the spec DEFERS a status-seeded scenario, it does not cancel it.
@@ -368,9 +369,13 @@ let darkSlotCache: DarkSlot[] | null = null;
  *  would be quadratic.
  *
  *  Ships whose targeting cannot be parsed or resolved are SKIPPED rather than counted either way:
- *  this is a geometry-reachability question, not targeting-text coverage. */
+ *  this is a geometry-reachability question, not targeting-text coverage.
+ *
+ *  Returns a shallow COPY of the memo, not the cached array itself: `darkNameCache` below is
+ *  derived from this array, so a caller that mutated the returned reference would corrupt the
+ *  memo and desync it from that derived cache. */
 export function darkSlotsOnPrimaryBoard(): DarkSlot[] {
-    if (darkSlotCache) return darkSlotCache;
+    if (darkSlotCache) return [...darkSlotCache];
     const out: DarkSlot[] = [];
     for (const name of corpusNames()) {
         const ship = buildTraceShip(name);
@@ -386,7 +391,7 @@ export function darkSlotsOnPrimaryBoard(): DarkSlot[] {
         }
     }
     darkSlotCache = out;
-    return out;
+    return [...darkSlotCache];
 }
 
 /** UPPERCASE names of every ship with at least one dark slot. Case-folded because

--- a/src/utils/combat/audit/kitFingerprintScenarios.ts
+++ b/src/utils/combat/audit/kitFingerprintScenarios.ts
@@ -106,7 +106,7 @@ export function boardFor(scenario: FingerprintScenario): BoardLayout {
  *  several board tests read it directly. */
 export const FOCUS_POSITION: Position = PRIMARY_BOARD.focus;
 
-/** How many enemies resolve onto the focus each round under the layout above (M3/M2/M1). Drives
+/** How many enemies resolve onto the focus each round under PRIMARY_BOARD (M3/M2/M1). Drives
  *  the incoming-damage budget in `fillerAttackFor`; verified by the "focus is the one being
  *  attacked" scenario test. */
 const ATTACKERS_ON_FOCUS = 3;
@@ -280,12 +280,13 @@ function seedFor(
 }
 
 /**
- * The scenario battle for one focus ship: the focus at FOCUS_POSITION on the player side with 3
- * inert filler allies, against 4 inert filler enemies (see FOCUS_POSITION for why those cells).
- * Only the seeded initial state varies by scenario. The focus ship keeps `canonicalPlacement`'s
- * un-modified level-60 base stats — no gear, no refits, no engineering — so its fingerprint
- * reflects its kit, not a gearing choice. The FILLER stats, by contrast, are tuned (HP, attack)
- * and are the only lever this fixture pulls on how hard the battle presses.
+ * The scenario battle for one focus ship: the focus on the player side with 3 inert filler
+ * allies, against 4 inert filler enemies. Both the board geometry and seeded initial state vary
+ * by scenario (see `boardFor` for geometry selection, PRIMARY_BOARD and SUPPORT_ANCHOR_BOARD for
+ * cell rationales). The focus ship keeps `canonicalPlacement`'s un-modified level-60 base stats
+ * — no gear, no refits, no engineering — so its fingerprint reflects its kit, not a gearing
+ * choice. The FILLER stats, by contrast, are tuned (HP, attack) and are the only lever this
+ * fixture pulls on how hard the battle presses.
  */
 export function buildScenarioBattle(
     focus: Ship,

--- a/src/utils/combat/audit/kitFingerprintScenarios.ts
+++ b/src/utils/combat/audit/kitFingerprintScenarios.ts
@@ -320,20 +320,31 @@ export function buildScenarioBattle(
     };
 }
 
-/** Fingerprint one ship across all three scenarios. Every battle goes through runSeededBattle —
+/** The scenarios THIS ship runs: the three universal ones, plus `supportAnchor` when the primary
+ *  board cannot reach one of its targeting slots. */
+export function scenariosFor(ship: Ship): FingerprintScenario[] {
+    return darkShipNames().has(ship.name.toUpperCase())
+        ? [...SCENARIOS, 'supportAnchor']
+        : [...SCENARIOS];
+}
+
+/** The three universal scenarios are always present; `supportAnchor` only for dark ships. */
+export type FingerprintResult = Record<ScenarioName, string[]> & { supportAnchor?: string[] };
+
+/** Fingerprint one ship across every scenario it runs. Every battle goes through runSeededBattle —
  *  its `finally` restores Math.random rather than any ambient seed, so a raw simulateBattle call
  *  afterwards would be nondeterministic.
  *
  *  Lives here (rather than in the `.test.ts` file that consumes it) so both the vitest suite and
  *  `scripts/reportThinKitFingerprints.ts` (run under plain `tsx`, no vitest globals) can import it
  *  without importing a `.test.ts` module. */
-export function fingerprintShip(ship: Ship): Record<ScenarioName, string[]> {
-    const out = {} as Record<ScenarioName, string[]>;
-    for (const scenario of SCENARIOS) {
+export function fingerprintShip(ship: Ship): FingerprintResult {
+    const out: Partial<Record<FingerprintScenario, string[]>> = {};
+    for (const scenario of scenariosFor(ship)) {
         const result = runSeededBattle(buildScenarioBattle(ship, scenario), SEED);
         out[scenario] = fingerprintActorTokens(result, FOCUS_ACTOR_ID);
     }
-    return out;
+    return out as FingerprintResult;
 }
 
 /** One targeting slot of one ship that resolves to no occupied cell on a given board. */

--- a/src/utils/combat/audit/kitFingerprintScenarios.ts
+++ b/src/utils/combat/audit/kitFingerprintScenarios.ts
@@ -5,6 +5,8 @@ import type { BattlePlacement, BattleSimulationInput } from '../../calculators/b
 import { buildTraceShip } from '../../../../scripts/lib/traceShipFactory';
 import { loadShipSkillRecords } from '../../../../scripts/lib/shipSkillCsv';
 import { calculateDamageReduction } from '../../autogear/priorityScore';
+import { parseShipTargeting, type ParsedPattern } from '../../targetingParser';
+import { resolveCells } from '../../targeting/resolvePattern';
 import { canonicalPlacement } from './fixtures';
 import { runSeededBattle } from './seededBattle';
 import { fingerprintActorTokens } from './fingerprint';
@@ -332,6 +334,59 @@ export function fingerprintShip(ship: Ship): Record<ScenarioName, string[]> {
         out[scenario] = fingerprintActorTokens(result, FOCUS_ACTOR_ID);
     }
     return out;
+}
+
+/** One targeting slot of one ship that resolves to no occupied cell on a given board. */
+export interface DarkSlot {
+    name: string;
+    slot: 'active' | 'charged';
+}
+
+/** How many of a pattern's resolved cells are actually OCCUPIED on `board`, anchored at that
+ *  board's focus cell. Zero means the slot can never fire from there: the ability resolves, finds
+ *  nobody, and produces no log entry — a silent hole in that ship's fingerprint. */
+export function occupiedCellCount(pattern: ParsedPattern, board: BoardLayout): number {
+    const occupied = new Set<string>([board.focus, ...board.allies, ...board.enemies]);
+    return resolveCells(pattern, board.focus).filter((c) => occupied.has(c.position)).length;
+}
+
+let darkSlotCache: DarkSlot[] | null = null;
+
+/** Every corpus slot the PRIMARY board cannot reach. Memoized: `scenariosFor` is called once per
+ *  ship in a 147-ship loop, and this sweep rebuilds the whole corpus — without the memo the suite
+ *  would be quadratic.
+ *
+ *  Ships whose targeting cannot be parsed or resolved are SKIPPED rather than counted either way:
+ *  this is a geometry-reachability question, not targeting-text coverage. */
+export function darkSlotsOnPrimaryBoard(): DarkSlot[] {
+    if (darkSlotCache) return darkSlotCache;
+    const out: DarkSlot[] = [];
+    for (const name of corpusNames()) {
+        const ship = buildTraceShip(name);
+        if (!ship) continue;
+        for (const slot of ['active', 'charged'] as const) {
+            try {
+                const pattern = parseShipTargeting(ship)?.[slot]?.pattern;
+                if (!pattern) continue;
+                if (occupiedCellCount(pattern, PRIMARY_BOARD) === 0) out.push({ name, slot });
+            } catch {
+                continue;
+            }
+        }
+    }
+    darkSlotCache = out;
+    return out;
+}
+
+/** UPPERCASE names of every ship with at least one dark slot. Case-folded because
+ *  `loadShipSkillRecords()` names and `Ship.name` are not guaranteed to agree in case — the filler
+ *  inertness guard already compares this way. */
+let darkNameCache: Set<string> | null = null;
+export function darkShipNames(): ReadonlySet<string> {
+    if (!darkNameCache) {
+        darkNameCache = new Set(darkSlotsOnPrimaryBoard().map((d) => d.name.toUpperCase()));
+    }
+    return darkNameCache;
 }
 
 /** Corpus ship names, sorted for a stable order (CSV row order is not guaranteed). */


### PR DESCRIPTION
## The hole

`realKitFingerprints.test.ts` is the golden suite's only real-ship coverage — 147 corpus ships, each reduced to a set of `kind[:slot]` behaviour tokens. Every focus ship was anchored at **M4, the front-most column** of its row.

`Pattern-Line-Support-*` extends **forward**, toward column 4. Anchored on the front column it has no cells ahead of it and resolves to **zero**. Faust and Mender therefore fingerprinted as a bare `["charge-changed"]` — green, deterministic, and observing nothing.

Two things the earlier write-up had wrong:

- **The charged slot was dark too, and was never guarded.** `parseShipTargeting` inherits active targeting when both charged columns are blank, and all three ships have blank charged columns — so the old `active`-only guard reported half the problem. Measured: **6 dark slots across 3 ships**, not 3.
- **"Put an ally at M3" doesn't work.** Forward is `+q`; M3 is *behind* M4.

## Why two boards and not a moved anchor

`selectTargets` takes the front-most occupied cell of the first row holding a target. For a Line-Support caster to have anyone to support, allies must sit **forward of it in its own row** — which makes one of *them* front-most, so the focus stops being attacked. The primary board's entire purpose is that the focus takes real incoming damage (before #298's final fix, 136 of 147 fixtures had it taking zero and all on-damaged kit was silent).

The two requirements are mutually exclusive on one board. I checked whether a back-selecting enemy could break the tie — all ten inert filler ships are `front,Pattern-Base`, so there is no inert backline attacker to use.

So: one board each. `SUPPORT_ANCHOR_BOARD` puts the focus at **M1** with allies at M2/M3/M4 and enemies out of row M. It reuses `wounded`'s HP seeding verbatim — load-bearing, not tidiness: Faust and Mender *repair* their allies, and a repair aimed at a full-HP 500,000,000-HP filler is an overheal that may log nothing. It gets no fragile ally; a dying support target would make reach flaky.

The focus takes zero incoming damage on that board, unavoidably. Nothing is lost — these ships keep their full primary-board fingerprints. `supportAnchor` is kept **out of the `SCENARIOS` array** that the corpus-wide live invariants iterate, so it is excluded by construction rather than by an exemption that can go stale.

## Derived, not allow-listed

`KNOWN_UNREACHABLE` is deleted. Membership now comes from a memoized sweep over both slots, so a future corpus ship with an unreachable geometry is routed automatically. The six-entry pin is a change-detector on the *result*, not a gate on the behaviour — a new dark ship gets its fourth scenario and the pin tells a human about it.

## Result

| Ship | Before | After (`supportAnchor`) |
|---|---|---|
| Faust | `["charge-changed"]` | `buff`, `buff:active`, `buff:charged`, `charge-changed`, `heal` |
| Mender | `["charge-changed"]` | `buff`, `buff:charged`, `charge-changed`, `heal` |
| Refine | `["buff", "charge-changed"]` | `buff`, `buff:active`, `buff:charged`, `charge-changed` |

**Snapshot move is additive: 19 insertions, 0 deletions, confined to those three entries.** The other 144 are byte-identical.

## Two findings worth reading

**Mender has no `:active` token, but its active fires.** Traced from the raw log: it heals two allies for 4,179.35 each, every round 1–20, alone in its turn with no competing handler to lose the single-use `consumePendingSkill()` race to — that heal path simply never calls it. Recorded in the pinned test's docstring so nobody re-opens it as an engine bug, and it is why the pinned assertions are kind-level rather than `kind:slot`.

**`realKitFingerprints.test.ts` was invisible to `grep`.** It carried four raw control bytes (3× NUL + 1× `\x01`) in the corpus digest, so `file(1)` called it `data` and plain `grep`/`rg` skipped it **silently, with exit 1**. A repo sweep over the suite's only real-ship file returned "clean" for a reason unrelated to the code — including this branch's own `KNOWN_UNREACHABLE` check, which was false (a live hit sits in a comment). Pre-existing from #298; fixed by writing them as escapes, identical runtime string, digest snapshot unmoved.

The final review also caught **a test I wrote into the plan that could not fail** — titled as a support-anchor check but testing `PRIMARY_BOARD`, re-implementing the derivation's own loop over the complement of its output. Deleted; its sibling gates the property that matters over a non-empty list.

## Verification

- 469 files / 5325 tests green; `tsc --noEmit` and lint clean.
- Snapshot diff audited as additions-only against `main`.
- No production engine, parser, or UI file touched. No changelog entry (test-only, per CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSGWjgR1PAY61kCDSqFywz
