### PR TITLE
fix(sim): outgoing proc gates at sub-attack scope (multi-hit epic PR4)

### DIFF
--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -35,6 +35,7 @@ export const UNRELEASED_CHANGES: string[] = [
     'Combat log now shows which ship granted a buff to an ally, instead of only naming the ship that received it.',
     'Recruitment calculator: Centurion is now recruitable through beacons. It was on the non-recruitable list, so the calculator gave it no beacon odds at all.',
     'Combat simulator: enemy ships now fire their passive repairs and shields, as they do in game. Three separate gaps all skipped the passive slot for enemies only: Volk\'s passive repair never went off, Malvex\'s and Quixilver\'s "gain a Shield when damaged" never triggered, and the "gain a Shield from the damage you deal" passives on FrontLine, Magnolia, Valerian and Valkyrie never paid out. Your own ships were always unaffected, so these enemies were easier to kill in the simulator than they are in game.',
+    'Combat simulator: a multi-hit skill is a series of separate attacks, so chance-based effects now get one roll per hit instead of one for the whole turn. Enforcer\'s three-hit active gives Menace and Giant Slayer three chances to amplify rather than one, Insidiousness fires on each of the three attacks, and a ship being hit three times gets three triggers of its own "when attacked" passives. Menace and Giant Slayer were also rolling twice over for every enemy in an area attack, with the reported damage and the damage actually dealt decided by two different rolls; both now follow the one roll made for that attack.',
 ];
 
 export const CHANGELOG: ChangelogEntry[] = [

--- a/src/types/abilities.ts
+++ b/src/types/abilities.ts
@@ -1111,11 +1111,17 @@ export interface Ability {
      *  → fires on every qualifying trigger. */
     procChance?: number;
     /** Proc-roll granularity for a probabilistic reactive ability. `'per-attack'` draws the
-     *  gate ONCE per actor turn and reuses that verdict for every qualifying trigger event in
-     *  the same attack, via IntentExecContext.procDecisionThisAttack — so Insidiousness either
+     *  gate ONCE per ATTACK and reuses that verdict for every qualifying trigger event in that
+     *  same attack, via IntentExecContext.procDecisionThisSubAttack — so Insidiousness either
      *  damages EVERY enemy its attack debuffed or none of them, matching the game. Absent →
      *  per-event draws, the historical behaviour of every other procChance ability (Adaptive
-     *  Plating, Smokescreen, Ambush, Bloodthirst, Reactive Ward, Tenacity, Bulwark). */
+     *  Plating, Smokescreen, Ambush, Bloodthirst, Reactive Ward, Tenacity, Bulwark).
+     *
+     *  "Attack" here means ONE attack, and a `hits: N` skill is N consecutive full-walk attacks
+     *  (multi-hit full-walk epic, R1), so a 3-hit skill draws THREE verdicts — one per sub-attack,
+     *  each shared across that sub-attack's footprint. Until PR4 the verdict was keyed without the
+     *  sub-attack and cleared only at actor turn-start, making this per-TURN and replaying
+     *  sub-attack #1's verdict for all N. */
     procScope?: 'per-attack';
     /** Reactive event-frequency gate: fire this ability only every Nth qualifying trigger
      *  event, counted per SOURCE (the triggering actor). N=2 → every second event. Gated

--- a/src/utils/combat/__tests__/emitAttacked.test.ts
+++ b/src/utils/combat/__tests__/emitAttacked.test.ts
@@ -30,6 +30,10 @@ describe('emitAttacked', () => {
             shieldWasHit: true,
             didCrit: true,
             damage: 500,
+            // PR4: with no explicit `subAttackIndex` the caller is the non-positional one, which
+            // passes the whole cast's hitOutcomes in ONE call — so the hit's own position IS its
+            // sub-attack index (a `hits: N` cast is N consecutive attacks, R1).
+            subAttackIndex: 0,
         });
         expect(events[1]).toEqual({
             type: 'attacked',
@@ -39,7 +43,27 @@ describe('emitAttacked', () => {
             isPrimaryTarget: true,
             shieldWasHit: true,
             damage: 500,
+            subAttackIndex: 1,
         });
+    });
+
+    it('an explicit subAttackIndex overrides the hit position (the positional callers)', () => {
+        const { events, bus } = fakeBus();
+        // The positional path groups signals by sub-attack, so each call carries exactly ONE hit
+        // outcome and the index it belongs to — which is NOT its position within this call.
+        emitAttacked({
+            bus,
+            round: 2,
+            targetId: 't1',
+            attackerId: 'a1',
+            hitOutcomes: [true],
+            isPrimaryTarget: true,
+            shieldWasHit: false,
+            damage: 500,
+            subAttackIndex: 2,
+        });
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({ subAttackIndex: 2 });
     });
 
     it('omits shieldWasHit/damage when falsy and isPrimaryTarget when false', () => {
@@ -54,6 +78,14 @@ describe('emitAttacked', () => {
             shieldWasHit: false,
             damage: 0,
         });
-        expect(events[0]).toEqual({ type: 'attacked', targetId: 't', attackerId: 'a', round: 1 });
+        expect(events[0]).toEqual({
+            type: 'attacked',
+            targetId: 't',
+            attackerId: 'a',
+            round: 1,
+            // PR4: `subAttackIndex` is NOT conditional — every `attacked` carries one, so the
+            // once-per-attack rider guard always has an attack identity to key on.
+            subAttackIndex: 0,
+        });
     });
 });

--- a/src/utils/combat/__tests__/emitPerVictimAttacked.test.ts
+++ b/src/utils/combat/__tests__/emitPerVictimAttacked.test.ts
@@ -64,6 +64,9 @@ describe('emitPerVictimAttacked', () => {
             round: 1,
             isPrimaryTarget: true,
             damage: 50,
+            // PR4: every `attacked` carries a sub-attack index. No `subAttackIndex` was passed
+            // here, so it falls back to the hit's position within the call — 0.
+            subAttackIndex: 0,
         });
     });
 

--- a/src/utils/combat/__tests__/subAttackProcGates.integration.test.ts
+++ b/src/utils/combat/__tests__/subAttackProcGates.integration.test.ts
@@ -250,3 +250,86 @@ describe('PR4 Task 2 — the amplification proc rolls once per sub-attack', () =
         expect(amplified[0]).toBeGreaterThan(baseline[0]);
     });
 });
+
+/**
+ * Insidiousness's shape: a `procScope:'per-attack'` reactive damage rider on on-crit.
+ * `procChance` is optional here because the two gates it must clear are independent:
+ *  - with NO procChance, `passesProcChanceGate` returns early and only the per-victim
+ *    `reactionFiredThisAttack` suppression is in play;
+ *  - with one, the verdict MEMO is consulted too.
+ * Both were per-TURN before PR4 and both had to be re-keyed, so both are exercised below.
+ */
+const procScopedRider = (procChance?: number): ShipSkills['slots'][number] => ({
+    slot: 'passive',
+    abilities: [
+        ab({
+            type: 'damage',
+            target: 'enemy',
+            trigger: 'on-crit',
+            procScope: 'per-attack',
+            ...(procChance !== undefined ? { procChance } : {}),
+            config: { type: 'damage', multiplier: 40 },
+        }),
+    ],
+});
+
+describe('PR4 Task 3 — procScope:"per-attack" is per SUB-attack, not per turn', () => {
+    afterEach(() => resetRateGateRng());
+
+    // Pre-fix: 1 fire for hits=3. The verdict was memoized on `${owner}:${ability}` and cleared
+    // only at actor turn-start, so "ThisAttack" was really a per-TURN cache and sub-attacks
+    // #2..#N replayed #1's verdict (spec §4.4 — the misnomer IS the bug's hiding place).
+    it.each([
+        [1, 1],
+        [3, 3],
+    ])('hits=%i fires the rider %i time(s)', (hits, expected) => {
+        idc = 0;
+        alwaysFire();
+        expect(
+            countOf(
+                focusCast([attackSkill(hits), procScopedRider()], basePattern()),
+                'reactive-damage-performed'
+            )
+        ).toBe(expected);
+    });
+
+    it('within ONE sub-attack the verdict is still shared across victims', () => {
+        idc = 0;
+        alwaysFire();
+        // The whole point of procScope: an AoE footprint is one attack, so its victims share one
+        // roll and the rider hits once (R3). Re-keying by sub-attack must not break that — this is
+        // the guard against "fixed" meaning "now fires per victim".
+        expect(
+            countOf(
+                focusCast([attackSkill(1), procScopedRider()], allPattern()),
+                'reactive-damage-performed'
+            )
+        ).toBe(1);
+    });
+
+    it('each sub-attack draws its OWN verdict — the memo is not replayed', () => {
+        idc = 0;
+        // This is the case that pins the verdict MEMO specifically (the test above pins the
+        // per-victim suppression instead: with no procChance, passesProcChanceGate returns early
+        // and never touches the memo).
+        //
+        // A 3-hit cast with a 50% rider under the draw sequence FAIL, FIRE, FIRE. Pre-PR4 the
+        // verdict was memoized on `${owner}:${ability}` and cleared only at actor turn-start, so
+        // sub-attack #1's FAIL was replayed for #2 and #3 → 0 fires. Keyed by sub-attack, each
+        // draws its own → 2 fires. A count of 3 would mean the memo stopped memoizing at all.
+        let n = 0;
+        setRateGateRng(() => 0);
+        setKeyedRng((key) => (key.startsWith('attacker:proc') ? (n++ === 0 ? 1 : 0) : 0));
+        const bus = createEventBus();
+        let fires = 0;
+        bus.on('reactive-damage-performed', () => {
+            fires++;
+        });
+        runCombat({
+            ...focusCast([attackSkill(3), procScopedRider(0.5)], basePattern()),
+            bus,
+        });
+        expect(n).toBe(3);
+        expect(fires).toBe(2);
+    });
+});

--- a/src/utils/combat/__tests__/subAttackProcGates.integration.test.ts
+++ b/src/utils/combat/__tests__/subAttackProcGates.integration.test.ts
@@ -72,6 +72,8 @@ const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
 });
 /** Single-cell footprint: the anchor only. */
 const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+/** Whole-roster footprint: every occupied cell is struck by each sub-attack. */
