### PR TITLE
test(audit): placement-symmetry oracle — real-kit coverage for the engine's other two actor paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "trace:ship": "tsx scripts/traceShip.ts",
         "audit:kit-ledger": "tsx scripts/writeKitLedger.ts",
         "audit:interactions": "tsx scripts/auditInteractions.ts",
+        "audit:placement-symmetry": "tsx scripts/auditPlacementSymmetry.ts",
         "fetch:ship-skills": "tsx scripts/fetch-ship-skills.ts",
         "fetch:ship-data": "tsx scripts/fetch-ship-data.ts",
         "audit": "node scripts/audit.mjs"

--- a/scripts/auditPlacementSymmetry.ts
+++ b/scripts/auditPlacementSymmetry.ts
@@ -53,9 +53,14 @@ function main(): void {
             'actor-id resolution for the attack pathway only. heal/shield/buff/death/charge-changed ' +
             'attribution is NOT exercised by this gate, not ruled out.)'
     );
+    console.log(
+        '  (caveat: RNG is actor-id-keyed and re-draws per placement, and playerTeam[0] is also the ' +
+            "engine's positional heal target — see the ledger's caveat block before instrumenting a " +
+            'low-ship-count or heal finding.)'
+    );
 
     const diffs: PlacementDiff[] = [];
-    const emptyByPlacement = { focus: 0, team: 0, enemy: 0 } as Record<Placement, number>;
+    const emptyByPlacement: Record<Placement, number> = { focus: 0, team: 0, enemy: 0 };
     const kindsSeen = {
         focus: new Set<CombatLogEntryKind>(),
         team: new Set<CombatLogEntryKind>(),

--- a/scripts/auditPlacementSymmetry.ts
+++ b/scripts/auditPlacementSymmetry.ts
@@ -1,0 +1,125 @@
+/* eslint-disable no-console */
+import fs from 'fs';
+import path from 'path';
+import {
+    buildPlacementLedgerJson,
+    parsePlacementArgs,
+    renderPlacementLedgerMarkdown,
+    type PlacementHealth,
+} from './lib/placementLedger';
+import { buildTraceShip } from './lib/traceShipFactory';
+import { csvAvailable } from './lib/shipSkillCsv';
+import { shipDataAvailable } from './lib/shipDataSnapshot';
+import { corpusNames, SEED } from '../src/utils/combat/audit/kitFingerprintScenarios';
+import {
+    diffAllPlacements,
+    fingerprintSubject,
+    runCalibration,
+    seedsFrom,
+} from '../src/utils/combat/audit/placementSymmetry';
+import { PLACEMENTS, type Placement, type PlacementDiff } from '../src/utils/combat/audit/types';
+import type { CombatLogEntryKind } from '../src/utils/combat/log/types';
+
+const LEDGER_DIR = path.join(process.cwd(), 'docs');
+
+function main(): void {
+    if (!csvAvailable() || !shipDataAvailable()) {
+        console.error(
+            'docs/ship-skills.csv and/or docs/ship-data.json are missing from this worktree ' +
+                '(gitignored reference data) — cannot build the ship corpus.'
+        );
+        process.exit(1);
+    }
+
+    const args = parsePlacementArgs(process.argv.slice(2));
+    const baseSeed = Number.isNaN(args.baseSeed) ? SEED : args.baseSeed;
+    const seeds = seedsFrom(baseSeed, args.seeds);
+
+    // Calibration first: a kitless ship must fingerprint identically in all three placements, or the
+    // asymmetry is in the harness and no real finding can be trusted.
+    console.log(`CALIBRATION: inert subjects over ${seeds.length} seed(s)...`);
+    const calibration = runCalibration(seeds);
+    if (calibration.length > 0) {
+        console.error('CALIBRATION FAILED — an inert kit is not placement-symmetric:');
+        for (const d of calibration) {
+            console.error(`  ${d.shipName}: ${d.from} -> ${d.to} lost ${d.missing.join(', ')}`);
+        }
+        console.error('No ledger written. Fix the harness asymmetry before trusting a sweep.');
+        process.exit(1);
+    }
+    console.log('CALIBRATION: clean');
+    console.log(
+        '  (caveat: the calibration subjects only ever produce {} or {attack} — this proves ' +
+            'actor-id resolution for the attack pathway only. heal/shield/buff/death/charge-changed ' +
+            'attribution is NOT exercised by this gate, not ruled out.)'
+    );
+
+    const diffs: PlacementDiff[] = [];
+    const emptyByPlacement = { focus: 0, team: 0, enemy: 0 } as Record<Placement, number>;
+    const kindsSeen = {
+        focus: new Set<CombatLogEntryKind>(),
+        team: new Set<CombatLogEntryKind>(),
+        enemy: new Set<CombatLogEntryKind>(),
+    };
+    let shipsSwept = 0;
+    let symmetricShips = 0;
+
+    for (const name of corpusNames()) {
+        const subject = buildTraceShip(name);
+        if (!subject) continue;
+        shipsSwept++;
+
+        const byPlacement = {} as Record<Placement, Set<CombatLogEntryKind>>;
+        for (const placement of PLACEMENTS) {
+            const observed = fingerprintSubject(subject, placement, seeds);
+            byPlacement[placement] = observed;
+            if (observed.size === 0) emptyByPlacement[placement]++;
+            for (const kind of observed) kindsSeen[placement].add(kind);
+        }
+
+        const shipDiffs = diffAllPlacements(subject.name, byPlacement);
+        if (shipDiffs.length === 0) symmetricShips++;
+        diffs.push(...shipDiffs);
+
+        if (shipsSwept % 25 === 0) {
+            console.log(`  ...${shipsSwept} ships, ${diffs.length} findings so far`);
+        }
+    }
+
+    const health: PlacementHealth = {
+        shipsSwept,
+        seeds: [...seeds],
+        emptyByPlacement,
+        kindsByPlacement: {
+            focus: kindsSeen.focus.size,
+            team: kindsSeen.team.size,
+            enemy: kindsSeen.enemy.size,
+        },
+        symmetricShips,
+    };
+
+    fs.writeFileSync(
+        path.join(LEDGER_DIR, 'placement-symmetry-ledger.json'),
+        `${JSON.stringify(buildPlacementLedgerJson(diffs, health), null, 2)}\n`
+    );
+    fs.writeFileSync(
+        path.join(LEDGER_DIR, 'placement-symmetry-ledger.md'),
+        renderPlacementLedgerMarkdown(diffs, health)
+    );
+
+    console.log('');
+    console.log(`shipsSwept:      ${shipsSwept}`);
+    console.log(`symmetricShips:  ${symmetricShips}`);
+    console.log(`findings:        ${diffs.length}`);
+    for (const placement of PLACEMENTS) {
+        console.log(
+            `  ${placement}: ${health.kindsByPlacement[placement]} distinct kinds, ` +
+                `${emptyByPlacement[placement]} ships observed nothing`
+        );
+    }
+    console.log('');
+    console.log('Ledger: docs/placement-symmetry-ledger.{json,md}');
+    console.log('Findings are CANDIDATES — confirm each with engine instrumentation.');
+}
+
+main();

--- a/scripts/lib/__tests__/placementLedger.test.ts
+++ b/scripts/lib/__tests__/placementLedger.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+    buildPlacementLedgerJson,
+    parsePlacementArgs,
+    renderPlacementLedgerMarkdown,
+    type PlacementHealth,
+} from '../placementLedger';
+import type { PlacementDiff } from '../../../src/utils/combat/audit/types';
+import type { CombatLogEntryKind } from '../../../src/utils/combat/log/types';
+
+const health: PlacementHealth = {
+    shipsSwept: 147,
+    seeds: [1, 2],
+    emptyByPlacement: { focus: 0, team: 0, enemy: 0 },
+    kindsByPlacement: { focus: 21, team: 20, enemy: 19 },
+    symmetricShips: 140,
+};
+
+const diff: PlacementDiff = {
+    shipName: 'Sentinel',
+    from: 'focus',
+    to: 'enemy',
+    missing: ['heal'] as CombatLogEntryKind[],
+};
+
+describe('parsePlacementArgs', () => {
+    it('defaults to 5 seeds', () => {
+        expect(parsePlacementArgs([]).seeds).toBe(5);
+    });
+
+    it('parses --seeds and --base-seed', () => {
+        expect(parsePlacementArgs(['--seeds', '3', '--base-seed', '99'])).toEqual({
+            seeds: 3,
+            baseSeed: 99,
+        });
+    });
+
+    it('ignores unrecognized tokens', () => {
+        expect(parsePlacementArgs(['--nope', 'x']).seeds).toBe(5);
+    });
+});
+
+describe('buildPlacementLedgerJson', () => {
+    it('carries the health block and the findings', () => {
+        const json = buildPlacementLedgerJson([diff], health);
+        expect(json.health.shipsSwept).toBe(147);
+        expect(json.findings).toEqual([diff]);
+        expect(json.findingCount).toBe(1);
+    });
+});
+
+describe('renderPlacementLedgerMarkdown', () => {
+    it('renders the health block and each finding', () => {
+        const md = renderPlacementLedgerMarkdown([diff], health);
+        expect(md).toContain('# Placement Symmetry Ledger');
+        expect(md).toContain('Ships swept: **147**');
+        expect(md).toContain('Sentinel');
+        expect(md).toContain('focus');
+        expect(md).toContain('heal');
+    });
+
+    it('says so explicitly when there are no findings', () => {
+        const md = renderPlacementLedgerMarkdown([], health);
+        expect(md).toContain('No placement asymmetries');
+    });
+
+    it('flags a zero-kind placement as a vacuity warning', () => {
+        const md = renderPlacementLedgerMarkdown([], {
+            ...health,
+            emptyByPlacement: { focus: 0, team: 4, enemy: 0 },
+        });
+        expect(md).toMatch(/VACUITY WARNING/i);
+    });
+});

--- a/scripts/lib/__tests__/placementLedger.test.ts
+++ b/scripts/lib/__tests__/placementLedger.test.ts
@@ -71,4 +71,16 @@ describe('renderPlacementLedgerMarkdown', () => {
         });
         expect(md).toMatch(/VACUITY WARNING/i);
     });
+
+    it('discloses the actor-id-keyed RNG seed-noise caveat', () => {
+        const md = renderPlacementLedgerMarkdown([diff], health);
+        expect(md).toMatch(/seed noise/i);
+        expect(md).toContain('--base-seed');
+    });
+
+    it("discloses the playerTeam[0]-is-the-heal-target caveat", () => {
+        const md = renderPlacementLedgerMarkdown([diff], health);
+        expect(md).toMatch(/heal target/i);
+        expect(md).toContain('positionalTeamBattle');
+    });
 });

