### PR TITLE
fix(recruitment): Centurion is recruitable through beacons

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -32,6 +32,7 @@ export const UNRELEASED_CHANGES: string[] = [
     "Combat simulator: Malvex's normal skill follows the same rule — it only shields itself for 15% of its max health when the target it hits has a Shield. It used to bank that Shield on every cast, which also fed the bonus damage its skills deal based on its own current Shield.",
     'Autogear: Defence and Crit Chance priorities are now weighted on the same scale as every other stat. Both were being compared against their raw values instead of a typical value for the stat, which made a Defence priority around 5000x too strong and a Crit Chance priority around 25x too strong — either one would swamp the priorities listed above it. If you have saved configurations that use Defence or Crit Chance as a priority, re-run autogear to get the corrected recommendation.',
     'Combat log now shows which ship granted a buff to an ally, instead of only naming the ship that received it.',
+    'Recruitment calculator: Centurion is now recruitable through beacons. It was on the non-recruitable list, so the calculator gave it no beacon odds at all.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/recruitmentCalculator.ts
+++ b/src/utils/recruitmentCalculator.ts
@@ -11,7 +11,6 @@ const NON_RECRUITABLE_SHIPS = [
     'Asphodel',
     'Lev',
     'Incinerator',
-    'Centurion',
 ];
 
 // Ships that are only available during events (event-only ships)


### PR DESCRIPTION
Centurion sat in `NON_RECRUITABLE_SHIPS`, so `calculateShipProbability` gave it no beacon odds at all. It is beacon-obtainable — entry dropped.

No test referenced the constant. Recruitment suite (10 tests) green, tsc clean, and the husky pre-commit ran the full suite: **469 files / 5325 tests passing**.

Changelog entry added to `UNRELEASED_CHANGES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6or8HzPQ6Ydx1bAB9rGHz