+const allPattern = (): ParsedPattern => ({ raw: 'all', shape: 'all', range: 'all', modifiers: {} });
 
 /** A positioned enemy that never fires back. */
 const passiveEnemyAt = (id: string, position: Position) =>
@@ -147,5 +149,104 @@ describe('PR4 Task 1 — the on-crit reactive debuff path is already per-sub-att
         expect(
             countOf(focusCast([attackSkill(hits), onCritShred()], basePattern()), 'debuff-applied')
         ).toBe(expected);
+    });
+});
+
+/** Menace's shape: passive-slot outgoing-amplification, crit-conditional, 50% proc. */
+const menacePassive = (): ShipSkills['slots'][number] => ({
+    slot: 'passive',
+    abilities: [
+        {
+            id: 'MENACE',
+            type: 'outgoing-amplification',
+            target: 'self',
+            trigger: 'passive',
+            conditions: [],
+            config: {
+                type: 'outgoing-amplification',
+                condition: 'amplify-on-crit',
+                ampPct: 50,
+                procChance: 0.5,
+            },
+        } as unknown as Ability,
+    ],
+});
+
+/**
+ * Counts draws on the amplification proc's own RNG sub-stream. `rollRateGate` keys amp draws
+ * `${actorId}:${abilityId}`, and `setKeyedRng` gives every key its own stream — so this counts
+ * exactly the amplification rolls and nothing else.
+ */
+const ampDrawsFor = (input: CombatEngineInput): number => {
+    let draws = 0;
+    setRateGateRng(() => 0);
+    setKeyedRng((key) => {
+        if (key === 'attacker:MENACE') draws++;
+        return 0;
+    });
+    runCombat({ ...input, bus: createEventBus() });
+    return draws;
+};
+
+describe('PR4 Task 2 — the amplification proc rolls once per sub-attack', () => {
+    afterEach(() => resetRateGateRng());
+
+    // Pre-fix draw counts were `hits × (1 + victims)` — 2 / 6 / 3 / 9 — because runPlayerTurn's
+    // per-hit loop drew once per hit AND the positional per-victim apply drew again per
+    // (hit, victim), both against the same `procChanceGates` key (spec §4.3 + the §4.6
+    // double-advance, confirmed by measurement). The correct count is `hits`, independent of
+    // footprint size: an AoE footprint is ONE attack and shares one roll (R3), while each
+    // multi-hit sub-attack draws its own (R1).
+    it.each([
+        ['base', 1, 1],
+        ['base', 3, 3],
+        ['all', 1, 1],
+        ['all', 3, 3],
+    ] as const)('%s pattern, hits=%i draws exactly %i time(s)', (shape, hits, expected) => {
+        idc = 0;
+        const pattern = shape === 'base' ? basePattern() : allPattern();
+        expect(ampDrawsFor(focusCast([attackSkill(hits), menacePassive()], pattern))).toBe(
+            expected
+        );
+    });
+
+    /** Per-victim booked damage for one cast, under a caller-supplied MENACE draw sequence. */
+    const perVictimDamage = (
+        slots: ShipSkills['slots'],
+        menaceDraw: (n: number) => number
+    ): number[] => {
+        let n = 0;
+        setRateGateRng(() => 0);
+        setKeyedRng((key) => (key === 'attacker:MENACE' ? menaceDraw(n++) : 0));
+        const bus = createEventBus();
+        const perVictim = new Map<string, number>();
+        bus.on('attacked', (e) => {
+            perVictim.set(e.targetId, (perVictim.get(e.targetId) ?? 0) + (e.damage ?? 0));
+        });
+        runCombat({ ...focusCast(slots, allPattern()), bus });
+        return [...perVictim.values()];
+    };
+
+    it('every victim of one sub-attack shares that sub-attack’s single verdict', () => {
+        idc = 0;
+        // Fire draw #1 and fail every later one, then check BOTH victims came out amplified.
+        //
+        // The equality of the two victims alone would be a VACUOUS assertion: pre-fix, draw #1 was
+        // runPlayerTurn's discarded aggregate roll, so both victims saw a FAILING draw and were
+        // equal-but-unamplified. Comparing against a no-amplification baseline is what makes this
+        // discriminate — post-fix the single fired verdict is the one both victims resolve off, so
+        // both take strictly more than baseline.
+        const baseline = perVictimDamage([attackSkill(1)], () => 0);
+        idc = 0;
+        const amplified = perVictimDamage([attackSkill(1), menacePassive()], (n) =>
+            n === 0 ? 0 : 1
+        );
+        expect(baseline).toHaveLength(2);
+        expect(amplified).toHaveLength(2);
+        expect(baseline[0]).toBeGreaterThan(0);
+        // Shared verdict: the two victims of the one sub-attack agree...
+        expect(amplified[0]).toBeCloseTo(amplified[1], 6);
+        // ...and they agree on the AMPLIFIED value, not on having both missed the proc.
+        expect(amplified[0]).toBeGreaterThan(baseline[0]);
     });
 });

