### PR TITLE
feat(sim): the sub-attack as a first-class concept (multi-hit epic PR1)

### DIFF
--- a/src/utils/combat/__tests__/positionalApplyPerVictimCrit.test.ts
+++ b/src/utils/combat/__tests__/positionalApplyPerVictimCrit.test.ts
@@ -172,7 +172,20 @@ describe('applyPositionalDamage — rollVictimCrit callback (per-victim crit sea
             rollVictimCrit: (v) => v.id === 'covered', // only covered crits
         });
 
-        expect(result).toEqual({ anyCrit: true, critPairs: 1, critVictimIds: ['covered'] });
+        expect(result).toEqual({
+            anyCrit: true,
+            critPairs: 1,
+            critVictimIds: ['covered'],
+            subAttacks: [
+                {
+                    index: 0,
+                    whiffed: false,
+                    didCrit: true,
+                    damage: expect.any(Number),
+                    victimIds: ['origin', 'covered'],
+                },
+            ],
+        });
     });
 
     /**
@@ -201,7 +214,20 @@ describe('applyPositionalDamage — rollVictimCrit callback (per-victim crit sea
             // No rollVictimCrit → fallback to hitCrits[h]=false → nobody crits
         });
 
-        expect(result).toEqual({ anyCrit: false, critPairs: 0, critVictimIds: [] });
+        expect(result).toEqual({
+            anyCrit: false,
+            critPairs: 0,
+            critVictimIds: [],
+            subAttacks: [
+                {
+                    index: 0,
+                    whiffed: false,
+                    didCrit: false,
+                    damage: expect.any(Number),
+                    victimIds: ['origin', 'covered'],
+                },
+            ],
+        });
     });
 
     /**
@@ -280,10 +306,30 @@ describe('applyPositionalDamage — rollVictimCrit callback (per-victim crit sea
         // 2 hits × 2 victims, all crit → 4 critting pairs, but only 2 DISTINCT crit victims:
         // critVictimIds de-duplicates across hits ("deals X to that enemy" is per enemy, not per
         // critting (hit, victim) pair), and lists them in first-crit order.
+        //
+        // critPairs (4) and subAttacks.length (2) are DIFFERENT numbers measuring different axes:
+        // critPairs multiplies hits × victims, whereas a sub-attack is one full-walk attack whose
+        // AoE footprint is a single spread. Do NOT "fix" either to match the other.
         expect(result).toEqual({
             anyCrit: true,
             critPairs: 4,
             critVictimIds: ['origin', 'covered'],
+            subAttacks: [
+                {
+                    index: 0,
+                    whiffed: false,
+                    didCrit: true,
+                    damage: expect.any(Number),
+                    victimIds: ['origin', 'covered'],
+                },
+                {
+                    index: 1,
+                    whiffed: false,
+                    didCrit: true,
+                    damage: expect.any(Number),
+                    victimIds: ['origin', 'covered'],
+                },
+            ],
         });
     });
 });

--- a/src/utils/combat/__tests__/positionalApplySubAttack.test.ts
+++ b/src/utils/combat/__tests__/positionalApplySubAttack.test.ts
@@ -140,3 +140,95 @@ describe('applyPositionalDamage — SubAttackOutcome', () => {
         });
     });
 });
+
+describe('applyPositionalDamage — subAttackIndex threading', () => {
+    it('every per-victim callback receives the index of its sub-attack', () => {
+        const applyIdx: number[] = [];
+        const emitIdx: number[] = [];
+        const resolvedIdx: number[] = [];
+        const reductionIdx: number[] = [];
+        const ampIdx: number[] = [];
+
+        applyPositionalDamage({
+            hitCrits: [false, false, false],
+            scalars: scalars(3),
+            pattern: parsePattern('Pattern-Base'),
+            actorPosition: 'M2',
+            target: parseTarget('front'),
+            opposingLiving: [actor('front', 'M4')],
+            defenseProfileOf: profile,
+            applyToVictim: (victim, damage, _isAnchor, subAttackIndex) => {
+                applyIdx.push(subAttackIndex as number);
+                return bookingApply(victim, damage);
+            },
+            emitHit: (_v, _d, _c, subAttackIndex) => {
+                emitIdx.push(subAttackIndex as number);
+            },
+            onVictimResolved: (_v, _d, _o, _c, subAttackIndex) => {
+                resolvedIdx.push(subAttackIndex as number);
+            },
+            incomingReductionFor: (_v, _c, subAttackIndex) => {
+                reductionIdx.push(subAttackIndex as number);
+                return 0;
+            },
+            outgoingAmplificationFor: (_v, _c, subAttackIndex) => {
+                ampIdx.push(subAttackIndex as number);
+                return 0;
+            },
+        });
+
+        expect(applyIdx).toEqual([0, 1, 2]);
+        expect(emitIdx).toEqual([0, 1, 2]);
+        expect(resolvedIdx).toEqual([0, 1, 2]);
+        expect(reductionIdx).toEqual([0, 1, 2]);
+        expect(ampIdx).toEqual([0, 1, 2]);
+    });
+
+    it('an AoE sub-attack passes the SAME index to every footprint victim', () => {
+        const seen: Array<{ id: string; idx: number }> = [];
+
+        applyPositionalDamage({
+            hitCrits: [false, false],
+            scalars: scalars(2),
+            pattern: parsePattern('Pattern-Line-Range-1'),
+            actorPosition: 'M2',
+            target: parseTarget('front'),
+            opposingLiving: [actor('origin', 'M4'), actor('covered', 'M3')],
+            defenseProfileOf: profile,
+            applyToVictim: (victim, damage, _isAnchor, subAttackIndex) => {
+                seen.push({ id: victim.id, idx: subAttackIndex as number });
+                return bookingApply(victim, damage);
+            },
+        });
+
+        // Two sub-attacks x two footprint victims. Both victims of sub-attack 0 see index 0.
+        expect(seen).toEqual([
+            { id: 'origin', idx: 0 },
+            { id: 'covered', idx: 0 },
+            { id: 'origin', idx: 1 },
+            { id: 'covered', idx: 1 },
+        ]);
+    });
+
+    it('rollVictimCrit receives the sub-attack index', () => {
+        const rollIdx: number[] = [];
+
+        applyPositionalDamage({
+            hitCrits: [false, false],
+            scalars: scalars(2),
+            pattern: parsePattern('Pattern-Line-Range-1'),
+            actorPosition: 'M2',
+            target: parseTarget('front'),
+            opposingLiving: [actor('origin', 'M4'), actor('covered', 'M3')],
+            defenseProfileOf: profile,
+            applyToVictim: bookingApply,
+            // Only non-anchor victims resolve via this callback.
+            rollVictimCrit: (_victim, subAttackIndex) => {
+                rollIdx.push(subAttackIndex as number);
+                return false;
+            },
+        });
+
+        expect(rollIdx).toEqual([0, 1]);
+    });
+});

--- a/src/utils/combat/__tests__/positionalApplySubAttack.test.ts
+++ b/src/utils/combat/__tests__/positionalApplySubAttack.test.ts
@@ -232,3 +232,88 @@ describe('applyPositionalDamage — subAttackIndex threading', () => {
         expect(rollIdx).toEqual([0, 1]);
     });
 });
+
+describe('applyPositionalDamage — PR1 invariants', () => {
+    it('N=1: a single-hit cast produces exactly one sub-attack whose damage is the cast total', () => {
+        const booked: number[] = [];
+
+        const result = applyPositionalDamage({
+            hitCrits: [false],
+            scalars: scalars(1),
+            pattern: parsePattern('Pattern-Line-Range-1'),
+            actorPosition: 'M2',
+            target: parseTarget('front'),
+            opposingLiving: [actor('origin', 'M4'), actor('covered', 'M3')],
+            defenseProfileOf: profile,
+            applyToVictim: bookingApply,
+            emitHit: (_v, damage) => {
+                booked.push(damage);
+            },
+        });
+
+        expect(result.subAttacks).toHaveLength(1);
+        const total = booked.reduce((s, d) => s + d, 0);
+        expect(result.subAttacks[0].damage).toBeCloseTo(total, 10);
+    });
+
+    it('the cast-level aggregates are unchanged by the sub-attack addition', () => {
+        // 2 sub-attacks x 2 footprint victims, all critting → critPairs 4, 2 distinct victims,
+        // and 2 sub-attacks each flagged didCrit. critPairs must NOT collapse to the sub-attack
+        // count, and subAttacks must NOT collapse to critPairs.
+        const result = applyPositionalDamage({
+            hitCrits: [true, true],
+            scalars: scalars(2),
+            pattern: parsePattern('Pattern-Line-Range-1'),
+            actorPosition: 'M2',
+            target: parseTarget('front'),
+            opposingLiving: [actor('origin', 'M4'), actor('covered', 'M3')],
+            defenseProfileOf: profile,
+            applyToVictim: bookingApply,
+            rollVictimCrit: () => true,
+        });
+
+        expect(result.anyCrit).toBe(true);
+        expect(result.critPairs).toBe(4);
+        expect(result.critVictimIds).toEqual(['origin', 'covered']);
+        expect(result.subAttacks).toHaveLength(2);
+        expect(result.subAttacks.map((s) => s.didCrit)).toEqual([true, true]);
+    });
+
+    it('sub-attack damage reconciles with the total booked across the whole cast', () => {
+        const booked: number[] = [];
+
+        const result = applyPositionalDamage({
+            hitCrits: [false, true, false],
+            scalars: scalars(3),
+            pattern: parsePattern('Pattern-Line-Range-1'),
+            actorPosition: 'M2',
+            target: parseTarget('front'),
+            opposingLiving: [actor('origin', 'M4'), actor('covered', 'M3')],
+            defenseProfileOf: profile,
+            applyToVictim: bookingApply,
+            emitHit: (_v, damage) => {
+                booked.push(damage);
+            },
+        });
+
+        const castTotal = booked.reduce((s, d) => s + d, 0);
+        const subTotal = result.subAttacks.reduce((s, a) => s + a.damage, 0);
+        expect(subTotal).toBeCloseTo(castTotal, 10);
+    });
+
+    it('subAttacks[h].index always equals its array position, whiffs included', () => {
+        const only = actor('only', 'M4', 1);
+        const result = applyPositionalDamage({
+            hitCrits: [false, false, false, false],
+            scalars: scalars(4),
+            pattern: parsePattern('Pattern-Base'),
+            actorPosition: 'M2',
+            target: parseTarget('front'),
+            opposingLiving: [only],
+            defenseProfileOf: profile,
+            applyToVictim: bookingApply,
+        });
+
+        result.subAttacks.forEach((s, i) => expect(s.index).toBe(i));
+    });
+});

--- a/src/utils/combat/__tests__/positionalApplySubAttack.test.ts
+++ b/src/utils/combat/__tests__/positionalApplySubAttack.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { parsePattern, parseTarget } from '../../targetingParser';
+import { applyPositionalDamage } from '../positionalApply';
+import type { AttackerDamageScalars, VictimDefenseProfile } from '../victimDamage';
+import type { CombatActor } from '../state';
+
+// CHARACTERIZATION TESTS (epic: multi-hit full-walk attacks, PR1).
+// Several assertions here pass on first run by design. Their value is failing LATER —
+// they pin the sub-attack surface that PR2-PR5 build on, and the N=1 invariant that
+// bounds the epic's blast radius. See
+// docs/superpowers/specs/2026-08-07-multi-hit-full-walk-attacks-design.md §7.
+
+const actor = (id: string, position: CombatActor['position'], currentHp = 1e9): CombatActor =>
+    ({ id, position, currentHp }) as CombatActor;
+
+const scalars = (hits: number): AttackerDamageScalars => ({
+    effectiveAttack: 1000,
+    multiplierPct: 100,
+    secondaryStatValue: 0,
+    hits,
+    effectiveCritDamage: 0,
+    outgoingDamageBuffPct: 0,
+    incomingDamageModifierPct: 0,
+    defensePenetrationPct: 0,
+    attackerAffinity: 'chemical',
+});
+
+const profile = (): VictimDefenseProfile => ({
+    defence: 0,
+    defenceModifierPct: 0,
+    affinity: 'chemical',
+});
+
+/** applyToVictim stub that books the full hit, matching the engine's real funnel. */
+const bookingApply = (victim: CombatActor, damage: number) => {
+    victim.currentHp -= damage;
+    return { shieldBefore: 0, hpDamage: damage, barriered: false, incomingBooked: damage };
+};
+
+describe('applyPositionalDamage — SubAttackOutcome', () => {
+    it('hits:3 single-target → one entry per sub-attack, indexed 0..2', () => {
+        const result = applyPositionalDamage({
+            hitCrits: [false, false, false],
+            scalars: scalars(3),
+            pattern: parsePattern('Pattern-Base'),
+            actorPosition: 'M2',
+            target: parseTarget('front'),
+            opposingLiving: [actor('front', 'M4')],
+            defenseProfileOf: profile,
+            applyToVictim: bookingApply,
+        });
+
+        expect(result.subAttacks).toHaveLength(3);
+        expect(result.subAttacks.map((s) => s.index)).toEqual([0, 1, 2]);
+        expect(result.subAttacks.every((s) => s.whiffed === false)).toBe(true);
+        expect(result.subAttacks.map((s) => s.victimIds)).toEqual([
+            ['front'],
+            ['front'],
+            ['front'],
+        ]);
+    });
+
+    it("per-sub-attack damage sums that sub-attack's booked victim damage, and the total reconciles", () => {
+        const result = applyPositionalDamage({
+            hitCrits: [false, false, false],
+            scalars: scalars(3),
+            pattern: parsePattern('Pattern-Base'),
+            actorPosition: 'M2',
+            target: parseTarget('front'),
+            opposingLiving: [actor('front', 'M4')],
+            defenseProfileOf: profile,
+            applyToVictim: bookingApply,
+        });
+
+        // Each sub-attack books a positive amount, and all three are equal (same victim,
+        // same scalars, no crits) — the fold re-split is even.
+        const [a, b, c] = result.subAttacks.map((s) => s.damage);
+        expect(a).toBeGreaterThan(0);
+        expect(b).toBeCloseTo(a, 10);
+        expect(c).toBeCloseTo(a, 10);
+    });
+
+    it('didCrit is per sub-attack, not per cast', () => {
+        const result = applyPositionalDamage({
+            hitCrits: [false, true, false],
+            scalars: scalars(3),
+            pattern: parsePattern('Pattern-Base'),
+            actorPosition: 'M2',
+            target: parseTarget('front'),
+            opposingLiving: [actor('front', 'M4')],
+            defenseProfileOf: profile,
+            applyToVictim: bookingApply,
+        });
+
+        expect(result.subAttacks.map((s) => s.didCrit)).toEqual([false, true, false]);
+        // The existing cast-level aggregates are unchanged by this addition.
+        expect(result.anyCrit).toBe(true);
+        expect(result.critPairs).toBe(1);
+    });
+
+    it('an AoE sub-attack lists every footprint victim in one entry', () => {
+        // Pattern-Line-Range-1 @ M4 → origin M4, covered M3.
+        const result = applyPositionalDamage({
+            hitCrits: [false],
+            scalars: scalars(1),
+            pattern: parsePattern('Pattern-Line-Range-1'),
+            actorPosition: 'M2',
+            target: parseTarget('front'),
+            opposingLiving: [actor('origin', 'M4'), actor('covered', 'M3')],
+            defenseProfileOf: profile,
+            applyToVictim: bookingApply,
+        });
+
+        expect(result.subAttacks).toHaveLength(1);
+        expect(result.subAttacks[0].victimIds).toEqual(['origin', 'covered']);
+    });
+
+    it('a whiffed sub-attack still produces an entry, so indices stay aligned', () => {
+        // Sole target has 1 HP and dies on sub-attack 0; sub-attacks 1-2 whiff.
+        const only = actor('only', 'M4', 1);
+        const result = applyPositionalDamage({
+            hitCrits: [false, false, false],
+            scalars: scalars(3),
+            pattern: parsePattern('Pattern-Base'),
+            actorPosition: 'M2',
+            target: parseTarget('front'),
+            opposingLiving: [only],
+            defenseProfileOf: profile,
+            applyToVictim: bookingApply,
+        });
+
+        expect(result.subAttacks).toHaveLength(3);
+        expect(result.subAttacks.map((s) => s.whiffed)).toEqual([false, true, true]);
+        expect(result.subAttacks[1]).toEqual({
+            index: 1,
+            whiffed: true,
+            didCrit: false,
+            damage: 0,
+            victimIds: [],
+        });
+    });
+});

