### PR TITLE
feat(sim): one ability-performed per sub-attack (multi-hit epic PR2)

### DIFF
--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -169,9 +169,13 @@ export type AbilityTrigger =
     // event's slot discriminator). Self-scoped: the listener matches actorId === ownerId
     // && slot === 'charged'. Used by the Spearhead implant (all-allies Attack Up grant).
     | 'on-charged-cast'
-    // Warpstrike: owner dealt direct damage on its turn. Rides the aggregate
-    // ability-performed event emitted once per damage-dealing turn (runPlayerTurn
-    // emits exactly one; positional path emits none — engine.ts ~2887).
+    // Warpstrike: owner dealt direct damage on its turn. Rides the `ability-performed` event,
+    // which since the multi-hit full-walk epic (PR2) is emitted once per SUB-ATTACK, not once per
+    // turn: a `hits: N` skill is N consecutive full-walk attacks and fires this N times. An AoE
+    // footprint is ONE attack and fires once, however many victims it covers. On the positional
+    // path runPlayerTurn emits none and the engine emits them all after its per-victim apply
+    // (`emitDeferredAbilityPerformed`); on the non-positional/DPS path runPlayerTurn still emits
+    // exactly one per turn (its per-sub-attack split is PR5).
     | 'on-deal-damage'
     | 'on-enemy-charged-cast' // Phase 4: opposing-scoped reaction to an ENEMY casting its
     // charged skill (Curator purge/Block-Buff, FrontLine damage+shield). Mirror of

--- a/src/utils/combat/__tests__/engine.events.test.ts
+++ b/src/utils/combat/__tests__/engine.events.test.ts
@@ -188,6 +188,8 @@ describe('runCombat event emission', () => {
     });
 
     it('emits one ability-performed (damage) per round with the round crit flag', () => {
+        // One event per SUB-ATTACK since the multi-hit full-walk epic (PR2); this fixture's skill
+        // is single-hit, so that is one per round and the count still matches rounds.length.
         const { events, result } = collect(baseInput());
         const performed = events.filter((e) => e.type === 'ability-performed');
         expect(performed.length).toBe(result.rounds.length);

--- a/src/utils/combat/__tests__/hermesAllyCritCharge.integration.test.ts
+++ b/src/utils/combat/__tests__/hermesAllyCritCharge.integration.test.ts
@@ -2,9 +2,16 @@
  * Hermes on-ally-crit charge gain — "per attack that crits", not "per crit".
  *
  * Hermes (docs/ship-skills.csv, first passive, verbatim): "When an ally critically hits an
- * enemy, this Unit gains 1 charge to its Charged Skill." The intended rule is ONE charge per
- * ally ATTACK that lands a crit — a single AoE (or multi-hit) attack that crits several victims
- * must grant exactly 1 charge, not one per critting (hit, victim) pair.
+ * enemy, this Unit gains 1 charge to its Charged Skill." The rule is ONE charge per ally ATTACK
+ * that lands a crit, never one per critting (hit, victim) pair — so an AoE footprint that crits
+ * several victims grants exactly 1.
+ *
+ * "ATTACK" means SUB-ATTACK. A `hits: N` skill is N consecutive FULL-WALK attacks (locked game
+ * rule) emitting N `ability-performed` events, so it grants N charges. Both halves are asserted
+ * below, and they are what discriminate the two mechanisms: the per-attack collapse lives in the
+ * `on-ally-crit` LISTENER (at most one enqueue per event) and is what fixes the original bug,
+ * while the executor's `oncePerAttackGuardKey` — which used to hold self riders at one per actor
+ * TURN — no longer covers this trigger.
  *
  * The ability is extracted through the REAL production path (buildShipAbilities on verbatim CSV
  * skill text), never a hand-built ability.
@@ -134,9 +141,10 @@ const hermesObserver = (position: Position): TeamActorEngineInput =>
         },
     }) as TeamActorEngineInput;
 