--- a/src/utils/combat/__tests__/subAttackProcGates.integration.test.ts
+++ b/src/utils/combat/__tests__/subAttackProcGates.integration.test.ts
@@ -333,3 +333,70 @@ describe('PR4 Task 3 — procScope:"per-attack" is per SUB-attack, not per turn'
         expect(fires).toBe(2);
     });
 });
+
+/** A self-target buff rider on on-attacked — the shape `oncePerAttackGuardKey` guards. */
+const onAttackedSelfBuff = (): ShipSkills['slots'][number] => ({
+    slot: 'passive',
+    abilities: [
+        ab({
+            type: 'buff',
+            target: 'self',
+            trigger: 'on-attacked',
+            config: {
+                type: 'buff',
+                buffName: 'Everliving Regeneration',
+                parsedEffects: { attack: 5 },
+                stacks: 1,
+                isStackable: true,
+                maxStacks: 20,
+                duration: 3,
+            },
+        }),
+    ],
+});
+
+/** An enemy at M4 that actually attacks, `hits` times, and outruns the focus. */
+const aggressorAt = (hits: number) =>
+    ({
+        id: 'aggressor',
+        stats: { attack: 5000, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 999 },
+        chargeCount: 0,
+        startCharged: false,
+        position: 'M4',
+        affinity: 'antimatter',
+        shipSkills: { slots: [attackSkill(hits)] },
+    }) as NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+describe('PR4 Task 4 — the once-per-attack rider guard resets per sub-attack', () => {
+    afterEach(() => resetRateGateRng());
+
+    // The VICTIM carries the rider here, so the ENEMY must be the one attacking. One attack fans
+    // into one `attacked` per hit per victim and the self-rider must collapse across those — but a
+    // `hits: N` attack is N consecutive attacks (R1) and must NOT collapse across those. Pre-PR4
+    // `reactionFiredThisAttack` was keyed `owner:ability:victim` and cleared only at actor
+    // turn-start, so all N collapsed to 1 (spec §4.4).
+    //
+    // Index-keying is safe here in a way it was not for `on-ally-crit` (see PER_HIT_REACTIVE_TRIGGERS
+    // in triggers.ts, where two different critting allies both carrying index 0 ruled it out):
+    // adding a component to a key can only SPLIT keys, never merge them, so this can never collapse
+    // something the pre-PR4 guard kept separate.
+    it.each([
+        [1, 1],
+        [3, 3],
+    ])('an enemy hits:%i attack grants the rider %i time(s)', (hits, expected) => {
+        idc = 0;
+        alwaysFire();
+        const bus = createEventBus();
+        let grants = 0;
+        bus.on('buff-applied', (e) => {
+            if (e.actorId === 'attacker' && e.buffName === 'Everliving Regeneration') grants++;
+        });
+        runCombat({
+            ...focusCast([attackSkill(1), onAttackedSelfBuff()], basePattern()),
+            numRounds: 1,
+            enemyAttackers: [aggressorAt(hits)],
+            bus,
+        });
+        expect(grants).toBe(expected);
+    });
+});

