### PR TITLE
fix(sim): enemy ships fire their passive-slot repairs and shields

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -34,6 +34,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Autogear: Defence and Crit Chance priorities are now weighted on the same scale as every other stat. Both were being compared against their raw values instead of a typical value for the stat, which made a Defence priority around 5000x too strong and a Crit Chance priority around 25x too strong — either one would swamp the priorities listed above it. If you have saved configurations that use Defence or Crit Chance as a priority, re-run autogear to get the corrected recommendation.',
     'Combat log now shows which ship granted a buff to an ally, instead of only naming the ship that received it.',
     'Recruitment calculator: Centurion is now recruitable through beacons. It was on the non-recruitable list, so the calculator gave it no beacon odds at all.',
+    'Combat simulator: enemy ships now fire their passive repairs and shields, as they do in game. Three separate gaps all skipped the passive slot for enemies only: Volk\'s passive repair never went off, Malvex\'s and Quixilver\'s "gain a Shield when damaged" never triggered, and the "gain a Shield from the damage you deal" passives on FrontLine, Magnolia, Valerian and Valkyrie never paid out. Your own ships were always unaffected, so these enemies were easier to kill in the simulator than they are in game.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/utils/combat/__tests__/enemyPassiveSlotSupport.integration.test.ts
+++ b/src/utils/combat/__tests__/enemyPassiveSlotSupport.integration.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Integration: a ship's PASSIVE-slot heal/shield fires on either side of the board.
+ *
+ * User-confirmed game rule (2026-08-07): "all ships fire their passives if the skill conditions
+ * are met, no matter what side they are on." The engine agreed for the cast slots but not the
+ * passive slot, via three independent drops — all of them invisible to the 147-ship real-kit
+ * fingerprint suite, which places every subject at the player focus and so never exercises the
+ * enemy actor path (the coverage hole `npm run audit:placement-symmetry` exists to expose).
+ *
+ * The three drops, each covered by a mirror-image pair below (player control / enemy case):
+ *
+ *   1. ON-CAST PASSIVE (`healEventOnly`, playerTurn.ts). The enemy turn binding sets
+ *      `healEventOnly: true`; that mode built its heal-ability list from the CAST skill alone,
+ *      where normal mode concatenates the passive slot. Every enemy passive repair/shield was
+ *      dropped. Corpus: Volk.
+ *
+ *   2. DAMAGE-TAKEN LEECH ("when damaged, gain a shield"). Two halves: `takenLeechesByOwner` was
+ *      built from the PLAYER runtimes only, and the per-victim proc hook was wired only at the
+ *      enemy→player attack site, so an enemy victim's own leech had neither an entry nor a
+ *      caller. Corpus: Malvex, Quixilver.
+ *
+ *   3. DAMAGE-DEALT LEECH ("when dealing damage, gain a shield"). Same two halves mirrored:
+ *      `standingLeeches` was player-only and the proc was wired at the player→enemy sites only.
+ *      Corpus: FrontLine, Magnolia, Valerian, Valkyrie.
+ *
+ * Drops 2 and 3 are the [hand-enumerated-layer] class: of the EIGHT sibling per-owner ability
+ * maps built in one block of engine.ts, six already swept both runtime collections and these two
+ * did not.
+ *
+ * Harness notes:
+ *   - SHIELD is the observable throughout, never heal: `shieldPool` is readable on the live actor
+ *     with no incoming damage required, whereas a self-heal is a silent no-op on an undamaged
+ *     actor. State is read off the roster via `__testTapActors` — the same objects the engine
+ *     mutates — not inferred from the log and not via the per-round `perActorShield` accounting
+ *     (which is a second layer that could itself be side-asymmetric; the actor's own pool cannot).
+ *   - The subject sits at M4 (the FRONT cell) on whichever side it occupies, and its opposite
+ *     number sits at M4 on the other side targeting `front`, so the two engage identically in
+ *     both placements.
+ *   - `opponentAttack` is per case, because a surviving pool is what makes `shieldPool` readable:
+ *     a shield granted on the subject's OWN turn (drops 1 and 3) is absorbed again by the next
+ *     incoming hit and reads 0 at the end, so those cases face a passive opponent. The
+ *     damage-taken case (drop 2) necessarily faces an attacking one — its shield is granted
+ *     immediately AFTER the hit that pays for it, and so survives.
+ *   - `harness sanity` pins the damage flow each case depends on. Without it a leech assertion
+ *     could be red simply because nobody engaged (#298 fixture-vacuity class).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { runCombat, type CombatEngineInput } from '../engine';
+import { parsePattern, parseTarget } from '../../targetingParser';
+import type { Ability, ShipSkills } from '../../../types/abilities';
+import type { CombatActor } from '../state';
+
+/** The subject's id in both placements — only its side changes. */
+const SUBJECT = 'subject';
+const ROUNDS = 3;
+const SUBJECT_HP = 10_000;
+const SUBJECT_ATTACK = 100;
+/** Opposing damage, chosen well below SUBJECT_HP so the subject survives all ROUNDS. */
+const OPPONENT_ATTACK = 100;
+
+type Side = 'player' | 'enemy';
+
+// ─── Passive-slot fixtures (the only thing that varies between cases) ───────────
+
+/** Drop 1: an ordinary on-cast passive self-shield, 20% of the caster's own max HP. */
+const passiveOnCastShield = (): Ability => ({
+    id: 'p-oncast-shield',
+    type: 'shield',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'shield', pct: 20, basis: 'target-hp' },
+});
+
+/** Drop 2: Malvex's "when directly damaged, gain a Shield equal to X% of the damage dealt". */
+const passiveTakenLeech = (): Ability => ({
+    id: 'p-taken-leech',
+    type: 'shield',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'shield', pct: 50, basis: 'damage-taken' },
+});
+
+/** Drop 3: a standing "X% of damage dealt" leech. */
+const passiveDealtLeech = (): Ability => ({
+    id: 'p-dealt-leech',
+    type: 'shield',
+    target: 'self',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'shield', pct: 50, basis: 'damage-dealt' },
+});
+
+const strike = (id: string, multiplier: number): Ability => ({
+    id,
+    type: 'damage',
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    config: { type: 'damage', multiplier },
+});
+
+/** The subject's kit: a plain damage active plus the passive under test. */
+const subjectSkills = (passive: Ability): ShipSkills => ({
+    slots: [
+        { slot: 'active', abilities: [strike('subject-hit', 100)] },
+        { slot: 'passive', abilities: [passive] },
+    ],
+});
+
+/** A bare damage dealer, used as the subject's opposite number. */
+const plainSkills = (): ShipSkills => ({
+    slots: [{ slot: 'active', abilities: [strike('plain-hit', 100)] }],
+});
+
+// ─── Board ──────────────────────────────────────────────────────────────────────
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const teamActor = (id: string, position: string, skills: ShipSkills, attack: number) =>
+    ({
+        id,
+        speed: 100,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        target: parseTarget('front'),
+        pattern: parsePattern('Pattern-Base'),
+        walk: {
+            shipSkills: skills,
+            stats: {
+                attack,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking: 0,
+                defence: 0,
+                hp: SUBJECT_HP,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    }) as any;
+
+const enemyActor = (id: string, position: string, skills: ShipSkills, attack: number) =>
+    ({
+        id,
+        stats: { attack, crit: 0, critDamage: 0, speed: 100, defence: 0, hp: SUBJECT_HP },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        target: parseTarget('front'),
+        pattern: parsePattern('Pattern-Base'),
+        shipSkills: skills,
+    }) as any;
+
+/**
+ * One board, two placements. The subject always occupies M4 on `side` and always faces a damage
+ * dealer at M4 on the other side; every other cell is empty. The player focus is unavoidable
+ * (the engine always mints `playerTeam[0]` as the 'attacker'), so it doubles as the opposing
+ * damage dealer when the subject is on the enemy side, and is a harmless 0-multiplier bystander
+ * at M1 when the subject is on the player side.
+ */
+const buildInput = (
+    side: Side,
+    passive: Ability,
+    opponentAttack: number,
+    tap: (a: CombatActor[]) => void
+) => {
+    const subjectOnPlayer = side === 'player';
+    const input: CombatEngineInput = {
+        // The focus. Damage dealer at M4 when the subject is the enemy; inert at M1 otherwise.
+        attack: subjectOnPlayer ? 0 : opponentAttack,
+        crit: 0,
+        critDamage: 0,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: { slots: [{ slot: 'active', abilities: [strike('focus-hit', 100)] }] },
+        enemyDefense: 0,
+        enemyHp: 1_000_000,
+        numRounds: ROUNDS,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: SUBJECT_HP,
+        healTargetId: 'attacker',
+        positionalTeamBattle: true,
+        position: subjectOnPlayer ? 'M1' : 'M4',
+        target: parseTarget('front'),
+        pattern: parsePattern('Pattern-Base'),
+        teamActors: subjectOnPlayer
+            ? [teamActor(SUBJECT, 'M4', subjectSkills(passive), SUBJECT_ATTACK)]
+            : [],
+        enemyAttackers: subjectOnPlayer
+            ? [enemyActor('opponent', 'M4', plainSkills(), opponentAttack)]
+            : [enemyActor(SUBJECT, 'M4', subjectSkills(passive), SUBJECT_ATTACK)],
+        __testTapActors: tap,
+    } as any;
+    return input;
+};
+
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+interface Run {
+    /** The subject's own live actor — the pool read comes off this. */
+    subject: CombatActor;
+    /** The subject's opposite number, for the "did it actually deal damage" sanity read. */
+    opponent: CombatActor;
+}
+
+/** Run one placement. `opponentAttack` 0 leaves the subject unharassed (see the header note). */
+const run = (side: Side, passive: Ability, opponentAttack: number): Run => {
+    let captured: CombatActor[] = [];
+    runCombat(buildInput(side, passive, opponentAttack, (a) => (captured = a)));
+    const subject = captured.find((a) => a.id === SUBJECT);
+    // The opposite number is the M4 actor on the other side: the named enemy 'opponent' when the
+    // subject is a player, the focus otherwise. (The legacy non-positional dummy has no position
+    // and is never it.)
+    const opponent = captured.find(
+        (a) => a.id !== SUBJECT && a.position === 'M4' && a.side !== subject?.side
+    );
+    if (!subject) throw new Error(`no actor '${SUBJECT}' in the ${side} roster`);
+    if (!opponent) throw new Error(`no M4 opposite number in the ${side} roster`);
+    return { subject, opponent };
+};
+
+// ─── Harness sanity ─────────────────────────────────────────────────────────────
+
+describe('harness sanity', () => {
+    it.each(['player', 'enemy'] as const)(
+        'the %s-side subject DEALS damage to its opposite number',
+        (side) => {
+            // Drops 1 and 3 depend on the subject acting at all. Without this a green fix and a
+            // board where nobody ever engaged look identical. (#298 fixture-vacuity class.)
+            const { opponent } = run(side, passiveDealtLeech(), 0);
+
+            expect(opponent.currentHp).toBeLessThan(opponent.stats.hp);
+        }
+    );
+
+    it.each(['player', 'enemy'] as const)(
+        'the %s-side subject TAKES damage from its opposite number',
+        (side) => {
+            // Drop 2 additionally depends on the subject being hit. Asserted with a passive that
+            // grants no pool, so nothing can absorb the damage and mask it.
+            const { subject } = run(side, passiveDealtLeech(), OPPONENT_ATTACK);
+
+            expect(subject.currentHp).toBeLessThan(SUBJECT_HP);
+        }
+    );
+});
+
+// ─── Drop 1: on-cast passive heal/shield ────────────────────────────────────────
+
+describe('passive-slot on-cast shield', () => {
+    it('a PLAYER-side passive self-shield grants a pool (control)', () => {
+        const { subject } = run('player', passiveOnCastShield(), 0);
+
+        expect(subject.shieldPool).toBeGreaterThan(0);
+    });
+
+    it('an ENEMY-side passive self-shield grants a pool too', () => {
+        // The regression: `healEventOnly` built its ability list from the cast slot alone, so the
+        // enemy's passive never ran. Identical kit, identical cells — only the side differs.
+        const { subject } = run('enemy', passiveOnCastShield(), 0);
+
+        expect(subject.shieldPool).toBeGreaterThan(0);
+    });
+});
+
+// ─── Drop 2: damage-taken leech ─────────────────────────────────────────────────
+
+describe('passive-slot damage-taken leech', () => {
+    it('a PLAYER-side victim gains a shield from the damage it took (control)', () => {
+        const { subject } = run('player', passiveTakenLeech(), OPPONENT_ATTACK);
+
+        expect(subject.shieldPool).toBeGreaterThan(0);
+    });
+
+    it('an ENEMY-side victim gains a shield from the damage it took too', () => {
+        // `takenLeechesByOwner` held no entry for an enemy owner, and the per-victim proc was
+        // wired only where the victims are players.
+        const { subject } = run('enemy', passiveTakenLeech(), OPPONENT_ATTACK);
+
+        expect(subject.shieldPool).toBeGreaterThan(0);
+    });
+});
+
+// ─── Drop 3: damage-dealt leech ─────────────────────────────────────────────────
+
+describe('passive-slot damage-dealt leech', () => {
+    it('a PLAYER-side attacker gains a shield from the damage it dealt (control)', () => {
+        const { subject } = run('player', passiveDealtLeech(), 0);
+
+        expect(subject.shieldPool).toBeGreaterThan(0);
+    });
+
+    it('an ENEMY-side attacker gains a shield from the damage it dealt too', () => {
+        // `standingLeeches` held no entry for an enemy owner, and the proc was wired only at the
+        // player→enemy attack sites.
+        const { subject } = run('enemy', passiveDealtLeech(), 0);
+
+        expect(subject.shieldPool).toBeGreaterThan(0);
+    });
+});

--- a/src/utils/combat/audit/__tests__/placementSymmetry.test.ts
+++ b/src/utils/combat/audit/__tests__/placementSymmetry.test.ts
@@ -502,10 +502,15 @@ describe('calibration — an inert kit is placement-symmetric', () => {
         expect(CALIBRATION_SUBJECT_NAMES.length).toBeGreaterThan(0);
     });
 
+    // Explicit timeout: this runs 4 subjects × 3 placements × 3 scenarios × 2 seeds of REAL
+    // battles. It costs ~0.7s alone but is the most expensive single test in the suite, and
+    // under full-suite worker contention it can exceed vitest's 5s default and fail as a
+    // timeout — a flake with nothing to do with placement symmetry. Budget, not speed-up: if
+    // this ever takes 30s of CPU rather than 30s of waiting, that IS a regression worth failing.
     it('reports no asymmetry for any inert subject', () => {
         const diffs = runCalibration(seedsFrom(SEED, 2));
         expect(diffs).toEqual([]);
-    });
+    }, 30_000);
 
     it('is not vacuous — an inert subject still produces kinds', () => {
         const subject = subjectShip(CALIBRATION_SUBJECT_NAMES[0]);

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3102,6 +3102,17 @@ export function runCombat(input: CombatEngineInput): {
         ...teamRuntimeById,
     ]);
 
+    // Every actor's runtime regardless of side. `runtimesById` is PLAYER-side only, which is the
+    // right scope for owner-routed player accounting but the wrong one for any per-owner ABILITY
+    // scan: a ship carries its kit onto whichever side it is placed. Used by the leech maps and
+    // their procs below so an enemy's passive leech is registered and resolvable exactly like a
+    // player's. Player entries win a key collision (the focus is keyed 'attacker', so there is
+    // none in practice) — same precedence as `runtimeFor`.
+    const allRuntimesById = new Map<string, PlayerActorRuntime>([
+        ...enemyPlayerRuntimeByActorId,
+        ...runtimesById,
+    ]);
+
     // Passive-slot standing leeches per owner (damage-leech spec §4): X% of credited
     // damage repaired/shielded immediately at credit time. Scanned once at setup from each
     // runtime's reactive-partitioned castSkills (passive-slot heal/shield abilities are
@@ -3115,7 +3126,7 @@ export function runCombat(input: CombatEngineInput): {
     }
     const standingLeeches = new Map<string, StandingLeech[]>();
     if (healTarget) {
-        for (const [ownerId, rt] of runtimesById) {
+        for (const [ownerId, rt] of allRuntimesById) {
             const entries: StandingLeech[] = [];
             for (const slot of rt.castSkills.slots) {
                 if (slot.slot !== 'passive') continue;
@@ -3150,7 +3161,7 @@ export function runCombat(input: CombatEngineInput): {
     }
     const takenLeechesByOwner = new Map<string, TakenLeech[]>();
     if (healTarget) {
-        for (const [ownerId, rt] of runtimesById) {
+        for (const [ownerId, rt] of allRuntimesById) {
             const entries: TakenLeech[] = [];
             for (const slot of rt.castSkills.slots) {
                 if (slot.slot !== 'passive') continue;
@@ -3522,8 +3533,9 @@ export function runCombat(input: CombatEngineInput): {
         if (!healingCtx || amount <= 0) return;
         const entries = standingLeeches.get(sourceId);
         if (!entries) return;
-        const owner = runtimesById.get(sourceId);
+        const owner = allRuntimesById.get(sourceId);
         if (!owner) return;
+        const ownerIsEnemy = owner.actor.side === 'enemy';
         for (const e of entries) {
             // Per-victim damage rides the `direct` channel only; detonation-scoped leeches
             // never fire here (bombs credit through the aggregate detonation path instead).
@@ -3536,16 +3548,29 @@ export function runCombat(input: CombatEngineInput): {
                     raw *= 1 + owner.critDamage / 100;
                 }
             }
+            // Recipient routing is SIDE-RELATIVE: "allies" means the owner's own side.
+            // `ally` (the single designated recipient) has no enemy-side equivalent — the player
+            // heal target is a player-only concept — and no corpus ship reaches it here: every
+            // passive leech that survives the reactive partition into `standingLeeches` targets
+            // `self` (Magnolia, Malvex, Quixilver, Valerian; Valkyrie's `ally` one is
+            // `on-bomb-detonated`, so it is reactive and never enters this map). An enemy owner
+            // therefore resolves to NO recipient rather than silently repairing a PLAYER — the
+            // same nothing it got before enemy owners were registered at all. Wire a real rule
+            // here if a future enemy kit needs one.
             const recipients =
                 e.target === 'ally'
-                    ? [healTarget!.id]
+                    ? ownerIsEnemy
+                        ? []
+                        : [healTarget!.id]
                     : e.target === 'all-allies'
-                      ? healingCtx.playerIds
+                      ? ownerIsEnemy
+                          ? healingCtx.enemyIds
+                          : healingCtx.playerIds
                       : [sourceId];
             for (const rid of recipients) {
                 // Resolve the recipient's live actor for the pool application (Task-1 closures
-                // take an explicit victim). runtimesById, not allActorsById: the focus is 'attacker'.
-                const recipientActor = runtimesById.get(rid)?.actor;
+                // take an explicit victim). Runtime maps, not allActorsById: the focus is 'attacker'.
+                const recipientActor = allRuntimesById.get(rid)?.actor;
                 if (e.kind === 'heal') {
                     healingCtx.credit(sourceId, 'directHeal', raw);
                     if (recipientActor) {
@@ -3597,7 +3622,7 @@ export function runCombat(input: CombatEngineInput): {
         if (outcome.barriered) return;
         const entries = takenLeechesByOwner.get(victim.id);
         if (!entries) return;
-        const rt = runtimesById.get(victim.id);
+        const rt = allRuntimesById.get(victim.id);
         for (const e of entries) {
             // requiresHpDamage gate (per victim): shield present at hit start AND HP damage dealt.
             if (e.requiresHpDamage && !(outcome.shieldBefore > 0 && outcome.hpDamage > 0)) {
@@ -7797,8 +7822,13 @@ export function runCombat(input: CombatEngineInput): {
                                         deferredAbilityPerformed: turn.deferredAbilityPerformed,
                                         positionalDetonation: turn.positionalDetonation,
                                     },
-                                    (_victim, damage) =>
-                                        procStandingLeechesPerVictim(actor.id, damage),
+                                    // Both leech directions — see the enemy site's note: the
+                                    // actor's damage-DEALT leech and each victim's damage-TAKEN
+                                    // leech resolve at every attack, whichever side is acting.
+                                    (victim, damage, outcome) => {
+                                        procStandingLeechesPerVictim(actor.id, damage);
+                                        procTakenLeechesPerVictim(victim, damage, outcome);
+                                    },
                                     (attackedSignals) => {
                                         if (attackedSignals.size > 0) {
                                             emitPerVictimAttacked({
@@ -8023,8 +8053,11 @@ export function runCombat(input: CombatEngineInput): {
                                         deferredAbilityPerformed: teamTurn.deferredAbilityPerformed,
                                         positionalDetonation: teamTurn.positionalDetonation,
                                     },
-                                    (_victim, damage) =>
-                                        procStandingLeechesPerVictim(actor.id, damage),
+                                    // Both leech directions — see the enemy site's note.
+                                    (victim, damage, outcome) => {
+                                        procStandingLeechesPerVictim(actor.id, damage);
+                                        procTakenLeechesPerVictim(victim, damage, outcome);
+                                    },
                                     (attackedSignals) => {
                                         if (attackedSignals.size > 0) {
                                             emitPerVictimAttacked({
@@ -8687,6 +8720,13 @@ export function runCombat(input: CombatEngineInput): {
                                         },
                                         (victim, dmg, outcome) => {
                                             procTakenLeechesPerVictim(victim, dmg, outcome);
+                                            // Both leech directions resolve at every attack: the
+                                            // victim's damage-TAKEN leech above, and the actor's
+                                            // own damage-DEALT leech here. This site used to proc
+                                            // only the first and the player→enemy sites only the
+                                            // second, so each side could run just one of its two
+                                            // passive leeches.
+                                            procStandingLeechesPerVictim(actor.id, dmg);
                                             if (victim.id === tgt.id) {
                                                 positionalShieldCaptured = true;
                                                 positionalShieldWasHit =

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -3652,6 +3652,29 @@ export function runCombat(input: CombatEngineInput): {
         }
     };
 
+    // BOTH leech directions for one resolved victim, in one place. Every positional attack pays
+    // out two independent passives: the ACTOR's damage-dealt standing leech and the VICTIM's
+    // damage-taken leech. All three attack sites (focus / walked team / enemy) call exactly this.
+    //
+    // Deliberately a single helper rather than the two calls hand-written per site: writing them
+    // out three times is the very shape that produced the bugs this seam fixes — the enemy site
+    // procced only the taken direction and the two player sites only the standing one, so each
+    // side ran just one of its two passive leeches. Duplicated call pairs drift; a single one
+    // cannot.
+    //
+    // The two procs act on DISJOINT actors (an actor is never its own victim) and accumulate
+    // additively into per-actor maps, so their relative order is not observable — it is fixed
+    // here only so no site has to think about it.
+    const procLeechesForVictim = (
+        actorId: string,
+        victim: CombatActor,
+        damage: number,
+        outcome: VictimDamageOutcome
+    ): void => {
+        procStandingLeechesPerVictim(actorId, damage);
+        procTakenLeechesPerVictim(victim, damage, outcome);
+    };
+
     // C2b-2 T5: the id of the actor whose turn is CURRENTLY executing. Set once at the top of
     // each actor's turn (after the dead-actor skips, before any damage is applied), so the
     // DIRECT-damage wrappers can stamp the lethal attacker onto ship-destroyed (Faust reads it
@@ -7822,13 +7845,8 @@ export function runCombat(input: CombatEngineInput): {
                                         deferredAbilityPerformed: turn.deferredAbilityPerformed,
                                         positionalDetonation: turn.positionalDetonation,
                                     },
-                                    // Both leech directions — see the enemy site's note: the
-                                    // actor's damage-DEALT leech and each victim's damage-TAKEN
-                                    // leech resolve at every attack, whichever side is acting.
-                                    (victim, damage, outcome) => {
-                                        procStandingLeechesPerVictim(actor.id, damage);
-                                        procTakenLeechesPerVictim(victim, damage, outcome);
-                                    },
+                                    (victim, damage, outcome) =>
+                                        procLeechesForVictim(actor.id, victim, damage, outcome),
                                     (attackedSignals) => {
                                         if (attackedSignals.size > 0) {
                                             emitPerVictimAttacked({
@@ -8053,11 +8071,8 @@ export function runCombat(input: CombatEngineInput): {
                                         deferredAbilityPerformed: teamTurn.deferredAbilityPerformed,
                                         positionalDetonation: teamTurn.positionalDetonation,
                                     },
-                                    // Both leech directions — see the enemy site's note.
-                                    (victim, damage, outcome) => {
-                                        procStandingLeechesPerVictim(actor.id, damage);
-                                        procTakenLeechesPerVictim(victim, damage, outcome);
-                                    },
+                                    (victim, damage, outcome) =>
+                                        procLeechesForVictim(actor.id, victim, damage, outcome),
                                     (attackedSignals) => {
                                         if (attackedSignals.size > 0) {
                                             emitPerVictimAttacked({
@@ -8719,14 +8734,7 @@ export function runCombat(input: CombatEngineInput): {
                                             positionalDetonation: enemyPositionalDetonation,
                                         },
                                         (victim, dmg, outcome) => {
-                                            procTakenLeechesPerVictim(victim, dmg, outcome);
-                                            // Both leech directions resolve at every attack: the
-                                            // victim's damage-TAKEN leech above, and the actor's
-                                            // own damage-DEALT leech here. This site used to proc
-                                            // only the first and the player→enemy sites only the
-                                            // second, so each side could run just one of its two
-                                            // passive leeches.
-                                            procStandingLeechesPerVictim(actor.id, dmg);
+                                            procLeechesForVictim(actor.id, victim, dmg, outcome);
                                             if (victim.id === tgt.id) {
                                                 positionalShieldCaptured = true;
                                                 positionalShieldWasHit =

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -3075,13 +3075,19 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
             if (c.basis === 'damage-taken') return true;
             return c.basis === 'damage-dealt' && fromPassive;
         };
-        // Event-only mode (enemy walk, Task 5): the enemy path now performs the SAME real effects
-        // as the player path — heals restore each recipient's OWN currentHp (E5 §4.1), shields
-        // grant real pools (#166), and cleanse removes real debuffs (this lift) — via the
-        // side-agnostic helpers over recipientsFor; it only credits NO player healing/metric bucket
-        // and never mutates the player heal-target. Scope to the CAST skill only (the spec: "the
-        // cast skill carries"), never the passive. Normal (player/team) mode keeps both slots and
-        // credits/mutates as before.
+        // Event-only mode (enemy walk, Task 5): the enemy path performs the SAME real effects as
+        // the player path — heals restore each recipient's OWN currentHp (E5 §4.1), shields grant
+        // real pools (#166), and cleanse removes real debuffs (#167) — via the side-agnostic
+        // helpers over recipientsFor; it only credits NO player healing/metric bucket and never
+        // mutates the player heal-target.
+        //
+        // It used to scope to the CAST skill alone ("the cast skill carries"), dropping the
+        // passive slot entirely, so no enemy ever fired a passive-slot repair or shield. That is
+        // not the game rule: a ship fires its passives whenever their conditions are met, on
+        // either side of the board (user-confirmed 2026-08-07). Both modes now build the same
+        // list; healEventOnly continues to govern CREDIT, not which abilities run. The passive
+        // entries carry the same `isHookOwned(a, true)` filter as normal mode, so a leech-basis
+        // passive still belongs to its engine hook and cannot double-count here.
         // Epic PR4: pre-combat abilities ("At the start of combat, this Unit gains a Shield …" —
         // Crucialis/FrontLine) are one-time pre-fight grants seeded ONCE by the engine
         // (seedPreCombatShields, r === 1); processing them here would re-grant the pool on every
@@ -3091,18 +3097,14 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         // Each entry carries the slot it came from: `recipientsFor` needs it to decide whether
         // the firing skill's support footprint applies (cast: always; passive: only when the
         // ability is `patternScoped`). See `scopedByFootprint`.
-        const healAbilities: { ability: Ability; fromPassive: boolean }[] = healEventOnly
-            ? (gatedSkill?.abilities ?? [])
-                  .filter((a) => !isHookOwned(a, false) && notPreCombat(a))
-                  .map((ability) => ({ ability, fromPassive: false }))
-            : [
-                  ...(gatedSkill?.abilities ?? [])
-                      .filter((a) => !isHookOwned(a, false) && notPreCombat(a))
-                      .map((ability) => ({ ability, fromPassive: false })),
-                  ...(gatedPassive?.abilities ?? [])
-                      .filter((a) => !isHookOwned(a, true) && notPreCombat(a))
-                      .map((ability) => ({ ability, fromPassive: true })),
-              ];
+        const healAbilities: { ability: Ability; fromPassive: boolean }[] = [
+            ...(gatedSkill?.abilities ?? [])
+                .filter((a) => !isHookOwned(a, false) && notPreCombat(a))
+                .map((ability) => ({ ability, fromPassive: false })),
+            ...(gatedPassive?.abilities ?? [])
+                .filter((a) => !isHookOwned(a, true) && notPreCombat(a))
+                .map((ability) => ({ ability, fromPassive: true })),
+        ];
         const healTargets: string[] = [];
         let healCritCount = 0;
         let healRawSum = 0;


### PR DESCRIPTION
A ship fires its passives whenever their conditions are met, on either side of the board (user-confirmed game rule, 2026-08-07). The engine agreed for the cast slots but not the passive slot, via **three independent drops**, all enemy-side only.

Found by `npm run audit:placement-symmetry` — the coverage hole it exists to expose. The 147-ship real-kit fingerprint suite places every subject at the player focus, so it never exercises the enemy actor path.

## The three drops

| # | Mechanism | Corpus ships |
|---|---|---|
| 1 | `healEventOnly` (the enemy turn binding) built its heal-ability list from the CAST skill alone, where normal mode concatenates the passive slot — so no enemy ever fired a passive repair or shield | Volk |
| 2 | `takenLeechesByOwner` ("gain a Shield when damaged") was built from the player runtimes only, **and** its per-victim proc was wired only at the enemy→player attack site | Malvex, Quixilver |
| 3 | `standingLeeches` ("gain a Shield from damage dealt") mirrored both halves: player-only map, proc wired only at the player→enemy sites | FrontLine, Magnolia, Valerian, Valkyrie |

Drop 1 was documented as deliberate ("Scope to the CAST skill only"), dating from the E5 heal-lift when passive-slot heals were not yet modelled. The flag now governs **credit**, not which abilities run; passive entries keep the same `isHookOwned` filter as normal mode, so a leech-basis passive still belongs to its engine hook and cannot double-count.

Drops 2 and 3 are the **hand-enumerated-layer class**: of the eight sibling per-owner ability maps built in one block of `engine.ts`, six already swept both runtime collections and these two did not. Both leech directions now resolve at every attack whichever side is acting — no double-proc risk, since at each site the actor and its victims are on fixed opposite sides.

## Judgment call worth a look

An enemy owner with an `ally`-target leech now resolves to **no recipient** rather than repairing a player. No corpus ship reaches that branch — every passive leech surviving the reactive partition targets `self` (Valkyrie's `ally` one is `on-bomb-detonated`, so it is reactive and never enters the map). I chose the no-op, which preserves the exact prior behaviour for the unreachable case, over inventing an enemy-side designated-recipient rule.

## Verification

- **New test file, written RED first.** All 3 enemy cases failed with `expected 0 to be greater than 0` while 3 same-kit player controls passed, so each fix is pinned against a working control. 4 harness-sanity tests assert the subject actually deals and takes damage in both placements (#298 fixture-vacuity class).
- Full suite **473 files / 5391 tests** green; `tsc --noEmit` and `lint` clean.
- **Oracle at 15 seeds: 6 findings → 2**, symmetric ships 139 → 146, and the enemy path's distinct-kind count **12 → 13**, matching focus and team for the first time. The 2 remaining are the known Enforcer `debuff-resisted` landing-RNG noise, pointing the opposite way.

Zero golden churn — expected rather than reassuring here, since the goldens are synthetic and the real-kit suite is focus-only. The oracle re-run is the regression signal, not `npm test`.

## Unrelated rider

The placement-symmetry calibration test gets an explicit 30s timeout. It is the suite's most expensive single test and was flaking on vitest's 5s default under full-suite worker contention, which this PR's new integration file makes marginally more likely. Measured identical before/after this change (694/626ms clean vs 704/655ms with it), so this is a budget fix, not masking a slowdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6or8HzPQ6Ydx1bAB9rGHz