### PR TITLE
feat(sim): debuff clauses land per sub-attack (multi-hit epic PR8)

### DIFF
--- a/src/utils/combat/__tests__/debuffRecipients.test.ts
+++ b/src/utils/combat/__tests__/debuffRecipients.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Recipient resolution for a direct enemy-debuff clause (multi-hit full-walk epic, PR8 Task 1).
+ *
+ * Extracted VERBATIM from playerTurn.ts's cast-time ternary so the cast-time path and PR8's
+ * per-sub-attack path cannot drift. Every branch below mirrors one arm of that ternary; the
+ * `undefined` recipient is the DPS/non-positional dummy sink ("resolve to the turn's `enemy`"),
+ * which is why the return type is `(string | undefined)[]` and not `string[]`.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveDebuffRecipientIds } from '../debuffRecipients';
+
+const adjacentOf = (anchorId: string): string[] => [`${anchorId}-left`, `${anchorId}-right`];
+
+describe('resolveDebuffRecipientIds', () => {
+    it('adjacent-enemies fans over the anchor’s neighbours and excludes the anchor', () => {
+        expect(
+            resolveDebuffRecipientIds({
+                abTarget: 'adjacent-enemies',
+                anchorId: 'v1',
+                aoeVictimIds: undefined,
+                adjacentEnemyIdsFor: adjacentOf,
+                positionalLanding: true,
+            })
+        ).toEqual(['v1-left', 'v1-right']);
+    });
+
+    it('adjacent-enemies with no anchor resolves to nothing', () => {
+        expect(
+            resolveDebuffRecipientIds({
+                abTarget: 'adjacent-enemies',
+                anchorId: undefined,
+                aoeVictimIds: undefined,
+                adjacentEnemyIdsFor: adjacentOf,
+                positionalLanding: true,
+            })
+        ).toEqual([]);
+    });
+
+    it('target-and-adjacent-enemies puts the anchor FIRST, then its neighbours', () => {
+        expect(
+            resolveDebuffRecipientIds({
+                abTarget: 'target-and-adjacent-enemies',
+                anchorId: 'v1',
+                aoeVictimIds: undefined,
+                adjacentEnemyIdsFor: adjacentOf,
+                positionalLanding: true,
+            })
+        ).toEqual(['v1', 'v1-left', 'v1-right']);
+    });
+
+    it('target-and-adjacent-enemies with no anchor: positional resolves to nothing, non-positional to the dummy sink', () => {
+        const base = {
+            abTarget: 'target-and-adjacent-enemies' as const,
+            anchorId: undefined,
+            aoeVictimIds: undefined,
+            adjacentEnemyIdsFor: adjacentOf,
+        };
+        expect(resolveDebuffRecipientIds({ ...base, positionalLanding: true })).toEqual([]);
+        expect(resolveDebuffRecipientIds({ ...base, positionalLanding: false })).toEqual([
+            undefined,
+        ]);
+    });
+
+    it('all-enemies positional uses the supplied footprint, even when empty', () => {
+        expect(
+            resolveDebuffRecipientIds({
+                abTarget: 'all-enemies',
+                anchorId: 'v1',
+                aoeVictimIds: ['v1', 'v2'],
+                adjacentEnemyIdsFor: undefined,
+                positionalLanding: true,
+            })
+        ).toEqual(['v1', 'v2']);
+        expect(
+            resolveDebuffRecipientIds({
+                abTarget: 'all-enemies',
+                anchorId: 'v1',
+                aoeVictimIds: undefined,
+                adjacentEnemyIdsFor: undefined,
+                positionalLanding: true,
+            })
+        ).toEqual([]);
+    });
+
+    it('all-enemies non-positional uses the footprint only when non-empty, else falls back to the anchor', () => {
+        expect(
+            resolveDebuffRecipientIds({
+                abTarget: 'all-enemies',
+                anchorId: 'v1',
+                aoeVictimIds: ['v2', 'v3'],
+                adjacentEnemyIdsFor: undefined,
+                positionalLanding: false,
+            })
+        ).toEqual(['v2', 'v3']);
+        expect(
+            resolveDebuffRecipientIds({
+                abTarget: 'all-enemies',
+                anchorId: 'v1',
+                aoeVictimIds: [],
+                adjacentEnemyIdsFor: undefined,
+                positionalLanding: false,
+            })
+        ).toEqual(['v1']);
+    });
+
+    it('single-target resolves to the anchor; with no anchor, positional is empty and non-positional is the dummy sink', () => {
+        expect(
+            resolveDebuffRecipientIds({
+                abTarget: 'enemy',
+                anchorId: 'v1',
+                aoeVictimIds: undefined,
+                adjacentEnemyIdsFor: undefined,
+                positionalLanding: true,
+            })
+        ).toEqual(['v1']);
+        expect(
+            resolveDebuffRecipientIds({
+                abTarget: 'enemy',
+                anchorId: undefined,
+                aoeVictimIds: undefined,
+                adjacentEnemyIdsFor: undefined,
+                positionalLanding: true,
+            })
+        ).toEqual([]);
+        expect(
+            resolveDebuffRecipientIds({
+                abTarget: 'enemy',
+                anchorId: undefined,
+                aoeVictimIds: undefined,
+                adjacentEnemyIdsFor: undefined,
+                positionalLanding: false,
+            })
+        ).toEqual([undefined]);
+    });
+
+    it('an undefined abTarget (no matching ability found) behaves as single-target', () => {
+        expect(
+            resolveDebuffRecipientIds({
+                abTarget: undefined,
+                anchorId: 'v1',
+                aoeVictimIds: ['v1', 'v2'],
+                adjacentEnemyIdsFor: adjacentOf,
+                positionalLanding: true,
+            })
+        ).toEqual(['v1']);
+    });
+
+    it('adjacentEnemyIdsFor absent yields no neighbours (the DPS/non-positional caller supplies none)', () => {
+        expect(
+            resolveDebuffRecipientIds({
+                abTarget: 'target-and-adjacent-enemies',
+                anchorId: 'v1',
+                aoeVictimIds: undefined,
+                adjacentEnemyIdsFor: undefined,
+                positionalLanding: true,
+            })
+        ).toEqual(['v1']);
+    });
+});