-/** The main focus is an ally that lands a 3-hit crit (all hits crit -> critPairs === 3) on a
- *  single enemy. Hermes, its ally, should gain exactly ONE charge from that single attack. */
-function runHermes() {
+/** The focus ally crits, and Hermes counts the ATTACKS. Two shapes are driven through the same
+ *  input: `hits: 3` on one enemy (three consecutive full-walk attacks → three charges) and a
+ *  single-hit whole-roster AoE critting two victims (ONE attack → one charge). */
+function runHermes(opts: { hits: number; pattern: ParsedPattern; enemies: EnemyAttacker[] }) {
     const input: CombatEngineInput = {
         attack: 1000,
         crit: 100, // every hit crits
@@ -154,7 +162,11 @@ function runHermes() {
                             target: 'enemy',
                             trigger: 'on-cast',
                             conditions: [],
-                            config: { type: 'damage', multiplier: 100, hits: 3 },
+                            config: {
+                                type: 'damage',
+                                multiplier: 100,
+                                ...(opts.hits > 1 ? { hits: opts.hits } : {}),
+                            },
                         },
                     ],
                 },
@@ -178,25 +190,56 @@ function runHermes() {
         healTargetId: 'hermes',
         position: 'M1',
         target: parsedTarget('front'),
-        pattern: basePattern(),
+        pattern: opts.pattern,
         teamActors: [hermesObserver('M3')],
-        enemyAttackers: [dummyEnemy('enemy-a', 'M4')],
+        enemyAttackers: opts.enemies,
     };
 
     const bus = createEventBus();
     const chargeGains: Extract<CombatEvent, { type: 'charge-changed' }>[] = [];
+    const perf: Extract<CombatEvent, { type: 'ability-performed' }>[] = [];
+    bus.on('ability-performed', (e) => {
+        if (e.actorId === 'attacker') perf.push(e);
+    });
     bus.on('charge-changed', (e) => {
         if (e.actorId === 'hermes' && e.reason === 'manip') chargeGains.push(e);
     });
     runCombat({ ...input, bus });
-    return { chargeGains };
+    return {
+        totalGained: chargeGains.reduce((s, e) => s + (e.newCharge - e.oldCharge), 0),
+        perf,
+    };
 }
 
 describe('Hermes on-ally-crit charge — one charge per attack that crits, not per crit', () => {
-    it('a single 3-hit attack that crits grants Hermes exactly one charge', () => {
-        const { chargeGains } = runHermes();
-        // Pre-fix: 3 (one per critting hit). Post-fix: 1 (one per attack that crits).
-        const totalGained = chargeGains.reduce((s, e) => s + (e.newCharge - e.oldCharge), 0);
+    it('a hits:3 attack that crits every sub-attack grants Hermes three charges', () => {
+        const { totalGained, perf } = runHermes({
+            hits: 3,
+            pattern: basePattern(),
+            enemies: [dummyEnemy('enemy-a', 'M4')],
+        });
+        // Fixture self-check: three attacks, one critting victim each.
+        expect(perf).toHaveLength(3);
+        expect(perf.map((e) => e.critHits)).toEqual([1, 1, 1]);
+        // `hits: 3` is THREE consecutive full-walk attacks (locked game rule), each emitting its
+        // own `ability-performed`, so "one charge per attack that crits" is three charges. This
+        // read 1 while `on-ally-crit` sat in PER_HIT_REACTIVE_TRIGGERS and the executor collapsed
+        // self riders per actor TURN — a user-approved behaviour change, not the per-crit bug.
+        expect(totalGained).toBe(3);
+    });
+
+    it('a single-hit AoE critting TWO victims still grants exactly one charge', () => {
+        const { totalGained, perf } = runHermes({
+            hits: 1,
+            pattern: { raw: 'all', shape: 'all', range: 'all', modifiers: {} } as ParsedPattern,
+            enemies: [dummyEnemy('enemy-a', 'M4'), dummyEnemy('enemy-b', 'M3')],
+        });
+        // Fixture self-check: ONE attack, TWO critting (hit, victim) pairs — the axis under test.
+        expect(perf).toHaveLength(1);
+        expect(perf[0].critHits).toBe(2);
+        // THE original bug, which must stay fixed: pre-fix this read 2 (one per critting pair).
+        // The collapse lives in the listener (at most one enqueue per `ability-performed`), NOT in
+        // the executor's per-turn guard, so it survives the behaviour change above.
         expect(totalGained).toBe(1);
     });
 });

--- a/src/utils/combat/__tests__/hermesOncePerAttack.integration.test.ts
+++ b/src/utils/combat/__tests__/hermesOncePerAttack.integration.test.ts
@@ -1,24 +1,35 @@
 /**
- * Task 5 — reactive SELF-scoped riders fire ONCE PER ATTACK, not per hit / per AoE victim.
+ * Reactive SELF-scoped riders on `on-ally-crit` fire ONCE PER ATTACK — never per hit and never
+ * per AoE victim — where "attack" means SUB-ATTACK.
  *
  * User-reported bug: Hermes's reactive passive over-triggers against AoE / multi-hit attacks —
- * the combat log shows "Everliving Regeneration III" 2–4× for a single incoming attack, while the
- * charge gain nets exactly +1.
+ * the combat log shows "Everliving Regeneration III" 2–4× for a single attack, while the charge
+ * gain nets exactly +1.
  *
- * ROOT CAUSE (verified in triggers.ts, `case 'on-ally-crit'`, ~lines 519-542):
+ * ROOT CAUSE (verified in triggers.ts, `case 'on-ally-crit'`):
  *   Hermes's charge AND Everliving Regeneration III are BOTH self-target riders on the
- *   `on-ally-crit` trigger (parsed from the R4 passive — see the mutation guard below). When an
- *   ally lands a multi-hit / AoE crit, the engine emits ONE `ability-performed` carrying
- *   `critHits = N`. The listener enqueues the rider `n` times where
+ *   `on-ally-crit` trigger (parsed from the R4 passive — see the mutation guard below). The
+ *   listener used to enqueue the rider `n` times per `ability-performed`, where
  *       n = config.type === 'charge' ? (didCrit ? 1 : 0) : (critHits ?? (didCrit ? 1 : 0))
- *   so the CHARGE is already collapsed to 1 (explicit special-case), but the BUFF uses `critHits`
- *   → the Everliving intent is enqueued N times → the buff re-applies N× to Hermes. THAT is why
- *   the two diverge: the charge has a hand-rolled once-per-attack collapse; the buff does not.
+ *   so the CHARGE was collapsed to 1 by an explicit special-case but the BUFF fanned out on
+ *   `critHits` — hits × victims — and re-applied that many times. THAT is why the two diverged.
  *
- * The other on-ally-crit riders (Sentinel's reactive DAMAGE → 'enemy', Sentinel/Howler's heal /
- * cleanse / Blast → 'ally', routed per-victim via damagedAllyId) LEGITIMATELY fire once per
- * critting hit. So the fix collapses ONLY self-target buff/heal/charge riders, keyed
- * `${ownerId}:${abilityId}`, cleared at each actor turn-start (mirroring `counterFiredThisTurn`).
+ * THE FIX, and where it lives now. The collapse is in the LISTENER: it enqueues AT MOST ONCE per
+ * `ability-performed`, for self- and ally-routed riders alike. So the two over-fire axes are shut
+ * off structurally — a 3-victim AoE crit is one event and grants once, and there is no
+ * `critHits` loop left to multiply anything.
+ *
+ * WHAT IS NOT COLLAPSED, by decision. A `hits: N` skill is N consecutive FULL-WALK attacks
+ * (locked game rule) and since PR2 of the multi-hit epic it emits N `ability-performed` events.
+ * Hermes therefore gains 3 charges and 3 Everliving applications from a 3-sub-attack ally crit —
+ * one per critting sub-attack. This is a USER-APPROVED behaviour change; previously the executor's
+ * `oncePerAttackGuardKey` (cleared per actor TURN) held it at 1, and `on-ally-crit` has been
+ * removed from `PER_HIT_REACTIVE_TRIGGERS` so it no longer does. The guard is untouched and still
+ * load-bearing for `on-attacked` / `on-ally-attacked`, which genuinely fan ONE attack into many
+ * events.
+ *
+ * The two axes are independent and both are pinned below: per-sub-attack fan-out (3) and
+ * per-AoE-victim collapse (1).
  *
  * Everything is extracted through the REAL production path (buildShipAbilities on verbatim CSV
  * skill text, driven through runCombat) — never a hand-built self-rider.
@@ -159,9 +170,9 @@ const hermesObserver = (position: Position): TeamActorEngineInput =>
         },
     }) as TeamActorEngineInput;
 
-/** The focus ally lands a 3-hit crit (all hits crit → critHits === 3) on a single enemy in ONE
- *  attack. Hermes, its ally, should apply Everliving Regeneration III EXACTLY once and gain
- *  EXACTLY one charge from that single attack. */
+/** The focus ally fires `hits: 3` at a single enemy, critting on every sub-attack. That is THREE
+ *  consecutive full-walk attacks, so Hermes applies Everliving Regeneration III three times and
+ *  gains three charges — once per critting sub-attack. */
 function runHermes() {
     const input: CombatEngineInput = {
         attack: 1000,
@@ -223,12 +234,113 @@ function runHermes() {
     return { everlivingApplications: everliving.length, chargeGained };
 }
 
-describe('Hermes Everliving Regeneration — once per attack, not per hit/victim', () => {
-    it('a single 3-hit crit applies Everliving once and grants exactly one charge', () => {
+describe('Hermes Everliving Regeneration — once per SUB-ATTACK, not per hit/victim', () => {
+    it('a hits:3 ally crit applies Everliving three times and grants three charges', () => {
         const { everlivingApplications, chargeGained } = runHermes();
-        // Pre-fix: Everliving 3× (one per critting hit). Post-fix: 1× (one per attack that crits).
+        // `hits: 3` is THREE full-walk attacks, each with its own critting `ability-performed`.
+        // History of this number: 3 (the original per-critHits over-fire bug) → 1 (the listener
+        // collapse PLUS the executor's per-TURN guard) → 3 again, but for a DIFFERENT and correct
+        // reason — three attacks, one grant each. The AoE case below is what discriminates the two
+        // 3s: under the old bug it read 2, and it must now read 1.
+        expect(everlivingApplications).toBe(3);
+        // The charge rides the same trigger and now tracks the buff exactly. Previously the
+        // listener's hand-rolled special-case held it at +1 while the buff over-fired; that
+        // divergence is gone.
+        expect(chargeGained).toBe(3);
+    });
+});
+
+/**
+ * THE OTHER AXIS — the user-reported bug itself, which must STAY fixed.
+ *
+ * ONE single-hit attack whose AoE footprint crits TWO victims. That is one attack, so Hermes gets
+ * ONE Everliving application and ONE charge, however many footprint victims crit. Pre-fix this
+ * read 2 (the `critHits`-driven enqueue loop); it is structurally impossible now because the
+ * listener enqueues at most once per `ability-performed`, and it is deliberately NOT protected by
+ * `oncePerAttackGuardKey` any more — so this test is the only thing standing between the codebase
+ * and a regression of the original report.
+ */
+function runHermesAoe() {
+    const observer = hermesObserver('M3');
+    const input: CombatEngineInput = {
+        attack: 1000,
+        crit: 100, // every footprint victim crits
+        critDamage: 100,
+        defensePenetration: 0,
+        chargeCount: 0,
+        shipSkills: {
+            slots: [
+                {
+                    slot: 'active',
+                    abilities: [
+                        {
+                            id: 'single-hit-aoe',
+                            type: 'damage',
+                            target: 'enemy',
+                            trigger: 'on-cast',
+                            conditions: [],
+                            // hits: 1 — ONE attack. The spread comes from the pattern below.
+                            config: { type: 'damage', multiplier: 100 },
+                        },
+                    ],
+                },
+            ],
+        },
+        enemyDefense: 0,
+        enemyHp: 1_000_000_000,
+        numRounds: 1,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        selfDotModifier: 0,
+        defensePenetrationBuff: 0,
+        hasChargedSkill: false,
+        startCharged: false,
+        affinityDamageModifier: 0,
+        affinityCritCap: 100,
+        affinityCritPenalty: 0,
+        defence: 0,
+        hp: 1_000_000_000,
+        speed: 500,
+        healTargetId: 'hermes',
+        position: 'M1',
+        target: parsedTarget('front'),
+        // Whole-roster footprint: one attack, two victims, both critting.
+        pattern: { raw: 'all', shape: 'all', range: 'all', modifiers: {} } as ParsedPattern,
+        teamActors: [observer],
+        enemyAttackers: [dummyEnemy('enemy-a', 'M4'), dummyEnemy('enemy-b', 'M3')],
+    };
+
+    const bus = createEventBus();
+    const everliving: Extract<CombatEvent, { type: 'buff-applied' }>[] = [];
+    const chargeGains: Extract<CombatEvent, { type: 'charge-changed' }>[] = [];
+    const perf: Extract<CombatEvent, { type: 'ability-performed' }>[] = [];
+    bus.on('ability-performed', (e) => {
+        if (e.actorId === 'attacker') perf.push(e);
+    });
+    bus.on('buff-applied', (e) => {
+        if (e.actorId === 'hermes' && /Everliving/.test(e.buffName)) everliving.push(e);
+    });
+    bus.on('charge-changed', (e) => {
+        if (e.actorId === 'hermes' && e.reason === 'manip') chargeGains.push(e);
+    });
+    runCombat({ ...input, bus });
+    return {
+        everlivingApplications: everliving.length,
+        chargeGained: chargeGains.reduce((s, e) => s + (e.newCharge - e.oldCharge), 0),
+        perf,
+    };
+}
+
+describe('Hermes Everliving Regeneration — an AoE footprint is still ONE attack', () => {
+    it('a single-hit crit across TWO victims applies Everliving once and grants one charge', () => {
+        const { everlivingApplications, chargeGained, perf } = runHermesAoe();
+        // Fixture self-check: the fan-out axis under test must actually exist. ONE attack, TWO
+        // critting victims — without this the assertions below would be vacuously satisfied.
+        expect(perf).toHaveLength(1);
+        expect(perf[0].critHits).toBe(2);
+
+        // THE user-reported bug. Pre-fix: 2 (one per critting victim). Must stay 1.
         expect(everlivingApplications).toBe(1);
-        // Charge was already collapsed to +1 by the listener special-case; must stay +1.
         expect(chargeGained).toBe(1);
     });
 });

--- a/src/utils/combat/__tests__/hermesOncePerAttack.integration.test.ts
+++ b/src/utils/combat/__tests__/hermesOncePerAttack.integration.test.ts
@@ -235,14 +235,20 @@ describe('Hermes Everliving Regeneration — once per attack, not per hit/victim
 
 /**
  * Regression lock — an ALLY-target rider on on-ally-crit (the shape of Howler's Blast grant /
- * Sentinel's ally repair) also fires exactly ONCE per critting attack.
+ * Sentinel's ally repair) fires exactly ONCE PER CRITTING ATTACK.
  *
- * This used to fire 3× for a 3-hit crit: the once-per-attack collapse lived in the executor and
- * was deliberately narrowed to `target: 'self'`, so ally-routed riders kept re-applying per
- * critting hit. That produced the user-reported "Sentinel heals → Ruiner: 1,152" twice for ONE
- * Ruiner AoE. The collapse now lives in the LISTENER and covers the whole on-ally-crit trigger:
- * "when an ally critically hits an enemy, this Unit <does X>" is one reaction per attack, whatever
- * X targets. Per-ENEMY fan-out for "…to that enemy" riders happens inside the damage executor via
+ * The unit of "attack" changed in the multi-hit full-walk epic (PR2): a `hits: N` skill is N
+ * consecutive full-walk attacks, so it emits N `ability-performed` events and this rider fires
+ * N times — once per critting sub-attack. That is the epic's approved decision ("an ally crits on
+ * 2 of 3 sub-attacks → fires twice"), and it is NOT the bug this file locks.
+ *
+ * The bug this file locks is per-HIT and per-VICTIM over-firing WITHIN one attack: the
+ * once-per-attack collapse used to live in the executor and was narrowed to `target: 'self'`, so
+ * ally-routed riders re-applied per critting (hit, victim) pair. That produced the user-reported
+ * "Sentinel heals → Ruiner: 1,152" twice for ONE Ruiner AoE. The collapse now lives in the
+ * LISTENER, which enqueues at most once per `ability-performed`: an AoE footprint is ONE attack
+ * and still grants ONCE however many victims crit (the `critHits`-driven fan-out is gone).
+ * Per-ENEMY fan-out for "…to that enemy" riders happens inside the damage executor via
  * eventCtx.critVictimIds, not by re-enqueuing.
  *
  * The executor's self-target guard is untouched and still load-bearing for the other per-hit
@@ -330,8 +336,11 @@ function runAllyTargetRider() {
 }
 
 describe('ally-target on-ally-crit rider — once per attack', () => {
-    it('an ally-target buff fires once for a 3-hit critting attack, not three times', () => {
-        // The crediting ally landed 3 critting hits in ONE attack → one ally-routed grant.
-        expect(runAllyTargetRider()).toBe(1);
+    it('an ally-target buff fires once per critting SUB-ATTACK of a 3-hit attack', () => {
+        // PR2 (multi-hit full-walk): `hits: 3` is THREE consecutive full-walk attacks, each with
+        // its own `ability-performed`, so the ally-routed grant lands three times — once per
+        // critting sub-attack, never per (hit, victim) pair. Pre-PR2 this read 1, because the
+        // engine collapsed the whole cast into a single event.
+        expect(runAllyTargetRider()).toBe(3);
     });
 });

--- a/src/utils/combat/__tests__/perSubAttackEvents.integration.test.ts
+++ b/src/utils/combat/__tests__/perSubAttackEvents.integration.test.ts
@@ -227,6 +227,111 @@ describe('per-sub-attack ability-performed — cardinality and payload', () => {
 });
 
 /**
+ * THE FUNNEL-DIVERSION CASE — a sub-attack that struck victims but BOOKED NOTHING.
+ *
+ * `SubAttackOutcome.damage` is the POST-funnel `incomingBooked` sum, so it is legitimately 0 for a
+ * sub-attack whose whole hit the funnel diverted: a Protection cascade moving it onto an ally, or
+ * a one-shot transform deferring it into a DoT. Under the locked rule that is still a real
+ * attack — it resolved an anchor, expanded a footprint and rolled — so it MUST emit its own
+ * `ability-performed`.
+ *
+ * The plan originally prescribed gating on `victimIds.length === 0 || damage === 0`, which gets
+ * this wrong TWICE over: the diverted sub-attack vanishes, AND the survivors are re-inflated,
+ * because the per-event damage is `dap.damage / emitting.length` — drop one of three and the other
+ * two each report half the cast instead of a third. The gate tests the footprint alone.
+ *
+ * `Hit Mitigation` is the vehicle because it is a genuine ONE-SHOT (`hitMitigation.ts`): it blocks
+ * the NEXT direct hit and is consumed, so exactly sub-attack 0 is diverted and 1-2 land normally —
+ * the asymmetry that makes the inflation visible.
+ */
+describe('a sub-attack whose damage is fully diverted still emits its own event', () => {
+    afterEach(() => resetRateGateRng());
+
+    /** An enemy that self-casts a long `Hit Mitigation` from its ACTIVE slot and acts first, so
+     *  the one-shot block is armed before the focus attacker's cast. Deals nothing itself. */
+    const blockingEnemyAt = (id: string, position: Position) =>
+        ({
+            id,
+            stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 999 },
+            chargeCount: 0,
+            startCharged: false,
+            position,
+            affinity: 'antimatter',
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            shipSkills: {
+                slots: [
+                    {
+                        slot: 'active',
+                        abilities: [
+                            ab({
+                                type: 'buff',
+                                target: 'self',
+                                config: {
+                                    type: 'buff',
+                                    buffName: 'Hit Mitigation',
+                                    parsedEffects: {},
+                                    stacks: 1,
+                                    isStackable: false,
+                                    duration: 99, // never expires inside the fixture
+                                },
+                            }),
+                            ab({ type: 'damage', config: { type: 'damage', multiplier: 0 } }),
+                        ],
+                    },
+                ],
+            },
+        }) as NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+    const run = (blocked: boolean) => {
+        idc = 0;
+        setRateGateRng(() => 0.9);
+        setKeyedRng(() => 0.9);
+        const bus = createEventBus();
+        const perf: AbilityPerformed[] = [];
+        const attacked: Attacked[] = [];
+        bus.on('ability-performed', (e) => {
+            if (e.actorId === 'attacker') perf.push(e);
+        });
+        bus.on('attacked', (e) => {
+            if (e.attackerId === 'attacker') attacked.push(e);
+        });
+        runCombat({
+            ...focusCast(3, basePattern(), 0),
+            speed: 1, // slower than the enemy, so the block is up before the cast
+            enemyAttackers: [
+                blocked ? blockingEnemyAt('anchor', 'M4') : passiveEnemyAt('anchor', 'M4'),
+            ],
+            bus,
+        });
+        return { perf, attacked };
+    };
+
+    it('emits all THREE events and leaves the surviving shares uninflated', () => {
+        const blockedRun = run(true);
+        const control = run(false);
+
+        // Fixture self-check: the block really did swallow sub-attack 0 and nothing else. A
+        // fully-transformed hit suppresses its `attacked` signal (it dealt no direct damage), so
+        // the blocked run shows 2 where the control shows 3. Without this the test could pass
+        // vacuously against a fixture where Hit Mitigation never fired.
+        expect(control.attacked).toHaveLength(3);
+        expect(blockedRun.attacked).toHaveLength(2);
+
+        // THE cardinality claim: a diverted sub-attack is still an attack.
+        expect(blockedRun.perf).toHaveLength(3);
+
+        // THE inflation claim: every event carries the same share as the unblocked control — one
+        // third of the cast. Under the rejected `damage === 0` gate this run would have produced
+        // TWO events each carrying HALF the cast, i.e. 1.5× these numbers.
+        const share = control.perf[0].damage!;
+        expect(share).toBeGreaterThan(0);
+        for (const e of blockedRun.perf) expect(e.damage).toBeCloseTo(share, 6);
+        expect(blockedRun.perf.reduce((s, e) => s + (e.damage ?? 0), 0)).toBeCloseTo(3 * share, 6);
+    });
+});
+
+/**
  * MANDATORY EXTRA COVERAGE 1 — Tenacity's "> 25% of max HP" gate.
  *
  * The gate reads `attacked.damage`. Before PR2 every per-hit `attacked` of a multi-hit cast
@@ -315,7 +420,14 @@ describe('attacked payload — Tenacity’s >25%-of-max-HP gate sees ONE sub-att
         const bus = createEventBus();
         const attacked: Attacked[] = [];
         const protections: CombatEvent[] = [];
+        // Ordered enemy-side stream: the enemy path is the only one that splits emission across
+        // `deferEmission` / `emitDeferred`, so its interleaving needs its own lock.
+        const stream: CombatEvent[] = [];
+        bus.on('ability-performed', (e) => {
+            if (e.actorId === 'enemy-mh') stream.push(e as CombatEvent);
+        });
         bus.on('attacked', (e) => {
+            if (e.attackerId === 'enemy-mh') stream.push(e as CombatEvent);
             if (e.targetId === 'victim') attacked.push(e);
         });
         bus.on('buff-applied', (e) => {
@@ -352,7 +464,7 @@ describe('attacked payload — Tenacity’s >25%-of-max-HP gate sees ONE sub-att
             enemyAttackers: [enemyMultiHit()],
             bus,
         });
-        return { attacked, protections: protections.length };
+        return { attacked, protections: protections.length, stream };
     };
 
     it('each attacked carries its SUB-ATTACK’s damage, not the cast aggregate', () => {
@@ -387,6 +499,33 @@ describe('attacked payload — Tenacity’s >25%-of-max-HP gate sees ONE sub-att
         // maxHp = 3.5·slice → 25% of it is 0.875·slice, under one sub-attack, and the victim still
         // outlives the 3·slice cast. The gate is genuinely satisfiable on the new basis.
         expect(runVictim(3.5 * slice).protections).toBeGreaterThan(0);
+    });
+
+    /**
+     * THE ENEMY-PATH INTERLEAVING LOCK.
+     *
+     * `deferEmission` / `emitDeferred` is PR2's only asymmetric plumbing: the enemy site keeps a
+     * LEADING `ability-performed` where the single aggregate emit has always sat and runs the rest
+     * of the sequence after its own inline damage-taken-leech tail (SP-U U5). Everything else in
+     * this file drives the PLAYER path, which runs the whole sequence in one place, so the enemy
+     * split is otherwise covered only by inference.
+     *
+     * This repo's history is that the enemy path rots silently and specifically (#305 enemy
+     * support ships never spent their charges, #306 enemy ships dropped their whole passive slot),
+     * so the shape is pinned literally for PR3-PR6 to inherit.
+     */
+    it('the ENEMY path interleaves too: P a P a P a for a hits:3 enemy cast', () => {
+        idc = 0;
+        setRateGateRng(() => 0.9);
+        setKeyedRng(() => 0.9);
+        const { stream } = runVictim(1_000_000_000);
+        const kinds = stream.map((e) => (e.type === 'ability-performed' ? 'P' : 'a'));
+        expect(kinds.join('')).toBe('PaPaPa');
+        // Stated as the invariant too: an event is never followed directly by another event, which
+        // is what would leave rows 1..N-1 target-less for finalizeMissEntry to splice out.
+        for (let i = 1; i < kinds.length; i++) {
+            if (kinds[i] === 'P') expect(kinds[i - 1]).toBe('a');
+        }
     });
 });
 

--- a/src/utils/combat/__tests__/perSubAttackEvents.integration.test.ts
+++ b/src/utils/combat/__tests__/perSubAttackEvents.integration.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Multi-hit full-walk attacks, PR2 Task 3 — one `ability-performed` per SUB-ATTACK.
+ *
+ * A multi-hit skill is N consecutive full-walk attacks (locked game rule), so a positional cast
+ * emits N `ability-performed` events instead of one aggregate, each IMMEDIATELY followed by that
+ * sub-attack's own `attacked` events.
+ *
+ * What this file pins, and why each assertion is load-bearing:
+ *
+ *  1. CARDINALITY — `hits: 3` gives 3 events, `hits: 1` gives exactly 1. The N=1 case is the
+ *     cheapest correctness check in the epic: every corpus ship except Enforcer is single-hit, so
+ *     any movement there means the change is wrong.
+ *  2. INTERLEAVING — at least one `attacked` sits between consecutive events. buildCombatLog's
+ *     `attacked` handler fills whichever attack row was created MOST RECENTLY; emitting all N
+ *     events first would leave rows 1..N-1 target-less and `finalizeMissEntry` would silently
+ *     splice them out as phantom rows. The log-row assertion below is the end-to-end proof.
+ *  3. DAMAGE BASIS — Σ of the N events' `damage` equals the one number the single aggregate event
+ *     carried (the cast's pre-funnel `directDamage`). The basis is deliberately unchanged; only
+ *     the cardinality moved.
+ *  4. CRIT ACCOUNTING — Σ of the N events' `critHits` equals the old cast-wide `critPairs`. Using
+ *     `critPairs` on every event instead would make `on-crit` count the whole cast N times over.
+ *
+ *  5-6. THE `attacked` PAYLOAD CHANGE (mandatory extra coverage). Dropping the cast-wide flatten
+ *     changes each `attacked` event's `damage` from the victim's cast aggregate to that
+ *     sub-attack's slice. No existing corpus test can see it — Enforcer, the only multi-hit ship,
+ *     is `Pattern-Base`, so its log amount comes from the ability's own damage, not from
+ *     `attacked.damage`. Two real consumers read that field and are pinned here:
+ *       • Tenacity's "> 25% of max HP in ONE hit" gate (`emitAttacked.ts` → `triggers.ts`'s
+ *         `requireIncomingDamageFracOfMaxHp`), which now correctly sees one sub-attack's damage.
+ *       • The combat log's NON-PRIMARY (splash) target `amount`, which takes `attacked.damage`.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { setRateGateRng, setKeyedRng, resetRateGateRng } from '../../calculators/rateAccumulator';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+type AbilityPerformed = Extract<CombatEvent, { type: 'ability-performed' }>;
+type Attacked = Extract<CombatEvent, { type: 'attacked' }>;
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `psa${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+/** A damage active whose folded multiplier is re-split across `hits` sub-attacks. */
+const attackSkill = (hits: number): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        ab({
+            type: 'damage',
+            target: 'enemy',
+            config: { type: 'damage', multiplier: 100, ...(hits > 1 ? { hits } : {}) },
+        }),
+    ],
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+/** Single-cell footprint: the anchor only. */
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+/** Whole-roster footprint: every occupied cell is struck by each sub-attack. */
+const allPattern = (): ParsedPattern => ({ raw: 'all', shape: 'all', range: 'all', modifiers: {} });
+
+/** A positioned enemy that never fires back. */
+const passiveEnemyAt = (id: string, position: Position, hp = 1_000_000_000) =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        affinity: 'antimatter',
+        shipSkills: { slots: [] },
+    }) as NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+/**
+ * The focus player at M1 fires a `hits`-hit positional cast. `crit: 100` with a neutral-affinity
+ * roster makes every (sub-attack, victim) pair crit, so `critHits` is fully exercised.
+ */
+const focusCast = (hits: number, pattern: ParsedPattern, crit = 100): CombatEngineInput => ({
+    attack: 5000,
+    crit,
+    critDamage: 100,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots: [attackSkill(hits)] },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    affinity: 'antimatter',
+    defence: 0,
+    hp: 1_000_000_000,
+    healTargetId: 'attacker',
+    position: 'M1',
+    target: parsedTarget('front'),
+    pattern,
+    enemyAttackers: [passiveEnemyAt('anchor', 'M4'), passiveEnemyAt('covered', 'M3')],
+});
+
+/** Captures the ORDERED event stream (both types) so interleaving is observable. */
+const runStream = (input: CombatEngineInput): CombatEvent[] => {
+    const bus = createEventBus();
+    const stream: CombatEvent[] = [];
+    bus.on('ability-performed', (e) => stream.push(e as CombatEvent));
+    bus.on('attacked', (e) => stream.push(e as CombatEvent));
+    runCombat({ ...input, bus });
+    return stream;
+};
+
+const perfOf = (stream: CombatEvent[], actorId: string): AbilityPerformed[] =>
+    stream.filter(
+        (e): e is AbilityPerformed => e.type === 'ability-performed' && e.actorId === actorId
+    );
+
+describe('per-sub-attack ability-performed — cardinality and payload', () => {
+    afterEach(() => resetRateGateRng());
+
+    const alwaysCrit = () => {
+        // Per-victim crit gates carry `${victimId}:active-crit` stream keys, so the keyed provider
+        // must be set too or the covered victim bypasses the constant draw.
+        setRateGateRng(() => 0);
+        setKeyedRng(() => 0);
+    };
+
+    it('a hits:3 positional cast emits THREE ability-performed events', () => {
+        idc = 0;
+        alwaysCrit();
+        expect(perfOf(runStream(focusCast(3, basePattern())), 'attacker')).toHaveLength(3);
+    });
+
+    it('a hits:1 positional cast emits EXACTLY ONE — the N=1 invariant', () => {
+        idc = 0;
+        alwaysCrit();
+        // Every corpus ship except Enforcer lands here. If this ever reads anything but 1, the
+        // whole golden corpus moves.
+        expect(perfOf(runStream(focusCast(1, basePattern())), 'attacker')).toHaveLength(1);
+    });
+
+    it('each event is IMMEDIATELY followed by its own sub-attack’s attacked events', () => {
+        idc = 0;
+        alwaysCrit();
+        const stream = runStream(focusCast(3, basePattern())).filter(
+            (e) =>
+                (e.type === 'ability-performed' && e.actorId === 'attacker') ||
+                (e.type === 'attacked' && e.attackerId === 'attacker')
+        );
+        // Shape: performed, attacked, performed, attacked, performed, attacked.
+        const kinds = stream.map((e) => (e.type === 'ability-performed' ? 'P' : 'a'));
+        expect(kinds.join('')).toBe('PaPaPa');
+        // Stated as the invariant rather than the literal shape: NO two events are adjacent.
+        for (let i = 1; i < kinds.length; i++) {
+            if (kinds[i] === 'P') expect(kinds[i - 1]).toBe('a');
+        }
+    });
+
+    it('Σ of the three events’ damage equals the cast total the single event carried', () => {
+        idc = 0;
+        alwaysCrit();
+        // MEASURED, not assumed: `multiplier: 100, hits: 3` is three FULL 100% hits (the folded
+        // multiplier is 300, re-split three ways), so a 3-hit cast deals 3× a 1-hit cast — NOT the
+        // same total split three ways. The plan's suggested "capture the total from a
+        // hits:1-equivalent run" would have pinned the wrong number.
+        const stream = runStream(focusCast(3, basePattern()));
+        const triple = perfOf(stream, 'attacker');
+        expect(triple).toHaveLength(3);
+
+        // Independent reference for the cast total: the `attacked` events' own damage, which is
+        // the post-funnel booked intake. With no shield/barrier/transfer in this fixture the two
+        // bases coincide, so Σ of the events must reproduce it exactly.
+        const booked = stream
+            .filter((e): e is Attacked => e.type === 'attacked' && e.attackerId === 'attacker')
+            .reduce((s, e) => s + (e.damage ?? 0), 0);
+        expect(booked).toBeGreaterThan(0);
+        expect(triple.reduce((s, e) => s + (e.damage ?? 0), 0)).toBeCloseTo(booked, 6);
+
+        // Split EVENLY, not front-loaded — and one sub-attack of a 3-hit cast reports exactly what
+        // a 1-hit cast's single aggregate event reports.
+        const single = perfOf(runStream(focusCast(1, basePattern())), 'attacker');
+        for (const e of triple) expect(e.damage).toBeCloseTo(single[0].damage!, 6);
+    });
+
+    it('Σ of the events’ critHits equals the cast-wide critPairs it replaced', () => {
+        idc = 0;
+        alwaysCrit();
+        // 3 sub-attacks × 2 footprint victims, all critting → the pre-PR2 single event carried
+        // critPairs = 6. Each per-sub-attack event must carry 2, never 6.
+        const triple = perfOf(runStream(focusCast(3, allPattern())), 'attacker');
+        expect(triple).toHaveLength(3);
+        for (const e of triple) {
+            expect(e.didCrit).toBe(true);
+            expect(e.critHits).toBe(2);
+            expect([...(e.critVictimIds ?? [])].sort()).toEqual(['anchor', 'covered']);
+        }
+        expect(triple.reduce((s, e) => s + (e.critHits ?? 0), 0)).toBe(6);
+    });
+
+    it('a non-critting hits:3 cast still emits three events, each with critHits omitted', () => {
+        idc = 0;
+        setRateGateRng(() => 0.9);
+        setKeyedRng(() => 0.9);
+        const triple = perfOf(runStream(focusCast(3, basePattern(), 0)), 'attacker');
+        expect(triple).toHaveLength(3);
+        for (const e of triple) {
+            expect(e.didCrit).toBe(false);
+            expect(e.critHits).toBeUndefined();
+        }
+    });
+});
+
+/**
+ * MANDATORY EXTRA COVERAGE 1 — Tenacity's "> 25% of max HP" gate.
+ *
+ * The gate reads `attacked.damage`. Before PR2 every per-hit `attacked` of a multi-hit cast
+ * carried the victim's CAST-WIDE aggregate, so a 3-hit attack whose individual hits were each
+ * well under the threshold still tripped it (three times over). Now each event carries its own
+ * sub-attack's slice, so the gate measures what it says it measures: one hit.
+ *
+ * Self-calibrating: the first run measures the actual per-sub-attack slice, and the two graded
+ * runs pick a max HP relative to it. `3·slice < maxHp < 4·slice` is the window where the victim
+ * survives the cast AND one slice clears 25% of its max HP.
+ */
+describe('attacked payload — Tenacity’s >25%-of-max-HP gate sees ONE sub-attack', () => {
+    afterEach(() => resetRateGateRng());
+
+    /** The real TENACITY shape (buildEquipmentAbilities): on-attacked, frac-gated, no proc roll. */
+    const tenacityLike = (): Ability => ({
+        id: 'tenacity-like',
+        type: 'buff',
+        target: 'self',
+        trigger: 'on-attacked',
+        conditions: [],
+        config: {
+            type: 'buff',
+            buffName: 'Buff Protection',
+            duration: 2,
+            stacks: 1,
+            isStackable: false,
+            parsedEffects: {},
+        },
+        requireIncomingDamageFracOfMaxHp: 0.25,
+    });
+
+    /** A player victim at M3 carrying the frac-gated reactive, with a chosen max HP. */
+    const victim = (hp: number): NonNullable<CombatEngineInput['teamActors']>[number] =>
+        ({
+            id: 'victim',
+            speed: 1,
+            chargeCount: 0,
+            startCharged: false,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            position: 'M3' as Position,
+            affinity: 'antimatter',
+            walk: {
+                shipSkills: { slots: [{ slot: 'passive', abilities: [tenacityLike()] }] },
+                stats: {
+                    attack: 0,
+                    crit: 0,
+                    critDamage: 0,
+                    defensePenetration: 0,
+                    hacking: 0,
+                    defence: 0,
+                    hp,
+                },
+                selfDotModifier: 0,
+                defensePenetrationBuff: 0,
+                affinityDamageModifier: 0,
+                affinityCritCap: 100,
+                affinityCritPenalty: 0,
+                hasChargedSkill: false,
+            },
+        }) as NonNullable<CombatEngineInput['teamActors']>[number];
+
+    /** A 3-hit ENEMY attacker at M4 pointed at the player victim (enemy→player positional path). */
+    const enemyMultiHit = () =>
+        ({
+            id: 'enemy-mh',
+            stats: {
+                attack: 5000,
+                crit: 0,
+                critDamage: 100,
+                defence: 0,
+                hp: 1_000_000_000,
+                speed: 200,
+            },
+            chargeCount: 0,
+            startCharged: false,
+            position: 'M4' as Position,
+            affinity: 'antimatter',
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            shipSkills: { slots: [attackSkill(3)] },
+        }) as NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+    const runVictim = (hp: number) => {
+        const bus = createEventBus();
+        const attacked: Attacked[] = [];
+        const protections: CombatEvent[] = [];
+        bus.on('attacked', (e) => {
+            if (e.targetId === 'victim') attacked.push(e);
+        });
+        bus.on('buff-applied', (e) => {
+            if (e.buffName === 'Buff Protection') protections.push(e as CombatEvent);
+        });
+        runCombat({
+            // The focus player sits at M1 and does nothing meaningful; the enemy is the attacker.
+            attack: 0,
+            crit: 0,
+            critDamage: 100,
+            defensePenetration: 0,
+            chargeCount: 0,
+            shipSkills: { slots: [attackSkill(1)] },
+            enemyDefense: 0,
+            enemyHp: 1_000_000_000,
+            numRounds: 1,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            hasChargedSkill: false,
+            startCharged: false,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            affinity: 'antimatter',
+            defence: 0,
+            hp: 1_000_000_000,
+            healTargetId: 'victim',
+            position: 'M1',
+            target: parsedTarget('front'),
+            pattern: basePattern(),
+            teamActors: [victim(hp)],
+            enemyAttackers: [enemyMultiHit()],
+            bus,
+        });
+        return { attacked, protections: protections.length };
+    };
+
+    it('each attacked carries its SUB-ATTACK’s damage, not the cast aggregate', () => {
+        idc = 0;
+        setRateGateRng(() => 0.9);
+        setKeyedRng(() => 0.9);
+        const { attacked } = runVictim(1_000_000_000);
+        // Three sub-attacks, one victim → three `attacked`, each with an equal third of the cast.
+        expect(attacked).toHaveLength(3);
+        const slices = attacked.map((e) => e.damage!);
+        for (const s of slices) expect(s).toBeGreaterThan(0);
+        for (const s of slices) expect(s).toBeCloseTo(slices[0], 6);
+        // Pre-PR2 every one of these carried the cast total (3× this). That over-reporting is what
+        // the two graded runs below discriminate.
+    });
+
+    it('does NOT fire when only the CAST total clears 25% — one sub-attack does not', () => {
+        idc = 0;
+        setRateGateRng(() => 0.9);
+        setKeyedRng(() => 0.9);
+        const slice = runVictim(1_000_000_000).attacked[0].damage!;
+        // maxHp = 8·slice → 25% of it is 2·slice. One sub-attack (1·slice) is under; the cast
+        // total (3·slice) is over. Pre-PR2 this fired three times; it must now fire zero.
+        expect(runVictim(8 * slice).protections).toBe(0);
+    });
+
+    it('DOES fire when a single sub-attack clears 25% on its own', () => {
+        idc = 0;
+        setRateGateRng(() => 0.9);
+        setKeyedRng(() => 0.9);
+        const slice = runVictim(1_000_000_000).attacked[0].damage!;
+        // maxHp = 3.5·slice → 25% of it is 0.875·slice, under one sub-attack, and the victim still
+        // outlives the 3·slice cast. The gate is genuinely satisfiable on the new basis.
+        expect(runVictim(3.5 * slice).protections).toBeGreaterThan(0);
+    });
+});
+
+/**
+ * MANDATORY EXTRA COVERAGE 2 — the combat log's NON-PRIMARY target amount.
+ *
+ * `buildCombatLog`'s `attacked` handler takes the primary target's amount from the ability's own
+ * damage but a SPLASH victim's amount straight from `attacked.damage`. With a multi-hit AoE that
+ * field is now the sub-attack's slice, so each of the N rows reports one sub-attack — the rows sum
+ * to the cast rather than each claiming the whole of it.
+ *
+ * This also proves the INTERLEAVING end-to-end: three rows survive only because each event's own
+ * `attacked` arrived before the next event opened a new row. All-events-first would have left rows
+ * 1 and 2 target-less and `finalizeMissEntry` would have spliced them out.
+ */
+describe('combat log — one attack row per sub-attack, splash amount per sub-attack', () => {
+    afterEach(() => resetRateGateRng());
+
+    const LOG_ROSTER = [
+        { actorId: 'attacker', name: 'Attacker', side: 'player' as const },
+        { actorId: 'anchor', name: 'Anchor', side: 'enemy' as const },
+        { actorId: 'covered', name: 'Covered', side: 'enemy' as const },
+    ];
+
+    const runLog = (hits: number) => {
+        const bus = createEventBus();
+        const events: CombatEvent[] = [];
+        for (const t of [
+            'round-started',
+            'turn-started',
+            'skill-fired',
+            'ability-performed',
+            'attacked',
+            'hp-changed',
+            'turn-ended',
+            'round-ended',
+        ] as const) {
+            bus.on(t, (e) => events.push(e as CombatEvent));
+        }
+        runCombat({ ...focusCast(hits, allPattern()), bus });
+        return events;
+    };
+
+    it('a hits:3 AoE produces THREE attack rows, each tagged with the skill', async () => {
+        idc = 0;
+        setRateGateRng(() => 0);
+        setKeyedRng(() => 0);
+        const { buildCombatLog } = await import('../log/buildCombatLog');
+        const events = runLog(3);
+        const log = buildCombatLog(events, LOG_ROSTER, new Map());
+        const turn = log[0].turns.find((t) => t.actorId === 'attacker')!;
+        const rows = turn.entries.filter((e) => e.kind === 'attack' && e.actorId === 'attacker');
+
+        // THE phantom-row check: three rows survived finalizeMissEntry because each carries its
+        // own targets.
+        expect(rows).toHaveLength(3);
+        for (const row of rows) {
+            expect(row.targets.map((t) => t.targetId).sort()).toEqual(['anchor', 'covered']);
+            // Task 1's sticky tag: rows 2 and 3 are the same named skill, not bare.
+            expect(row.slot).toBe(rows[0].slot);
+            expect(row.skillName).toBe(rows[0].skillName);
+        }
+
+        // The splash victim's amount comes from `attacked.damage` — one sub-attack's slice, so the
+        // three rows are equal and sum to the cast rather than each reporting the whole cast.
+        const splash = rows.map(
+            (row) => row.targets.find((t) => t.targetId === 'covered')!.amount!
+        );
+        for (const a of splash) expect(a).toBeCloseTo(splash[0], 6);
+
+        // Cross-check against the single-hit control: ONE row, whose splash amount equals ONE of
+        // the three above — a sub-attack is a whole attack, so each row reports a full hit rather
+        // than the cast-wide aggregate the pre-PR2 single row carried (which was 3× this).
+        const singleEvents = runLog(1);
+        const singleLog = buildCombatLog(singleEvents, LOG_ROSTER, new Map());
+        const singleRows = singleLog[0].turns
+            .find((t) => t.actorId === 'attacker')!
+            .entries.filter((e) => e.kind === 'attack' && e.actorId === 'attacker');
+        expect(singleRows).toHaveLength(1);
+        const singleSplash = singleRows[0].targets.find((t) => t.targetId === 'covered')!.amount!;
+        for (const a of splash) expect(a).toBeCloseTo(singleSplash, 6);
+        // The three rows together report the whole cast, which is 3× a single-hit cast.
+        expect(splash.reduce((s, a) => s + a, 0)).toBeCloseTo(3 * singleSplash, 6);
+    });
+});

--- a/src/utils/combat/__tests__/perSubAttackEvents.integration.test.ts
+++ b/src/utils/combat/__tests__/perSubAttackEvents.integration.test.ts
@@ -630,10 +630,12 @@ describe('combat log — one attack row per sub-attack, splash amount per sub-at
  *    stays ONE attack however many victims crit.
  *
  * GUARD SCOPE (verified, not assumed). `oncePerAttackGuardKey` keys only `target: 'self'` riders
- * on the per-hit triggers and is cleared at each actor TURN-start (`engine.ts`), so a self rider
- * (Hermes's charge + Everliving Regeneration) stays once-per-turn across sub-attacks while
- * ally-routed and enemy-routed riders fan out per sub-attack. That asymmetry is deliberate and is
- * locked from the other side by `hermesOncePerAttack.integration.test.ts`.
+ * on `PER_HIT_REACTIVE_TRIGGERS`, and `on-ally-crit` is no longer in that set — self-routed riders
+ * (Hermes's charge + Everliving Regeneration) therefore fan out per sub-attack exactly like the
+ * ally- and enemy-routed ones, which is the approved decision. The AoE collapse does not depend on
+ * the guard at all: it comes from the listener enqueuing at most once per `ability-performed`.
+ * Both halves are locked from the other side by `hermesOncePerAttack.integration.test.ts`. The
+ * guard itself is untouched and still load-bearing for `on-attacked` / `on-ally-attacked`.
  */
 
 /** A keyed RNG walking a fixed draw sequence per stream key; unlisted keys always draw `fallback`. */

--- a/src/utils/combat/__tests__/perSubAttackEvents.integration.test.ts
+++ b/src/utils/combat/__tests__/perSubAttackEvents.integration.test.ts
@@ -472,3 +472,260 @@ describe('combat log — one attack row per sub-attack, splash amount per sub-at
         expect(splash.reduce((s, a) => s + a, 0)).toBeCloseTo(3 * singleSplash, 6);
     });
 });
+
+/**
+ * TASK 4 — the three OUTGOING reactive triggers, measured against the new cardinality.
+ *
+ * Task 3 changed emission; this block pins what the listeners actually do with it. Each rider is
+ * a hand-built stand-in for the real equipment ability of the same shape (the corpus versions are
+ * gear/implant-sourced and drag their own proc rolls in):
+ *
+ *  • `on-deal-damage` → Burner's Inferno rider. Fires once per `ability-performed` that dealt
+ *    damage (`triggers.ts`'s `(e.damage ?? 0) <= 0` guard), so N sub-attacks = N applications.
+ *  • `on-crit`        → Bloodthirst's damage-dealt self-repair. Enqueues `critHits` times per
+ *    event and scales off THAT event's `damage`. This is the headline bug PR2 fixes: pre-PR2 the
+ *    single aggregate event carried the WHOLE cast's damage, so all three fires healed off the
+ *    full total. The amount, not just the count, is pinned below.
+ *  • `on-ally-crit`   → Howler/Sentinel's ally-routed grant. ONE enqueue per critting
+ *    `ability-performed`, which now means one per critting SUB-ATTACK while an AoE footprint
+ *    stays ONE attack however many victims crit.
+ *
+ * GUARD SCOPE (verified, not assumed). `oncePerAttackGuardKey` keys only `target: 'self'` riders
+ * on the per-hit triggers and is cleared at each actor TURN-start (`engine.ts`), so a self rider
+ * (Hermes's charge + Everliving Regeneration) stays once-per-turn across sub-attacks while
+ * ally-routed and enemy-routed riders fan out per sub-attack. That asymmetry is deliberate and is
+ * locked from the other side by `hermesOncePerAttack.integration.test.ts`.
+ */
+
+/** A keyed RNG walking a fixed draw sequence per stream key; unlisted keys always draw `fallback`. */
+const sequencedKeyedRng = (seqByKey: Record<string, number[]>, fallback = 0.9) => {
+    const cursor = new Map<string, number>();
+    return (key: string): number => {
+        const seq = seqByKey[key];
+        if (!seq) return fallback;
+        const i = cursor.get(key) ?? 0;
+        cursor.set(key, i + 1);
+        return seq[Math.min(i, seq.length - 1)];
+    };
+};
+
+describe('outgoing reactive triggers — per-sub-attack fan-out', () => {
+    afterEach(() => resetRateGateRng());
+
+    /** Burner: "applies Inferno" off the wearer's own damage. */
+    const burnerLike = (): Ability =>
+        ab({
+            type: 'dot',
+            target: 'enemy',
+            trigger: 'on-deal-damage',
+            config: { type: 'dot', dotType: 'inferno', tier: 15, stacks: 1, duration: 2 },
+        });
+
+    /** Bloodthirst: "repair itself for N% of the damage dealt" on a crit. No procChance so every
+     *  enqueue lands — the fixture measures fan-out and amount, not the proc roll. */
+    const bloodthirstLike = (): Ability =>
+        ab({
+            type: 'heal',
+            target: 'self',
+            trigger: 'on-crit',
+            config: { type: 'heal', pct: 20, basis: 'damage-dealt' },
+        });
+
+    /** Howler/Sentinel shape: an ALLY-routed grant on on-ally-crit (never self, so ungated). */
+    const allyCritRider = (): Ability =>
+        ab({
+            type: 'buff',
+            target: 'ally',
+            trigger: 'on-ally-crit',
+            config: {
+                type: 'buff',
+                buffName: 'Blast',
+                duration: 2,
+                stacks: 1,
+                isStackable: false,
+                parsedEffects: {},
+            },
+        });
+
+    /** A do-nothing same-side ally at M3 carrying `abilities` as its passive slot. */
+    const observer = (abilities: Ability[]): NonNullable<CombatEngineInput['teamActors']>[number] =>
+        ({
+            id: 'observer',
+            speed: 1,
+            chargeCount: 0,
+            startCharged: false,
+            selfBuffs: [],
+            enemyDebuffs: [],
+            position: 'M3' as Position,
+            affinity: 'antimatter',
+            walk: {
+                shipSkills: { slots: [{ slot: 'passive', abilities }] },
+                stats: {
+                    attack: 0,
+                    crit: 0,
+                    critDamage: 0,
+                    defensePenetration: 0,
+                    hacking: 0,
+                    defence: 0,
+                    hp: 1_000_000_000,
+                },
+                selfDotModifier: 0,
+                defensePenetrationBuff: 0,
+                affinityDamageModifier: 0,
+                affinityCritCap: 100,
+                affinityCritPenalty: 0,
+                hasChargedSkill: false,
+            },
+        }) as NonNullable<CombatEngineInput['teamActors']>[number];
+
+    /** The focus cast with `riders` bolted on as its own passive slot. */
+    const focusWithRiders = (
+        hits: number,
+        pattern: ParsedPattern,
+        riders: Ability[],
+        crit = 100
+    ): CombatEngineInput => {
+        const base = focusCast(hits, pattern, crit);
+        return {
+            ...base,
+            speed: 500, // act before the observer, whose own turn does nothing
+            shipSkills: { slots: [attackSkill(hits), { slot: 'passive', abilities: riders }] },
+        };
+    };
+
+    // -- 1. on-deal-damage ---------------------------------------------------------------
+
+    it('on-deal-damage fires once per SUB-ATTACK: a hits:3 Burner lands three Infernos', () => {
+        idc = 0;
+        // Every gate open: the reactive DoT still has to clear the wearer's debuff-landing gate.
+        setRateGateRng(() => 0);
+        setKeyedRng(() => 0);
+
+        const run = (hits: number) => {
+            const bus = createEventBus();
+            const infernos: Extract<CombatEvent, { type: 'dot-applied' }>[] = [];
+            bus.on('dot-applied', (e) => {
+                if (e.sourceId === 'attacker' && e.dotType === 'inferno') infernos.push(e);
+            });
+            runCombat({ ...focusWithRiders(hits, basePattern(), [burnerLike()]), bus });
+            return infernos;
+        };
+
+        // Pre-PR2 the whole cast collapsed into ONE ability-performed, so the rider fired once
+        // however many hits landed. Three sub-attacks are three attacks and apply three stacks.
+        expect(run(3)).toHaveLength(3);
+        // N=1 control: the single-hit path is untouched.
+        expect(run(1)).toHaveLength(1);
+    });
+
+    // -- 2. on-crit (the headline bug) ---------------------------------------------------
+
+    it('on-crit fires per critting sub-attack and scales off THAT sub-attack’s damage', () => {
+        idc = 0;
+        setRateGateRng(() => 0);
+        setKeyedRng(() => 0);
+
+        const bus = createEventBus();
+        const perf: AbilityPerformed[] = [];
+        const heals: Extract<CombatEvent, { type: 'reactive-heal-performed' }>[] = [];
+        bus.on('ability-performed', (e) => {
+            if (e.actorId === 'attacker') perf.push(e);
+        });
+        // A reactive heal deliberately emits NO heal-performed (chain guard); this is its event,
+        // and its `amount` is the RAW repair, so the focus's full HP cannot clip the measurement.
+        bus.on('reactive-heal-performed', (e) => {
+            if (e.casterId === 'attacker') heals.push(e);
+        });
+        runCombat({ ...focusWithRiders(3, basePattern(), [bloodthirstLike()]), bus });
+
+        // Three critting sub-attacks (one victim each → critHits 1) → three enqueues.
+        expect(perf).toHaveLength(3);
+        for (const e of perf) expect(e.critHits).toBe(1);
+        expect(heals).toHaveLength(3);
+
+        // THE amount assertion. Each fire repairs 20% of ITS OWN sub-attack's damage.
+        const slice = perf[0].damage!;
+        expect(slice).toBeGreaterThan(0);
+        for (const h of heals) expect(h.amount).toBeCloseTo(0.2 * slice, 6);
+
+        // Stated as the bug it fixes: pre-PR2 the one aggregate event carried the cast total, so
+        // all three fires healed off 3× this. Σ heals must equal 20% of the CAST, not 60%.
+        const castTotal = perf.reduce((s, e) => s + (e.damage ?? 0), 0);
+        expect(castTotal).toBeCloseTo(3 * slice, 6);
+        expect(heals.reduce((s, h) => s + h.amount, 0)).toBeCloseTo(0.2 * castTotal, 6);
+        for (const h of heals) expect(h.amount).toBeLessThan(0.2 * castTotal);
+    });
+
+    // -- 3. on-ally-crit, per critting sub-attack ----------------------------------------
+
+    it('on-ally-crit fires once per CRITTING sub-attack: 2 of 3 crit → two grants', () => {
+        idc = 0;
+        // crit 50 → rate 0.5. Draws 0.1/0.1/0.9 on the attacker's own crit sub-stream make
+        // sub-attacks 0 and 1 crit and sub-attack 2 whiff the roll. Every other stream draws 0.9,
+        // which clears the (rate 1.0) debuff-landing gate and fires nothing else.
+        setRateGateRng(() => 0.9);
+        setKeyedRng(sequencedKeyedRng({ 'attacker:active-crit': [0.1, 0.1, 0.9] }));
+
+        const bus = createEventBus();
+        const perf: AbilityPerformed[] = [];
+        const grants: Extract<CombatEvent, { type: 'buff-applied' }>[] = [];
+        bus.on('ability-performed', (e) => {
+            if (e.actorId === 'attacker') perf.push(e);
+        });
+        bus.on('buff-applied', (e) => {
+            if (e.buffName === 'Blast') grants.push(e);
+        });
+        runCombat({
+            ...focusCast(3, basePattern(), 50),
+            speed: 500,
+            teamActors: [observer([allyCritRider()])],
+            bus,
+        });
+
+        // Fixture self-check: the crit pattern really is crit / crit / no-crit.
+        expect(perf).toHaveLength(3);
+        expect(perf.map((e) => e.didCrit)).toEqual([true, true, false]);
+
+        // The approved decision: an ally critting on 2 of 3 sub-attacks fires the rider TWICE.
+        expect(grants).toHaveLength(2);
+        for (const g of grants) expect(g.actorId).toBe('attacker'); // ally-routed onto the critter
+    });
+
+    // -- 4. …but an AoE footprint is still ONE attack ------------------------------------
+
+    it('a single-hit 3-victim AoE that crits TWO victims still fires on-ally-crit ONCE', () => {
+        idc = 0;
+        setRateGateRng(() => 0.9);
+        // One crit draw per footprint victim: two crit, the third does not.
+        setKeyedRng(sequencedKeyedRng({ 'attacker:active-crit': [0.1, 0.1, 0.9] }));
+
+        const bus = createEventBus();
+        const perf: AbilityPerformed[] = [];
+        const grants: Extract<CombatEvent, { type: 'buff-applied' }>[] = [];
+        bus.on('ability-performed', (e) => {
+            if (e.actorId === 'attacker') perf.push(e);
+        });
+        bus.on('buff-applied', (e) => {
+            if (e.buffName === 'Blast') grants.push(e);
+        });
+        runCombat({
+            ...focusCast(1, allPattern(), 50),
+            speed: 500,
+            teamActors: [observer([allyCritRider()])],
+            enemyAttackers: [
+                passiveEnemyAt('anchor', 'M4'),
+                passiveEnemyAt('covered', 'M3'),
+                passiveEnemyAt('third', 'M2'),
+            ],
+            bus,
+        });
+
+        // Fixture self-check: ONE attack, TWO critting victims — the (hit, victim) collapse is
+        // what is under test, so the fixture must actually have multiple critting pairs.
+        expect(perf).toHaveLength(1);
+        expect(perf[0].critHits).toBe(2);
+
+        // The distinction that must survive PR2: per SUB-ATTACK, not per critting pair.
+        expect(grants).toHaveLength(1);
+    });
+});

--- a/src/utils/combat/__tests__/perVictimCritBattle.integration.test.ts
+++ b/src/utils/combat/__tests__/perVictimCritBattle.integration.test.ts
@@ -352,7 +352,10 @@ describe('per-victim crit — attacker ability-performed crit signal (Task 5)', 
             (e): e is Extract<CombatEvent, { type: 'ability-performed' }> =>
                 e.type === 'ability-performed' && e.actorId === 'attacker'
         );
-        expect(focusPerf.length).toBe(1); // exactly one ability-performed per positional cast
+        // One ability-performed per SUB-ATTACK (multi-hit full-walk epic, PR2). This fixture is
+        // single-hit — an AoE footprint is ONE attack however many victims it spreads over — so
+        // the count stays 1. It is the CARDINALITY of hits, not of victims, that fans this out.
+        expect(focusPerf.length).toBe(1);
         const perf = focusPerf[0];
 
         // The heart of Task 5: the attacker signal reflects the per-victim outcomes.
@@ -495,7 +498,9 @@ describe('per-victim crit — attacker ability-performed crit signal (Task 5)', 
             (e): e is Extract<CombatEvent, { type: 'ability-performed' }> =>
                 e.type === 'ability-performed' && e.actorId === 'enemy-zero'
         );
-        // The 0-damage fallback branch must emit exactly one ability-performed for the enemy.
+        // The 0-damage fallback branch must emit exactly one ability-performed for the enemy: no
+        // apply ran, so there are no sub-attacks to fan out over and the cast-wide anchor payload
+        // is emitted once (unchanged by PR2).
         expect(enemyPerf.length).toBe(1);
     });
 

--- a/src/utils/combat/__tests__/positionalApplyPerVictimCrit.test.ts
+++ b/src/utils/combat/__tests__/positionalApplyPerVictimCrit.test.ts
@@ -183,6 +183,7 @@ describe('applyPositionalDamage — rollVictimCrit callback (per-victim crit sea
                     didCrit: true,
                     damage: expect.any(Number),
                     victimIds: ['origin', 'covered'],
+                    critVictimIds: ['covered'],
                 },
             ],
         });
@@ -225,6 +226,7 @@ describe('applyPositionalDamage — rollVictimCrit callback (per-victim crit sea
                     didCrit: false,
                     damage: expect.any(Number),
                     victimIds: ['origin', 'covered'],
+                    critVictimIds: [],
                 },
             ],
         });
@@ -321,6 +323,11 @@ describe('applyPositionalDamage — rollVictimCrit callback (per-victim crit sea
                     didCrit: true,
                     damage: expect.any(Number),
                     victimIds: ['origin', 'covered'],
+                    // Per-SUB-ATTACK crit slice: each sub-attack crit both victims, so Σ of the
+                    // two lengths (2 + 2) reproduces the cast-wide critPairs of 4 exactly. This is
+                    // the number PR2 puts on each sub-attack's own `ability-performed` as
+                    // `critHits` — the cast-wide 4 there would count every crit N times over.
+                    critVictimIds: ['origin', 'covered'],
                 },
                 {
                     index: 1,
@@ -328,6 +335,7 @@ describe('applyPositionalDamage — rollVictimCrit callback (per-victim crit sea
                     didCrit: true,
                     damage: expect.any(Number),
                     victimIds: ['origin', 'covered'],
+                    critVictimIds: ['origin', 'covered'],
                 },
             ],
         });

--- a/src/utils/combat/__tests__/positionalApplySubAttack.test.ts
+++ b/src/utils/combat/__tests__/positionalApplySubAttack.test.ts
@@ -137,6 +137,7 @@ describe('applyPositionalDamage — SubAttackOutcome', () => {
             didCrit: false,
             damage: 0,
             victimIds: [],
+            critVictimIds: [],
         });
     });
 });

--- a/src/utils/combat/__tests__/positionalApplySubAttack.test.ts
+++ b/src/utils/combat/__tests__/positionalApplySubAttack.test.ts
@@ -317,3 +317,55 @@ describe('applyPositionalDamage — PR1 invariants', () => {
         result.subAttacks.forEach((s, i) => expect(s.index).toBe(i));
     });
 });
+
+// PR2 Task 2 — the engine buckets its `attacked` signals by (subAttackIndex, victim) instead of
+// by victim alone. These pin the enumeration that grouping relies on: exactly one visit per
+// (sub-attack, victim) pair, so every bucket holds exactly ONE hitOutcome and the TOTAL number of
+// `attacked` events a cast emits is unchanged by the regrouping.
+describe('applyPositionalDamage — attacked signal grouping', () => {
+    it('total attacked cardinality is unchanged when grouped by sub-attack', () => {
+        // 3 sub-attacks x 2 footprint victims = 6 (sub-attack, victim) pairs.
+        // Grouping must not add or drop any.
+        const pairs: Array<{ idx: number; id: string }> = [];
+
+        const result = applyPositionalDamage({
+            hitCrits: [false, false, false],
+            scalars: scalars(3),
+            pattern: parsePattern('Pattern-Line-Range-1'),
+            actorPosition: 'M2',
+            target: parseTarget('front'),
+            opposingLiving: [actor('origin', 'M4'), actor('covered', 'M3')],
+            defenseProfileOf: profile,
+            applyToVictim: (victim, damage, _isAnchor, subAttackIndex) => {
+                pairs.push({ idx: subAttackIndex as number, id: victim.id });
+                return bookingApply(victim, damage);
+            },
+        });
+
+        expect(pairs).toHaveLength(6);
+        expect(result.subAttacks.map((s) => s.victimIds.length)).toEqual([2, 2, 2]);
+        // Every (sub-attack, victim) pair appears exactly once — so bucketing by the pair yields
+        // one hitOutcome per bucket and 6 `attacked` events in total, the same 6 the flat
+        // victim-keyed map produced as 2 victims x 3 outcomes.
+        expect(new Set(pairs.map((p) => `${p.idx}:${p.id}`)).size).toBe(6);
+    });
+
+    it('a victim killed on sub-attack 0 is absent from later sub-attacks', () => {
+        const frail = actor('origin', 'M4', 1);
+        const result = applyPositionalDamage({
+            hitCrits: [false, false, false],
+            scalars: scalars(3),
+            pattern: parsePattern('Pattern-Line-Range-1'),
+            actorPosition: 'M2',
+            target: parseTarget('front'),
+            opposingLiving: [frail, actor('covered', 'M3')],
+            defenseProfileOf: profile,
+            applyToVictim: bookingApply,
+        });
+
+        expect(result.subAttacks[0].victimIds).toContain('origin');
+        // origin died on sub-attack 0 → later sub-attacks re-anchor and must not list it.
+        expect(result.subAttacks[1].victimIds).not.toContain('origin');
+        expect(result.subAttacks[2].victimIds).not.toContain('origin');
+    });
+});

--- a/src/utils/combat/audit/fingerprint.ts
+++ b/src/utils/combat/audit/fingerprint.ts
@@ -50,15 +50,25 @@ export function diffFingerprints(
  *
  *  The `:slot` suffix is NOT a reliable CAST-vs-passive/reactive marker, despite appearances.
  *  `ctx.pendingSkill` (`{skillName, slot}`) is set exactly once per cast — from the single
- *  `skill-fired` event emitted before any of its clauses resolve (`playerTurn.ts`) — and several
+ *  `skill-fired` event emitted before any of its clauses resolve (`playerTurn.ts`) — and EIGHT
  *  log-entry handlers in `buildCombatLog.ts` each spread `...(ctx.consumePendingSkill() ?? {})`,
- *  which reads-and-clears it. So the tag is single-use FOR THE WHOLE CAST: whichever handler runs
- *  first wins `:slot`, and every later entry from that same cast lands BARE. A bare token can
- *  therefore be a genuine cast entry that simply lost the race, not a passive/reactive one.
+ *  which reads-and-clears it. So the tag is single-use FOR THE WHOLE CAST: whichever of those
+ *  handlers runs first wins `:slot`, and every later entry from that same cast lands BARE. A bare
+ *  token can therefore be a genuine cast entry that simply lost the race, not a passive/reactive
+ *  one.
  *  Concretely, Malvex's charged cast grants Barrier via a named buff routed through the
  *  `timedSelfBySlot` loop, which runs BEFORE the attack's `ability-performed` emission — so
  *  `buff-applied` consumes the tag (`buff:charged`) and THAT cast's attack lands as a bare
- *  `attack`. Its committed `richEnemy` snapshot carries both `attack` and `attack:charged` for
+ *  `attack`.
+ *
+ *  ONE handler is no longer among the eight: since the multi-hit full-walk epic (PR2) the
+ *  `ability-performed` handler calls `ctx.currentSkillTag()` instead, which LATCHES the tag for
+ *  the rest of the cast so all N of a multi-hit skill's attack rows read as the same named skill.
+ *  That does not change the outcome described above — `currentSkillTag` still consumes
+ *  `pendingSkill` on its first call, so a handler that ran earlier has already cleared it and the
+ *  attack still lands bare (verified: the Malvex snapshot is unmoved). Only the mechanism differs:
+ *  the `attack` token can lose the race, but it can no longer lose it to a SIBLING attack row of
+ *  its own cast. Its committed `richEnemy` snapshot carries both `attack` and `attack:charged` for
  *  exactly this reason: once the seeded enemy shield is spent, later charged casts grant no Barrier
  *  and so keep their own tag. Which entry carries the slot is therefore a function of emission
  *  ORDER in `playerTurn.ts`; a pure refactor that reorders emission (no behaviour change) can flip

--- a/src/utils/combat/emitAttacked.ts
+++ b/src/utils/combat/emitAttacked.ts
@@ -16,7 +16,16 @@ export function emitAttacked(args: {
     hitOutcomes: boolean[];
     isPrimaryTarget: boolean;
     shieldWasHit: boolean;
-    /** per-attack aggregate dealt to the focus victim (Tenacity's >25%-maxHP gate reads this). */
+    /**
+     * The damage this victim took from the ONE attack these events belong to (Tenacity's
+     * >25%-maxHP gate reads it).
+     *
+     * Multi-hit full-walk epic, PR2: on the positional path the engine now groups its signals by
+     * SUB-ATTACK and calls this once per sub-attack, so for a `hits: N` cast this is that
+     * sub-attack's slice, not the victim's cast-wide aggregate. That is the corrected basis — a
+     * gate phrased "in one hit" was previously fed N hits' worth. N=1 is unchanged, and the
+     * non-positional call sites (one attack per call) were never affected.
+     */
     damage: number;
 }): void {
     const { bus, round, targetId, attackerId, hitOutcomes, isPrimaryTarget, shieldWasHit, damage } =

--- a/src/utils/combat/emitPerVictimAttacked.ts
+++ b/src/utils/combat/emitPerVictimAttacked.ts
@@ -2,17 +2,20 @@ import type { CombatEventBus } from './events';
 import { emitAttacked } from './emitAttacked';
 
 /**
- * Emits per-victim `attacked` events for an AoE cast: one event per hit per
- * footprint victim, each carrying that victim's OWN damage / shieldWasHit /
- * hitOutcomes, with `isPrimaryTarget` set only on the selected target. Delegates
- * to `emitAttacked` per victim so the per-event conditional-spread shape stays
- * identical to the legacy focus-only emit. Direction-agnostic (caller supplies
- * attacker/victim ids).
+ * Emits per-victim `attacked` events for ONE attack's AoE footprint: one event
+ * per hit per footprint victim, each carrying that victim's OWN damage /
+ * shieldWasHit / hitOutcomes, with `isPrimaryTarget` set only on the selected
+ * target. Delegates to `emitAttacked` per victim so the per-event
+ * conditional-spread shape stays identical to the legacy focus-only emit.
+ * Direction-agnostic (caller supplies attacker/victim ids).
  *
- * Each victim carries its OWN `hitOutcomes` (one entry per hit the victim was
- * actually present for): a victim killed on an earlier hit drops out of later
- * hits, so it collects fewer outcomes than the attack-wide hit count and emits
- * exactly that many `attacked` events — no over-firing of its on-hit reactives.
+ * Multi-hit full-walk epic, PR2: the engine calls this once per SUB-ATTACK, so
+ * `victims` is one sub-attack's footprint and each signal carries exactly one
+ * `hitOutcomes` entry. The drop-out story therefore lives in the engine's outer
+ * sub-attack map, not here: a victim killed on an earlier sub-attack simply has
+ * no entry in the later sub-attacks' maps, so it collects fewer `attacked`
+ * events than the cast's hit count — no over-firing of its on-hit reactives.
+ * Total `attacked` cardinality across the cast is unchanged by the regrouping.
  */
 export function emitPerVictimAttacked(args: {
     bus: CombatEventBus;

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -5931,9 +5931,11 @@ export function runCombat(input: CombatEngineInput): {
 
         // ── Deferred ability-performed emit helper ────────────────────────────────────
         // Extracted from the four structurally identical bus.emit sites (focus positional,
-        // walked-team positional, enemy positional, enemy 0-damage fallback). The caller
-        // supplies the per-victim crit aggregate (anyCrit / critPairs) — or the anchor-based
-        // fallback values for the 0-damage path — so each site only passes what it knows.
+        // walked-team positional, enemy positional, enemy 0-damage fallback). The caller supplies
+        // this event's crit identity — since PR2 that is ONE SUB-ATTACK's `didCrit` /
+        // `critVictimIds` on the interleaved path, or the cast-wide per-victim aggregate
+        // (`anyCrit` / `critPairs`) on the nothing-landed and 0-damage fallbacks — so each site
+        // only passes what it knows.
         //
         // PR2 Task 3: a multi-hit skill is N consecutive full-walk attacks, so a positional cast
         // now calls this ONCE PER SUB-ATTACK (see the interleaved emission block in
@@ -6535,8 +6537,10 @@ export function runCombat(input: CombatEngineInput): {
         //     detonation); the enemy site DEFERS everything but its first `ability-performed` to
         //     AFTER its inline non-positional damage-taken-leech tail (its row-14 accounting, kept
         //     inline → U5) by passing `deferEmission` and running the returned `emitDeferred` there.
-        // Returns { critAgg, attackedSignals, emitDeferred } so the enemy site can record
-        // enemyCritAgg (for its 0-damage deferred-emit fallback) and run that remainder. sel carries
+        // Returns { critAgg, emitDeferred } so the enemy site can record enemyCritAgg (for its
+        // 0-damage deferred-emit fallback) and run that remainder. The signal map itself is NOT
+        // returned: since PR2 Task 3 every consumer reads it through `emitAttackedForSubAttack` /
+        // `emitDeferred`, so exposing it would only invite a second, out-of-order drain. sel carries
         // the pre-call head-locals the block reads (esp. preTurnVictimStatus, which MUST be the
         // pre-runPlayerTurn snapshot — never recomputed post-hoc).
         /**
@@ -6631,7 +6635,6 @@ export function runCombat(input: CombatEngineInput): {
                 critVictimIds: string[];
                 subAttacks: SubAttackOutcome[];
             };
-            attackedSignals: PositionalAttackedSignals;
             /** Runs the deferred remainder of the emission sequence. No-op unless `deferEmission`. */
             emitDeferred: () => void;
         } => {
@@ -6747,16 +6750,25 @@ export function runCombat(input: CombatEngineInput): {
             const signalledIndices = [...attackedSignals.keys()].sort((a, b) => a - b);
             if (sel.deferredAbilityPerformed) {
                 const dap = sel.deferredAbilityPerformed;
-                // Gate on the FOOTPRINT, not on `whiffed`: `whiffed` records only that the anchor
-                // failed to resolve, so a resolved anchor over an empty footprint yields
-                // {whiffed:false, victimIds:[], damage:0} and emitting there would be a phantom
-                // attack. `on-crit` and `on-debuff-inflicted` have no damage guard the way
-                // `on-deal-damage` incidentally does, so a phantom event really would fire them.
-                const emitting = critAgg.subAttacks.filter(
-                    (sub) => sub.victimIds.length > 0 && sub.damage !== 0
-                );
+                // Gate on the FOOTPRINT ALONE, not on `whiffed` and not on the damage:
+                //  • `whiffed` records only that the anchor failed to resolve, so a resolved anchor
+                //    over an empty footprint yields {whiffed:false, victimIds:[], damage:0} and
+                //    emitting there would be a phantom attack. `on-crit` and `on-debuff-inflicted`
+                //    have no damage guard the way `on-deal-damage` incidentally does, so a phantom
+                //    event really would fire them.
+                //  • `sub.damage` is the POST-funnel `incomingBooked` sum, which is legitimately 0
+                //    for a sub-attack whose whole hit was redirected by Protection or transformed
+                //    into a DoT. That is a real attack under the locked rule — it struck victims,
+                //    it rolled, it must emit — and excluding it ALSO re-inflates the survivors,
+                //    because `share = dap.damage / emitting.length` divides the cast's pre-funnel
+                //    directDamage by the emitting count. (The plan prescribed `damage === 0` here;
+                //    that was a plan defect, corrected in the plan file too.)
+                const emitting = critAgg.subAttacks.filter((sub) => sub.victimIds.length > 0);
                 if (emitting.length === 0) {
-                    // Nothing landed (every sub-attack whiffed, or the funnel booked nothing).
+                    // Nothing landed: every sub-attack either whiffed (no anchor) or resolved over
+                    // an EMPTY footprint. Note this is a footprint test only — a sub-attack that
+                    // struck victims but booked no damage (Protection redirect, DoT transform) is
+                    // still an attack and emits above.
                     // The cast still reports ONE attack with the cast-wide aggregate — exactly the
                     // pre-PR2 emit, which is what keeps a whiffed/absorbed N=1 cast byte-identical
                     // (its target-less row is pruned by finalizeMissEntry unless a reactive nested
@@ -6811,9 +6823,12 @@ export function runCombat(input: CombatEngineInput): {
                                     ),
                             });
                         }
-                        // A bucket with signals but no event (every victim's booked damage was
-                        // diverted away) still emits its `attacked`: total attacked cardinality is
-                        // invariant across PR2, which is what keeps incoming procs correct.
+                        // Emitted unconditionally on the index, independent of whether this bucket
+                        // also produced an event: total `attacked` cardinality is invariant across
+                        // PR2, which is what keeps incoming procs correct. (Since the gate above
+                        // tests the footprint alone, a bucket with signals always has an event too
+                        // — signals only exist for victims — but the two are kept independent so a
+                        // future gate change cannot silently drop `attacked` events.)
                         const victims = attackedSignals.get(idx);
                         if (victims && victims.size > 0) {
                             steps.push({
@@ -6837,12 +6852,20 @@ export function runCombat(input: CombatEngineInput): {
             }
             let emitDeferred = (): void => {};
             if (deferEmission) {
-                // Keep ONLY the first `ability-performed` here (its historical position); the rest
+                // Keep ONLY a LEADING `ability-performed` here (its historical position); the rest
                 // of the sequence — including that event's own `attacked` — runs at the call
                 // site's emit point.
-                const firstEvent = steps.findIndex((step) => step.isEvent);
-                if (firstEvent >= 0) steps[firstEvent].run();
-                const rest = steps.filter((_, i) => i !== firstEvent);
+                //
+                // The hoist tests `steps[0]` specifically, NOT `findIndex(isEvent)`. Searching past
+                // leading non-event steps would REORDER the stream whenever sub-attack 0 produced
+                // `attacked` signals but no event: it would pull sub-attack 1's event forward past
+                // sub-attack 0's `attacked`, which then replays after it and attaches sub-attack 0's
+                // victims to sub-attack 1's log row. When step 0 is not an event we defer the whole
+                // list, which keeps relative order intact at the cost of the historical position of
+                // the first event — the strictly safer trade.
+                const hoistFirst = steps.length > 0 && steps[0].isEvent;
+                if (hoistFirst) steps[0].run();
+                const rest = hoistFirst ? steps.slice(1) : steps;
                 emitDeferred = () => {
                     for (const step of rest) step.run();
                 };
@@ -6859,7 +6882,7 @@ export function runCombat(input: CombatEngineInput): {
             if (recipe && recipe.dets.length > 0) {
                 applyPerVictimDetonation(recipe, detonationTargets, sink, actor.id, tb);
             }
-            return { critAgg, attackedSignals, emitDeferred };
+            return { critAgg, emitDeferred };
         };
 
         // H1 Task 6: rebind the per-round shield-granted accumulator EVERY round (not gated on

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -5716,8 +5716,11 @@ export function runCombat(input: CombatEngineInput): {
         // the victim's own self-buff store (both channels: scheduled + ability payload).
         // Direction-agnostic: victimIncomingModifiers(v.id) works for ENEMY victims
         // (focus/team site) and PLAYER victims (enemy site) alike.
-        // No emitHit: runPlayerTurn already emits ONE aggregate ability-performed per turn;
-        // per-hit/per-victim event fidelity is a documented Phase-5 follow-up.
+        // No emitHit: this pure driver emits nothing. On the positional path runPlayerTurn defers
+        // its `ability-performed` to the engine, which emits one per SUB-ATTACK from the outcomes
+        // this driver returns (see drivePositionalTurnApply's interleaved emission block).
+        // Per-HIT event fidelity below the sub-attack — one event per (hit, victim) pair — remains
+        // a documented follow-up.
         const drivePositionalApply = (args: {
             scalars: AttackerDamageScalars;
             // hitCrits is co-populated with positionalScalars by Task 7 (both are set iff a damage

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -59,6 +59,7 @@ import {
     footprintVictims,
     type VictimDamageOutcome,
     type AppliedVictimDamage,
+    type SubAttackOutcome,
 } from './positionalApply';
 import type { AttackerDamageScalars } from './victimDamage';
 import { victimHitDamage } from './victimDamage';
@@ -3910,7 +3911,23 @@ export function runCombat(input: CombatEngineInput): {
         // identical, and the attack entry already exists to nest under. NO combat listener
         // subscribes to `reactive-damage-performed` → it can never chain.
         let deferReflectLogs = false;
-        const pendingReflectLogs: { sourceId: string; targetId: string; amount: number }[] = [];
+        /**
+         * The sub-attack currently being applied (epic: multi-hit full-walk attacks, PR2 Task 3),
+         * or `undefined` outside a positional apply. Set by `drivePositionalApply`'s
+         * `applyToVictim` wrapper, which is the ONLY entry point into the funnel during a
+         * positional cast, so every row the funnel buffers below can be stamped with the
+         * sub-attack that raised it. Needed because the buffers fill during the WHOLE apply (all
+         * N sub-attacks) but drain during emission: an untagged flush called once per sub-attack
+         * would empty the entire buffer on the FIRST call and nest sub-attack 1..N-1's rows under
+         * sub-attack 0's attack row.
+         */
+        let currentSubAttackIndex: number | undefined;
+        const pendingReflectLogs: {
+            sourceId: string;
+            targetId: string;
+            amount: number;
+            subAttack?: number;
+        }[] = [];
         // Shared LOG-ONLY consequence-event buffer. Carries the log-only twins
         // `shield-destroyed-log` / `cheat-death-log` (NOT the real shield-destroyed /
         // cheat-death-activated events, which emit inline for their combat listeners). NO combat
@@ -3919,13 +3936,27 @@ export function runCombat(input: CombatEngineInput): {
         // applyVictimDamage during drivePositionalApply must wait until the attack entry exists
         // (post emitDeferredAbilityPerformed) so buildCombatLog's routeReaction nests them under
         // it instead of a preceding sibling entry in the attacker's turn.
-        const pendingConsequenceLogs: CombatEvent[] = [];
+        const pendingConsequenceLogs: { ev: CombatEvent; subAttack?: number }[] = [];
         // Flush the log-only consequence twins buffered by an application. Split out of
         // flushReflectLogs so the REACTIVE-damage path can flush consequences alone (it buffers no
         // reflect rows), after its own attack row exists — see `deferConsequenceLogs`.
-        const flushConsequenceLogs = (): void => {
-            for (const ev of pendingConsequenceLogs) bus.emit(ev);
+        //
+        // PR2 Task 3: `subAttack` drains ONLY the rows raised by that sub-attack (plus any
+        // untagged row, which can only come from a non-positional buffering path), so each
+        // sub-attack's twins nest under ITS OWN attack row. Omitted ⟹ drain everything, which is
+        // what every non-positional caller (triggers.ts's `ctx.flushConsequenceLogs`) wants and
+        // what the positional path's post-loop sweep uses to guarantee nothing leaks into the
+        // next turn.
+        const flushConsequenceLogs = (subAttack?: number): void => {
+            if (pendingConsequenceLogs.length === 0) return;
+            const kept: typeof pendingConsequenceLogs = [];
+            for (const row of pendingConsequenceLogs) {
+                if (subAttack === undefined || row.subAttack === undefined) bus.emit(row.ev);
+                else if (row.subAttack === subAttack) bus.emit(row.ev);
+                else kept.push(row);
+            }
             pendingConsequenceLogs.length = 0;
+            pendingConsequenceLogs.push(...kept);
         };
         // A reactive-damage proc (Insidiousness, counters) applies its hit and only THEN emits its
         // own `reactive-damage-performed` log row (triggers.ts emitReactiveDamageLog). Consequence
@@ -3935,8 +3966,18 @@ export function runCombat(input: CombatEngineInput): {
         // they buffer instead; triggers.ts flushes them via `ctx.flushConsequenceLogs` immediately
         // after the attack row is emitted, so cause precedes consequence.
         let deferConsequenceLogs = false;
-        const flushReflectLogs = (): void => {
+        // PR2 Task 3: `subAttack` filters exactly as flushConsequenceLogs above — see its note.
+        const flushReflectLogs = (subAttack?: number): void => {
+            const kept: typeof pendingReflectLogs = [];
             for (const row of pendingReflectLogs) {
+                if (
+                    subAttack !== undefined &&
+                    row.subAttack !== undefined &&
+                    row.subAttack !== subAttack
+                ) {
+                    kept.push(row);
+                    continue;
+                }
                 bus.emit({
                     type: 'reactive-damage-performed',
                     sourceId: row.sourceId,
@@ -3949,7 +3990,8 @@ export function runCombat(input: CombatEngineInput): {
                 });
             }
             pendingReflectLogs.length = 0;
-            flushConsequenceLogs();
+            pendingReflectLogs.push(...kept);
+            flushConsequenceLogs(subAttack);
         };
         const applyVictimDamage = (
             rawDamage: number,
@@ -4429,7 +4471,10 @@ export function runCombat(input: CombatEngineInput): {
                         triggerActorId: actingActorId,
                     };
                     if (deferReflectLogs || deferConsequenceLogs)
-                        pendingConsequenceLogs.push(shieldConverterGrantLogEv);
+                        pendingConsequenceLogs.push({
+                            ev: shieldConverterGrantLogEv,
+                            subAttack: currentSubAttackIndex,
+                        });
                     else bus.emit(shieldConverterGrantLogEv);
                 }
             }
@@ -4577,7 +4622,10 @@ export function runCombat(input: CombatEngineInput): {
                             triggerActorId: actingActorId,
                         };
                         if (deferReflectLogs || deferConsequenceLogs)
-                            pendingConsequenceLogs.push(grantLogEv);
+                            pendingConsequenceLogs.push({
+                                ev: grantLogEv,
+                                subAttack: currentSubAttackIndex,
+                            });
                         else bus.emit(grantLogEv);
                     }
                 }
@@ -4614,7 +4662,8 @@ export function runCombat(input: CombatEngineInput): {
                     duringTurnOf: actingActorId,
                     triggerActorId: actingActorId,
                 };
-                if (deferReflectLogs || deferConsequenceLogs) pendingConsequenceLogs.push(logEv);
+                if (deferReflectLogs || deferConsequenceLogs)
+                    pendingConsequenceLogs.push({ ev: logEv, subAttack: currentSubAttackIndex });
                 else bus.emit(logEv);
             }
             victim.currentHp = Math.max(0, victim.currentHp - hpDamage);
@@ -4679,7 +4728,10 @@ export function runCombat(input: CombatEngineInput): {
                         triggerActorId: actingActorId,
                     };
                     if (deferReflectLogs || deferConsequenceLogs)
-                        pendingConsequenceLogs.push(cheatDeathLogEv);
+                        pendingConsequenceLogs.push({
+                            ev: cheatDeathLogEv,
+                            subAttack: currentSubAttackIndex,
+                        });
                     else bus.emit(cheatDeathLogEv);
                 } else {
                     // First reach 0 (no intercept) → record the destroyed round + emit
@@ -4967,6 +5019,7 @@ export function runCombat(input: CombatEngineInput): {
                                     sourceId: victim.id,
                                     targetId: attacker.id,
                                     amount: reflected,
+                                    subAttack: currentSubAttackIndex,
                                 });
                             } else {
                                 bus.emit({
@@ -5715,7 +5768,15 @@ export function runCombat(input: CombatEngineInput): {
             // keyed by victim id. Required for a non-zero delta — see the causality note above
             // perVictimOutgoingDeltaPct. Unsupplied → delta stays 0 for every victim.
             preTurnVictimStatus?: Map<string, PreTurnVictimStatusSnapshot>;
-        }): { anyCrit: boolean; critPairs: number; critVictimIds: string[] } => {
+        }): {
+            anyCrit: boolean;
+            critPairs: number;
+            critVictimIds: string[];
+            // PR2 Task 3: PR1's per-sub-attack outcomes. applyPositionalDamage has always returned
+            // them (the object below is forwarded verbatim); this declaration merely stops hiding
+            // them from the callers that now emit one `ability-performed` per entry.
+            subAttacks: SubAttackOutcome[];
+        } => {
             // Task 3: this is the ONE deferred (positional) apply path — reflects fired here must
             // buffer their log row until emitDeferredAbilityPerformed creates the attack entry
             // (see the deferReflectLogs doc above applyVictimDamage). try/finally so the flag
@@ -5766,7 +5827,20 @@ export function runCombat(input: CombatEngineInput): {
                             ]).includes('Defensive Affinity Override'),
                         };
                     },
-                    applyToVictim: args.applyToVictim,
+                    // PR2 Task 3: stamp the sub-attack under application so the funnel's deferred
+                    // LOG buffers (reflect rows + consequence twins) can be drained per sub-attack
+                    // rather than all under the first attack row. Save/restore rather than clear:
+                    // a reflect proc re-enters the funnel from INSIDE this call and still belongs
+                    // to the same sub-attack.
+                    applyToVictim: (victim, damage, isAnchor, subAttackIndex) => {
+                        const prevSubAttack = currentSubAttackIndex;
+                        currentSubAttackIndex = subAttackIndex;
+                        try {
+                            return args.applyToVictim(victim, damage, isAnchor);
+                        } finally {
+                            currentSubAttackIndex = prevSubAttack;
+                        }
+                    },
                     // Pure ACCUMULATOR (not a bus emit): record per-victim damage into the
                     // per-round map so the RoundData row can expose perTargetDamage. Identical
                     // across all three sites (focus / team / enemy), so it lives here.
@@ -5860,15 +5934,29 @@ export function runCombat(input: CombatEngineInput): {
         // walked-team positional, enemy positional, enemy 0-damage fallback). The caller
         // supplies the per-victim crit aggregate (anyCrit / critPairs) — or the anchor-based
         // fallback values for the 0-damage path — so each site only passes what it knows.
+        //
+        // PR2 Task 3: a multi-hit skill is N consecutive full-walk attacks, so a positional cast
+        // now calls this ONCE PER SUB-ATTACK (see the interleaved emission block in
+        // drivePositionalTurnApply) with that sub-attack's own damage slice and crit identity. `damage` and `subAttack` are therefore explicit
+        // parameters rather than being read off `dap`.
         const emitDeferredAbilityPerformed = (
             dap: NonNullable<PlayerTurnResult['deferredAbilityPerformed']>,
+            // This event's damage. The cast's `dap.damage` (pre-funnel directDamage) for the
+            // single-event paths; that same basis split across the emitting sub-attacks for a
+            // multi-hit cast. Deliberately NOT SubAttackOutcome.damage, which is the post-funnel
+            // `incomingBooked` sum — a different number, and changing the basis and the
+            // cardinality in one PR would conflate two behaviour moves.
+            damage: number,
             didCrit: boolean,
             critHits: number,
-            // The DISTINCT enemies this cast critically hit (positionalApply's per-victim crit
+            // The DISTINCT enemies this event critically hit (positionalApply's per-victim crit
             // identity). Carried on the event so an `on-ally-crit` reactive can route "that enemy"
             // to the enemies actually crit rather than the cast's SELECTED anchor (which may not
             // have crit at all in an AoE). Empty on the 0-damage fallback path (no apply ran).
-            critVictimIds: string[]
+            critVictimIds: string[],
+            // Which sub-attack this event belongs to, for the deferred-log drain below. Omitted on
+            // the single-event paths ⟹ drain everything (the pre-PR2 behaviour).
+            subAttack?: number
         ) => {
             bus.emit({
                 type: 'ability-performed',
@@ -5876,16 +5964,17 @@ export function runCombat(input: CombatEngineInput): {
                 targetId: dap.targetId,
                 round: dap.round,
                 abilityType: 'damage',
-                damage: dap.damage,
+                damage,
                 didCrit,
                 ...(critHits > 0 ? { critHits } : {}),
                 ...(critVictimIds.length > 0 ? { critVictimIds } : {}),
                 didHit: true,
             });
-            // Task 3: the attack entry now exists — drain any reflect rows buffered during this
-            // cast's per-victim apply so buildCombatLog nests them UNDER this attack (not a
-            // preceding charge/buff entry in the attacker's turn). No-op when none buffered.
-            flushReflectLogs();
+            // Task 3: the attack entry now exists — drain the reflect rows THIS sub-attack
+            // buffered during the per-victim apply so buildCombatLog nests them UNDER this attack
+            // (not a preceding charge/buff entry in the attacker's turn, nor — since PR2 — under
+            // an earlier sub-attack's row). No-op when none buffered.
+            flushReflectLogs(subAttack);
         };
 
         // ── Unified per-actor turn resolvers (bySide unification PR6a) ──────────────
@@ -6441,12 +6530,13 @@ export function runCombat(input: CombatEngineInput): {
         //     player→enemy sites proc a STANDING leech off the dealt damage; the enemy→player site
         //     procs a TAKEN leech off the damage each player victim took (+ captures the focus
         //     victim's shield-hit flag). Called at the SAME per-victim point for all three.
-        //   • emitAttacked — the per-victim `attacked` emit. The player→enemy sites emit it HERE
-        //     (before the per-victim detonation); the enemy site DEFERS its emit to AFTER its inline
-        //     non-positional damage-taken-leech tail (its row-14 accounting, kept inline → U5) and so
-        //     passes a no-op, consuming the RETURNED attackedSignals there instead.
-        // Returns { critAgg, attackedSignals } so the enemy site can record enemyCritAgg (for its
-        // 0-damage deferred-emit fallback) and run its deferred per-victim attacked emit. sel carries
+        //   • emitAttackedForSubAttack — ONE sub-attack's `attacked` emit (PR2 Task 3). The
+        //     player→enemy sites run the whole interleaved sequence HERE (before the per-victim
+        //     detonation); the enemy site DEFERS everything but its first `ability-performed` to
+        //     AFTER its inline non-positional damage-taken-leech tail (its row-14 accounting, kept
+        //     inline → U5) by passing `deferEmission` and running the returned `emitDeferred` there.
+        // Returns { critAgg, attackedSignals, emitDeferred } so the enemy site can record
+        // enemyCritAgg (for its 0-damage deferred-emit fallback) and run that remainder. sel carries
         // the pre-call head-locals the block reads (esp. preTurnVictimStatus, which MUST be the
         // pre-runPlayerTurn snapshot — never recomputed post-hoc).
         /**
@@ -6497,45 +6587,18 @@ export function runCombat(input: CombatEngineInput): {
          * exactly ONE `hitOutcomes` entry. The per-hit `attacked` cardinality that incoming
          * procs (Reactive Ward / Tenacity / Second Wind) depend on is therefore unchanged —
          * it simply moves from "one victim entry with N outcomes" to "N sub-attack entries
-         * with one outcome each". See {@link flattenAttackedSignals}.
+         * with one outcome each".
+         *
+         * PR2 Task 3 consumes the grouping: the buckets are emitted one at a time, each right
+         * after its own sub-attack's `ability-performed`. Two payload fields therefore change for
+         * a multi-hit cast (and ONLY for a multi-hit cast — with N=1 there is one bucket and the
+         * numbers are the cast's): each `attacked` now carries its SUB-ATTACK's damage rather than
+         * the victim's cast-wide aggregate, and `shieldWasHit` is that sub-attack's flag rather
+         * than an OR across the cast. Both are the corrected values — a per-hit `attacked` that
+         * reported the whole cast's damage over-fed Tenacity's >25%-maxHP gate and the log's
+         * splash `amount`.
          */
         type PositionalAttackedSignals = Map<number, Map<string, PositionalVictimSignal>>;
-        /**
-         * Collapse the sub-attack-grouped signals back into the cast-wide, victim-keyed view the
-         * three emit sites have always consumed.
-         *
-         * BYTE-IDENTICAL to the pre-grouping map, by construction: sub-attacks are folded in
-         * ascending index order and a victim is visited at most once per sub-attack, so the
-         * damage summation order, the `hitOutcomes` order, and the victim insertion order all
-         * reproduce the single flat accumulator exactly.
-         *
-         * Transitional: Task 2 is a pure data-structure change, so emission must not move. Task 3
-         * replaces this flatten with a per-sub-attack interleaved emit — at which point each
-         * `attacked` will carry its OWN sub-attack's damage instead of the cast aggregate. That
-         * payload change is deliberately NOT part of this commit.
-         */
-        const flattenAttackedSignals = (
-            grouped: PositionalAttackedSignals
-        ): Map<string, PositionalVictimSignal> => {
-            const flat = new Map<string, PositionalVictimSignal>();
-            for (const [, victims] of [...grouped.entries()].sort((a, b) => a[0] - b[0])) {
-                for (const [victimId, sig] of victims) {
-                    const prev = flat.get(victimId);
-                    if (!prev) {
-                        flat.set(victimId, {
-                            damage: sig.damage,
-                            shieldWasHit: sig.shieldWasHit,
-                            hitOutcomes: [...sig.hitOutcomes],
-                        });
-                        continue;
-                    }
-                    prev.damage += sig.damage;
-                    prev.shieldWasHit = prev.shieldWasHit || sig.shieldWasHit;
-                    prev.hitOutcomes.push(...sig.hitOutcomes);
-                }
-            }
-            return flat;
-        };
         const drivePositionalTurnApply = (
             actor: CombatActor,
             tb: TurnBindings,
@@ -6546,16 +6609,36 @@ export function runCombat(input: CombatEngineInput): {
                 outcome: VictimDamageOutcome,
                 didCrit: boolean
             ) => void,
-            emitAttacked: (attackedSignals: PositionalAttackedSignals) => void
+            /**
+             * Emits ONE sub-attack's `attacked` events (PR2 Task 3 — was one call for the whole
+             * cast). Invoked once per sub-attack that produced signals, in ascending index order,
+             * immediately after that sub-attack's own `ability-performed`.
+             */
+            emitAttackedForSubAttack: (victims: Map<string, PositionalVictimSignal>) => void,
+            /**
+             * The enemy site emits its `attacked` AFTER the helper returns (its row-14 accounting
+             * tail is kept inline — SP-U U5). Set to defer everything except the FIRST
+             * `ability-performed`, which stays exactly where the single aggregate emit has always
+             * been (before the per-victim detonation): the returned `emitDeferred` runs the rest
+             * of the interleaved sequence at the call site's own emit point. With N=1 that is
+             * byte-identical to the pre-PR2 order (event → detonation → attacked).
+             */
+            deferEmission = false
         ): {
-            critAgg: { anyCrit: boolean; critPairs: number; critVictimIds: string[] };
+            critAgg: {
+                anyCrit: boolean;
+                critPairs: number;
+                critVictimIds: string[];
+                subAttacks: SubAttackOutcome[];
+            };
             attackedSignals: PositionalAttackedSignals;
+            /** Runs the deferred remainder of the emission sequence. No-op unless `deferEmission`. */
+            emitDeferred: () => void;
         } => {
             // Record EACH footprint victim's damage + shield-hit flag so the post-apply emit wakes
             // EVERY hit victim's on-attacked reactives (counters + self-repairs/defensive buffs),
-            // not just the anchor. Keyed by (subAttackIndex, victim.id) since PR2 Task 2 — the
-            // per-hit aggregation the emit sites still consume is rebuilt by
-            // flattenAttackedSignals, which is byte-identical to the old victim-keyed accumulator.
+            // not just the anchor. Keyed by (subAttackIndex, victim.id) since PR2 Task 2, and
+            // consumed one bucket at a time by the interleaved emit below.
             const attackedSignals: PositionalAttackedSignals = new Map();
             // Per-footprint Stasis-break: collect EVERY covered footprint victim (≠ anchor) stasised
             // at hit time so its Stasis is broken too — the anchor break is handled at the call site.
@@ -6640,25 +6723,132 @@ export function runCombat(input: CombatEngineInput): {
                     }
                 },
             });
-            // Emit this attacker's ONE aggregate ability-performed AFTER the per-victim apply, but
-            // BEFORE the per-victim `attacked` emits, with the TRUE per-victim crit signal. Present
-            // ⟺ this turn resolved positionally (same suppression condition).
-            if (sel.deferredAbilityPerformed) {
-                emitDeferredAbilityPerformed(
-                    sel.deferredAbilityPerformed,
-                    critAgg.anyCrit,
-                    critAgg.critPairs,
-                    critAgg.critVictimIds
-                );
-            }
             // Set the DEFERRED Stasis break for every covered victim (unconditional — covered victims
             // have no same-turn re-apply vector). The victim's own skip branch consumes it next turn.
+            // Pure state, no events: hoisted ABOVE the emission block (PR2 Task 3) so the
+            // interleaved event/attacked pairs below stay adjacent, with nothing between them.
             for (const victimId of coveredStasisVictims) {
                 stasisBreakPending.set(victimId, true);
             }
-            // Player→enemy sites emit the per-victim `attacked` HERE (before detonation); the enemy
-            // site passes a no-op and emits from the RETURNED attackedSignals in its inline tail.
-            emitAttacked(attackedSignals);
+            // ── Interleaved per-sub-attack emission (PR2 Task 3) ───────────────────────────
+            // A multi-hit skill is N consecutive full-walk attacks, so this cast emits ONE
+            // `ability-performed` per sub-attack that landed, each IMMEDIATELY followed by that
+            // sub-attack's own `attacked` events.
+            //
+            // The adjacency is load-bearing, not cosmetic: buildCombatLog's `attacked` handler
+            // fills `openAttackEntry`, which is whichever attack row was created most recently.
+            // Emitting all N events first would leave rows 1..N-1 with zero targets, and
+            // `finalizeMissEntry` silently splices a target-less non-miss row out as a phantom —
+            // collapsing N rows into one and losing the per-sub-attack detail.
+            //
+            // Built as a step list rather than emitted inline so the enemy site can run the first
+            // step here and the remainder after its own tail (see `deferEmission`).
+            const steps: { isEvent: boolean; run: () => void }[] = [];
+            const signalledIndices = [...attackedSignals.keys()].sort((a, b) => a - b);
+            if (sel.deferredAbilityPerformed) {
+                const dap = sel.deferredAbilityPerformed;
+                // Gate on the FOOTPRINT, not on `whiffed`: `whiffed` records only that the anchor
+                // failed to resolve, so a resolved anchor over an empty footprint yields
+                // {whiffed:false, victimIds:[], damage:0} and emitting there would be a phantom
+                // attack. `on-crit` and `on-debuff-inflicted` have no damage guard the way
+                // `on-deal-damage` incidentally does, so a phantom event really would fire them.
+                const emitting = critAgg.subAttacks.filter(
+                    (sub) => sub.victimIds.length > 0 && sub.damage !== 0
+                );
+                if (emitting.length === 0) {
+                    // Nothing landed (every sub-attack whiffed, or the funnel booked nothing).
+                    // The cast still reports ONE attack with the cast-wide aggregate — exactly the
+                    // pre-PR2 emit, which is what keeps a whiffed/absorbed N=1 cast byte-identical
+                    // (its target-less row is pruned by finalizeMissEntry unless a reactive nested
+                    // under it, and that pruning decision must not change).
+                    steps.push({
+                        isEvent: true,
+                        run: () =>
+                            emitDeferredAbilityPerformed(
+                                dap,
+                                dap.damage,
+                                critAgg.anyCrit,
+                                critAgg.critPairs,
+                                critAgg.critVictimIds
+                            ),
+                    });
+                    for (const idx of signalledIndices) {
+                        const victims = attackedSignals.get(idx)!;
+                        steps.push({
+                            isEvent: false,
+                            run: () => emitAttackedForSubAttack(victims),
+                        });
+                    }
+                } else {
+                    // Per-event damage: the cast's pre-funnel `directDamage` split across the
+                    // emitting sub-attacks — today's basis, N ways (see the Decisions table).
+                    // N=1 ⟹ the divisor is 1 ⟹ the exact same number as before.
+                    const share = dap.damage / emitting.length;
+                    const emittingIndices = new Set(emitting.map((sub) => sub.index));
+                    const indices = [
+                        ...new Set([
+                            ...critAgg.subAttacks.map((sub) => sub.index),
+                            ...signalledIndices,
+                        ]),
+                    ].sort((a, b) => a - b);
+                    for (const idx of indices) {
+                        const sub = critAgg.subAttacks[idx];
+                        if (sub && emittingIndices.has(idx)) {
+                            steps.push({
+                                isEvent: true,
+                                run: () =>
+                                    emitDeferredAbilityPerformed(
+                                        dap,
+                                        share,
+                                        sub.didCrit,
+                                        // THIS sub-attack's critting victims, not the cast-wide
+                                        // critPairs — that count is hits × victims and would make
+                                        // `on-crit` fire the whole cast's tally N times over. Σ of
+                                        // these lengths reproduces critPairs exactly.
+                                        sub.critVictimIds.length,
+                                        sub.critVictimIds,
+                                        idx
+                                    ),
+                            });
+                        }
+                        // A bucket with signals but no event (every victim's booked damage was
+                        // diverted away) still emits its `attacked`: total attacked cardinality is
+                        // invariant across PR2, which is what keeps incoming procs correct.
+                        const victims = attackedSignals.get(idx);
+                        if (victims && victims.size > 0) {
+                            steps.push({
+                                isEvent: false,
+                                run: () => emitAttackedForSubAttack(victims),
+                            });
+                        }
+                    }
+                }
+                // Sweep: a sub-attack that buffered log rows but emitted no event (nothing landed)
+                // would otherwise leak them into the next turn's row. No-op in every normal case.
+                steps.push({ isEvent: false, run: () => flushReflectLogs() });
+            } else {
+                // runPlayerTurn already emitted this cast's `ability-performed` inline — only the
+                // `attacked` fan-out is ours. Same events, same per-victim order, now grouped by
+                // sub-attack.
+                for (const idx of signalledIndices) {
+                    const victims = attackedSignals.get(idx)!;
+                    steps.push({ isEvent: false, run: () => emitAttackedForSubAttack(victims) });
+                }
+            }
+            let emitDeferred = (): void => {};
+            if (deferEmission) {
+                // Keep ONLY the first `ability-performed` here (its historical position); the rest
+                // of the sequence — including that event's own `attacked` — runs at the call
+                // site's emit point.
+                const firstEvent = steps.findIndex((step) => step.isEvent);
+                if (firstEvent >= 0) steps[firstEvent].run();
+                const rest = steps.filter((_, i) => i !== firstEvent);
+                emitDeferred = () => {
+                    for (const step of rest) step.run();
+                };
+            } else {
+                for (const step of steps) step.run();
+            }
             // Per-victim skill-triggered detonation. Each victim HIT by this cast that is STILL ALIVE
             // detonates its OWN containers (no role-scale — full stored stacks). Bombs = full shield
             // drain/no pen; inferno+corrosion BYPASS shield (DoT semantics). Credited to the
@@ -6669,7 +6859,7 @@ export function runCombat(input: CombatEngineInput): {
             if (recipe && recipe.dets.length > 0) {
                 applyPerVictimDetonation(recipe, detonationTargets, sink, actor.id, tb);
             }
-            return { critAgg, attackedSignals };
+            return { critAgg, attackedSignals, emitDeferred };
         };
 
         // H1 Task 6: rebind the per-round shield-granted accumulator EVERY round (not gated on
@@ -7918,12 +8108,9 @@ export function runCombat(input: CombatEngineInput): {
                                     },
                                     (victim, damage, outcome) =>
                                         procLeechesForVictim(actor.id, victim, damage, outcome),
-                                    (attackedSignals) => {
-                                        // PR2 Task 2: the signals arrive grouped by sub-attack;
-                                        // flatten (in index order) to the cast-wide victim view
-                                        // this emit has always consumed. Task 3 replaces the
-                                        // flatten with a per-sub-attack interleaved emit.
-                                        const victims = flattenAttackedSignals(attackedSignals);
+                                    // PR2 Task 3: ONE sub-attack's victims per call, emitted right
+                                    // after that sub-attack's own `ability-performed`.
+                                    (victims) => {
                                         if (victims.size > 0) {
                                             emitPerVictimAttacked({
                                                 bus,
@@ -8149,9 +8336,8 @@ export function runCombat(input: CombatEngineInput): {
                                     },
                                     (victim, damage, outcome) =>
                                         procLeechesForVictim(actor.id, victim, damage, outcome),
-                                    (attackedSignals) => {
-                                        // PR2 Task 2 — mirror of the focus site's flatten.
-                                        const victims = flattenAttackedSignals(attackedSignals);
+                                    // PR2 Task 3 — mirror of the focus site's per-sub-attack emit.
+                                    (victims) => {
                                         if (victims.size > 0) {
                                             emitPerVictimAttacked({
                                                 bus,
@@ -8496,7 +8682,12 @@ export function runCombat(input: CombatEngineInput): {
                             // skipped), the deferred emit below falls back to the anchor-based crit values
                             // (byte-identical to the pre-Task-5 inline emit for that 0-damage edge case).
                             let enemyCritAgg:
-                                | { anyCrit: boolean; critPairs: number; critVictimIds: string[] }
+                                | {
+                                      anyCrit: boolean;
+                                      critPairs: number;
+                                      critVictimIds: string[];
+                                      subAttacks: SubAttackOutcome[];
+                                  }
                                 | undefined;
                             // Task 5: predict enemy positional apply (mirror of focus/team) so runPlayerTurn
                             // defers its inline ability-performed emit. The opposing roster from the enemy's
@@ -8773,7 +8964,11 @@ export function runCombat(input: CombatEngineInput): {
                                 // helper return when enemyPositional; stays undefined on the non-positional
                                 // path (legacy single emit). The covered-victim Stasis break + detonation
                                 // targets are now owned INSIDE the helper.
-                                let enemyAttackedSignals: PositionalAttackedSignals | undefined;
+                                // PR2 Task 3: the deferred remainder of the enemy cast's
+                                // interleaved emission sequence (its first `ability-performed`
+                                // already fired inside the helper, at the position the single
+                                // aggregate emit has always held). Runs in the inline tail below.
+                                let enemyEmitDeferred: (() => void) | undefined;
                                 if (enemyPositional) {
                                     // Opposing roster + victim wrapper from the per-side bindings
                                     // (enemy→player here). PLAYER-side wrapper: each player victim takes
@@ -8787,14 +8982,14 @@ export function runCombat(input: CombatEngineInput): {
                                     // SP-U U2: shared drivePositionalTurnApply helper. The enemy injects the
                                     // enemy→player TAKEN leech (E2 Task 5 — each player victim procs its OWN
                                     // damage-taken heal/shield leech off the damage IT took) PLUS the focus
-                                    // victim's shield-hit capture; and it passes a NO-OP emitAttacked because
+                                    // victim's shield-hit capture; and it passes `deferEmission` because
                                     // the enemy defers its per-victim `attacked` emit to its inline row-14
                                     // tail below (after the non-positional damage-taken-leech block) — see the
                                     // U5 deferral note there. enemyRollVictimCrit is defined whenever
                                     // enemyPositional (captured from enemyTurn.rollVictimCrit in the same
                                     // non-dead block). The helper owns the detonation targets + covered-victim
                                     // Stasis break; it returns critAgg (for the 0-damage deferred-emit
-                                    // fallback) and attackedSignals (for the deferred emit).
+                                    // fallback) and emitDeferred (the rest of the interleaved sequence).
                                     const tb = turnBindings(actor.side);
                                     const posApply = drivePositionalTurnApply(
                                         actor,
@@ -8823,11 +9018,24 @@ export function runCombat(input: CombatEngineInput): {
                                                         outcome.hpDamage < dmg);
                                             }
                                         },
-                                        // Enemy defers its per-victim `attacked` emit to the inline tail (U5).
-                                        () => {}
+                                        // PR2 Task 3: ONE sub-attack's victims per call. The enemy
+                                        // still DEFERS the whole fan-out to its inline tail (U5),
+                                        // so these calls run from `emitDeferred` below, not here.
+                                        (victims) => {
+                                            if (victims.size > 0) {
+                                                emitPerVictimAttacked({
+                                                    bus,
+                                                    round: r,
+                                                    attackerId: actor.id,
+                                                    primaryId: tgt.id,
+                                                    victims,
+                                                });
+                                            }
+                                        },
+                                        true
                                     );
                                     enemyCritAgg = posApply.critAgg;
-                                    enemyAttackedSignals = posApply.attackedSignals;
+                                    enemyEmitDeferred = posApply.emitDeferred;
                                 } else {
                                     // SP-U U2: the enemy's non-positional INCOMING-damage accounting tail
                                     // (applyIncomingToTarget + the damage-taken heal/shield leech block + the
@@ -8959,22 +9167,12 @@ export function runCombat(input: CombatEngineInput): {
                                     // SP-U U2: DEFERRED here (not inside the shared helper) because the enemy
                                     // emits AFTER its non-positional damage-taken-leech tail; enemyAttackedSignals
                                     // is the helper's returned per-victim signals (set whenever enemyPositional).
-                                    // PR2 Task 2 — mirror of the two player-side sites' flatten.
-                                    // The outer map is non-empty iff at least one victim was
-                                    // recorded (a bucket is created only when a victim lands in
-                                    // it), so the gate is equivalent to the pre-grouping one.
-                                    const enemyVictims = enemyAttackedSignals
-                                        ? flattenAttackedSignals(enemyAttackedSignals)
-                                        : undefined;
-                                    if (enemyVictims && enemyVictims.size > 0) {
-                                        emitPerVictimAttacked({
-                                            bus,
-                                            round: r,
-                                            attackerId: actor.id,
-                                            primaryId: tgt.id,
-                                            victims: enemyVictims,
-                                        });
-                                    }
+                                    // PR2 Task 3 — the remainder of the interleaved sequence the
+                                    // helper handed back: sub-attack 0's `attacked`, then each
+                                    // later sub-attack's `ability-performed` immediately followed
+                                    // by its own `attacked`. With N=1 this is exactly the single
+                                    // per-victim fan-out that stood here before.
+                                    enemyEmitDeferred?.();
                                 } else {
                                     // LEGACY non-positional single emit — byte-identical to pre-Task-4.
                                     const shieldWasHit = positionalShieldCaptured
@@ -9011,6 +9209,7 @@ export function runCombat(input: CombatEngineInput): {
                                 const dap = enemyDeferredAbilityPerformed;
                                 emitDeferredAbilityPerformed(
                                     dap,
+                                    dap.damage,
                                     dap.didCrit,
                                     dap.critHits ?? 0,
                                     []

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -5688,11 +5688,17 @@ export function runCombat(input: CombatEngineInput): {
             // enemy) and taken (enemy→player) leech need opposite logic, each site supplies its
             // own callback (Tasks 3/5) rather than branching inside the shared inline path.
             // Unsupplied by every current caller → fully inert.
+            // PR2 Task 2: widened with PR1's trailing `subAttackIndex`. PR1 added it to
+            // applyPositionalDamage's own callback contract but NOT to this engine-side wrapper
+            // type, so the parameter was reachable at runtime (the hook is forwarded verbatim,
+            // below) yet un-typeable by a caller. Trailing and optional, so callers that ignore
+            // it keep compiling.
             onVictimResolved?: (
                 victim: CombatActor,
                 damage: number,
                 outcome: VictimDamageOutcome,
-                didCrit: boolean
+                didCrit: boolean,
+                subAttackIndex?: number
             ) => void;
             // Per-victim crit resolver (per-victim crit). The anchor victim reuses hitCrits[h];
             // each COVERED footprint victim rolls the attacker's crit gate at ITS OWN affinity-
@@ -6473,10 +6479,63 @@ export function runCombat(input: CombatEngineInput): {
             deferredAbilityPerformed: PlayerTurnResult['deferredAbilityPerformed'];
             positionalDetonation: DetonationRecipe | undefined;
         }
-        type PositionalAttackedSignals = Map<
-            string,
-            { damage: number; shieldWasHit: boolean; hitOutcomes: boolean[] }
-        >;
+        /** One footprint victim's `attacked` signal within ONE sub-attack. */
+        interface PositionalVictimSignal {
+            damage: number;
+            shieldWasHit: boolean;
+            hitOutcomes: boolean[];
+        }
+        /**
+         * A cast's `attacked` signals grouped by SUB-ATTACK (epic: multi-hit full-walk attacks,
+         * PR2 Task 2). Outer key = the 0-based sub-attack index PR1 threads through every
+         * per-victim callback; inner key = victim id. A multi-hit skill is N consecutive
+         * full-walk attacks, so each sub-attack owns its own footprint and its own signals —
+         * which is what lets PR2 Task 3 interleave sub-attack k's `ability-performed` with
+         * sub-attack k's `attacked` events.
+         *
+         * Because a victim appears at most ONCE per sub-attack, every inner signal carries
+         * exactly ONE `hitOutcomes` entry. The per-hit `attacked` cardinality that incoming
+         * procs (Reactive Ward / Tenacity / Second Wind) depend on is therefore unchanged —
+         * it simply moves from "one victim entry with N outcomes" to "N sub-attack entries
+         * with one outcome each". See {@link flattenAttackedSignals}.
+         */
+        type PositionalAttackedSignals = Map<number, Map<string, PositionalVictimSignal>>;
+        /**
+         * Collapse the sub-attack-grouped signals back into the cast-wide, victim-keyed view the
+         * three emit sites have always consumed.
+         *
+         * BYTE-IDENTICAL to the pre-grouping map, by construction: sub-attacks are folded in
+         * ascending index order and a victim is visited at most once per sub-attack, so the
+         * damage summation order, the `hitOutcomes` order, and the victim insertion order all
+         * reproduce the single flat accumulator exactly.
+         *
+         * Transitional: Task 2 is a pure data-structure change, so emission must not move. Task 3
+         * replaces this flatten with a per-sub-attack interleaved emit — at which point each
+         * `attacked` will carry its OWN sub-attack's damage instead of the cast aggregate. That
+         * payload change is deliberately NOT part of this commit.
+         */
+        const flattenAttackedSignals = (
+            grouped: PositionalAttackedSignals
+        ): Map<string, PositionalVictimSignal> => {
+            const flat = new Map<string, PositionalVictimSignal>();
+            for (const [, victims] of [...grouped.entries()].sort((a, b) => a[0] - b[0])) {
+                for (const [victimId, sig] of victims) {
+                    const prev = flat.get(victimId);
+                    if (!prev) {
+                        flat.set(victimId, {
+                            damage: sig.damage,
+                            shieldWasHit: sig.shieldWasHit,
+                            hitOutcomes: [...sig.hitOutcomes],
+                        });
+                        continue;
+                    }
+                    prev.damage += sig.damage;
+                    prev.shieldWasHit = prev.shieldWasHit || sig.shieldWasHit;
+                    prev.hitOutcomes.push(...sig.hitOutcomes);
+                }
+            }
+            return flat;
+        };
         const drivePositionalTurnApply = (
             actor: CombatActor,
             tb: TurnBindings,
@@ -6492,9 +6551,11 @@ export function runCombat(input: CombatEngineInput): {
             critAgg: { anyCrit: boolean; critPairs: number; critVictimIds: string[] };
             attackedSignals: PositionalAttackedSignals;
         } => {
-            // Aggregate EACH footprint victim's per-attack damage + OR its shield-hit flag across the
-            // attack's hits so the post-apply emit wakes EVERY hit victim's on-attacked reactives
-            // (counters + self-repairs/defensive buffs), not just the anchor. Keyed by victim.id.
+            // Record EACH footprint victim's damage + shield-hit flag so the post-apply emit wakes
+            // EVERY hit victim's on-attacked reactives (counters + self-repairs/defensive buffs),
+            // not just the anchor. Keyed by (subAttackIndex, victim.id) since PR2 Task 2 — the
+            // per-hit aggregation the emit sites still consume is rebuilt by
+            // flattenAttackedSignals, which is byte-identical to the old victim-keyed accumulator.
             const attackedSignals: PositionalAttackedSignals = new Map();
             // Per-footprint Stasis-break: collect EVERY covered footprint victim (≠ anchor) stasised
             // at hit time so its Stasis is broken too — the anchor break is handled at the call site.
@@ -6528,7 +6589,7 @@ export function runCombat(input: CombatEngineInput): {
                 rollVictimCrit: sel.rollVictimCrit
                     ? (v) => sel.rollVictimCrit!(v.affinity ?? 'antimatter')
                     : undefined,
-                onVictimResolved: (victim, damage, outcome, didCrit) => {
+                onVictimResolved: (victim, damage, outcome, didCrit, subAttackIndex) => {
                     // Injected per-site leech direction (Note A): standing (player→enemy) vs taken
                     // (enemy→player, which also captures the focus victim's shield-hit flag).
                     onVictimResolved(victim, damage, outcome, didCrit);
@@ -6544,7 +6605,17 @@ export function runCombat(input: CombatEngineInput): {
                     // (the victim WAS targeted).
                     const fullyTransformedToDot = (outcome.transformedToDot ?? 0) > 0;
                     if (!fullyTransformedToDot) {
-                        const prev = attackedSignals.get(victim.id) ?? {
+                        // PR2 Task 2: bucket by sub-attack first. `subAttackIndex` is optional on
+                        // the callback contract (PR1 added it trailing so pre-existing callers keep
+                        // compiling); applyPositionalDamage always supplies it, and `?? 0` degrades
+                        // to the single-bucket, pre-grouping behaviour for any caller that does not.
+                        const subAttack = subAttackIndex ?? 0;
+                        let bySubAttack = attackedSignals.get(subAttack);
+                        if (!bySubAttack) {
+                            bySubAttack = new Map<string, PositionalVictimSignal>();
+                            attackedSignals.set(subAttack, bySubAttack);
+                        }
+                        const prev = bySubAttack.get(victim.id) ?? {
                             damage: 0,
                             shieldWasHit: false,
                             hitOutcomes: [],
@@ -6557,7 +6628,7 @@ export function runCombat(input: CombatEngineInput): {
                                 outcome.shieldBefore > 0 &&
                                 outcome.hpDamage < damage);
                         prev.hitOutcomes.push(didCrit);
-                        attackedSignals.set(victim.id, prev);
+                        bySubAttack.set(victim.id, prev);
                     }
                     // Record covered (non-anchor) victims stasised at hit time for the post-apply break.
                     if (
@@ -7848,13 +7919,18 @@ export function runCombat(input: CombatEngineInput): {
                                     (victim, damage, outcome) =>
                                         procLeechesForVictim(actor.id, victim, damage, outcome),
                                     (attackedSignals) => {
-                                        if (attackedSignals.size > 0) {
+                                        // PR2 Task 2: the signals arrive grouped by sub-attack;
+                                        // flatten (in index order) to the cast-wide victim view
+                                        // this emit has always consumed. Task 3 replaces the
+                                        // flatten with a per-sub-attack interleaved emit.
+                                        const victims = flattenAttackedSignals(attackedSignals);
+                                        if (victims.size > 0) {
                                             emitPerVictimAttacked({
                                                 bus,
                                                 round: r,
                                                 attackerId: actor.id,
                                                 primaryId: tgt.id,
-                                                victims: attackedSignals,
+                                                victims,
                                             });
                                         }
                                     }
@@ -8074,13 +8150,15 @@ export function runCombat(input: CombatEngineInput): {
                                     (victim, damage, outcome) =>
                                         procLeechesForVictim(actor.id, victim, damage, outcome),
                                     (attackedSignals) => {
-                                        if (attackedSignals.size > 0) {
+                                        // PR2 Task 2 — mirror of the focus site's flatten.
+                                        const victims = flattenAttackedSignals(attackedSignals);
+                                        if (victims.size > 0) {
                                             emitPerVictimAttacked({
                                                 bus,
                                                 round: r,
                                                 attackerId: actor.id,
                                                 primaryId: tgt.id,
-                                                victims: attackedSignals,
+                                                victims,
                                             });
                                         }
                                     }
@@ -8881,13 +8959,20 @@ export function runCombat(input: CombatEngineInput): {
                                     // SP-U U2: DEFERRED here (not inside the shared helper) because the enemy
                                     // emits AFTER its non-positional damage-taken-leech tail; enemyAttackedSignals
                                     // is the helper's returned per-victim signals (set whenever enemyPositional).
-                                    if (enemyAttackedSignals && enemyAttackedSignals.size > 0) {
+                                    // PR2 Task 2 — mirror of the two player-side sites' flatten.
+                                    // The outer map is non-empty iff at least one victim was
+                                    // recorded (a bucket is created only when a victim lands in
+                                    // it), so the gate is equivalent to the pre-grouping one.
+                                    const enemyVictims = enemyAttackedSignals
+                                        ? flattenAttackedSignals(enemyAttackedSignals)
+                                        : undefined;
+                                    if (enemyVictims && enemyVictims.size > 0) {
                                         emitPerVictimAttacked({
                                             bus,
                                             round: r,
                                             attackerId: actor.id,
                                             primaryId: tgt.id,
-                                            victims: enemyAttackedSignals,
+                                            victims: enemyVictims,
                                         });
                                     }
                                 } else {

--- a/src/utils/combat/log/__tests__/buildCombatLog.test.ts
+++ b/src/utils/combat/log/__tests__/buildCombatLog.test.ts
@@ -2445,4 +2445,80 @@ describe('buildCombatLog — sticky skill tag across sub-attack rows', () => {
         expect(attacks.map((a) => a.skillName)).toEqual(['First', 'Second']);
         expect(attacks.map((a) => a.slot)).toEqual(['active', 'charged']);
     });
+
+    it('a second cast whose debuff clause resolves FIRST is not mislabelled with the previous skill', () => {
+        // The gap the sibling test above cannot see. `currentSkillTag()` latches `pendingSkill`,
+        // but eight other handlers still `consumePendingSkill()` — so an intra-cast debuff written
+        // ahead of the damage clause consumes it before this cast's first `ability-performed`.
+        // Without an explicit clear on `skill-fired`, the latch still held 'First' and the second
+        // attack row was labelled with the FIRST skill's name.
+        const events: CombatEvent[] = [
+            ev({ type: 'round-started', round: 1 }),
+            ev({ type: 'turn-started', actorId: 'A', round: 1 }),
+            ev({ type: 'skill-fired', actorId: 'A', round: 1, slot: 'active', skillName: 'First' }),
+            ev({
+                type: 'ability-performed',
+                actorId: 'A',
+                targetId: 'B',
+                round: 1,
+                abilityType: 'damage',
+                damage: 10,
+                didCrit: false,
+                didHit: true,
+            }),
+            ev({
+                type: 'attacked',
+                attackerId: 'A',
+                targetId: 'B',
+                round: 1,
+                damage: 10,
+                isPrimaryTarget: true,
+            }),
+            ev({
+                type: 'skill-fired',
+                actorId: 'A',
+                round: 1,
+                slot: 'charged',
+                skillName: 'Second',
+            }),
+            // The clause-order case: this consumes `pendingSkill` before the damage clause lands.
+            ev({
+                type: 'debuff-applied',
+                sourceId: 'A',
+                targetId: 'B',
+                round: 1,
+                buffName: 'Attack Down I',
+            }),
+            ev({
+                type: 'ability-performed',
+                actorId: 'A',
+                targetId: 'B',
+                round: 1,
+                abilityType: 'damage',
+                damage: 10,
+                didCrit: false,
+                didHit: true,
+            }),
+            ev({
+                type: 'attacked',
+                attackerId: 'A',
+                targetId: 'B',
+                round: 1,
+                damage: 10,
+                isPrimaryTarget: true,
+            }),
+            ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
+            ev({ type: 'round-ended', round: 1 }),
+        ];
+
+        const log = buildCombatLog(events, roster, initialCharge);
+        const attacks = log[0].turns[0].entries.filter((e) => e.kind === 'attack');
+
+        // The second row must NOT read 'First'. It may carry 'Second' or no tag at all
+        // (the debuff handler consumed the pending tag) — what must never happen is the
+        // previous cast's identity leaking onto it.
+        expect(attacks).toHaveLength(2);
+        expect(attacks[0].skillName).toBe('First');
+        expect(attacks[1].skillName).not.toBe('First');
+    });
 });

--- a/src/utils/combat/log/__tests__/buildCombatLog.test.ts
+++ b/src/utils/combat/log/__tests__/buildCombatLog.test.ts
@@ -2303,3 +2303,146 @@ describe('buildCombatLog — turn entry display order', () => {
         expect(turn.entries[0].reactions.map((r) => r.actorId)).toEqual(['B']);
     });
 });
+
+// ─── PR2 Task 1: sticky skill tag across sub-attack rows ─────────────────────
+
+describe('buildCombatLog — sticky skill tag across sub-attack rows', () => {
+    it('every ability-performed in one cast carries the skill name and slot', () => {
+        // Three sub-attack rows from ONE skill-fired, each followed by its own attacked.
+        const events: CombatEvent[] = [
+            ev({ type: 'round-started', round: 1 }),
+            ev({ type: 'turn-started', actorId: 'A', round: 1 }),
+            ev({
+                type: 'skill-fired',
+                actorId: 'A',
+                round: 1,
+                slot: 'active',
+                skillName: 'Volley',
+            }),
+            ev({
+                type: 'ability-performed',
+                actorId: 'A',
+                targetId: 'B',
+                round: 1,
+                abilityType: 'damage',
+                damage: 10,
+                didCrit: false,
+                didHit: true,
+            }),
+            ev({
+                type: 'attacked',
+                attackerId: 'A',
+                targetId: 'B',
+                round: 1,
+                damage: 10,
+                isPrimaryTarget: true,
+            }),
+            ev({
+                type: 'ability-performed',
+                actorId: 'A',
+                targetId: 'B',
+                round: 1,
+                abilityType: 'damage',
+                damage: 10,
+                didCrit: false,
+                didHit: true,
+            }),
+            ev({
+                type: 'attacked',
+                attackerId: 'A',
+                targetId: 'B',
+                round: 1,
+                damage: 10,
+                isPrimaryTarget: true,
+            }),
+            ev({
+                type: 'ability-performed',
+                actorId: 'A',
+                targetId: 'B',
+                round: 1,
+                abilityType: 'damage',
+                damage: 10,
+                didCrit: false,
+                didHit: true,
+            }),
+            ev({
+                type: 'attacked',
+                attackerId: 'A',
+                targetId: 'B',
+                round: 1,
+                damage: 10,
+                isPrimaryTarget: true,
+            }),
+            ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
+            ev({ type: 'round-ended', round: 1 }),
+        ];
+
+        const log = buildCombatLog(events, roster, initialCharge);
+        const attacks = log[0].turns[0].entries.filter((e) => e.kind === 'attack');
+
+        expect(attacks).toHaveLength(3);
+        for (const a of attacks) {
+            expect(a.skillName).toBe('Volley');
+            expect(a.slot).toBe('active');
+        }
+    });
+
+    it('a NEW skill-fired replaces the sticky tag', () => {
+        const events: CombatEvent[] = [
+            ev({ type: 'round-started', round: 1 }),
+            ev({ type: 'turn-started', actorId: 'A', round: 1 }),
+            ev({ type: 'skill-fired', actorId: 'A', round: 1, slot: 'active', skillName: 'First' }),
+            ev({
+                type: 'ability-performed',
+                actorId: 'A',
+                targetId: 'B',
+                round: 1,
+                abilityType: 'damage',
+                damage: 10,
+                didCrit: false,
+                didHit: true,
+            }),
+            ev({
+                type: 'attacked',
+                attackerId: 'A',
+                targetId: 'B',
+                round: 1,
+                damage: 10,
+                isPrimaryTarget: true,
+            }),
+            ev({
+                type: 'skill-fired',
+                actorId: 'A',
+                round: 1,
+                slot: 'charged',
+                skillName: 'Second',
+            }),
+            ev({
+                type: 'ability-performed',
+                actorId: 'A',
+                targetId: 'B',
+                round: 1,
+                abilityType: 'damage',
+                damage: 10,
+                didCrit: false,
+                didHit: true,
+            }),
+            ev({
+                type: 'attacked',
+                attackerId: 'A',
+                targetId: 'B',
+                round: 1,
+                damage: 10,
+                isPrimaryTarget: true,
+            }),
+            ev({ type: 'turn-ended', actorId: 'A', round: 1 }),
+            ev({ type: 'round-ended', round: 1 }),
+        ];
+
+        const log = buildCombatLog(events, roster, initialCharge);
+        const attacks = log[0].turns[0].entries.filter((e) => e.kind === 'attack');
+
+        expect(attacks.map((a) => a.skillName)).toEqual(['First', 'Second']);
+        expect(attacks.map((a) => a.slot)).toEqual(['active', 'charged']);
+    });
+});

--- a/src/utils/combat/log/buildCombatLog.ts
+++ b/src/utils/combat/log/buildCombatLog.ts
@@ -425,6 +425,14 @@ const handlers: Partial<{ [K in CombatEventType]: Handler<K> }> = {
     'skill-fired': (e, ctx) => {
         if (!ctx.currentTurn) return;
         ctx.pendingSkill = { skillName: e.skillName, slot: e.slot };
+        // Drop the previous cast's latched tag: a NEW skill fired, so any sub-attack row from here
+        // on belongs to THIS skill. Clearing here rather than relying on `pendingSkill` being
+        // non-empty at the next `currentSkillTag()` call is load-bearing — eight other handlers
+        // still `consumePendingSkill()`, so a clause that emits before this cast's first
+        // `ability-performed` (an intra-cast debuff written ahead of the damage clause, say) would
+        // consume `pendingSkill` first and leave `currentSkillTag()` serving the STALE latch,
+        // mislabelling the attack row with the previous skill's name.
+        ctx.castSkillTag = undefined;
     },
 
     'charge-changed': (e, ctx) => {

--- a/src/utils/combat/log/buildCombatLog.ts
+++ b/src/utils/combat/log/buildCombatLog.ts
@@ -111,6 +111,15 @@ interface BuildContext {
      */
     pendingSkill: { skillName?: string; slot: 'active' | 'charged' } | undefined;
     /**
+     * The skill identity of the cast currently being logged, latched from
+     * `pendingSkill` by the first `ability-performed` of the cast.
+     *
+     * Sticky for the whole cast: a multi-hit skill emits one ability-performed per
+     * sub-attack (PR2) and every row must carry the same skill identity. Cleared at
+     * turn-started and replaced by the next skill-fired.
+     */
+    castSkillTag: { skillName?: string; slot: 'active' | 'charged' } | undefined;
+    /**
      * Reaction stamp for the event currently being dispatched. Captured in the
      * dispatch loop from the event's ReactiveStamp; consumed by attachEntry to
      * route the produced entry into a trigger entry's `.reactions`.
@@ -157,6 +166,18 @@ interface BuildContext {
      * Call when creating an action-producing entry so it picks up the skill tag.
      */
     consumePendingSkill(): { skillName?: string; slot: 'active' | 'charged' } | undefined;
+    /**
+     * Returns the skill tag for the cast currently being logged WITHOUT clearing it.
+     *
+     * Sticky for the whole cast: a multi-hit skill emits one ability-performed per
+     * sub-attack (PR2) and every row must carry the same skill identity. Cleared at
+     * turn-started and replaced by the next skill-fired.
+     *
+     * The first call of a cast still *consumes* `pendingSkill` (latching it into
+     * `castSkillTag`), so the non-attack handlers keep their existing single-use
+     * semantics — only repeated `ability-performed` rows share the tag.
+     */
+    currentSkillTag(): { skillName?: string; slot: 'active' | 'charged' } | undefined;
 }
 
 function createBuildContext(
@@ -185,6 +206,7 @@ function createBuildContext(
         runningCharge,
         chargeMax: chargeMaxMap,
         pendingSkill: undefined,
+        castSkillTag: undefined,
         currentStamp: undefined,
         reactiveEntries: new WeakSet<CombatLogEntry>(),
 
@@ -344,12 +366,22 @@ function createBuildContext(
             ctx.openAttackAbilityDidHit = undefined;
             // Clear pending skill at every turn/round boundary so it never bleeds.
             ctx.pendingSkill = undefined;
+            // The cast-sticky tag is scoped to the turn for the same reason.
+            ctx.castSkillTag = undefined;
         },
 
         consumePendingSkill() {
             const pending = ctx.pendingSkill;
             ctx.pendingSkill = undefined;
             return pending;
+        },
+
+        currentSkillTag() {
+            // Latch a freshly-fired skill; otherwise keep returning the cast's tag so
+            // every sub-attack row of a multi-hit skill reads as the same named skill.
+            const pending = ctx.consumePendingSkill();
+            if (pending) ctx.castSkillTag = pending;
+            return ctx.castSkillTag;
         },
     };
     return ctx;
@@ -424,13 +456,14 @@ const handlers: Partial<{ [K in CombatEventType]: Handler<K> }> = {
         if (!ctx.currentTurn && !ctx.currentRound) return;
         // Finalize any pending miss entry before opening a new one.
         ctx.finalizeMissEntry();
-        // Consume pending skill-fired data (if any) and stamp onto the entry.
+        // Stamp the cast's skill tag onto the entry. Sticky, not consuming: a multi-hit
+        // skill emits one ability-performed per sub-attack and every row must carry it.
         const entry: CombatLogEntry = {
             kind: 'attack',
             actorId: e.actorId,
             targets: [],
             reactions: [],
-            ...(ctx.consumePendingSkill() ?? {}),
+            ...(ctx.currentSkillTag() ?? {}),
         };
         ctx.attachEntry(entry);
         ctx.openAttackEntry = entry;

--- a/src/utils/combat/log/buildCombatLog.ts
+++ b/src/utils/combat/log/buildCombatLog.ts
@@ -22,10 +22,13 @@ const dotNote = (dotType: DoTType, tier: number | undefined, stacks: number): st
  * then everything that FOLLOWED from the skill.
  *
  * Why a display sort rather than reordering the engine's emissions: the log renders events in
- * emission order, and for a POSITIONAL cast the engine deliberately defers its one aggregate
+ * emission order, and for a POSITIONAL cast the engine deliberately defers its
  * `ability-performed` until AFTER the per-victim apply (engine.ts `emitDeferredAbilityPerformed`),
- * so it can report the TRUE per-victim crit outcome instead of the anchor-only guess. That is why
- * the attack line landed last, under its own consequences:
+ * so it can report the TRUE per-victim crit outcome instead of the anchor-only guess. (Since the
+ * multi-hit full-walk epic, PR2, there is one such event per SUB-ATTACK rather than one per cast —
+ * a `hits: N` skill produces N attack rows, all carrying the same sticky skill tag. The deferral,
+ * and therefore this sort, is unchanged.) That is why the attack line landed last, under its own
+ * consequences:
  *
  *     Butcher: charge 0→1
  *     Butcher → Enemy Heliodor: Inferno II resisted

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -2396,10 +2396,13 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     // (deferAbilityPerformedToEngine set AND a damage ability fired — the exact condition under
     // which the engine runs its per-victim apply, since its `positional` gate requires
     // positionalScalars != null ⟺ hasDamageAbility), DO NOT emit here. The engine emits ONE
-    // aggregate `ability-performed` AFTER its per-victim apply so `didCrit`/`critHits` reflect the
-    // TRUE per-victim outcomes (anyCrit OR / critPairs count) rather than the anchor-only values.
-    // Emitting once, later, keeps exactly ONE ability-performed per positional cast (no combat-log
-    // pollution) and preserves the ability-performed → per-victim `attacked` bus order.
+    // `ability-performed` AFTER its per-victim apply so `didCrit`/`critHits` reflect the TRUE
+    // per-victim outcomes rather than the anchor-only values.
+    // Since PR2 of the multi-hit full-walk epic the engine emits ONE event per SUB-ATTACK (a
+    // `hits: N` skill is N consecutive full-walk attacks), each immediately followed by that
+    // sub-attack's own `attacked` events — so what deferring preserves is the
+    // ability-performed → per-victim `attacked` bus order, per sub-attack. With N=1 that is one
+    // event per positional cast, exactly as before.
     // Non-positional / DPS / healing (flag absent, or no damage ability) → emit inline as before
     // → byte-identical.
     const deferAbilityPerformed = args.deferAbilityPerformedToEngine === true && hasDamageAbility;

--- a/src/utils/combat/positionalApply.ts
+++ b/src/utils/combat/positionalApply.ts
@@ -86,7 +86,7 @@ export type AppliedVictimDamage = VictimDamageOutcome & { incomingBooked: number
  * Emitted for EVERY iteration including whiffs, so `subAttacks[h]` always corresponds to loop
  * iteration `h`.
  *
- * Nothing consumes this yet — PR2 turns each entry into its own `ability-performed`.
+ * PR2 turns each NON-EMPTY entry into its own `ability-performed`.
  * See docs/superpowers/specs/2026-08-07-multi-hit-full-walk-attacks-design.md.
  */
 export interface SubAttackOutcome {
@@ -104,6 +104,16 @@ export interface SubAttackOutcome {
     damage: number;
     /** Victims struck by this sub-attack, in footprint order. */
     victimIds: string[];
+    /**
+     * The victims THIS sub-attack critically hit, in footprint order.
+     *
+     * The per-sub-attack slice of the cast-wide `critVictimIds`/`critPairs` pair: a victim appears
+     * at most once per sub-attack (one footprint cell each), so this list's LENGTH is also this
+     * sub-attack's critting-(victim) count and Σ over the cast reproduces `critPairs` exactly.
+     * PR2 carries it on each sub-attack's own `ability-performed` as `critHits`/`critVictimIds`,
+     * so `on-crit` counts one attack's crits rather than the whole cast's.
+     */
+    critVictimIds: string[];
 }
 
 /** Per-cell damage scale keyed off the resolved CellRole. */
@@ -169,7 +179,8 @@ export function footprintVictims(
  *          enemies actually crit rather than the cast's selected anchor;
  *          `subAttacks` — one {@link SubAttackOutcome} per loop iteration, in order, including
  *          whiffs. Carries the SUB-ATTACK identity that `critPairs` also throws away (it
- *          multiplies hits × victims into one number). Unconsumed as of PR1.
+ *          multiplies hits × victims into one number). Consumed since PR2: the engine emits one
+ *          `ability-performed` per non-empty sub-attack off these entries.
  */
 export function applyPositionalDamage(args: {
     hitCrits: boolean[];
@@ -305,6 +316,7 @@ export function applyPositionalDamage(args: {
                 didCrit: false,
                 damage: 0,
                 victimIds: [],
+                critVictimIds: [],
             });
             continue;
         }
@@ -313,6 +325,7 @@ export function applyPositionalDamage(args: {
         let subDidCrit = false;
         let subDamage = 0;
         const subVictimIds: string[] = [];
+        const subCritVictimIds: string[] = [];
 
         for (const { victim, roleScale } of footprintVictims(
             pattern,
@@ -327,6 +340,7 @@ export function applyPositionalDamage(args: {
                 critPairs += 1;
                 critVictims.add(victim.id);
                 subDidCrit = true;
+                subCritVictimIds.push(victim.id);
             }
             const equipReductionPct = incomingReductionFor?.(victim, didCrit, h) ?? 0;
             const dmgBase = victimHitDamage(
@@ -362,6 +376,7 @@ export function applyPositionalDamage(args: {
             didCrit: subDidCrit,
             damage: subDamage,
             victimIds: subVictimIds,
+            critVictimIds: subCritVictimIds,
         });
     }
     return { anyCrit, critPairs, critVictimIds: [...critVictims], subAttacks };

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -412,10 +412,15 @@ export function registerReactiveListeners(args: {
                         // Per-event copy: carry e.damage (total damage for this ability-performed
                         // event) into eventCtx.triggerDamage so that a reactive basis:'damage-dealt'
                         // heal (e.g. Bloodthirst) scales off the triggering hit's damage.
-                        // KNOWN APPROXIMATION: for a multi-hit ability, each critting hit enqueues
-                        // with the same event-total damage (not per-hit damage), so the heal is
-                        // proportionally over-counted per fire when critHits > 1. Per-hit attribution
-                        // is not supported in the event model today; document and accept.
+                        // PR2 narrowed the old "multi-hit over-counts" approximation on the
+                        // POSITIONAL path: a `hits: N` skill now emits one event per SUB-ATTACK
+                        // carrying that sub-attack's own damage, so N crits heal off N slices
+                        // rather than N × the whole cast.
+                        // KNOWN APPROXIMATION, still: within ONE event, critHits > 1 (a multi-victim
+                        // AoE) enqueues that many times, each with the whole footprint's damage
+                        // rather than the critting victim's share. The non-positional DPS path also
+                        // still folds a multi-hit cast into a single event (that is PR5).
+                        // Per-victim attribution is not supported in the event model today.
                         for (let i = 0; i < n; i++) {
                             enqueue({
                                 ...intent,
@@ -426,13 +431,17 @@ export function registerReactiveListeners(args: {
                     break;
                 case 'on-deal-damage':
                     bus.on('ability-performed', (e) => {
-                        // Warpstrike duration-reduction: fires on the OWNER's own damage-dealing
-                        // turn. runPlayerTurn emits exactly ONE aggregate ability-performed per
-                        // turn (positional path defers its emit; the engine emits exactly one
-                        // ability-performed post-apply), so this is once-per-turn for single-hit,
-                        // multi-hit, and AoE alike — no once-per-turn guard needed. The
-                        // while-debuffed requirement is an ability condition (self-debuff),
-                        // enforced at drain via gateConditions.
+                        // Fires on the OWNER's own damage-dealing attack. runPlayerTurn emits one
+                        // ability-performed per SUB-ATTACK (multi-hit full-walk, PR2): a multi-hit
+                        // skill is N consecutive full-walk attacks, so this fires N times, once
+                        // per sub-attack that dealt damage. An AoE footprint is ONE attack and
+                        // fires once however many victims it hits. Riders: Burner's Inferno,
+                        // Warpstrike's duration-reduction, Zeolite's purge. There is no
+                        // once-per-turn guard, and adding one would be wrong — per-sub-attack IS
+                        // the intended cardinality (pinned by
+                        // perSubAttackEvents.integration.test.ts). The while-debuffed requirement
+                        // is an ability condition (self-debuff), enforced at drain via
+                        // gateConditions.
                         if (e.actorId !== ownerId) return;
                         if ((e.damage ?? 0) <= 0) return;
                         // Capture the owner's own attack target so a reactive DoT rider (Burner's
@@ -647,6 +656,17 @@ export function registerReactiveListeners(args: {
                         // (Charge was already collapsed this way by an explicit special-case; the
                         // per-critHits loop for every other rider was the over-fire bug — Sentinel
                         // healed Ruiner twice for one AoE.)
+                        //
+                        // "ATTACK" here means SUB-ATTACK (multi-hit full-walk, PR2): a `hits: N`
+                        // skill is N consecutive full-walk attacks emitting N ability-performed
+                        // events, so an ally critting on 2 of 3 sub-attacks fires this TWICE. The
+                        // (hit, victim) collapse is what this one-enqueue-per-event shape guards,
+                        // and it survives untouched — a single-hit 3-victim AoE that crits two
+                        // victims still fires ONCE. Both halves are pinned by
+                        // perSubAttackEvents.integration.test.ts; the self-target side stays
+                        // once-per-TURN via oncePerAttackGuardKey (charge/buff branches only,
+                        // cleared at actor turn-start), locked by
+                        // hermesOncePerAttack.integration.test.ts.
                         if (!e.didCrit && (e.critHits ?? 0) === 0) return;
                         // The enemies actually crit. `critVictimIds` is present only on the
                         // POSITIONAL deferred emit; the single-target inline emit omits it, where

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -290,7 +290,11 @@ export function partitionReactiveAbilities(shipSkills: ShipSkills): {
  * Register each owner's reactive abilities as bus listeners. Listener bodies are
  * PURE (Phase 1 contract): they only `enqueue` an intent — never mutate combat state. Match
  * guards are now per OWNER (Task 6) so a team ship's reactive ability keys on ITS OWN events:
- *  - on-crit → ability-performed where actorId === ownerId; enqueues once per CRITTING HIT (critHits field; falls back to the didCrit binary for events without it)
+ *  - on-crit → ability-performed where actorId === ownerId; enqueues once per critting VICTIM
+ *    WITHIN that event (its `critHits` field; falls back to the didCrit binary for events without
+ *    it). Since PR2 an event is one SUB-ATTACK, so a `hits: N` cast fans out per sub-attack and,
+ *    within each, per critting footprint victim — not once per cast-wide critting (hit, victim)
+ *    pair, which counted hits × victims on a single event
  *  - on-debuff-inflicted → debuff-applied | dot-applied with `sourceId === ownerId`
  *  - on-ally-debuff-inflicted → debuff-applied OR dot-applied where the source is a same-side
  *    ally (not opposing, not the owner itself). For the PLAYER registration this is any OTHER
@@ -309,8 +313,10 @@ export function partitionReactiveAbilities(shipSkills: ShipSkills): {
  *    of Power). Stamps eventCtx.repairedAllyIds (the non-self recipients) so the buff branch fans
  *    the grant out to exactly those allies. One enqueue per qualifying cast.
  *  - on-ally-crit → an ALLY's ability-performed with critting hits (mirrors on-crit ally-scoped):
- *    fires once PER CRITTING HIT; the owner's own casts and every opposing actor are excluded
- *    (a walked enemy attacker now emits ability-performed, but its crit is NOT an ally crit).
+ *    fires once per critting ability-performed — i.e. once per critting SUB-ATTACK, and ONCE for
+ *    an AoE footprint however many victims it crit, never per (hit, victim) pair; the owner's own
+ *    casts and every opposing actor are excluded (a walked enemy attacker now emits
+ *    ability-performed, but its crit is NOT an ally crit).
  *  - start-of-round → round-started (global — every owner's start-of-round fires once per round)
  *  - end-of-round → round-ended (global — every owner's end-of-round fires once per round; C2b-2)
  *  - on-charged-cast → skill-fired where actorId === ownerId && slot === 'charged' (self-scoped;
@@ -663,10 +669,12 @@ export function registerReactiveListeners(args: {
                         // (hit, victim) collapse is what this one-enqueue-per-event shape guards,
                         // and it survives untouched — a single-hit 3-victim AoE that crits two
                         // victims still fires ONCE. Both halves are pinned by
-                        // perSubAttackEvents.integration.test.ts; the self-target side stays
-                        // once-per-TURN via oncePerAttackGuardKey (charge/buff branches only,
-                        // cleared at actor turn-start), locked by
-                        // hermesOncePerAttack.integration.test.ts.
+                        // perSubAttackEvents.integration.test.ts. SELF-target riders (Hermes's
+                        // charge + Everliving Regeneration) behave the SAME as ally-routed ones:
+                        // `on-ally-crit` was removed from PER_HIT_REACTIVE_TRIGGERS, so
+                        // oncePerAttackGuardKey no longer collapses them across sub-attacks. This
+                        // one-enqueue-per-event shape is the whole collapse, and it is enough.
+                        // Locked by hermesOncePerAttack.integration.test.ts.
                         if (!e.didCrit && (e.critHits ?? 0) === 0) return;
                         // The enemies actually crit. `critVictimIds` is present only on the
                         // POSITIONAL deferred emit; the single-target inline emit omits it, where
@@ -1447,10 +1455,9 @@ export interface IntentExecContext {
      *  counter branch is inert without the engine ctx). */
     counterFiredThisTurn?: Set<string>;
     /** Task 5: per-actor-turn once-per-attack guard for SELF-scoped reactive buff/charge
-     *  riders (Hermes's Everliving Regeneration + charge on `on-ally-crit`). Keyed
-     *  `ownerId:abilityId`, cleared at each actor turn-start (engine) — mirroring
-     *  `counterFiredThisTurn`. The per-hit / per-victim reactive triggers (on-ally-crit,
-     *  on-attacked, on-ally-attacked) enqueue one intent per critting-hit / hit / victim; a
+     *  riders. Keyed `ownerId:abilityId`, cleared at each actor turn-start (engine) — mirroring
+     *  `counterFiredThisTurn`. The per-hit / per-victim reactive triggers (on-attacked,
+     *  on-ally-attacked) enqueue one intent per hit per victim; a
      *  SELF-target buff/charge must land only ONCE for that whole attack. Ally/enemy-routed
      *  reactions (Sentinel damage, Howler/Cultivator/Graphite ally heal) are per-victim by design,
      *  and reactive HEALS/SHIELDS scale per hit (Isha/Adaptive Plating) — neither is keyed here
@@ -2300,22 +2307,38 @@ function emitReactiveDamageLog(
     ctx.flushConsequenceLogs?.();
 }
 
-/** Task 5: reactive triggers that fan a single ATTACK into multiple `attacked`/`ability-performed`
- *  events — one per hit, per AoE victim, or per critting hit. A SELF-scoped fixed-state rider
- *  (buff/charge) on one of these must apply only ONCE for the whole attack; per-victim ally /
- *  enemy routing legitimately fires per event, and reactive HEALS/SHIELDS scale per hit (see the
- *  heal branch's scope note) so they are excluded too. */
+/** Task 5: reactive triggers that fan a single ATTACK into multiple `attacked` events — one per
+ *  hit and per AoE victim. A SELF-scoped fixed-state rider (buff/charge) on one of these must
+ *  apply only ONCE for the whole attack; per-victim ally / enemy routing legitimately fires per
+ *  event, and reactive HEALS/SHIELDS scale per hit (see the heal branch's scope note) so they are
+ *  excluded too.
+ *
+ *  `on-ally-crit` USED to be listed here and no longer is (multi-hit full-walk epic, PR2). Two
+ *  independent facts make the guard both unnecessary and actively wrong for it:
+ *   1. UNNECESSARY. Its listener was rewritten to enqueue AT MOST ONCE per `ability-performed`
+ *      (the `critHits`-driven fan-out is gone), so the per-hit / per-AoE-victim over-fire this
+ *      guard existed to stop — the user-reported "Everliving Regeneration III ×2-4 for one
+ *      attack" — is already impossible. An AoE footprint is ONE attack, one event, one grant.
+ *   2. WRONG. The guard is cleared per actor TURN, but a `hits: N` skill is N consecutive
+ *      full-walk attacks emitting N events. Keeping it collapsed a 3-sub-attack ally crit into a
+ *      single Hermes charge instead of three. Approved behaviour change: once per critting
+ *      SUB-ATTACK. Dropping the trigger achieves exactly that — one fire per event — without
+ *      threading a sub-attack index onto the guard key, which would have been strictly worse
+ *      (two DIFFERENT allies critting in one turn both carry index 0 and would collapse).
+ *  Both halves are locked by `hermesOncePerAttack.integration.test.ts`.
+ *
+ *  The two remaining triggers genuinely fan one attack into many events and keep the guard. */
 const PER_HIT_REACTIVE_TRIGGERS: ReadonlySet<AbilityTrigger> = new Set<AbilityTrigger>([
-    'on-ally-crit',
     'on-attacked',
     'on-ally-attacked',
 ]);
 
 /** Returns the once-per-attack guard key `ownerId:abilityId` when this intent is a SELF-target
- *  rider on a per-hit reactive trigger (Hermes's Everliving Regeneration + charge), else undefined
- *  — meaning "not guarded". Only `target: 'self'` qualifies: ally-routed grants (damagedAllyId —
- *  Cultivator/Graphite/Howler/Sentinel repair) and enemy-routed damage (Sentinel) must stay
- *  per-victim, so they never key here. Cross-referenced by the charge and buff branches only. */
+ *  rider on a per-hit reactive trigger (an on-attacked / on-ally-attacked buff or charge), else
+ *  undefined — meaning "not guarded". Only `target: 'self'` qualifies: ally-routed grants
+ *  (damagedAllyId — Cultivator/Graphite/Howler/Sentinel repair) and enemy-routed damage (Sentinel)
+ *  must stay per-victim, so they never key here. Cross-referenced by the charge and buff branches
+ *  only. `on-ally-crit` is deliberately NOT in the set — see {@link PER_HIT_REACTIVE_TRIGGERS}. */
 function oncePerAttackGuardKey(intent: Intent): string | undefined {
     return intent.ability.target === 'self' && PER_HIT_REACTIVE_TRIGGERS.has(intent.ability.trigger)
         ? `${intent.ownerId}:${intent.ability.id}`
@@ -2481,8 +2504,9 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
 
     if (cfg.type === 'charge') {
         if (!passesOncePerRoundGate(intent, ctx)) return;
-        // Task 5: a SELF-target charge on a per-hit reactive trigger (Hermes's on-ally-crit
-        // charge) collapses to +1 per attack. undefined key → not guarded (enemy/ally charges).
+        // Task 5: a SELF-target charge on a per-hit reactive trigger (on-attacked /
+        // on-ally-attacked) collapses to +1 per attack. undefined key → not guarded (enemy/ally
+        // charges, and every on-ally-crit rider — see PER_HIT_REACTIVE_TRIGGERS).
         const chargeGuardKey = oncePerAttackGuardKey(intent);
         if (chargeGuardKey && ctx.reactionFiredThisAttack?.has(chargeGuardKey)) return;
         if (intent.ability.target === 'enemy' || intent.ability.target === 'all-enemies') {
@@ -2533,12 +2557,13 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
     }
 
     if (cfg.type === 'buff') {
-        // Task 5: a SELF-target reactive buff on a per-hit trigger (Hermes's Everliving
-        // Regeneration on on-ally-crit) applies once per attack — a multi-hit / AoE crit enqueues
-        // this intent once per critting hit, but the self-buff must land only once. Checked FIRST
-        // (before the once-per-combat/per-ally consumes below) so a collapsed duplicate burns no
-        // other cap; the key is consumed only once the buff actually applies (after all gates).
-        // undefined key → not guarded (ally/all-allies grants stay per-victim/per-hit).
+        // Task 5: a SELF-target reactive buff on a per-hit trigger (on-attacked /
+        // on-ally-attacked) applies once per attack — one attack fans into one `attacked` per hit
+        // per victim, but the self-buff must land only once. Checked FIRST (before the
+        // once-per-combat/per-ally consumes below) so a collapsed duplicate burns no other cap;
+        // the key is consumed only once the buff actually applies (after all gates). undefined key
+        // → not guarded (ally/all-allies grants stay per-victim/per-hit, and on-ally-crit riders
+        // are collapsed by their LISTENER instead — see PER_HIT_REACTIVE_TRIGGERS).
         const buffGuardKey = oncePerAttackGuardKey(intent);
         if (buffGuardKey && ctx.reactionFiredThisAttack?.has(buffGuardKey)) return;
         // "Once per battle" buff grant (Tycho/Shelter/Los Barrier): same combat-lifetime


### PR DESCRIPTION
**Stacked on #307** — review that first. This PR's diff is only its own four commits.

Second PR of the multi-hit full-walk attacks epic. PR1 gave the sub-attack an identity; PR2 gives it its own event.

## The defect

The engine emitted exactly **one aggregate `ability-performed` per turn**, and that single event anchors *every* outgoing reactive trigger — `on-deal-damage`, `on-crit`, `on-debuff-inflicted`. So a multi-hit skill's three real attacks were reported as one, and three separate mechanics were wrong:

- **Bloodthirst healed 3x too much.** `on-crit` looped `critHits` (positionally = `critPairs` = hits x victims) and every fire carried the *whole cast's* damage. Measured on a `hits: 3` fixture: heals were `[6000, 6000, 6000]` = 18000, i.e. 60% of a cast for a 20% implant. Now `[2000, 2000, 2000]` = 6000 = 20%.
- **`on-deal-damage` fired once per turn**, so Burner applied one Inferno stack regardless of sub-attack count. Now three. Same for Warpstrike's duration reduction and Zeolite's purge.
- **`on-ally-crit`** saw one crit event for a cast that crit on multiple sub-attacks.

## The commits

- `7a8738ee` — the log's skill tag is sticky for the cast, so all N rows read as the same named skill rather than one named row followed by anonymous ones.
- `da15afe1` — regroup attacked signals by `(subAttackIndex, victim)`. Behaviour-neutral, verified by a byte-identical event-stream diff.
- `0df03fbb` — emit one event per sub-attack, interleaved. **The ordering is load-bearing:** emitting all N before any `attacked` leaves rows 1..N-1 target-less and the log's phantom-row prune silently splices them out.
- `25c7c79f` — verification tests for the three trigger families, and rewrites of comments that asserted the now-false once-per-turn invariant.

## Verification

- Full suite **475 files / 5421 tests** green
- **Zero golden fixture movement across the whole stack**, including Enforcer's real-kit fingerprint. That is the N=1 invariant: 146 of 147 corpus ships are single-hit, so any diff there would mean the change is wrong.
- `npm run audit:placement-symmetry --seeds 15` at baseline: **2 findings / 146 symmetric / 13-13-13**
- `tsc --noEmit` and `lint` clean

## Things a reviewer should push on

**Exactly one corpus ship is multi-hit** — Enforcer (active 3, charged 4), confirmed by running `parseHitCount`'s own regexes over all 147 ships. So the golden suite would stay green whether or not this work is correct, and the real verification is carried by synthetic fixtures. Every behaviour claim above is pinned by an explicit new test asserting *amounts*, not just counts, and each was mutation-checked to confirm it is non-vacuous.

**The `attacked` payload changed and no existing test could see it.** Each event's `damage` moves from the victim's cast-wide aggregate to that sub-attack's slice — correct, since a per-hit event carrying whole-cast damage was already wrong, but invisible to the corpus because Enforcer is `Pattern-Base` (single victim, always primary) so its log amount comes from `openAttackAbilityDamage`. New fixtures cover the two real consumers: Tenacity's >25%-maxHP gate and the log's non-primary target amount.

**One assertion flipped 1 -> 3** in `hermesOncePerAttack.integration.test.ts` (the *ally-target* rider). This does not revert the user-reported bug that file locks: that bug was **self-target** riders over-firing, and those still assert 1. The file's own header states ally-routed riders "LEGITIMATELY fire once per critting hit". The AoE collapse — one attack over many victims fires once — is intact and separately tested.

**Reflect and consequence log buffers** drained on the first flush, so later sub-attacks' rows would nest under the wrong row. Both are now tagged with the sub-attack that raised them. Corpus-reachable: buffers were non-empty at the emit point in 1519 N=1 casts.

The DPS path is deliberately untouched — it still folds multi-hit into one multiplier. That is PR5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6or8HzPQ6Ydx1bAB9rGHz