--- a/src/utils/combat/__tests__/subAttackProcGates.integration.test.ts
+++ b/src/utils/combat/__tests__/subAttackProcGates.integration.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Multi-hit full-walk attacks, PR4 — OUTGOING proc gates at sub-attack scope.
+ *
+ * A multi-hit skill is N consecutive full-walk attacks (locked game rule R1), and effects based on
+ * OUTGOING hits resolve per attack — i.e. per sub-attack (R2). PR1 threaded a `subAttackIndex`
+ * through every per-victim callback and PR2 made the engine emit one `ability-performed` per
+ * sub-attack; PR4 makes the *gates* consume that identity.
+ *
+ * Task 1 pins a PR2 deliverable that nothing else covers. Enforcer's Defense Shred is a PASSIVE
+ * `on-crit` reactive debuff, not a slot clause, so PR2's per-sub-attack emission is what gives her
+ * N stacks — and Enforcer is `Pattern-Base`, so no fingerprint golden can see a regression here.
+ * Measured against 7829f531: hits=1 → 1 application, hits=3 → 3.
+ *
+ * Fixtures are copied from `perSubAttackEvents.integration.test.ts` rather than imported: that
+ * file exports nothing and PR2 deliberately kept its fixtures local.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { setRateGateRng, setKeyedRng, resetRateGateRng } from '../../calculators/rateAccumulator';
+import { runCombat, CombatEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `pg${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+/** An N-hit damage active. `hits` is omitted at N=1 so the fixture matches a normal ship. */
+const attackSkill = (hits: number): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [
+        ab({
+            type: 'damage',
+            target: 'enemy',
+            config: { type: 'damage', multiplier: 100, ...(hits > 1 ? { hits } : {}) },
+        }),
+    ],
+});
+
+/** Enforcer's real shred shape: passive-slot `on-crit` debuff, inflict application. */
+const onCritShred = (): ShipSkills['slots'][number] => ({
+    slot: 'passive',
+    abilities: [
+        ab({
+            type: 'debuff',
+            target: 'enemy',
+            trigger: 'on-crit',
+            config: {
+                type: 'debuff',
+                buffName: 'Defense Shred',
+                parsedEffects: { defense: -2 },
+                stacks: 1,
+                isStackable: true,
+                maxStacks: 20,
+                duration: 3,
+                application: 'inflict',
+            },
+        }),
+    ],
+});
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+/** Single-cell footprint: the anchor only. */
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+/** A positioned enemy that never fires back. */
+const passiveEnemyAt = (id: string, position: Position) =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp: 1_000_000_000, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        affinity: 'antimatter',
+        shipSkills: { slots: [] },
+    }) as NonNullable<CombatEngineInput['enemyAttackers']>[number];
+
+/**
+ * The focus player at M1 fires `slots`. `crit: 100` with a neutral-affinity roster makes every
+ * (sub-attack, victim) pair crit; `hacking` is high so debuff landing rolls never resist.
+ */
+const focusCast = (slots: ShipSkills['slots'], pattern: ParsedPattern): CombatEngineInput => ({
+    attack: 5000,
+    crit: 100,
+    critDamage: 100,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots },
+    enemyDefense: 0,
+    enemyHp: 1_000_000_000,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    affinity: 'antimatter',
+    defence: 0,
+    hp: 1_000_000_000,
+    hacking: 100_000,
+    healTargetId: 'attacker',
+    position: 'M1',
+    target: parsedTarget('front'),
+    pattern,
+    enemyAttackers: [passiveEnemyAt('anchor', 'M4'), passiveEnemyAt('covered', 'M3')],
+});
+
+/** Everything fires: crit gates, landing gates, proc gates. */
+const alwaysFire = (): void => {
+    setRateGateRng(() => 0);
+    setKeyedRng(() => 0);
+};
+
+const countOf = (input: CombatEngineInput, type: CombatEvent['type']): number => {
+    const bus = createEventBus();
+    let n = 0;
+    bus.on(type, () => {
+        n++;
+    });
+    runCombat({ ...input, bus });
+    return n;
+};
+
+describe('PR4 Task 1 — the on-crit reactive debuff path is already per-sub-attack (PR2)', () => {
+    afterEach(() => resetRateGateRng());
+
+    it.each([
+        [1, 1],
+        [3, 3],
+    ])('hits=%i inflicts the debuff %i time(s)', (hits, expected) => {
+        idc = 0;
+        alwaysFire();
+        expect(
+            countOf(focusCast([attackSkill(hits), onCritShred()], basePattern()), 'debuff-applied')
+        ).toBe(expected);
+    });
+});

--- a/src/utils/combat/__tests__/triggers.test.ts
+++ b/src/utils/combat/__tests__/triggers.test.ts
@@ -4128,7 +4128,7 @@ describe("procScope 'per-attack' verdict cache", () => {
             recordResisted: () => {},
             oncePerRoundConsumed: new Set<string>(),
             procChanceGates: new Map(),
-            procDecisionThisAttack: new Map<string, boolean>(),
+            procDecisionThisSubAttack: new Map<string, boolean>(),
             reactionFiredThisAttack: new Set<string>(),
             applyReactiveDamage: (_o: string, victim: string) => calls.push(victim),
             ...over,
@@ -4190,7 +4190,7 @@ describe("procScope 'per-attack' verdict cache", () => {
         const cache = new Map<string, boolean>();
         const fired = new Set<string>();
         const { ctx, calls } = makeCtx({
-            procDecisionThisAttack: cache,
+            procDecisionThisSubAttack: cache,
             reactionFiredThisAttack: fired,
         });
         executeIntent(intent('enemy1', true), ctx);

--- a/src/utils/combat/emitAttacked.ts
+++ b/src/utils/combat/emitAttacked.ts
@@ -27,10 +27,31 @@ export function emitAttacked(args: {
      * non-positional call sites (one attack per call) were never affected.
      */
     damage: number;
+    /**
+     * Which sub-attack of the attacker's cast these events belong to (multi-hit full-walk epic,
+     * PR4). Carried on the event so a victim-side once-per-attack rider guard can reset between the
+     * attacker's consecutive attacks instead of collapsing all N into one grant.
+     *
+     * Supplied by the POSITIONAL callers, where the engine has already grouped signals by
+     * sub-attack and `hitOutcomes` therefore holds exactly one entry per call. OMITTED by the
+     * non-positional caller, which passes the whole cast's `hitOutcomes` in ONE call — there the
+     * loop index below IS the sub-attack index (a `hits: N` cast is N consecutive attacks, R1), so
+     * it is used as the fallback rather than leaving the field absent.
+     */
+    subAttackIndex?: number;
 }): void {
-    const { bus, round, targetId, attackerId, hitOutcomes, isPrimaryTarget, shieldWasHit, damage } =
-        args;
-    for (const hitCrit of hitOutcomes) {
+    const {
+        bus,
+        round,
+        targetId,
+        attackerId,
+        hitOutcomes,
+        isPrimaryTarget,
+        shieldWasHit,
+        damage,
+        subAttackIndex,
+    } = args;
+    hitOutcomes.forEach((hitCrit, hitIndex) => {
         bus.emit({
             type: 'attacked',
             targetId,
@@ -40,6 +61,7 @@ export function emitAttacked(args: {
             ...(shieldWasHit ? { shieldWasHit: true } : {}),
             ...(hitCrit ? { didCrit: true } : {}),
             ...(damage > 0 ? { damage } : {}),
+            subAttackIndex: subAttackIndex ?? hitIndex,
         });
-    }
+    });
 }

--- a/src/utils/combat/emitPerVictimAttacked.ts
+++ b/src/utils/combat/emitPerVictimAttacked.ts
@@ -23,6 +23,8 @@ export function emitPerVictimAttacked(args: {
     attackerId: string;
     primaryId: string;
     victims: Map<string, { damage: number; shieldWasHit: boolean; hitOutcomes: boolean[] }>;
+    /** The sub-attack `victims` belongs to (PR4) — stamped onto every event it emits. */
+    subAttackIndex?: number;
 }): void {
     for (const [victimId, sig] of args.victims) {
         emitAttacked({
@@ -34,6 +36,7 @@ export function emitPerVictimAttacked(args: {
             isPrimaryTarget: victimId === args.primaryId,
             shieldWasHit: sig.shieldWasHit,
             damage: sig.damage,
+            ...(args.subAttackIndex !== undefined ? { subAttackIndex: args.subAttackIndex } : {}),
         });
     }
 }

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -2846,10 +2846,12 @@ export function runCombat(input: CombatEngineInput): {
     // `${ownerId}:${abilityId}`; each gate is a RateGate that fires with the ability's
     // procChance probability on each draw (random, like the crit/landing gates).
     const procChanceGates = new Map<string, RateGate>();
-    // Per-actor-turn verdict cache for procScope:'per-attack' proc abilities (Insidiousness).
-    // Keyed `${ownerId}:${abilityId}`; cleared at each actor turn-start beside
+    // Per-SUB-ATTACK verdict cache for procScope:'per-attack' proc abilities (Insidiousness).
+    // Keyed `${ownerId}:${abilityId}:${subAttackIndex}` (multi-hit full-walk epic, PR4 — was
+    // `${ownerId}:${abilityId}`, which silently made it per-TURN, so a hits:N skill replayed
+    // sub-attack #1's verdict for all N); cleared at each actor turn-start beside
     // reactionFiredThisAttack so a later attack rolls afresh.
-    const procDecisionThisAttack = new Map<string, boolean>();
+    const procDecisionThisSubAttack = new Map<string, boolean>();
     // G PR1: dedicated crit-gate for counterattacks. A NEW map (NOT any existing per-actor
     // crit gate) so it only ever creates keys for counter-carriers → no draw, no perturbation
     // for every existing fixture → byte-identical.
@@ -5984,8 +5986,9 @@ export function runCombat(input: CombatEngineInput): {
             // to the enemies actually crit rather than the cast's SELECTED anchor (which may not
             // have crit at all in an AoE). Empty on the 0-damage fallback path (no apply ran).
             critVictimIds: string[],
-            // Which sub-attack this event belongs to, for the deferred-log drain below. Omitted on
-            // the single-event paths ⟹ drain everything (the pre-PR2 behaviour).
+            // Which sub-attack this event belongs to, for the deferred-log drain below AND (PR4) as
+            // the event's own sub-attack identity. Omitted on the single-event paths ⟹ drain
+            // everything (the pre-PR2 behaviour) and emit no index.
             subAttack?: number
         ) => {
             bus.emit({
@@ -5998,6 +6001,10 @@ export function runCombat(input: CombatEngineInput): {
                 didCrit,
                 ...(critHits > 0 ? { critHits } : {}),
                 ...(critVictimIds.length > 0 ? { critVictimIds } : {}),
+                // PR4: the OUTGOING reactive listeners stamp this onto the intents they enqueue, so
+                // the drain (which runs once per turn, after every sub-attack) can gate per
+                // sub-attack. Conditional spread → the single-event paths stay byte-identical.
+                ...(subAttack !== undefined ? { subAttackIndex: subAttack } : {}),
                 didHit: true,
             });
             // Task 3: the attack entry now exists — drain the reflect rows THIS sub-attack
@@ -7205,7 +7212,7 @@ export function runCombat(input: CombatEngineInput): {
                         procChanceGates,
                         // Per-attack proc verdict cache (Insidiousness): one roll per attack,
                         // replayed for every debuff event that attack inflicts.
-                        procDecisionThisAttack,
+                        procDecisionThisSubAttack,
                         // Phase 4c PR 6: live lowest-speed-ally gate. UNCONDITIONAL (unlike the
                         // healing-only selfHpPctFor spread) — in DPS mode the set is {attacker}, so
                         // the lone attacker resolves true and DPS gating stays byte-identical.
@@ -7688,9 +7695,11 @@ export function runCombat(input: CombatEngineInput): {
                 // Task 5: reset the self-rider once-per-attack guard beside the counter guard so a
                 // later attack re-applies Hermes's Everliving Regeneration / charge.
                 reactionFiredThisAttack.clear();
-                // Insidiousness: drop the per-attack proc verdicts so this attack draws its own
-                // single roll (and every debuff it inflicts shares that one verdict).
-                procDecisionThisAttack.clear();
+                // Insidiousness: drop the per-sub-attack proc verdicts so each sub-attack of this
+                // turn draws its own single roll (and every debuff ONE sub-attack inflicts shares
+                // that sub-attack's verdict). Keys carry the sub-attack index since PR4, so this
+                // clear is what stops turn N+1's sub-attack 0 reading turn N's verdict.
+                procDecisionThisSubAttack.clear();
 
                 // Set the active carrier for the own-turn self-buff reprieve: a TIMED self-buff
                 // written during this actor's own turn is flagged appliedThisTurn so it survives

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -6652,8 +6652,15 @@ export function runCombat(input: CombatEngineInput): {
              * Emits ONE sub-attack's `attacked` events (PR2 Task 3 — was one call for the whole
              * cast). Invoked once per sub-attack that produced signals, in ascending index order,
              * immediately after that sub-attack's own `ability-performed`.
+             *
+             * PR4: the bucket's index is passed too, so it can be stamped onto each `attacked`
+             * event. A victim-side once-per-attack rider guard needs it to reset between the
+             * attacker's consecutive attacks instead of collapsing all N into one.
              */
-            emitAttackedForSubAttack: (victims: Map<string, PositionalVictimSignal>) => void,
+            emitAttackedForSubAttack: (
+                victims: Map<string, PositionalVictimSignal>,
+                subAttackIndex: number
+            ) => void,
             /**
              * The enemy site emits its `attacked` AFTER the helper returns (its row-14 accounting
              * tail is kept inline — SP-U U5). Set to defer everything except the FIRST
@@ -6823,7 +6830,7 @@ export function runCombat(input: CombatEngineInput): {
                         const victims = attackedSignals.get(idx)!;
                         steps.push({
                             isEvent: false,
-                            run: () => emitAttackedForSubAttack(victims),
+                            run: () => emitAttackedForSubAttack(victims, idx),
                         });
                     }
                 } else {
@@ -6868,7 +6875,7 @@ export function runCombat(input: CombatEngineInput): {
                         if (victims && victims.size > 0) {
                             steps.push({
                                 isEvent: false,
-                                run: () => emitAttackedForSubAttack(victims),
+                                run: () => emitAttackedForSubAttack(victims, idx),
                             });
                         }
                     }
@@ -6882,7 +6889,10 @@ export function runCombat(input: CombatEngineInput): {
                 // sub-attack.
                 for (const idx of signalledIndices) {
                     const victims = attackedSignals.get(idx)!;
-                    steps.push({ isEvent: false, run: () => emitAttackedForSubAttack(victims) });
+                    steps.push({
+                        isEvent: false,
+                        run: () => emitAttackedForSubAttack(victims, idx),
+                    });
                 }
             }
             let emitDeferred = (): void => {};
@@ -8169,8 +8179,9 @@ export function runCombat(input: CombatEngineInput): {
                                     (victim, damage, outcome) =>
                                         procLeechesForVictim(actor.id, victim, damage, outcome),
                                     // PR2 Task 3: ONE sub-attack's victims per call, emitted right
-                                    // after that sub-attack's own `ability-performed`.
-                                    (victims) => {
+                                    // after that sub-attack's own `ability-performed`. PR4 stamps
+                                    // the index onto each event.
+                                    (victims, subAttackIndex) => {
                                         if (victims.size > 0) {
                                             emitPerVictimAttacked({
                                                 bus,
@@ -8178,6 +8189,7 @@ export function runCombat(input: CombatEngineInput): {
                                                 attackerId: actor.id,
                                                 primaryId: tgt.id,
                                                 victims,
+                                                subAttackIndex,
                                             });
                                         }
                                     }
@@ -8397,7 +8409,7 @@ export function runCombat(input: CombatEngineInput): {
                                     (victim, damage, outcome) =>
                                         procLeechesForVictim(actor.id, victim, damage, outcome),
                                     // PR2 Task 3 — mirror of the focus site's per-sub-attack emit.
-                                    (victims) => {
+                                    (victims, subAttackIndex) => {
                                         if (victims.size > 0) {
                                             emitPerVictimAttacked({
                                                 bus,
@@ -8405,6 +8417,7 @@ export function runCombat(input: CombatEngineInput): {
                                                 attackerId: actor.id,
                                                 primaryId: tgt.id,
                                                 victims,
+                                                subAttackIndex,
                                             });
                                         }
                                     }
@@ -9081,7 +9094,7 @@ export function runCombat(input: CombatEngineInput): {
                                         // PR2 Task 3: ONE sub-attack's victims per call. The enemy
                                         // still DEFERS the whole fan-out to its inline tail (U5),
                                         // so these calls run from `emitDeferred` below, not here.
-                                        (victims) => {
+                                        (victims, subAttackIndex) => {
                                             if (victims.size > 0) {
                                                 emitPerVictimAttacked({
                                                     bus,
@@ -9089,6 +9102,7 @@ export function runCombat(input: CombatEngineInput): {
                                                     attackerId: actor.id,
                                                     primaryId: tgt.id,
                                                     victims,
+                                                    subAttackIndex,
                                                 });
                                             }
                                         },

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -5780,6 +5780,19 @@ export function runCombat(input: CombatEngineInput): {
             // them from the callers that now emit one `ability-performed` per entry.
             subAttacks: SubAttackOutcome[];
         } => {
+            // ONE amplification verdict per (ability, sub-attack), for THIS cast only (multi-hit
+            // full-walk epic, PR4 — spec §4.3). A multi-hit skill is N consecutive attacks, each
+            // drawing its own roll (R1); an AoE footprint is ONE attack whose victims share a
+            // single roll (R3). Declared here, per cast — `drivePositionalApply` runs once per cast
+            // — so a later turn's sub-attack 0 can never reuse this turn's verdict.
+            //
+            // Drawn LAZILY, from inside `outgoingAmplificationForHit`, which checks `conditionMet`
+            // before it calls `rollProc`. That is what preserves "eligibility gates the gate": a
+            // sub-attack whose every victim is ineligible (nothing crit / no higher-attack target)
+            // still advances nothing. It is also why the roll cannot simply be hoisted into
+            // runPlayerTurn — eligibility for 'amplify-vs-higher-attack' is per victim, and on this
+            // path so is crit.
+            const ampVerdictBySubAttack = new Map<string, boolean>();
             // Task 3: this is the ONE deferred (positional) apply path — reflects fired here must
             // buffer their log row until emitDeferredAbilityPerformed creates the attack entry
             // (see the deferReflectLogs doc above applyVictimDamage). try/finally so the flag
@@ -5902,7 +5915,7 @@ export function runCombat(input: CombatEngineInput): {
                     // D-PR4: attacker-side outgoing amplification (Menace/Giant Slayer), per footprint
                     // victim per sub-hit. outgoingAmplificationForHit returns 0 for attackers with no
                     // outgoing-amplification ability → byte-identical when no such equipment exists.
-                    outgoingAmplificationFor: (victim, didCrit) => {
+                    outgoingAmplificationFor: (victim, didCrit, subAttackIndex) => {
                         // Fast path: skip the per-victim effectiveStatsOf folds when the attacker has no
                         // outgoing-amplification ability (the overwhelmingly common case) — matches the
                         // aggregate path's `ampAbilities.length > 0` guard. Byte-identical (returns 0).
@@ -5918,12 +5931,24 @@ export function runCombat(input: CombatEngineInput): {
                                     effectiveStatsOf(statusEngine, selfBuffLookup, victim).attack >
                                     effectiveStatsOf(statusEngine, selfBuffLookup, attacker).attack,
                             },
-                            (abilityId, chance) =>
-                                rollRateGate(
+                            (abilityId, chance) => {
+                                // PR4: the verdict belongs to the SUB-ATTACK, not to this victim —
+                                // one roll decides *whether*, each victim decides *if it qualifies*
+                                // (its own `conditionMet`, checked before this closure is reached).
+                                // `subAttackIndex` is optional on PR1's callback contract; `?? 0`
+                                // makes a caller that omits it behave as the single sub-attack it
+                                // is. Scoped to `ampVerdictBySubAttack`, which is per cast.
+                                const key = `${abilityId}:${subAttackIndex ?? 0}`;
+                                const cached = ampVerdictBySubAttack.get(key);
+                                if (cached !== undefined) return cached;
+                                const verdict = rollRateGate(
                                     procChanceGates,
                                     `${args.actingId}:${abilityId}`,
                                     chance
-                                )
+                                );
+                                ampVerdictBySubAttack.set(key, verdict);
+                                return verdict;
+                            }
                         );
                     },
                 });

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -539,6 +539,12 @@ export type CombatEvent =
            *  penetrated to HP, a Barrier blocked it (shield untouched), or Shield Converter
            *  converted the hit (shield gained, not drained). */
           shieldWasHit?: boolean;
+          /** The 0-based sub-attack of the ATTACKER's cast that produced this hit (multi-hit
+           *  full-walk epic, PR4). PR2 already emits one `attacked` per (sub-attack, victim); this
+           *  names which sub-attack, so a victim-side once-per-attack guard can reset between the
+           *  attacker's consecutive attacks instead of collapsing all N into one. Absent on
+           *  non-positional emits (a single aggregate attack). */
+          subAttackIndex?: number;
       };
 
 export type CombatEventType = CombatEvent['type'];

--- a/src/utils/combat/events.ts
+++ b/src/utils/combat/events.ts
@@ -87,6 +87,18 @@ export type CombatEvent =
            *  victims but not the selected anchor, `targetId` names a victim that never crit, so a
            *  "deals X to that enemy" reactive routed off `targetId` hits the wrong ship. */
           critVictimIds?: string[];
+          /** The 0-based sub-attack this event belongs to (multi-hit full-walk epic, PR4). A
+           *  multi-hit skill is N consecutive full-walk attacks and PR2 emits one event per
+           *  sub-attack; this names which one. Absent on the non-positional inline emit (a single
+           *  aggregate attack) — consumers must read absent as "the only sub-attack", and must NOT
+           *  substitute 0 when comparing across DIFFERENT actors, since every actor's first
+           *  sub-attack is also 0.
+           *
+           *  Exists so a reactive intent enqueued during sub-attack k can be gated at sub-attack
+           *  scope: intents from all N sub-attacks drain together at end of turn (drainIntentsFor),
+           *  long after the engine's ambient `currentSubAttackIndex` has been cleared, so the
+           *  identity has to travel on the event. */
+          subAttackIndex?: number;
           didHit?: boolean;
       } & ReactiveStamp)
     | ({
@@ -510,10 +522,10 @@ export type CombatEvent =
           attackerId: string;
           round: number;
           didCrit?: boolean;
-          /** D-PR16: per-ATTACK aggregate direct damage dealt this turn (identical across the
-           *  turn's per-hit events — per-hit damage is not tracked, same approximation as
-           *  Bloodthirst's triggerDamage). Present only when a damage aggregate is in scope.
-           *  Tenacity's >25%-max-HP filter reads this. */
+          /** D-PR16: direct damage this SUB-ATTACK dealt to this victim (multi-hit full-walk epic,
+           *  PR2 — previously the per-TURN aggregate, repeated identically on every per-hit event).
+           *  Present only when a damage aggregate is in scope. Tenacity's >25%-max-HP filter reads
+           *  this, and it needs ONE hit's damage rather than the cast's. */
           damage?: number;
           /** G PR1: true when the victim was the directly-targeted (primary) target of the
            *  attack, false/absent for splash/covered AoE victims. Today the sole emit is the

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -2018,6 +2018,11 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     const hitCrits: boolean[] = [];
     let ampNonCritWeight = 0;
     let ampCritWeight = 0;
+    // The engine resolves amplification per footprint victim exactly when it also takes over the
+    // `ability-performed` emit — the same condition, spelled the same way as `deferAbilityPerformed`
+    // further down. Kept as its own named const so the two reads cannot drift apart.
+    const deferAmplificationToEngine =
+        args.deferAbilityPerformedToEngine === true && hasDamageAbility;
     for (let h = 0; h < drawHits; h++) {
         const didCritHit = critGate(effectiveCrit / 100);
         if (didCritHit) critHits += 1;
@@ -2026,8 +2031,20 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         if (hasDamageAbility) hitCrits.push(didCritHit);
         // Only call outgoingAmplificationForHit when amplification is actually present AND a
         // proc gate is supplied — keeps the critGate sequence and behaviour untouched otherwise.
+        //
+        // NOT on the positional path (multi-hit full-walk epic, PR4 — spec §4.6). There the
+        // engine's per-victim apply is the authority on amplification: it resolves the condition
+        // against each footprint victim's OWN crit outcome and attack matchup, and THIS aggregate
+        // result is never applied to anyone's HP. Drawing here anyway advanced the SAME
+        // `procChanceGates` key (`${ownerId}:${abilityId}`) a second time — measured
+        // `hits × (1 + victims)` draws for one cast — and left the deferred `ability-performed`
+        // damage basis decided by a coin flip the applied damage ignored. One verdict per
+        // sub-attack, drawn where eligibility is actually known, is the fix; the accepted cost is
+        // that the positional event's pre-funnel `damage` basis no longer carries amplification
+        // (it never reflected any other per-victim outcome either). Non-positional / DPS / healing
+        // casts are the sole remaining consumer here and stay byte-identical.
         const amp =
-            ampAbilities.length > 0 && rollOutgoingProc
+            ampAbilities.length > 0 && rollOutgoingProc && !deferAmplificationToEngine
                 ? outgoingAmplificationForHit(
                       ampAbilities,
                       { didCrit: didCritHit, targetHigherAttack },

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -136,6 +136,13 @@ export interface Intent {
         counterTargetId?: string;
         damagedAllyId?: string;
         fromPurgeEvent?: boolean;
+        /** The sub-attack that raised the triggering event (multi-hit full-walk epic, PR4).
+         *  Stamped by the OUTGOING listeners (`on-crit`, `on-deal-damage`) from
+         *  `ability-performed.subAttackIndex`. Undefined for triggers with no attack identity
+         *  (start-of-round / end-of-round) — those keep per-turn gating, which is correct for them.
+         *  Read by `passesProcChanceGate`'s memo key, so `procScope:'per-attack'` means per
+         *  sub-attack rather than per turn. */
+        subAttackIndex?: number;
         /** The damage of the triggering event, used by a reactive heal/shield to scale off
          *  that hit rather than the owner's max HP. Two consumers: `basis:'damage-dealt'`
          *  (ability-performed.damage — damage the owner DEALT, e.g. Bloodthirst) and
@@ -430,7 +437,14 @@ export function registerReactiveListeners(args: {
                         for (let i = 0; i < n; i++) {
                             enqueue({
                                 ...intent,
-                                eventCtx: { ...intent.eventCtx, triggerDamage: e.damage },
+                                eventCtx: {
+                                    ...intent.eventCtx,
+                                    triggerDamage: e.damage,
+                                    // PR4: carry this sub-attack's identity to the drain, which runs
+                                    // once per turn — after every sub-attack — so it cannot ask the
+                                    // engine which sub-attack it is in.
+                                    subAttackIndex: e.subAttackIndex,
+                                },
                             });
                         }
                     });
@@ -457,7 +471,12 @@ export function registerReactiveListeners(args: {
                         // (Warpstrike duration-reduction) ignore victimId, so this is inert there.
                         enqueue({
                             ...intent,
-                            eventCtx: { ...intent.eventCtx, victimId: e.targetId },
+                            eventCtx: {
+                                ...intent.eventCtx,
+                                victimId: e.targetId,
+                                // PR4: see the on-crit listener above.
+                                subAttackIndex: e.subAttackIndex,
+                            },
                         });
                     });
                     break;
@@ -1464,13 +1483,21 @@ export interface IntentExecContext {
      *  (see oncePerAttackGuardKey + the heal branch). Absent → no guard (unit ctxs without the
      *  engine keep firing per intent, byte-identical). */
     reactionFiredThisAttack?: Set<string>;
-    /** Per-actor-turn verdict cache for `procScope:'per-attack'` abilities (Insidiousness).
-     *  Keyed `ownerId:abilityId` → the single roll's outcome, cleared at each actor turn-start
-     *  (engine) beside `reactionFiredThisAttack`. Distinct from that Set: this is not a
-     *  suppression guard but a memo, so EVERY qualifying event in the attack still executes
-     *  against its own victim under one shared pass/fail. Absent (unit ctxs) → per-event draws,
-     *  byte-identical. */
-    procDecisionThisAttack?: Map<string, boolean>;
+    /** Per-SUB-ATTACK verdict cache for `procScope:'per-attack'` abilities (Insidiousness).
+     *  Keyed `ownerId:abilityId:subAttackIndex` → the single roll's outcome; the map is cleared at
+     *  each actor turn-start (engine) beside `reactionFiredThisAttack`.
+     *
+     *  Named `…ThisSubAttack` deliberately: the field this replaced was called
+     *  `procDecisionThisAttack` while keying on `ownerId:abilityId` alone, which made it a
+     *  per-TURN cache — so a `hits: N` skill replayed sub-attack #1's verdict for all N (multi-hit
+     *  full-walk epic, spec §4.4). The misnomer is why that read as correct to every reviewer for
+     *  months. `procScope` itself KEEPS the value name `'per-attack'`: with the index in the key it
+     *  is now accurate, because a sub-attack IS an attack (R1).
+     *
+     *  Distinct from `reactionFiredThisAttack`: this is not a suppression guard but a memo, so
+     *  EVERY qualifying event in the sub-attack still executes against its own victim under one
+     *  shared pass/fail. Absent (unit ctxs) → per-event draws, byte-identical. */
+    procDecisionThisSubAttack?: Map<string, boolean>;
     /** Resolve the opposing actor carrying the most buffs (Rhodium's enemy-most-buffs purge).
      *  Per-side: a player owner scans the enemy roster, an enemy owner scans the player roster.
      *  Returns undefined when no opposing actor exists (DPS dummy) → executor falls back to
@@ -2114,8 +2141,15 @@ function passesProcChanceGate(intent: Intent, ctx: IntentExecContext): boolean {
     // debuffed enemy. Opt-in by design — this gate is shared with the heal/shield/buff/debuff
     // branches, and memoizing unconditionally would silently convert every other proc ability
     // (Adaptive Plating, Smokescreen, Ambush, Bloodthirst, Reactive Ward, Tenacity) to per-turn.
-    const memo = intent.ability.procScope === 'per-attack' ? ctx.procDecisionThisAttack : undefined;
-    const cached = memo?.get(gateKey);
+    const memo =
+        intent.ability.procScope === 'per-attack' ? ctx.procDecisionThisSubAttack : undefined;
+    // PR4: one verdict per SUB-ATTACK. The gate/stream key stays `${owner}:${ability}` — that is the
+    // owner's shared "proc" sub-stream and fragmenting it would re-roll cross-actor locality — but
+    // the MEMO key carries the sub-attack, so attacks #2..#N draw afresh instead of replaying #1's
+    // verdict. An event with no sub-attack identity (start-of-round, on-attacked, the
+    // non-positional inline emit) keys 'x' and keeps exactly today's per-turn behaviour.
+    const memoKey = `${gateKey}:${intent.eventCtx?.subAttackIndex ?? 'x'}`;
+    const cached = memo?.get(memoKey);
     if (cached !== undefined) return cached;
     let gate = ctx.procChanceGates?.get(gateKey);
     if (ctx.procChanceGates && !gate) {
@@ -2127,7 +2161,7 @@ function passesProcChanceGate(intent: Intent, ctx: IntentExecContext): boolean {
         ctx.procChanceGates.set(gateKey, gate);
     }
     const verdict = !gate || gate(pc);
-    memo?.set(gateKey, verdict);
+    memo?.set(memoKey, verdict);
     return verdict;
 }
 
@@ -3645,7 +3679,12 @@ export function executeIntent(intent: Intent, rawCtx: IntentExecContext): void {
             // `reactionFiredThisAttack`, which the engine clears at each actor turn-start beside
             // the proc verdict cache. Absent set (unit ctxs) → no dedupe, byte-identical.
             if (intent.ability.procScope === 'per-attack') {
-                const firedKey = `${intent.ownerId}:${intent.ability.id}:${victimId}`;
+                // PR4: the key carries the SUB-ATTACK too. `reactionFiredThisAttack` is cleared
+                // only at actor turn-start, so without the index this suppressed a victim for
+                // sub-attacks #2..#N of a multi-hit cast — collapsing three attacks into one hit
+                // even after the verdict memo above was re-keyed. Missing index → 'x', i.e. exactly
+                // today's per-turn behaviour for every single-attack path.
+                const firedKey = `${intent.ownerId}:${intent.ability.id}:${victimId}:${intent.eventCtx?.subAttackIndex ?? 'x'}`;
                 if (ctx.reactionFiredThisAttack?.has(firedKey)) continue;
                 ctx.reactionFiredThisAttack?.add(firedKey);
             }

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -819,6 +819,11 @@ export function registerReactiveListeners(args: {
                                 triggerDamage: e.damage,
                                 isPrimaryTarget: e.isPrimaryTarget,
                                 shieldWasHit: e.shieldWasHit,
+                                // PR4: which of the attacker's consecutive attacks this hit
+                                // belonged to. Read ONLY by `oncePerAttackGuardKey` — the per-hit
+                                // cardinality this trigger fans out at is unchanged (and correct:
+                                // incoming effects resolve per hit, R2).
+                                subAttackIndex: e.subAttackIndex,
                             },
                         });
                     });
@@ -939,7 +944,13 @@ export function registerReactiveListeners(args: {
                         // payloads to exactly the hit ally (Cultivator/Refine/Graphite).
                         enqueue({
                             ...intent,
-                            eventCtx: { counterTargetId: e.attackerId, damagedAllyId: e.targetId },
+                            eventCtx: {
+                                counterTargetId: e.attackerId,
+                                damagedAllyId: e.targetId,
+                                // PR4: see the on-attacked listener — read only by
+                                // `oncePerAttackGuardKey`.
+                                subAttackIndex: e.subAttackIndex,
+                            },
                         });
                     });
                     break;
@@ -2372,10 +2383,20 @@ const PER_HIT_REACTIVE_TRIGGERS: ReadonlySet<AbilityTrigger> = new Set<AbilityTr
  *  undefined — meaning "not guarded". Only `target: 'self'` qualifies: ally-routed grants
  *  (damagedAllyId — Cultivator/Graphite/Howler/Sentinel repair) and enemy-routed damage (Sentinel)
  *  must stay per-victim, so they never key here. Cross-referenced by the charge and buff branches
- *  only. `on-ally-crit` is deliberately NOT in the set — see {@link PER_HIT_REACTIVE_TRIGGERS}. */
+ *  only. `on-ally-crit` is deliberately NOT in the set — see {@link PER_HIT_REACTIVE_TRIGGERS}.
+ *
+ *  PR4: the key carries the ATTACKER's sub-attack index. One attack fans into one `attacked` per
+ *  hit per victim and the rider must collapse across those — but a `hits: N` attack is N
+ *  consecutive attacks (R1) and must NOT collapse across those; `reactionFiredThisAttack` is
+ *  cleared only at actor turn-start, so before PR4 all N collapsed into one grant.
+ *
+ *  Safe here in a way it was not for `on-ally-crit` (where two DIFFERENT critting allies both
+ *  carrying index 0 ruled it out): adding a component to a key can only SPLIT keys, never merge
+ *  them, so this can never collapse something the pre-PR4 guard kept separate. Missing index → 'x',
+ *  i.e. exactly today's behaviour on every non-positional path. */
 function oncePerAttackGuardKey(intent: Intent): string | undefined {
     return intent.ability.target === 'self' && PER_HIT_REACTIVE_TRIGGERS.has(intent.ability.trigger)
-        ? `${intent.ownerId}:${intent.ability.id}`
+        ? `${intent.ownerId}:${intent.ability.id}:${intent.eventCtx?.subAttackIndex ?? 'x'}`
         : undefined;
 }
 


### PR DESCRIPTION
Fourth PR of the multi-hit full-walk epic. Makes every OUTGOING proc gate resolve **once per sub-attack** instead of once per turn (or once per hit × victim), so `procScope: 'per-attack'` and `reactionFiredThisAttack` mean what their names say.

Spec: `docs/superpowers/specs/2026-08-07-multi-hit-full-walk-attacks-design.md` §4.3, §4.4, §4.6.
Plan: `docs/superpowers/plans/2026-08-08-multi-hit-full-walk-pr4-proc-gates.md`.

## ⚠️ This PR reorders the epic — PR3's original justification is void

The plan called for PR3 (debuffs inside the hit loop) next, on the premise that Enforcer still gained 1 Defense Shred stack instead of N. **Measured against `7829f531`, that premise is false.** Enforcer's shred is a `passive` **`on-crit` reactive** debuff, not a slot clause, so PR2 already delivered it:

| path | hits=1 | hits=3 | R1 wants | owner |
| --- | --- | --- | --- | --- |
| `on-crit` reactive debuff (Enforcer's real shred) | 1 | **3 ✅** | 3 | already fixed by PR2 |
| slot-timed debuff clause | 1 | **1 ❌** | 3 | PR3 |
| `procScope:'per-attack'` reactive | 1 | **1 ❌** | 3 | **this PR** |

A scan of all 148 ships through `buildShipAbilities` also shows PR3's remaining target has **zero corpus reach**: Enforcer is the only ship with `hits > 1`, and both her multi-hit slots have no sibling abilities at all. PR4's targets, by contrast, are confirmed live bugs on the equipment that real teams run.

## §4.6's "SUSPECTED" double-advance: CONFIRMED

Amplification proc draws for one cast, measured before this PR — exactly `hits × (1 + victims)`:

| pattern | hits=1 | hits=3 |
| --- | --- | --- |
| base (1 victim) | **2** → 1 | **6** → 3 |
| all (2 victims) | **3** → 1 | **9** → 3 |

`runPlayerTurn`'s per-hit loop drew once per hit **and** the positional per-victim apply drew again per (hit, victim), both against the same `procChanceGates` key.

It was not merely wasted draws. The measured `ability-performed` damage was `15000` where an unamplified hit is `10000` — so the **aggregate** roll decided the event's damage basis (and hence Bloodthirst's heal basis) while the **per-victim** roll decided the damage actually applied. Two independent coin flips describing one hit.

## What changed

1. **One amplification roll per sub-attack** (`a5d977a4`). Drawn lazily inside the positional apply and memoized per (ability, sub-attack), preserving "eligibility gates the gate": one roll decides *whether*, each victim decides *if it qualifies*. `runPlayerTurn` no longer draws on positional casts.
2. **`procScope` verdict keyed by sub-attack** (`f020b526`). Both gates behind it were per-TURN — the verdict memo *and* the per-victim suppression in the reactive damage executor. `ability-performed` gained `subAttackIndex`; the on-crit / on-deal-damage listeners stamp it onto the intents they enqueue. The index has to travel on the event because the intent drain runs once per turn, after every sub-attack.
3. **Once-per-attack rider guard reset between sub-attacks** (`2bfbaafa`). `attacked` gained `subAttackIndex` and `oncePerAttackGuardKey` keys on it, so a hits:3 enemy attack grants a victim's on-attacked rider three times, not once.

## Accepted cost, documented at the site

The positional `ability-performed` damage basis **no longer carries amplification**. This is strictly better than the status quo, where a second independent roll decided it and the applied damage ignored that roll — and the event `damage` is a pre-funnel aggregate that reflects no other per-victim outcome either.

**Deferred, not done here:** re-coupling each sub-attack's event damage to that sub-attack's amplification verdict. Representable (the whole apply completes before PR2's emission loop), but the amp is per-victim, so "the sub-attack's amp" is only well-defined for a single-victim footprint. Needs its own behaviour decision.

## Not closed by this PR

**Insidiousness is not correct end-to-end.** Its gate is now per-sub-attack, but it triggers on `debuff-applied`, and the slot-debuff path still emits one per cast — that is PR3.

## Naming

`procScope: 'per-attack'` **keeps its name**: with the index in the key it is now accurate, because a sub-attack IS an attack (R1). Only the cache was renamed, `procDecisionThisAttack` → `procDecisionThisSubAttack`. The misnomer was the bug's hiding place — two caches named "ThisAttack" that were per-turn read as correct to every reviewer for months.

## Verification

- `npx tsc --noEmit`, `npm run lint`, `npm run audit` — all clean.
- `npm test` — **476 files / 5440 tests green**.
- **Zero golden churn.** Amp draws are keyed to their own RNG sub-stream, and `outgoing-amplification` is equipment-sourced while the fingerprint corpus runs trace ships.
- `npm run audit:placement-symmetry -- --seeds 15` — **exactly baseline: 2 findings, 146 symmetric, 13/13/13**, and the two findings are the same pair as before (Enforcer `debuff-resisted`, enemy→focus and enemy→team).

**Epic prediction, recorded:** the two open oracle findings were hypothesised to be a multi-hit artefact. They survived PR2 unchanged and now survive PR4 unchanged, having been carried through both the emission-cardinality change and the outgoing-proc-gating change. The RNG-noise explanation gains further weight.

## Test-design notes

Every new assertion was mutation-checked, because two of them were vacuous when first written:
- The "victims share one verdict" case passed pre-fix, since both victims landed *unamplified*; it now compares against a no-amplification baseline.
- The first `procScope` test never touched the verdict memo at all (no `procChance` → `passesProcChanceGate` returns early), so a second case exercises the memo specifically with a FAIL, FIRE, FIRE draw sequence.

Three exhaustive `toEqual` assertions broke on the added `attacked` field and were **extended, not loosened** to `toMatchObject` — PR1's lesson, and that exhaustiveness is a deliberate tripwire this epic keeps tripping. One renamed test call site sat behind an `as unknown as` cast where `tsc` could not see it; left unrenamed it would have silently disabled the memo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6or8HzPQ6Ydx1bAB9rGHz