--- a/src/utils/combat/__tests__/exposedStatus.integration.test.ts
+++ b/src/utils/combat/__tests__/exposedStatus.integration.test.ts
@@ -279,7 +279,14 @@ describe('Exposed — +100% on the next direct hit, then consumed', () => {
         const exposed = playerHitsExposedEnemy('Exposed', 1, 'cast');
 
         expect(control).toBeGreaterThan(0);
-        expect(exposed / control).toBeCloseTo(1.5, 5);
+        // 2.0, not the 1.5 the REACTIVE fixture above reads, and the difference is the point.
+        // This `applier: 'cast'` shape puts the Exposed clause BEFORE the damage clause in the same
+        // slot, and since PR8 (multi-hit full-walk epic) a 2-hit cast is two full attacks that each
+        // run the whole pipeline — so each attack applies its own Exposed and then spends it on its
+        // own hit. The reactive fixture plants ONE Exposed before the cast with nothing re-applying
+        // it, so only its first hit is amplified: that pair is what shows the doubling here comes
+        // from per-sub-attack re-application rather than from a blanket always-on amplification.
+        expect(exposed / control).toBeCloseTo(2, 5);
     });
 
     it('is team-symmetric — an enemy-applied Exposed amplifies a PLAYER victim identically', () => {
@@ -412,8 +419,16 @@ describe('Exposed is not spent by hit types that never amplified it', () => {
     it("a counterattack leaves the victim's Exposed intact for the next real cast", () => {
         const plain = foeDamagePerRound(false);
         expect(plain.r1).toBeGreaterThan(0);
-        // Premise: round 2 IS amplified by round 1's Exposed (first hit doubled, second plain).
-        expect(plain.r2 / plain.r1).toBeCloseTo(1.5, 5);
+        // Premise: round 2 IS amplified by the Exposed round 1 left standing.
+        //
+        // The ratio is 4/3, not the pre-PR8 1.5, because since PR8 (multi-hit full-walk epic) each
+        // of the cast's 2 hits is a full attack that lands its own post-damage Exposed:
+        //   round 1 = plain + doubled  (attack 0 lands it, attack 1 spends it) = 3 half-shares,
+        //   round 2 = doubled + doubled (attack 0 spends the one left standing and re-lands it,
+        //             attack 1 spends that)                                    = 4 half-shares.
+        // Still strictly greater than 1, which is all this premise needs to set up the invariant
+        // below — the ratio itself is pinned only to catch a silent change in the fixture's shape.
+        expect(plain.r2 / plain.r1).toBeCloseTo(4 / 3, 5);
 
         // With the counter in play the round-over-round GAIN must be identical: the counter lands on
         // the Exposed holder first, but it is not an amplified hit, so it must not consume it.

--- a/src/utils/combat/__tests__/exposedStatus.integration.test.ts
+++ b/src/utils/combat/__tests__/exposedStatus.integration.test.ts
@@ -270,10 +270,10 @@ describe('Exposed — +100% on the next direct hit, then consumed', () => {
     // path rather than the reactive executor's — a different application site into the same
     // per-victim store, so it needs its own guard.
     //
-    // Note the ratio is 1.5, not 1.0: a debuff applied by a cast is in the store by the time that
-    // same cast's damage resolves, so it amplifies the cast's own first hit. That is INHERITED
-    // ordering, not something Exposed introduces — a cast-applied `Inc. Damage Up II` on the same
-    // fixture amplifies both of its own hits (ratio 2.0) through the identical channel.
+    // The ratio here is 2.0, not 1.5: this `applier: 'cast'` shape puts the Exposed clause BEFORE
+    // the damage clause in the same slot, so each of the cast's sub-attacks applies its own Exposed,
+    // rides it into its own hit, and spends it — see the inline comment below for the full
+    // breakdown of why that differs from the REACTIVE (pre-planted, non-reapplying) fixture above.
     it('works when applied by a cast (Nayra) as well as by a reaction (Amartya)', () => {
         const control = playerHitsExposedEnemy(CONTROL, 1, 'cast');
         const exposed = playerHitsExposedEnemy('Exposed', 1, 'cast');
@@ -351,13 +351,15 @@ const counterAbility = (): Ability => ({
 });
 
 /**
- * Per-round damage dealt to the foe over two rounds. The player casts damage-then-Exposed (that
- * order, so the cast never self-amplifies the status it applies), and is SLOWER than the foe, so
- * each round runs: foe attacks → player's counter lands on the foe → player casts.
+ * Per-round damage dealt to the foe over two rounds. The player casts damage-then-Exposed (a
+ * post-damage clause), and is SLOWER than the foe, so each round runs: foe attacks → player's
+ * counter lands on the foe → player casts.
  *
- * Round 1's cast is unamplified (no Exposed yet). Round 2's rides the Exposed applied in round 1 —
- * unless a hit in between wrongly spent it. Counter damage is a per-round constant, so comparing
- * the round2−round1 DELTA against the counter-free run cancels it out exactly.
+ * The cast is two full sub-attacks, so round 1 already self-amplifies: attack 0 lands plain and
+ * applies Exposed, attack 1 rides and spends that stack (then reapplies its own, left standing).
+ * Round 2's first hit rides the Exposed round 1 left behind — unless a hit in between wrongly spent
+ * it. Counter damage is a per-round constant, so comparing the round2−round1 DELTA against the
+ * counter-free run cancels it out exactly.
  */
 function foeDamagePerRound(withCounter: boolean): { r1: number; r2: number } {
     const focusSlots: ShipSkills['slots'] = [

--- a/src/utils/combat/__tests__/incomingDebuffArrivalCardinality.integration.test.ts
+++ b/src/utils/combat/__tests__/incomingDebuffArrivalCardinality.integration.test.ts
@@ -1,25 +1,14 @@
 /**
- * Multi-hit full-walk attacks, PR6 Tier 3 — debuff ARRIVAL cardinality.
+ * Multi-hit full-walk attacks — debuff ARRIVAL cardinality.
  *
- * *** THIS FILE PINS BEHAVIOUR THAT IS KNOWN TO BE WRONG. ***
+ * R1: each sub-attack runs the full pipeline including the debuff landing roll, so a 3-hit cast
+ * carrying a direct debuff clause applies THREE stacks. PR8 made that true; before it, the landing
+ * was drawn once per cast in runPlayerTurn and flushed once after all N sub-attacks.
  *
- * R1 says each sub-attack runs the full pipeline including the debuff landing roll, so a 3-hit
- * cast carrying a direct debuff clause should apply THREE stacks. It applies ONE: the landing is
- * drawn once per cast inside runPlayerTurn (playerTurn.ts ~1580) and flushed once after all N
- * sub-attacks (flushDeferredEnemyApplications, engine.ts:6615). Everything downstream of
- * application — Firewall's `on-debuffed`, Lockdown's `on-debuff-resisted` — inherits that
- * cardinality.
- *
- * That is PR8's charter, NOT a bug this PR fixes. The assertions below record the CURRENT numbers
- * so PR8 has a before-picture and so its change is proven to move exactly this and nothing else.
- *
- * PR8 FLIPS the two assertions marked `PRE-PR8` below (the direct debuff-application count and the
- * downstream on-debuffed reactive count) and leaves every other assertion in this file untouched.
- * If PR8 moves anything else in this file, that is a regression, not expected churn.
- *
- * Do NOT read these titles as endorsing once-per-cast arrival. This epic has already shipped one
- * test whose NAME blessed a regression the code explicitly forbids; the titles here say
- * "PRE-PR8" for that reason.
+ * The two N=1 assertions and the two zero-controls below are the regression fence: N=1 arrival is
+ * unchanged by PR8 (a single sub-attack keeps the cast-time draw and the historical flush point),
+ * and the controls prove the counts are driven by the clause rather than by a stray event or a
+ * hard-coded counter.
  *
  * DEVIATIONS FROM task-4-brief.md, corrected per the task's own instructions before writing a
  * single assertion:
@@ -222,23 +211,23 @@ const buffGrantsOf = (input: CombatEngineInput, buffName: string, recipientId: s
     return n;
 };
 
-describe('PR6 Tier 3 — debuff arrival is once per CAST (PRE-PR8 behaviour, recorded not endorsed)', () => {
+describe('multi-hit full-walk attacks — debuff arrival is once per SUB-ATTACK (R1)', () => {
     afterEach(() => resetRateGateRng());
 
-    it('control: with NO debuff clause at all, a 3-hit cast produces zero debuff-applied events — proves the "1" below is driven by the clause, not a stray unrelated event or a hard-coded counter', () => {
+    it('control: with NO debuff clause at all, a 3-hit cast produces zero debuff-applied events — proves the count below is driven by the clause, not a stray unrelated event or a hard-coded counter', () => {
         const victim = enemyAt('victim', 'M4');
         const n = debuffApplications(focusCast([attackSkill(3)], [victim]), 'Corrode', 'victim');
         expect(n).toBe(0);
     });
 
-    it('PRE-PR8: a 3-hit cast with a direct debuff clause applies the debuff ONCE (R1 wants 3 — PR8 flips this to 3)', () => {
+    it('a 3-hit cast with a direct debuff clause applies the debuff ONCE PER SUB-ATTACK (R1)', () => {
         const victim = enemyAt('victim', 'M4');
         const n = debuffApplications(
             focusCast([activeWithDebuffClause(3)], [victim]),
             'Corrode',
             'victim'
         );
-        expect(n).toBe(1);
+        expect(n).toBe(3);
     });
 
     it('N=1 applies the debuff once — this assertion is CORRECT today and must NOT move in PR8', () => {
@@ -251,20 +240,20 @@ describe('PR6 Tier 3 — debuff arrival is once per CAST (PRE-PR8 behaviour, rec
         expect(n).toBe(1);
     });
 
-    it('control: with NO debuff clause at all, the on-debuffed reactive never fires — proves the "1" below is driven by an actual debuff-applied event, not a stray grant', () => {
+    it('control: with NO debuff clause at all, the on-debuffed reactive never fires — proves the count below is driven by an actual debuff-applied event, not a stray grant', () => {
         const victim = enemyAt('victim', 'M4', [onDebuffedSelfBuff('Firewall')]);
         const n = buffGrantsOf(focusCast([attackSkill(3)], [victim]), 'Firewall', 'victim');
         expect(n).toBe(0);
     });
 
-    it('PRE-PR8: an on-debuffed reactive on the victim therefore fires ONCE (PR8 flips this to 3)', () => {
+    it('an on-debuffed reactive on the victim therefore fires once per sub-attack', () => {
         const victim = enemyAt('victim', 'M4', [onDebuffedSelfBuff('Firewall')]);
         const n = buffGrantsOf(
             focusCast([activeWithDebuffClause(3)], [victim]),
             'Firewall',
             'victim'
         );
-        expect(n).toBe(1);
+        expect(n).toBe(3);
     });
 
     it('N=1 on-debuffed reactive fires exactly once — this assertion is CORRECT today and must NOT move in PR8', () => {

--- a/src/utils/combat/__tests__/intraCastClauseOrder.integration.test.ts
+++ b/src/utils/combat/__tests__/intraCastClauseOrder.integration.test.ts
@@ -15,6 +15,25 @@
  * The chosen model is FULL resolution order: a post-damage clause's application, its
  * `debuff-applied` event, and anything reacting to it all land after the damage. Only the LANDING
  * ROLL stays at its original point in the turn, so the RNG draw order is untouched.
+ *
+ * MULTI-HIT SCOPE (PR8 of the multi-hit full-walk epic). Every fixture below is a 2-HIT cast, and
+ * the unit this rule is scoped to is the SUB-ATTACK, not the cast — because the other locked rule
+ * says a multi-hit skill is N consecutive FULL attacks, each running the entire pipeline. So for a
+ * 2-hit cast:
+ *
+ *   damage-then-debuff → attack 0 deals plain damage, THEN lands the debuff; attack 1's damage
+ *                        rides it. Total = 1.5x a debuff-free control (one of the two hits
+ *                        amplified), not 1.0x.
+ *   debuff-then-damage → each attack lands the debuff and then spends it. Total = 2.0x.
+ *
+ * The rule still has its teeth: 1.5x is what "a post-damage clause never amplifies the damage it
+ * follows" looks like once the unit is the attack — the clause misses its OWN attack every time.
+ * Were it still applying before the damage it followed, these would read 2.0x, which is exactly
+ * what the debuff-first fixtures do read. The gap between the two orders is the assertion.
+ *
+ * These numbers were 1.0x / 1.5x before PR8, when the landing was drawn once per cast and flushed
+ * once after all N sub-attacks. N=1 is unchanged (the Zosimos corpus case at the bottom is a
+ * single-hit cast and still reads exactly its control).
  */
 import { describe, it, expect } from 'vitest';
 import { parsePattern, parseTarget } from '../../targetingParser';
@@ -184,20 +203,23 @@ function enemyCast(abilities: Ability[]): number {
 const INC_UP = { incomingDamage: 100 };
 
 describe('intra-cast clause order — a debuff clause AFTER the damage clause misses that damage', () => {
-    it('Exposed inflicted AFTER the damage clause does not amplify its own cast', () => {
+    it('Exposed inflicted AFTER the damage clause does not amplify the sub-attack it follows', () => {
         const plain = focusCast([twoHitAttack()]).damageTo('foe');
         const damageFirst = focusCast([twoHitAttack(), castDebuff('Exposed')]).damageTo('foe');
 
         expect(plain).toBeGreaterThan(0);
-        expect(damageFirst).toBe(plain);
+        // Attack 0 plain, then Exposed lands; attack 1 doubled and spends it → 3 half-shares vs 2.
+        // The clause missing its OWN attack is what keeps this below the 2.0 the debuff-first
+        // ordering reads.
+        expect(damageFirst / plain).toBeCloseTo(1.5, 5);
     });
 
-    it('Exposed inflicted BEFORE the damage clause is spent on that same cast', () => {
+    it('Exposed inflicted BEFORE the damage clause is spent on that same sub-attack', () => {
         const plain = focusCast([twoHitAttack()]).damageTo('foe');
         const debuffFirst = focusCast([castDebuff('Exposed'), twoHitAttack()]).damageTo('foe');
 
-        // Hit 1 doubled, hit 2 plain (Exposed consumed) → 3 half-shares vs 2.
-        expect(debuffFirst / plain).toBeCloseTo(1.5, 5);
+        // Each attack applies Exposed and then spends it on its own hit → both hits doubled.
+        expect(debuffFirst / plain).toBeCloseTo(2, 5);
     });
 
     it('the same rule governs the stat channels — Inc. Damage Up after damage misses it', () => {
@@ -211,7 +233,10 @@ describe('intra-cast clause order — a debuff clause AFTER the damage clause mi
             twoHitAttack(),
         ]).damageTo('foe');
 
-        expect(damageFirst).toBe(plain);
+        // Attack 0 plain, then Inc. Damage Up lands; attack 1 carries it. A standing modifier is
+        // never consumed, so at N=2 this reads the same 1.5 as Exposed — the distinguishing
+        // comparison is against the debuff-first ordering below.
+        expect(damageFirst / plain).toBeCloseTo(1.5, 5);
         // Not consumed on hit — a standing modifier amplifies BOTH hits of its own cast.
         expect(debuffFirst / plain).toBeCloseTo(2, 5);
     });
@@ -226,14 +251,26 @@ describe('intra-cast clause order — a debuff clause AFTER the damage clause mi
         expect(damageTo('foe')).toBeGreaterThan(plain);
     });
 
-    it('a post-damage clause emits its debuff-applied AFTER the hits it follows', () => {
+    it("a post-damage clause emits each debuff-applied AFTER its own sub-attack's hits", () => {
         const { events } = focusCast([twoHitAttack(), castDebuff('Exposed')]);
-        const firstApplied = events.findIndex((e) => e.type === 'debuff-applied');
-        const lastAttacked = events.map((e) => e.type).lastIndexOf('attacked');
 
-        expect(firstApplied).toBeGreaterThan(-1);
-        expect(lastAttacked).toBeGreaterThan(-1);
-        expect(firstApplied).toBeGreaterThan(lastAttacked);
+        // One landing per sub-attack, each emitted after THAT sub-attack's `attacked` — never
+        // before it (which would report the debuff as active for damage it did not amplify) and
+        // never both at the end (which is the once-per-cast flush PR8 replaced). Asserted as the
+        // exact interleaving rather than a pair of indices: the whole point is the alternation.
+        expect(events.map((e) => e.type)).toEqual([
+            'attacked',
+            'debuff-applied',
+            'attacked',
+            'debuff-applied',
+        ]);
+        // And the amounts confirm which side of its own landing each attack fell on: attack 0
+        // unamplified, attack 1 doubled by attack 0's Exposed.
+        const amounts = events
+            .filter((e): e is Extract<CombatEvent, { type: 'attacked' }> => e.type === 'attacked')
+            .map((e) => e.damage ?? 0);
+        expect(amounts[0]).toBeGreaterThan(0);
+        expect(amounts[1] / amounts[0]).toBeCloseTo(2, 5);
     });
 
     it('is team-symmetric — an ENEMY cast obeys clause order against a player victim', () => {
@@ -242,8 +279,11 @@ describe('intra-cast clause order — a debuff clause AFTER the damage clause mi
         const debuffFirst = enemyCast([castDebuff('Exposed'), twoHitAttack()]);
 
         expect(plain).toBeGreaterThan(0);
-        expect(damageFirst).toBe(plain);
-        expect(debuffFirst / plain).toBeCloseTo(1.5, 5);
+        // Same two ratios as the player-side cases above (1.5 post-damage, 2.0 pre-damage) — the
+        // enemy path routes through the same shared positional helper, so a regression that reached
+        // only one side would split them.
+        expect(damageFirst / plain).toBeCloseTo(1.5, 5);
+        expect(debuffFirst / plain).toBeCloseTo(2, 5);
     });
 });
 

--- a/src/utils/combat/__tests__/intraCastClauseOrder.integration.test.ts
+++ b/src/utils/combat/__tests__/intraCastClauseOrder.integration.test.ts
@@ -222,7 +222,7 @@ describe('intra-cast clause order — a debuff clause AFTER the damage clause mi
         expect(debuffFirst / plain).toBeCloseTo(2, 5);
     });
 
-    it('the same rule governs the stat channels — Inc. Damage Up after damage misses it', () => {
+    it('the same rule governs the stat channels — Inc. Damage Up after damage misses the sub-attack it follows', () => {
         const plain = focusCast([twoHitAttack()]).damageTo('foe');
         const damageFirst = focusCast([
             twoHitAttack(),
@@ -247,7 +247,9 @@ describe('intra-cast clause order — a debuff clause AFTER the damage clause mi
 
         // It was really applied, not dropped.
         expect(events.filter((e) => e.type === 'debuff-applied')).not.toHaveLength(0);
-        // Round 1 unamplified; round 2's first hit rides the Exposed round 1 left behind.
+        // Round 1 already reads 1.5x (attack 0 plain, attack 1 rides and spends what attack 0
+        // applied, then reapplies a fresh Exposed after its own damage). That leftover carries into
+        // round 2, so BOTH of round 2's hits ride and reapply it in turn — round 2 reads 2.0x.
         expect(damageTo('foe')).toBeGreaterThan(plain);
     });
 

--- a/src/utils/combat/__tests__/perSubAttackDebuffLanding.integration.test.ts
+++ b/src/utils/combat/__tests__/perSubAttackDebuffLanding.integration.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Direct debuff clauses land per SUB-ATTACK (multi-hit full-walk epic, PR8).
+ *
+ * R1: a multi-hit skill is N consecutive FULL-WALK attacks, each running the entire pipeline
+ * including the debuff landing roll. This file owns PR8's fidelity assertions; the
+ * once-per-cast before-picture lives in `incomingDebuffArrivalCardinality.integration.test.ts`.
+ *
+ * CORPUS-INERT (measured 2026-08-09): 147 ships, only Enforcer has `hits > 1`, 49 ships carry a
+ * direct active/charged debuff-inflict clause, intersection EMPTY. Every fixture here is
+ * therefore synthetic, and synthetic fixtures are the only verification this behaviour gets —
+ * which is why each assertion below carries an anti-vacuity control.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { resetRateGateRng } from '../../calculators/rateAccumulator';
+import { runPlayerTurn } from '../playerTurn';
+
+describe('PR8 Task 3 — runPlayerTurn exposes a per-sub-attack landing applier', () => {
+    afterEach(() => resetRateGateRng());
+
+    it('exports the split deferred-application shape', () => {
+        // Compile-time contract: the pair must be {applyState, emitEvents}, not a bare thunk.
+        // A bare thunk cannot be run in two places, which is exactly what PR8 needs — state at the
+        // sub-attack boundary, events interleaved into the engine's emission steps.
+        const probe: import('../playerTurn').DeferredEnemyApplication = {
+            applyState: () => {},
+            emitEvents: () => {},
+        };
+        expect(typeof probe.applyState).toBe('function');
+        expect(typeof probe.emitEvents).toBe('function');
+        expect(typeof runPlayerTurn).toBe('function');
+    });
+});

--- a/src/utils/combat/__tests__/perSubAttackDebuffLanding.integration.test.ts
+++ b/src/utils/combat/__tests__/perSubAttackDebuffLanding.integration.test.ts
@@ -12,10 +12,11 @@
  *
  * ANTI-VACUITY DISCIPLINE. Every numeric constant below was MEASURED against this fixture before
  * it was written down (task-5-report.md holds the probe transcripts), and every test was
- * confirmed to go RED under a mutation of the production line it targets — the four mutations
+ * confirmed to go RED under a mutation of the production line it targets — the five mutations
  * used are `sub.index < sel.scalars.hits - 1` forced to `false` and to `true` (engine.ts ~6860),
- * `applyDebuffsForSubAttack` returning `[]` (playerTurn.ts ~1759), and the `onSubAttackStart` /
- * `onSubAttackEnd` hooks (engine.ts ~6843 / ~6853) no-oped. Each test names its own killer.
+ * `applyDebuffsForSubAttack` returning `[]` (playerTurn.ts ~1759), the `onSubAttackStart` /
+ * `onSubAttackEnd` hooks (engine.ts ~6843 / ~6853) no-oped, and `aoeVictimIds: sub.victimIds`
+ * reverted to the CAST's footprint (playerTurn.ts ~1774). Each test names its own killer.
  *
  * DEVIATIONS FROM task-5-brief.md (measured against source before writing a single assertion):
  *
@@ -90,8 +91,9 @@ const ALLY_SLICE = 5_000;
 // COPIED VERBATIM from `incomingDebuffArrivalCardinality.integration.test.ts` (`ab`,
 // `attackSkill`, `activeWithDebuffClause`, `parsedTarget`, `basePattern`, `enemyAt`, `focusCast`,
 // `debuffApplications`), not imported — this epic's established convention is that fixtures are
-// copied per file. `focusCast` gained two optional trailing parameters and an explicit `speed`;
-// both are additive and documented on the helper itself.
+// copied per file. `focusCast` gained three optional trailing parameters and an explicit `speed`;
+// all are additive and documented on the helper itself. `allPattern` is the multi-cell footprint
+// shape the sibling positional suites use (`subAttackProcGates`, `perSubAttackEvents`, …).
 
 let idc = 0;
 const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
@@ -110,11 +112,18 @@ const damageClause = (hits: number): Ability =>
         config: { type: 'damage', multiplier: 100, ...(hits > 1 ? { hits } : {}) },
     });
 
-/** A direct enemy-debuff clause. `parsedEffects` empty for name-keyed statuses (Exposed). */
-const debuffClause = (buffName: string, parsedEffects: Record<string, number>): Ability =>
+/** A direct enemy-debuff clause. `parsedEffects` empty for name-keyed statuses (Exposed).
+ *  `abTarget` defaults to single-target `'enemy'`, for which `resolveDebuffRecipientIds` returns
+ *  `[anchorId]` and NEVER READS THE FOOTPRINT — so the footprint fence below must pass
+ *  `'all-enemies'` to reach the branch that does. */
+const debuffClause = (
+    buffName: string,
+    parsedEffects: Record<string, number>,
+    abTarget: Ability['target'] = 'enemy'
+): Ability =>
     ab({
         type: 'debuff',
-        target: 'enemy',
+        target: abTarget,
         config: {
             type: 'debuff',
             buffName,
@@ -139,6 +148,15 @@ const attackSkill = (hits: number): ShipSkills['slots'][number] => ({
 const activeWithDebuffClause = (hits: number): ShipSkills['slots'][number] => ({
     slot: 'active',
     abilities: [damageClause(hits), debuffClause('Corrode', { defense: -2 })],
+});
+
+/** As `activeWithDebuffClause`, but the debuff ability targets ALL ENEMIES, so
+ *  `resolveDebuffRecipientIds` takes its `positionalLanding && isAllEnemies` branch and fans the
+ *  status over the footprint it is handed. Paired with `allPattern` this is the only fixture in the
+ *  file whose landing is footprint-driven rather than anchor-driven. */
+const activeWithAllEnemiesDebuffClause = (hits: number): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [damageClause(hits), debuffClause('Corrode', { defense: -2 }, 'all-enemies')],
 });
 
 /** `[damage, debuff]` — the clause is written AFTER the damage clause. */
@@ -167,6 +185,11 @@ const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
     selection,
 });
 const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+/** The MULTI-CELL footprint shape, copied from the sibling positional suites
+ *  (`subAttackProcGates.integration.test.ts` ~76, `perSubAttackEvents.integration.test.ts` ~74).
+ *  Every OTHER fixture in this file uses `basePattern`, a single-victim footprint — which is why
+ *  none of them can observe which footprint the per-sub-attack applier is handed. */
+const allPattern = (): ParsedPattern => ({ raw: 'all', shape: 'all', range: 'all', modifiers: {} });
 
 /** A positioned enemy carrying `slots`, which never attacks unless given an active. `hp` is
  *  exposed so the overkill fixture can size the front victim below one slice. */
@@ -264,12 +287,14 @@ const residualProbeAlly = (): TeamActor => teamActor('probe', 'M2', [attackSkill
 /** The focus player at M1 fires `slots` at the front enemy (column 4). `hacking` is high by
  *  default so the debuff landing roll never resists and confounds a count; the gate test lowers
  *  it deliberately. `speed: 500` is explicit so the walked residual probe (speed 1) is
- *  guaranteed to act after this cast. */
+ *  guaranteed to act after this cast. `pattern` defaults to the single-victim `basePattern`; only
+ *  the footprint fence overrides it, with `allPattern`. */
 const focusCast = (
     slots: ShipSkills['slots'],
     enemies: EnemyAttacker[],
     team: TeamActor[] = [],
-    hacking: number = 100_000
+    hacking: number = 100_000,
+    pattern: ParsedPattern = basePattern()
 ): CombatEngineInput => ({
     attack: 5000,
     crit: 100,
@@ -297,7 +322,7 @@ const focusCast = (
     position: 'M1',
     speed: 500,
     target: parsedTarget('front'),
-    pattern: basePattern(),
+    pattern,
     positionalTeamBattle: true,
     enemyAttackers: enemies,
     ...(team.length > 0 ? { teamActors: team } : {}),
@@ -362,6 +387,22 @@ const residualExposedStacks = (input: CombatEngineInput): number => {
     const ratio = amount! / ALLY_SLICE;
     expect(Number.isInteger(ratio)).toBe(true);
     return ratio - 1;
+};
+
+/**
+ * Every `ability-performed` `actorId` in emission order.
+ *
+ * Exists so the residual readings can state their own TURN-ORDER PREMISE instead of inheriting it:
+ * `residualExposedStacks` only decodes the victim's leftover stacks if the probe ally really acted
+ * AFTER the focus's last sub-attack. A probe that acted FIRST would read 0 stacks too — the same
+ * number a correct 0-residual fixture reads — so the ordering is asserted rather than assumed.
+ */
+const abilityPerformedActors = (input: CombatEngineInput): string[] => {
+    const bus = createEventBus();
+    const out: string[] = [];
+    bus.on('ability-performed', (e: AbilityPerformed) => out.push(e.actorId));
+    runCombat({ ...input, bus });
+    return out;
 };
 
 const sum = (xs: (number | undefined)[]): number => xs.reduce<number>((a, b) => a + (b ?? 0), 0);
@@ -532,15 +573,20 @@ describe('PR8 — clause order within a sub-attack', () => {
         expect(delivered).toEqual([2 * SLICE, 2 * SLICE]);
         expect(delivered[0]!).toBeGreaterThan(control[0]!);
         expect(sum(delivered)).toBe(2 * sum(control));
-        expect(
-            residualExposedStacks(
-                focusCast(
-                    [beforeDamage(2, EXPOSED())],
-                    [enemyAt('victim', 'M4')],
-                    [residualProbeAlly()]
-                )
-            )
-        ).toBe(0);
+
+        // The 0-residual reading below is only meaningful if the probe ally acted AFTER the focus's
+        // LAST sub-attack — a probe that acted first would read 0 too, and so would a fixture whose
+        // clause never landed at all. So the turn-order premise is asserted here rather than
+        // inherited from `teamActor`'s speed comment or from the sibling test above.
+        const withProbe = focusCast(
+            [beforeDamage(2, EXPOSED())],
+            [enemyAt('victim', 'M4')],
+            [residualProbeAlly()]
+        );
+        const actorOrder = abilityPerformedActors(withProbe);
+        expect(actorOrder).toContain('probe');
+        expect(actorOrder.lastIndexOf('probe')).toBeGreaterThan(actorOrder.lastIndexOf('attacker'));
+        expect(residualExposedStacks(withProbe)).toBe(0);
     });
 });
 
@@ -577,6 +623,59 @@ describe('PR8 — overkill retargeting', () => {
         const one = debuffApplicationsByTarget(overkillCast(1), 'Corrode');
         expect(one.frontling).toBe(1);
         expect(one.survivor).toBeUndefined();
+    });
+});
+
+describe('PR8 — the per-sub-attack FOOTPRINT', () => {
+    afterEach(() => resetRateGateRng());
+
+    /** As `overkillCast`, but the clause targets ALL ENEMIES over an `allPattern` footprint, so
+     *  recipient resolution is footprint-driven. `frontling` at column 4 (the FRONT) is the anchor
+     *  and is sized below one DOUBLED slice; `survivor` behind it is at the full 10,000,000. */
+    const footprintCast = (hits: number) =>
+        focusCast(
+            [activeWithAllEnemiesDebuffClause(hits)],
+            [enemyAt('frontling', 'M4', [], 5_000), enemyAt('survivor', 'M3')],
+            [],
+            100_000,
+            allPattern()
+        );
+
+    it('an all-enemies clause fans over the victims THAT sub-attack struck, so a killed victim drops out', () => {
+        // THE GAP THIS CLOSES: every other fixture in this file uses `basePattern` and an `abTarget`
+        // of `'enemy'`, for which `resolveDebuffRecipientIds` returns `[anchorId]` and never looks at
+        // `aoeVictimIds` at all — so mutating playerTurn.ts's `aoeVictimIds: sub.victimIds` back to
+        // the CAST's footprint (the pre-PR8 value) left the whole suite green. This is the only test
+        // that reads the footprint argument.
+        //
+        // DERIVATION (MEASURED against this fixture, `deliveredDamage` [20,000, 10,000, 10,000]):
+        //   the `all` shape scales every cell at 1.0, so one sub-attack delivers 10,000 to EACH of
+        //   the two enemies. `frontling`'s 5,000 HP is below that DOUBLED slice (crit 100 /
+        //   critDamage 100 doubles every hit — the per-hit slice is 10,000, not 5,000), so:
+        //   sub-attack 0: footprint [survivor, frontling] -> one landing EACH; frontling DIES
+        //   sub-attack 1: footprint re-expands over the LIVING roster -> [survivor] only
+        //   sub-attack 2: [survivor] only
+        //   => frontling exactly 1, survivor exactly 3, four `debuff-applied` in total.
+        // Under the mutation the later sub-attacks reuse the cast-time footprint, which still holds
+        // the dead `frontling`, and its count reads 3.
+        //
+        // ANTI-VACUITY: `survivor: 3` alone would also be produced by an anchor-collapsing
+        // resolution (sub-attacks 1-2 re-resolve `front` to `survivor` anyway), so the load-bearing
+        // legs are `frontling: 1` — which pins that the footprint SHRANK — and the total of 4, which
+        // pins that sub-attack 0 fanned over BOTH cells and no landing was silently dropped.
+        // KILLED BY: `aoeVictimIds: sub.victimIds` -> the cast's `aoeVictimIds` (playerTurn.ts
+        // ~1774), and by `applyDebuffsForSubAttack` returning [].
+        const counts = debuffApplicationsByTarget(footprintCast(3), 'Corrode');
+        expect(counts.frontling).toBe(1);
+        expect(counts.survivor).toBe(3);
+        expect(sum(Object.values(counts))).toBe(4);
+
+        // N=1 control: a single sub-attack fans over the cast-time footprint and nothing more, so
+        // both enemies take exactly one landing. This is what pins the 1-vs-3 split above as a
+        // multi-hit effect rather than a property of the `all-enemies` fan-out itself.
+        const one = debuffApplicationsByTarget(footprintCast(1), 'Corrode');
+        expect(one.frontling).toBe(1);
+        expect(one.survivor).toBe(1);
     });
 });
 

--- a/src/utils/combat/__tests__/perSubAttackDebuffLanding.integration.test.ts
+++ b/src/utils/combat/__tests__/perSubAttackDebuffLanding.integration.test.ts
@@ -9,6 +9,9 @@
  * direct active/charged debuff-inflict clause, intersection EMPTY. Every fixture here is
  * therefore synthetic, and synthetic fixtures are the only verification this behaviour gets —
  * which is why each assertion below carries an anti-vacuity control.
+ *
+ * Task 5 fills in the fidelity assertions; this file currently holds only the compile-time shape
+ * probe below.
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import { resetRateGateRng } from '../../calculators/rateAccumulator';

--- a/src/utils/combat/__tests__/perSubAttackDebuffLanding.integration.test.ts
+++ b/src/utils/combat/__tests__/perSubAttackDebuffLanding.integration.test.ts
@@ -10,12 +10,386 @@
  * therefore synthetic, and synthetic fixtures are the only verification this behaviour gets —
  * which is why each assertion below carries an anti-vacuity control.
  *
- * Task 5 fills in the fidelity assertions; this file currently holds only the compile-time shape
- * probe below.
+ * ANTI-VACUITY DISCIPLINE. Every numeric constant below was MEASURED against this fixture before
+ * it was written down (task-5-report.md holds the probe transcripts), and every test was
+ * confirmed to go RED under a mutation of the production line it targets — the four mutations
+ * used are `sub.index < sel.scalars.hits - 1` forced to `false` and to `true` (engine.ts ~6860),
+ * `applyDebuffsForSubAttack` returning `[]` (playerTurn.ts ~1759), and the `onSubAttackStart` /
+ * `onSubAttackEnd` hooks (engine.ts ~6843 / ~6853) no-oped. Each test names its own killer.
+ *
+ * DEVIATIONS FROM task-5-brief.md (measured against source before writing a single assertion):
+ *
+ * 1. THE VISIBILITY MECHANIC IS AN INCOMING-AMPLIFICATION CLAUSE, NOT A DEFENCE-REDUCING ONE.
+ *    The brief reached for a defence debuff so that "a defence debuff changes the arithmetic".
+ *    `Exposed` (+100 percentage points incoming direct damage per stack, exposedStatus.ts) and
+ *    `Inc. Damage Up` (`parsedEffects.incomingDamage`, folded by `toEnemyModifiers`) ride the SAME
+ *    per-victim `victimIncomingModifiers` fold a defence debuff would, but their arithmetic is an
+ *    exact multiple of the plain slice rather than a defence-curve output — so every expected
+ *    number below is derivable in one line and a wrong constant cannot hide inside a curve. The
+ *    owner also supplied ground truth in these terms (1.5x / 2.0x cast totals, and the residual
+ *    stack counts), so this is the shape the assertions are written against.
+ *
+ * 2. `Exposed` IS ONE-SHOT AND SPENDS ONE STACK PER AMPLIFIED HIT. It is not capped in effect or
+ *    in duration: a victim holding k stacks amplifies the next direct hit by +100k%, and that hit
+ *    SPENDS one stack. That spend-one mechanism is what makes the residual-stack readings below
+ *    meaningful. (`consumeExposed` currently removes every stack rather than decrementing by one —
+ *    tracked separately, deliberately not this PR's business, and invisible here: no fixture in
+ *    this file ever leaves the victim holding two stacks at once.)
+ *
+ * 3. THE RESIDUAL STACK COUNT IS READ OFF A FOLLOW-UP ALLY HIT. `runCombat`'s result exposes no
+ *    end-of-run status snapshot, and a status removed by `consumeExposed` emits nothing (the only
+ *    expiry event, `buff-expired`, was confirmed by probe never to fire for these enemy-side timed
+ *    statuses even over a 5-round run). A second round does NOT work either: a BEFORE-damage clause
+ *    re-arms its own sub-attack 0, so round 2's first slice is amplified whether or not a stack
+ *    survived round 1 — measured, and the reason that route was abandoned. What DOES work is a
+ *    walked team ally (`residualProbeAlly`) that fires one PLAIN hit at the same victim AFTER the
+ *    focus: at crit 0 its slice is 5,000 flat, so its delivered damage reads the victim's residual
+ *    stack count directly as 5,000 x (1 + stacks) — 5,000 for 0 stacks, 10,000 for 1, 15,000 for 2.
+ *    This is the strong discriminator: a total-damage assertion alone can be produced by the wrong
+ *    mechanism, whereas the leftover stack pins the apply/ride/spend sequence itself.
+ *
+ * 4. THE `hits - 1` BOUNDARY COULD NOT BE FENCED, and this is recorded rather than papered over.
+ *    Mutating `sub.index < sel.scalars.hits - 1` to `<=` leaves this file (and, per the previous
+ *    task's reviewer, the whole suite) green. The guard sits inside the `sub.index === 0` branch,
+ *    so `<` and `<=` differ ONLY when `hits - 1 === 0`, i.e. N=1 — and for N=1 the two candidate
+ *    flush points have nothing between them that reads the enemy debuff store, so no observable
+ *    differs. A full event-order dump for N=1 (post- and pre-damage clause) was byte-identical
+ *    under both spellings. No fixture was contorted to manufacture coverage.
+ *
+ * FIXTURE ARITHMETIC, once, since every test below quotes it:
+ *   focus:  attack 5,000 x multiplier 100% = 5,000 raw; crit 100 / critDamage 100 means EVERY hit
+ *           crits and doubles -> PLAIN SLICE = 10,000 per sub-attack, against defence 0.
+ *   ally:   attack 5,000 x multiplier 100%, crit 0 -> PLAIN SLICE = 5,000 (no doubling).
+ *   Exposed stack:        slice x (1 + 100/100) = 2x  -> 20,000 focus / 10,000 ally.
+ *   Inc. Damage Up (+50): slice x (1 + 50/100) = 1.5x -> 15,000 focus.
+ * Victim HP is 10,000,000 everywhere except the deliberate overkill fixture, i.e. far above
+ * `hits x 10_000`, so no mid-cast death confounds a count.
  */
 import { describe, it, expect, afterEach } from 'vitest';
-import { resetRateGateRng } from '../../calculators/rateAccumulator';
+import { resetRateGateRng, setupKeyedTestRng } from '../../calculators/rateAccumulator';
 import { runPlayerTurn } from '../playerTurn';
+import { runCombat, CombatEngineInput, TeamActorEngineInput } from '../engine';
+import { createEventBus, CombatEvent } from '../events';
+import { Ability, ShipSkills } from '../../../types/abilities';
+import type { ParsedTarget, ParsedPattern } from '../../targetingParser';
+import type { Position } from '../../../types/encounters';
+
+type EnemyAttacker = NonNullable<CombatEngineInput['enemyAttackers']>[number];
+type TeamActor = NonNullable<CombatEngineInput['teamActors']>[number];
+type AbilityPerformed = Extract<CombatEvent, { type: 'ability-performed' }>;
+type DebuffApplied = Extract<CombatEvent, { type: 'debuff-applied' }>;
+type Attacked = Extract<CombatEvent, { type: 'attacked' }>;
+
+const HP = 10_000_000;
+/** The measured per-sub-attack delivered damage of the focus cast (see the header's arithmetic). */
+const SLICE = 10_000;
+/** The measured per-hit delivered damage of the residual-probe ally (crit 0 — no doubling). */
+const ALLY_SLICE = 5_000;
+
+// ── Fixture harness ────────────────────────────────────────────────────────────────────────
+// COPIED VERBATIM from `incomingDebuffArrivalCardinality.integration.test.ts` (`ab`,
+// `attackSkill`, `activeWithDebuffClause`, `parsedTarget`, `basePattern`, `enemyAt`, `focusCast`,
+// `debuffApplications`), not imported — this epic's established convention is that fixtures are
+// copied per file. `focusCast` gained two optional trailing parameters and an explicit `speed`;
+// both are additive and documented on the helper itself.
+
+let idc = 0;
+const ab = (p: Partial<Ability> & Pick<Ability, 'type' | 'config'>): Ability => ({
+    id: `pr8t5-${++idc}`,
+    target: 'enemy',
+    trigger: 'on-cast',
+    conditions: [],
+    ...p,
+});
+
+/** The N-hit damage clause every active below is built around. */
+const damageClause = (hits: number): Ability =>
+    ab({
+        type: 'damage',
+        target: 'enemy',
+        config: { type: 'damage', multiplier: 100, ...(hits > 1 ? { hits } : {}) },
+    });
+
+/** A direct enemy-debuff clause. `parsedEffects` empty for name-keyed statuses (Exposed). */
+const debuffClause = (buffName: string, parsedEffects: Record<string, number>): Ability =>
+    ab({
+        type: 'debuff',
+        target: 'enemy',
+        config: {
+            type: 'debuff',
+            buffName,
+            parsedEffects,
+            stacks: 1,
+            isStackable: true,
+            maxStacks: 20,
+            duration: 3,
+            application: 'inflict',
+        },
+    });
+
+/** A plain N-hit damage active, no debuff clause — the "clause absent" control fixture. */
+const attackSkill = (hits: number): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [damageClause(hits)],
+});
+
+/** A direct debuff clause on the ACTIVE slot alongside the N-hit damage — the shape PR8 makes
+ *  per-sub-attack. Written AFTER the damage clause, so `registerActorAbilityStatuses` stamps
+ *  `afterDamageClause` (engine.ts ~370) and it misses its own sub-attack's damage. */
+const activeWithDebuffClause = (hits: number): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [damageClause(hits), debuffClause('Corrode', { defense: -2 })],
+});
+
+/** `[damage, debuff]` — the clause is written AFTER the damage clause. */
+const afterDamage = (hits: number, clause: Ability): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [damageClause(hits), clause],
+});
+
+/** `[debuff, damage]` — the clause is written BEFORE the damage clause, so no
+ *  `afterDamageClause` stamp and it folds into its own sub-attack's damage. */
+const beforeDamage = (hits: number, clause: Ability): ShipSkills['slots'][number] => ({
+    slot: 'active',
+    abilities: [clause, damageClause(hits)],
+});
+
+/** A zero-multiplier active, so the focus can be present-but-inert while a walked ally or an
+ *  enemy attacker does the multi-hit casting (the two team-symmetry paths). */
+const noopActive: ShipSkills['slots'][number] = {
+    slot: 'active',
+    abilities: [ab({ type: 'damage', target: 'enemy', config: { type: 'damage', multiplier: 0 } })],
+};
+
+const parsedTarget = (selection: ParsedTarget['selection']): ParsedTarget => ({
+    raw: selection,
+    side: 'enemy',
+    selection,
+});
+const basePattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+
+/** A positioned enemy carrying `slots`, which never attacks unless given an active. `hp` is
+ *  exposed so the overkill fixture can size the front victim below one slice. */
+const enemyAt = (
+    id: string,
+    position: Position,
+    slots: ShipSkills['slots'] = [],
+    hp: number = HP
+): EnemyAttacker =>
+    ({
+        id,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp, speed: 1 },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        affinity: 'antimatter',
+        shipSkills: { slots },
+    }) as EnemyAttacker;
+
+/** An ENEMY attacker that fires `slots` at the player front. Speed 1,000 outruns the focus's 500
+ *  so it casts first. `hacking` is explicit and LOAD-BEARING: `liveDebuffLandingChance` is
+ *  `clamp(effHacking - effSecurity, 0..100)/100` and a player victim's default security is 100, so
+ *  a low-hacking attacker would resist every landing and make the whole test vacuous. */
+const offensiveEnemy = (
+    id: string,
+    position: Position,
+    slots: ShipSkills['slots']
+): EnemyAttacker =>
+    ({
+        id,
+        stats: {
+            attack: 5000,
+            crit: 100,
+            critDamage: 100,
+            defence: 0,
+            hp: HP,
+            speed: 1000,
+            hacking: 100_000,
+        },
+        chargeCount: 0,
+        startCharged: false,
+        position,
+        affinity: 'antimatter',
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        shipSkills: { slots },
+    }) as EnemyAttacker;
+
+/** A WALKED player team actor at `position` firing `slots` at the enemy front. Speed defaults to
+ *  1 so it acts AFTER the focus (whose speed is 500) — load-bearing for the residual probe, which
+ *  must observe the victim's state as the multi-hit cast left it. `hacking` defaults to 0 (fine
+ *  for a probe with no debuff clause) and must be raised for any actor that DOES carry one, for
+ *  the same landing-chance reason `offensiveEnemy` documents. */
+const teamActor = (
+    id: string,
+    position: Position,
+    slots: ShipSkills['slots'],
+    attack: number = 0,
+    hacking: number = 0
+): TeamActor =>
+    ({
+        id,
+        speed: 1,
+        chargeCount: 0,
+        startCharged: false,
+        selfBuffs: [],
+        enemyDebuffs: [],
+        position,
+        target: parsedTarget('front'),
+        pattern: basePattern(),
+        walk: {
+            shipSkills: { slots: slots },
+            stats: {
+                attack,
+                crit: 0,
+                critDamage: 0,
+                defensePenetration: 0,
+                hacking,
+                defence: 0,
+                hp: HP,
+            },
+            selfDotModifier: 0,
+            defensePenetrationBuff: 0,
+            affinityDamageModifier: 0,
+            affinityCritCap: 100,
+            affinityCritPenalty: 0,
+            hasChargedSkill: false,
+        },
+    }) as TeamActorEngineInput;
+
+/** The residual-stack probe (see DEVIATION 3): one PLAIN hit at the enemy front, no debuff clause,
+ *  crit 0 so its slice is a flat 5,000 and its delivered damage reads `5,000 x (1 + stacks)`. */
+const residualProbeAlly = (): TeamActor => teamActor('probe', 'M2', [attackSkill(1)], 5000, 0);
+
+/** The focus player at M1 fires `slots` at the front enemy (column 4). `hacking` is high by
+ *  default so the debuff landing roll never resists and confounds a count; the gate test lowers
+ *  it deliberately. `speed: 500` is explicit so the walked residual probe (speed 1) is
+ *  guaranteed to act after this cast. */
+const focusCast = (
+    slots: ShipSkills['slots'],
+    enemies: EnemyAttacker[],
+    team: TeamActor[] = [],
+    hacking: number = 100_000
+): CombatEngineInput => ({
+    attack: 5000,
+    crit: 100,
+    critDamage: 100,
+    defensePenetration: 0,
+    chargeCount: 0,
+    shipSkills: { slots },
+    enemyDefense: 0,
+    enemyHp: HP,
+    numRounds: 1,
+    selfBuffs: [],
+    enemyDebuffs: [],
+    selfDotModifier: 0,
+    defensePenetrationBuff: 0,
+    hasChargedSkill: false,
+    startCharged: false,
+    affinityDamageModifier: 0,
+    affinityCritCap: 100,
+    affinityCritPenalty: 0,
+    affinity: 'antimatter',
+    defence: 0,
+    hp: HP,
+    hacking,
+    healTargetId: 'attacker',
+    position: 'M1',
+    speed: 500,
+    target: parsedTarget('front'),
+    pattern: basePattern(),
+    positionalTeamBattle: true,
+    enemyAttackers: enemies,
+    ...(team.length > 0 ? { teamActors: team } : {}),
+});
+
+/** Counts `debuff-applied` events naming `buffName` on `targetId`. */
+const debuffApplications = (
+    input: CombatEngineInput,
+    buffName: string,
+    targetId: string
+): number => {
+    const bus = createEventBus();
+    let n = 0;
+    bus.on('debuff-applied', (e: DebuffApplied) => {
+        if (e.buffName === buffName && e.targetId === targetId) n++;
+    });
+    runCombat({ ...input, bus });
+    return n;
+};
+
+/** `debuff-applied` counts for `buffName`, keyed by victim — the overkill fixture's readout. */
+const debuffApplicationsByTarget = (
+    input: CombatEngineInput,
+    buffName: string
+): Record<string, number> => {
+    const bus = createEventBus();
+    const counts: Record<string, number> = {};
+    bus.on('debuff-applied', (e: DebuffApplied) => {
+        if (e.buffName === buffName) counts[e.targetId] = (counts[e.targetId] ?? 0) + 1;
+    });
+    runCombat({ ...input, bus });
+    return counts;
+};
+
+/**
+ * `ability-performed.deliveredDamage` for `actorId`'s own casts, in sub-attack order.
+ *
+ * `deliveredDamage`, never `damage`: `damage` is the cast's PRE-funnel `directDamage` (events.ts
+ * ~95) and reads a flat 10,000 on every sub-attack regardless of amplification — measured, and
+ * exactly the trap that would make this whole file vacuous. `deliveredDamage` is PR7's
+ * post-crit / post-amplification / post-victim-defence number, which is the one that moves.
+ */
+const deliveredDamagesOf = (input: CombatEngineInput, actorId: string): (number | undefined)[] => {
+    const bus = createEventBus();
+    const out: (number | undefined)[] = [];
+    bus.on('ability-performed', (e: AbilityPerformed) => {
+        if (e.actorId === actorId) out.push(e.deliveredDamage);
+    });
+    runCombat({ ...input, bus });
+    return out;
+};
+
+/** The residual Exposed stack count the victim was left holding, decoded from the probe ally's
+ *  delivered damage (`ALLY_SLICE x (1 + stacks)` — see DEVIATION 3). Throws rather than silently
+ *  returning a wrong count if the probe's amount is not a whole multiple, so a fixture drift
+ *  cannot be read as "0 stacks". */
+const residualExposedStacks = (input: CombatEngineInput): number => {
+    const delivered = deliveredDamagesOf(input, 'probe');
+    expect(delivered).toHaveLength(1);
+    const amount = delivered[0];
+    expect(amount).toBeDefined();
+    const ratio = amount! / ALLY_SLICE;
+    expect(Number.isInteger(ratio)).toBe(true);
+    return ratio - 1;
+};
+
+const sum = (xs: (number | undefined)[]): number => xs.reduce<number>((a, b) => a + (b ?? 0), 0);
+
+/** The victim named by the FIRST event of each of three independently-resolved paths: the cast's
+ *  own `ability-performed` primary target, the positional walk's iteration-0 `attacked`, and the
+ *  first `debuff-applied`. */
+const firstNamedVictims = (
+    input: CombatEngineInput,
+    buffName: string
+): { cast?: string; struck?: string; debuffed?: string } => {
+    const bus = createEventBus();
+    const out: { cast?: string; struck?: string; debuffed?: string } = {};
+    bus.on('ability-performed', (e: AbilityPerformed) => {
+        if (e.actorId === 'attacker' && out.cast === undefined) out.cast = e.targetId;
+    });
+    bus.on('attacked', (e: Attacked) => {
+        if (out.struck === undefined) out.struck = e.targetId;
+    });
+    bus.on('debuff-applied', (e: DebuffApplied) => {
+        if (e.buffName === buffName && out.debuffed === undefined) out.debuffed = e.targetId;
+    });
+    runCombat({ ...input, bus });
+    return out;
+};
+
+const EXPOSED = () => debuffClause('Exposed', {});
+const INC_UP = () => debuffClause('Inc. Damage Up', { incomingDamage: 50 });
 
 describe('PR8 Task 3 — runPlayerTurn exposes a per-sub-attack landing applier', () => {
     afterEach(() => resetRateGateRng());
@@ -31,5 +405,302 @@ describe('PR8 Task 3 — runPlayerTurn exposes a per-sub-attack landing applier'
         expect(typeof probe.applyState).toBe('function');
         expect(typeof probe.emitEvents).toBe('function');
         expect(typeof runPlayerTurn).toBe('function');
+    });
+});
+
+describe('PR8 — cross-sub-attack visibility (the user-locked rule: later hits see earlier hits’ effects)', () => {
+    afterEach(() => resetRateGateRng());
+
+    it('an amplification clause landed by sub-attack 1 increases sub-attack 2’s damage', () => {
+        // The clause is written AFTER the damage clause, so it must miss its OWN sub-attack and
+        // land for the next — which is exactly the behaviour PR8 buys. DERIVATION:
+        //   sub-attack 0: plain slice                        = 10,000, then lands 1 Exposed stack
+        //   sub-attack 1: rides that stack, 10,000 x (1+100%) = 20,000, and SPENDS it
+        //   cast total 30,000 = 1.5x the no-clause control's 20,000 (the owner's locked figure)
+        // ANTI-VACUITY: the increase is asserted WITHIN one cast (cross-side/cross-actor amounts
+        // are meaningless — the RNG is keyed by ownerId), and the no-clause control below proves
+        // the same shape is FLAT without the clause, so the rise cannot be per-sub-attack drift.
+        // KILLED BY: `sub.index < sel.scalars.hits - 1` forced to false (sub-attack 0's stack is
+        // then never in the store when sub-attack 1 computes its damage), by
+        // `applyDebuffsForSubAttack` returning [], and by no-oping `onSubAttackEnd`.
+        const delivered = deliveredDamagesOf(
+            focusCast([afterDamage(2, EXPOSED())], [enemyAt('victim', 'M4')]),
+            'attacker'
+        );
+        expect(delivered).toEqual([SLICE, 2 * SLICE]);
+        expect(delivered[1]!).toBeGreaterThan(delivered[0]!);
+        const control = deliveredDamagesOf(
+            focusCast([attackSkill(2)], [enemyAt('victim', 'M4')]),
+            'attacker'
+        );
+        expect(sum(delivered)).toBe(1.5 * sum(control));
+    });
+
+    it('control: with no debuff clause, consecutive sub-attacks deal equal damage', () => {
+        // Proves the increase above is the debuff and not some other per-sub-attack drift. The
+        // LENGTH assertions matter as much as the flatness: they show the apparatus really does
+        // observe one event per sub-attack, so the sibling test's `[10_000, 20_000]` is a
+        // measurement rather than an artefact of a collapsed emission.
+        expect(
+            deliveredDamagesOf(focusCast([attackSkill(2)], [enemyAt('victim', 'M4')]), 'attacker')
+        ).toEqual([SLICE, SLICE]);
+        expect(
+            deliveredDamagesOf(focusCast([attackSkill(3)], [enemyAt('victim', 'M4')]), 'attacker')
+        ).toEqual([SLICE, SLICE, SLICE]);
+    });
+
+    it('a PERSISTENT (non-consumed) amplification clause stays visible to EVERY later sub-attack', () => {
+        // A second, independent mechanism on the same fold, chosen because `Exposed` is consumed
+        // by the hit it amplifies — so the test above cannot distinguish "the store carries the
+        // stack forward" from "the stack survived exactly one hit". `Inc. Damage Up` (+50
+        // percentage points, `parsedEffects.incomingDamage`) is never consumed, so DERIVATION:
+        //   sub-attack 0: plain 10,000, then lands the debuff
+        //   sub-attack 1: 10,000 x (1 + 50%) = 15,000
+        //   sub-attack 2: 15,000 as well — MEASURED, and deliberately not 20,000: re-applying the
+        //     same buffName REFRESHES the timed payload rather than adding a second stack, so the
+        //     amplification does not climb. The discriminator is that BOTH later sub-attacks are
+        //     amplified while a per-cast landing leaves all three at the control's flat 10,000.
+        // KILLED BY: the same three mutations as the test above.
+        expect(
+            deliveredDamagesOf(
+                focusCast([afterDamage(3, INC_UP())], [enemyAt('victim', 'M4')]),
+                'attacker'
+            )
+        ).toEqual([SLICE, 1.5 * SLICE, 1.5 * SLICE]);
+    });
+});
+
+describe('PR8 — clause order within a sub-attack', () => {
+    afterEach(() => resetRateGateRng());
+
+    it('a clause written AFTER the damage clause misses its own sub-attack’s damage', () => {
+        // The locked intra-cast rule, re-proved per sub-attack: sub-attack 0's damage must equal
+        // the no-clause control's sub-attack 0 damage EXACTLY. DERIVATION as in the visibility
+        // test: [10,000, 20,000], total 30,000 = 1.5x the control's 20,000.
+        // THE RESIDUAL LEG is the strong discriminator (DEVIATION 3): sub-attack 1 spends the
+        // stack sub-attack 0 left and lands a fresh one of its own, which nothing after it spends
+        // — so the victim ends the cast holding EXACTLY 1. A total-damage assertion alone could be
+        // produced by the wrong mechanism; the leftover stack pins the apply/ride/spend sequence.
+        // KILLED BY: `sub.index < sel.scalars.hits - 1` forced to false (the residual then reads 2
+        // — sub-attack 0's landing arrives at the historical flush, unspent, alongside sub-attack
+        // 1's), by `applyDebuffsForSubAttack` returning [] (residual 1 but total 1.0x, not 1.5x),
+        // and by no-oping `onSubAttackEnd`.
+        const cast = focusCast([afterDamage(2, EXPOSED())], [enemyAt('victim', 'M4')]);
+        const controlCast = focusCast([attackSkill(2)], [enemyAt('victim', 'M4')]);
+        const delivered = deliveredDamagesOf(cast, 'attacker');
+        const control = deliveredDamagesOf(controlCast, 'attacker');
+        expect(delivered[0]).toBe(control[0]);
+        expect(delivered[0]).toBe(SLICE);
+        expect(sum(delivered)).toBe(1.5 * sum(control));
+        expect(
+            residualExposedStacks(
+                focusCast(
+                    [afterDamage(2, EXPOSED())],
+                    [enemyAt('victim', 'M4')],
+                    [residualProbeAlly()]
+                )
+            )
+        ).toBe(1);
+        // The probe ally reads 0 residual stacks on the no-clause control, so the 1 above is the
+        // clause's leftover and not something the probe itself manufactures.
+        expect(
+            residualExposedStacks(
+                focusCast([attackSkill(2)], [enemyAt('victim', 'M4')], [residualProbeAlly()])
+            )
+        ).toBe(0);
+    });
+
+    it('a clause written BEFORE the damage clause is folded into its own sub-attack’s damage', () => {
+        // The debuff ability sits AHEAD of the damage ability in the slot's `abilities` array, so
+        // `registerActorAbilityStatuses` never stamps `afterDamageClause` and each sub-attack
+        // applies before computing its own damage. DERIVATION:
+        //   sub-attack 0: applies, rides (10,000 x 2 = 20,000), spends
+        //   sub-attack 1: applies, rides (20,000), spends
+        //   cast total 40,000 = 2.0x the control's 20,000, and the victim ends holding 0 stacks.
+        // The 0-residual is what separates this from the after-damage case's 1 — the two casts
+        // deal 30,000 and 40,000 AND leave 1 and 0 stacks, so neither leg can be faked by the
+        // other's mechanism.
+        // KILLED BY: no-oping `onSubAttackStart` (sub-attack 1 then arms nothing and delivers a
+        // plain 10,000, giving [20,000, 10,000] and a 1-stack residual), and by
+        // `applyDebuffsForSubAttack` returning [].
+        const cast = focusCast([beforeDamage(2, EXPOSED())], [enemyAt('victim', 'M4')]);
+        const delivered = deliveredDamagesOf(cast, 'attacker');
+        const control = deliveredDamagesOf(
+            focusCast([attackSkill(2)], [enemyAt('victim', 'M4')]),
+            'attacker'
+        );
+        expect(delivered).toEqual([2 * SLICE, 2 * SLICE]);
+        expect(delivered[0]!).toBeGreaterThan(control[0]!);
+        expect(sum(delivered)).toBe(2 * sum(control));
+        expect(
+            residualExposedStacks(
+                focusCast(
+                    [beforeDamage(2, EXPOSED())],
+                    [enemyAt('victim', 'M4')],
+                    [residualProbeAlly()]
+                )
+            )
+        ).toBe(0);
+    });
+});
+
+describe('PR8 — overkill retargeting', () => {
+    afterEach(() => resetRateGateRng());
+
+    /** Front victim sized BELOW one slice so sub-attack 0 kills it; the survivor behind it is at
+     *  the full 10,000,000 and outlives all three slices. Column 4 is the FRONT, so `M4` dies and
+     *  `front` re-resolves to `M3`. */
+    const overkillCast = (hits: number) =>
+        focusCast(
+            [activeWithDebuffClause(hits)],
+            [enemyAt('frontling', 'M4', [], 5_000), enemyAt('survivor', 'M3')]
+        );
+
+    it('when sub-attack 1 kills its victim, sub-attacks 2–3 land their stacks on the NEW victim and the dead one holds exactly one', () => {
+        // DERIVATION: one plain slice delivers 10,000 against `frontling`'s 5,000 HP, so it dies
+        // on sub-attack 0 having taken exactly one landing (the cast-time one). Sub-attacks 1 and
+        // 2 re-resolve their own anchor, find `survivor` at the front, and land there — the
+        // footprint `applyDebuffsForSubAttack` passes is the victims THAT sub-attack actually
+        // struck, which is what makes retargeting correct for free.
+        // ANTI-VACUITY: the survivor's count is asserted non-zero AND the total is asserted to be
+        // 3, so a silently-dropped landing cannot pass by shifting a count from one victim to the
+        // other. The N=1 control pins that the split only appears over a multi-hit cast.
+        // KILLED BY: `applyDebuffsForSubAttack` returning [] (survivor drops to 0, total 1) and by
+        // no-oping `onSubAttackEnd`. Forcing `sub.index < sel.scalars.hits - 1` to false leaves
+        // the counts intact — this test is about WHO, not about when the state write lands.
+        const counts = debuffApplicationsByTarget(overkillCast(3), 'Corrode');
+        expect(counts.frontling).toBe(1);
+        expect(counts.survivor).toBe(2);
+        expect(counts.survivor).toBeGreaterThan(0);
+        expect(sum(Object.values(counts))).toBe(3);
+
+        const one = debuffApplicationsByTarget(overkillCast(1), 'Corrode');
+        expect(one.frontling).toBe(1);
+        expect(one.survivor).toBeUndefined();
+    });
+});
+
+describe('PR8 — independent landing rolls', () => {
+    afterEach(() => resetRateGateRng());
+
+    it('with a landing chance below 1, the stack count varies across seeds', () => {
+        // `liveDebuffLandingChance` is `clamp(effHacking - effSecurity, 0..100)/100`; the victim's
+        // security defaults to 100, so `hacking: 150` makes the gate a genuine 50% draw
+        // ((150-100)/100). A single draw shared by all three sub-attacks can only ever produce a
+        // count of 0 or 3 — never 1 or 2 — so any count strictly between them disproves the
+        // pre-PR8 single-draw model outright, however the RNG stream is seeded.
+        //
+        // MEASURED (throwaway probe, seeds 1-10 against this exact fixture): counts
+        // [2,1,3,2,1,1,2,1,2,1]. Seed 1's `2` is pinned exactly below — an observation impossible
+        // under a single per-cast draw — alongside the general sweep, so a future engine change
+        // has to break BOTH the concrete seed and the search to pass.
+        // KILLED BY: `applyDebuffsForSubAttack` returning [] (every seed collapses to 1 — only
+        // the cast-time draw survives, so the distinct set has ONE member and no count exceeds 1)
+        // and by no-oping `onSubAttackEnd`.
+        const gated = (seed: number): number => {
+            setupKeyedTestRng(seed);
+            return debuffApplications(
+                focusCast([activeWithDebuffClause(3)], [enemyAt('victim', 'M4')], [], 150),
+                'Corrode',
+                'victim'
+            );
+        };
+
+        expect(gated(1)).toBe(2);
+
+        const counts = new Set<number>();
+        for (let seed = 1; seed <= 10; seed++) counts.add(gated(seed));
+        expect(counts.size).toBeGreaterThan(1);
+        const partial = [...counts].filter((c) => c > 0 && c < 3);
+        expect(partial.length).toBeGreaterThan(0);
+        expect(Math.max(...counts)).toBeLessThanOrEqual(3);
+    });
+});
+
+describe('PR8 — team symmetry', () => {
+    afterEach(() => resetRateGateRng());
+
+    it('a WALKED TEAM ally’s multi-hit debuff clause lands per sub-attack', () => {
+        // Same shape via the team path, not the focus path: the focus fires a zero-multiplier
+        // no-op and the walked ally at M2 does the casting. Its `hacking` is raised to 100,000 for
+        // the reason `teamActor` documents — at the default 0 the landing chance is 0 and this
+        // test would read 0 for both legs and look like a passing regression.
+        // KILLED BY: `applyDebuffsForSubAttack` returning [] and by no-oping `onSubAttackEnd`
+        // (both collapse the 3 to 1). The N=1 leg is the fence that PR8 did not move N=1.
+        const build = (hits: number) =>
+            focusCast(
+                [noopActive],
+                [enemyAt('victim', 'M4')],
+                [teamActor('ally', 'M2', [activeWithDebuffClause(hits)], 5000, 100_000)]
+            );
+        expect(debuffApplications(build(3), 'Corrode', 'victim')).toBe(3);
+        expect(debuffApplications(build(1), 'Corrode', 'victim')).toBe(1);
+    });
+
+    it('an ENEMY attacker’s multi-hit debuff clause lands per sub-attack on a player victim', () => {
+        // The enemy site is the one that has twice silently dropped a mechanic (#305, #306), so it
+        // gets its own mirror rather than being assumed side-agnostic. Everything asserted here is
+        // read WITHIN the enemy side (the foe's own `debuff-applied` count) — the RNG is keyed by
+        // ownerId, so comparing this cast's amounts against the player-side fixture's would be
+        // meaningless.
+        // KILLED BY: `applyDebuffsForSubAttack` returning [] and by no-oping `onSubAttackEnd`.
+        const build = (hits: number) =>
+            focusCast(
+                [noopActive],
+                [offensiveEnemy('foe', 'M1', [activeWithDebuffClause(hits)])],
+                [teamActor('pvictim', 'M4', [])]
+            );
+        expect(debuffApplications(build(3), 'Corrode', 'pvictim')).toBe(3);
+        expect(debuffApplications(build(1), 'Corrode', 'pvictim')).toBe(1);
+    });
+});
+
+describe('PR8 — sub-attack 0 recipient equivalence', () => {
+    afterEach(() => resetRateGateRng());
+
+    it('sub-attack 0’s recipients equal the cast-time recipients (the k=0 cast-time draw is not a compatibility hack)', () => {
+        // Decision 3 keeps the CAST-TIME landing draw for sub-attack 0 rather than re-rolling it
+        // through `applyDebuffsForSubAttack`, on the grounds that `selectTurnTarget` and iteration
+        // 0's `resolvePositionalTarget` resolve the same anchor. That is asserted here, not
+        // assumed: the first `debuff-applied` (resolved from the cast's own `targetId`) must name
+        // the same victim the positional walk's iteration-0 `attacked` struck, and the same victim
+        // the cast's `ability-performed` reports as its primary target — three independently
+        // resolved paths agreeing on one id, which is exactly the claim.
+        //
+        // The OVERKILL fixture is what makes this discriminating rather than tautological. With
+        // both enemies alive every sub-attack resolves the same anchor, so dropping sub-attack 0's
+        // landing entirely would still leave `frontling` as the first name. Sizing `frontling`
+        // below one slice means sub-attacks 1 and 2 resolve `survivor` instead, so if the k=0
+        // draw were absent or resolved off a later anchor the first `debuff-applied` would read
+        // `survivor` and this test goes red.
+        // KILLED BY: passing `anchorId: undefined` at the cast-time
+        // `resolveDebuffRecipientIds` call (playerTurn.ts ~1748) — sub-attack 0 then lands
+        // nothing and the first `debuff-applied` names `survivor`. ALSO killed (measured, not
+        // predicted) by forcing `sub.index < sel.scalars.hits - 1` to false: sub-attack 0's
+        // landing is then left to the historical post-walk flush instead of being buffered into
+        // sub-attack 0's emission step, so sub-attack 1's `survivor` landing is emitted FIRST.
+        const overkill = firstNamedVictims(
+            focusCast(
+                [activeWithDebuffClause(3)],
+                [enemyAt('frontling', 'M4', [], 5_000), enemyAt('survivor', 'M3')]
+            ),
+            'Corrode'
+        );
+        expect(overkill.debuffed).toBe('frontling');
+        expect(overkill.struck).toBe('frontling');
+        expect(overkill.cast).toBe('frontling');
+
+        // The brief's own literal shape, with both enemies surviving: `front` is column 4, so the
+        // three paths must agree on `frontling` here too.
+        const bothAlive = firstNamedVictims(
+            focusCast(
+                [activeWithDebuffClause(3)],
+                [enemyAt('frontling', 'M4'), enemyAt('survivor', 'M3')]
+            ),
+            'Corrode'
+        );
+        expect(bothAlive.debuffed).toBe('frontling');
+        expect(bothAlive.struck).toBe('frontling');
+        expect(bothAlive.cast).toBe('frontling');
     });
 });

--- a/src/utils/combat/__tests__/positionalApply.subAttackBoundary.test.ts
+++ b/src/utils/combat/__tests__/positionalApply.subAttackBoundary.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Sub-attack boundary hooks (multi-hit full-walk epic, PR8 Task 2).
+ *
+ * These two seams are what lets PR8 apply a debuff landing INSIDE the hit loop, so sub-attack k's
+ * stack is in the store when sub-attack k+1 reads `defenseProfileOf`. This file pins the contract
+ * only — no debuff logic reaches here.
+ */
+import { describe, it, expect } from 'vitest';
+import { applyPositionalDamage } from '../positionalApply';
+import type { CombatActor } from '../state';
+import type { ParsedPattern, ParsedTarget } from '../../targetingParser';
+
+const actor = (id: string, position: string, hp = 1_000_000): CombatActor =>
+    ({
+        id,
+        position,
+        currentHp: hp,
+        shieldPool: 0,
+        stats: { attack: 0, crit: 0, critDamage: 0, defence: 0, hp, speed: 1 },
+        affinity: 'antimatter',
+    }) as unknown as CombatActor;
+
+const pattern = (): ParsedPattern => ({ raw: 'base', shape: 'base', range: 0, modifiers: {} });
+const target = (): ParsedTarget => ({ raw: 'front', side: 'enemy', selection: 'front' });
+
+const run = (args: {
+    hits: number;
+    opposing: CombatActor[];
+    onSubAttackStart?: Parameters<typeof applyPositionalDamage>[0]['onSubAttackStart'];
+    onSubAttackEnd?: Parameters<typeof applyPositionalDamage>[0]['onSubAttackEnd'];
+    applyToVictim?: Parameters<typeof applyPositionalDamage>[0]['applyToVictim'];
+}) =>
+    applyPositionalDamage({
+        hitCrits: Array.from({ length: args.hits }, () => false),
+        scalars: { hits: args.hits } as unknown as Parameters<
+            typeof applyPositionalDamage
+        >[0]['scalars'],
+        pattern: pattern(),
+        actorPosition: 'M1',
+        target: target(),
+        opposingLiving: args.opposing,
+        statusOf: () => ({}) as never,
+        acting: {},
+        defenseProfileOf: (v) => ({
+            defence: 0,
+            defenceModifierPct: 0,
+            incomingDamageModifierPct: 0,
+            affinity: v.affinity ?? 'antimatter',
+        }),
+        applyToVictim:
+            args.applyToVictim ??
+            (() => ({ hpDamage: 0, shieldBefore: 0, incomingBooked: 0 }) as never),
+        onSubAttackStart: args.onSubAttackStart,
+        onSubAttackEnd: args.onSubAttackEnd,
+    });
+
+describe('applyPositionalDamage sub-attack boundary hooks', () => {
+    it('calls start then end once per sub-attack, in ascending index order', () => {
+        const calls: string[] = [];
+        run({
+            hits: 3,
+            opposing: [actor('v1', 'M4')],
+            onSubAttackStart: (s) => calls.push(`start:${s.index}`),
+            onSubAttackEnd: (s) => calls.push(`end:${s.index}`),
+        });
+        expect(calls).toEqual(['start:0', 'end:0', 'start:1', 'end:1', 'start:2', 'end:2']);
+    });
+
+    it('reports the sub-attack’s own anchor and footprint', () => {
+        const seen: { index: number; anchorId: string; victimIds: string[] }[] = [];
+        run({
+            hits: 2,
+            opposing: [actor('v1', 'M4'), actor('v2', 'M3')],
+            onSubAttackEnd: (s) => seen.push({ ...s, victimIds: [...s.victimIds] }),
+        });
+        expect(seen).toHaveLength(2);
+        for (const s of seen) {
+            expect(s.anchorId).toBe('v1');
+            expect(s.victimIds).toContain('v1');
+        }
+    });
+
+    it('start fires BEFORE that sub-attack’s damage and end AFTER all of it', () => {
+        const calls: string[] = [];
+        run({
+            hits: 2,
+            opposing: [actor('v1', 'M4')],
+            onSubAttackStart: (s) => calls.push(`start:${s.index}`),
+            onSubAttackEnd: (s) => calls.push(`end:${s.index}`),
+            applyToVictim: ((v: CombatActor) => {
+                calls.push(`hit:${v.id}`);
+                return { hpDamage: 0, shieldBefore: 0, incomingBooked: 0 };
+            }) as never,
+        });
+        expect(calls).toEqual(['start:0', 'hit:v1', 'end:0', 'start:1', 'hit:v1', 'end:1']);
+    });
+
+    it('a WHIFF calls neither hook but still consumes its index', () => {
+        const calls: string[] = [];
+        const out = run({
+            hits: 2,
+            opposing: [],
+            onSubAttackStart: (s) => calls.push(`start:${s.index}`),
+            onSubAttackEnd: (s) => calls.push(`end:${s.index}`),
+        });
+        expect(calls).toEqual([]);
+        expect(out.subAttacks.map((s) => s.whiffed)).toEqual([true, true]);
+    });
+
+    it('omitting both hooks changes nothing (they are optional)', () => {
+        const out = run({ hits: 2, opposing: [actor('v1', 'M4')] });
+        expect(out.subAttacks).toHaveLength(2);
+    });
+});

--- a/src/utils/combat/debuffRecipients.ts
+++ b/src/utils/combat/debuffRecipients.ts
@@ -1,0 +1,54 @@
+import type { Ability } from '../../types/abilities';
+
+/**
+ * Which actors a direct enemy-debuff clause lands on, given the ability's `target` and a RESOLVED
+ * anchor. Extracted verbatim from playerTurn.ts's cast-time ternary (multi-hit full-walk epic,
+ * PR8 Task 1) so the cast-time path and the per-sub-attack path cannot drift — PR8 calls this
+ * once per cast for sub-attack 0 and again per later sub-attack, with THAT sub-attack's live
+ * anchor and footprint.
+ *
+ * `undefined` in the result is the non-positional dummy sink ("resolve to the turn's `enemy`"),
+ * which is why the array is `(string | undefined)[]`. A positional caller never receives it: with
+ * no anchor there is genuinely nobody to inflict, and inventing the sink there would record a
+ * debuff on a target that does not exist.
+ *
+ * @param abTarget          the matching debuff ability's `target`; `undefined` when no ability
+ *                          matched the status, which behaves as single-target (the ternary's tail).
+ * @param anchorId          the resolved victim id this clause hangs off — the cast's `targetId` at
+ *                          cast time, or the sub-attack's own re-resolved anchor.
+ * @param aoeVictimIds      the footprint to fan `all-enemies` over. Cast time passes the cast's
+ *                          splash footprint; PR8's per-sub-attack path passes the victims THAT
+ *                          sub-attack actually struck, which is what makes overkill retargeting
+ *                          correct for free.
+ * @param positionalLanding `deferAbilityPerformedToEngine` — true when the engine resolves this
+ *                          cast against a real positioned roster.
+ */
+export function resolveDebuffRecipientIds(args: {
+    abTarget: Ability['target'] | undefined;
+    anchorId: string | undefined;
+    aoeVictimIds: string[] | undefined;
+    adjacentEnemyIdsFor: ((anchorId: string) => string[]) | undefined;
+    positionalLanding: boolean;
+}): (string | undefined)[] {
+    const { abTarget, anchorId, aoeVictimIds, adjacentEnemyIdsFor, positionalLanding } = args;
+    const isAllEnemies = abTarget === 'all-enemies';
+    const adjacentEnemyRecipients: string[] =
+        anchorId !== undefined && adjacentEnemyIdsFor ? adjacentEnemyIdsFor(anchorId) : [];
+    return abTarget === 'adjacent-enemies'
+        ? adjacentEnemyRecipients
+        : abTarget === 'target-and-adjacent-enemies'
+          ? anchorId !== undefined
+              ? [anchorId, ...adjacentEnemyRecipients]
+              : positionalLanding
+                ? []
+                : [undefined]
+          : positionalLanding && isAllEnemies
+            ? (aoeVictimIds ?? [])
+            : isAllEnemies && aoeVictimIds && aoeVictimIds.length > 0
+              ? aoeVictimIds
+              : anchorId !== undefined
+                ? [anchorId]
+                : positionalLanding
+                  ? []
+                  : [undefined];
+}

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -6854,8 +6854,14 @@ export function runCombat(input: CombatEngineInput): {
                     if (sub.index === 0) {
                         // Sub-attack 0 keeps its CAST-TIME roll (three consumers read that outcome
                         // before this loop runs — see applyDebuffsForSubAttack's doc). What moves is
-                        // only the state write, and only when a LATER sub-attack exists to see it.
-                        // With one sub-attack there is no next reader, so the write stays at the
+                        // the state write AND the paired `debuff-applied`'s EMISSION POINT: the
+                        // `bufferDebuffEmitters` call below reattaches sub-attack 0's events to
+                        // sub-attack 0's own emission step instead of leaving them to the historical
+                        // post-walk flush. That ordering is observable — with a victim killed on
+                        // sub-attack 0, the cast's first `debuff-applied` names that victim here and
+                        // names a LATER sub-attack's victim with this branch forced off. Both effects
+                        // are gated on a LATER sub-attack existing to see them: with one sub-attack
+                        // there is no next reader, so the write and the emission both stay at the
                         // historical flush site and N=1 is byte-identical BY CONSTRUCTION.
                         if (sub.index < sel.scalars.hits - 1) {
                             const pending = sel.deferredEnemyApplications.splice(

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -5791,6 +5791,21 @@ export function runCombat(input: CombatEngineInput): {
             // keyed by victim id. Required for a non-zero delta — see the causality note above
             // perVictimOutgoingDeltaPct. Unsupplied → delta stays 0 for every victim.
             preTurnVictimStatus?: Map<string, PreTurnVictimStatusSnapshot>;
+            // PR8: applyPositionalDamage's sub-attack boundary hooks (Task 2), forwarded verbatim
+            // below. Widened here for the same reason PR2 Task 2 had to widen `onVictimResolved`:
+            // this engine-side wrapper declares its OWN args type, so a hook that exists on
+            // applyPositionalDamage is un-typeable by an engine caller until it is repeated here.
+            // Unsupplied by a caller → no boundary work → byte-identical.
+            onSubAttackStart?: (sub: {
+                index: number;
+                anchorId: string;
+                victimIds: string[];
+            }) => void;
+            onSubAttackEnd?: (sub: {
+                index: number;
+                anchorId: string;
+                victimIds: string[];
+            }) => void;
         }): {
             anyCrit: boolean;
             critPairs: number;
@@ -5897,6 +5912,9 @@ export function runCombat(input: CombatEngineInput): {
                     },
                     // E2: forward the per-direction leech hook (unsupplied by all current callers).
                     onVictimResolved: args.onVictimResolved,
+                    // PR8: forward the sub-attack boundary hooks (the per-sub-attack debuff landing).
+                    onSubAttackStart: args.onSubAttackStart,
+                    onSubAttackEnd: args.onSubAttackEnd,
                     // Per-victim crit: forward the firing turn's per-victim crit resolver.
                     rollVictimCrit: args.rollVictimCrit,
                     // D-PR3: victim-side incoming %-reduction, per footprint victim per sub-hit. Shared
@@ -6638,6 +6656,15 @@ export function runCombat(input: CombatEngineInput): {
             rollVictimCrit?: (victimAffinity: AffinityName) => boolean;
             deferredAbilityPerformed: PlayerTurnResult['deferredAbilityPerformed'];
             positionalDetonation: DetonationRecipe | undefined;
+            /**
+             * PR8: this cast's per-sub-attack debuff applier and its cast-time deferred list.
+             * The helper owns WHEN each landing's state write happens; playerTurn owns the roll.
+             * Both optional in effect — `applyDebuffsForSubAttack` is undefined for a cast with no
+             * gated debuff clause, and the deferred list is empty for a cast whose clauses all
+             * precede its damage, which is almost the whole corpus.
+             */
+            applyDebuffsForSubAttack: PlayerTurnResult['applyDebuffsForSubAttack'];
+            deferredEnemyApplications: PlayerTurnResult['deferredEnemyApplications'];
         }
         /** One footprint victim's `attacked` signal within ONE sub-attack. */
         interface PositionalVictimSignal {
@@ -6716,6 +6743,21 @@ export function runCombat(input: CombatEngineInput): {
             // not just the anchor. Keyed by (subAttackIndex, victim.id) since PR2 Task 2, and
             // consumed one bucket at a time by the interleaved emit below.
             const attackedSignals: PositionalAttackedSignals = new Map();
+            // PR8: buffered `debuff-applied` / `debuff-resisted` emitters, keyed by the sub-attack
+            // whose boundary produced them. The STATE writes already ran in the loop (that is the
+            // point — sub-attack k's stack must be in the store when sub-attack k+1 reads
+            // defenseProfileOf); only the events wait here, so each lands after its own
+            // sub-attack's `ability-performed` row exists.
+            const debuffEmittersBySubAttack = new Map<number, (() => void)[]>();
+            const bufferDebuffEmitters = (
+                index: number,
+                pairs: PlayerTurnResult['deferredEnemyApplications']
+            ): void => {
+                if (pairs.length === 0) return;
+                const at = debuffEmittersBySubAttack.get(index) ?? [];
+                for (const pair of pairs) at.push(pair.emitEvents);
+                debuffEmittersBySubAttack.set(index, at);
+            };
             // Per-footprint Stasis-break: collect EVERY covered footprint victim (≠ anchor) stasised
             // at hit time so its Stasis is broken too — the anchor break is handled at the call site.
             // Covered victims have no same-turn re-apply vector → unconditional break.
@@ -6798,6 +6840,38 @@ export function runCombat(input: CombatEngineInput): {
                         coveredStasisVictims.add(victim.id);
                     }
                 },
+                onSubAttackStart: (sub) => {
+                    // Clauses written BEFORE the damage clause apply ahead of this sub-attack's
+                    // damage — the locked intra-cast order, now per sub-attack. Sub-attack 0's
+                    // before-damage clauses already applied inline at cast time.
+                    if (sub.index === 0) return;
+                    bufferDebuffEmitters(
+                        sub.index,
+                        sel.applyDebuffsForSubAttack?.(sub, 'before-damage') ?? []
+                    );
+                },
+                onSubAttackEnd: (sub) => {
+                    if (sub.index === 0) {
+                        // Sub-attack 0 keeps its CAST-TIME roll (three consumers read that outcome
+                        // before this loop runs — see applyDebuffsForSubAttack's doc). What moves is
+                        // only the state write, and only when a LATER sub-attack exists to see it.
+                        // With one sub-attack there is no next reader, so the write stays at the
+                        // historical flush site and N=1 is byte-identical BY CONSTRUCTION.
+                        if (sub.index < sel.scalars.hits - 1) {
+                            const pending = sel.deferredEnemyApplications.splice(
+                                0,
+                                sel.deferredEnemyApplications.length
+                            );
+                            for (const pair of pending) pair.applyState();
+                            bufferDebuffEmitters(sub.index, pending);
+                        }
+                        return;
+                    }
+                    bufferDebuffEmitters(
+                        sub.index,
+                        sel.applyDebuffsForSubAttack?.(sub, 'after-damage') ?? []
+                    );
+                },
             });
             // Set the DEFERRED Stasis break for every covered victim (unconditional — covered victims
             // have no same-turn re-apply vector). The victim's own skip branch consumes it next turn.
@@ -6820,7 +6894,30 @@ export function runCombat(input: CombatEngineInput): {
             // Built as a step list rather than emitted inline so the enemy site can run the first
             // step here and the remainder after its own tail (see `deferEmission`).
             const steps: { isEvent: boolean; run: () => void }[] = [];
+            /** Push sub-attack `idx`'s buffered debuff events, after that index's `attacked`. */
+            const pushDebuffSteps = (idx: number): void => {
+                const emitters = debuffEmittersBySubAttack.get(idx);
+                if (!emitters || emitters.length === 0) return;
+                steps.push({
+                    isEvent: false,
+                    run: () => {
+                        for (const emit of emitters) emit();
+                    },
+                });
+            };
             const signalledIndices = [...attackedSignals.keys()].sort((a, b) => a - b);
+            // PR8: the indices that owe an emission step in the two loops that would otherwise walk
+            // `attacked` signals ALONE — the nothing-landed fallback and the inline-emitted `else`.
+            // A sub-attack can hold buffered debuff events with NO signals: the boundary hooks fire
+            // whenever the anchor resolved, including over an EMPTY footprint, and a single-target
+            // clause lands on the anchor regardless. Walking signals alone would drop those events.
+            // Every signalled index has size > 0 (entries exist only once a signal is pushed), so
+            // for a cast with no buffered events this set is `signalledIndices` and both loops stay
+            // byte-identical. The main per-index loop below needs no such union: its `indices` is
+            // already built over every `critAgg.subAttacks` entry, whiffs included.
+            const emissionIndices = [
+                ...new Set([...signalledIndices, ...debuffEmittersBySubAttack.keys()]),
+            ].sort((a, b) => a - b);
             if (sel.deferredAbilityPerformed) {
                 const dap = sel.deferredAbilityPerformed;
                 // Gate on the FOOTPRINT ALONE, not on `whiffed` and not on the damage:
@@ -6865,12 +6962,15 @@ export function runCombat(input: CombatEngineInput): {
                                 critAgg.critVictimIds
                             ),
                     });
-                    for (const idx of signalledIndices) {
-                        const victims = attackedSignals.get(idx)!;
-                        steps.push({
-                            isEvent: false,
-                            run: () => emitAttackedForSubAttack(victims, idx),
-                        });
+                    for (const idx of emissionIndices) {
+                        const victims = attackedSignals.get(idx);
+                        if (victims && victims.size > 0) {
+                            steps.push({
+                                isEvent: false,
+                                run: () => emitAttackedForSubAttack(victims, idx),
+                            });
+                        }
+                        pushDebuffSteps(idx);
                     }
                 } else {
                     // Per-event damage: the cast's pre-funnel `directDamage` split across the
@@ -6918,6 +7018,10 @@ export function runCombat(input: CombatEngineInput): {
                                 run: () => emitAttackedForSubAttack(victims, idx),
                             });
                         }
+                        // PR8: this sub-attack's own debuff events, after its `attacked`.
+                        // Unconditional on the index — a bucket can hold debuff events with no
+                        // `attacked` signals when every hit was transformed into a DoT.
+                        pushDebuffSteps(idx);
                     }
                 }
                 // Sweep: a sub-attack that buffered log rows but emitted no event (nothing landed)
@@ -6927,12 +7031,15 @@ export function runCombat(input: CombatEngineInput): {
                 // runPlayerTurn already emitted this cast's `ability-performed` inline — only the
                 // `attacked` fan-out is ours. Same events, same per-victim order, now grouped by
                 // sub-attack.
-                for (const idx of signalledIndices) {
-                    const victims = attackedSignals.get(idx)!;
-                    steps.push({
-                        isEvent: false,
-                        run: () => emitAttackedForSubAttack(victims, idx),
-                    });
+                for (const idx of emissionIndices) {
+                    const victims = attackedSignals.get(idx);
+                    if (victims && victims.size > 0) {
+                        steps.push({
+                            isEvent: false,
+                            run: () => emitAttackedForSubAttack(victims, idx),
+                        });
+                    }
+                    pushDebuffSteps(idx);
                 }
             }
             let emitDeferred = (): void => {};
@@ -8146,6 +8253,21 @@ export function runCombat(input: CombatEngineInput): {
                                     : undefined,
                             });
                             if (turnStasisHitVictims.size > 0) {
+                                // KNOWN LIMITATION, deliberate for PR8 (multi-hit full-walk epic):
+                                // this reads `inflictedEnemyDebuffs` as it stands the moment
+                                // runPlayerTurn returns, which is BEFORE the positional drive runs
+                                // the per-sub-attack landings. `inflictedEnemyDebuffs` is not
+                                // `collect`-guarded, so a sub-attack ≥ 1's landing does push a row —
+                                // but it pushes it too late to be seen here. Consequence: a Stasis
+                                // that RESISTED on sub-attack 0 and LANDED on sub-attack 1 reads as
+                                // "not re-inflicted", so the break fires anyway and shaves a turn off
+                                // the freshly applied Stasis. The walked-team and enemy sites are
+                                // asymmetric the same way (the enemy spreads the list into its entry
+                                // before its own drive call too).
+                                // Corpus-inert today: Enforcer is the only ship with hits > 1 and she
+                                // carries no direct debuff-inflict clause, so nothing can reach this
+                                // shape. Left as-is on purpose — restructuring the check would move
+                                // the N=1 break decision, which PR8 must keep byte-identical.
                                 const reInflictedStasis = turn.inflictedEnemyDebuffs.some((ab) =>
                                     isStasis(ab.buffName)
                                 );
@@ -8217,6 +8339,8 @@ export function runCombat(input: CombatEngineInput): {
                                         rollVictimCrit: turn.rollVictimCrit,
                                         deferredAbilityPerformed: turn.deferredAbilityPerformed,
                                         positionalDetonation: turn.positionalDetonation,
+                                        applyDebuffsForSubAttack: turn.applyDebuffsForSubAttack,
+                                        deferredEnemyApplications: turn.deferredEnemyApplications,
                                     },
                                     (victim, damage, outcome) =>
                                         procLeechesForVictim(actor.id, victim, damage, outcome),
@@ -8447,6 +8571,9 @@ export function runCombat(input: CombatEngineInput): {
                                         rollVictimCrit: teamTurn.rollVictimCrit,
                                         deferredAbilityPerformed: teamTurn.deferredAbilityPerformed,
                                         positionalDetonation: teamTurn.positionalDetonation,
+                                        applyDebuffsForSubAttack: teamTurn.applyDebuffsForSubAttack,
+                                        deferredEnemyApplications:
+                                            teamTurn.deferredEnemyApplications,
                                     },
                                     (victim, damage, outcome) =>
                                         procLeechesForVictim(actor.id, victim, damage, outcome),
@@ -8791,6 +8918,12 @@ export function runCombat(input: CombatEngineInput): {
                             // damage — positional or not. Empty for a dead-target/flat-card turn.
                             let enemyDeferredApplications: PlayerTurnResult['deferredEnemyApplications'] =
                                 [];
+                            // PR8: the enemy cast's per-sub-attack debuff applier, hoisted for the
+                            // same scoping reason as the list above — the positional drive call sits
+                            // OUTSIDE the else block that declares `enemyTurn`. Undefined on a
+                            // dead-target/flat-card turn and for any cast with no gated debuff
+                            // clause, which the helper's `?.` call already tolerates.
+                            let enemyApplyDebuffsForSubAttack: PlayerTurnResult['applyDebuffsForSubAttack'];
                             // Task 5: the per-victim crit aggregate from the enemy positional apply, hoisted
                             // out of the `if (damage > 0)` block. Present only when the positional apply
                             // actually ran; when the enemy turn is positional but deals 0 damage (apply
@@ -8951,7 +9084,13 @@ export function runCombat(input: CombatEngineInput): {
                                 // enemy inline emit was suppressed, i.e. enemyPositional true).
                                 enemyDeferredAbilityPerformed = enemyTurn.deferredAbilityPerformed;
                                 // Clause order: capture the held-back landings for the post-damage flush.
+                                // PR8: THIS array identity is what the positional drive splices at a
+                                // sub-attack boundary AND what the fallback flush below drains — the
+                                // two must be the same object or the enemy path silently keeps
+                                // once-per-cast arrival. Both captures happen HERE, before the drive
+                                // call, so the helper sees them.
                                 enemyDeferredApplications = enemyTurn.deferredEnemyApplications;
+                                enemyApplyDebuffsForSubAttack = enemyTurn.applyDebuffsForSubAttack;
                                 // PR3: capture the per-victim detonation recipe (returned whenever
                                 // `positional: true` was set for this enemy turn — see the positional
                                 // hint gate). Consumed by the enemy-site per-victim detonation loop below.
@@ -9120,6 +9259,10 @@ export function runCombat(input: CombatEngineInput): {
                                             rollVictimCrit: enemyRollVictimCrit,
                                             deferredAbilityPerformed: enemyDeferredAbilityPerformed,
                                             positionalDetonation: enemyPositionalDetonation,
+                                            applyDebuffsForSubAttack: enemyApplyDebuffsForSubAttack,
+                                            // The SAME array the fallback flush below drains (see
+                                            // the capture note), never a fresh one.
+                                            deferredEnemyApplications: enemyDeferredApplications,
                                         },
                                         (victim, dmg, outcome) => {
                                             procLeechesForVictim(actor.id, victim, dmg, outcome);

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -6613,12 +6613,19 @@ export function runCombat(input: CombatEngineInput): {
          *
          * Empties the list, making a second call a no-op — the sites are allowed to overlap.
          * Team-symmetric: one helper, all three sites (focus / walked team / enemy).
+         *
+         * PR8 split the thunk into {applyState, emitEvents}. Running them back-to-back here is
+         * byte-identical to the pre-PR8 single thunk — the split only matters where the engine
+         * deliberately separates them (the sub-attack boundary wiring, Task 4).
          */
         const flushDeferredEnemyApplications = (
             deferred: PlayerTurnResult['deferredEnemyApplications']
         ): void => {
             if (deferred.length === 0) return;
-            for (const apply of deferred.splice(0, deferred.length)) apply();
+            for (const pending of deferred.splice(0, deferred.length)) {
+                pending.applyState();
+                pending.emitEvents();
+            }
         };
         interface PositionalTurnSel {
             tgt: CombatActor;

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -6632,6 +6632,17 @@ export function runCombat(input: CombatEngineInput): {
          * Empties the list, making a second call a no-op — the sites are allowed to overlap.
          * Team-symmetric: one helper, all three sites (focus / walked team / enemy).
          *
+         * NOT the only application point since PR8 (multi-hit full-walk epic). It is now the
+         * FALLBACK plus the FINAL flush:
+         *   • A multi-hit cast's sub-attack-0 landings are spliced out of this list and applied at
+         *     the end of iteration 0 by the `onSubAttackEnd` hook below, so sub-attack 1 can see
+         *     them. By the time this runs, that splice has already emptied the list — hence the
+         *     early return, not a second application.
+         *   • Sub-attacks ≥ 1 never populate this list at all; they roll and apply through
+         *     `applyDebuffsForSubAttack` at their own boundaries.
+         *   • A single-hit cast, a whiff, a non-positional cast, or any cast the hooks never see
+         *     still lands HERE — which is what keeps N=1 on its historical path.
+         *
          * PR8 split the thunk into {applyState, emitEvents}. Running them back-to-back here is
          * byte-identical to the pre-PR8 single thunk — the split only matters where the engine
          * deliberately separates them (the sub-attack boundary wiring, Task 4).
@@ -8531,8 +8542,9 @@ export function runCombat(input: CombatEngineInput): {
                             });
                             if (teamTurnStasisHitVictims.size > 0) {
                                 // KNOWN LIMITATION — see the focus site's note above its own
-                                // `reInflictedStasis` read (~line 8256) for the full explanation;
-                                // this read has the same pre-positional-drive ordering.
+                                // `reInflictedStasis` read (search `turnStasisHitVictims.size > 0`)
+                                // for the full explanation; this read has the same
+                                // pre-positional-drive ordering.
                                 const reInflictedStasis = teamTurn.inflictedEnemyDebuffs.some(
                                     (ab) => isStasis(ab.buffName)
                                 );
@@ -9051,7 +9063,8 @@ export function runCombat(input: CombatEngineInput): {
                                 // §4.5: resolve Stasis break for player victims hit by this enemy.
                                 if (enemyTurnStasisHitVictims.size > 0) {
                                     // KNOWN LIMITATION — see the focus site's note above its own
-                                    // `reInflictedStasis` read (~line 8256) for the full explanation;
+                                    // `reInflictedStasis` read (search
+                                    // `turnStasisHitVictims.size > 0`) for the full explanation;
                                     // this read has the same pre-positional-drive ordering.
                                     const reInflictedStasis = enemyTurn.inflictedEnemyDebuffs.some(
                                         (ab) => isStasis(ab.buffName)

--- a/src/utils/combat/engine.ts
+++ b/src/utils/combat/engine.ts
@@ -8524,6 +8524,9 @@ export function runCombat(input: CombatEngineInput): {
                                     : undefined,
                             });
                             if (teamTurnStasisHitVictims.size > 0) {
+                                // KNOWN LIMITATION — see the focus site's note above its own
+                                // `reInflictedStasis` read (~line 8256) for the full explanation;
+                                // this read has the same pre-positional-drive ordering.
                                 const reInflictedStasis = teamTurn.inflictedEnemyDebuffs.some(
                                     (ab) => isStasis(ab.buffName)
                                 );
@@ -9041,6 +9044,9 @@ export function runCombat(input: CombatEngineInput): {
                                 });
                                 // §4.5: resolve Stasis break for player victims hit by this enemy.
                                 if (enemyTurnStasisHitVictims.size > 0) {
+                                    // KNOWN LIMITATION — see the focus site's note above its own
+                                    // `reInflictedStasis` read (~line 8256) for the full explanation;
+                                    // this read has the same pre-positional-drive ordering.
                                     const reInflictedStasis = enemyTurn.inflictedEnemyDebuffs.some(
                                         (ab) => isStasis(ab.buffName)
                                     );

--- a/src/utils/combat/exposedStatus.ts
+++ b/src/utils/combat/exposedStatus.ts
@@ -26,11 +26,17 @@ export const EXPOSED_INCOMING_PCT = 100;
  * `victimIncomingModifiers`).
  *
  * Stack scaling matches the repo-wide convention for status effects (`value * stacks`, see
- * dpsBuffHelpers' `toEnemyModifiers`): Amartya's 2 stacks amplify the next hit by 200%, consumed
- * together. OPEN GAME-RULE QUESTION: the alternative reading is that each stack arms its OWN hit
- * (2 stacks → two consecutive hits at +100%). The game text's single "removed after taking direct
- * damage" — not "removes one stack" — is what tips this to all-at-once; revisit if in-game
- * observation says otherwise.
+ * dpsBuffHelpers' `toEnemyModifiers`): Amartya's 2 stacks amplify the next hit by +200%. SETTLED
+ * (owner ruling, in-game observation): this read side is correct as written — stacks sum onto the
+ * one hit they amplify, not one stack arming its own separate hit. What was genuinely open was
+ * CONSUMPTION, and the owner's ruling there is the alternative reading: the amplified hit spends
+ * only ONE stack, leaving the rest standing for the next hit (2 stacks → that hit reads +200%, the
+ * next reads +100% off the 1 left over). {@link consumeExposed} does not implement that yet — it
+ * calls `removeTimedEnemyStatus`, which deletes every stack the victim holds rather than
+ * decrementing by one. Fixing consumption to spend a single stack per hit is tracked separately and
+ * is deliberately NOT part of this PR. The divergence is invisible in this PR's own fixtures: every
+ * corpus applier here lands exactly one stack per sub-attack and the very next hit spends it, so two
+ * stacks are never simultaneously held.
  *
  * Reads the victim's TIMED per-victim enemy store directly rather than the caller's assembled
  * three-channel debuff list, because that is exactly the channel {@link consumeExposed} can delete

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -172,6 +172,23 @@ export interface HealingRuntimeCtx {
     teamBattle?: boolean;
 }
 
+/**
+ * One enemy-debuff landing this cast decided but has not yet written, split so the ENGINE can run
+ * its two halves at different moments (multi-hit full-walk epic, PR8).
+ *
+ * `applyState` performs the `applyTimedAbilityStatus` write plus the display-list refresh;
+ * `emitEvents` emits the paired discrete `debuff-applied`. They are separate because a multi-hit
+ * cast needs the STATE in the store at its sub-attack's boundary — so the next sub-attack's
+ * `defenseProfileOf` read sees it — while the EVENT must wait for that sub-attack's
+ * `ability-performed` row to exist, or `buildCombatLog`'s `openAttackEntry` misattributes it.
+ * `flushDeferredEnemyApplications` runs them back-to-back, which is what keeps a single-sub-attack
+ * cast byte-identical to the pre-PR8 single thunk.
+ */
+export interface DeferredEnemyApplication {
+    applyState: () => void;
+    emitEvents: () => void;
+}
+
 /** Everything one player actor's turn contributes to the round's RoundData row. */
 export interface PlayerTurnResult {
     action: 'active' | 'charged';
@@ -189,15 +206,46 @@ export interface PlayerTurnResult {
     /**
      * Enemy-debuff landings this cast decided but held back, because their clause follows a damage
      * clause in the same firing slot (user-confirmed game rule: "deals X% damage and inflicts
-     * Defense Down" resolves the damage first). Each thunk performs the deferred
-     * `applyTimedAbilityStatus` + its discrete `debuff-applied`; the landing roll already happened.
+     * Defense Down" resolves the damage first). Each pair's `applyState` performs the deferred
+     * `applyTimedAbilityStatus` write; `emitEvents` emits its discrete `debuff-applied`. The
+     * landing roll already happened.
      *
      * The ENGINE must flush these once this turn's damage has landed (`flushDeferredEnemyApplications`),
      * before the actor's Post-Turn decrement so the status still runs its normal window. Empty for
      * every cast whose debuff clauses all precede its damage — i.e. for almost the whole corpus,
      * which keeps those byte-identical.
+     *
+     * PR8 split the element from a bare `() => void` thunk into `{applyState, emitEvents}` so the
+     * engine can run the two halves at different moments at a multi-hit cast's sub-attack boundary.
      */
-    deferredEnemyApplications: (() => void)[];
+    deferredEnemyApplications: DeferredEnemyApplication[];
+    /**
+     * Rolls and applies this cast's direct enemy-debuff clauses for ONE sub-attack ≥ 1
+     * (multi-hit full-walk epic, PR8). Present only on a positional cast that has at least one
+     * condition-gated direct debuff clause; `undefined` everywhere else, which is what keeps DPS
+     * mode, healing mode and every non-positional path on the single-flush behaviour they have
+     * today.
+     *
+     * Sub-attack 0 is NOT served by this — it keeps its cast-time draw, because three consumers
+     * read that outcome before the positional loop runs: `resistedTimedEnemyNames` (gates this
+     * turn's `control-applied` emission, inside this function), `resistedEnemyDebuffs` (the round
+     * display list), and `inflictedEnemyDebuffs` (the engine's `reInflictedStasis` check, which
+     * runs immediately after this function returns). Keeping the k=0 draw where it is also keeps
+     * the `${ownerId}:landing` RNG stream's draw order untouched for a single-hit cast.
+     *
+     * `phase` selects clause order WITHIN the sub-attack: `'before-damage'` for clauses written
+     * ahead of the damage clause (applied at the sub-attack's start), `'after-damage'` for those
+     * written after it (applied at its end). The locked intra-cast rule therefore holds per
+     * sub-attack rather than per cast.
+     *
+     * Returns the landings' {@link DeferredEnemyApplication} pairs with `applyState` ALREADY RUN —
+     * the caller only has to emit. The roll is fresh per call, against the anchor and footprint
+     * that sub-attack actually resolved, so overkill retargeting is correct without extra work.
+     */
+    applyDebuffsForSubAttack?: (
+        sub: { index: number; anchorId: string; victimIds: string[] },
+        phase: 'before-damage' | 'after-damage'
+    ) => DeferredEnemyApplication[];
     directDamage: number;
     secondaryDamage: number;
     conditionalDamage: number;
@@ -1523,7 +1571,151 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     const resistedTimedEnemyNames: string[] = [];
     // Landings held back by intra-cast clause order (see the `afterDamageClause` branch below).
     // Returned on the turn result; the engine flushes them once this turn's damage has landed.
-    const deferredEnemyApplications: (() => void)[] = [];
+    const deferredEnemyApplications: DeferredEnemyApplication[] = [];
+
+    /**
+     * Roll + apply ONE timed enemy status over one recipient list. Extracted from the cast-time
+     * loop (multi-hit full-walk epic, PR8) so sub-attacks ≥ 1 re-run the IDENTICAL body against
+     * their own anchor and footprint — a second copy is how the two paths would drift on the
+     * resist bookkeeping or the display refresh.
+     *
+     * `collect`: when supplied, a landing's pair (landed OR resisted) is pushed here instead of
+     * being applied/emitted inline, and `applyState` is NOT run by this function — the caller owns
+     * both halves' timing. When absent (the cast-time path) behaviour is exactly pre-PR8: a
+     * before-damage clause applies inline, an after-damage clause is pushed to the deferred list
+     * unapplied.
+     *
+     * Cast-time inline note: the inline (before-damage, `collect` absent) branch deliberately does
+     * NOT call `pair.applyState` — it performs the raw store write directly instead. `applyState`
+     * also re-reads the live status to refresh the `landedEnemyDebuffs` DISPLAY list, closing over
+     * the `const landedEnemyDebuffs` declared further down this function (after `landedAbilityEnemy`
+     * is computed from a POST-write store read, which is what already carries an inline write into
+     * the round's display list without any refresh). Calling `pair.applyState` from inside this
+     * loop — before that later declaration runs — would throw (TDZ). It is safe only for the
+     * deferred/collect callers (`flushDeferredEnemyApplications`, `applyDebuffsForSubAttack`),
+     * which always run after runPlayerTurn has returned.
+     */
+    const landStatusOnRecipients = (
+        status: TimedStatus,
+        recipientIds: (string | undefined)[],
+        collect?: DeferredEnemyApplication[]
+    ): void => {
+        let anyLanded = false;
+        for (const vid of recipientIds) {
+            const victim =
+                vid !== undefined
+                    ? (opposingVictimById?.get(vid) ?? (vid === enemy.id ? enemy : undefined))
+                    : enemy;
+            const usePerVictim =
+                positionalLanding && opposingVictimById != null && vid !== undefined;
+            if (usePerVictim && victim === undefined) continue;
+            const resolvedVictim = victim ?? enemy;
+            const emitTargetId = vid ?? resolvedVictim.id;
+
+            const lands = usePerVictim
+                ? landsDebuffOnVictim(status.payload.application, resolvedVictim)
+                : landsTimedEnemyApplicationLive(status.payload.application);
+
+            if (lands) {
+                // Intra-cast clause order: a clause that follows a damage clause in this same slot
+                // must not be in the store while that damage resolves. Since PR8 the unit of
+                // "that damage" is the SUB-ATTACK, not the cast.
+                // NOT deferred:
+                //  - the LANDING decision for sub-attack 0 (drawn at the cast-time call site) — so
+                //    its RNG draw order and the resist bookkeeping below, which gates this turn's
+                //    control-applied emission, are untouched;
+                //  - `inflictedEnemyDebuffs`, a record of what THIS cast inflicted rather than of
+                //    store state. The §4.5 Stasis-break re-inflict check reads it back before the
+                //    flush runs (engine, `reInflictedStasis`); deferring the row let that check
+                //    conclude "not re-inflicted" and shave a turn off a freshly applied Stasis.
+                const pair: DeferredEnemyApplication = {
+                    applyState: () => {
+                        statusEngine.applyTimedAbilityStatus(r, status, actor.id, vid);
+                        // DISPLAY ONLY: the round's reported enemy-debuff window
+                        // (RoundData.activeEnemyDebuffs, sourced from `landedEnemyDebuffs`) is
+                        // assembled below, BEFORE this write runs — so re-read this status and
+                        // add/refresh its row. Without it a debuff the cast really did apply is
+                        // missing from the round it landed in, and a persistent-stacking family
+                        // reports one stack short. With N sub-attacks that shortfall multiplies,
+                        // which is why the refresh re-reads the LIVE stack count every time rather
+                        // than incrementing. Touches ONLY the display list: the modifier fold
+                        // (`roundEnemyDebuffs`) and every gate ctx are already computed, which is
+                        // exactly the rule — this sub-attack's own damage and its later clauses
+                        // must not see the status. Referencing a `const` declared further down is
+                        // safe because every caller runs after runPlayerTurn returned.
+                        const live = statusEngine
+                            .timedAbilityStatuses('enemy', actor.id, vid ?? targetId)
+                            .find((s) => s.payload.buffName === status.payload.buffName);
+                        if (live) {
+                            const at = landedEnemyDebuffs.findIndex(
+                                (b) => b.buffName === live.active.buffName
+                            );
+                            if (at >= 0) landedEnemyDebuffs[at] = live.active;
+                            else landedEnemyDebuffs.push(live.active);
+                        }
+                    },
+                    emitEvents: () => {
+                        emitDebuffApplied(actor.id, status.payload.buffName, emitTargetId);
+                    },
+                };
+                if (collect) {
+                    collect.push(pair);
+                } else if (status.afterDamageClause === true) {
+                    deferredEnemyApplications.push(pair);
+                } else {
+                    // Cast-time inline apply: EXACTLY pre-PR8 — the raw write plus the discrete
+                    // emit, without the display-list refresh (see the TDZ note above pair).
+                    statusEngine.applyTimedAbilityStatus(r, status, actor.id, vid);
+                    pair.emitEvents();
+                }
+                if (!anyLanded) {
+                    inflictedEnemyDebuffs.push({
+                        buffName: status.payload.buffName,
+                        turnsRemaining: status.duration,
+                    });
+                }
+                anyLanded = true;
+            } else if (collect) {
+                // A later sub-attack's resist: the event still fires, but buffered like its
+                // landed sibling so the log row it attaches to is that sub-attack's own.
+                collect.push({
+                    applyState: () => {},
+                    emitEvents: () => emitDebuffResisted(status.payload.buffName, emitTargetId),
+                });
+            } else {
+                emitDebuffResisted(status.payload.buffName, emitTargetId);
+            }
+        }
+
+        // Resist bookkeeping is CAST-TIME only. It gates this turn's control-applied emission
+        // (below), which is emitted before any sub-attack ≥ 1 has rolled — a later sub-attack's
+        // resist cannot retroactively suppress an event that already fired, and adding it here
+        // would double-count the name in the round's display list.
+        if (!collect && !anyLanded && recipientIds.length > 0) {
+            resistedAbilityTimedEnemy.push({
+                buffName: status.payload.buffName,
+                turnsRemaining: status.duration,
+            });
+            resistedTimedEnemyNames.push(status.payload.buffName);
+        }
+    };
+
+    /**
+     * The condition-gated direct debuff clauses of THIS cast, captured for replay on sub-attacks
+     * ≥ 1 (multi-hit full-walk epic, PR8).
+     *
+     * DELIBERATE SCOPE LINE: the recipe carries the RESULT of the cast-time
+     * `conditionsMet(status.conditions, preDebuffGateCtx)` gate, not the conditions themselves.
+     * Re-evaluating per sub-attack means rebuilding `preDebuffGateCtx` (~30 live-sourced fields,
+     * built earlier in this function) inside the hit loop; that is a separate change. Consequence:
+     * a clause gated on state the cast itself changes (e.g. the victim's HP%) is judged once, at
+     * cast time, for all N sub-attacks.
+     */
+    const perSubAttackDebuffRecipes: {
+        status: TimedStatus;
+        abTarget: Ability['target'] | undefined;
+    }[] = [];
+
     for (const status of timedEnemyBySlot) {
         if (status.sourceSlot !== action) continue;
         if (!conditionsMet(status.conditions, preDebuffGateCtx)) continue;
@@ -1548,85 +1740,36 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
             positionalLanding,
         });
 
-        let anyLanded = false;
-        for (const vid of recipientIds) {
-            const victim =
-                vid !== undefined
-                    ? (opposingVictimById?.get(vid) ?? (vid === enemy.id ? enemy : undefined))
-                    : enemy;
-            const usePerVictim =
-                positionalLanding && opposingVictimById != null && vid !== undefined;
-            if (usePerVictim && victim === undefined) continue;
-            const resolvedVictim = victim ?? enemy;
-            const emitTargetId = vid ?? resolvedVictim.id;
-
-            const lands = usePerVictim
-                ? landsDebuffOnVictim(status.payload.application, resolvedVictim)
-                : landsTimedEnemyApplicationLive(status.payload.application);
-
-            if (lands) {
-                // Intra-cast clause order: a clause that follows a damage clause in this same slot
-                // must not be in the store while the cast's damage resolves. Deferred to the
-                // engine's post-apply flush: the state write and its discrete `debuff-applied`.
-                // NOT deferred:
-                //  - the LANDING decision (already drawn above) — so the RNG draw order and the
-                //    resist bookkeeping below, which gates this turn's control-applied emission,
-                //    are untouched;
-                //  - `inflictedEnemyDebuffs`, a record of what THIS cast inflicted rather than of
-                //    store state. The §4.5 Stasis-break re-inflict check reads it back before the
-                //    flush runs (engine, `reInflictedStasis`); deferring the row let that check
-                //    conclude "not re-inflicted" and shave a turn off a freshly applied Stasis.
-                const applyLanding = (): void => {
-                    statusEngine.applyTimedAbilityStatus(r, status, actor.id, vid);
-                    emitDebuffApplied(actor.id, status.payload.buffName, emitTargetId);
-                };
-                if (status.afterDamageClause === true) {
-                    deferredEnemyApplications.push(() => {
-                        applyLanding();
-                        // DISPLAY ONLY: the round's reported enemy-debuff window
-                        // (RoundData.activeEnemyDebuffs, sourced from `landedEnemyDebuffs`) is
-                        // assembled below, BEFORE this deferred write runs — so re-read this status
-                        // and add/refresh its row. Without it a debuff the cast really did apply is
-                        // missing from the round it landed in, and a persistent-stacking family
-                        // reports one stack short every round. Touches ONLY the display list: the
-                        // modifier fold (`roundEnemyDebuffs`) and every gate ctx are already
-                        // computed, which is exactly the rule — this cast's own damage and its later
-                        // clauses must not see the status. Referencing a `const` declared further
-                        // down is safe HERE and only here: this thunk runs after runPlayerTurn has
-                        // returned (the inline branch below would hit its TDZ), and the returned
-                        // result holds this very array.
-                        const live = statusEngine
-                            .timedAbilityStatuses('enemy', actor.id, vid ?? targetId)
-                            .find((s) => s.payload.buffName === status.payload.buffName);
-                        if (live) {
-                            const at = landedEnemyDebuffs.findIndex(
-                                (b) => b.buffName === live.active.buffName
-                            );
-                            if (at >= 0) landedEnemyDebuffs[at] = live.active;
-                            else landedEnemyDebuffs.push(live.active);
-                        }
-                    });
-                } else applyLanding();
-                if (!anyLanded) {
-                    inflictedEnemyDebuffs.push({
-                        buffName: status.payload.buffName,
-                        turnsRemaining: status.duration,
-                    });
-                }
-                anyLanded = true;
-            } else {
-                emitDebuffResisted(status.payload.buffName, emitTargetId);
-            }
-        }
-
-        if (!anyLanded && recipientIds.length > 0) {
-            resistedAbilityTimedEnemy.push({
-                buffName: status.payload.buffName,
-                turnsRemaining: status.duration,
-            });
-            resistedTimedEnemyNames.push(status.payload.buffName);
-        }
+        landStatusOnRecipients(status, recipientIds);
+        if (positionalLanding) perSubAttackDebuffRecipes.push({ status, abTarget });
     }
+
+    /** PR8: sub-attacks ≥ 1 re-roll every gated clause against their own anchor + footprint. */
+    const applyDebuffsForSubAttack = (
+        sub: { index: number; anchorId: string; victimIds: string[] },
+        phase: 'before-damage' | 'after-damage'
+    ): DeferredEnemyApplication[] => {
+        const collected: DeferredEnemyApplication[] = [];
+        for (const { status, abTarget } of perSubAttackDebuffRecipes) {
+            const isAfter = status.afterDamageClause === true;
+            if (isAfter !== (phase === 'after-damage')) continue;
+            landStatusOnRecipients(
+                status,
+                resolveDebuffRecipientIds({
+                    abTarget,
+                    anchorId: sub.anchorId,
+                    // THIS sub-attack's real footprint, not the cast's — so an `all-enemies`
+                    // clause fans over who it actually struck and a killed victim drops out.
+                    aoeVictimIds: sub.victimIds,
+                    adjacentEnemyIdsFor,
+                    positionalLanding: true,
+                }),
+                collected
+            );
+        }
+        for (const pair of collected) pair.applyState();
+        return collected;
+    };
 
     // Caster-ctx resolver (Task 5): activeAbilityStatuses gates each aura/accum against ITS
     // CASTER's context. For the acting actor's OWN statuses (casterId === actor.id) the resolver
@@ -3651,6 +3794,12 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         inflictedEnemyDebuffs,
         resistedEnemyDebuffs,
         deferredEnemyApplications,
+        // PR8: only meaningful on a positional cast that has gated clauses to replay. Left
+        // undefined otherwise so the engine's wiring is a no-op for DPS/healing/non-positional.
+        applyDebuffsForSubAttack:
+            positionalLanding && perSubAttackDebuffRecipes.length > 0
+                ? applyDebuffsForSubAttack
+                : undefined,
         directDamage,
         secondaryDamage,
         conditionalDamage,

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1778,6 +1778,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         for (const { status, abTarget } of perSubAttackDebuffRecipes) {
             const isAfter = status.afterDamageClause === true;
             if (isAfter !== (phase === 'after-damage')) continue;
+            const before = collected.length;
             landStatusOnRecipients(
                 status,
                 resolveDebuffRecipientIds({
@@ -1791,8 +1792,16 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 }),
                 collected
             );
+            // Write THIS clause's landings before the next clause resolves, mirroring the cast-time
+            // path — where a before-damage clause applies inline and after-damage clauses run
+            // sequentially at the flush, so clause 2 always evaluates against clause 1's store
+            // write. Collecting every pair and applying afterwards would make sub-attacks >= 1
+            // asymmetric with sub-attack 0 for a cast carrying two same-phase debuff clauses:
+            // clause 2's landing roll reads the victim's live status (the Block-Debuff gate in
+            // `landsDebuffOnVictim`), so it must see what clause 1 just applied. Latent today —
+            // no corpus ship has that shape (CodeRabbit, PR #314).
+            for (let i = before; i < collected.length; i++) collected[i].applyState();
         }
-        for (const pair of collected) pair.applyState();
         return collected;
     };
 

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1628,31 +1628,42 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 //    store state. The §4.5 Stasis-break re-inflict check reads it back before the
                 //    flush runs (engine, `reInflictedStasis`); deferring the row let that check
                 //    conclude "not re-inflicted" and shave a turn off a freshly applied Stasis.
+                // Single source of truth for the store write — both the deferred `applyState`
+                // path and the cast-time inline branch below call this instead of each keeping
+                // their own copy of `statusEngine.applyTimedAbilityStatus(...)` (a second copy is
+                // exactly how the two paths would drift, per the doc comment above).
+                const writeState = (): void => {
+                    statusEngine.applyTimedAbilityStatus(r, status, actor.id, vid);
+                };
+                // DISPLAY ONLY: the round's reported enemy-debuff window
+                // (RoundData.activeEnemyDebuffs, sourced from `landedEnemyDebuffs`) is
+                // assembled below, BEFORE this write runs — so re-read this status and
+                // add/refresh its row. Without it a debuff the cast really did apply is
+                // missing from the round it landed in, and a persistent-stacking family
+                // reports one stack short. With N sub-attacks that shortfall multiplies,
+                // which is why the refresh re-reads the LIVE stack count every time rather
+                // than incrementing. Touches ONLY the display list: the modifier fold
+                // (`roundEnemyDebuffs`) and every gate ctx are already computed, which is
+                // exactly the rule — this sub-attack's own damage and its later clauses
+                // must not see the status. Referencing a `const` declared further down is
+                // safe only because `applyState` is never invoked from inside `runPlayerTurn`
+                // — the inline branch calls `writeState` directly for exactly this reason.
+                const refreshDisplayRow = (): void => {
+                    const live = statusEngine
+                        .timedAbilityStatuses('enemy', actor.id, vid ?? targetId)
+                        .find((s) => s.payload.buffName === status.payload.buffName);
+                    if (live) {
+                        const at = landedEnemyDebuffs.findIndex(
+                            (b) => b.buffName === live.active.buffName
+                        );
+                        if (at >= 0) landedEnemyDebuffs[at] = live.active;
+                        else landedEnemyDebuffs.push(live.active);
+                    }
+                };
                 const pair: DeferredEnemyApplication = {
                     applyState: () => {
-                        statusEngine.applyTimedAbilityStatus(r, status, actor.id, vid);
-                        // DISPLAY ONLY: the round's reported enemy-debuff window
-                        // (RoundData.activeEnemyDebuffs, sourced from `landedEnemyDebuffs`) is
-                        // assembled below, BEFORE this write runs — so re-read this status and
-                        // add/refresh its row. Without it a debuff the cast really did apply is
-                        // missing from the round it landed in, and a persistent-stacking family
-                        // reports one stack short. With N sub-attacks that shortfall multiplies,
-                        // which is why the refresh re-reads the LIVE stack count every time rather
-                        // than incrementing. Touches ONLY the display list: the modifier fold
-                        // (`roundEnemyDebuffs`) and every gate ctx are already computed, which is
-                        // exactly the rule — this sub-attack's own damage and its later clauses
-                        // must not see the status. Referencing a `const` declared further down is
-                        // safe because every caller runs after runPlayerTurn returned.
-                        const live = statusEngine
-                            .timedAbilityStatuses('enemy', actor.id, vid ?? targetId)
-                            .find((s) => s.payload.buffName === status.payload.buffName);
-                        if (live) {
-                            const at = landedEnemyDebuffs.findIndex(
-                                (b) => b.buffName === live.active.buffName
-                            );
-                            if (at >= 0) landedEnemyDebuffs[at] = live.active;
-                            else landedEnemyDebuffs.push(live.active);
-                        }
+                        writeState();
+                        refreshDisplayRow();
                     },
                     emitEvents: () => {
                         emitDebuffApplied(actor.id, status.payload.buffName, emitTargetId);
@@ -1665,7 +1676,7 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
                 } else {
                     // Cast-time inline apply: EXACTLY pre-PR8 — the raw write plus the discrete
                     // emit, without the display-list refresh (see the TDZ note above pair).
-                    statusEngine.applyTimedAbilityStatus(r, status, actor.id, vid);
+                    writeState();
                     pair.emitEvents();
                 }
                 if (!anyLanded) {

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -1544,11 +1544,20 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     if (targetId !== undefined) onHitBreakStasis?.(targetId);
 
     // (b) Gate + apply this round's firing-skill TIMED enemy debuff abilities.
-    // Each application that passes its condition gate draws the landing decision
-    // ONCE here (Task 7): 'apply' → lands unless affinity-disadvantaged (no draw);
-    // otherwise draws the hacking-vs-security gate. Resisted → the apply is SKIPPED
-    // (no status stored), recorded resisted with its would-be duration, and emitted.
-    // Landed → emit debuff-applied ONCE at this infliction site (Phase 3 retiming).
+    // Each application that passes its condition gate draws the landing decision here
+    // (Task 7): 'apply' → lands unless affinity-disadvantaged (no draw); otherwise draws
+    // the hacking-vs-security gate. Resisted → the apply is SKIPPED (no status stored),
+    // recorded resisted with its would-be duration, and emitted. Landed → emit
+    // debuff-applied at this infliction site (Phase 3 retiming).
+    //
+    // CARDINALITY (multi-hit full-walk epic, PR8): this draw is SUB-ATTACK 0's, not the
+    // whole cast's. A multi-hit skill is N consecutive full attacks, so sub-attacks ≥ 1
+    // re-roll every clause below against their OWN anchor and footprint, via
+    // `applyDebuffsForSubAttack` (defined after this loop, driven by the engine's
+    // sub-attack boundary hooks). Reading this block as "the cast's one landing decision"
+    // is only correct at N=1. The condition GATE, the resist bookkeeping and the
+    // `control-applied` gating below do stay cast-time — see `perSubAttackDebuffRecipes`
+    // and `resistedTimedEnemyNames` for why each has to.
     const resistedAbilityTimedEnemy: ActiveBuff[] = [];
     // Debuffs THIS actor discretely inflicted on the target this turn (source-accurate
     // attribution for the enemy-effects overview — Task 10a). Unlike landedEnemyDebuffs,
@@ -1570,7 +1579,10 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
     // still emits (only Block-Debuff immunity gates a standalone control — preserved separately).
     const resistedTimedEnemyNames: string[] = [];
     // Landings held back by intra-cast clause order (see the `afterDamageClause` branch below).
-    // Returned on the turn result; the engine flushes them once this turn's damage has landed.
+    // Returned on the turn result. PR8: the engine drains this at ONE of two points — at the end of
+    // sub-attack 0 when a later sub-attack exists (so hit 2 can see hit 1's stack), otherwise at the
+    // historical post-walk `flushDeferredEnemyApplications`. Both run before the actor's Post-Turn
+    // decrement, so either way the status keeps its normal window.
     const deferredEnemyApplications: DeferredEnemyApplication[] = [];
 
     /**
@@ -1734,11 +1746,13 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         const matchingAbility = firingSkill?.abilities.find(
             (a) => a.config.type === 'debuff' && a.config.buffName === status.payload.buffName
         );
-        // Ship-kit W5 Task A3: 'adjacent-enemies' / 'target-and-adjacent-enemies' fan the status
-        // over the resolved target's board neighbours (adjacentEnemyIdsFor, engine.ts's
-        // buildTurnArgs — team-symmetric via bySide). Only meaningful once a real `targetId` is
-        // resolved (positional cast on a real opposing actor); DPS/non-positional callers never
-        // supply `adjacentEnemyIdsFor` (or `targetId` is undefined there), so this is [] then.
+        // Ship-kit W5 Task A3 introduced the 'adjacent-enemies' / 'target-and-adjacent-enemies'
+        // board-neighbour fan-out (`adjacentEnemyIdsFor`, supplied by engine.ts's buildTurnArgs —
+        // team-symmetric via bySide). That mapping is no longer written here: PR8 Task 1 moved the
+        // whole nine-branch ternary into ./debuffRecipients, whose JSDoc is now the one place it is
+        // described (including why a positional caller gets [] rather than the non-positional
+        // `undefined` sink). Do not restate the branch rules here — two copies is exactly how the
+        // cast-time and per-sub-attack paths would drift.
         const abTarget = matchingAbility?.target;
         // PR8 Task 1: the nine-branch mapping now lives in ./debuffRecipients so the
         // per-sub-attack path (PR8 Task 3) resolves recipients by exactly the same rules,

--- a/src/utils/combat/playerTurn.ts
+++ b/src/utils/combat/playerTurn.ts
@@ -54,6 +54,7 @@ import { recipientCarriesBlockBuff } from './blockBuffBuffs';
 import { BARRIER_BUFFS } from './barrierBuffs';
 import { BARRIER_RECHARGING, holdsBarrierRecharging } from './barrierRecharging';
 import { resolveSupportRecipients } from './supportRecipients';
+import { resolveDebuffRecipientIds } from './debuffRecipients';
 import { supportFootprintAllyIds } from './supportFootprint';
 import type { AttackerDamageScalars } from './victimDamage';
 import type { PreFightCombatModifiers } from './preFight/types';
@@ -1530,37 +1531,22 @@ export function runPlayerTurn(args: PlayerTurnArgs): PlayerTurnResult {
         const matchingAbility = firingSkill?.abilities.find(
             (a) => a.config.type === 'debuff' && a.config.buffName === status.payload.buffName
         );
-        const isAllEnemies = matchingAbility?.target === 'all-enemies';
         // Ship-kit W5 Task A3: 'adjacent-enemies' / 'target-and-adjacent-enemies' fan the status
         // over the resolved target's board neighbours (adjacentEnemyIdsFor, engine.ts's
         // buildTurnArgs — team-symmetric via bySide). Only meaningful once a real `targetId` is
         // resolved (positional cast on a real opposing actor); DPS/non-positional callers never
         // supply `adjacentEnemyIdsFor` (or `targetId` is undefined there), so this is [] then.
         const abTarget = matchingAbility?.target;
-        const adjacentEnemyRecipients: string[] =
-            targetId !== undefined && adjacentEnemyIdsFor ? adjacentEnemyIdsFor(targetId) : [];
-        const recipientIds: (string | undefined)[] =
-            abTarget === 'adjacent-enemies'
-                ? adjacentEnemyRecipients
-                : abTarget === 'target-and-adjacent-enemies'
-                  ? targetId !== undefined
-                      ? [targetId, ...adjacentEnemyRecipients]
-                      : // DPS-parity fallback: no real anchor to fan out from (mirrors the
-                        // plain-'enemy' tail below) — non-positional lands on the dummy sink
-                        // (`[undefined]` → victim resolves to `enemy`), positional-with-no-target
-                        // (shouldn't occur for a real opposing cast) no-ops.
-                        positionalLanding
-                        ? []
-                        : [undefined]
-                  : positionalLanding && isAllEnemies
-                    ? (aoeVictimIds ?? [])
-                    : isAllEnemies && aoeVictimIds && aoeVictimIds.length > 0
-                      ? aoeVictimIds
-                      : targetId !== undefined
-                        ? [targetId]
-                        : positionalLanding
-                          ? []
-                          : [undefined];
+        // PR8 Task 1: the nine-branch mapping now lives in ./debuffRecipients so the
+        // per-sub-attack path (PR8 Task 3) resolves recipients by exactly the same rules,
+        // keyed off ITS OWN re-resolved anchor and footprint instead of the cast's.
+        const recipientIds: (string | undefined)[] = resolveDebuffRecipientIds({
+            abTarget,
+            anchorId: targetId,
+            aoeVictimIds,
+            adjacentEnemyIdsFor,
+            positionalLanding,
+        });
 
         let anyLanded = false;
         for (const vid of recipientIds) {

--- a/src/utils/combat/positionalApply.ts
+++ b/src/utils/combat/positionalApply.ts
@@ -297,6 +297,23 @@ export function applyPositionalDamage(args: {
      * Unsupplied → every victim uses hitCrits[h] → byte-identical.
      */
     rollVictimCrit?: (victim: CombatActor, subAttackIndex?: number) => boolean;
+    /**
+     * Boundary hooks for ONE sub-attack (multi-hit full-walk epic, PR8 Task 2). `onSubAttackStart`
+     * runs after the anchor resolves and BEFORE any of that sub-attack's damage; `onSubAttackEnd`
+     * runs after ALL of it. A WHIFF (no living anchor) calls neither — there is no attack to hang a
+     * clause on — but still consumes its loop index, so `subAttacks[h]` stays aligned.
+     *
+     * They exist so a direct debuff clause can land per sub-attack, in written clause order
+     * relative to that sub-attack's own damage, and be visible to the NEXT sub-attack's
+     * `defenseProfileOf` read. Both optional: an unsupplied hook makes the loop byte-identical.
+     *
+     * `victimIds` is this sub-attack's footprint in hit order — the anchor plus every covered
+     * cell — and is the set PR8 re-rolls the landing against. Overkill retargeting is correct for
+     * free: the anchor is re-resolved against the live roster at the top of every iteration, so a
+     * victim killed on an earlier sub-attack simply is not here.
+     */
+    onSubAttackStart?: (sub: { index: number; anchorId: string; victimIds: string[] }) => void;
+    onSubAttackEnd?: (sub: { index: number; anchorId: string; victimIds: string[] }) => void;
 }): {
     anyCrit: boolean;
     critPairs: number;
@@ -319,6 +336,8 @@ export function applyPositionalDamage(args: {
         incomingReductionFor,
         outgoingAmplificationFor,
         rollVictimCrit,
+        onSubAttackStart,
+        onSubAttackEnd,
     } = args;
 
     let anyCrit = false;
@@ -363,11 +382,14 @@ export function applyPositionalDamage(args: {
         const subVictimIds: string[] = [];
         const subCritVictimIds: string[] = [];
 
-        for (const { victim, roleScale } of footprintVictims(
-            pattern,
-            anchorActor.position,
-            opposingLiving
-        )) {
+        const footprint = footprintVictims(pattern, anchorActor.position, opposingLiving);
+        const subVictimIdsForHooks = footprint.map((f) => f.victim.id);
+        onSubAttackStart?.({
+            index: h,
+            anchorId: anchorActor.id,
+            victimIds: subVictimIdsForHooks,
+        });
+        for (const { victim, roleScale } of footprint) {
             // Anchor reuses the pre-rolled hitCrits[h]; covered victims resolve via callback.
             const isAnchor = victim.id === anchorActor.id;
             const didCrit = isAnchor ? anchorCrit : (rollVictimCrit?.(victim, h) ?? anchorCrit);
@@ -410,6 +432,12 @@ export function applyPositionalDamage(args: {
             subDelivered += booked + (outcome.protectionRedirected ?? 0);
             subVictimIds.push(victim.id);
         }
+
+        onSubAttackEnd?.({
+            index: h,
+            anchorId: anchorActor.id,
+            victimIds: subVictimIdsForHooks,
+        });
 
         subAttacks.push({
             index: h,

--- a/src/utils/combat/triggers.ts
+++ b/src/utils/combat/triggers.ts
@@ -311,7 +311,10 @@ export function partitionReactiveAbilities(shipSkills: ShipSkills): {
  *    Exception: the two CAST-SCOPED fallback emits (engine.ts's nothing-landed and enemy
  *    0-damage sites) publish `e.damage` as the cast total (`dap.damage`), not a share — harmless
  *    today since both carry 0, but not "already a share" like the rest.
- *  - on-debuff-inflicted → debuff-applied | dot-applied with `sourceId === ownerId`
+ *  - on-debuff-inflicted → debuff-applied | dot-applied with `sourceId === ownerId`.
+ *    Cardinality follows the LANDING, which since PR8 (multi-hit full-walk epic) is once per
+ *    SUB-ATTACK for a direct debuff clause, not once per cast: an N-hit cast that lands its clause
+ *    every hit enqueues N times. Unchanged at N=1, which is the whole ship corpus today.
  *  - on-ally-debuff-inflicted → debuff-applied OR dot-applied where the source is a same-side
  *    ally (not opposing, not the owner itself). For the PLAYER registration this is any OTHER
  *    PLAYER's infliction; for the ENEMY registration this is any other enemy actor's infliction.


### PR DESCRIPTION
Closes the multi-hit full-walk epic (PR8 of 8).

R1 of the epic says each sub-attack of a multi-hit skill runs the entire pipeline including the debuff landing roll. Direct debuff clauses landed **once per cast**. Now each sub-attack rolls its own landing against the anchor and footprint it actually resolved, and — per the owner's ruling that consecutive attacks contain the effects of earlier ones — sub-attack k's stack is in the store when sub-attack k+1 computes its damage (`defenseProfileOf` reads victim status live, per hit).

## Design

The spec's §3 shape was **superseded**, with the reason recorded in the plan: it proposed flushing against `PositionalAttackedSignals`, but that map only exists *after* `drivePositionalApply` returns, so it structurally cannot make a stack visible to the next sub-attack — and it excludes DoT-transformed victims, which is the wrong victim set for a landing that never consulted damage. Instead:

- New `onSubAttackStart` / `onSubAttackEnd` hooks on `applyPositionalDamage`'s hit loop, carrying that sub-attack's own `{index, anchorId, victimIds}`. Overkill retargeting is correct for free — the anchor is re-resolved against the live roster every iteration.
- Each landing splits into `{ applyState, emitEvents }` so the state write can happen at the sub-attack boundary while the paired `debuff-applied` is interleaved into the existing emission steps, keeping `buildCombatLog`'s row attribution intact.
- **Sub-attack 0 keeps its cast-time draw.** Three consumers read that outcome before the positional loop runs: the `control-applied` gate inside `runPlayerTurn`, the `resistedEnemyDebuffs` display list, and `reInflictedStasis`. Only its state write moves forward, gated on *"is there a later sub-attack?"* (`h < scalars.hits - 1`) rather than on `hits > 1` — so N=1 runs today's exact path by construction.
- Team-symmetric: one helper, all three turn sites (focus / walked team / enemy). Both new `PositionalTurnSel` fields are non-optional, so a fourth turn site cannot silently skip them.

## Verification

| Gate | Result |
|---|---|
| Suite | 487 files / 5545 tests green |
| `tsc --noEmit` / `lint` / `npm run audit` | clean |
| `audit:placement-symmetry --seeds 15` | **2 / 146 / 13-13-13 — exact baseline** |
| Golden & snapshot movement | **zero** |

Corpus-inert by measurement: 147 ships, only Enforcer has `hits > 1`, 49 carry a direct active/charged debuff-inflict clause, intersection EMPTY. Hence no changelog entry — nothing user-visible changes in today's corpus.

Nine assertions moved rather than the two the plan predicted: `intraCastClauseOrder` and `exposedStatus` build fixtures with `HITS = 2` and so sit on the changed path. Owner-confirmed numbers on a 2-hit cast: **post-damage clause 1.5x plain with 1 residual stack; pre-damage 2.0x with 0**. The locked intra-cast rule keeps its teeth — a post-damage clause still misses its own sub-attack.

## Known limitations, documented not fixed

- **R1 is closed for the `timed` family only.** A firing-slot clause carrying a `stackTrigger` classifies as `accumulating` (`engine.ts:331`), never reaches `timedEnemyBySlot`, and still applies once per cast. No shipped ship hits this.
- **`reInflictedStasis` cannot see a Stasis landing on sub-attack >= 1** — the read precedes the drive at all three sites. Noted at all three.
- **`control-applied` suppression is one-directional**: a control resisted on sub-attack 0 but landed on sub-attack 1 emits no event.
- The `h < hits - 1` guard is **unfenced by any test** and this is deliberate: it sits inside an `index === 0` branch, so `<`, `<=` and `true` differ only at N=1 where the event stream is byte-identical. Its sibling (`false`) kills 9 tests. A unit test on the expression would assert its own derivation. Please do not "fix" this by adding one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V65xi1NsFW1sP32DYcxqug