--- a/scripts/lib/__tests__/placementLedger.test.ts
+++ b/scripts/lib/__tests__/placementLedger.test.ts
@@ -38,6 +38,35 @@ describe('parsePlacementArgs', () => {
     it('ignores unrecognized tokens', () => {
         expect(parsePlacementArgs(['--nope', 'x']).seeds).toBe(5);
     });
+
+    it('rejects a non-numeric --seeds, naming the offending token', () => {
+        expect(() => parsePlacementArgs(['--seeds', 'abc'])).toThrow(/abc/);
+    });
+
+    it('rejects --seeds 0, naming the offending token', () => {
+        expect(() => parsePlacementArgs(['--seeds', '0'])).toThrow(/0/);
+    });
+
+    it('rejects a fractional --seeds instead of silently truncating', () => {
+        expect(() => parsePlacementArgs(['--seeds', '3.7'])).toThrow(/3\.7/);
+    });
+
+    it('rejects a trailing --seeds with no value', () => {
+        expect(() => parsePlacementArgs(['--seeds'])).toThrow(/positive integer/);
+    });
+
+    it('rejects a negative --seeds', () => {
+        expect(() => parsePlacementArgs(['--seeds', '-1'])).toThrow(/-1/);
+    });
+
+    it('rejects a non-numeric --base-seed, naming the offending token', () => {
+        expect(() => parsePlacementArgs(['--base-seed', 'abc'])).toThrow(/abc/);
+    });
+
+    it('accepts a negative or zero --base-seed', () => {
+        expect(parsePlacementArgs(['--base-seed', '-1']).baseSeed).toBe(-1);
+        expect(parsePlacementArgs(['--base-seed', '0']).baseSeed).toBe(0);
+    });
 });
 
 describe('buildPlacementLedgerJson', () => {
@@ -64,6 +93,12 @@ describe('renderPlacementLedgerMarkdown', () => {
         expect(md).toContain('No placement asymmetries');
     });
 
+    it('does not hardcode the CombatLogEntryKind union size in the calibration caveat', () => {
+        const md = renderPlacementLedgerMarkdown([diff], health);
+        expect(md).toContain('CombatLogEntryKind');
+        expect(md).not.toContain('17 `CombatLogEntryKind`');
+    });
+
     it('flags a zero-kind placement as a vacuity warning', () => {
         const md = renderPlacementLedgerMarkdown([], {
             ...health,
@@ -76,6 +111,19 @@ describe('renderPlacementLedgerMarkdown', () => {
         const md = renderPlacementLedgerMarkdown([diff], health);
         expect(md).toMatch(/seed noise/i);
         expect(md).toContain('--base-seed');
+    });
+
+    it('derives the seed count in the seed-noise caveat instead of hardcoding it', () => {
+        const md = renderPlacementLedgerMarkdown([diff], health);
+        expect(md).toContain(`K=${health.seeds.length}`);
+    });
+
+    it('does not hardcode a specific run\'s findings in the generic seed-noise caveat', () => {
+        const md = renderPlacementLedgerMarkdown([diff], health);
+        expect(md).not.toContain('debuff-resisted');
+        expect(md).not.toContain('Belladonna');
+        expect(md).not.toContain('Enforcer');
+        expect(md).not.toContain('Valerian');
     });
 
     it("discloses the playerTeam[0]-is-the-heal-target caveat", () => {

--- a/scripts/lib/placementLedger.ts
+++ b/scripts/lib/placementLedger.ts
@@ -1,4 +1,4 @@
-import type { Placement, PlacementDiff } from '../../src/utils/combat/audit/types';
+import { PLACEMENTS, type Placement, type PlacementDiff } from '../../src/utils/combat/audit/types';
 
 const DEFAULT_SEEDS = 5;
 
@@ -56,7 +56,7 @@ export function renderPlacementLedgerMarkdown(
         '| placement | distinct kinds | ships observing nothing |',
         '| --- | --- | --- |',
     ];
-    for (const placement of ['focus', 'team', 'enemy'] as Placement[]) {
+    for (const placement of PLACEMENTS) {
         lines.push(
             `| ${placement} | ${health.kindsByPlacement[placement]} | ${health.emptyByPlacement[placement]} |`
         );
@@ -78,6 +78,24 @@ export function renderPlacementLedgerMarkdown(
         "subject's actor id resolves correctly in all three placements for the `attack` pathway. It does NOT",
         'rule out an asymmetry in heal, shield, buff, death, or charge-changed attribution — those pathways',
         'are simply **not exercised** by the calibration gate at all.',
+        ''
+    );
+    lines.push(
+        '**Seed noise, not just calibration scope, is a confound.** The RNG sub-stream is keyed by actor',
+        'id, which necessarily changes with placement. Measured on this branch: the same crit landed at',
+        'rounds 6+13 as `focus`, 5+16 as `team`, 7+20 as `enemy` — same physical ship, same seed, three',
+        'different draws. Union-over-K-seeds is the mitigation, but at the default K=5 its strength is',
+        'unquantified, and a landing- or proc-gated kind can still differ between placements purely by',
+        'draw. The three `debuff-resisted` findings below (Belladonna, Enforcer, Valerian) point in',
+        'MUTUALLY INCONSISTENT directions across ships — that pattern is the signature of seed noise, not',
+        'a path gap. Before instrumenting a low-ship-count finding, re-run with a different `--base-seed`',
+        'and see if it survives.',
+        '',
+        "**`playerTeam[0]` is also the engine's heal target in positional mode**",
+        '(`src/utils/combat/engine.ts:2282`: `healTarget = explicitHealTarget ?? (input.positionalTeamBattle',
+        '? attacker : undefined)`). So the subject is the heal target ONLY in the `focus` placement — a',
+        'real engine-role difference the transform cannot remove, not a harness bug. Read any `heal`',
+        'finding below with that in mind.',
         ''
     );
     lines.push('## Findings', '');

--- a/scripts/lib/placementLedger.ts
+++ b/scripts/lib/placementLedger.ts
@@ -1,0 +1,96 @@
+import type { Placement, PlacementDiff } from '../../src/utils/combat/audit/types';
+
+const DEFAULT_SEEDS = 5;
+
+/** Pure: parses `--seeds <K>` / `--base-seed <N>`. `--seeds` is the number of consecutive seeds to
+ *  union over, not a seed value. Unrecognized tokens are ignored (no positional args). */
+export function parsePlacementArgs(argv: string[]): { seeds: number; baseSeed: number } {
+    const out = { seeds: DEFAULT_SEEDS, baseSeed: Number.NaN };
+    for (let i = 0; i < argv.length; i++) {
+        if (argv[i] === '--seeds') out.seeds = Number(argv[++i]);
+        else if (argv[i] === '--base-seed') out.baseSeed = Number(argv[++i]);
+    }
+    return out;
+}
+
+/** Numbers that make a zero-finding sweep auditable instead of merely reassuring. */
+export interface PlacementHealth {
+    shipsSwept: number;
+    seeds: number[];
+    /** Ships that produced NO kinds at all, per placement. Must be 0 — a nonzero count means the
+     *  sweep observed nothing and every "missing" finding is an artifact. */
+    emptyByPlacement: Record<Placement, number>;
+    /** Distinct kinds observed across the corpus, per placement. */
+    kindsByPlacement: Record<Placement, number>;
+    /** Ships whose three placements agreed exactly. */
+    symmetricShips: number;
+}
+
+export function buildPlacementLedgerJson(diffs: PlacementDiff[], health: PlacementHealth) {
+    return { health, findingCount: diffs.length, findings: diffs };
+}
+
+function hasVacuity(health: PlacementHealth): boolean {
+    return Object.values(health.emptyByPlacement).some((n) => n > 0);
+}
+
+export function renderPlacementLedgerMarkdown(
+    diffs: PlacementDiff[],
+    health: PlacementHealth
+): string {
+    const lines: string[] = [
+        '# Placement Symmetry Ledger',
+        '',
+        'Each corpus ship run by all three engine actor paths (`attacker` / `team` / `enemy`) on',
+        'byte-identical cells. A finding is a log-entry kind produced in one placement and never in',
+        'another. **Findings are CANDIDATES** — confirm with direct engine instrumentation before',
+        'recording any of them as a real bug.',
+        '',
+        `- Ships swept: **${health.shipsSwept}**`,
+        `- Seeds unioned: **${health.seeds.length}** (${health.seeds.join(', ')})`,
+        `- Ships symmetric across all three placements: **${health.symmetricShips}**`,
+        `- Findings: **${diffs.length}**`,
+        '',
+        '## Suite health',
+        '',
+        '| placement | distinct kinds | ships observing nothing |',
+        '| --- | --- | --- |',
+    ];
+    for (const placement of ['focus', 'team', 'enemy'] as Placement[]) {
+        lines.push(
+            `| ${placement} | ${health.kindsByPlacement[placement]} | ${health.emptyByPlacement[placement]} |`
+        );
+    }
+    lines.push('');
+    if (hasVacuity(health)) {
+        lines.push(
+            '> **VACUITY WARNING:** at least one placement observed nothing for some ships. Every',
+            '> "missing" finding below is suspect until that is explained — an unresolved subject id',
+            '> fingerprints an empty set and looks exactly like a total behaviour loss.',
+            ''
+        );
+    }
+    lines.push(
+        '**Calibration is narrower than it sounds.** The calibration subjects (`CALIBRATION_SUBJECT_NAMES`)',
+        'have no passives, no charge skill, and only a bare damage-dealing active, so their fingerprint is',
+        'structurally bounded to `{}` or `{attack}` — none of the other 17 `CombatLogEntryKind` values can',
+        'EVER appear for them, in any placement, at any seed count. A clean calibration therefore proves the',
+        "subject's actor id resolves correctly in all three placements for the `attack` pathway. It does NOT",
+        'rule out an asymmetry in heal, shield, buff, death, or charge-changed attribution — those pathways',
+        'are simply **not exercised** by the calibration gate at all.',
+        ''
+    );
+    lines.push('## Findings', '');
+    if (diffs.length === 0) {
+        lines.push('No placement asymmetries observed.', '');
+    } else {
+        for (const d of diffs) {
+            lines.push(
+                `- **${d.shipName}** — fires as \`${d.from}\` but never as \`${d.to}\`: ` +
+                    `${d.missing.map((k) => `\`${k}\``).join(', ')}`
+            );
+        }
+        lines.push('');
+    }
+    return lines.join('\n');
+}

--- a/scripts/lib/placementLedger.ts
+++ b/scripts/lib/placementLedger.ts
@@ -2,13 +2,31 @@ import { PLACEMENTS, type Placement, type PlacementDiff } from '../../src/utils/
 
 const DEFAULT_SEEDS = 5;
 
+function parsePositiveIntArg(flag: string, raw: string | undefined): number {
+    const n = Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new Error(`${flag} must be a positive integer, got ${JSON.stringify(raw)}`);
+    }
+    return n;
+}
+
+function parseIntArg(flag: string, raw: string | undefined): number {
+    const n = Number(raw);
+    if (!Number.isInteger(n)) {
+        throw new Error(`${flag} must be an integer, got ${JSON.stringify(raw)}`);
+    }
+    return n;
+}
+
 /** Pure: parses `--seeds <K>` / `--base-seed <N>`. `--seeds` is the number of consecutive seeds to
- *  union over, not a seed value. Unrecognized tokens are ignored (no positional args). */
+ *  union over, not a seed value, and must be a positive integer. `--base-seed` is a seed value
+ *  itself (any integer, including negative and zero). Unrecognized tokens are ignored (no
+ *  positional args). Throws with the offending raw token on an invalid value. */
 export function parsePlacementArgs(argv: string[]): { seeds: number; baseSeed: number } {
     const out = { seeds: DEFAULT_SEEDS, baseSeed: Number.NaN };
     for (let i = 0; i < argv.length; i++) {
-        if (argv[i] === '--seeds') out.seeds = Number(argv[++i]);
-        else if (argv[i] === '--base-seed') out.baseSeed = Number(argv[++i]);
+        if (argv[i] === '--seeds') out.seeds = parsePositiveIntArg('--seeds', argv[++i]);
+        else if (argv[i] === '--base-seed') out.baseSeed = parseIntArg('--base-seed', argv[++i]);
     }
     return out;
 }
@@ -73,8 +91,8 @@ export function renderPlacementLedgerMarkdown(
     lines.push(
         '**Calibration is narrower than it sounds.** The calibration subjects (`CALIBRATION_SUBJECT_NAMES`)',
         'have no passives, no charge skill, and only a bare damage-dealing active, so their fingerprint is',
-        'structurally bounded to `{}` or `{attack}` — none of the other 17 `CombatLogEntryKind` values can',
-        'EVER appear for them, in any placement, at any seed count. A clean calibration therefore proves the',
+        'structurally bounded to `{}` or `{attack}` — no other `CombatLogEntryKind` value can EVER appear',
+        'for them, in any placement, at any seed count. A clean calibration therefore proves the',
         "subject's actor id resolves correctly in all three placements for the `attack` pathway. It does NOT",
         'rule out an asymmetry in heal, shield, buff, death, or charge-changed attribution — those pathways',
         'are simply **not exercised** by the calibration gate at all.',
@@ -84,10 +102,10 @@ export function renderPlacementLedgerMarkdown(
         '**Seed noise, not just calibration scope, is a confound.** The RNG sub-stream is keyed by actor',
         'id, which necessarily changes with placement. Measured on this branch: the same crit landed at',
         'rounds 6+13 as `focus`, 5+16 as `team`, 7+20 as `enemy` — same physical ship, same seed, three',
-        'different draws. Union-over-K-seeds is the mitigation, but at the default K=5 its strength is',
-        'unquantified, and a landing- or proc-gated kind can still differ between placements purely by',
-        'draw. The three `debuff-resisted` findings below (Belladonna, Enforcer, Valerian) point in',
-        'MUTUALLY INCONSISTENT directions across ships — that pattern is the signature of seed noise, not',
+        `different draws. Union-over-K-seeds is the mitigation, but at K=${health.seeds.length} on this run its`,
+        'strength is unquantified, and a landing- or proc-gated kind can still differ between placements',
+        'purely by draw. A kind that appears in one placement and not another, for only a handful of',
+        'ships, and with no consistent direction across those ships, is the signature of seed noise, not',
         'a path gap. Before instrumenting a low-ship-count finding, re-run with a different `--base-seed`',
         'and see if it survives.',
         '',

--- a/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
+++ b/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
@@ -8,7 +8,6 @@
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import {
-    boardFor,
     buildScenarioBattle,
     darkSlotsOnPrimaryBoard,
     FILLER_HP,
@@ -20,10 +19,10 @@ import {
     ROUNDS,
     SCENARIOS,
     SEED,
-    subjectSideFor,
     SUPPORT_ANCHOR_BOARD,
 } from '../kitFingerprintScenarios';
 import { PLACEMENTS } from '../types';
+import { resolveSubjectActorId } from '../placementSymmetry';
 import { runSeededBattle } from '../seededBattle';
 import { positionTurnRank } from '../../state';
 import { buildTraceShip } from '../../../../../scripts/lib/traceShipFactory';
@@ -195,21 +194,13 @@ describe('live battle invariants', () => {
             expect(ship).not.toBeNull();
             for (const scenario of SCENARIOS) {
                 for (const placement of PLACEMENTS) {
-                    const subjectSide = subjectSideFor(placement);
-                    const subjectCell = boardFor(scenario).focus;
                     const result = runSeededBattle(
                         buildScenarioBattle(ship!, scenario, placement),
                         SEED
                     );
                     // `focus` mints the reserved 'attacker' id; `team`/`enemy` don't, so the
                     // subject is resolved by (side, cell) via the roster, same as `seedFor`.
-                    const subjectActorId = result.roster.find(
-                        (r) => r.side === subjectSide && r.position === subjectCell
-                    )?.actorId;
-                    expect(
-                        subjectActorId,
-                        `${name}/${scenario}/${placement}: subject not found in the roster`
-                    ).toBeDefined();
+                    const subjectActorId = resolveSubjectActorId(result, scenario, placement);
                     const rows = result.rounds
                         .flatMap((r) => r.ships)
                         .filter((s) => s.actorId === subjectActorId);
@@ -442,35 +433,10 @@ describe('turn-order invariance — why a placement swap cannot reorder turns', 
         const ranks = cells.map(positionTurnRank);
         expect(new Set(ranks).size).toBe(8);
     });
-
-    it('positionTurnRank never returns the position-less sentinel for a real cell', () => {
-        // A position-less actor ranks POSITIVE_INFINITY and would tie every other position-less
-        // actor, falling through to the side tiebreak. No board cell may do that.
-        const cells = [
-            PRIMARY_BOARD.focus,
-            ...PRIMARY_BOARD.allies,
-            ...PRIMARY_BOARD.enemies,
-            SUPPORT_ANCHOR_BOARD.focus,
-            ...SUPPORT_ANCHOR_BOARD.allies,
-            ...SUPPORT_ANCHOR_BOARD.enemies,
-        ];
-        for (const cell of cells) {
-            expect(Number.isFinite(positionTurnRank(cell))).toBe(true);
-        }
-    });
 });
 
 describe('fragile ally is keyed by board position, not array index', () => {
     beforeAll(requireReferenceData);
-
-    it("puts the 1-HP ally on the primary board's first ally cell", () => {
-        const subject = buildTraceShip('Sentinel');
-        if (!subject) throw new Error('Sentinel did not resolve from the corpus');
-        const input = buildScenarioBattle(subject, 'wounded');
-        const fragile = input.playerTeam.filter((p) => p.statOverrides?.hp === 1);
-        expect(fragile).toHaveLength(1);
-        expect(fragile[0].position).toBe(PRIMARY_BOARD.allies[0]);
-    });
 
     it('has no fragile ally in plain, richEnemy or supportAnchor', () => {
         const subject = buildTraceShip('Sentinel');

--- a/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
+++ b/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import {
+    boardFor,
     buildScenarioBattle,
     darkSlotsOnPrimaryBoard,
     FILLER_HP,
@@ -19,8 +20,10 @@ import {
     ROUNDS,
     SCENARIOS,
     SEED,
+    subjectSideFor,
     SUPPORT_ANCHOR_BOARD,
 } from '../kitFingerprintScenarios';
+import { PLACEMENTS } from '../types';
 import { runSeededBattle } from '../seededBattle';
 import { positionTurnRank } from '../../state';
 import { buildTraceShip } from '../../../../../scripts/lib/traceShipFactory';
@@ -182,27 +185,47 @@ describe('live battle invariants', () => {
     beforeAll(requireReferenceData);
 
     it.each(['Xiaodao', 'Malvex'])(
-        '%s takes real incoming damage and survives all 20 rounds in every scenario',
+        // PRIMARY-board scenarios only (SCENARIOS excludes `supportAnchor` by construction — see
+        // its docstring): the support-anchor board takes zero incoming damage by design, so
+        // asserting `taken > 0` there would be a bug hunt against an accepted limitation, not a
+        // coverage extension.
+        '%s takes real incoming damage and survives all 20 rounds in every scenario and placement',
         (name) => {
             const ship = buildTraceShip(name);
             expect(ship).not.toBeNull();
             for (const scenario of SCENARIOS) {
-                const result = runSeededBattle(buildScenarioBattle(ship!, scenario), SEED);
-                const rows = result.rounds
-                    .flatMap((r) => r.ships)
-                    .filter((s) => s.actorId === FOCUS_ACTOR_ID);
-                const taken = rows.reduce((sum, s) => sum + s.damageTaken, 0);
-                expect(
-                    taken,
-                    `${name}/${scenario}: focus took no damage — the enemies are not resolving ` +
-                        'onto it, so every on-damaged clause in the corpus is silent'
-                ).toBeGreaterThan(0);
-                expect(
-                    rows.every((s) => s.alive),
-                    `${name}/${scenario}: focus died — its fingerprint is truncated at the round ` +
-                        'it fell, so kill timing now leaks into the snapshot'
-                ).toBe(true);
-                expect(result.outcome.lastRound).toBe(ROUNDS);
+                for (const placement of PLACEMENTS) {
+                    const subjectSide = subjectSideFor(placement);
+                    const subjectCell = boardFor(scenario).focus;
+                    const result = runSeededBattle(
+                        buildScenarioBattle(ship!, scenario, placement),
+                        SEED
+                    );
+                    // `focus` mints the reserved 'attacker' id; `team`/`enemy` don't, so the
+                    // subject is resolved by (side, cell) via the roster, same as `seedFor`.
+                    const subjectActorId = result.roster.find(
+                        (r) => r.side === subjectSide && r.position === subjectCell
+                    )?.actorId;
+                    expect(
+                        subjectActorId,
+                        `${name}/${scenario}/${placement}: subject not found in the roster`
+                    ).toBeDefined();
+                    const rows = result.rounds
+                        .flatMap((r) => r.ships)
+                        .filter((s) => s.actorId === subjectActorId);
+                    const taken = rows.reduce((sum, s) => sum + s.damageTaken, 0);
+                    expect(
+                        taken,
+                        `${name}/${scenario}/${placement}: focus took no damage — the enemies are ` +
+                            'not resolving onto it, so every on-damaged clause in the corpus is silent'
+                    ).toBeGreaterThan(0);
+                    expect(
+                        rows.every((s) => s.alive),
+                        `${name}/${scenario}/${placement}: focus died — its fingerprint is ` +
+                            'truncated at the round it fell, so kill timing now leaks into the snapshot'
+                    ).toBe(true);
+                    expect(result.outcome.lastRound).toBe(ROUNDS);
+                }
             }
         }
     );

--- a/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
+++ b/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
@@ -420,3 +420,25 @@ describe('turn-order invariance — why a placement swap cannot reorder turns', 
         }
     });
 });
+
+describe('fragile ally is keyed by board position, not array index', () => {
+    beforeAll(requireReferenceData);
+
+    it("puts the 1-HP ally on the primary board's first ally cell", () => {
+        const subject = buildTraceShip('Sentinel');
+        if (!subject) throw new Error('Sentinel did not resolve from the corpus');
+        const input = buildScenarioBattle(subject, 'wounded');
+        const fragile = input.playerTeam.filter((p) => p.statOverrides?.hp === 1);
+        expect(fragile).toHaveLength(1);
+        expect(fragile[0].position).toBe(PRIMARY_BOARD.allies[0]);
+    });
+
+    it('has no fragile ally in plain, richEnemy or supportAnchor', () => {
+        const subject = buildTraceShip('Sentinel');
+        if (!subject) throw new Error('Sentinel did not resolve from the corpus');
+        for (const scenario of ['plain', 'richEnemy', 'supportAnchor'] as const) {
+            const input = buildScenarioBattle(subject, scenario);
+            expect(input.playerTeam.filter((p) => p.statOverrides?.hp === 1)).toHaveLength(0);
+        }
+    });
+});

--- a/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
+++ b/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
@@ -15,12 +15,14 @@ import {
     FOCUS_ACTOR_ID,
     FOCUS_POSITION,
     occupiedCellCount,
+    PRIMARY_BOARD,
     ROUNDS,
     SCENARIOS,
     SEED,
     SUPPORT_ANCHOR_BOARD,
 } from '../kitFingerprintScenarios';
 import { runSeededBattle } from '../seededBattle';
+import { positionTurnRank } from '../../state';
 import { buildTraceShip } from '../../../../../scripts/lib/traceShipFactory';
 import { csvAvailable, loadShipSkillRecords } from '../../../../../scripts/lib/shipSkillCsv';
 import { shipDataAvailable } from '../../../../../scripts/lib/shipDataSnapshot';
@@ -381,5 +383,40 @@ describe('support-anchor board', () => {
         const last = result.rounds[result.rounds.length - 1];
         const dead = last.ships.filter((s) => !s.alive).map((s) => s.actorId);
         expect(dead, 'nothing may die on the support-anchor board').toEqual([]);
+    });
+});
+
+describe('turn-order invariance — why a placement swap cannot reorder turns', () => {
+    // orderByTurnPriority (state.ts:331) is speed DESC -> positionTurnRank -> player-side-first ->
+    // input order. The side tiebreak WOULD be a confound for the placement-symmetry oracle: it is
+    // deterministic, so unioning over seeds cannot suppress it, and 33 of 147 corpus ships tie a
+    // filler's base speed. It is unreachable only because positionTurnRank is injective over
+    // positions and every board cell is distinct, so the comparator always returns at the position
+    // step. If a future board edit ever put two actors on one cell, this test fails and the oracle's
+    // soundness argument fails with it.
+    it.each([
+        ['primary', PRIMARY_BOARD],
+        ['support-anchor', SUPPORT_ANCHOR_BOARD],
+    ] as const)('%s board: all eight cells have distinct positionTurnRank', (_name, board) => {
+        const cells = [board.focus, ...board.allies, ...board.enemies];
+        expect(cells).toHaveLength(8);
+        const ranks = cells.map(positionTurnRank);
+        expect(new Set(ranks).size).toBe(8);
+    });
+
+    it('positionTurnRank never returns the position-less sentinel for a real cell', () => {
+        // A position-less actor ranks POSITIVE_INFINITY and would tie every other position-less
+        // actor, falling through to the side tiebreak. No board cell may do that.
+        const cells = [
+            PRIMARY_BOARD.focus,
+            ...PRIMARY_BOARD.allies,
+            ...PRIMARY_BOARD.enemies,
+            SUPPORT_ANCHOR_BOARD.focus,
+            ...SUPPORT_ANCHOR_BOARD.allies,
+            ...SUPPORT_ANCHOR_BOARD.enemies,
+        ];
+        for (const cell of cells) {
+            expect(Number.isFinite(positionTurnRank(cell))).toBe(true);
+        }
     });
 });

--- a/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
+++ b/src/utils/combat/audit/__tests__/kitFingerprintScenarios.test.ts
@@ -28,6 +28,7 @@ import { csvAvailable, loadShipSkillRecords } from '../../../../../scripts/lib/s
 import { shipDataAvailable } from '../../../../../scripts/lib/shipDataSnapshot';
 import { parseShipTargeting } from '../../../targetingParser';
 import type { Ship } from '../../../../types/ship';
+import type { Position } from '../../../../types/encounters';
 import type { CombatActor } from '../../state';
 
 function requireReferenceData(): void {
@@ -40,10 +41,22 @@ function requireReferenceData(): void {
 }
 
 /** A stand-in roster for the seeding taps: two max-HP sizes per side so a FRACTION-of-max-HP
- *  seed and an ABSOLUTE seed can be told apart. */
-const fakeRoster = () =>
+ *  seed and an ABSOLUTE seed can be told apart. The focus actor also carries a `position`
+ *  (default `FOCUS_POSITION`, i.e. PRIMARY_BOARD's focus cell): `seedFor`'s `wounded`/`richEnemy`
+ *  taps now identify the subject by (side, position), not by id (Task 4 — only the `focus`
+ *  placement mints the 'attacker' id, so a placement-agnostic tap can't key off it). Callers
+ *  comparing a tap built for a different board (e.g. SUPPORT_ANCHOR_BOARD) must pass its focus
+ *  cell explicitly. */
+const fakeRoster = (focusPosition: Position = FOCUS_POSITION) =>
     [
-        { id: FOCUS_ACTOR_ID, side: 'player', shieldPool: 0, currentHp: 1000, stats: { hp: 1000 } },
+        {
+            id: FOCUS_ACTOR_ID,
+            side: 'player',
+            shieldPool: 0,
+            currentHp: 1000,
+            stats: { hp: 1000 },
+            position: focusPosition,
+        },
         { id: 'p:ally', side: 'player', shieldPool: 0, currentHp: 4000, stats: { hp: 4000 } },
         { id: 'e:small', side: 'enemy', shieldPool: 0, currentHp: 1000, stats: { hp: 1000 } },
         { id: 'e:big', side: 'enemy', shieldPool: 0, currentHp: 4000, stats: { hp: 4000 } },
@@ -358,8 +371,11 @@ describe('support-anchor board', () => {
         // Load-bearing, not tidiness: Faust and Mender's actives REPAIR allies, and a repair aimed
         // at a full-HP 500,000,000-HP filler is an overheal that may log nothing at all. A
         // plain-seeded support-anchor board would be green, deterministic, and observing nothing.
-        const anchorActors = fakeRoster();
-        const woundedActors = fakeRoster();
+        // Each roster's focus actor sits on ITS board's own focus cell (the two boards disagree —
+        // M1 vs M4) so `isSubject` still resolves the same actor index on both, and the resulting
+        // fractions compare like for like.
+        const anchorActors = fakeRoster(SUPPORT_ANCHOR_BOARD.focus);
+        const woundedActors = fakeRoster(PRIMARY_BOARD.focus);
         buildScenarioBattle(focus, 'supportAnchor').__testTapActors?.(anchorActors);
         buildScenarioBattle(focus, 'wounded').__testTapActors?.(woundedActors);
         expect(anchorActors.map((a) => a.currentHp)).toEqual(woundedActors.map((a) => a.currentHp));

--- a/src/utils/combat/audit/__tests__/placementSymmetry.test.ts
+++ b/src/utils/combat/audit/__tests__/placementSymmetry.test.ts
@@ -13,7 +13,7 @@ import {
     FRAGILE_ALLY_HP,
     SEED,
     FOCUS_ACTOR_ID,
-    FILLER_NAMES,
+    ALLY_FILLER_NAMES,
 } from '../kitFingerprintScenarios';
 import { PLACEMENTS, PLACEMENT_PAIRS } from '../types';
 import { runSeededBattle } from '../seededBattle';
@@ -489,11 +489,15 @@ describe('calibration — an inert kit is placement-symmetric', () => {
     beforeAll(requireReferenceData);
 
     it('uses only fillers that never share a side with their own twin', () => {
-        // The subject sits with the ALLY fillers (FILLER_NAMES.slice(4,7)). Drawing a calibration
-        // subject from that group would put the same ship twice on one side — an illegal in-game
-        // state. The ENEMY-side fillers are always on the opposite side from the subject.
+        // The subject sits with the ALLY fillers. Drawing a calibration subject from that group
+        // would put the same ship twice on one side — an illegal in-game state. The ENEMY-side
+        // fillers are always on the opposite side from the subject.
+        //
+        // Reads ALLY_FILLER_NAMES rather than re-slicing FILLER_NAMES: a literal slice here would
+        // keep passing if the real split ever moved, so the test would silently stop proving what
+        // its own name claims.
         for (const name of CALIBRATION_SUBJECT_NAMES) {
-            expect(FILLER_NAMES.slice(4, 7)).not.toContain(name);
+            expect(ALLY_FILLER_NAMES).not.toContain(name);
         }
         expect(CALIBRATION_SUBJECT_NAMES.length).toBeGreaterThan(0);
     });

--- a/src/utils/combat/audit/__tests__/placementSymmetry.test.ts
+++ b/src/utils/combat/audit/__tests__/placementSymmetry.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The placement transform: the same subject on the same cells, run by each of the engine's three
+ * actor paths. These tests pin the SHAPE of each placement — identical cells, the fragile ally
+ * never at index 0, and scenario seeding that follows the subject rather than the player side.
+ * Spec: docs/superpowers/specs/2026-08-06-placement-symmetry-oracle-design.md
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+    buildScenarioBattle,
+    boardFor,
+    subjectSideFor,
+    FRAGILE_ALLY_HP,
+} from '../kitFingerprintScenarios';
+import { PLACEMENTS } from '../types';
+import { buildTraceShip } from '../../../../../scripts/lib/traceShipFactory';
+import { csvAvailable, loadShipSkillRecords } from '../../../../../scripts/lib/shipSkillCsv';
+import { shipDataAvailable } from '../../../../../scripts/lib/shipDataSnapshot';
+import type { Ship } from '../../../../types/ship';
+import type { Position } from '../../../../types/encounters';
+import type { BattlePlacement } from '../../../calculators/battleSimulator';
+
+function requireReferenceData(): void {
+    if (!csvAvailable() || !shipDataAvailable()) {
+        throw new Error(
+            'docs/ship-skills.csv and/or docs/ship-data.json are missing from this worktree ' +
+                '(gitignored reference data) — tests need them to resolve real ship skill text/stats.'
+        );
+    }
+}
+
+function subjectShip(name = 'Sentinel'): Ship {
+    const ship = buildTraceShip(name);
+    if (!ship) throw new Error(`${name} did not resolve from the corpus`);
+    return ship;
+}
+
+const positionsOf = (team: BattlePlacement[]): Position[] => team.map((p) => p.position);
+const sorted = (xs: Position[]): Position[] => [...xs].sort();
+
+describe('placement transform — board shape', () => {
+    beforeAll(requireReferenceData);
+
+    it('subjectSideFor maps the three placements onto two sides', () => {
+        expect(subjectSideFor('focus')).toBe('player');
+        expect(subjectSideFor('team')).toBe('player');
+        expect(subjectSideFor('enemy')).toBe('enemy');
+    });
+
+    it('places the subject on the same cell in all three placements', () => {
+        const subject = subjectShip();
+        const cell = boardFor('plain').focus;
+        for (const placement of PLACEMENTS) {
+            const input = buildScenarioBattle(subject, 'plain', placement);
+            const team = placement === 'enemy' ? input.enemyTeam : input.playerTeam;
+            const found = team.find((p) => p.ship.name === subject.name);
+            expect(found, `subject missing in ${placement}`).toBeDefined();
+            expect(found?.position, `subject moved in ${placement}`).toBe(cell);
+        }
+    });
+
+    it('uses the identical set of eight cells in all three placements', () => {
+        const subject = subjectShip();
+        const board = boardFor('plain');
+        const expectedSubjectSide = sorted([board.focus, ...board.allies]);
+        const expectedOtherSide = sorted([...board.enemies]);
+
+        for (const placement of PLACEMENTS) {
+            const input = buildScenarioBattle(subject, 'plain', placement);
+            const subjectSide = placement === 'enemy' ? input.enemyTeam : input.playerTeam;
+            const otherSide = placement === 'enemy' ? input.playerTeam : input.enemyTeam;
+            expect(sorted(positionsOf(subjectSide))).toEqual(expectedSubjectSide);
+            expect(sorted(positionsOf(otherSide))).toEqual(expectedOtherSide);
+        }
+    });
+
+    it('gives the subject the attacker slot ONLY in the focus placement', () => {
+        const subject = subjectShip();
+        expect(buildScenarioBattle(subject, 'plain', 'focus').playerTeam[0].ship.name).toBe(
+            subject.name
+        );
+        expect(buildScenarioBattle(subject, 'plain', 'team').playerTeam[0].ship.name).not.toBe(
+            subject.name
+        );
+        // In `enemy` the subject is on the other side entirely, so playerTeam[0] is a filler.
+        expect(buildScenarioBattle(subject, 'plain', 'enemy').playerTeam[0].ship.name).not.toBe(
+            subject.name
+        );
+    });
+
+    it('never makes the fragile 1-HP ally the attacker focus', () => {
+        const subject = subjectShip();
+        for (const placement of PLACEMENTS) {
+            const input = buildScenarioBattle(subject, 'wounded', placement);
+            expect(
+                input.playerTeam[0].statOverrides?.hp,
+                `fragile ally became the focus in ${placement}`
+            ).not.toBe(FRAGILE_ALLY_HP);
+        }
+    });
+
+    it('keeps the fragile ally on the first ally cell in every placement', () => {
+        const subject = subjectShip();
+        const fragileCell = boardFor('wounded').allies[0];
+        for (const placement of PLACEMENTS) {
+            const input = buildScenarioBattle(subject, 'wounded', placement);
+            const all = [...input.playerTeam, ...input.enemyTeam];
+            const fragile = all.filter((p) => p.statOverrides?.hp === FRAGILE_ALLY_HP);
+            expect(fragile, `wrong fragile count in ${placement}`).toHaveLength(1);
+            expect(fragile[0].position).toBe(fragileCell);
+        }
+    });
+
+    it('omitting the placement argument is byte-identical to focus', () => {
+        for (const name of loadShipSkillRecords()
+            .slice(0, 12)
+            .map((r) => r.name)) {
+            const ship = buildTraceShip(name);
+            if (!ship) continue;
+            for (const scenario of ['plain', 'richEnemy', 'wounded'] as const) {
+                const legacy = buildScenarioBattle(ship, scenario);
+                const explicit = buildScenarioBattle(ship, scenario, 'focus');
+                // __testTapActors is a fresh closure each call and can't be compared by value.
+                const strip = (i: ReturnType<typeof buildScenarioBattle>) => ({
+                    ...i,
+                    __testTapActors: undefined,
+                });
+                expect(strip(legacy)).toEqual(strip(explicit));
+            }
+        }
+    });
+});

--- a/src/utils/combat/audit/__tests__/placementSymmetry.test.ts
+++ b/src/utils/combat/audit/__tests__/placementSymmetry.test.ts
@@ -13,6 +13,7 @@ import {
     FRAGILE_ALLY_HP,
     SEED,
     FOCUS_ACTOR_ID,
+    FILLER_NAMES,
 } from '../kitFingerprintScenarios';
 import { PLACEMENTS, PLACEMENT_PAIRS } from '../types';
 import { runSeededBattle } from '../seededBattle';
@@ -23,6 +24,8 @@ import {
     fingerprintSubject,
     resolveSubjectActorId,
     seedsFrom,
+    CALIBRATION_SUBJECT_NAMES,
+    runCalibration,
 } from '../placementSymmetry';
 import type { CombatLogEntryKind } from '../../log/types';
 import { buildTraceShip } from '../../../../../scripts/lib/traceShipFactory';
@@ -478,6 +481,35 @@ describe('fingerprintSubject — non-vacuity', () => {
             expect(spy.mock.calls.length - callsBefore).toBe(expectedCalls);
         } finally {
             spy.mockRestore();
+        }
+    });
+});
+
+describe('calibration — an inert kit is placement-symmetric', () => {
+    beforeAll(requireReferenceData);
+
+    it('uses only fillers that never share a side with their own twin', () => {
+        // The subject sits with the ALLY fillers (FILLER_NAMES.slice(4,7)). Drawing a calibration
+        // subject from that group would put the same ship twice on one side — an illegal in-game
+        // state. The ENEMY-side fillers are always on the opposite side from the subject.
+        for (const name of CALIBRATION_SUBJECT_NAMES) {
+            expect(FILLER_NAMES.slice(4, 7)).not.toContain(name);
+        }
+        expect(CALIBRATION_SUBJECT_NAMES.length).toBeGreaterThan(0);
+    });
+
+    it('reports no asymmetry for any inert subject', () => {
+        const diffs = runCalibration(seedsFrom(SEED, 2));
+        expect(diffs).toEqual([]);
+    });
+
+    it('is not vacuous — an inert subject still produces kinds', () => {
+        const subject = subjectShip(CALIBRATION_SUBJECT_NAMES[0]);
+        for (const placement of PLACEMENTS) {
+            expect(
+                fingerprintSubject(subject, placement, seedsFrom(SEED, 1)).size,
+                `${placement} observed nothing for an inert subject`
+            ).toBeGreaterThan(0);
         }
     });
 });

--- a/src/utils/combat/audit/__tests__/placementSymmetry.test.ts
+++ b/src/utils/combat/audit/__tests__/placementSymmetry.test.ts
@@ -10,14 +10,17 @@ import {
     boardFor,
     subjectSideFor,
     FRAGILE_ALLY_HP,
+    SEED,
 } from '../kitFingerprintScenarios';
 import { PLACEMENTS } from '../types';
+import { runSeededBattle } from '../seededBattle';
 import { buildTraceShip } from '../../../../../scripts/lib/traceShipFactory';
 import { csvAvailable, loadShipSkillRecords } from '../../../../../scripts/lib/shipSkillCsv';
 import { shipDataAvailable } from '../../../../../scripts/lib/shipDataSnapshot';
 import type { Ship } from '../../../../types/ship';
 import type { Position } from '../../../../types/encounters';
-import type { BattlePlacement } from '../../../calculators/battleSimulator';
+import type { BattlePlacement, BattleSimulationInput } from '../../../calculators/battleSimulator';
+import type { CombatActor } from '../../state';
 
 function requireReferenceData(): void {
     if (!csvAvailable() || !shipDataAvailable()) {
@@ -127,5 +130,148 @@ describe('placement transform — board shape', () => {
                 expect(strip(legacy)).toEqual(strip(explicit));
             }
         }
+    });
+});
+
+/** A plain snapshot of the fields these tests need, taken the instant seeding runs — NOT a live
+ *  `CombatActor` reference. The array `__testTapActors` receives is the engine's own roster, which
+ *  the 20-round battle keeps mutating in place after the tap returns (real damage, shield spend),
+ *  so reading `.currentHp`/`.shieldPool` off it AFTER `runSeededBattle` resolves would observe the
+ *  end-of-battle state, not the seeded one. */
+interface ActorSeedSnapshot {
+    side: 'player' | 'enemy';
+    position?: Position;
+    currentHp: number;
+    maxHp: number;
+    shieldPool: number;
+}
+
+/** Runs the battle through `runSeededBattle`, wrapping `__testTapActors` so the real seeding tap
+ *  still runs (this must exercise the engine's actual seeding, not a hand-built stand-in), then
+ *  snapshots the actors immediately afterward — before combat has a chance to mutate them. */
+function capturedSeedSnapshot(input: BattleSimulationInput): ActorSeedSnapshot[] {
+    let captured: ActorSeedSnapshot[] = [];
+    const original = input.__testTapActors;
+    input.__testTapActors = (actors) => {
+        original?.(actors);
+        captured = actors.map((a) => ({
+            side: a.side,
+            position: a.position,
+            currentHp: a.currentHp,
+            maxHp: a.stats.hp,
+            shieldPool: a.shieldPool,
+        }));
+    };
+    runSeededBattle(input, SEED);
+    return captured;
+}
+
+/** Actors that carry a board `position`. One actor in every run — a vestigial enemy-side dummy
+ *  used for player-offense DPS accounting (battleSimulator.ts) — legitimately has none, and must
+ *  be excluded rather than tripping these assertions. */
+const positioned = (actors: ActorSeedSnapshot[]): ActorSeedSnapshot[] =>
+    actors.filter((a) => a.position !== undefined);
+
+const hpFraction = (a: ActorSeedSnapshot): number => a.currentHp / a.maxHp;
+
+describe('placement transform — live seeding regression (Finding 1)', () => {
+    // These pin the two behaviours Task 4 exists to fix. Both are extensionally equal to the OLD
+    // (focus-only) predicates under the default 'focus' placement, so every other test in this
+    // suite (and the whole existing corpus) stays green even if either predicate regresses —
+    // only a non-'focus' placement can catch it. Verified by hand: reverting
+    // `a.side !== subjectSide` to `a.side === 'enemy'` in the `richEnemy` branch, or `isSubject(a)`
+    // to `a.id === FOCUS_ACTOR_ID`, fails the corresponding test below.
+    beforeAll(requireReferenceData);
+
+    it("enemy placement: 'wounded' seeds the subject actor to 45% HP and fillers to 35%", () => {
+        const subject = subjectShip();
+        const subjectCell = boardFor('wounded').focus;
+        const actors = capturedSeedSnapshot(buildScenarioBattle(subject, 'wounded', 'enemy'));
+
+        const subjectActor = actors.find((a) => a.side === 'enemy' && a.position === subjectCell);
+        expect(subjectActor, 'subject actor not found on the enemy side at its cell').toBeDefined();
+        expect(hpFraction(subjectActor!)).toBeCloseTo(0.45, 5);
+
+        const fillers = positioned(actors).filter((a) => a !== subjectActor);
+        expect(fillers.length).toBeGreaterThan(0);
+        for (const filler of fillers) {
+            expect(hpFraction(filler)).toBeCloseTo(0.35, 5);
+        }
+    });
+
+    it("enemy placement: 'richEnemy' zeroes the subject's shieldPool and arms the player fillers", () => {
+        const subject = subjectShip();
+        const subjectCell = boardFor('richEnemy').focus;
+        const actors = capturedSeedSnapshot(buildScenarioBattle(subject, 'richEnemy', 'enemy'));
+
+        const subjectActor = actors.find((a) => a.side === 'enemy' && a.position === subjectCell);
+        expect(subjectActor, 'subject actor not found on the enemy side at its cell').toBeDefined();
+        expect(subjectActor!.shieldPool).toBe(0);
+
+        const playerFillers = actors.filter((a) => a.side === 'player');
+        expect(playerFillers.length).toBeGreaterThan(0);
+        for (const filler of playerFillers) {
+            expect(filler.shieldPool).toBeGreaterThan(0);
+        }
+    });
+
+    it("team placement: 'wounded' seeds the subject actor to 45% HP and fillers to 35%", () => {
+        const subject = subjectShip();
+        const subjectCell = boardFor('wounded').focus;
+        const actors = capturedSeedSnapshot(buildScenarioBattle(subject, 'wounded', 'team'));
+
+        const subjectActor = actors.find((a) => a.side === 'player' && a.position === subjectCell);
+        expect(
+            subjectActor,
+            'subject actor not found on the player side at its cell'
+        ).toBeDefined();
+        expect(hpFraction(subjectActor!)).toBeCloseTo(0.45, 5);
+
+        const fillers = positioned(actors).filter((a) => a !== subjectActor);
+        expect(fillers.length).toBeGreaterThan(0);
+        for (const filler of fillers) {
+            expect(hpFraction(filler)).toBeCloseTo(0.35, 5);
+        }
+    });
+
+    it("team placement: 'richEnemy' zeroes the subject's own shieldPool and arms the enemy fillers", () => {
+        const subject = subjectShip();
+        const subjectCell = boardFor('richEnemy').focus;
+        const actors = capturedSeedSnapshot(buildScenarioBattle(subject, 'richEnemy', 'team'));
+
+        const subjectActor = actors.find((a) => a.side === 'player' && a.position === subjectCell);
+        expect(
+            subjectActor,
+            'subject actor not found on the player side at its cell'
+        ).toBeDefined();
+        expect(subjectActor!.shieldPool).toBe(0);
+
+        const enemyFillers = actors.filter((a) => a.side === 'enemy' && a.position !== undefined);
+        expect(enemyFillers.length).toBeGreaterThan(0);
+        for (const filler of enemyFillers) {
+            expect(filler.shieldPool).toBeGreaterThan(0);
+        }
+    });
+});
+
+describe('placement transform — subject match-count guard (Finding 2)', () => {
+    // If `isSubject` ever matches zero actors, the 'wounded'/'supportAnchor' tap would otherwise
+    // silently degrade to a uniform 35% seed with nothing failing. `focus` is protected by the
+    // 147-ship snapshot; `team`/`enemy` have none, so this guard is the only thing standing between
+    // a broken predicate and a spurious placement-asymmetry finding that reads like an engine bug.
+    beforeAll(requireReferenceData);
+
+    it('throws when no actor matches the expected (side, cell)', () => {
+        const subject = subjectShip();
+        const tap = buildScenarioBattle(subject, 'wounded', 'enemy').__testTapActors;
+        expect(tap).toBeDefined();
+
+        // Deliberately no actor at (side: 'enemy', position: boardFor('wounded').focus).
+        const noMatch = [
+            { side: 'player', position: 'M4', currentHp: 100, stats: { hp: 100 } },
+            { side: 'enemy', position: 'T3', currentHp: 100, stats: { hp: 100 } },
+        ] as unknown as CombatActor[];
+
+        expect(() => tap!(noMatch)).toThrow(/expected exactly 1 subject actor/);
     });
 });

--- a/src/utils/combat/audit/__tests__/placementSymmetry.test.ts
+++ b/src/utils/combat/audit/__tests__/placementSymmetry.test.ts
@@ -4,17 +4,19 @@
  * never at index 0, and scenario seeding that follows the subject rather than the player side.
  * Spec: docs/superpowers/specs/2026-08-06-placement-symmetry-oracle-design.md
  */
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import {
     buildScenarioBattle,
     boardFor,
     subjectSideFor,
+    scenariosFor,
     FRAGILE_ALLY_HP,
     SEED,
     FOCUS_ACTOR_ID,
 } from '../kitFingerprintScenarios';
-import { PLACEMENTS } from '../types';
+import { PLACEMENTS, PLACEMENT_PAIRS } from '../types';
 import { runSeededBattle } from '../seededBattle';
+import * as seededBattleModule from '../seededBattle';
 import {
     diffAllPlacements,
     diffPlacements,
@@ -375,10 +377,54 @@ describe('diffAllPlacements', () => {
         const diffs = diffAllPlacements('X', {
             focus: kinds('attack'),
             team: kinds('attack'),
-            enemy: kinds('attack', 'counter'),
+            enemy: kinds('attack', 'debuff'),
         });
         expect(diffs).toHaveLength(2);
         expect(diffs.every((d) => d.from === 'enemy')).toBe(true);
+    });
+
+    it('reports all six ordered pairs when every placement has mutually distinct kinds (Finding 1)', () => {
+        // No shared kinds at all between any two placements, so every one of the six ORDERED
+        // comparisons (2 directions x 3 unordered pairs) must independently report a diff. If
+        // `PLACEMENT_PAIRS` silently dropped a pair (e.g. `['focus', 'team']`), this would catch
+        // it directly: the count would fall to 4 rather than staying accidentally green like the
+        // two focus==team-shaped cases above.
+        const diffs = diffAllPlacements('X', {
+            focus: kinds('attack', 'buff'),
+            team: kinds('heal', 'shield'),
+            enemy: kinds('dot-applied', 'cleanse'),
+        });
+        expect(diffs).toHaveLength(6);
+
+        const orderedPairs = diffs.map((d) => `${d.from}->${d.to}`);
+        expect(new Set(orderedPairs).size).toBe(6);
+    });
+});
+
+describe('PLACEMENT_PAIRS coverage (Finding 1)', () => {
+    it('covers every unordered pair of PLACEMENTS exactly once', () => {
+        // Derived from PLACEMENTS.length, not hardcoded to 3, so a fourth placement that never
+        // gets paired up fails this assertion loudly instead of silently under-comparing.
+        const expectedPairCount = (PLACEMENTS.length * (PLACEMENTS.length - 1)) / 2;
+        expect(PLACEMENT_PAIRS).toHaveLength(expectedPairCount);
+
+        const unorderedKey = (a: string, b: string) => [a, b].sort().join('|');
+        const seen = new Set<string>();
+        for (const [a, b] of PLACEMENT_PAIRS) {
+            const key = unorderedKey(a, b);
+            expect(seen.has(key), `pair ${key} appears more than once in PLACEMENT_PAIRS`).toBe(
+                false
+            );
+            seen.add(key);
+        }
+
+        const expectedPairs = new Set<string>();
+        for (let i = 0; i < PLACEMENTS.length; i++) {
+            for (let j = i + 1; j < PLACEMENTS.length; j++) {
+                expectedPairs.add(unorderedKey(PLACEMENTS[i], PLACEMENTS[j]));
+            }
+        }
+        expect(seen).toEqual(expectedPairs);
     });
 });
 
@@ -398,6 +444,40 @@ describe('fingerprintSubject — non-vacuity', () => {
         const subject = subjectShip();
         const one = fingerprintSubject(subject, 'focus', seedsFrom(SEED, 1));
         const three = fingerprintSubject(subject, 'focus', seedsFrom(SEED, 3));
+        // Without this, an empty `one` would make the loop below assert nothing at all
+        // (Finding 3) — a regression that produced a vacuous set would still pass.
+        expect(one.size).toBeGreaterThan(0);
         for (const kind of one) expect(three.has(kind)).toBe(true);
+    });
+
+    it('throws rather than silently returning an empty set when seeds is empty (Finding 2)', () => {
+        // `seedsFrom(base, 0)` returns `[]`; without a guard the inner loop never runs and
+        // every kind reads as "missing in that placement" — the exact vacuity failure mode
+        // `resolveSubjectActorId` already throws to avoid.
+        const subject = subjectShip();
+        expect(() => fingerprintSubject(subject, 'focus', [])).toThrow(
+            new RegExp(`${subject.name}.*focus`)
+        );
+    });
+
+    it('runs exactly scenarios.length * seeds.length battles (Finding 4)', () => {
+        // Pins the union's BREADTH directly. A regression that iterated only
+        // `scenariosFor(subject)[0]` or only `seeds[0]` would keep the non-vacuity and
+        // monotonicity tests above green (they only check size > 0 / superset), so this is the
+        // only thing standing between such a regression and a silently narrowed sweep.
+        const subject = subjectShip();
+        const seeds = seedsFrom(SEED, 3);
+        const expectedCalls = scenariosFor(subject).length * seeds.length;
+
+        // spyOn (no mockImplementation) calls through to the real runSeededBattle, so this
+        // exercises the actual engine rather than becoming a mock-only tautology.
+        const spy = vi.spyOn(seededBattleModule, 'runSeededBattle');
+        const callsBefore = spy.mock.calls.length;
+        try {
+            fingerprintSubject(subject, 'focus', seeds);
+            expect(spy.mock.calls.length - callsBefore).toBe(expectedCalls);
+        } finally {
+            spy.mockRestore();
+        }
     });
 });

--- a/src/utils/combat/audit/__tests__/placementSymmetry.test.ts
+++ b/src/utils/combat/audit/__tests__/placementSymmetry.test.ts
@@ -11,9 +11,11 @@ import {
     subjectSideFor,
     FRAGILE_ALLY_HP,
     SEED,
+    FOCUS_ACTOR_ID,
 } from '../kitFingerprintScenarios';
 import { PLACEMENTS } from '../types';
 import { runSeededBattle } from '../seededBattle';
+import { resolveSubjectActorId } from '../placementSymmetry';
 import { buildTraceShip } from '../../../../../scripts/lib/traceShipFactory';
 import { csvAvailable, loadShipSkillRecords } from '../../../../../scripts/lib/shipSkillCsv';
 import { shipDataAvailable } from '../../../../../scripts/lib/shipDataSnapshot';
@@ -273,5 +275,32 @@ describe('placement transform — subject match-count guard (Finding 2)', () => 
         ] as unknown as CombatActor[];
 
         expect(() => tap!(noMatch)).toThrow(/expected exactly 1 subject actor/);
+    });
+});
+
+describe('subject actor-id resolution', () => {
+    beforeAll(requireReferenceData);
+
+    it('resolves the expected id SHAPE for each placement', () => {
+        const subject = subjectShip();
+        const ids: Record<string, string> = {};
+        for (const placement of PLACEMENTS) {
+            const result = runSeededBattle(buildScenarioBattle(subject, 'plain', placement), SEED);
+            ids[placement] = resolveSubjectActorId(result, 'plain', placement);
+        }
+        expect(ids.focus).toBe(FOCUS_ACTOR_ID);
+        expect(ids.team).toMatch(/^p:/);
+        expect(ids.enemy).toMatch(/^e:/);
+        // Distinctness is the vacuity guard: two placements resolving the same id would compare a
+        // fingerprint against itself and report a permanently clean sweep.
+        expect(new Set(Object.values(ids)).size).toBe(3);
+    });
+
+    it('throws rather than returning a wrong id when the shape does not match', () => {
+        const subject = subjectShip();
+        const result = runSeededBattle(buildScenarioBattle(subject, 'plain', 'focus'), SEED);
+        // Asking for the `enemy` placement's subject in a `focus` battle resolves the enemy at the
+        // subject cell — which does not exist on that board — so it must throw, not guess.
+        expect(() => resolveSubjectActorId(result, 'plain', 'enemy')).toThrow(/could not resolve/i);
     });
 });

--- a/src/utils/combat/audit/__tests__/placementSymmetry.test.ts
+++ b/src/utils/combat/audit/__tests__/placementSymmetry.test.ts
@@ -15,7 +15,14 @@ import {
 } from '../kitFingerprintScenarios';
 import { PLACEMENTS } from '../types';
 import { runSeededBattle } from '../seededBattle';
-import { resolveSubjectActorId } from '../placementSymmetry';
+import {
+    diffAllPlacements,
+    diffPlacements,
+    fingerprintSubject,
+    resolveSubjectActorId,
+    seedsFrom,
+} from '../placementSymmetry';
+import type { CombatLogEntryKind } from '../../log/types';
 import { buildTraceShip } from '../../../../../scripts/lib/traceShipFactory';
 import { csvAvailable, loadShipSkillRecords } from '../../../../../scripts/lib/shipSkillCsv';
 import { shipDataAvailable } from '../../../../../scripts/lib/shipDataSnapshot';
@@ -302,5 +309,95 @@ describe('subject actor-id resolution', () => {
         // Asking for the `enemy` placement's subject in a `focus` battle resolves the enemy at the
         // subject cell — which does not exist on that board — so it must throw, not guess.
         expect(() => resolveSubjectActorId(result, 'plain', 'enemy')).toThrow(/could not resolve/i);
+    });
+});
+
+const kinds = (...xs: string[]) => new Set(xs as CombatLogEntryKind[]);
+
+describe('seedsFrom', () => {
+    it('produces `count` consecutive seeds from `base`', () => {
+        expect(seedsFrom(100, 3)).toEqual([100, 101, 102]);
+    });
+
+    it('produces a single seed for count 1', () => {
+        expect(seedsFrom(7, 1)).toEqual([7]);
+    });
+});
+
+describe('diffPlacements', () => {
+    it('returns null when the sets are equal', () => {
+        expect(diffPlacements('X', 'focus', 'enemy', kinds('attack'), kinds('attack'))).toBeNull();
+    });
+
+    it('returns null when `to` is a strict SUPERSET of `from`', () => {
+        // This direction is not a finding — the reverse direction reports it.
+        expect(
+            diffPlacements('X', 'focus', 'enemy', kinds('attack'), kinds('attack', 'shield'))
+        ).toBeNull();
+    });
+
+    it('reports kinds present in `from` but absent in `to`', () => {
+        const diff = diffPlacements(
+            'X',
+            'focus',
+            'enemy',
+            kinds('attack', 'shield', 'heal'),
+            kinds('attack')
+        );
+        expect(diff).toEqual({
+            shipName: 'X',
+            from: 'focus',
+            to: 'enemy',
+            missing: ['heal', 'shield'],
+        });
+    });
+});
+
+describe('diffAllPlacements', () => {
+    it('returns nothing when all three placements agree', () => {
+        const same = kinds('attack', 'buff');
+        expect(diffAllPlacements('X', { focus: same, team: same, enemy: same })).toEqual([]);
+    });
+
+    it('reports BOTH directions of an asymmetry', () => {
+        const diffs = diffAllPlacements('X', {
+            focus: kinds('attack', 'shield'),
+            team: kinds('attack', 'shield'),
+            enemy: kinds('attack'),
+        });
+        // focus->enemy and team->enemy lose `shield`; the reverse directions are clean.
+        expect(diffs).toHaveLength(2);
+        expect(diffs.every((d) => d.to === 'enemy')).toBe(true);
+        expect(diffs.every((d) => d.missing.includes('shield' as CombatLogEntryKind))).toBe(true);
+    });
+
+    it('reports an `extra`-style asymmetry as the reverse direction', () => {
+        const diffs = diffAllPlacements('X', {
+            focus: kinds('attack'),
+            team: kinds('attack'),
+            enemy: kinds('attack', 'counter'),
+        });
+        expect(diffs).toHaveLength(2);
+        expect(diffs.every((d) => d.from === 'enemy')).toBe(true);
+    });
+});
+
+describe('fingerprintSubject — non-vacuity', () => {
+    beforeAll(requireReferenceData);
+
+    it('produces a NON-EMPTY kind set in every placement for a real kit', () => {
+        const subject = subjectShip();
+        const seeds = seedsFrom(SEED, 2);
+        for (const placement of PLACEMENTS) {
+            const observed = fingerprintSubject(subject, placement, seeds);
+            expect(observed.size, `${placement} observed nothing`).toBeGreaterThan(0);
+        }
+    });
+
+    it('unioning more seeds never SHRINKS the observed set', () => {
+        const subject = subjectShip();
+        const one = fingerprintSubject(subject, 'focus', seedsFrom(SEED, 1));
+        const three = fingerprintSubject(subject, 'focus', seedsFrom(SEED, 3));
+        for (const kind of one) expect(three.has(kind)).toBe(true);
     });
 });

--- a/src/utils/combat/audit/kitFingerprintScenarios.ts
+++ b/src/utils/combat/audit/kitFingerprintScenarios.ts
@@ -133,6 +133,15 @@ export const FILLER_NAMES: readonly string[] = [
     'Rookie',
 ] as const;
 
+/** The enemy-side split of `FILLER_NAMES` (first 4). Exported so every consumer that needs "the
+ *  enemy fillers" derives it from the same slice instead of re-slicing `FILLER_NAMES` — a desync
+ *  between independent slices would put the same ship twice on one side, an illegal in-game state,
+ *  with nothing failing. */
+export const ENEMY_FILLER_NAMES: readonly string[] = FILLER_NAMES.slice(0, 4);
+
+/** The ally-side split of `FILLER_NAMES` (last 3). See `ENEMY_FILLER_NAMES`. */
+export const ALLY_FILLER_NAMES: readonly string[] = FILLER_NAMES.slice(4, 7);
+
 /** Filler survive the whole window: without this, a damage-formula change shifts kill timing,
  *  which shifts which clauses get to fire — numeric sensitivity leaking into a structural suite.
  *  Deliberately absurd rather than merely large: the corpus's per-battle damage output spans more
@@ -217,12 +226,14 @@ function fillerPlacement(
     return { ...base, statOverrides: { ...base.statOverrides, hp, attack } };
 }
 
-/** `richEnemy`'s seeded enemy shield, as a multiple of the focus ship's base attack — an ABSOLUTE
- *  pool, not a fraction of the filler's (absurd) max HP. A fraction was the original choice and it
- *  was inert: 20% of 500M is 100M against ~1.2k hits, so `enemy-shield` gates read true for the
- *  entire battle and nothing ever punched through. Three attack points' worth survives the first
- *  cast or two — long enough for a shield-gated clause to fire at least once — then depletes, so
- *  shield-removal and punch-through clauses see the other side of the gate too. */
+/** `richEnemy`'s seeded shield on the subject's OPPONENTS, as a multiple of the focus ship's base
+ *  attack — an ABSOLUTE pool, not a fraction of the filler's (absurd) max HP. A fraction was the
+ *  original choice and it was inert: 20% of 500M is 100M against ~1.2k hits, so `enemy-shield` gates
+ *  read true for the entire battle and nothing ever punched through. Three attack points' worth
+ *  survives the first cast or two — long enough for a shield-gated clause to fire at least once —
+ *  then depletes, so shield-removal and punch-through clauses see the other side of the gate too.
+ *  "Opponents" is placement-relative, not side-relative: in `focus`/`team` that's the enemy side, but
+ *  in `enemy` the subject IS the enemy side, so this seeds the PLAYER side instead (see `seedFor`). */
 const SHIELD_POOL_HITS = 3;
 
 /** `wounded` seeds every filler on BOTH sides to 35% HP: under the corpus's 40%- and 50%-HP gates
@@ -239,9 +250,11 @@ const HURT_FRACTION = 0.35;
  *  drops below 40%" clauses (Tycho) require and a static low start would never produce. */
 const FOCUS_HURT_FRACTION = 0.45;
 
-/** The focus ship is always the first player placement, and simulateBattle mints the first player
- *  actor with the reserved id 'attacker' (battleSimulator's minting scheme; the rest are
- *  `p:<shipId>:<idx>`). So the focus actor id is fixed. */
+/** The reserved actor id simulateBattle mints for the first player placement (battleSimulator's
+ *  minting scheme; the rest are `p:<shipId>:<idx>` / `e:<shipId>:<idx>`). The SUBJECT only gets this
+ *  id in the `focus` placement — in `team` it gives up index 0 to a filler and mints `p:...`, and in
+ *  `enemy` it sits on the enemy side entirely and mints `e:...`. Resolve the subject by (side, cell)
+ *  via `resolveSubjectActorId`, never by assuming this id. */
 export const FOCUS_ACTOR_ID = 'attacker';
 
 const maxHpOf = (a: CombatActor): number => a.stats.hp;
@@ -317,13 +330,18 @@ function seedFor(
 }
 
 /**
- * The scenario battle for one focus ship: the focus on the player side with 3 inert filler
- * allies, against 4 inert filler enemies. Both the board geometry and seeded initial state vary
- * by scenario (see `boardFor` for geometry selection, PRIMARY_BOARD and SUPPORT_ANCHOR_BOARD for
- * cell rationales). The focus ship keeps `canonicalPlacement`'s un-modified level-60 base stats
- * — no gear, no refits, no engineering — so its fingerprint reflects its kit, not a gearing
- * choice. The FILLER stats, by contrast, are tuned (HP, attack) and are the only lever this
- * fixture pulls on how hard the battle presses.
+ * The scenario battle for one subject ship, on one of the three engine actor paths named by
+ * `placement` (default `'focus'`, kept for the 147-ship fingerprint snapshot's byte-identical call
+ * shape — see `realKitFingerprints.test.ts`). In `'focus'` the subject sits first on the player side
+ * with 3 inert filler allies, against 4 inert filler enemies. In `'team'` it keeps its cell but gives
+ * up player index 0 to a filler, so the engine walks it as a 'team' actor instead of minting it
+ * 'attacker'. In `'enemy'` it is on the ENEMY side against the filler allies-turned-opponents — the
+ * geometric mirror of `'focus'`. Both the board geometry and seeded initial state vary by scenario
+ * (see `boardFor` for geometry selection, PRIMARY_BOARD and SUPPORT_ANCHOR_BOARD for cell
+ * rationales). The subject keeps `canonicalPlacement`'s un-modified level-60 base stats — no gear,
+ * no refits, no engineering — so its fingerprint reflects its kit, not a gearing choice. The FILLER
+ * stats, by contrast, are tuned (HP, attack) and are the only lever this fixture pulls on how hard
+ * the battle presses.
  */
 export function buildScenarioBattle(
     subject: Ship,
@@ -331,8 +349,8 @@ export function buildScenarioBattle(
     placement: Placement = 'focus'
 ): BattleSimulationInput {
     const board = boardFor(scenario);
-    const enemyNames = FILLER_NAMES.slice(0, 4);
-    const allyNames = FILLER_NAMES.slice(4, 7);
+    const enemyNames = ENEMY_FILLER_NAMES;
+    const allyNames = ALLY_FILLER_NAMES;
     const tap = seedFor(subject, scenario, placement);
     const attack = fillerAttackFor(subject);
     const rest = { rounds: ROUNDS, ...(tap ? { __testTapActors: tap } : {}) };

--- a/src/utils/combat/audit/kitFingerprintScenarios.ts
+++ b/src/utils/combat/audit/kitFingerprintScenarios.ts
@@ -300,6 +300,16 @@ export function buildScenarioBattle(
     const allyNames = FILLER_NAMES.slice(4, 7);
     const tap = seedFor(focus, scenario);
     const attack = fillerAttackFor(focus);
+
+    // The fragile ally is identified by its CELL, not by its index in this array. Task 4's `team`
+    // placement reorders playerTeam so the subject is not index 0, and index and position decouple
+    // there: keying on index would make the 1-HP ally the 'attacker' focus, where it dies to the
+    // first hit and the whole `wounded` scenario collapses. Baking fragility into the placement by
+    // position means any later reordering carries it along. Note `scenario === 'wounded'` and NOT
+    // the seeding branch: supportAnchor reuses wounded's HP seeding but must NOT get a fragile ally,
+    // because a dying support target would make reach flaky.
+    const fragileCell = scenario === 'wounded' ? board.allies[0] : undefined;
+
     return {
         playerTeam: [
             canonicalPlacement(focus, board.focus),
@@ -308,10 +318,7 @@ export function buildScenarioBattle(
                     name,
                     board.allies[i],
                     attack,
-                    // Note `scenario === 'wounded'` and NOT the seeding branch: supportAnchor
-                    // reuses wounded's HP seeding but must NOT get its fragile ally, because a
-                    // dying support target would make reach flaky.
-                    scenario === 'wounded' && i === 0 ? FRAGILE_ALLY_HP : FILLER_HP
+                    board.allies[i] === fragileCell ? FRAGILE_ALLY_HP : FILLER_HP
                 )
             ),
         ],

--- a/src/utils/combat/audit/kitFingerprintScenarios.ts
+++ b/src/utils/combat/audit/kitFingerprintScenarios.ts
@@ -10,6 +10,7 @@ import { resolveCells } from '../../targeting/resolvePattern';
 import { canonicalPlacement } from './fixtures';
 import { runSeededBattle } from './seededBattle';
 import { fingerprintActorTokens } from './fingerprint';
+import type { Placement } from './types';
 
 export type ScenarioName = 'plain' | 'richEnemy' | 'wounded';
 
@@ -184,7 +185,7 @@ function fillerAttackFor(focus: Ship): number {
  *  resolves to stats.hp = 1 and currentHp = 1 at actor construction — the ally starts ALIVE, then
  *  dies to the very first hit it takes. It sits at T4, the only ally cell an enemy resolves onto,
  *  and 1 HP makes the kill timing immune to any damage-formula change: ANY hit is lethal. */
-const FRAGILE_ALLY_HP = 1;
+export const FRAGILE_ALLY_HP = 1;
 
 let cache: Map<string, Ship> | null = null;
 
@@ -245,18 +246,36 @@ export const FOCUS_ACTOR_ID = 'attacker';
 
 const maxHpOf = (a: CombatActor): number => a.stats.hp;
 
+/** Which side the subject sits on for a given placement. `focus` and `team` differ only by ARRAY
+ *  INDEX within playerTeam — see buildScenarioBattle. */
+export function subjectSideFor(placement: Placement): 'player' | 'enemy' {
+    return placement === 'enemy' ? 'enemy' : 'player';
+}
+
 function seedFor(
-    focus: Ship,
-    scenario: FingerprintScenario
+    subject: Ship,
+    scenario: FingerprintScenario,
+    placement: Placement
 ): ((actors: CombatActor[]) => void) | undefined {
+    const subjectSide = subjectSideFor(placement);
+    const subjectCell = boardFor(scenario).focus;
+    // The subject is identified by (side, cell), never by actor id: only the `focus` placement mints
+    // the reserved 'attacker' id, and never by array index, which differs per placement. Every board
+    // cell is distinct, so (side, cell) is unique.
+    const isSubject = (a: CombatActor): boolean =>
+        a.side === subjectSide && a.position === subjectCell;
+
     switch (scenario) {
         case 'plain':
             return undefined;
         case 'richEnemy': {
-            const pool = SHIELD_POOL_HITS * focus.baseStats.attack;
+            const pool = SHIELD_POOL_HITS * subject.baseStats.attack;
+            // The subject's OPPONENTS get the shield, not "the enemy side". In the `enemy`
+            // placement the subject IS on the enemy side, and seeding by side would hand it the
+            // pool it is supposed to be punching through — inverting the scenario.
             return (actors) => {
                 for (const a of actors) {
-                    if (a.side === 'enemy') a.shieldPool = pool;
+                    if (a.side !== subjectSide) a.shieldPool = pool;
                 }
             };
         }
@@ -267,15 +286,14 @@ function seedFor(
         case 'supportAnchor':
             return (actors) => {
                 for (const a of actors) {
-                    const fraction = a.id === FOCUS_ACTOR_ID ? FOCUS_HURT_FRACTION : HURT_FRACTION;
+                    const fraction = isSubject(a) ? FOCUS_HURT_FRACTION : HURT_FRACTION;
                     a.currentHp = maxHpOf(a) * fraction;
                 }
             };
         default: {
             // Exhaustiveness guard: `undefined` is a legitimate return for 'plain', so a fifth
             // ScenarioName falling through the switch would silently run unseeded and still
-            // produce a plausible-looking (but vacuous) snapshot. Force a compile error instead —
-            // the spec DEFERS a status-seeded scenario, it does not cancel it.
+            // produce a plausible-looking (but vacuous) snapshot. Force a compile error instead.
             const exhaustive: never = scenario;
             throw new Error(`kitFingerprintScenarios: unhandled scenario ${String(exhaustive)}`);
         }
@@ -292,40 +310,67 @@ function seedFor(
  * fixture pulls on how hard the battle presses.
  */
 export function buildScenarioBattle(
-    focus: Ship,
-    scenario: FingerprintScenario
+    subject: Ship,
+    scenario: FingerprintScenario,
+    placement: Placement = 'focus'
 ): BattleSimulationInput {
     const board = boardFor(scenario);
     const enemyNames = FILLER_NAMES.slice(0, 4);
     const allyNames = FILLER_NAMES.slice(4, 7);
-    const tap = seedFor(focus, scenario);
-    const attack = fillerAttackFor(focus);
+    const tap = seedFor(subject, scenario, placement);
+    const attack = fillerAttackFor(subject);
+    const rest = { rounds: ROUNDS, ...(tap ? { __testTapActors: tap } : {}) };
 
-    // The fragile ally is identified by its CELL, not by its index in this array. Task 4's `team`
-    // placement reorders playerTeam so the subject is not index 0, and index and position decouple
-    // there: keying on index would make the 1-HP ally the 'attacker' focus, where it dies to the
-    // first hit and the whole `wounded` scenario collapses. Baking fragility into the placement by
-    // position means any later reordering carries it along. Note `scenario === 'wounded'` and NOT
-    // the seeding branch: supportAnchor reuses wounded's HP seeding but must NOT get a fragile ally,
-    // because a dying support target would make reach flaky.
+    const subjectPlacement = canonicalPlacement(subject, board.focus);
+
+    // Fragility travels with the placement by CELL, so the reordering below cannot move it.
     const fragileCell = scenario === 'wounded' ? board.allies[0] : undefined;
+    const allyFillers = allyNames.map((name, i) =>
+        fillerPlacement(
+            name,
+            board.allies[i],
+            attack,
+            board.allies[i] === fragileCell ? FRAGILE_ALLY_HP : FILLER_HP
+        )
+    );
+    const enemyFillers = enemyNames.map((name, i) =>
+        fillerPlacement(name, board.enemies[i], attack)
+    );
 
-    return {
-        playerTeam: [
-            canonicalPlacement(focus, board.focus),
-            ...allyNames.map((name, i) =>
-                fillerPlacement(
-                    name,
-                    board.allies[i],
-                    attack,
-                    board.allies[i] === fragileCell ? FRAGILE_ALLY_HP : FILLER_HP
-                )
-            ),
-        ],
-        enemyTeam: enemyNames.map((name, i) => fillerPlacement(name, board.enemies[i], attack)),
-        rounds: ROUNDS,
-        ...(tap ? { __testTapActors: tap } : {}),
-    };
+    switch (placement) {
+        case 'focus':
+            return {
+                playerTeam: [subjectPlacement, ...allyFillers],
+                enemyTeam: enemyFillers,
+                ...rest,
+            };
+        case 'team': {
+            // The subject keeps its cell but gives up index 0, so the engine runs it as a walked
+            // 'team' actor. Index 0 takes the filler on the LAST ally cell: the fragile 1-HP ally
+            // is always on the FIRST one, and a 1-HP focus would die to the first hit and collapse
+            // the scenario.
+            const lead = allyFillers[allyFillers.length - 1];
+            const rear = allyFillers.slice(0, -1);
+            return {
+                playerTeam: [lead, subjectPlacement, ...rear],
+                enemyTeam: enemyFillers,
+                ...rest,
+            };
+        }
+        case 'enemy':
+            // Exact geometric mirror: selectTargets works in the acting side's own frame
+            // (selectTargets.ts:9) and rowScanOrder is side-agnostic, so every cell keeps its
+            // meaning. The subject's allies and opponents are physically unchanged.
+            return {
+                playerTeam: enemyFillers,
+                enemyTeam: [subjectPlacement, ...allyFillers],
+                ...rest,
+            };
+        default: {
+            const exhaustive: never = placement;
+            throw new Error(`buildScenarioBattle: unhandled placement ${String(exhaustive)}`);
+        }
+    }
 }
 
 /** The scenarios THIS ship runs: the three universal ones, plus `supportAnchor` when the primary

--- a/src/utils/combat/audit/kitFingerprintScenarios.ts
+++ b/src/utils/combat/audit/kitFingerprintScenarios.ts
@@ -285,6 +285,21 @@ function seedFor(
         case 'wounded':
         case 'supportAnchor':
             return (actors) => {
+                // Guard against isSubject matching anything other than exactly one actor: zero
+                // matches would silently degrade this to a uniform HURT_FRACTION seed (a plausible
+                // -looking but vacuous 'wounded'/'supportAnchor' battle), and more than one would mean
+                // (side, cell) stopped being unique. Neither failure mode would otherwise raise —
+                // in 'focus' the 147-ship snapshot would catch it, but 'team'/'enemy' have no
+                // snapshots and would instead surface later as a spurious placement asymmetry that
+                // reads exactly like an engine bug.
+                const matches = actors.filter(isSubject).length;
+                if (matches !== 1) {
+                    throw new Error(
+                        `kitFingerprintScenarios: expected exactly 1 subject actor for placement ` +
+                            `'${placement}' at side '${subjectSide}', cell '${subjectCell}', ` +
+                            `found ${matches}`
+                    );
+                }
                 for (const a of actors) {
                     const fraction = isSubject(a) ? FOCUS_HURT_FRACTION : HURT_FRACTION;
                     a.currentHp = maxHpOf(a) * fraction;
@@ -293,7 +308,8 @@ function seedFor(
         default: {
             // Exhaustiveness guard: `undefined` is a legitimate return for 'plain', so a fifth
             // ScenarioName falling through the switch would silently run unseeded and still
-            // produce a plausible-looking (but vacuous) snapshot. Force a compile error instead.
+            // produce a plausible-looking (but vacuous) snapshot. Force a compile error instead —
+            // the spec DEFERS a status-seeded scenario, it does not cancel it.
             const exhaustive: never = scenario;
             throw new Error(`kitFingerprintScenarios: unhandled scenario ${String(exhaustive)}`);
         }
@@ -323,7 +339,10 @@ export function buildScenarioBattle(
 
     const subjectPlacement = canonicalPlacement(subject, board.focus);
 
-    // Fragility travels with the placement by CELL, so the reordering below cannot move it.
+    // Fragility travels with the placement by CELL, so the reordering below cannot move it. Note
+    // this checks `scenario === 'wounded'` and NOT the seeding branch: supportAnchor reuses
+    // wounded's HP seeding but must NOT get a fragile ally, because a dying support target would
+    // make support-pattern reach flaky.
     const fragileCell = scenario === 'wounded' ? board.allies[0] : undefined;
     const allyFillers = allyNames.map((name, i) =>
         fillerPlacement(

--- a/src/utils/combat/audit/placementSymmetry.ts
+++ b/src/utils/combat/audit/placementSymmetry.ts
@@ -1,0 +1,45 @@
+import type { BattleResult } from '../../calculators/battleSimulator';
+import {
+    boardFor,
+    subjectSideFor,
+    FOCUS_ACTOR_ID,
+    type FingerprintScenario,
+} from './kitFingerprintScenarios';
+import type { Placement } from './types';
+
+/** What a correctly-resolved subject id looks like per placement. `playerTeam[0]` mints the
+ *  reserved `'attacker'`; the rest mint `p:<shipId>:<idx>` / `e:<shipId>:<idx>`
+ *  (battleSimulator.ts:842-845). Checked rather than assumed: a mis-resolved id fingerprints an
+ *  EMPTY set, so every kind reads as "missing in that placement" and the sweep reports confident
+ *  nonsense. This is the #298 fixture-vacuity failure mode. */
+const EXPECTED_ID_SHAPE: Record<Placement, (id: string) => boolean> = {
+    focus: (id) => id === FOCUS_ACTOR_ID,
+    team: (id) => id.startsWith('p:'),
+    enemy: (id) => id.startsWith('e:'),
+};
+
+/** The subject's actor id in an already-run scenario battle, located by `(side, cell)` — the only
+ *  key that is stable across placements. Array index differs by construction and the actor id is
+ *  what we are resolving. Throws on a miss or a shape mismatch; never guesses. */
+export function resolveSubjectActorId(
+    result: BattleResult,
+    scenario: FingerprintScenario,
+    placement: Placement
+): string {
+    const side = subjectSideFor(placement);
+    const cell = boardFor(scenario).focus;
+    const entry = result.roster.find((r) => r.side === side && r.position === cell);
+    if (!entry) {
+        throw new Error(
+            `placementSymmetry: could not resolve the subject actorId for ${placement} ` +
+                `(${side}@${cell}) in the ${scenario} roster`
+        );
+    }
+    if (!EXPECTED_ID_SHAPE[placement](entry.actorId)) {
+        throw new Error(
+            `placementSymmetry: resolved actorId "${entry.actorId}" for ${placement} ` +
+                `(${side}@${cell}) does not match the expected shape for that placement`
+        );
+    }
+    return entry.actorId;
+}

--- a/src/utils/combat/audit/placementSymmetry.ts
+++ b/src/utils/combat/audit/placementSymmetry.ts
@@ -1,11 +1,17 @@
+import type { Ship } from '../../../types/ship';
 import type { BattleResult } from '../../calculators/battleSimulator';
+import type { CombatLogEntryKind } from '../log/types';
+import { fingerprintActor } from './fingerprint';
+import { runSeededBattle } from './seededBattle';
 import {
     boardFor,
+    buildScenarioBattle,
+    scenariosFor,
     subjectSideFor,
     FOCUS_ACTOR_ID,
     type FingerprintScenario,
 } from './kitFingerprintScenarios';
-import type { Placement } from './types';
+import { PLACEMENT_PAIRS, type Placement, type PlacementDiff } from './types';
 
 /** What a correctly-resolved subject id looks like per placement. `playerTeam[0]` mints the
  *  reserved `'attacker'`; the rest mint `p:<shipId>:<idx>` / `e:<shipId>:<idx>`
@@ -42,4 +48,70 @@ export function resolveSubjectActorId(
         );
     }
     return entry.actorId;
+}
+
+/** `count` consecutive seeds starting at `base`. Consecutive rather than hashed: the sweep's job is
+ *  to widen the RNG sample, and a reader reproducing a finding needs to be able to type the seeds. */
+export function seedsFrom(base: number, count: number): number[] {
+    return Array.from({ length: count }, (_, i) => base + i);
+}
+
+/** Everything the subject did in one placement: the UNION of bare log-entry kinds over every
+ *  scenario it runs and every seed.
+ *
+ *  BARE kinds, via `fingerprintActor` — never `fingerprintActorTokens`. The `:slot` suffix records
+ *  which log handler won the single-use `consumePendingSkill()` race, so it tracks emission ORDER
+ *  and would flip across a placement change on its own, manufacturing diffs.
+ *
+ *  Union over seeds is what neutralises ownerId-keyed RNG: the same physical ship draws a different
+ *  crit/landing/proc stream depending on its owner id, so a proc-gated kind can appear in one
+ *  placement and not another purely by draw. A kind the placement can produce AT ALL shows up in the
+ *  union of enough seeds, so only a kind appearing in ZERO seeds is reported. Union over scenarios
+ *  goes the same way, trading "which scenario exposed it" for a lower false-positive rate. Both are
+ *  deliberate false-negative trades: each finding costs a manual engine-instrumentation triage. */
+export function fingerprintSubject(
+    subject: Ship,
+    placement: Placement,
+    seeds: readonly number[]
+): Set<CombatLogEntryKind> {
+    const observed = new Set<CombatLogEntryKind>();
+    for (const scenario of scenariosFor(subject)) {
+        for (const seed of seeds) {
+            const result = runSeededBattle(buildScenarioBattle(subject, scenario, placement), seed);
+            const actorId = resolveSubjectActorId(result, scenario, placement);
+            for (const kind of fingerprintActor(result, actorId)) observed.add(kind);
+        }
+    }
+    return observed;
+}
+
+/** One DIRECTED comparison: kinds the subject produced in `from` but never in `to`. Null when there
+ *  are none — including when `to` is a strict superset, which the reverse direction reports. Sorted
+ *  so a ledger diff never churns on set-iteration order. */
+export function diffPlacements(
+    shipName: string,
+    from: Placement,
+    to: Placement,
+    fromKinds: ReadonlySet<CombatLogEntryKind>,
+    toKinds: ReadonlySet<CombatLogEntryKind>
+): PlacementDiff | null {
+    const missing = [...fromKinds].filter((k) => !toKinds.has(k)).sort();
+    return missing.length === 0 ? null : { shipName, from, to, missing };
+}
+
+/** Every asymmetry between the three placements, in BOTH directions per pair. "Fires as attacker but
+ *  never as enemy" and "fires as enemy but never as attacker" are both defects, so neither direction
+ *  is privileged. */
+export function diffAllPlacements(
+    shipName: string,
+    byPlacement: Record<Placement, ReadonlySet<CombatLogEntryKind>>
+): PlacementDiff[] {
+    const out: PlacementDiff[] = [];
+    for (const [a, b] of PLACEMENT_PAIRS) {
+        const ab = diffPlacements(shipName, a, b, byPlacement[a], byPlacement[b]);
+        if (ab) out.push(ab);
+        const ba = diffPlacements(shipName, b, a, byPlacement[b], byPlacement[a]);
+        if (ba) out.push(ba);
+    }
+    return out;
 }

--- a/src/utils/combat/audit/placementSymmetry.ts
+++ b/src/utils/combat/audit/placementSymmetry.ts
@@ -10,7 +10,7 @@ import {
     scenariosFor,
     subjectSideFor,
     FOCUS_ACTOR_ID,
-    FILLER_NAMES,
+    ENEMY_FILLER_NAMES,
     type FingerprintScenario,
 } from './kitFingerprintScenarios';
 import { PLACEMENT_PAIRS, type Placement, type PlacementDiff } from './types';
@@ -67,10 +67,13 @@ export function seedsFrom(base: number, count: number): number[] {
  *
  *  Union over seeds is what neutralises ownerId-keyed RNG: the same physical ship draws a different
  *  crit/landing/proc stream depending on its owner id, so a proc-gated kind can appear in one
- *  placement and not another purely by draw. A kind the placement can produce AT ALL shows up in the
- *  union of enough seeds, so only a kind appearing in ZERO seeds is reported. Union over scenarios
- *  goes the same way, trading "which scenario exposed it" for a lower false-positive rate. Both are
- *  deliberate false-negative trades: each finding costs a manual engine-instrumentation triage. */
+ *  placement and not another purely by draw. Union over enough seeds makes that convergent — a kind
+ *  the placement can produce AT ALL becomes overwhelmingly likely to show up — but this is a
+ *  probabilistic mitigation, not a guarantee, and at the CLI's default of 5 seeds it has REAL
+ *  measured residual: a landing- or proc-gated kind can still differ between placements purely by
+ *  draw (see the ledger's seed-noise caveat). Union over scenarios goes the same way, trading "which
+ *  scenario exposed it" for a lower false-positive rate. Both are deliberate false-negative trades:
+ *  each finding costs a manual engine-instrumentation triage. */
 export function fingerprintSubject(
     subject: Ship,
     placement: Placement,
@@ -124,7 +127,7 @@ export function diffAllPlacements(
     return out;
 }
 
-/** Calibration subjects: the ENEMY-side fillers only (`FILLER_NAMES.slice(0, 4)`).
+/** Calibration subjects: the ENEMY-side fillers only (`ENEMY_FILLER_NAMES`).
  *
  *  Verified kitless — no passives, no charge skill, a bare "deals 90% damage" active, guarded by the
  *  existing filler-inertness test — so their fingerprints are a function of the ENGINE alone. Any
@@ -133,7 +136,7 @@ export function diffAllPlacements(
  *  Deliberately NOT the ally-side fillers: the subject shares a side with those, so using one would
  *  put the same ship twice on one side — an illegal in-game state. An enemy-side filler is on the
  *  opposite side from the subject in every placement. */
-export const CALIBRATION_SUBJECT_NAMES: readonly string[] = FILLER_NAMES.slice(0, 4);
+export const CALIBRATION_SUBJECT_NAMES: readonly string[] = ENEMY_FILLER_NAMES;
 
 /** Run the placement sweep over the inert calibration subjects. An empty result is the pass
  *  condition; anything returned is a HARNESS asymmetry and invalidates the real sweep. */

--- a/src/utils/combat/audit/placementSymmetry.ts
+++ b/src/utils/combat/audit/placementSymmetry.ts
@@ -1,6 +1,7 @@
 import type { Ship } from '../../../types/ship';
 import type { BattleResult } from '../../calculators/battleSimulator';
 import type { CombatLogEntryKind } from '../log/types';
+import { buildTraceShip } from '../../../../scripts/lib/traceShipFactory';
 import { fingerprintActor } from './fingerprint';
 import { runSeededBattle } from './seededBattle';
 import {
@@ -9,6 +10,7 @@ import {
     scenariosFor,
     subjectSideFor,
     FOCUS_ACTOR_ID,
+    FILLER_NAMES,
     type FingerprintScenario,
 } from './kitFingerprintScenarios';
 import { PLACEMENT_PAIRS, type Placement, type PlacementDiff } from './types';
@@ -118,6 +120,40 @@ export function diffAllPlacements(
         if (ab) out.push(ab);
         const ba = diffPlacements(shipName, b, a, byPlacement[b], byPlacement[a]);
         if (ba) out.push(ba);
+    }
+    return out;
+}
+
+/** Calibration subjects: the ENEMY-side fillers only (`FILLER_NAMES.slice(0, 4)`).
+ *
+ *  Verified kitless — no passives, no charge skill, a bare "deals 90% damage" active, guarded by the
+ *  existing filler-inertness test — so their fingerprints are a function of the ENGINE alone. Any
+ *  placement difference is therefore a harness asymmetry, not a kit one.
+ *
+ *  Deliberately NOT the ally-side fillers: the subject shares a side with those, so using one would
+ *  put the same ship twice on one side — an illegal in-game state. An enemy-side filler is on the
+ *  opposite side from the subject in every placement. */
+export const CALIBRATION_SUBJECT_NAMES: readonly string[] = FILLER_NAMES.slice(0, 4);
+
+/** Run the placement sweep over the inert calibration subjects. An empty result is the pass
+ *  condition; anything returned is a HARNESS asymmetry and invalidates the real sweep. */
+export function runCalibration(seeds: readonly number[]): PlacementDiff[] {
+    const out: PlacementDiff[] = [];
+    for (const name of CALIBRATION_SUBJECT_NAMES) {
+        const subject = buildTraceShip(name);
+        if (!subject) {
+            throw new Error(
+                `placementSymmetry: calibration subject "${name}" did not resolve — ` +
+                    'docs/ship-skills.csv / docs/ship-data.json are gitignored reference data ' +
+                    'expected on dev machines (see CLAUDE.md).'
+            );
+        }
+        const byPlacement = {
+            focus: fingerprintSubject(subject, 'focus', seeds),
+            team: fingerprintSubject(subject, 'team', seeds),
+            enemy: fingerprintSubject(subject, 'enemy', seeds),
+        };
+        out.push(...diffAllPlacements(subject.name, byPlacement));
     }
     return out;
 }

--- a/src/utils/combat/audit/placementSymmetry.ts
+++ b/src/utils/combat/audit/placementSymmetry.ts
@@ -74,6 +74,12 @@ export function fingerprintSubject(
     placement: Placement,
     seeds: readonly number[]
 ): Set<CombatLogEntryKind> {
+    if (seeds.length === 0) {
+        throw new Error(
+            `fingerprintSubject: seeds is empty for "${subject.name}" in the ${placement} ` +
+                'placement — an empty seed list silently reads every kind as missing'
+        );
+    }
     const observed = new Set<CombatLogEntryKind>();
     for (const scenario of scenariosFor(subject)) {
         for (const seed of seeds) {

--- a/src/utils/combat/audit/types.ts
+++ b/src/utils/combat/audit/types.ts
@@ -50,3 +50,28 @@ export interface Finding {
     minimalRepro?: { playerShips: string[]; enemyShips: string[] };
     severity: 'high' | 'med' | 'low';
 }
+
+/** Which of the engine's three actor paths runs the subject. `playerTeam[0]` becomes the
+ *  `'attacker'` focus by ARRAY INDEX (battleSimulator.ts:842), `playerTeam[1..3]` become `'team'`
+ *  walked actors, and the enemy side is `'enemy'` — three distinct code paths for the same kit
+ *  (state.ts:133). */
+export type Placement = 'focus' | 'team' | 'enemy';
+
+export const PLACEMENTS: readonly Placement[] = ['focus', 'team', 'enemy'] as const;
+
+/** The unordered pairs to compare. Each yields TWO findings-directions (a→b and b→a), so all six
+ *  ordered comparisons are covered without duplicating a pair. */
+export const PLACEMENT_PAIRS: readonly (readonly [Placement, Placement])[] = [
+    ['focus', 'team'],
+    ['focus', 'enemy'],
+    ['team', 'enemy'],
+] as const;
+
+/** One directed placement asymmetry: kinds the subject produced in `from` but never in `to`.
+ *  `missing` is non-empty by construction — `diffPlacements` returns null otherwise. */
+export interface PlacementDiff {
+    shipName: string;
+    from: Placement;
+    to: Placement;
+    missing: CombatLogEntryKind[];
+}


### PR DESCRIPTION
## Why

The interaction-audit harness (#270) deferred a "team symmetry" oracle as structurally confounded — it was the only one that could see the enemy side, since the differential oracle compares player-side only.

Reading the code turned up a bigger hole. The engine has **three** actor kinds, not two (`state.ts:133`): `playerTeam[0]` becomes the `'attacker'` focus with its stats/target/pattern riding the top-level input, `playerTeam[1..3]` become `'team'` walked actors, and the enemy side is `'enemy'`. The real-kit fingerprint suite from #298/#300 places every subject at the focus slot, so **all 147 ships of coverage exercise the `'attacker'` path and nothing else** — and in the simulator, three of a user's own four ships run `'team'`.

So this is placement symmetry, not team symmetry: does a kit execute the same way regardless of which of the three paths runs it?

## How

Each corpus ship runs in three placements on **byte-identical board cells** — only `(side, array index)` changes, because `playerTeam[0]` becomes the focus by array index, not by position:

| placement | `playerTeam` | `enemyTeam` |
|---|---|---|
| `focus` | `[subject@M4, f@T4, f@T2, f@B4]` | `[f@M3, f@M2, f@M1, f@T3]` |
| `team` | `[f@B4, subject@M4, f@T4, f@T2]` | `[f@M3, f@M2, f@M1, f@T3]` |
| `enemy` | `[f@M3, f@M2, f@M1, f@T3]` | `[subject@M4, f@T4, f@T2, f@B4]` |

Bare `kind` tokens (never `kind:slot` — that tracks emission order and would flip on its own), unioned over scenario × seed, diffed pairwise in both directions.

`buildScenarioBattle(subject, scenario)` with no third argument is **byte-identical to before**; the committed 147-ship inline snapshot is untouched across the whole branch.

## Results

`npm run audit:placement-symmetry -- --seeds 5` → **147 swept, 117 symmetric, 60 findings over 30 ships**, 0 ships observing nothing in any placement.

`charge-changed` 21 ships · `buff-expired` 12 · `debuff-resisted` 3 · `buff` 2 · `shield-destroyed`/`dot-ticked`/`heal` 1 each.

**56 of 60 are "fires as focus/team, never as enemy"**, with focus and team agreeing almost everywhere.

**All 60 are CANDIDATES. Nothing was fixed, exempted, or recorded as a bug** — the spec requires direct engine instrumentation before any finding is treated as real.

## What this does NOT prove

Deliberately disclosed in the ledger rather than glossed:

- **Calibration is narrower than its name.** Inert filler subjects can structurally only ever produce `{}` or `{attack}`, so a clean calibration proves id resolution works for the `attack` pathway and carries zero evidential weight for `charge-changed` or `buff-expired` — the two kinds that dominate the findings.
- **RNG is keyed by actor id**, so streams are unrelated across placements (measured: the same crit at rounds 6+13 / 5+16 / 7+20). Union-over-K is a probabilistic mitigation, not a guarantee. The three `debuff-resisted` findings point in mutually inconsistent directions across ships — the signature of seed noise; the ledger tells triagers to vary `--base-seed` first.
- **`playerTeam[0]` is also the engine's heal target** in positional mode (`engine.ts:2282`), so the subject is the heal target only in `focus`. Identical cells is not identical engine roles.

## Notes

- Sweep is a CLI, **not** part of `npm test`. The ledger is gitignored local reference data like the existing audit ledgers.
- No snapshot pins the 60 findings, so the sweep has not been quietly promoted to a gate.
- Turn order is provably invariant across placements: `positionTurnRank` is injective and both boards use 8 distinct cells, so `orderByTurnPriority`'s player-side-first tiebreak is unreachable — which matters, because 33 of 147 ships tie a filler's base speed. Pinned by a test.
- Internal tooling only — no changelog entry.

Suite: **471 files / 5368 tests** green. tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6or8HzPQ6Ydx1bAB9rGHz