--- a/src/utils/combat/positionalApply.ts
+++ b/src/utils/combat/positionalApply.ts
@@ -75,6 +75,37 @@ export interface VictimDamageOutcome {
  *  by a minimal stub. */
 export type AppliedVictimDamage = VictimDamageOutcome & { incomingBooked: number };
 
+/**
+ * The outcome of ONE sub-attack — one iteration of `applyPositionalDamage`'s hit loop.
+ *
+ * A multi-hit skill is N consecutive FULL-WALK attacks (locked game rule: Enforcer critting on
+ * every sub-attack inflicts N Defense Shred stacks), so the sub-attack — not the cast and not the
+ * (hit, victim) pair — is the unit that outgoing effects resolve against. Its AoE footprint is
+ * ONE attack's spread and shares a single outgoing roll.
+ *
+ * Emitted for EVERY iteration including whiffs, so `subAttacks[h]` always corresponds to loop
+ * iteration `h`.
+ *
+ * Nothing consumes this yet — PR2 turns each entry into its own `ability-performed`.
+ * See docs/superpowers/specs/2026-08-07-multi-hit-full-walk-attacks-design.md.
+ */
+export interface SubAttackOutcome {
+    /** 0-based index within the cast. Always equals this entry's position in the array. */
+    index: number;
+    /** The anchor failed to resolve — this sub-attack landed nothing (no victims, no damage). */
+    whiffed: boolean;
+    /** At least one victim of THIS sub-attack critted. */
+    didCrit: boolean;
+    /**
+     * Sum of `incomingBooked` across this sub-attack's footprint victims — the funnel's own
+     * recorded intake, the same basis `emitHit` books. NOT the computed pre-funnel hit: a
+     * Protection cascade, incoming-block proc or DoT transform alters what actually landed.
+     */
+    damage: number;
+    /** Victims struck by this sub-attack, in footprint order. */
+    victimIds: string[];
+}
+
 /** Per-cell damage scale keyed off the resolved CellRole. */
 const roleScaleFor = (role: CellRole): number => (role === 'origin' ? 1.0 : 0.5);
 
@@ -135,7 +166,10 @@ export function footprintVictims(
  *          `critVictimIds` — the DISTINCT victims that took at least one critting hit, in
  *          first-crit order. Carries the per-victim crit IDENTITY that `critPairs` (a bare
  *          count) throws away, so an `on-ally-crit` reactive can route "that enemy" to the
- *          enemies actually crit rather than the cast's selected anchor.
+ *          enemies actually crit rather than the cast's selected anchor;
+ *          `subAttacks` — one {@link SubAttackOutcome} per loop iteration, in order, including
+ *          whiffs. Carries the SUB-ATTACK identity that `critPairs` also throws away (it
+ *          multiplies hits × victims into one number). Unconsumed as of PR1.
  */
 export function applyPositionalDamage(args: {
     hitCrits: boolean[];
@@ -191,7 +225,12 @@ export function applyPositionalDamage(args: {
      * Unsupplied → every victim uses hitCrits[h] → byte-identical.
      */
     rollVictimCrit?: (victim: CombatActor) => boolean;
-}): { anyCrit: boolean; critPairs: number; critVictimIds: string[] } {
+}): {
+    anyCrit: boolean;
+    critPairs: number;
+    critVictimIds: string[];
+    subAttacks: SubAttackOutcome[];
+} {
     const {
         hitCrits,
         scalars,
@@ -215,6 +254,7 @@ export function applyPositionalDamage(args: {
     // Insertion-ordered DISTINCT crit victims. A multi-hit cast that crits the same victim twice
     // lists it once — "deals X to that enemy" is per ENEMY, not per critting (hit, victim) pair.
     const critVictims = new Set<string>();
+    const subAttacks: SubAttackOutcome[] = [];
 
     // Canonical hit count: derive the loop count from `scalars.hits` (the single source of
     // truth that victimHitDamage also reads), avoiding silent under/over-application from a
@@ -230,11 +270,22 @@ export function applyPositionalDamage(args: {
             acting
         );
         if (anchorActor === null || anchorActor.position === undefined) {
-            // WHIFF — no living target resolvable for this hit. Skip entirely.
+            // WHIFF — no living target resolvable for this sub-attack. Skip entirely, but still
+            // record an entry so `subAttacks[h]` stays aligned with the loop index.
+            subAttacks.push({
+                index: h,
+                whiffed: true,
+                didCrit: false,
+                damage: 0,
+                victimIds: [],
+            });
             continue;
         }
 
         const anchorCrit = hitCrits[h] ?? false;
+        let subDidCrit = false;
+        let subDamage = 0;
+        const subVictimIds: string[] = [];
 
         for (const { victim, roleScale } of footprintVictims(
             pattern,
@@ -248,6 +299,7 @@ export function applyPositionalDamage(args: {
                 anyCrit = true;
                 critPairs += 1;
                 critVictims.add(victim.id);
+                subDidCrit = true;
             }
             const equipReductionPct = incomingReductionFor?.(victim, didCrit) ?? 0;
             const dmgBase = victimHitDamage(
@@ -270,13 +322,20 @@ export function applyPositionalDamage(args: {
             //
             // Fallback keeps the previous shape for a caller that supplies no `incomingBooked` —
             // only test stubs of `applyToVictim`; the engine's own funnel always sets it.
-            emitHit?.(
-                victim,
-                outcome.incomingBooked ?? dmg - (outcome.transformedToDot ?? 0),
-                didCrit
-            );
+            const booked = outcome.incomingBooked ?? dmg - (outcome.transformedToDot ?? 0);
+            emitHit?.(victim, booked, didCrit);
             onVictimResolved?.(victim, dmg, outcome, didCrit);
+            subDamage += booked;
+            subVictimIds.push(victim.id);
         }
+
+        subAttacks.push({
+            index: h,
+            whiffed: false,
+            didCrit: subDidCrit,
+            damage: subDamage,
+            victimIds: subVictimIds,
+        });
     }
-    return { anyCrit, critPairs, critVictimIds: [...critVictims] };
+    return { anyCrit, critPairs, critVictimIds: [...critVictims], subAttacks };
 }

--- a/src/utils/combat/positionalApply.ts
+++ b/src/utils/combat/positionalApply.ts
@@ -183,6 +183,14 @@ export function applyPositionalDamage(args: {
     acting?: { ignoresForcedTargeting?: boolean; ignoresStealth?: boolean; provokedBy?: string };
     defenseProfileOf: (v: CombatActor) => VictimDefenseProfile;
     /**
+     * SUB-ATTACK INDEX (epic: multi-hit full-walk attacks, PR1). Every per-victim callback below
+     * takes a trailing optional `subAttackIndex` — the 0-based index of the sub-attack currently
+     * resolving. Trailing and optional so existing engine call sites compile unchanged and JS
+     * drops the extra argument, exactly as `isAnchor` was introduced. Every footprint victim of
+     * ONE sub-attack sees the SAME index: an AoE footprint is one attack's spread, whereas each
+     * multi-hit sub-attack is a separate attack.
+     */
+    /**
      * Engine wrapper — decrements the victim's currentHp (Task 8 passes applyOutgoingToEnemy)
      * and returns the resolved {@link VictimDamageOutcome} (shield-before / HP-damage / barriered).
      * Epic PR12 (A): the third param is `isAnchor` — true when this victim IS the attacker's
@@ -190,8 +198,18 @@ export function applyPositionalDamage(args: {
      * "reflects damage taken … as a PRIMARY TARGET" requirePrimaryTarget gate). Optional so
      * every pre-PR12 caller keeps compiling unchanged (JS simply drops the extra arg).
      */
-    applyToVictim: (victim: CombatActor, damage: number, isAnchor?: boolean) => VictimDamageOutcome;
-    emitHit?: (victim: CombatActor, damage: number, didCrit: boolean) => void;
+    applyToVictim: (
+        victim: CombatActor,
+        damage: number,
+        isAnchor?: boolean,
+        subAttackIndex?: number
+    ) => VictimDamageOutcome;
+    emitHit?: (
+        victim: CombatActor,
+        damage: number,
+        didCrit: boolean,
+        subAttackIndex?: number
+    ) => void;
     /**
      * OPTIONAL per-victim hook (E2 — per-victim leech). Invoked once per footprint victim AFTER
      * the hit resolves, with the resolved {@link VictimDamageOutcome}. Direction-specific leech
@@ -202,7 +220,8 @@ export function applyPositionalDamage(args: {
         victim: CombatActor,
         damage: number,
         outcome: VictimDamageOutcome,
-        didCrit: boolean
+        didCrit: boolean,
+        subAttackIndex?: number
     ) => void;
     /**
      * OPTIONAL per-sub-hit victim-side incoming %-reduction hook (D-PR3). Invoked per footprint
@@ -210,21 +229,29 @@ export function applyPositionalDamage(args: {
      * additively into the incoming term of {@link victimHitDamage}. Unsupplied → 0 → byte-identical
      * (inert for victims without an incoming-reduction ability).
      */
-    incomingReductionFor?: (victim: CombatActor, didCrit: boolean) => number;
+    incomingReductionFor?: (
+        victim: CombatActor,
+        didCrit: boolean,
+        subAttackIndex?: number
+    ) => number;
     /**
      * OPTIONAL per-hit attacker-side outgoing amplification % hook (D-PR4 — Menace/Giant Slayer).
      * Invoked per footprint victim with that victim's per-hit crit outcome; the returned percentage
      * is applied multiplicatively on the resolved hit BEFORE {@link applyToVictim}. Unsupplied → 0 →
      * byte-identical (inert for attackers without an outgoing-amplification ability).
      */
-    outgoingAmplificationFor?: (victim: CombatActor, didCrit: boolean) => number;
+    outgoingAmplificationFor?: (
+        victim: CombatActor,
+        didCrit: boolean,
+        subAttackIndex?: number
+    ) => number;
     /**
      * OPTIONAL per-victim crit resolver.
      * The anchor victim (the resolved target, `victim.id === anchorActor.id`) reuses
      * hitCrits[h]; each other footprint victim resolves via this callback.
      * Unsupplied → every victim uses hitCrits[h] → byte-identical.
      */
-    rollVictimCrit?: (victim: CombatActor) => boolean;
+    rollVictimCrit?: (victim: CombatActor, subAttackIndex?: number) => boolean;
 }): {
     anyCrit: boolean;
     critPairs: number;
@@ -294,14 +321,14 @@ export function applyPositionalDamage(args: {
         )) {
             // Anchor reuses the pre-rolled hitCrits[h]; covered victims resolve via callback.
             const isAnchor = victim.id === anchorActor.id;
-            const didCrit = isAnchor ? anchorCrit : (rollVictimCrit?.(victim) ?? anchorCrit);
+            const didCrit = isAnchor ? anchorCrit : (rollVictimCrit?.(victim, h) ?? anchorCrit);
             if (didCrit) {
                 anyCrit = true;
                 critPairs += 1;
                 critVictims.add(victim.id);
                 subDidCrit = true;
             }
-            const equipReductionPct = incomingReductionFor?.(victim, didCrit) ?? 0;
+            const equipReductionPct = incomingReductionFor?.(victim, didCrit, h) ?? 0;
             const dmgBase = victimHitDamage(
                 scalars,
                 defenseProfileOf(victim),
@@ -309,9 +336,9 @@ export function applyPositionalDamage(args: {
                 roleScale,
                 equipReductionPct
             );
-            const ampPct = outgoingAmplificationFor?.(victim, didCrit) ?? 0;
+            const ampPct = outgoingAmplificationFor?.(victim, didCrit, h) ?? 0;
             const dmg = ampPct !== 0 ? dmgBase * (1 + ampPct / 100) : dmgBase;
-            const outcome = applyToVictim(victim, dmg, isAnchor);
+            const outcome = applyToVictim(victim, dmg, isAnchor, h);
             // Credit the victim the intake the funnel actually RECORDED for it, not the hit we
             // computed. The two differ whenever the funnel altered the hit before recording it: a
             // Protection cascade diverted a chunk to an ally (booked on that ally's own row by the
@@ -323,8 +350,8 @@ export function applyPositionalDamage(args: {
             // Fallback keeps the previous shape for a caller that supplies no `incomingBooked` —
             // only test stubs of `applyToVictim`; the engine's own funnel always sets it.
             const booked = outcome.incomingBooked ?? dmg - (outcome.transformedToDot ?? 0);
-            emitHit?.(victim, booked, didCrit);
-            onVictimResolved?.(victim, dmg, outcome, didCrit);
+            emitHit?.(victim, booked, didCrit, h);
+            onVictimResolved?.(victim, dmg, outcome, didCrit, h);
             subDamage += booked;
             subVictimIds.push(victim.id);
         }


### PR DESCRIPTION
First PR of the **multi-hit full-walk attacks** epic. Pure plumbing, no behaviour change.

## Locked game rule this epic implements

A multi-hit skill is **N consecutive full-walk attacks**, not one attack applied N times. Each sub-attack independently runs the whole pipeline: target resolution, crit roll, damage, debuff landing roll, status application, and reactive emission to both sides. In-game verified — Enforcer critting on every sub-attack inflicts N Defense Shred stacks, and Cultivator's passive fires each time an enemy Enforcer sub-attacks.

Corollary: effects based on **incoming** hits resolve per hit; effects based on **outgoing** hits resolve per attack (= per sub-attack). Every attacking skill is N sub-attacks, with N=1 for all but one corpus ship.

## What PR1 does

`applyPositionalDamage` already loops `for (h = 0; h < scalars.hits; h++)`, re-resolving the anchor against the live roster each iteration — the execution was already N real attacks. What was missing is that `h` never left the loop, and `critPairs` collapsed hits x victims into a single number. PR1 fixes only that:

- `613d71ac` — `SubAttackOutcome[]` on the return: index, whiffed, didCrit, booked damage, victimIds. An entry for every iteration **including whiffs**, so `subAttacks[h]` stays index-aligned.
- `0f50ab2c` — a trailing optional `subAttackIndex` on all six per-victim callbacks, using the same mechanism `isAnchor` used, so existing engine call sites compile unchanged.
- `6da8f31f` — invariant pins: the N=1 check, and that `critPairs` still counts (hit, victim) pairs rather than collapsing into the sub-attack count.

Nothing consumes either yet. PR2 turns each entry into its own `ability-performed`.

## Verification

- Full suite **474 files / 5403 tests** green
- **Zero golden fixture changes** — the signal that matters for a PR claiming behaviour neutrality
- `tsc --noEmit` and `lint` clean (lint is a separate gate here; neither `npm test` nor husky runs it)
- `npm run audit:placement-symmetry --seeds 15` unchanged at **2 findings / 146 symmetric / 13-13-13**. This is the real regression signal — goldens are synthetic and the 147-ship real-kit suite is focus-actor-only, so a green suite alone does not demonstrate enemy- or team-path correctness.

## Notes for review

**The new tests are characterization tests** — they pass on first run by design, and their value is failing later in PR2-PR5. Called out so this doesn't read as tests written to fit the implementation.

**`whiffed: false` does not mean "landed something."** It records only that the anchor failed to resolve; a resolved anchor with an empty footprint yields `{whiffed:false, victimIds:[], damage:0}`. Currently unreachable in the damage path (all four corpus `not-self` patterns are Support patterns, and this function walks `opposingLiving`) but representable — so PR2 gates emission on `victimIds.length`, not on `whiffed`.

**One deliberate deviation from the spec:** it listed `victimHitDamage` among the functions to thread the index through. Excluded — it is a pure damage kernel with no branch that could depend on which sub-attack it is in, so the parameter would be dead weight inviting a later reader to assume it means something.

Spec and plan live in `docs/superpowers/` (gitignored, local only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6or8HzPQ6Ydx1bAB9rGHz